### PR TITLE
Use stream ids for blacklisting in stream router engine.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamRouterEngine.java
@@ -163,10 +163,10 @@ public class StreamRouterEngine {
      */
     public List<Stream> match(Message message) {
         final Set<Stream> result = Sets.newHashSet();
-        final Set<Stream> blackList = Sets.newHashSet();
+        final Set<String> blackList = Sets.newHashSet();
 
         for (final Rule rule : rulesList) {
-            if (blackList.contains(rule.getStream())) {
+            if (blackList.contains(rule.getStreamId())) {
                 continue;
             }
 
@@ -178,7 +178,7 @@ public class StreamRouterEngine {
                 if (matchingType == Stream.MatchingType.AND) {
                     result.remove(rule.getStream());
                     // blacklist stream because it can't match anymore
-                    blackList.add(rule.getStream());
+                    blackList.add(rule.getStreamId());
                 }
 
                 continue;
@@ -195,13 +195,13 @@ public class StreamRouterEngine {
                 if (matchingType == Stream.MatchingType.AND) {
                     result.remove(rule.getStream());
                     // blacklist stream because it can't match anymore
-                    blackList.add(rule.getStream());
+                    blackList.add(rule.getStreamId());
                 }
             } else {
                 result.add(stream);
                 if (matchingType == Stream.MatchingType.OR) {
                     // blacklist stream because it is already matched
-                    blackList.add(rule.getStream());
+                    blackList.add(rule.getStreamId());
                 }
             }
         }
@@ -327,6 +327,10 @@ public class StreamRouterEngine {
 
         public Stream getStream() {
             return stream;
+        }
+
+        public String getStreamId() {
+            return streamId;
         }
     }
 


### PR DESCRIPTION
## Description
## Motivation and Context
This change is a performance optimization for the stream router engine.
When matching a message against the configured stream rules, it maintains a blacklist containing streams that have already been processed and are a) either unable to match anymore (in case of an `AND`-matched stream that already has a mismatch) or b) have already matched finally (in case of an `OR`-matched stream that already has one match).

This blacklist contains complete `Stream` objects, which means that a check if the stream of the current rule is already blacklisted (by calling `blacklist.contains(obj)`) is generating hash codes for comparison by iterating over all fields of both streams.

In our case comparing the two stream IDs is enough, as they can be considered unique and a mismatch between the two means that the streams are not equal. So this PR is changing the blacklist to a set of strings which allows more lightweight comparison.

Before and after were benchmarked by generating 1000 streams with 10 stream rules each which do not match, leading to a 90% skip rate of streams. Additionally, the stream rules are `GREATER` rules which require the presence of the configured field and the field itself is missing, leading to an automatic mismatch. Each work unit in the benchmark consists of matching 1000 messages against the configured streams.

After a warmup period of 20 work units, the benchmark is started by performing 30 work units for the code before and after this change. The results are the following:

| (durations in ms) | before  | after   |
|-------------------|---------|---------|
| mean              | 610.9   | 251.2   |
| stddev            | +-13.54 | +-24.99 |

This means that in some configurations, the stream router engine overhead (matching, without executing actual matchers) can be reduced by 60%.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.