### PR TITLE
Updating OkHttp from 3.11.0 to 3.14.2.

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/shared/bindings/providers/OkHttpClientProviderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/bindings/providers/OkHttpClientProviderTest.java
@@ -92,7 +92,7 @@ public class OkHttpClientProviderTest {
         assertThat(server.getRequestCount()).isEqualTo(1);
         final RecordedRequest recordedRequest = server.takeRequest();
         assertThat(recordedRequest.getMethod()).isEqualTo("GET");
-        assertThat(recordedRequest.getPath()).isEqualTo("http://www.example.com/");
+        assertThat(recordedRequest.getPath()).isEqualTo("/");
         assertThat(recordedRequest.getHeader(HttpHeaders.HOST)).isEqualTo("www.example.com");
     }
 
@@ -111,12 +111,12 @@ public class OkHttpClientProviderTest {
         assertThat(server.getRequestCount()).isEqualTo(2);
         final RecordedRequest unauthenticatedRequest = server.takeRequest();
         assertThat(unauthenticatedRequest.getMethod()).isEqualTo("GET");
-        assertThat(unauthenticatedRequest.getPath()).isEqualTo("http://www.example.com/");
+        assertThat(unauthenticatedRequest.getPath()).isEqualTo("/");
         assertThat(unauthenticatedRequest.getHeader(HttpHeaders.HOST)).isEqualTo("www.example.com");
         assertThat(unauthenticatedRequest.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).isNull();
         final RecordedRequest authenticatedRequest = server.takeRequest();
         assertThat(authenticatedRequest.getMethod()).isEqualTo("GET");
-        assertThat(authenticatedRequest.getPath()).isEqualTo("http://www.example.com/");
+        assertThat(authenticatedRequest.getPath()).isEqualTo("/");
         assertThat(authenticatedRequest.getHeader(HttpHeaders.HOST)).isEqualTo("www.example.com");
         assertThat(authenticatedRequest.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).isEqualTo(Credentials.basic("user", "password"));
     }
@@ -136,12 +136,12 @@ public class OkHttpClientProviderTest {
         assertThat(server.getRequestCount()).isEqualTo(2);
         final RecordedRequest unauthenticatedRequest = server.takeRequest();
         assertThat(unauthenticatedRequest.getMethod()).isEqualTo("GET");
-        assertThat(unauthenticatedRequest.getPath()).isEqualTo("http://www.example.com/");
+        assertThat(unauthenticatedRequest.getPath()).isEqualTo("/");
         assertThat(unauthenticatedRequest.getHeader(HttpHeaders.HOST)).isEqualTo("www.example.com");
         assertThat(unauthenticatedRequest.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).isNull();
         final RecordedRequest authenticatedRequest = server.takeRequest();
         assertThat(authenticatedRequest.getMethod()).isEqualTo("GET");
-        assertThat(authenticatedRequest.getPath()).isEqualTo("http://www.example.com/");
+        assertThat(authenticatedRequest.getPath()).isEqualTo("/");
         assertThat(authenticatedRequest.getHeader(HttpHeaders.HOST)).isEqualTo("www.example.com");
         assertThat(authenticatedRequest.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).isEqualTo(Credentials.basic("user", "password"));
     }
@@ -160,7 +160,7 @@ public class OkHttpClientProviderTest {
         assertThat(server.getRequestCount()).isEqualTo(1);
         final RecordedRequest recordedRequest = server.takeRequest();
         assertThat(recordedRequest.getMethod()).isEqualTo("GET");
-        assertThat(recordedRequest.getPath()).isEqualTo("http://www.example.com/");
+        assertThat(recordedRequest.getPath()).isEqualTo("/");
         assertThat(recordedRequest.getHeader(HttpHeaders.HOST)).isEqualTo("www.example.com");
     }
 
@@ -179,12 +179,12 @@ public class OkHttpClientProviderTest {
         assertThat(server.getRequestCount()).isEqualTo(2);
         final RecordedRequest unauthenticatedRequest = server.takeRequest();
         assertThat(unauthenticatedRequest.getMethod()).isEqualTo("GET");
-        assertThat(unauthenticatedRequest.getPath()).isEqualTo("http://www.example.com/");
+        assertThat(unauthenticatedRequest.getPath()).isEqualTo("/");
         assertThat(unauthenticatedRequest.getHeader(HttpHeaders.HOST)).isEqualTo("www.example.com");
         assertThat(unauthenticatedRequest.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).isNull();
         final RecordedRequest authenticatedRequest = server.takeRequest();
         assertThat(authenticatedRequest.getMethod()).isEqualTo("GET");
-        assertThat(authenticatedRequest.getPath()).isEqualTo("http://www.example.com/");
+        assertThat(authenticatedRequest.getPath()).isEqualTo("/");
         assertThat(authenticatedRequest.getHeader(HttpHeaders.HOST)).isEqualTo("www.example.com");
         assertThat(authenticatedRequest.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).isEqualTo(Credentials.basic("user", "password"));
     }
@@ -213,13 +213,13 @@ public class OkHttpClientProviderTest {
 
         final RecordedRequest unauthenticatedRequest = server.takeRequest();
         assertThat(unauthenticatedRequest.getMethod()).isEqualTo("GET");
-        assertThat(unauthenticatedRequest.getPath()).isEqualTo("http://www.example.com/");
+        assertThat(unauthenticatedRequest.getPath()).isEqualTo("/");
         assertThat(unauthenticatedRequest.getHeader(HttpHeaders.HOST)).isEqualTo("www.example.com");
         assertThat(unauthenticatedRequest.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).isNull();
 
         final RecordedRequest authenticatedRequest = server.takeRequest();
         assertThat(authenticatedRequest.getMethod()).isEqualTo("GET");
-        assertThat(authenticatedRequest.getPath()).isEqualTo("http://www.example.com/");
+        assertThat(authenticatedRequest.getPath()).isEqualTo("/");
         assertThat(authenticatedRequest.getHeader(HttpHeaders.HOST)).isEqualTo("www.example.com");
         assertThat(authenticatedRequest.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).isEqualTo(Credentials.basic("", "password"));
 
@@ -238,13 +238,13 @@ public class OkHttpClientProviderTest {
 
         final RecordedRequest unauthenticatedRequest = server.takeRequest();
         assertThat(unauthenticatedRequest.getMethod()).isEqualTo("GET");
-        assertThat(unauthenticatedRequest.getPath()).isEqualTo("http://www.example.com/");
+        assertThat(unauthenticatedRequest.getPath()).isEqualTo("/");
         assertThat(unauthenticatedRequest.getHeader(HttpHeaders.HOST)).isEqualTo("www.example.com");
         assertThat(unauthenticatedRequest.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).isNull();
 
         final RecordedRequest authenticatedRequest = server.takeRequest();
         assertThat(authenticatedRequest.getMethod()).isEqualTo("GET");
-        assertThat(authenticatedRequest.getPath()).isEqualTo("http://www.example.com/");
+        assertThat(authenticatedRequest.getPath()).isEqualTo("/");
         assertThat(authenticatedRequest.getHeader(HttpHeaders.HOST)).isEqualTo("www.example.com");
         assertThat(authenticatedRequest.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).isEqualTo(Credentials.basic("user", ""));
 
@@ -263,13 +263,13 @@ public class OkHttpClientProviderTest {
 
         final RecordedRequest unauthenticatedRequest = server.takeRequest();
         assertThat(unauthenticatedRequest.getMethod()).isEqualTo("GET");
-        assertThat(unauthenticatedRequest.getPath()).isEqualTo("http://www.example.com/");
+        assertThat(unauthenticatedRequest.getPath()).isEqualTo("/");
         assertThat(unauthenticatedRequest.getHeader(HttpHeaders.HOST)).isEqualTo("www.example.com");
         assertThat(unauthenticatedRequest.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).isNull();
 
         final RecordedRequest authenticatedRequest = server.takeRequest();
         assertThat(authenticatedRequest.getMethod()).isEqualTo("GET");
-        assertThat(authenticatedRequest.getPath()).isEqualTo("http://www.example.com/");
+        assertThat(authenticatedRequest.getPath()).isEqualTo("/");
         assertThat(authenticatedRequest.getHeader(HttpHeaders.HOST)).isEqualTo("www.example.com");
         assertThat(authenticatedRequest.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).isEqualTo(Credentials.basic("", ""));
 

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <natty.version>0.13</natty.version>
         <netty.version>4.1.36.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.25.Final</netty-tcnative-boringssl-static.version>
-        <okhttp.version>3.11.0</okhttp.version>
+        <okhttp.version>3.14.2</okhttp.version>
         <opencsv.version>2.3</opencsv.version>
         <os-platform-finder.version>1.2.3</os-platform-finder.version>
         <pkts.version>3.0.3</pkts.version>


### PR DESCRIPTION
## Description
## Motivation and Context

This PR is updating OkHttp to 3.14.2.

Any OkHttp version up to 3.12.0 include a vulnerability that allows an attacker doing MitM to bypass certificate pinning. It does require full control of the Graylog server before, as it requires the attacker to control the startup/process space of the Graylog process though.

Changelog: https://github.com/square/okhttp/blob/parent-3.14.2/CHANGELOG.md
Bug Report: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20200

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.