### PR TITLE
Dynamic pager in message lists

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -1,6 +1,5 @@
 // @flow strict
 import * as React from 'react';
-import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import * as Immutable from 'immutable';
 import connect from 'stores/connect';
@@ -24,10 +23,28 @@ import styles from './MessageList.css';
 
 const { InputsActions } = CombinedProvider.get('Inputs');
 
-const MessageList = createReactClass({
-  displayName: 'MessageList',
+type State = {
+  currentPage: number,
+  expandedMessages: Immutable.Set,
+}
 
-  propTypes: {
+type Props = {
+  fields: {},
+  pageSize: number,
+  config: MessagesWidgetConfig,
+  data: { messages: [] },
+  containerHeight: number,
+  selectedFields: {},
+  currentView: {
+    activeQuery: {},
+    view: {
+      id: number,
+    },
+  },
+};
+
+class MessageList extends React.Component<Props, State> {
+  static propTypes = {
     fields: CustomPropTypes.FieldListType.isRequired,
     pageSize: PropTypes.number,
     config: PropTypes.instanceOf(MessagesWidgetConfig),
@@ -37,47 +54,43 @@ const MessageList = createReactClass({
     containerHeight: PropTypes.number,
     selectedFields: PropTypes.object,
     currentView: PropTypes.object,
-  },
+  };
 
-  getDefaultProps() {
-    return {
-      pageSize: Messages.DEFAULT_LIMIT,
-      containerHeight: undefined,
-      selectedFields: Immutable.Set(),
-      currentView: { view: {}, activeQuery: undefined },
-      config: undefined,
-    };
-  },
+  static defaultProps = {
+    pageSize: Messages.DEFAULT_LIMIT,
+    containerHeight: undefined,
+    selectedFields: Immutable.Set(),
+    currentView: { view: {}, activeQuery: undefined },
+    config: undefined,
+  };
 
-  getInitialState() {
-    return {
-      currentPage: 1,
-      expandedMessages: Immutable.Set(),
-    };
-  },
+  state = {
+    currentPage: 1,
+    expandedMessages: Immutable.Set(),
+  };
 
   componentDidMount() {
     InputsActions.list();
-  },
+  }
 
-  _getSelectedFields() {
+  _getSelectedFields = () => {
     const { selectedFields, config } = this.props;
     if (config) {
       return Immutable.Set(config.fields);
     }
     return selectedFields;
-  },
+  };
 
-  _columnStyle(fieldName) {
+  _columnStyle = (fieldName) => {
     const { fields } = this.props;
     const selectedFields = Immutable.OrderedSet(fields);
     if (fieldName.toLowerCase() === 'source' && selectedFields.size > 1) {
       return { width: 180 };
     }
     return {};
-  },
+  };
 
-  _toggleMessageDetail(id) {
+  _toggleMessageDetail = (id) => {
     let newSet;
     const { expandedMessages } = this.state;
     if (expandedMessages.contains(id)) {
@@ -87,11 +100,11 @@ const MessageList = createReactClass({
       RefreshActions.disable();
     }
     this.setState({ expandedMessages: newSet });
-  },
+  };
 
-  _fieldTypeFor(fieldName, fields) {
+  _fieldTypeFor = (fieldName, fields : Immutable.List) => {
     return (fields.find(f => f.name === fieldName) || { type: FieldType.Unknown }).type;
-  },
+  };
 
   render() {
     const { containerHeight, data, fields, currentView, pageSize = 7, config } = this.props;
@@ -172,8 +185,8 @@ const MessageList = createReactClass({
         </div>
       </span>
     );
-  },
-});
+  }
+}
 
 export default connect(MessageList,
   {

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -118,13 +118,16 @@ const MessageList = createReactClass({
 
     return (
       <span>
-        <div className={styles.messageListPaginator}>
-          <MessageTablePaginator currentPage={Number(currentPage)}
-                                 onPageChange={newPage => this.setState({ currentPage: newPage })}
-                                 pageSize={pageSize}
-                                 position="top"
-                                 resultCount={messages.length} />
-        </div>
+        { messages.length > Messages.DEFAULT_LIMIT
+        && (
+          <div className={styles.messageListPaginator}>
+            <MessageTablePaginator currentPage={Number(currentPage)}
+                                   onPageChange={newPage => this.setState({ currentPage: newPage })}
+                                   pageSize={pageSize}
+                                   position="top"
+                                   resultCount={messages.length} />
+          </div>
+        ) }
 
         <div className="search-results-table" style={{ overflow: 'auto', height: 'calc(100% - 60px)', maxHeight: maxHeight }}>
           <div className="table-responsive">

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -131,7 +131,7 @@ class MessageList extends React.Component<Props, State> {
 
     return (
       <span>
-        { messages.length > Messages.DEFAULT_LIMIT
+        { messages.length > pageSize
         && (
           <div className={styles.messageListPaginator}>
             <MessageTablePaginator currentPage={Number(currentPage)}


### PR DESCRIPTION
## Description
Only display the pager in message lists, when the amount of messages is bigger
than the page size.

## Motivation and Context
We right now always show a pager, even though we never need it, since the we only
ask for max 150 messages and the page size 150.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
