### PR TITLE
Fix "Routed into streams" element on show message page

### DIFF
--- a/graylog2-web-interface/src/logic/message/MessageFormatter.js
+++ b/graylog2-web-interface/src/logic/message/MessageFormatter.js
@@ -4,25 +4,20 @@ import MessageFieldsFilter from 'logic/message/MessageFieldsFilter';
 const MessageFormatter = {
   formatMessageSummary(messageSummary) {
     const { message } = messageSummary;
-    return this.formatMessage(message._id, messageSummary.index, message, message, messageSummary.highlight_ranges, messageSummary.decoration_stats);
+    return this.formatMessage(message._id, messageSummary.index, message, messageSummary.highlight_ranges, messageSummary.decoration_stats);
   },
 
-  formatResultMessage(resultMessage) {
-    const { message } = resultMessage;
-    return this.formatMessage(message.id, resultMessage.index, message, message.fields, resultMessage.highlight_ranges, resultMessage.decoration_stats);
-  },
-
-  formatMessage(id, index, message, fields, highlightRanges, decorationStats) {
-    const filteredFields = MessageFieldsFilter.filterFields(fields);
+  formatMessage(id, index, message, highlightRanges, decorationStats) {
+    const filteredFields = MessageFieldsFilter.filterFields(message);
     return {
       id: id,
       timestamp: moment(message.timestamp).unix(),
       filtered_fields: filteredFields,
       formatted_fields: filteredFields,
-      fields: fields,
+      fields: message,
       index: index,
-      source_node_id: fields.gl2_source_node,
-      source_input_id: fields.gl2_source_input,
+      source_node_id: message.gl2_source_node,
+      source_input_id: message.gl2_source_input,
       stream_ids: message.streams,
       highlight_ranges: highlightRanges,
       decoration_stats: decorationStats,

--- a/graylog2-web-interface/src/stores/messages/MessagesStore.js
+++ b/graylog2-web-interface/src/stores/messages/MessagesStore.js
@@ -23,7 +23,7 @@ const MessagesStore = Reflux.createStore({
     const { url } = ApiRoutes.MessagesController.single(index.trim(), messageId.trim());
     const promise = fetch('GET', URLUtils.qualifyUrl(url))
       .then(
-        response => MessageFormatter.formatResultMessage(response),
+        response => MessageFormatter.formatMessageSummary(response),
         (errorThrown) => {
           UserNotification.error(`Loading message information failed with status: ${errorThrown}`,
             'Could not load message information');
@@ -58,7 +58,7 @@ const MessagesStore = Reflux.createStore({
 
     const promise = fetch('POST', URLUtils.qualifyUrl(url), payload)
       .then(
-        response => MessageFormatter.formatResultMessage(response),
+        response => MessageFormatter.formatMessageSummary(response),
         (error) => {
           if (error.additional && error.additional.status === 400) {
             UserNotification.error('Please ensure the selected codec and its configuration are right. '


### PR DESCRIPTION
The problem is that the MessageResource returns a ResultMessage instead
of a ResultMessageSummary. Due to that, we serialize the regular Message
object instead of only the fields. This exposes internals of the Message
object and also breaks the "Routed into streams" element on the show
message page because the UI elements don't expect the Message structure.

This change is basically backwards incompatible change for the get
message API because the response gets changed.
We need to check if that's okay.