### PR TITLE
Events beta readiness

### DIFF
--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
@@ -52,16 +52,6 @@ class HttpNotificationForm extends React.Component {
                value={config.url || ''}
                onChange={this.handleChange}
                required />
-
-        <FormGroup controlId="notification-http-body">
-          <ControlLabel>Request JSON body <small className="text-muted">(Optional)</small></ControlLabel>
-          <SourceCodeEditor id="notification-http-body"
-                            mode="json"
-                            theme="light"
-                            value={config.body || ''}
-                            onChange={this.handleBodyChange} />
-          <HelpBlock>Request JSON body Graylog will send in the request.</HelpBlock>
-        </FormGroup>
       </React.Fragment>
     );
   }

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
-import { ControlLabel, FormGroup, HelpBlock } from 'react-bootstrap';
 
 import { Input } from 'components/bootstrap';
-import { SourceCodeEditor } from 'components/common';
 import FormsUtils from 'util/FormsUtils';
 
 class HttpNotificationForm extends React.Component {

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationSummary.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationSummary.jsx
@@ -16,17 +16,12 @@ class HttpNotificationSummary extends React.Component {
 
   render() {
     const { notification } = this.props;
-    const body = notification.config.body
-      ? JSON.stringify(JSON.parse(notification.config.body), null, 2)
-      : <em>Empty body</em>;
 
     return (
       <CommonNotificationSummary {...this.props}>
         <React.Fragment>
           <dt>URL</dt>
           <dd><code>{notification.config.url}</code></dd>
-          <dt>Request JSON body</dt>
-          <dd><pre>{body}</pre></dd>
         </React.Fragment>
       </CommonNotificationSummary>
     );

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -103,7 +103,7 @@ const Navigation = ({ permissions, fullName, location, loginName }) => {
           </LinkContainer>
 
           <LinkContainer to={Routes.NEXT_ALERTS.LIST}>
-            <NavItem>Next Alerts</NavItem>
+            <NavItem>Events</NavItem>
           </LinkContainer>
 
           <LinkContainer to={Routes.DASHBOARDS}>

--- a/graylog2-web-interface/src/stores/event-definitions/EventDefinitionsStore.js
+++ b/graylog2-web-interface/src/stores/event-definitions/EventDefinitionsStore.js
@@ -134,6 +134,7 @@ const EventDefinitionsStore = Reflux.createStore({
       (response) => {
         UserNotification.success('Event Definition updated successfully',
           `Event Definition "${eventDefinition.title}" was updated successfully.`);
+        this.refresh();
         return response;
       },
       (error) => {

--- a/graylog2-web-interface/src/stores/event-definitions/EventDefinitionsStore.js
+++ b/graylog2-web-interface/src/stores/event-definitions/EventDefinitionsStore.js
@@ -116,7 +116,7 @@ const EventDefinitionsStore = Reflux.createStore({
       (response) => {
         UserNotification.success('Event Definition created successfully',
           `Event Definition "${eventDefinition.title}" was created successfully.`);
-        this.list();
+        this.refresh();
         return response;
       },
       (error) => {
@@ -151,7 +151,7 @@ const EventDefinitionsStore = Reflux.createStore({
       () => {
         UserNotification.success('Event Definition deleted successfully',
           `Event Definition "${eventDefinition.title}" was deleted successfully.`);
-        this.list();
+        this.refresh();
       },
       (error) => {
         UserNotification.error(`Deleting Event Definition "${eventDefinition.title}" failed with status: ${error}`,

--- a/graylog2-web-interface/src/stores/event-notifications/EventNotificationsStore.js
+++ b/graylog2-web-interface/src/stores/event-notifications/EventNotificationsStore.js
@@ -126,6 +126,7 @@ const EventNotificationsStore = Reflux.createStore({
     promise.then(
       (response) => {
         UserNotification.success('Notification updated successfully', `Notification "${notification.title}" was updated successfully.`);
+        this.refresh();
         return response;
       },
       (error) => {


### PR DESCRIPTION
This PR adds a couple of small changes in Events to be merged before the beta release:

- The first beta will ship with the old and new Alerting UI, so we are renaming the navigation entry for the new Alerting from `Next Alerts` to `Events`
- The HTTP JSON body customization feature still needs some work, and we are removing it from the UI for now

---

Edit: Also fixed an issue refreshing data in `EventDefinitionsStore`.