### PR TITLE
Modify index mappings for receive and processing timestamps

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/GeoIpResolverEngine.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/map/geoip/GeoIpResolverEngine.java
@@ -43,7 +43,6 @@ import static com.codahale.metrics.MetricRegistry.name;
 
 public class GeoIpResolverEngine {
     private static final Logger LOG = LoggerFactory.getLogger(GeoIpResolverEngine.class);
-    private static final String INTERNAL_FIELD_PREFIX = "gl2_";
 
     private final Timer resolveTime;
     private DatabaseReader databaseReader;
@@ -75,7 +74,7 @@ public class GeoIpResolverEngine {
 
         for (Map.Entry<String, Object> field : message.getFields().entrySet()) {
             final String key = field.getKey();
-            if (!key.startsWith(INTERNAL_FIELD_PREFIX)) {
+            if (!key.startsWith(Message.INTERNAL_FIELD_PREFIX)) {
                 final Optional<GeoLocationInformation> geoLocationInformation = extractGeoLocationInformation(field.getValue());
                 geoLocationInformation.ifPresent(locationInformation -> {
                     // We will store the coordinates as a "lat,long" string

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/CloneMessage.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/messages/CloneMessage.java
@@ -60,7 +60,7 @@ public class CloneMessage extends AbstractFunction<Message> {
 
             // Message#addFields() overwrites the "timestamp" field.
             clonedMessage.addField("timestamp", now);
-            clonedMessage.addField("gl2_original_timestamp", String.valueOf(tsField));
+            clonedMessage.addField(Message.FIELD_GL2_ORIGINAL_TIMESTAMP, String.valueOf(tsField));
         }
 
         clonedMessage.addStreams(currentMessage.getStreams());

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/PipelineInterpreter.java
@@ -53,7 +53,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import java.util.ArrayList;
@@ -69,8 +68,6 @@ import static org.jooq.lambda.tuple.Tuple.tuple;
 
 public class PipelineInterpreter implements MessageProcessor {
     private static final Logger log = LoggerFactory.getLogger(PipelineInterpreter.class);
-
-    public static final String GL2_PROCESSING_ERROR = "gl2_processing_error";
 
     private final Journal journal;
     private final Meter filteredOutMessages;
@@ -422,10 +419,10 @@ public class PipelineInterpreter implements MessageProcessor {
 
     private void appendProcessingError(Rule rule, Message message, String errorString) {
         final String msg = "For rule '" + rule.name() + "': " + errorString;
-        if (message.hasField(GL2_PROCESSING_ERROR)) {
-            message.addField(GL2_PROCESSING_ERROR, message.getFieldAs(String.class, GL2_PROCESSING_ERROR) + "," + msg);
+        if (message.hasField(Message.FIELD_GL2_PROCESSING_ERROR)) {
+            message.addField(Message.FIELD_GL2_PROCESSING_ERROR, message.getFieldAs(String.class, Message.FIELD_GL2_PROCESSING_ERROR) + "," + msg);
         } else {
-            message.addField(GL2_PROCESSING_ERROR, msg);
+            message.addField(Message.FIELD_GL2_PROCESSING_ERROR, msg);
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping5.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping5.java
@@ -17,6 +17,7 @@
 package org.graylog2.indexer;
 
 import com.google.common.collect.ImmutableMap;
+import org.graylog2.plugin.Message;
 
 import java.util.Map;
 
@@ -29,15 +30,18 @@ import java.util.Map;
 public class IndexMapping5 extends IndexMapping {
     @Override
     protected Map<String, Map<String, Object>> fieldProperties(String analyzer) {
-        return ImmutableMap.of(
-                "message", analyzedString(analyzer, false),
-                "full_message", analyzedString(analyzer, false),
+        return ImmutableMap.<String, Map<String, Object>>builder()
+                .put("message", analyzedString(analyzer, false))
+                .put("full_message", analyzedString(analyzer, false))
                 // http://joda-time.sourceforge.net/api-release/org/joda/time/format/DateTimeFormat.html
                 // http://www.elasticsearch.org/guide/reference/mapping/date-format.html
-                "timestamp", typeTimeWithMillis(),
+                .put("timestamp", typeTimeWithMillis())
+                .put(Message.FIELD_GL2_RECEIVE_TIMESTAMP, typeTimeWithMillis())
+                .put(Message.FIELD_GL2_PROCESSING_TIMESTAMP, typeTimeWithMillis())
                 // to support wildcard searches in source we need to lowercase the content (wildcard search lowercases search term)
-                "source", analyzedString("analyzer_keyword", true),
-                "streams", notAnalyzedString());
+                .put("source", analyzedString("analyzer_keyword", true))
+                .put("streams", notAnalyzedString())
+                .build();
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping6.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping6.java
@@ -18,6 +18,7 @@ package org.graylog2.indexer;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.graylog2.plugin.Message;
 
 import java.util.List;
 import java.util.Map;
@@ -60,15 +61,18 @@ public class IndexMapping6 extends IndexMapping {
 
     @Override
     protected Map<String, Map<String, Object>> fieldProperties(String analyzer) {
-        return ImmutableMap.of(
-            "message", analyzedString(analyzer, false),
-            "full_message", analyzedString(analyzer, false),
-            // http://joda-time.sourceforge.net/api-release/org/joda/time/format/DateTimeFormat.html
-            // http://www.elasticsearch.org/guide/reference/mapping/date-format.html
-            "timestamp", typeTimeWithMillis(),
-            // to support wildcard searches in source we need to lowercase the content (wildcard search lowercases search term)
-            "source", analyzedString("analyzer_keyword", true),
-            "streams", notAnalyzedString());
+        return ImmutableMap.<String, Map<String, Object>>builder()
+                .put("message", analyzedString(analyzer, false))
+                .put("full_message", analyzedString(analyzer, false))
+                // http://joda-time.sourceforge.net/api-release/org/joda/time/format/DateTimeFormat.html
+                // http://www.elasticsearch.org/guide/reference/mapping/date-format.html
+                .put("timestamp", typeTimeWithMillis())
+                .put(Message.FIELD_GL2_RECEIVE_TIMESTAMP, typeTimeWithMillis())
+                .put(Message.FIELD_GL2_PROCESSING_TIMESTAMP, typeTimeWithMillis())
+                // to support wildcard searches in source we need to lowercase the content (wildcard search lowercases search term)
+                .put("source", analyzedString("analyzer_keyword", true))
+                .put("streams", notAnalyzedString())
+                .build();
     }
 
     private Map<String, Object> analyzedString(String analyzer, boolean fieldData) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesClusterConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesClusterConfig.java
@@ -23,6 +23,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.graylog.autovalue.WithBeanGetter;
+import org.graylog2.plugin.Message;
 import org.joda.time.Period;
 
 import javax.annotation.Nullable;
@@ -59,7 +60,7 @@ public abstract class SearchesClusterConfig {
             .build();
     private static final Set<String> DEFAULT_SURROUNDING_FILTER_FIELDS = ImmutableSet.<String>builder()
             .add("source")
-            .add("gl2_source_input")
+            .add(Message.FIELD_GL2_SOURCE_INPUT)
             .add("file")
             .add("source_file")
             .build();

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -75,23 +75,87 @@ public class Message implements Messages {
     public static final String FIELD_TIMESTAMP = "timestamp";
     public static final String FIELD_LEVEL = "level";
     public static final String FIELD_STREAMS = "streams";
+
+    /**
+     * Graylog is writing internal metadata to messages using this field prefix. Users must not use this prefix for
+     * custom message fields.
+     */
+    public static final String INTERNAL_FIELD_PREFIX = "gl2_";
+
+    /**
+     * Can be set when a message timestamp gets modified to preserve the original timestamp. (e.g. "clone_message" pipeline function)
+     */
+    public static final String FIELD_GL2_ORIGINAL_TIMESTAMP = "gl2_original_timestamp";
+
+    /**
+     * Can be set to indicate a message processing error. (e.g. set by the pipeline interpreter when an error occurs)
+     */
+    public static final String FIELD_GL2_PROCESSING_ERROR = "gl2_processing_error";
+
+    /**
+     * Will be set to the hostname of the source node that sent a message. (if reverse lookup is enabled)
+     */
+    public static final String FIELD_GL2_REMOTE_HOSTNAME = "gl2_remote_hostname";
+
+    /**
+     * Will be set to the IP address of the source node that sent a message.
+     */
+    public static final String FIELD_GL2_REMOTE_IP = "gl2_remote_ip";
+
+    /**
+     * Will be set to the socket port of the source node that sent a message.
+     */
+    public static final String FIELD_GL2_REMOTE_PORT = "gl2_remote_port";
+
+    /**
+     * Can be set to the collector ID that sent a message. (e.g. used in the beats codec)
+     */
     public static final String FIELD_GL2_SOURCE_COLLECTOR = "gl2_source_collector";
+
+    /**
+     * @deprecated This was used in the legacy collector/sidecar system and contained the database ID of the collector input.
+     */
+    @Deprecated
+    public static final String FIELD_GL2_SOURCE_COLLECTOR_INPUT = "gl2_source_collector_input";
+
+    /**
+     * Will be set to the ID of the input that received the message.
+     */
+    public static final String FIELD_GL2_SOURCE_INPUT = "gl2_source_input";
+
+    /**
+     * Will be set to the ID of the node that received the message.
+     */
+    public static final String FIELD_GL2_SOURCE_NODE = "gl2_source_node";
+
+    /**
+     * @deprecated This was used with the now removed radio system and contained the ID of a radio node.
+     */
+    @Deprecated
+    public static final String FIELD_GL2_SOURCE_RADIO = "gl2_source_radio";
+
+    /**
+     * @deprecated This was used with the now removed radio system and contained the input ID of a radio node.
+     */
+    @Deprecated
+    public static final String FIELD_GL2_SOURCE_RADIO_INPUT = "gl2_source_radio_input";
 
     private static final Pattern VALID_KEY_CHARS = Pattern.compile("^[\\w\\.\\-@]*$");
     private static final char KEY_REPLACEMENT_CHAR = '_';
 
     private static final ImmutableSet<String> GRAYLOG_FIELDS = ImmutableSet.of(
-        "gl2_source_node",
-        "gl2_source_input",
+        FIELD_GL2_SOURCE_NODE,
+        FIELD_GL2_SOURCE_INPUT,
+
         // TODO Due to be removed in Graylog 3.x
-        "gl2_source_radio",
-        "gl2_source_radio_input",
+        FIELD_GL2_SOURCE_RADIO,
+        FIELD_GL2_SOURCE_RADIO_INPUT,
 
         FIELD_GL2_SOURCE_COLLECTOR,
-        "gl2_source_collector_input",
-        "gl2_remote_ip",
-        "gl2_remote_port",
-        "gl2_remote_hostname"
+        FIELD_GL2_SOURCE_COLLECTOR_INPUT,
+        FIELD_GL2_REMOTE_IP,
+        FIELD_GL2_REMOTE_PORT,
+        FIELD_GL2_REMOTE_HOSTNAME
     );
 
     private static final ImmutableSet<String> CORE_MESSAGE_FIELDS = ImmutableSet.of(
@@ -652,14 +716,14 @@ public class Message implements Messages {
     // drools seems to need the "get" prefix
     @Deprecated
     public boolean getIsSourceInetAddress() {
-        return fields.containsKey("gl2_remote_ip");
+        return fields.containsKey(FIELD_GL2_REMOTE_IP);
     }
 
     public InetAddress getInetAddress() {
-        if (!fields.containsKey("gl2_remote_ip")) {
+        if (!fields.containsKey(FIELD_GL2_REMOTE_IP)) {
             return null;
         }
-        final String ipAddr = (String) fields.get("gl2_remote_ip");
+        final String ipAddr = (String) fields.get(FIELD_GL2_REMOTE_IP);
         try {
             return InetAddresses.forString(ipAddr);
         } catch (IllegalArgumentException ignored) {

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -93,6 +93,18 @@ public class Message implements Messages {
     public static final String FIELD_GL2_PROCESSING_ERROR = "gl2_processing_error";
 
     /**
+     * Will be set to the message processing time after all message processors have been run.
+     * TODO: To be done in Graylog 3.2
+     */
+    public static final String FIELD_GL2_PROCESSING_TIMESTAMP = "gl2_processing_timestamp";
+
+    /**
+     * Will be set to the message receive time at the input.
+     * TODO: To be done in Graylog 3.2
+     */
+    public static final String FIELD_GL2_RECEIVE_TIMESTAMP = "gl2_receive_timestamp";
+
+    /**
      * Will be set to the hostname of the source node that sent a message. (if reverse lookup is enabled)
      */
     public static final String FIELD_GL2_REMOTE_HOSTNAME = "gl2_remote_hostname";
@@ -148,6 +160,8 @@ public class Message implements Messages {
     private static final ImmutableSet<String> GRAYLOG_FIELDS = ImmutableSet.of(
         FIELD_GL2_ORIGINAL_TIMESTAMP,
         FIELD_GL2_PROCESSING_ERROR,
+        FIELD_GL2_PROCESSING_TIMESTAMP,
+        FIELD_GL2_RECEIVE_TIMESTAMP,
         FIELD_GL2_REMOTE_HOSTNAME,
         FIELD_GL2_REMOTE_IP,
         FIELD_GL2_REMOTE_PORT,

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -130,12 +130,14 @@ public class Message implements Messages {
 
     /**
      * @deprecated This was used with the now removed radio system and contained the ID of a radio node.
+     * TODO: Due to be removed in Graylog 3.x
      */
     @Deprecated
     public static final String FIELD_GL2_SOURCE_RADIO = "gl2_source_radio";
 
     /**
      * @deprecated This was used with the now removed radio system and contained the input ID of a radio node.
+     * TODO: Due to be removed in Graylog 3.x
      */
     @Deprecated
     public static final String FIELD_GL2_SOURCE_RADIO_INPUT = "gl2_source_radio_input";
@@ -144,18 +146,17 @@ public class Message implements Messages {
     private static final char KEY_REPLACEMENT_CHAR = '_';
 
     private static final ImmutableSet<String> GRAYLOG_FIELDS = ImmutableSet.of(
-        FIELD_GL2_SOURCE_NODE,
-        FIELD_GL2_SOURCE_INPUT,
-
-        // TODO Due to be removed in Graylog 3.x
-        FIELD_GL2_SOURCE_RADIO,
-        FIELD_GL2_SOURCE_RADIO_INPUT,
-
-        FIELD_GL2_SOURCE_COLLECTOR,
-        FIELD_GL2_SOURCE_COLLECTOR_INPUT,
+        FIELD_GL2_ORIGINAL_TIMESTAMP,
+        FIELD_GL2_PROCESSING_ERROR,
+        FIELD_GL2_REMOTE_HOSTNAME,
         FIELD_GL2_REMOTE_IP,
         FIELD_GL2_REMOTE_PORT,
-        FIELD_GL2_REMOTE_HOSTNAME
+        FIELD_GL2_SOURCE_COLLECTOR,
+        FIELD_GL2_SOURCE_COLLECTOR_INPUT,
+        FIELD_GL2_SOURCE_INPUT,
+        FIELD_GL2_SOURCE_NODE,
+        FIELD_GL2_SOURCE_RADIO,
+        FIELD_GL2_SOURCE_RADIO_INPUT
     );
 
     private static final ImmutableSet<String> CORE_MESSAGE_FIELDS = ImmutableSet.of(

--- a/graylog2-server/src/main/java/org/graylog2/plugin/journal/RawMessage.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/journal/RawMessage.java
@@ -271,6 +271,7 @@ public class RawMessage implements Serializable {
 
         public enum Type {
             SERVER,
+            @Deprecated
             RADIO
         }
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/buffers/processors/DecodingProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/buffers/processors/DecodingProcessor.java
@@ -197,22 +197,22 @@ public class DecodingProcessor implements EventHandler<MessageEvent> {
             switch (node.type) {
                 case SERVER:
                     // Always use the last source node.
-                    if (message.getField("gl2_source_input") != null) {
+                    if (message.getField(Message.FIELD_GL2_SOURCE_INPUT) != null) {
                         LOG.debug("Multiple server nodes ({} {}) set for message id {}",
-                                message.getField("gl2_source_input"), node.nodeId, message.getId());
+                                message.getField(Message.FIELD_GL2_SOURCE_INPUT), node.nodeId, message.getId());
                     }
-                    message.addField("gl2_source_input", node.inputId);
-                    message.addField("gl2_source_node", node.nodeId);
+                    message.addField(Message.FIELD_GL2_SOURCE_INPUT, node.inputId);
+                    message.addField(Message.FIELD_GL2_SOURCE_NODE, node.nodeId);
                     break;
                 // TODO Due to be removed in Graylog 3.x
                 case RADIO:
                     // Always use the last source node.
-                    if (message.getField("gl2_source_radio_input") != null) {
+                    if (message.getField(Message.FIELD_GL2_SOURCE_RADIO_INPUT) != null) {
                         LOG.debug("Multiple radio nodes ({} {}) set for message id {}",
-                                message.getField("gl2_source_radio_input"), node.nodeId, message.getId());
+                                message.getField(Message.FIELD_GL2_SOURCE_RADIO_INPUT), node.nodeId, message.getId());
                     }
-                    message.addField("gl2_source_radio_input", node.inputId);
-                    message.addField("gl2_source_radio", node.nodeId);
+                    message.addField(Message.FIELD_GL2_SOURCE_RADIO_INPUT, node.inputId);
+                    message.addField(Message.FIELD_GL2_SOURCE_RADIO, node.nodeId);
                     break;
             }
         }
@@ -228,12 +228,12 @@ public class DecodingProcessor implements EventHandler<MessageEvent> {
         final ResolvableInetSocketAddress remoteAddress = raw.getRemoteAddress();
         if (remoteAddress != null) {
             final String addrString = InetAddresses.toAddrString(remoteAddress.getAddress());
-            message.addField("gl2_remote_ip", addrString);
+            message.addField(Message.FIELD_GL2_REMOTE_IP, addrString);
             if (remoteAddress.getPort() > 0) {
-                message.addField("gl2_remote_port", remoteAddress.getPort());
+                message.addField(Message.FIELD_GL2_REMOTE_PORT, remoteAddress.getPort());
             }
             if (remoteAddress.isReverseLookedUp()) { // avoid reverse lookup if the hostname is available
-                message.addField("gl2_remote_hostname", remoteAddress.getHostName());
+                message.addField(Message.FIELD_GL2_REMOTE_HOSTNAME, remoteAddress.getHostName());
             }
             if (Strings.isNullOrEmpty(message.getSource())) {
                 message.setSource(addrString);

--- a/graylog2-server/src/test/java/org/graylog/plugins/map/geoip/GeoIpResolverEngineTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/map/geoip/GeoIpResolverEngineTest.java
@@ -132,7 +132,7 @@ public class GeoIpResolverEngineTest {
         messageFields.put("source", "192.168.0.1");
         messageFields.put("message", "Hello from 1.2.3.4");
         messageFields.put("extracted_ip", "1.2.3.4");
-        messageFields.put("gl2_remote_ip", "1.2.3.4");
+        messageFields.put(Message.FIELD_GL2_REMOTE_IP, "1.2.3.4");
         messageFields.put("ipv6", "2001:4860:4860::8888");
 
         final Message message = new Message(messageFields);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
@@ -125,6 +125,8 @@ public class IndexFieldTypePollerIT extends ElasticsearchBase {
                     FieldTypeDTO.create("http_status", "keyword"),
                     FieldTypeDTO.create("http_response_time", "long"),
                     FieldTypeDTO.create("timestamp", "date"),
+                    FieldTypeDTO.create("gl2_receive_timestamp", "date"),
+                    FieldTypeDTO.create("gl2_processing_timestamp", "date"),
                     FieldTypeDTO.create("streams", "keyword")
             );
         } finally {
@@ -152,6 +154,8 @@ public class IndexFieldTypePollerIT extends ElasticsearchBase {
                     FieldTypeDTO.create("http_status", "keyword"),
                     FieldTypeDTO.create("http_response_time", "long"),
                     FieldTypeDTO.create("timestamp", "date"),
+                    FieldTypeDTO.create("gl2_receive_timestamp", "date"),
+                    FieldTypeDTO.create("gl2_processing_timestamp", "date"),
                     FieldTypeDTO.create("streams", "keyword")
             );
         } finally {


### PR DESCRIPTION
### Changes

- Create constants for all internal message fields used in the server
- Also document all of them and mark the deprecated ones.
- Added `gl2_receive_timestamp` and `gl2_processing_timestamp` fields