### PR TITLE
Reduce processing_status_persist_interval default value to 1 second

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusConfig.java
@@ -26,7 +26,7 @@ public class ProcessingStatusConfig {
     public static final String PERSIST_INTERVAL = "processing_status_persist_interval";
 
     @Parameter(value = PERSIST_INTERVAL, validators = {PositiveDurationValidator.class, Minimum1SecondValidator.class})
-    private Duration processingStatusPersistInterval = Duration.seconds(5);
+    private Duration processingStatusPersistInterval = Duration.seconds(1);
 
     public Duration getProcessingStatusPersistInterval() {
         return processingStatusPersistInterval;

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -640,5 +640,5 @@ proxied_requests_thread_pool_size = 32
 
 # The server is writing processing status information to the database on a regular basis. This setting controls how
 # often the data is written to the database.
-# Default: 5s (cannot be less than 1s)
-#processing_status_persist_interval = 5s
+# Default: 1s (cannot be less than 1s)
+#processing_status_persist_interval = 1s


### PR DESCRIPTION
Using 5 seconds is not often enough with regard to alert job execution.
Alert job execution checks this data in the database to decide if an
alert job can be executed or not.