### PR TITLE
Mocking FetchProvider globally for tests.

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -25,7 +25,8 @@
     ],
     "setupFiles": [
       "jest-localstorage-mock",
-      "./test/setup-jest.jsx"
+      "<rootDir>/test/setup-jest.jsx",
+      "<rootDir>/test/mock-FetchProvider.js"
     ],
     "setupFilesAfterEnv": ["./node_modules/jest-enzyme/lib/index.js"],
     "moduleDirectories": [

--- a/graylog2-web-interface/src/components/dashboard/AddToDashboardMenu.jsx
+++ b/graylog2-web-interface/src/components/dashboard/AddToDashboardMenu.jsx
@@ -15,7 +15,7 @@ import { EditDashboardModal } from 'components/dashboard';
 import style from './AddToDashboardMenu.css';
 
 const SearchStore = StoreProvider.getStore('Search');
-const { DashboardsActions, DashboardsStore } = CombinedProvider.get('Dashboards');
+const { DashboardsStore } = CombinedProvider.get('Dashboards');
 const WidgetsStore = StoreProvider.getStore('Widgets');
 
 const AddToDashboardMenu = createReactClass({
@@ -42,19 +42,19 @@ const AddToDashboardMenu = createReactClass({
 
   mixins: [Reflux.connect(DashboardsStore), PermissionsMixin],
 
-  getInitialState() {
-    return {
-      selectedDashboard: '',
-      loading: false,
-    };
-  },
-
   getDefaultProps() {
     return {
       bsStyle: 'default',
       configuration: {},
       hidden: false,
       pullRight: false,
+    };
+  },
+
+  getInitialState() {
+    return {
+      selectedDashboard: '',
+      loading: false,
     };
   },
 

--- a/graylog2-web-interface/src/components/dashboard/AddToDashboardMenu.jsx
+++ b/graylog2-web-interface/src/components/dashboard/AddToDashboardMenu.jsx
@@ -44,8 +44,11 @@ const AddToDashboardMenu = createReactClass({
 
   getDefaultProps() {
     return {
+      appendMenus: null,
       bsStyle: 'default',
+      children: null,
       configuration: {},
+      fields: [],
       hidden: false,
       pullRight: false,
     };
@@ -64,44 +67,43 @@ const AddToDashboardMenu = createReactClass({
   },
 
   _saveWidget(title, configuration) {
-    let widgetConfig = Immutable.Map(this.props.configuration);
+    const { configuration: configuration1, widgetType } = this.props;
+    let widgetConfig = Immutable.Map(configuration1);
     let searchParams = Immutable.Map(SearchStore.getOriginalSearchParams());
     if (searchParams.has('range_type')) {
       switch (searchParams.get('range_type')) {
         case 'relative':
-          const relativeTimeRange = Immutable.Map({
-            // Changes the "relative" key used to store relative time-range to "range"
-            range: searchParams.get('relative'),
-            type: 'relative',
-          });
           searchParams = searchParams
-            .set('timerange', relativeTimeRange)
+            .set('timerange', Immutable.Map({
+              // Changes the "relative" key used to store relative time-range to "range"
+              range: searchParams.get('relative'),
+              type: 'relative',
+            }))
             .delete('relative')
             .delete('range_type');
           break;
         case 'absolute':
-          const from = searchParams.get('from');
-          const to = searchParams.get('to');
-          const absoluteTimeRange = Immutable.Map({
-            type: 'absolute',
-            from: from,
-            to: to,
-          });
           searchParams = searchParams
-            .set('timerange', absoluteTimeRange)
+            .set('timerange', Immutable.Map({
+              type: 'absolute',
+              from: searchParams.get('from'),
+              to: searchParams.get('to'),
+            }))
             .delete('from')
             .delete('to')
             .delete('range_type');
           break;
         case 'keyword':
-          const keywordTimeRange = Immutable.Map({
-            type: 'keyword',
-            keyword: searchParams.get('keyword'),
-          });
           searchParams = searchParams
-            .set('timerange', keywordTimeRange)
+            .set('timerange', Immutable.Map({
+              type: 'keyword',
+              keyword: searchParams.get('keyword'),
+            }))
             .delete('keyword')
             .delete('range_type');
+          break;
+        default:
+          throw new Error(`Invalid time range type specified: ${searchParams.get('range_type')}`);
       }
     }
     // Stores stream ID with the right key name for the add widget request
@@ -117,7 +119,8 @@ const AddToDashboardMenu = createReactClass({
     widgetConfig = searchParams.merge(widgetConfig).merge(configuration);
 
     this.setState({ loading: true });
-    const promise = WidgetsStore.addWidget(this.state.selectedDashboard, this.props.widgetType, title, widgetConfig.toJS());
+    const { selectedDashboard } = this.state;
+    const promise = WidgetsStore.addWidget(selectedDashboard, widgetType, title, widgetConfig.toJS());
     promise
       .then(() => this.widgetModal.saved())
       .finally(() => this.setState({ loading: false }));
@@ -128,11 +131,12 @@ const AddToDashboardMenu = createReactClass({
   },
 
   _renderLoadingDashboardsMenu() {
+    const { pullRight, bsStyle, title } = this.props;
     return (
-      <DropdownButton bsStyle={this.props.bsStyle}
+      <DropdownButton bsStyle={bsStyle}
                       bsSize="small"
-                      title={this.props.title}
-                      pullRight={this.props.pullRight}
+                      title={title}
+                      pullRight={pullRight}
                       id="dashboard-selector-dropdown">
         <MenuItem disabled>Loading dashboards...</MenuItem>
       </DropdownButton>
@@ -142,7 +146,10 @@ const AddToDashboardMenu = createReactClass({
   _renderDashboardMenu() {
     let dashboards = Immutable.List();
 
-    this.state.writableDashboards
+    const { writableDashboards } = this.state;
+    const { pullRight, bsStyle, title } = this.props;
+
+    writableDashboards
       .sortBy(dashboard => dashboard.title)
       .forEach((dashboard) => {
         dashboards = dashboards.push(
@@ -153,10 +160,10 @@ const AddToDashboardMenu = createReactClass({
       });
 
     return (
-      <DropdownButton bsStyle={this.props.bsStyle}
+      <DropdownButton bsStyle={bsStyle}
                       bsSize="small"
-                      title={this.props.title}
-                      pullRight={this.props.pullRight}
+                      title={title}
+                      pullRight={pullRight}
                       onSelect={this._selectDashboard}
                       id="dashboard-selector-dropdown">
         {dashboards}
@@ -165,7 +172,8 @@ const AddToDashboardMenu = createReactClass({
   },
 
   _renderNoDashboardsMenu() {
-    const canCreateDashboard = this.isPermitted(this.props.permissions, ['dashboards:create']);
+    const { pullRight, permissions, bsStyle, title } = this.props;
+    const canCreateDashboard = this.isPermitted(permissions, ['dashboards:create']);
     let option;
     if (canCreateDashboard) {
       option = <MenuItem key="createDashboard">No dashboards, create one?</MenuItem>;
@@ -175,10 +183,10 @@ const AddToDashboardMenu = createReactClass({
 
     return (
       <div style={{ display: 'inline' }}>
-        <DropdownButton bsStyle={this.props.bsStyle}
+        <DropdownButton bsStyle={bsStyle}
                         bsSize="small"
-                        title={this.props.title}
-                        pullRight={this.props.pullRight}
+                        title={title}
+                        pullRight={pullRight}
                         onSelect={canCreateDashboard ? this._createNewDashboard : () => {}}
                         id="no-dashboards-available-dropdown">
           {option}
@@ -190,10 +198,12 @@ const AddToDashboardMenu = createReactClass({
 
   render() {
     let addToDashboardMenu;
-    if (this.state.writableDashboards === undefined) {
+    const { writableDashboards } = this.state;
+    const { fields, hidden, widgetType } = this.props;
+    if (writableDashboards === undefined) {
       addToDashboardMenu = this._renderLoadingDashboardsMenu();
     } else {
-      addToDashboardMenu = (!this.props.hidden && (this.state.writableDashboards.size > 0 ? this._renderDashboardMenu() : this._renderNoDashboardsMenu()));
+      addToDashboardMenu = (!hidden && (writableDashboards.size > 0 ? this._renderDashboardMenu() : this._renderNoDashboardsMenu()));
     }
 
     const { appendMenus, children } = this.props;
@@ -210,9 +220,9 @@ const AddToDashboardMenu = createReactClass({
           {children}
         </ButtonToolbar>
         <WidgetCreationModal ref={(widgetModal) => { this.widgetModal = widgetModal; }}
-                             widgetType={this.props.widgetType}
+                             widgetType={widgetType}
                              onConfigurationSaved={this._saveWidget}
-                             fields={this.props.fields}
+                             fields={fields}
                              loading={loading} />
       </div>
     );

--- a/graylog2-web-interface/src/components/dashboard/AddToDashboardMenu.test.jsx
+++ b/graylog2-web-interface/src/components/dashboard/AddToDashboardMenu.test.jsx
@@ -6,8 +6,17 @@ import 'jquery-ui/ui/widgets/mouse';
 import React from 'react';
 import Immutable from 'immutable';
 import { mount } from 'enzyme';
+
+import { StoreMock as MockStore } from 'helpers/mocking';
 import PermissionsMixin from 'util/PermissionsMixin';
 import AddToDashboardMenu from './AddToDashboardMenu';
+
+jest.mock('stores/dashboards/DashboardsStore', () => MockStore('listen'));
+jest.mock('stores/widgets/WidgetsStore', () => ({
+  addWidget: jest.fn(),
+}));
+const mockUser = { timezone: 'UTC' };
+jest.mock('stores/users/CurrentUserStore', () => MockStore('listen', ['get', () => mockUser], ['getInitialState', () => ({ mockUser })]));
 
 describe('<AddToDashboardMenu />', () => {
   const exampleProps = {

--- a/graylog2-web-interface/src/components/widgets/WidgetCreationModal.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetCreationModal.jsx
@@ -56,7 +56,8 @@ const WidgetCreationModal = createReactClass({
   },
 
   getInitialState() {
-    this.widgetPlugin = this._getWidgetPlugin(this.props.widgetType);
+    const { widgetType } = this.props;
+    this.widgetPlugin = this._getWidgetPlugin(widgetType);
 
     return {
       title: this._getDefaultWidgetTitle(this.widgetPlugin),
@@ -65,7 +66,8 @@ const WidgetCreationModal = createReactClass({
   },
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.widgetType !== nextProps.widgetType) {
+    const { widgetType } = this.props;
+    if (widgetType !== nextProps.widgetType) {
       this.widgetPlugin = this._getWidgetPlugin(nextProps.widgetType);
       this.setState({ config: this._getInitialConfiguration(this.widgetPlugin) });
     }
@@ -80,7 +82,8 @@ const WidgetCreationModal = createReactClass({
   },
 
   _setInitialDerivedConfiguration(initialConfig) {
-    const nextConfig = Object.assign({}, this.state.config, initialConfig);
+    const { config } = this.state;
+    const nextConfig = Object.assign({}, config, initialConfig);
     this.setState({ config: nextConfig });
   },
 
@@ -93,7 +96,9 @@ const WidgetCreationModal = createReactClass({
   },
 
   save() {
-    this.props.onConfigurationSaved(this.state.title, this.state.config);
+    const { title, config } = this.state;
+    const { onConfigurationSaved } = this.props;
+    onConfigurationSaved(title, config);
   },
 
   saved() {
@@ -112,7 +117,8 @@ const WidgetCreationModal = createReactClass({
   },
 
   _setConfigurationSetting(key, value) {
-    const newConfig = ObjectUtils.clone(this.state.config);
+    const { config } = this.state;
+    const newConfig = ObjectUtils.clone(config);
     newConfig[key] = value;
     this.setState({ config: newConfig });
   },
@@ -121,18 +127,13 @@ const WidgetCreationModal = createReactClass({
     this._setConfigurationSetting(event.target.name, FormsUtils.getValueFromInput(event.target));
   },
 
-  _onConfigurationValueChange() {
-    switch (arguments.length) {
-      // When a single value is passed, we treat it as an event handling
-      case 1:
-        this._bindConfigurationValue(arguments[0]);
-        break;
-      // When two arguments are given, treat it as a configuration key-value
-      case 2:
-        this._setConfigurationSetting(arguments[0], arguments[1]);
-        break;
-      default:
-        throw new Error('Wrong number of arguments, method only accepts an event or a configuration key-value pair');
+  _onConfigurationValueChange(key, value) {
+    // When a single value is passed, we treat it as an event handling
+    // When two arguments are given, treat it as a configuration key-value
+    if (value !== undefined) {
+      this._setConfigurationSetting(key, value);
+    } else {
+      this._bindConfigurationValue(key);
     }
   },
 
@@ -141,12 +142,13 @@ const WidgetCreationModal = createReactClass({
   },
 
   render() {
-    const { loading } = this.props;
+    const { loading, fields, onModalHidden } = this.props;
     const CustomCreateDialog = this.widgetPlugin.configurationCreateComponent;
+    const { title, config } = this.state;
     return (
       <BootstrapModalForm ref={(createModal) => { this.createModal = createModal; }}
                           title="Create Dashboard Widget"
-                          onModalClose={this.props.onModalHidden}
+                          onModalClose={onModalHidden}
                           onSubmitForm={this.save}
                           submitButtonText={loading ? 'Creating...' : 'Create'}
                           submitButtonDisabled={loading}>
@@ -156,13 +158,13 @@ const WidgetCreationModal = createReactClass({
                  name="title"
                  id="widget-title"
                  required
-                 defaultValue={this.state.title}
+                 defaultValue={title}
                  onChange={this._bindValue}
                  help="Type a name that describes your widget."
                  autoFocus />
           {CustomCreateDialog && (
-            <CustomCreateDialog config={this.state.config}
-                                fields={this.props.fields}
+            <CustomCreateDialog config={config}
+                                fields={fields}
                                 onChange={this._onConfigurationValueChange}
                                 setInitialConfiguration={this._setInitialDerivedConfiguration} />
           )}

--- a/graylog2-web-interface/src/components/widgets/WidgetCreationModal.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetCreationModal.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import lodash from 'lodash';
-import { Input } from 'components/bootstrap';
+import Input from 'components/bootstrap/Input';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';

--- a/graylog2-web-interface/src/stores/nodes/NodesStore.js
+++ b/graylog2-web-interface/src/stores/nodes/NodesStore.js
@@ -41,12 +41,14 @@ const NodesStore = Reflux.createStore({
     const promise = this.promises.list || fetchPeriodically('GET', URLUtils.qualifyUrl(ApiRoutes.ClusterApiResource.list().url))
       .then((response) => {
         this.nodes = {};
-        response.nodes.forEach((node) => {
-          this.nodes[node.node_id] = node;
-        });
-        this.clusterId = this._clusterId();
-        this.nodeCount = this._nodeCount();
-        this._propagateState();
+        if (response.nodes) {
+          response.nodes.forEach((node) => {
+            this.nodes[node.node_id] = node;
+          });
+          this.clusterId = this._clusterId();
+          this.nodeCount = this._nodeCount();
+          this._propagateState();
+        }
         return response;
       })
       .finally(() => delete this.promises.list);

--- a/graylog2-web-interface/src/stores/nodes/NodesStore.js
+++ b/graylog2-web-interface/src/stores/nodes/NodesStore.js
@@ -1,6 +1,6 @@
 import Reflux from 'reflux';
 import URLUtils from 'util/URLUtils';
-import { Builder, fetchPeriodically } from 'logic/rest/FetchProvider';
+import { fetchPeriodically } from 'logic/rest/FetchProvider';
 
 import ApiRoutes from 'routing/ApiRoutes';
 import CombinedProvider from 'injection/CombinedProvider';

--- a/graylog2-web-interface/test/mock-FetchProvider.js
+++ b/graylog2-web-interface/test/mock-FetchProvider.js
@@ -1,0 +1,27 @@
+const mockResponse = {};
+
+class MockBuilder {
+  authenticated = () => this;
+  session = () => this;
+  setHeader = () => this;
+  json = () => this;
+  plaintext = () => this;
+  noSessionExtension = () => this;
+  build = () => Promise.resolve({});
+}
+
+class MockFetchError {
+}
+
+const MockFetchProvider = Object.assign(
+  jest.fn(() => Promise.resolve(mockResponse)),
+  {
+    FetchError: MockFetchError,
+    Builder: MockBuilder,
+    default: jest.fn(() => Promise.resolve(mockResponse)),
+    fetchPlainText: jest.fn(() => Promise.resolve(mockResponse)),
+    fetchPeriodically: jest.fn(() => Promise.resolve(mockResponse)),
+  },
+);
+
+jest.mock('logic/rest/FetchProvider', () => MockFetchProvider);

--- a/graylog2-web-interface/test/mock-FetchProvider.js
+++ b/graylog2-web-interface/test/mock-FetchProvider.js
@@ -2,11 +2,17 @@ const mockResponse = {};
 
 class MockBuilder {
   authenticated = () => this;
+
   session = () => this;
+
   setHeader = () => this;
+
   json = () => this;
+
   plaintext = () => this;
+
   noSessionExtension = () => this;
+
   build = () => Promise.resolve({});
 }
 


### PR DESCRIPTION
## Description
## Motivation and Context

When implicit/transitive dependencies of a SUT require stores that are not mocked and those stores do remote calls during initialization, promises are instantiated which are rejected asynchronously and - depending on the runtime of all tests - may or may not be rejected in the background. This leads to build failures in some cases (the probability seems to be higher for concurrent build/test runs) which are not even assignable to a specific test (case).

This change is mocking `FetchProvider` globally for jest, so no remote calls can be done using our fetch API. This is a precaution against the scenario described above and also a good indication for anyone writing a test that it is not properly mocked (as remote calls should never happen in test cases).

For most tests/stores this was not a problem, two required additional changes:

  - The `AddToDashboardMenu` test required additional mocking of the `DashboardsStore` & `WidgetsStore`.
  - The `NodesStore` was unconditionally extracting information during init from a remote response (being `{}` now after mocking). This is now guarded by a condition checking the presence of the required key.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.