### PR TITLE
Improve handling of default configurations in Event Definitions and Notifications

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDetailsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDetailsForm.jsx
@@ -20,6 +20,13 @@ class EventDetailsForm extends React.Component {
     onChange: PropTypes.func.isRequired,
   };
 
+  getConditionPlugin = (type) => {
+    if (type === undefined) {
+      return {};
+    }
+    return PluginStore.exports('eventDefinitionTypes').find(edt => edt.type === type) || {};
+  };
+
   handleChange = (event) => {
     const { name } = event.target;
     const { onChange } = this.props;
@@ -33,8 +40,9 @@ class EventDetailsForm extends React.Component {
 
   handleEventDefinitionTypeChange = (nextType) => {
     const { onChange } = this.props;
-    const nextConfig = { type: nextType };
-    onChange('config', nextConfig);
+    const conditionPlugin = this.getConditionPlugin(nextType);
+    const defaultConfig = conditionPlugin.defaultConfig || {};
+    onChange('config', { ...defaultConfig, type: nextType });
   };
 
   formattedEventDefinitionTypes = () => {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldForm.jsx
@@ -48,6 +48,13 @@ class FieldForm extends React.Component {
     };
   }
 
+  getProviderPlugin = (type) => {
+    if (type === undefined) {
+      return {};
+    }
+    return PluginStore.exports('fieldValueProviders').find(edt => edt.type === type) || {};
+  };
+
   handleSubmit = () => {
     const { fieldName: prevFieldName, onChange } = this.props;
     const { fieldName, config, isKey, keyPosition } = this.state;
@@ -65,7 +72,14 @@ class FieldForm extends React.Component {
 
   handleProviderTypeChange = (nextProvider) => {
     const { config } = this.state;
-    const nextConfig = Object.assign({}, config, { providers: [{ type: nextProvider }] });
+    const providerPlugin = this.getProviderPlugin(nextProvider);
+    const defaultProviderConfig = providerPlugin.defaultConfig || {};
+    const nextConfig = Object.assign({}, config, {
+      providers: [{
+        ...defaultProviderConfig,
+        type: nextProvider,
+      }],
+    });
     this.handleConfigChange(nextConfig);
   };
 
@@ -77,13 +91,6 @@ class FieldForm extends React.Component {
   toggleKey = (event) => {
     const checked = FormsUtils.getValueFromInput(event.target);
     this.setState({ isKey: checked });
-  };
-
-  getProviderPlugin = (type) => {
-    if (type === undefined) {
-      return {};
-    }
-    return PluginStore.exports('fieldValueProviders').find(edt => edt.type === type) || {};
   };
 
   renderFieldValueProviderForm = () => {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.jsx
@@ -33,11 +33,6 @@ const initialAggregationConfig = {
   conditions: {},
 };
 
-const initialConfig = {
-  ...initialFilterConfig,
-  ...initialAggregationConfig,
-};
-
 class FilterAggregationForm extends React.Component {
   static propTypes = {
     action: PropTypes.oneOf(['create', 'edit']).isRequired,
@@ -46,6 +41,11 @@ class FilterAggregationForm extends React.Component {
     entityTypes: PropTypes.object.isRequired,
     streams: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired,
+  };
+
+  static defaultConfig = {
+    ...initialFilterConfig,
+    ...initialAggregationConfig,
   };
 
   constructor(props) {
@@ -61,13 +61,6 @@ class FilterAggregationForm extends React.Component {
       dataSource: defaultDataSource,
       conditionType: defaultConditionType,
     };
-  }
-
-  componentDidMount() {
-    // Set initial config for this type
-    const { eventDefinition } = this.props;
-    const defaultConfig = Object.assign({}, initialConfig, eventDefinition.config);
-    this.propagateChange('config', defaultConfig);
   }
 
   propagateChange = (key, value) => {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/index.js
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/index.js
@@ -1,6 +1,7 @@
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
 
 import FilterAggregationFormContainer from './FilterAggregationFormContainer';
+import FilterAggregationForm from './FilterAggregationForm';
 import FilterAggregationSummary from './FilterAggregationSummary';
 
 PluginStore.register(new PluginManifest({}, {
@@ -10,6 +11,7 @@ PluginStore.register(new PluginManifest({}, {
       displayName: 'Filter & Aggregation',
       formComponent: FilterAggregationFormContainer,
       summaryComponent: FilterAggregationSummary,
+      defaultConfig: FilterAggregationForm.defaultConfig,
     },
   ],
 }));

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
@@ -42,15 +42,17 @@ class EventNotificationForm extends React.Component {
     onChange('config', nextConfig);
   };
 
-  handleTypeChange = (nextType) => {
-    this.handleConfigChange({ type: nextType });
-  };
-
   getNotificationPlugin = (type) => {
     if (type === undefined) {
       return {};
     }
     return PluginStore.exports('eventNotificationTypes').find(n => n.type === type) || {};
+  };
+
+  handleTypeChange = (nextType) => {
+    const notificationPlugin = this.getNotificationPlugin(nextType);
+    const defaultConfig = notificationPlugin.defaultConfig || {};
+    this.handleConfigChange({ ...defaultConfig, type: nextType });
   };
 
   formattedEventNotificationTypes = () => {

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
@@ -41,19 +41,14 @@ class EmailNotificationForm extends React.Component {
     users: PropTypes.array.isRequired,
   };
 
-  componentDidMount() {
-    // Set initial config for this type
-    const { config, onChange } = this.props;
-    const initialConfig = {
-      sender: 'graylog@example.org', // TODO: Default sender should come from the server
-      // eslint-disable-next-line no-template-curly-in-string
-      subject: 'Graylog event notification: ${event_definition_title}', // TODO: Default subject should come from the server
-      body_template: DEFAULT_BODY_TEMPLATE, // TODO: Default body template should come from the server
-      user_recipients: [],
-      email_recipients: [],
-    };
-    onChange(Object.assign({}, initialConfig, config));
-  }
+  static defaultConfig = {
+    sender: 'graylog@example.org', // TODO: Default sender should come from the server
+    // eslint-disable-next-line no-template-curly-in-string
+    subject: 'Graylog event notification: ${event_definition_title}', // TODO: Default subject should come from the server
+    body_template: DEFAULT_BODY_TEMPLATE, // TODO: Default body template should come from the server
+    user_recipients: [],
+    email_recipients: [],
+  };
 
   propagateChange = (key, value) => {
     const { config, onChange } = this.props;

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
@@ -11,14 +11,9 @@ class HttpNotificationForm extends React.Component {
     onChange: PropTypes.func.isRequired,
   };
 
-  componentDidMount() {
-    // Set initial config for this type
-    const { config, onChange } = this.props;
-    const initialConfig = {
-      url: '',
-    };
-    onChange(Object.assign({}, initialConfig, config));
-  }
+  static defaultConfig = {
+    url: '',
+  };
 
   propagateChange = (key, value) => {
     const { config, onChange } = this.props;

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationForm.jsx
@@ -31,10 +31,21 @@ class LegacyNotificationForm extends React.Component {
       .map(typeName => ({ label: `Legacy ${legacyTypes[typeName].name}`, value: typeName }));
   };
 
+  getDefaultConfiguration = (legacyNotificationType) => {
+    const { legacyTypes } = this.props;
+    const { configuration } = legacyTypes[legacyNotificationType];
+    const defaultConfiguration = {};
+    Object.keys(configuration).forEach((configKey) => {
+      defaultConfiguration[configKey] = configuration[configKey].default_value;
+    });
+
+    return defaultConfiguration;
+  };
+
   handleSelectNotificationChange = (nextLegacyNotificationType) => {
     this.propagateMultiChange({
       callback_type: nextLegacyNotificationType,
-      configuration: {},
+      configuration: this.getDefaultConfiguration(nextLegacyNotificationType),
     });
   };
 
@@ -47,7 +58,7 @@ class LegacyNotificationForm extends React.Component {
 
     const configFields = Object.keys(configuration).map((configKey) => {
       const configField = configuration[configKey];
-      const configValue = config.configuration[configKey] || configField.default_value;
+      const configValue = config.configuration[configKey];
 
       return (
         <ConfigurationFormField key={configKey}

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/index.js
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/index.js
@@ -1,6 +1,7 @@
 import { PluginManifest, PluginStore } from 'graylog-web-plugin/plugin';
 
 import EmailNotificationFormContainer from './EmailNotificationFormContainer';
+import EmailNotificationForm from './EmailNotificationForm';
 import EmailNotificationSummary from './EmailNotificationSummary';
 import HttpNotificationForm from './HttpNotificationForm';
 import HttpNotificationSummary from './HttpNotificationSummary';
@@ -14,12 +15,14 @@ PluginStore.register(new PluginManifest({}, {
       displayName: 'Email Notification',
       formComponent: EmailNotificationFormContainer,
       summaryComponent: EmailNotificationSummary,
+      defaultConfig: EmailNotificationForm.defaultConfig,
     },
     {
       type: 'http-notification-v1',
       displayName: 'HTTP Notification',
       formComponent: HttpNotificationForm,
       summaryComponent: HttpNotificationSummary,
+      defaultConfig: HttpNotificationForm.defaultConfig,
     },
     {
       type: 'legacy-alarm-callback-notification-v1',


### PR DESCRIPTION
This PR changes how we handle default configurations from plugins.

Before, plugins had to do it on their own, mostly in the `componentDidMount()` lifecycle state, which is not great place for it and it is also easy to forget. Failing to do so may have ended up in default configuration options not being persisted.

After these changes, plugins can define a `defaultConfig` object, which we set alongside the plugin type. For example, changing the Notification type will get the `defaultConfig` (if any) for the selected type and apply it to the form data. Users can later do changes to those default values.

Applying default configurations on type change also helps us to fix #6185.