### PR TITLE
Do not refresh search if query input is blurred, but query is unchanged.

### DIFF
--- a/graylog2-web-interface/src/views/components/SearchBar.jsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.jsx
@@ -24,12 +24,7 @@ import { ViewStore } from 'views/stores/ViewStore';
 import View from 'views/logic/views/View';
 
 
-// eslint-disable-next-line no-undef
-const _performSearch = (event, onExecute) => {
-  if (event && event.preventDefault) {
-    // $FlowFixMe: Checking for presence of preventDefault before
-    event.preventDefault();
-  }
+const _performSearch = (onExecute) => {
   const { view } = ViewStore.getInitialState();
   onExecute(view);
 };
@@ -53,8 +48,11 @@ const SearchBar = ({ availableStreams, config, currentQuery, disableSearch = fal
   if (!currentQuery || !config) {
     return <Spinner />;
   }
-  // eslint-disable-next-line no-undef
-  const performSearch = e => _performSearch(e, onExecute);
+  const performSearch = () => _performSearch(onExecute);
+  const submitForm = (event) => {
+    event.preventDefault();
+    performSearch();
+  };
   const { timerange, query, id } = currentQuery;
   const { type, ...rest } = timerange;
   const rangeParams = Immutable.Map(rest);
@@ -70,7 +68,7 @@ const SearchBar = ({ availableStreams, config, currentQuery, disableSearch = fal
         <Col md={12}>
           <Row className="no-bm">
             <Col md={12}>
-              <form method="GET" onSubmit={performSearch}>
+              <form method="GET" onSubmit={submitForm}>
 
                 <Row className="no-bm extended-search-query-metadata">
                   <Col md={4}>
@@ -103,8 +101,7 @@ const SearchBar = ({ availableStreams, config, currentQuery, disableSearch = fal
 
                     <QueryInput value={query.query_string}
                                 placeholder={'Type your search query here and press enter. E.g.: ("not found" AND http) OR http_response_code:[400 TO 404]'}
-                                onChange={value => QueriesActions.query(id, value)}
-                                onBlur={performSearch}
+                                onChange={value => QueriesActions.query(id, value).then(performSearch).then(() => value)}
                                 onExecute={performSearch} />
                   </Col>
                 </Row>

--- a/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
@@ -122,12 +122,7 @@ class QueryInput extends Component<Props, State> {
     return emptyMessageNode !== undefined && emptyMessageNode !== null;
   };
 
-  _onChange = (newValue: string) => {
-    return new Promise(resolve => this.setState({ value: newValue }, resolve));
-  };
-
-  _onBlur = () => {
-    this.isFocussed = false;
+  _addPlaceholderIfEmptyQuery = () => {
     const editor = this.editor && this.editor.editor;
     if (editor) {
       const shouldShow = !editor.session.getValue().length;
@@ -135,6 +130,23 @@ class QueryInput extends Component<Props, State> {
         this._addPlaceholder(editor);
       }
     }
+  };
+
+  _removePlaceholderOnFocus = () => {
+    const editor = this.editor && this.editor.editor;
+    if (editor && this._placeholderExists(editor)) {
+      this._removePlaceholder(editor);
+    }
+  };
+
+  _onChange = (newValue: string) => {
+    return new Promise(resolve => this.setState({ value: newValue }, resolve));
+  };
+
+  _onBlur = () => {
+    this.isFocussed = false;
+    this._addPlaceholderIfEmptyQuery();
+
     const { onBlur, onChange } = this.props;
     const { value, lastValue } = this.state;
     const promise = (value !== lastValue)
@@ -148,10 +160,7 @@ class QueryInput extends Component<Props, State> {
 
   _onFocus = () => {
     this.isFocussed = true;
-    const editor = this.editor && this.editor.editor;
-    if (editor && this._placeholderExists(editor)) {
-      this._removePlaceholder(editor);
-    }
+    this._removePlaceholderOnFocus();
   };
 
   _onExecute = (editor: Editor) => {

--- a/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
@@ -90,7 +90,7 @@ class QueryInput extends Component<Props, State> {
     if (this.editor) {
       const { editor } = this.editor;
       if (nextProps.value && this._placeholderExists(editor)) {
-        this._removePlaceholder(this.editor.editor);
+        this._removePlaceholder(editor);
       }
 
       if (!nextProps.value && !this.isFocussed && !this._placeholderExists(editor)) {

--- a/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
@@ -169,7 +169,9 @@ class QueryInput extends Component<Props, State> {
       editor.completer.popup.hide();
     }
     const { value } = this.state;
-    onChange(value).then(onExecute);
+    new Promise(resolve => this.setState({ lastValue: value }, resolve))
+      .then(() => onChange(value))
+      .then(onExecute);
   };
 
   _bindEditor(editor: { editor: Editor }) {


### PR DESCRIPTION
## Description
## Motivation and Context

Before this change, when leaving the query input without changing the
query (e.g. when copying parts of the query to the clipboard), the
search was refreshed nonetheless.

This change is preventing this. Whenever the query input looses focus,
it is checked for changes and the `onChange` callback is executed only
if there was a change. The `onBlur` callback is triggered regardless of
that.

Fixes #6038.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.