### PR TITLE
Index mapping changes

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/EventsIndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/EventsIndexMapping.java
@@ -201,7 +201,7 @@ public class EventsIndexMapping implements IndexMappingTemplate {
                                                         .build())
                                                 .build())
                                          */
-                                        .put("triggered_tasks", map()
+                                        .put("triggered_jobs", map()
                                                 .put("type", "keyword")
                                                 .build())
                                         .build())

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
@@ -66,6 +66,7 @@ public abstract class IndexMapping implements IndexMappingTemplate {
     protected List<Map<String, Map<String, Object>>> dynamicTemplate() {
         final Map<String, Object> defaultInternal = ImmutableMap.of(
                 "match", "gl2_*",
+                "match_mapping_type", "string",
                 "mapping", notAnalyzedString());
         final Map<String, Map<String, Object>> templateInternal = ImmutableMap.of("internal_fields", defaultInternal);
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping6.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping6.java
@@ -47,6 +47,7 @@ public class IndexMapping6 extends IndexMapping {
         final Map<String, Map<String, Object>> templateInternal =
             ImmutableMap.of("internal_fields", ImmutableMap.of(
                 "match", "gl2_*",
+                "match_mapping_type", "string",
                 "mapping", notAnalyzedString()));
 
         final Map<String, Object> dynamicStrings = ImmutableMap.of(

--- a/graylog2-server/src/test/java/org/graylog2/indexer/EventsIndexMappingTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/EventsIndexMappingTest.java
@@ -116,7 +116,7 @@ public class EventsIndexMappingTest {
         at.jsonPathAsString("$.mappings.message.properties.priority.type").isEqualTo("long");
         at.jsonPathAsString("$.mappings.message.properties.fields.type").isEqualTo("object");
         at.jsonPathAsBoolean("$.mappings.message.properties.fields.dynamic").isTrue();
-        at.jsonPathAsString("$.mappings.message.properties.triggered_tasks.type").isEqualTo("keyword");
+        at.jsonPathAsString("$.mappings.message.properties.triggered_jobs.type").isEqualTo("keyword");
     }
 
     @Test


### PR DESCRIPTION
### Add "match_mapping_type" to the dynamic mapping for `gl2_*` fields

The previous mapping configuration forced all `gl2_*` fields which have
not been mapped explicitly to string/keyword. That means we couldn't
dynamically add new `gl2_*` fields which data types of boolean, long,
date or others.

With this commit we add "match_mapping_type" with value "string" to make
sure that all `gl2_*` string fields will be indexed as keyword instead
of text and others will be mapped automatically by Elasticsearch.

This allows us to index date fields and others with the correct type
without having to create an explicit mapping.

### Rename "triggered_tasks" mapping to "triggered_jobs" in events template

This has been changed for consistency. Our scheduler is using jobs and
not tasks.