### PR TITLE
Including `c3` and `d3` in vendor module.

### DIFF
--- a/graylog2-web-interface/vendor.modules.js
+++ b/graylog2-web-interface/vendor.modules.js
@@ -12,4 +12,7 @@ module.exports = [
   'reflux-core',
   'moment',
   'moment-timezone',
+  'c3',
+  'd3',
+  'leaflet',
 ];

--- a/graylog2-web-interface/webpack/vendor-module-ids.json
+++ b/graylog2-web-interface/webpack/vendor-module-ids.json
@@ -898,7 +898,10 @@
       "node_modules/moment/locale/en-SG.js": 33,
       "node_modules/moment/locale/ga.js": 37,
       "node_modules/moment/locale/it-ch.js": 38,
-      "node_modules/moment/locale/ku.js": 42
+      "node_modules/moment/locale/ku.js": 42,
+      "node_modules/d3/d3.js": 47,
+      "node_modules/c3/c3.js": 48,
+      "node_modules/leaflet/dist/leaflet-src.js": 49
     },
     "usedIds": {
       "0": 0,


### PR DESCRIPTION
## Description
## Motivation and Context

Either by implicit (by using a component from core that uses them) or
explicit import (by using `c3`/`d3` directly) plugins include `c3`
and/or `d3` in their bundles, leading to unnecessarily huge bundle
sizes.

This PR is adding `c3` and `d3` to the vendor module, effectively
sharing them with plugins consuming those dependencies.

This leads to a size decrease e.g. for the enterprise plugin, while not
leading to bigger bundle sizes for core:

| (sizes in kb) | before | after |
|---------------|--------|-------|
| core          | 37696  | 35048 |
| enterprise    | 18604  | 16264 |

Relative size improvements for the entry size of the enterprise plugin are even better:

| (sizes in bytes)  | before  | after   |
|-------------------|---------|---------|
| enterprise plugin | 2558278 | 2068562 |


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.