### PR TITLE
Using custom `instanceOf` prop-type in views.

### DIFF
--- a/graylog2-web-interface/src/views/components/CustomPropTypes.js
+++ b/graylog2-web-interface/src/views/components/CustomPropTypes.js
@@ -32,9 +32,14 @@ const OneOrMoreChildren = PropTypes.oneOfType([
 const prototypesOf = (target) => {
   let i = target;
   const result = [];
-  while (i && i.__proto__) {
-    result.push(i.__proto__);
-    i = i.__proto__;
+  while (i) {
+    try {
+      const prototype = Object.getPrototypeOf(i);
+      result.push(prototype);
+      i = prototype;
+    } catch {
+      i = undefined;
+    }
   }
 
   return result;
@@ -50,7 +55,7 @@ const createInstanceOf = (expectedClass, required = false) => {
         ? new Error(`Invalid prop ${propName} supplied to ${componentName}: expected to be instance of ${expectedConstructorName} but found ${value} instead`)
         : undefined;
     }
-    const valueConstructorName = get(value, ['__proto__', 'constructor', 'name']);
+    const valueConstructorName = get(prototypesOf(value)[0], ['constructor', 'name']);
     const constructorNames = prototypesOf(value)
       .map(proto => get(proto, ['constructor', 'name']))
       .filter(name => name !== undefined);

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilderPropTypes.js
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilderPropTypes.js
@@ -3,6 +3,7 @@ import Pivot from 'views/logic/aggregationbuilder/Pivot';
 import Series from 'views/logic/aggregationbuilder/Series';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
+import CustomPropTypes from '../CustomPropTypes';
 
 export const FieldList = PropTypes.arrayOf(
   PropTypes.shape({
@@ -11,12 +12,12 @@ export const FieldList = PropTypes.arrayOf(
   }),
 );
 
-export const PivotType = PropTypes.instanceOf(Pivot);
+export const PivotType = CustomPropTypes.instanceOf(Pivot);
 export const PivotList = PropTypes.arrayOf(PivotType);
-export const SeriesType = PropTypes.instanceOf(Series);
+export const SeriesType = CustomPropTypes.instanceOf(Series);
 export const SeriesList = PropTypes.arrayOf(SeriesType);
 export const SortList = PropTypes.arrayOf(PropTypes.string);
 export const VisualizationType = PropTypes.string;
-export const VisualizationConfigType = PropTypes.instanceOf(VisualizationConfig);
+export const VisualizationConfigType = CustomPropTypes.instanceOf(VisualizationConfig);
 
-export const AggregationType = PropTypes.instanceOf(AggregationWidgetConfig);
+export const AggregationType = CustomPropTypes.instanceOf(AggregationWidgetConfig);

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.jsx
@@ -34,7 +34,7 @@ type State = {
 export default class AggregationControls extends React.Component<Props, State> {
   static propTypes = {
     children: PropTypes.element.isRequired,
-    config: PropTypes.instanceOf(AggregationWidgetConfig).isRequired,
+    config: CustomPropTypes.instanceOf(AggregationWidgetConfig).isRequired,
     fields: CustomPropTypes.FieldListType.isRequired,
     onChange: PropTypes.func.isRequired,
   };

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/PivotConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/PivotConfiguration.jsx
@@ -2,9 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Button } from 'react-bootstrap';
+
+import FieldType from 'views/logic/fieldtypes/FieldType';
 import TimeHistogramPivot from './pivottypes/TimeHistogramPivot';
-import FieldType from '../../logic/fieldtypes/FieldType';
 import TermsPivotConfiguration from './pivottypes/TermsPivotConfiguration';
+import CustomPropTypes from '../CustomPropTypes';
 
 const _configurationComponentByType = (type, value, onChange) => {
   switch (type.type) {
@@ -15,7 +17,7 @@ const _configurationComponentByType = (type, value, onChange) => {
 
 export default class PivotConfiguration extends React.Component {
   static propTypes = {
-    type: PropTypes.instanceOf(FieldType).isRequired,
+    type: CustomPropTypes.instanceOf(FieldType).isRequired,
     config: PropTypes.shape({
       type: PropTypes.string.isRequired,
     }).isRequired,
@@ -30,6 +32,7 @@ export default class PivotConfiguration extends React.Component {
     };
   }
 
+  // eslint-disable-next-line react/destructuring-assignment
   _onSubmit = () => this.props.onClose(this.state);
 
   _onChange = config => this.setState({ config });

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/PivotConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/PivotConfiguration.jsx
@@ -18,9 +18,7 @@ const _configurationComponentByType = (type, value, onChange) => {
 export default class PivotConfiguration extends React.Component {
   static propTypes = {
     type: CustomPropTypes.instanceOf(FieldType).isRequired,
-    config: PropTypes.shape({
-      type: PropTypes.string.isRequired,
-    }).isRequired,
+    config: PropTypes.object.isRequired,
     onClose: PropTypes.func.isRequired,
   };
 

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/PivotSelect.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/PivotSelect.jsx
@@ -42,6 +42,7 @@ const PivotSelect = ({ onChange, fields, value, ...props }) => {
     const element = rest.data;
     const fieldTypes = fields.all.filter(v => v.name === element.label);
     const fieldType = fieldTypes.isEmpty() ? FieldType.Unknown : fieldTypes.first().type;
+    // eslint-disable-next-line react/prop-types
     const { className } = innerProps;
     return (
       <span className={className}>

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesSelect.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesSelect.jsx
@@ -9,6 +9,7 @@ import { parameterOptionsForType } from 'views/components/aggregationbuilder/Ser
 import ConfigurableElement from './ConfigurableElement';
 import SeriesConfiguration from './SeriesConfiguration';
 import SeriesFunctionsSuggester from './SeriesFunctionsSuggester';
+import CustomPropTypes from '../CustomPropTypes';
 
 type Option = {|
   label: string,
@@ -133,7 +134,7 @@ class SeriesSelect extends React.Component<Props, State> {
 
 SeriesSelect.propTypes = {
   onChange: PropTypes.func.isRequired,
-  series: PropTypes.arrayOf(PropTypes.instanceOf(Series)).isRequired,
+  series: PropTypes.arrayOf(CustomPropTypes.instanceOf(Series)).isRequired,
   suggester: PropTypes.any,
 };
 

--- a/graylog2-web-interface/src/views/components/views/View.jsx
+++ b/graylog2-web-interface/src/views/components/views/View.jsx
@@ -95,7 +95,10 @@ View.propTypes = {
   description: PropTypes.string,
   owner: PropTypes.string.isRequired,
   createdAt: PropTypes.string.isRequired,
-  requires: PropTypes.arrayOf(PropTypes.string).isRequired,
+  requires: PropTypes.objectOf(PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
+  })).isRequired,
   requirementsProvided: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 

--- a/graylog2-web-interface/src/views/components/views/View.jsx
+++ b/graylog2-web-interface/src/views/components/views/View.jsx
@@ -17,13 +17,19 @@ const formatTitle = (title, id, disabled = false) => (disabled
   ? <h2>{title}</h2>
   : <Link to={Routes.VIEWS.VIEWID(id)}>{title}</Link>);
 
-// eslint-disable-next-line react/prop-types
 const _OwnerTag = ({ owner, currentUser }) => {
   if (!owner || owner === currentUser.username) {
     return <span>Last saved</span>;
   }
 
   return <span>Shared by {owner}, last saved</span>;
+};
+
+_OwnerTag.propTypes = {
+  owner: PropTypes.string.isRequired,
+  currentUser: PropTypes.shape({
+    username: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 const OwnerTag = connect(_OwnerTag, { currentUser: CurrentUserStore }, ({ currentUser }) => ({ currentUser: currentUser.currentUser }));

--- a/graylog2-web-interface/src/views/components/visualizations/XYPlot.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/XYPlot.jsx
@@ -14,6 +14,7 @@ import Query from 'views/logic/queries/Query';
 
 import GenericPlot from './GenericPlot';
 import OnZoom from './OnZoom';
+import CustomPropTypes from '../CustomPropTypes';
 
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
@@ -48,9 +49,9 @@ const XYPlot = ({ config, chartData, currentQuery, timezone, effectiveTimerange,
 
 XYPlot.propTypes = {
   chartData: PropTypes.array.isRequired,
-  config: PropTypes.instanceOf(AggregationWidgetConfig).isRequired,
+  config: CustomPropTypes.instanceOf(AggregationWidgetConfig).isRequired,
   timezone: PropTypes.string.isRequired,
-  currentQuery: PropTypes.instanceOf(Query).isRequired,
+  currentQuery: CustomPropTypes.instanceOf(Query).isRequired,
   effectiveTimerange: PropTypes.shape({
     from: PropTypes.string.isRequired,
     to: PropTypes.string.isRequired,

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -30,7 +30,7 @@ const MessageList = createReactClass({
   propTypes: {
     fields: CustomPropTypes.FieldListType.isRequired,
     pageSize: PropTypes.number,
-    config: PropTypes.instanceOf(MessagesWidgetConfig),
+    config: CustomPropTypes.instanceOf(MessagesWidgetConfig),
     data: PropTypes.shape({
       messages: PropTypes.arrayOf(PropTypes.object).isRequired,
     }).isRequired,

--- a/graylog2-web-interface/src/views/components/widgets/WidgetPropTypes.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetPropTypes.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import Widget from 'views/logic/widgets/Widget';
+import CustomPropTypes from '../CustomPropTypes';
 
 export const Position = {
   col: PropTypes.number.isRequired,
@@ -13,9 +14,9 @@ export const PositionsMap = PropTypes.objectOf(PropTypes.shape(Position));
 
 export const ImmutablePositionsMap = ImmutablePropTypes.mapOf(ImmutablePropTypes.mapContains(Position), PropTypes.string);
 
-export const WidgetsMap = PropTypes.objectOf(PropTypes.instanceOf(Widget));
+export const WidgetsMap = PropTypes.objectOf(CustomPropTypes.instanceOf(Widget));
 
-export const ImmutableWidgetsMap = ImmutablePropTypes.mapOf(PropTypes.instanceOf(Widget), PropTypes.string);
+export const ImmutableWidgetsMap = ImmutablePropTypes.mapOf(CustomPropTypes.instanceOf(Widget), PropTypes.string);
 
 export const WidgetData = PropTypes.oneOfType([
   PropTypes.arrayOf(PropTypes.object),

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -27,6 +27,7 @@ import withPluginEntities from 'views/logic/withPluginEntities';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import style from '!style/useable!css!./ExtendedSearchPage.css';
+import CustomPropTypes from '../components/CustomPropTypes';
 
 type Props = {
   headerElements: Array<React.ComponentType<{}>>,
@@ -39,7 +40,7 @@ const ExtendedSearchPage = createReactClass({
   displayName: 'ExtendedSearchPage',
 
   propTypes: {
-    executionState: PropTypes.instanceOf(SearchExecutionState).isRequired,
+    executionState: CustomPropTypes.instanceOf(SearchExecutionState),
     headerElements: PropTypes.arrayOf(PropTypes.func).isRequired,
     queryBarElements: PropTypes.arrayOf(PropTypes.func).isRequired,
     route: PropTypes.object.isRequired,

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -40,7 +40,7 @@ const ExtendedSearchPage = createReactClass({
   displayName: 'ExtendedSearchPage',
 
   propTypes: {
-    executionState: CustomPropTypes.instanceOf(SearchExecutionState),
+    executionState: CustomPropTypes.instanceOf(SearchExecutionState).isRequired,
     headerElements: PropTypes.arrayOf(PropTypes.func).isRequired,
     queryBarElements: PropTypes.arrayOf(PropTypes.func).isRequired,
     route: PropTypes.object.isRequired,


### PR DESCRIPTION
## Description
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When using `PropType.instanceOf` in development with HMR or
`loadable-components`, classes are loaded more than once and equality
checks/the `instanceof` operator fails, therefore also the `instanceOf`
prop type. This leads to non-sensical error messages like:

```
checkPropTypes.js:20 Warning: Failed prop type: Invalid prop `config` of type `AggregationWidgetConfig` supplied to `BarVisualization`, expected instance of `AggregationWidgetConfig`.
```

This change is implementing a custom `CustomPropTypes.instanceOf`
predicate, which expects a class as an argument and creates a prop type
matcher. For every invocation, the matcher extracts the prototype chain
(if present) of a given value and checks if the constructor name of the
argument class is included in those of the prototype chain of the
current value.

This check is used in a number of components which used
`PropTypes.instanceOf` before and raised error messages in development.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.