### PR TITLE
Extracting `onZoom` function, using `tozero` for y axis's `rangemode`

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/OnZoom.js
+++ b/graylog2-web-interface/src/views/components/visualizations/OnZoom.js
@@ -1,7 +1,6 @@
 // @flow strict
 import moment from 'moment-timezone';
 import { QueriesActions } from 'views/stores/QueriesStore';
-import { SearchActions } from 'views/stores/SearchStore';
 import CombinedProvider from 'injection/CombinedProvider';
 import Query from 'views/logic/queries/Query';
 
@@ -16,7 +15,7 @@ const onZoom = (currentQuery: Query, from: string, to: string) => {
     to: moment.tz(to, timezone).toISOString(),
   };
 
-  QueriesActions.timerange(currentQuery.id, newTimerange).then(SearchActions.executeWithCurrentState);
+  QueriesActions.timerange(currentQuery.id, newTimerange);
   return false;
 };
 

--- a/graylog2-web-interface/src/views/components/visualizations/OnZoom.js
+++ b/graylog2-web-interface/src/views/components/visualizations/OnZoom.js
@@ -1,0 +1,23 @@
+// @flow strict
+import moment from 'moment-timezone';
+import { QueriesActions } from 'views/stores/QueriesStore';
+import { SearchActions } from 'views/stores/SearchStore';
+import CombinedProvider from 'injection/CombinedProvider';
+import Query from 'views/logic/queries/Query';
+
+const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
+
+const onZoom = (currentQuery: Query, from: string, to: string) => {
+  const { timezone } = CurrentUserStore.get();
+
+  const newTimerange = {
+    type: 'absolute',
+    from: moment.tz(from, timezone).toISOString(),
+    to: moment.tz(to, timezone).toISOString(),
+  };
+
+  QueriesActions.timerange(currentQuery.id, newTimerange).then(SearchActions.executeWithCurrentState);
+  return false;
+};
+
+export default onZoom;

--- a/graylog2-web-interface/src/views/components/visualizations/XYPlot.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/XYPlot.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment-timezone';
-import { get, isFinite, merge } from 'lodash';
+import { get, merge } from 'lodash';
 
 import connect from 'stores/connect';
 import CombinedProvider from 'injection/CombinedProvider';

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.jsx
@@ -1,7 +1,6 @@
 // @flow strict
 import * as React from 'react';
 import { mount } from 'enzyme';
-// $FlowFixMe: imports from core need to be fixed in flow
 import mockComponent from 'helpers/mocking/MockComponent';
 
 import XYPlot from 'views/components/visualizations/XYPlot';
@@ -9,12 +8,19 @@ import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationW
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
 import Query from 'views/logic/queries/Query';
 import { QueriesActions } from 'views/stores/QueriesStore';
-import SearchActions from 'views/actions/SearchActions';
+import { SearchActions } from 'views/stores/SearchStore';
+import CurrentUserStore from 'stores/users/CurrentUserStore';
+
+jest.mock('stores/users/CurrentUserStore', () => ({
+  get: jest.fn(),
+}));
 
 jest.mock('views/stores/SearchStore', () => ({
   SearchStore: {},
   // eslint-disable-next-line global-require
-  SearchActions: require('views/actions/SearchActions'),
+  SearchActions: {
+    executeWithCurrentState: jest.fn(),
+  },
 }));
 jest.mock('stores/connect', () => x => x);
 jest.mock('../GenericPlot', () => mockComponent('GenericPlot'));
@@ -22,56 +28,57 @@ jest.mock('views/stores/QueriesStore');
 
 describe('XYPlot', () => {
   const currentQuery = Query.fromJSON({ id: 'dummyquery', query: {}, timerange: {}, search_types: {} });
-  const currentUser = { timezone: 'GMT' };
   const timestampPivot = new Pivot('timestamp', 'time', {});
+  const config = AggregationWidgetConfig.builder().rowPivots([timestampPivot]).build();
   const getChartColor = () => {};
   const setChartColor = () => {};
+  const chartData = [{ y: [23, 42] }];
 
   beforeEach(() => {
     QueriesActions.timerange.mockReturnValueOnce(Promise.resolve());
   });
 
   it('renders generic X/Y-Plot when no timeline config is passed', () => {
-    const config = AggregationWidgetConfig.builder().build();
+    const emptyConfig = AggregationWidgetConfig.builder().build();
     const timerange = { from: 'foo', to: 'bar' };
     const wrapper = mount((
-      <XYPlot chartData={[23, 42]}
-              config={config}
+      <XYPlot chartData={chartData}
+              config={emptyConfig}
               getChartColor={getChartColor}
               setChartColor={setChartColor}
-              currentUser={currentUser}
+              timezone="UTC"
               currentQuery={currentQuery}
               effectiveTimerange={timerange} />
     ));
     const genericPlot = wrapper.find('GenericPlot');
-    expect(genericPlot).toHaveProp('layout', { yaxis: { fixedrange: true }, xaxis: { fixedrange: true } });
-    expect(genericPlot).toHaveProp('chartData', [23, 42]);
+    expect(genericPlot).toHaveProp('layout', { yaxis: { fixedrange: true, rangemode: 'tozero' }, xaxis: { fixedrange: true } });
+    expect(genericPlot).toHaveProp('chartData', chartData);
 
     genericPlot.get(0).props.onZoom('from', 'to');
     expect(QueriesActions.timerange).not.toHaveBeenCalled();
   });
 
-  it('adds zoom handler for timeline plot', (done) => {
-    const config = AggregationWidgetConfig.builder().rowPivots([timestampPivot]).build();
+  it('adds zoom handler for timeline plot', () => {
+    CurrentUserStore.get.mockReturnValue({ timezone: 'UTC' });
     const timerange = { from: '2018-10-12T02:04:21.723Z', to: '2018-10-12T10:04:21.723Z' };
     const wrapper = mount((
-      <XYPlot chartData={[23, 42]}
+      <XYPlot chartData={chartData}
               getChartColor={getChartColor}
               setChartColor={setChartColor}
               config={config}
-              currentUser={currentUser}
+              timezone="UTC"
               currentQuery={currentQuery}
               effectiveTimerange={timerange} />
     ));
     const genericPlot = wrapper.find('GenericPlot');
     expect(genericPlot).toHaveProp('layout', {
-      yaxis: { fixedrange: true },
+      yaxis: { fixedrange: true, rangemode: 'tozero' },
       xaxis: { range: ['2018-10-12T02:04:21Z', '2018-10-12T10:04:21Z'] },
     });
 
-    SearchActions.executeWithCurrentState.listen(done);
     genericPlot.get(0).props.onZoom('2018-10-12T04:04:21.723Z', '2018-10-12T08:04:21.723Z');
-    expect(QueriesActions.timerange).toHaveBeenCalled();
+
+    expect(SearchActions.executeWithCurrentState).not.toHaveBeenCalled();
     expect(QueriesActions.timerange).toHaveBeenCalledWith('dummyquery', {
       type: 'absolute',
       from: '2018-10-12T04:04:21.723Z',
@@ -80,23 +87,22 @@ describe('XYPlot', () => {
   });
 
   it('uses effective time range from pivot result if all messages are selected', () => {
-    const config = AggregationWidgetConfig.builder().rowPivots([timestampPivot]).build();
     const effectiveTimerange = { from: '2018-10-12T02:04:21.723Z', to: '2018-10-12T10:04:21.723Z' };
     const allMessages = { type: 'relative', range: 0 };
     const currentQueryForAllMessages = currentQuery.toBuilder().timerange(allMessages).build();
 
     const wrapper = mount((
-      <XYPlot chartData={[23, 42]}
+      <XYPlot chartData={chartData}
               getChartColor={getChartColor}
               setChartColor={setChartColor}
               config={config}
-              currentUser={currentUser}
+              timezone="UTC"
               currentQuery={currentQueryForAllMessages}
               effectiveTimerange={effectiveTimerange} />
     ));
     const genericPlot = wrapper.find('GenericPlot');
     expect(genericPlot).toHaveProp('layout', {
-      yaxis: { fixedrange: true },
+      yaxis: { fixedrange: true, rangemode: 'tozero' },
       xaxis: { range: ['2018-10-12T02:04:21Z', '2018-10-12T10:04:21Z'] },
     });
   });


### PR DESCRIPTION
## Description
## Motivation and Context

This change does the following:

   * Extract `onZoom` function from component for easier testing. It can now also be passed as prop, defaulting to the current implementation for backwards compatibility
   * Setting `rangemode` for y axis to `tozero`. It sets the range automatically according to the minimum/maximums of the values passed. If the minimum is greater than 0, the lower range of the chart will be set to 0 to ensure that charts with all positive values are aligned

Fixes #6037.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.