### PR TITLE
Show the event key in the event/alerts overview

### DIFF
--- a/graylog2-web-interface/src/components/events/events/Events.jsx
+++ b/graylog2-web-interface/src/components/events/events/Events.jsx
@@ -14,7 +14,7 @@ import EventDefinitionPriorityEnum from 'logic/alerts/EventDefinitionPriorityEnu
 
 import styles from './Events.css';
 
-const HEADERS = ['Description', 'Type', 'Event Definition', 'Timestamp'];
+const HEADERS = ['Description', 'Key', 'Type', 'Event Definition', 'Timestamp'];
 
 const TIME_UNITS = ['DAYS', 'HOURS', 'MINUTES', 'SECONDS'];
 
@@ -176,6 +176,7 @@ class Events extends React.Component {
             &nbsp;
             {event.message}
           </td>
+          <td>{event.key || <em>none</em>}</td>
           <td>{event.alert ? <Label bsStyle="warning">Alert</Label> : <Label bsStyle="info">Event</Label>}</td>
           <td>
             {eventDefinitionContext ? (


### PR DESCRIPTION
This change introduces another column in the events overview to show the event key.

![image](https://user-images.githubusercontent.com/461/61141972-fd377880-a4ce-11e9-9d78-06319ced6f6e.png)
