### PR TITLE
Removing `StopPropagation` wrapper from widget editing modal.

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.jsx
@@ -7,7 +7,6 @@ import { Modal } from 'react-bootstrap';
 import styles from '!style?insertAt=bottom!css!./EditWidgetFrame.css';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import globalStyles from '!style/useable!css!./EditWidgetFrame.global.css';
-import StopPropagation from '../common/StopPropagation';
 
 const EditWidgetDialog = ({ children, ...rest }) => (
   <Modal.Dialog {...rest}
@@ -40,18 +39,16 @@ export default class EditWidgetFrame extends React.Component<Props> {
   render() {
     const { children } = this.props;
     return (
-      <StopPropagation>
-        <Modal show animation={false} dialogComponentClass={EditWidgetDialog} enforceFocus={false}>
-          <Modal.Body style={{ height: 'calc(100% - 50px)' }}>
-            <div role="presentation" style={{ height: 'calc(100% - 20px)' }}>
-              {children[0]}
-            </div>
-          </Modal.Body>
-          <Modal.Footer>
-            {children[1]}
-          </Modal.Footer>
-        </Modal>
-      </StopPropagation>
+      <Modal show animation={false} dialogComponentClass={EditWidgetDialog} enforceFocus={false}>
+        <Modal.Body style={{ height: 'calc(100% - 50px)' }}>
+          <div role="presentation" style={{ height: 'calc(100% - 20px)' }}>
+            {children[0]}
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          {children[1]}
+        </Modal.Footer>
+      </Modal>
     );
   }
 }


### PR DESCRIPTION
## Description
## Motivation and Context

Stopping the `onClick` event lead to unwanted effects like checkboxes in
the pivot config modal not updating their state anymore.

Fixes #6093.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.