### PR TITLE
Apply custom highlighting only if field value matches configured value exactly.

### DIFF
--- a/graylog2-web-interface/src/views/components/messagelist/CustomHighlighting.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/CustomHighlighting.jsx
@@ -23,7 +23,7 @@ const CustomHighlighting = ({ children, field: fieldName, value: fieldValue, hig
   const rules = highlightingRules[fieldName] || [];
   rules.forEach((rule) => {
     const ranges = [];
-    if (String(fieldValue).includes(rule.value)) {
+    if (String(fieldValue) === String(rule.value)) {
       ranges.push({
         start: String(fieldValue).indexOf(rule.value),
         length: String(rule.value).length,

--- a/graylog2-web-interface/src/views/components/messagelist/CustomHighlighting.test.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/CustomHighlighting.test.jsx
@@ -1,0 +1,90 @@
+// @flow strict
+import * as React from 'react';
+import { mount } from 'enzyme';
+
+import DecoratorContext from 'views/components/messagelist/decoration/DecoratorContext';
+import HighlightingRule from 'views/logic/views/formatting/highlighting/HighlightingRule';
+import FieldType from 'views/logic/fieldtypes/FieldType';
+import CustomHighlighting from './CustomHighlighting';
+
+const renderDecorators = (decorators, field, value) => decorators.map(Decorator => (
+  <Decorator key={Decorator.name}
+             type={FieldType.Unknown}
+             field={field}
+             value={value} />
+));
+
+describe('CustomHighlighting', () => {
+  const field = 'foo';
+  const value = 42;
+  it('renders value as is when no rules exist', () => {
+    const wrapper = mount((
+      <CustomHighlighting field={field} value={value} highlightingRules={{}}>
+        <DecoratorContext.Consumer>
+          {decorators => renderDecorators(decorators, field, value)}
+        </DecoratorContext.Consumer>
+      </CustomHighlighting>
+    ));
+    expect(wrapper.find('PossiblyHighlight')).toMatchSnapshot();
+  });
+  it('renders value as is when no rule for this field exists', () => {
+    const rule = HighlightingRule.builder()
+      .field(field)
+      .value(String(value))
+      .color('#bc98fd')
+      .build();
+    const wrapper = mount((
+      <CustomHighlighting field={field} value={value} highlightingRules={{ bar: [rule] }}>
+        <DecoratorContext.Consumer>
+          {decorators => renderDecorators(decorators, field, value)}
+        </DecoratorContext.Consumer>
+      </CustomHighlighting>
+    ));
+    expect(wrapper.find('PossiblyHighlight')).toMatchSnapshot();
+  });
+  it('renders highlighted value if rule for value exists', () => {
+    const rule = HighlightingRule.builder()
+      .field(field)
+      .value(String(value))
+      .color('#bc98fd')
+      .build();
+    const wrapper = mount((
+      <CustomHighlighting field={field} value={value} highlightingRules={{ [field]: [rule] }}>
+        <DecoratorContext.Consumer>
+          {decorators => renderDecorators(decorators, field, value)}
+        </DecoratorContext.Consumer>
+      </CustomHighlighting>
+    ));
+    expect(wrapper.find('PossiblyHighlight')).toMatchSnapshot();
+  });
+  it('does not render highlight if rule value only matches substring', () => {
+    const rule = HighlightingRule.builder()
+      .field(field)
+      .value('2')
+      .color('#bc98fd')
+      .build();
+    const wrapper = mount((
+      <CustomHighlighting field={field} value={value} highlightingRules={{ [field]: [rule] }}>
+        <DecoratorContext.Consumer>
+          {decorators => renderDecorators(decorators, field, value)}
+        </DecoratorContext.Consumer>
+      </CustomHighlighting>
+    ));
+    expect(wrapper.find('PossiblyHighlight')).toMatchSnapshot();
+  });
+  it('does not render highlight if rule value does not match', () => {
+    const rule = HighlightingRule.builder()
+      .field(field)
+      .value('23')
+      .color('#bc98fd')
+      .build();
+    const wrapper = mount((
+      <CustomHighlighting field={field} value={value} highlightingRules={{ [field]: [rule] }}>
+        <DecoratorContext.Consumer>
+          {decorators => renderDecorators(decorators, field, value)}
+        </DecoratorContext.Consumer>
+      </CustomHighlighting>
+    ));
+    expect(wrapper.find('PossiblyHighlight')).toMatchSnapshot();
+  });
+});

--- a/graylog2-web-interface/src/views/components/messagelist/__snapshots__/CustomHighlighting.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/messagelist/__snapshots__/CustomHighlighting.test.jsx.snap
@@ -1,0 +1,74 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CustomHighlighting does not render highlight if rule value does not match 1`] = `
+<PossiblyHighlight
+  color="#ffec3d"
+  field="foo"
+  highlightRanges={Object {}}
+  value={42}
+>
+  42
+</PossiblyHighlight>
+`;
+
+exports[`CustomHighlighting does not render highlight if rule value only matches substring 1`] = `
+<PossiblyHighlight
+  color="#ffec3d"
+  field="foo"
+  highlightRanges={Object {}}
+  value={42}
+>
+  42
+</PossiblyHighlight>
+`;
+
+exports[`CustomHighlighting renders highlighted value if rule for value exists 1`] = `
+<PossiblyHighlight
+  color="#bc98fd"
+  field="foo"
+  highlightRanges={
+    Object {
+      "foo": Array [
+        Object {
+          "length": 2,
+          "start": 0,
+        },
+      ],
+    }
+  }
+  value={42}
+>
+  <span
+    key="highlight-0"
+    style={
+      Object {
+        "backgroundColor": "#bc98fd",
+      }
+    }
+  >
+    42
+  </span>
+</PossiblyHighlight>
+`;
+
+exports[`CustomHighlighting renders value as is when no rule for this field exists 1`] = `
+<PossiblyHighlight
+  color="#ffec3d"
+  field="foo"
+  highlightRanges={Object {}}
+  value={42}
+>
+  42
+</PossiblyHighlight>
+`;
+
+exports[`CustomHighlighting renders value as is when no rules exist 1`] = `
+<PossiblyHighlight
+  color="#ffec3d"
+  field="foo"
+  highlightRanges={Object {}}
+  value={42}
+>
+  42
+</PossiblyHighlight>
+`;


### PR DESCRIPTION
## Description
## Motivation and Context
Before this change, the configured value of a highlighting rule needed
to be a substring of the field's value only, to make it become
highlighted. This is counter-intuitive, especially for numeric field
values.

This change is changing this so the field value needs to match the
configured rule's value exactly.

Fixes Graylog2/graylog-plugin-enterprise#1118.

## Screenshots (if appropriate):
![Screen Shot 2019-07-08 at 14 42 27](https://user-images.githubusercontent.com/41929/60811011-ab20eb00-a18e-11e9-9e72-82e920903b22.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.