### PR TITLE
Add description and help link in Events page

### DIFF
--- a/graylog2-web-interface/src/pages/EventsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventsPage.jsx
@@ -3,9 +3,10 @@ import { LinkContainer } from 'react-router-bootstrap';
 import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 
 import { DocumentTitle, PageHeader } from 'components/common';
-
+import DocumentationLink from 'components/support/DocumentationLink';
 import EventsContainer from 'components/events/events/EventsContainer';
 
+import DocsHelper from 'util/DocsHelper';
 import Routes from 'routing/Routes';
 
 class EventsPage extends React.Component {
@@ -16,9 +17,16 @@ class EventsPage extends React.Component {
       <DocumentTitle title="Events">
         <span>
           <PageHeader title="Events">
-            <span />
+            <span>
+              Events are generated when Event Definitions you define are satisfied. Alerts also trigger
+              Notifications, being meant to capture relevant Events that may require your attention.
+            </span>
 
-            <span />
+            <span>
+              Graylog&apos;s new Alerting system let you define more flexible and powerful rules. Learn more in the{' '}
+              <DocumentationLink page={DocsHelper.PAGES.ALERTS}
+                                 text="documentation" />
+            </span>
 
             <ButtonToolbar>
               <LinkContainer to={Routes.NEXT_ALERTS.LIST}>


### PR DESCRIPTION
This PR adds a description to the Events page. It also adds a help link, even if it's not going anywhere at the moment and serves more as a placeholder and reminder that we need to add that in the near future.