### PR TITLE
Use `embedded-elasticsearch` in Es-related/integration tests.

### DIFF
--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -668,6 +668,12 @@
                 <version>${pkts.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>pl.allegro.tech</groupId>
+                <artifactId>embedded-elasticsearch</artifactId>
+                <version>${embedded-elasticsearch.version}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -551,6 +551,11 @@
             <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>pl.allegro.tech</groupId>
+            <artifactId>embedded-elasticsearch</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingTest.java
@@ -50,6 +50,7 @@ import static pl.allegro.tech.embeddedelasticsearch.PopularProperties.TRANSPORT_
 
 @RunWith(Parameterized.class)
 public class IndexMappingTest {
+    private static final String TEMP_DIR = System.getProperty("java.io.tmpdir", "/tmp");
     private static final String indexName = "testmessages";
     private static final String currentIndex = "testmessages_0";
     private static final ObjectMapper objectMapper = new ObjectMapperProvider().get();
@@ -71,7 +72,7 @@ public class IndexMappingTest {
                 .withSetting(CLUSTER_NAME, "test")
                 .withEsJavaOpts("-Xms128m -Xmx512m")
                 .withStartTimeout(1, MINUTES)
-                .withDownloadDirectory(new File("/tmp/embedded-elasticsearch-downloads"))
+                .withDownloadDirectory(new File(TEMP_DIR + File.separator + "embedded-elasticsearch-downloads"))
                 .withCleanInstallationDirectoryOnStop(false)
                 .build()
                 .start();

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.indexer;
 
 import com.codahale.metrics.MetricRegistry;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingTest.java
@@ -123,7 +123,11 @@ public class IndexMappingTest {
         indexMessage(ImmutableMap.of(
                 "gl2_boolean", true,
                 "gl2_number", 42,
-                "gl2_array", ImmutableList.of(23, 42)
+                "gl2_array", ImmutableList.of(23, 42),
+                "gl2_object", ImmutableMap.of(
+                        "the_fish", true,
+                        "how_much", 17
+                )
                 ));
 
         assertThat(searchFor("gl2_boolean:true").getTotal()).isEqualTo(1);
@@ -136,7 +140,9 @@ public class IndexMappingTest {
         final DocumentContext read = JsonPath.parse(currentMapping);
         jp(read).jsonPathAsString(fieldTypeMappingPath(currentIndex, "gl2_boolean")).isEqualTo("boolean");
         jp(read).jsonPathAsString(fieldTypeMappingPath(currentIndex, "gl2_number")).isEqualTo("long");
-        jp(read).jsonPathAsString(fieldTypeMappingPath(currentIndex, "gl2_array")).isEqualTo("array");
+        jp(read).jsonPathAsString(fieldTypeMappingPath(currentIndex, "gl2_array")).isEqualTo("long");
+        jp(read).jsonPathAsString(fieldTypeMappingPathPrefix(currentIndex, "gl2_object") + ".properties.the_fish.type").isEqualTo("boolean");
+        jp(read).jsonPathAsString(fieldTypeMappingPathPrefix(currentIndex, "gl2_object") + ".properties.how_much.type").isEqualTo("long");
     }
 
     private JsonPathAssert jp(DocumentContext ctx) {
@@ -177,6 +183,10 @@ public class IndexMappingTest {
     }
 
     private String fieldTypeMappingPath(String index, String field) {
-        return "$." + index + ".mappings.message.properties." + field + ".type";
+        return fieldTypeMappingPathPrefix(index, field) + ".type";
+    }
+
+    private String fieldTypeMappingPathPrefix(String index, String field) {
+        return "$." + index + ".mappings.message.properties." + field;
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingTest.java
@@ -1,0 +1,164 @@
+package org.graylog2.indexer;
+
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.joschi.jadconfig.util.Duration;
+import com.google.common.collect.ImmutableList;
+import io.searchbox.client.JestClient;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.index.query.QueryStringQueryBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.graylog2.audit.AuditEventSender;
+import org.graylog2.bindings.providers.JestClientProvider;
+import org.graylog2.indexer.cluster.Node;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indices.Indices;
+import org.graylog2.indexer.messages.Messages;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.system.NodeId;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import pl.allegro.tech.embeddedelasticsearch.EmbeddedElastic;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static pl.allegro.tech.embeddedelasticsearch.PopularProperties.CLUSTER_NAME;
+import static pl.allegro.tech.embeddedelasticsearch.PopularProperties.TRANSPORT_TCP_PORT;
+
+@RunWith(Parameterized.class)
+public class IndexMappingTest {
+    private static final String indexName = "testmessages";
+    private static final String currentIndex = "testmessages_0";
+    private static final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+    private final EmbeddedElastic embeddedElastic;
+    private final JestClient jestClient;
+
+    private final IndexSet indexSet;
+    private Indices indices;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> provideData() {
+        return Arrays.asList(new Object[][]{{"5.3.0"}, {"6.2.0"}});
+    }
+
+    public IndexMappingTest(String esVersion) throws IOException, InterruptedException {
+        embeddedElastic = EmbeddedElastic.builder()
+                .withElasticVersion(esVersion)
+                .withSetting(TRANSPORT_TCP_PORT, 0)
+                .withSetting(CLUSTER_NAME, "test")
+                .withEsJavaOpts("-Xms128m -Xmx512m")
+                //.withIndex(indexName, indexSettings)
+                .withStartTimeout(1, MINUTES)
+                .build()
+                .start();
+        jestClient = new JestClientProvider(
+                Collections.singletonList(URI.create("http://localhost:" + embeddedElastic.getHttpPort())),
+                Duration.seconds(30),
+                Duration.seconds(30),
+                Duration.seconds(30),
+                10,
+                10,
+                5,
+                false,
+                null,
+                Duration.seconds(30),
+                false,
+                objectMapper
+        ).get();
+
+        this.indexSet = mock(IndexSet.class);
+        final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
+        when(indexSet.getConfig()).thenReturn(indexSetConfig);
+        when(indexSet.getWriteIndexAlias()).thenReturn(currentIndex);
+        when(indexSet.getIndexWildcard()).thenReturn(indexName + "_*");
+        when(indexSetConfig.indexAnalyzer()).thenReturn("standard");
+        when(indexSetConfig.indexTemplateName()).thenReturn(indexName);
+        when(indexSetConfig.indexWildcard()).thenReturn(indexName + "_*");
+        when(indexSetConfig.replicas()).thenReturn(1);
+        when(indexSetConfig.shards()).thenReturn(1);
+    }
+
+    private Messages messages;
+
+    @Before
+    public void setUpClasses() {
+        final IndexMappingFactory indexMappingFactory = new IndexMappingFactory(new Node(jestClient));
+        final NodeId nodeId = mock(NodeId.class);
+        when(nodeId.toString()).thenReturn("deadbeef");
+        final AuditEventSender auditEventSender = mock(AuditEventSender.class);
+        indices = new Indices(jestClient, objectMapper, indexMappingFactory, null, nodeId, auditEventSender, null);
+
+        final MetricRegistry metricRegistry = new MetricRegistry();
+        messages = new Messages(metricRegistry, jestClient);
+        indices.create(currentIndex, indexSet);
+    }
+
+    @Test
+    public void ensureBooleanIndexing() throws IOException {
+        indexMessage(Collections.singletonMap("gl2_boolean", true));
+
+        final SearchResult result = searchFor("gl2_number:true");
+
+        assertThat(result.isSucceeded()).isTrue();
+        assertThat(result.getTotal()).isEqualTo(1);
+    }
+
+    @Test
+    public void ensureNumberIndexing() throws IOException {
+        indexMessage(Collections.singletonMap("gl2_number", 42));
+
+        final SearchResult result = searchFor("gl2_number >= 42");
+
+        assertThat(result.isSucceeded()).isTrue();
+        assertThat(result.getTotal()).isEqualTo(1);
+    }
+
+    @Test
+    public void ensureArrayIndexing() throws IOException {
+        indexMessage(Collections.singletonMap("gl2_array", ImmutableList.of(23, "fourtytwo")));
+
+        final SearchResult result = searchFor("gl2_array:23");
+
+        assertThat(result.isSucceeded()).isTrue();
+        assertThat(result.getTotal()).isEqualTo(1);
+    }
+
+    private void indexMessage(Map<String, Object> additionalFields) {
+        final Message message = new Message("foo", "bar", DateTime.now());
+        additionalFields.forEach(message::addField);
+        final List<Map.Entry<IndexSet, Message>> messageList = Collections.singletonList(new AbstractMap.SimpleEntry<>(indexSet, message));
+        final List<String> messageIds = messages.bulkIndex(messageList);
+
+        assertThat(messageIds).isEmpty();
+    }
+
+    private String queryFor(String query) {
+        return new SearchSourceBuilder()
+                .query(new QueryStringQueryBuilder(query))
+                .toString();
+    }
+
+    private SearchResult searchFor(String query) throws IOException {
+        final Search search = new Search.Builder(queryFor(query))
+                .addIndex(currentIndex)
+                .addType(IndexMapping.TYPE_MESSAGE)
+                .build();
+        return jestClient.execute(search);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingTest.java
@@ -41,6 +41,7 @@ import org.graylog2.plugin.Message;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -174,7 +175,7 @@ public class IndexMappingTest {
     }
 
     private void indexMessage(Map<String, Object> additionalFields) throws InterruptedException, IOException {
-        final Message message = new Message("foo", "bar", DateTime.now());
+        final Message message = new Message("foo", "bar", DateTime.now(DateTimeZone.UTC));
         additionalFields.forEach(message::addField);
         final List<Map.Entry<IndexSet, Message>> messageList = Collections.singletonList(new AbstractMap.SimpleEntry<>(indexSet, message));
         final List<String> messageIds = messages.bulkIndex(messageList);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingTest.java
@@ -40,6 +40,7 @@ import org.graylog2.indexer.messages.Messages;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.graylog2.system.processing.ProcessingStatusRecorder;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Before;
@@ -131,7 +132,7 @@ public class IndexMappingTest {
         indices = new Indices(jestClient, objectMapper, indexMappingFactory, null, nodeId, auditEventSender, null);
 
         final MetricRegistry metricRegistry = new MetricRegistry();
-        messages = new Messages(metricRegistry, jestClient);
+        messages = new Messages(metricRegistry, jestClient, mock(ProcessingStatusRecorder.class));
         indices.create(currentIndex, indexSet);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
         <commons-io.version>2.6</commons-io.version>
         <disruptor.version>3.4.2</disruptor.version>
         <elasticsearch.version>5.6.12</elasticsearch.version>
+        <embedded-elasticsearch.version>2.7.0</embedded-elasticsearch.version>
         <freemarker.version>2.3.28</freemarker.version>
         <jest.version>2.4.15+jackson</jest.version>
         <gelfclient.version>1.4.4</gelfclient.version>


### PR DESCRIPTION
## Description
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is not supposed to be merged, but to be discussed in order to move integration testing forward.

While reviewing #6039 a quick way to test the before/after states was needed. Unfortunately, the current Elasticsearch testing infrastructure became quite heavy after embedding a node was prohibited by elastic.
This is an attempt to utilize [embedded-elasticsearch](http://github.com/allegro/embedded-elasticsearch) to embed Es-related testing into the test codebase, making it independent from external bootstrapping/configuration and allowing a lightweight way to test with a full-fledged Elasticsearch.

The benefits of it are:

  - tests are self-contained, no need to run them in a specific environment (e.g. having to start Es using maven/docker/both before)
  - the Elasticsearch configuration is part of/accessible from the test suite, so it is possible to test with specific settings for each individual test suite/case
  - as Elasticsearch is bootstrapped for each test class (unless done differently), it makes clean slate testing (and parallelizing it) easier (as each test starts with an empty instance)

The disadvantage towards externally-managed Elasticsearch instances:

  - Per default Elasticsearch is started/stopped for each test class, resulting in longer run times

Obviously, this test bakes in bootstrapping into the actual test suite.
This is for demonstration purposes to make the required code compact and laid out in one file. If we decide to employ the library for testing, it would need to be extracted in a base class or junit rule to consolidate the bootstrapping code and its configuration.