### PR TITLE
Add "gl2_message_id" field to MessageFieldsFilter in the UI

### DIFF
--- a/graylog2-web-interface/src/logic/message/MessageFieldsFilter.js
+++ b/graylog2-web-interface/src/logic/message/MessageFieldsFilter.js
@@ -10,6 +10,7 @@ const MessageFieldsFilter = {
     '_score',
 
     // Our reserved fields.
+    'gl2_message_id',
     'gl2_source_node',
     'gl2_source_input',
     'gl2_source_collector',


### PR DESCRIPTION
The field should not show up in message details and the fields list, just like the other internal fields.

Refs #6074
Refs #5994 