### PR TITLE
Adapt to schema changes

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.jsx
@@ -37,7 +37,9 @@ class EventDefinitionFormContainer extends React.Component {
       config: {},
       field_spec: {},
       key_spec: [],
+      action_settings: { grace_period_ms: 0 },
       actions: [],
+      alert: false,
     },
     entityTypes: undefined,
   };

--- a/graylog2-web-interface/src/stores/event-definitions/EventDefinitionsStore.js
+++ b/graylog2-web-interface/src/stores/event-definitions/EventDefinitionsStore.js
@@ -7,6 +7,8 @@ import UserNotification from 'util/UserNotification';
 import fetch from 'logic/rest/FetchProvider';
 import CombinedProvider from 'injection/CombinedProvider';
 
+import { NOTIFICATION_TYPE } from 'components/event-notifications/event-notification-types';
+
 const { EventDefinitionsActions } = CombinedProvider.get('EventDefinitions');
 
 const EventDefinitionsStore = Reflux.createStore({
@@ -105,8 +107,13 @@ const EventDefinitionsStore = Reflux.createStore({
     EventDefinitionsActions.get.promise(promise);
   },
 
+  setAlertFlag(eventDefinition) {
+    const isAlert = eventDefinition.actions.some(action => action.type === NOTIFICATION_TYPE);
+    return Object.assign({}, eventDefinition, { alert: isAlert });
+  },
+
   create(eventDefinition) {
-    const promise = fetch('POST', this.eventDefinitionsUrl({}), eventDefinition);
+    const promise = fetch('POST', this.eventDefinitionsUrl({}), this.setAlertFlag(eventDefinition));
     promise.then(
       (response) => {
         UserNotification.success('Event Definition created successfully', `Event Definition "${eventDefinition.title}" was created successfully.`);
@@ -122,7 +129,7 @@ const EventDefinitionsStore = Reflux.createStore({
   },
 
   update(eventDefinitionId, eventDefinition) {
-    const promise = fetch('PUT', this.eventDefinitionsUrl({ segments: [eventDefinitionId] }), eventDefinition);
+    const promise = fetch('PUT', this.eventDefinitionsUrl({ segments: [eventDefinitionId] }), this.setAlertFlag(eventDefinition));
     promise.then(
       (response) => {
         UserNotification.success('Event Definition updated successfully', `Event Definition "${eventDefinition.title}" was updated successfully.`);


### PR DESCRIPTION
- Set `alert` flag if at least one notification is configured
- Set `grace_period_ms` to 0 until we add an input for that
