### PR TITLE
Fix closing of widget filter menu.

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/WidgetFilterMenu.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetFilterMenu.jsx
@@ -2,9 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 
-import connect from 'stores/connect';
-
-import { SearchStore } from 'views/stores/SearchStore';
 import QueryInput from '../searchbar/AsyncQueryInput';
 
 import style from './WidgetFilterMenu.css';
@@ -53,7 +50,7 @@ class WidgetFilterMenu extends React.Component {
           You can limit the results used by this widget by adding a custom filter here.
         </div>
         <div className={style.filterInput}>
-          <QueryInput onChange={value => this.setState({ filter: value })}
+          <QueryInput onChange={value => new Promise(resolve => this.setState({ filter: value }, resolve))}
                       onExecute={this._onUpdate}
                       placeholder="Add new widget filter"
                       maxLines={10}
@@ -79,4 +76,4 @@ class WidgetFilterMenu extends React.Component {
   }
 }
 
-export default connect(WidgetFilterMenu, { search: SearchStore });
+export default WidgetFilterMenu;


### PR DESCRIPTION
## Description
## Motivation and Context

Before this change, closing the widget filter menu popover resulted in
it immediately showing again and logging an error to the console. This
was the result of not passing a function for `onChange` to the
`QueryInput` component that returns a Promise.

This change is fixing that by returning a promise from the `onChange`
handler.

Before:
![WidgetFilterMenu-before](https://user-images.githubusercontent.com/41929/61545178-21eb9d00-aa47-11e9-9bac-876ab03c2f7a.gif)

After:
![WidgetFilterMenu-after](https://user-images.githubusercontent.com/41929/61545216-329c1300-aa47-11e9-97d2-107a9719bf61.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.