### PR TITLE
Display deleted Notifications in Event Definition form

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionSummary.jsx
@@ -94,19 +94,30 @@ class EventDefinitionSummary extends React.Component {
   renderNotification = (definitionNotification) => {
     const { notifications } = this.props;
     const notification = notifications.find(n => n.id === definitionNotification.notification_id);
-    const notificationPlugin = this.getPlugin('eventNotificationTypes', notification.config.type);
-    const component = (notificationPlugin.summaryComponent
-      ? React.createElement(notificationPlugin.summaryComponent, {
-        type: notificationPlugin.displayName,
-        notification: notification,
-        definitionNotification: definitionNotification,
-      })
-      : <span>Notification plugin <em>{notification.config.type}</em> does not provide a summary.</span>
-    );
+
+    let content;
+
+    if (notification) {
+      const notificationPlugin = this.getPlugin('eventNotificationTypes', notification.config.type);
+      content = (notificationPlugin.summaryComponent
+        ? React.createElement(notificationPlugin.summaryComponent, {
+          type: notificationPlugin.displayName,
+          notification: notification,
+          definitionNotification: definitionNotification,
+        })
+        : <span>Notification plugin <em>{notification.config.type}</em> does not provide a summary.</span>
+      );
+    } else {
+      content = (
+        <span>
+          Could not find information for Notification <em>{definitionNotification.notification_id}</em>.
+        </span>
+      );
+    }
 
     return (
       <React.Fragment key={definitionNotification.notification_id}>
-        {component}
+        {content}
       </React.Fragment>
     );
   };

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationList.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationList.jsx
@@ -28,11 +28,16 @@ class NotificationList extends React.Component {
   };
 
   notificationFormatter = (notification) => {
-    // Guard in case it is a new Notification, but its information has not been loaded yet
-    if (!notification) {
+    // Guard in case it is a new Notification or the Notification was deleted
+    if (notification.missing) {
       return (
         <tr>
-          <td><Spinner text="Loading Notification information..." /></td>
+          <td colSpan={2}>Could not find information for Notification <em>{notification.title}</em></td>
+          <td className="actions">
+            <Button bsStyle="info" bsSize="xsmall" onClick={this.handleRemoveClick(notification.title)}>
+              Remove from Event
+            </Button>
+          </td>
         </tr>
       );
     }
@@ -55,7 +60,12 @@ class NotificationList extends React.Component {
     const { eventDefinition, notifications, onAddNotificationClick } = this.props;
 
     const definitionNotifications = eventDefinition.notifications
-      .map(edn => notifications.find(n => n.id === edn.notification_id));
+      .map((edn) => {
+        return notifications.find(n => n.id === edn.notification_id) || {
+          title: edn.notification_id,
+          missing: true,
+        };
+      });
 
     if (definitionNotifications.length === 0) {
       return (

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationList.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationList.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, Col, Row } from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
-import { DataTable, Spinner } from 'components/common';
+import { DataTable } from 'components/common';
 
 class NotificationList extends React.Component {
   static propTypes = {


### PR DESCRIPTION
This PR takes care of fixing two issues when editing an Event Definition with deleted Notifications:

- In the Notifications step, having a deleted Notification will display a message indicating that we could not find information about the Notification and a button to remove the Notification, as we do with other Notifications

- In the Summary step, ensure the Notification was found on the list before trying to render its summary, and display a message otherwise


