### PR TITLE
Add support for nesed maps in list for Content Packs (#6003)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/references/ReferenceMapUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/references/ReferenceMapUtils.java
@@ -48,7 +48,20 @@ public final class ReferenceMapUtils {
     }
 
     private static ReferenceList toReferenceList(Collection<Object> list) {
-        // TODO: Support nested objects in list
+        if (list.size() == 0) {
+            return new ReferenceList();
+        }
+
+        if (list.iterator().next() instanceof Map) {
+            return list.stream()
+                    .map(r -> {
+                        @SuppressWarnings("unchecked")
+                        Map<String, Object> value = (Map) r;
+                        return ReferenceMapUtils.toReferenceMap(value);
+                    })
+                    .collect(Collectors.toCollection(ReferenceList::new));
+        }
+
         return list.stream()
                 .map(ValueReference::of)
                 .filter(Objects::nonNull)

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/model/entities/references/ReferenceMapUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/model/entities/references/ReferenceMapUtilsTest.java
@@ -38,6 +38,10 @@ public class ReferenceMapUtilsTest {
                 .put("string", "String")
                 .put("enum", TestEnum.A)
                 .put("list", ImmutableList.of(1, 2.0f, "3", true))
+                .put("nestedList", ImmutableList.of(
+                        ImmutableMap.of( "k1", "v1", "k2", 2),
+                        ImmutableMap.of( "k1", "v2", "k2", 4)
+                ))
                 .put("map", ImmutableMap.of(
                         "k1", "v1",
                         "k2", 2))
@@ -55,6 +59,13 @@ public class ReferenceMapUtilsTest {
                         ValueReference.of(2.0f),
                         ValueReference.of("3"),
                         ValueReference.of(true))))
+                .put("nestedList", new ReferenceList(ImmutableList.of(
+                        new ReferenceMap(ImmutableMap.of(
+                        "k1", ValueReference.of("v1"),
+                        "k2", ValueReference.of(2))),
+                        new ReferenceMap(ImmutableMap.of(
+                                "k1", ValueReference.of("v2"),
+                                "k2", ValueReference.of(4))))))
                 .put("map", new ReferenceMap(ImmutableMap.of(
                         "k1", ValueReference.of("v1"),
                         "k2", ValueReference.of(2))))
@@ -90,6 +101,13 @@ public class ReferenceMapUtilsTest {
                         ValueReference.of("3"),
                         ValueReference.of(true),
                         ValueReference.createParameter("STRING"))))
+                .put("nestedList", new ReferenceList(ImmutableList.of(
+                        new ReferenceMap(ImmutableMap.of(
+                                "k1", ValueReference.of("v1"),
+                                "k2", ValueReference.of(2))),
+                        new ReferenceMap(ImmutableMap.of(
+                                "k1", ValueReference.of("v2"),
+                                "k2", ValueReference.of(4))))))
                 .put("map", new ReferenceMap(ImmutableMap.of(
                         "k1", ValueReference.of("v1"),
                         "k2", ValueReference.of(2),
@@ -107,6 +125,10 @@ public class ReferenceMapUtilsTest {
                 .put("enum", "A")
                 .put("param_enum", "A")
                 .put("list", ImmutableList.of(1, 2.0f, "3", true, "String"))
+                .put("nestedList", ImmutableList.of(
+                        ImmutableMap.of( "k1", "v1", "k2", 2),
+                        ImmutableMap.of( "k1", "v2", "k2", 4)
+                ))
                 .put("map", ImmutableMap.of(
                         "k1", "v1",
                         "k2", 2,


### PR DESCRIPTION
Prior this change we missed support of maps in list of
a ReferenceMap. This is needed to support configurations
(like DashboardWidget) which can contain a list of maps.
(e.g series when two charts are merged into one)

This change will call toReferenceMap for every list item
which is a map.

Fixes #5742

(cherry picked from commit a661710024caf2ae08b1677738b0508ea5d3bb7f)