### PR TITLE
Fields form improvements

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionForm.jsx
@@ -103,6 +103,7 @@ class EventDefinitionForm extends React.Component {
     const { activeStep } = this.state;
 
     const defaultStepProps = {
+      key: eventDefinition.id, // Recreate components if ID changed
       action,
       entityTypes,
       eventDefinition,

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldForm.jsx
@@ -24,29 +24,30 @@ class FieldForm extends React.Component {
     keys: [],
   };
 
+  state = {
+    tempFieldName: undefined,
+  };
+
   handleRemoveField = () => {
     const { fieldName, onRemoveField } = this.props;
     onRemoveField(fieldName);
   };
 
   handleFieldNameChange = (event) => {
-    const { fieldName, onChange } = this.props;
     const nextValue = FormsUtils.getValueFromInput(event.target);
-    onChange(fieldName, 'fieldName', nextValue);
+    this.setState({ tempFieldName: nextValue });
+  };
+
+  handleFieldNameBlur = () => {
+    const { fieldName, onChange } = this.props;
+    const { tempFieldName } = this.state;
+    onChange(fieldName, 'fieldName', tempFieldName);
+    this.setState({ tempFieldName: undefined });
   };
 
   propagateConfigChange = (nextConfig) => {
     const { fieldName, onChange } = this.props;
     onChange(fieldName, 'config', nextConfig);
-  };
-
-  handleConfigChange = (event) => {
-    const { config } = this.props;
-    const key = event.target.name;
-    const value = FormsUtils.getValueFromInput(event.target);
-    const nextConfig = lodash.cloneDeep(config);
-    nextConfig[key] = value;
-    this.propagateConfigChange(nextConfig);
   };
 
   handleProviderTypeChange = (nextProvider) => {
@@ -122,6 +123,7 @@ class FieldForm extends React.Component {
 
   render() {
     const { fieldName, config, keys } = this.props;
+    const { tempFieldName } = this.state;
     const isKeyEnabled = keys.includes(fieldName);
     // Get the sorted position this field in the keys or the next available key
     const keyValue = (keys.indexOf(fieldName) < 0 ? keys.length : keys.indexOf(fieldName)) + 1;
@@ -141,8 +143,9 @@ class FieldForm extends React.Component {
                    name="name"
                    label="Name"
                    type="text"
-                   value={fieldName}
+                   value={tempFieldName || fieldName}
                    onChange={this.handleFieldNameChange}
+                   onBlur={this.handleFieldNameBlur}
                    help="Name for this Field."
                    required />
           </Col>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsForm.jsx
@@ -83,8 +83,12 @@ class FieldsForm extends React.Component {
       } else if (key === 'fieldName') {
         const config = eventDefinition.field_spec[fieldName];
         nextFieldSpec = lodash.omit(eventDefinition.field_spec, fieldName);
-        nextFieldSpec[value] = config;
-        this.syncWithState(value, fieldName);
+        let effectiveValue = value;
+        while (Object.keys(eventDefinition.field_spec).includes(effectiveValue)) {
+          effectiveValue += '_';
+        }
+        nextFieldSpec[effectiveValue] = config;
+        this.syncWithState(effectiveValue, fieldName);
       }
 
       onChange('field_spec', nextFieldSpec);

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsForm.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import lodash from 'lodash';
 import { Button, Col, Row } from 'react-bootstrap';
 import uuid from 'uuid/v4';
+import naturalSort from 'javascript-natural-sort';
 
 import FieldForm from './FieldForm';
 
@@ -20,7 +21,7 @@ class FieldsForm extends React.Component {
   constructor(props) {
     super(props);
 
-    const fieldNames = Object.keys(props.eventDefinition.field_spec);
+    const fieldNames = Object.keys(props.eventDefinition.field_spec).sort(naturalSort);
     const mapping = {};
     fieldNames.forEach((fieldName) => {
       mapping[fieldName] = uuid();

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/TemplateFieldValueProviderForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/TemplateFieldValueProviderForm.jsx
@@ -25,13 +25,7 @@ class TemplateFieldValueProviderForm extends React.Component {
     const nextProviders = lodash.cloneDeep(config.providers);
     const templateProvider = nextProviders.find(provider => provider.type === TemplateFieldValueProviderForm.type);
     templateProvider.template = nextTemplate;
-    templateProvider.dataType = 'string';
-    onChange(Object.assign({}, config, { providers: nextProviders }));
-  };
-
-  handleTypeChange = (nextType) => {
-    const { config, onChange } = this.props;
-    onChange(Object.assign({}, config, { data_type: nextType }));
+    onChange(Object.assign({}, config, { data_type: 'string', providers: nextProviders }));
   };
 
   render() {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/TemplateFieldValueProviderForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/TemplateFieldValueProviderForm.jsx
@@ -3,12 +3,10 @@ import PropTypes from 'prop-types';
 import {
   Col,
   ControlLabel,
-  DropdownButton,
   FormControl,
   FormGroup,
   HelpBlock,
   InputGroup,
-  MenuItem,
   Row,
 } from 'react-bootstrap';
 import lodash from 'lodash';
@@ -27,6 +25,7 @@ class TemplateFieldValueProviderForm extends React.Component {
     const nextProviders = lodash.cloneDeep(config.providers);
     const templateProvider = nextProviders.find(provider => provider.type === TemplateFieldValueProviderForm.type);
     templateProvider.template = nextTemplate;
+    templateProvider.dataType = 'string';
     onChange(Object.assign({}, config, { providers: nextProviders }));
   };
 
@@ -46,12 +45,7 @@ class TemplateFieldValueProviderForm extends React.Component {
             <ControlLabel>Value</ControlLabel>
             <InputGroup>
               <FormControl type="text" onChange={this.handleValueChange} value={provider.template || ''} />
-              <DropdownButton componentClass={InputGroup.Button}
-                              id="type"
-                              title={lodash.upperFirst(config.data_type || 'type')}
-                              onSelect={this.handleTypeChange}>
-                <MenuItem eventKey="string" active={config.data_type === 'string'}>String</MenuItem>
-              </DropdownButton>
+              <InputGroup.Addon>String</InputGroup.Addon>
             </InputGroup>
             <HelpBlock>Type a literal text Field Value or use Freemarker syntax to add a dynamic Value.</HelpBlock>
           </FormGroup>


### PR DESCRIPTION
This PR addresses some shortcomings of the field form inside the Events Definition Wizard:

- Add internal unique IDs, to help React track which components belong to which fields
- Add internal sorting of fields, to avoid components jumping on the page when updating the `Object` which contains all fields in the Events Definition data structure
- Sort fields when first rendering the fields form, avoiding any jumps while editing
- Append underscores to field names if they are not unique. Also avoid updating the object keys (which contain the field names) until the field name input loses the focus
- Set default data type to `string`, as the data type dropwdown is not expected to have more data types for now

Fixes #6127

Needs changes in https://github.com/Graylog2/graylog2-server/pull/6128 to properly load the Event Definitions page.