### PR TITLE
Prefix plugin navigation item path with app prefix.

### DIFF
--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -37,7 +37,7 @@ const _isActive = (requestPath, prefix) => {
 };
 
 const formatSinglePluginRoute = ({ description, path, permissions }) => {
-  const link = <NavigationLink key={description} description={description} path={path} />;
+  const link = <NavigationLink key={description} description={description} path={URLUtils.appPrefixed(path)} />;
   if (permissions) {
     return <IfPermitted key={description} permissions={permissions}>{link}</IfPermitted>;
   }

--- a/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
@@ -4,12 +4,18 @@ import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import mockComponent from 'helpers/mocking/MockComponent';
 import Routes from 'routing/Routes';
+import AppConfig from 'util/AppConfig';
 
 jest.mock('./SystemMenu', () => mockComponent('SystemMenu'));
 jest.mock('./NavigationBrand', () => mockComponent('NavigationBrand'));
 jest.mock('./NavigationLink', () => mockComponent('NavigationLink'));
 jest.mock('react-router', () => ({ withRouter: x => x }));
 jest.mock('components/navigation/NotificationBadge', () => mockComponent('NotificationBadge'));
+jest.mock('util/AppConfig', () => ({
+  gl2AppPathPrefix: jest.fn(() => ''),
+  gl2ServerUrl: jest.fn(() => undefined),
+  gl2DevMode: jest.fn(() => false),
+}));
 
 const findLink = (wrapper, title) => wrapper.find(`NavigationLink[description="${title}"]`);
 
@@ -74,6 +80,7 @@ describe('Navigation', () => {
       },
     };
     beforeEach(() => {
+      AppConfig.gl2AppPathPrefix = jest.fn(() => '');
       PluginStore.register(plugin);
     });
     afterEach(() => {
@@ -85,6 +92,14 @@ describe('Navigation', () => {
                                         location={{ pathname: '/' }}
                                         loginName="slowry" />);
       expect(findLink(wrapper, 'Perpetuum Mobile')).toExist();
+    });
+    it('prefix plugin navigation item paths with app prefix', () => {
+      AppConfig.gl2AppPathPrefix.mockReturnValue('/my/crazy/prefix');
+      const wrapper = mount(<Navigation permissions={[]}
+                                        fullName="Sam Lowry"
+                                        location={{ pathname: '/' }}
+                                        loginName="slowry" />);
+      expect(findLink(wrapper, 'Perpetuum Mobile')).toHaveProp('path', '/my/crazy/prefix/something');
     });
     it('does not contain navigation elements from plugins where permissions are missing', () => {
       const wrapper = mount(<Navigation permissions={[]}

--- a/graylog2-web-interface/src/components/navigation/SystemMenu.jsx
+++ b/graylog2-web-interface/src/components/navigation/SystemMenu.jsx
@@ -72,11 +72,12 @@ const SystemMenu = ({ location }) => {
   const pluginSystemNavigations = PluginStore.exports('systemnavigation')
     .sort((route1, route2) => naturalSort(route1.description.toLowerCase(), route2.description.toLowerCase()))
     .map(({ description, path, permissions }) => {
-      const link = <NavigationLink description={description} path={path} />;
+      const prefixedPath = URLUtils.appPrefixed(path);
+      const link = <NavigationLink description={description} path={prefixedPath} />;
       if (permissions) {
         return <IfPermitted key={description} permissions={permissions}>{link}</IfPermitted>;
       }
-      return <NavigationLink key={description} path={path} description={description} />;
+      return <NavigationLink key={description} path={prefixedPath} description={description} />;
     });
 
   return (


### PR DESCRIPTION
## Description
## Motivation and Context

Due to the introduction of #5703, routes in the navigation bar are not
prefixed anymore automatically. Unfortunately this is required for
navigation items coming from plugins, as they have no knowledge about
the configured app path prefix.

This change is now automatically prefixing navigation items coming from
plugins.

Fixes #6149.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.