### PR TITLE
Display all email configuration options in summary

### DIFF
--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationSummary.css
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationSummary.css
@@ -1,0 +1,3 @@
+:local(.bodyPreview) {
+    font-size: 12px;
+}

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationSummary.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationSummary.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 
 import CommonNotificationSummary from './CommonNotificationSummary';
 
+import styles from './EmailNotificationSummary.css';
+
 class EmailNotificationSummary extends React.Component {
   static propTypes = {
     type: PropTypes.string.isRequired,
@@ -19,10 +21,16 @@ class EmailNotificationSummary extends React.Component {
     return (
       <CommonNotificationSummary {...this.props}>
         <React.Fragment>
+          <dt>Sender</dt>
+          <dd>{notification.config.sender}</dd>
+          <dt>Subject</dt>
+          <dd>{notification.config.subject}</dd>
           <dt>User recipients</dt>
           <dd>{notification.config.user_recipients.join(', ') || 'No users will receive this notification.'}</dd>
           <dt>Email recipients</dt>
           <dd>{notification.config.email_recipients.join(', ') || 'No email addresses are configured to receive this notification.'}</dd>
+          <dt>Email Body</dt>
+          <dd><pre className={`${styles.bodyPreview} pre-scrollable`}>{notification.config.body_template}</pre></dd>
         </React.Fragment>
       </CommonNotificationSummary>
     );


### PR DESCRIPTION
On #6130 we added extra options to configure Email Notifications, but those were not displayed in the Notification summary. This PR adds them in the page.
