### PR TITLE
Unset default sender

### DIFF
--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
@@ -42,7 +42,7 @@ class EmailNotificationForm extends React.Component {
   };
 
   static defaultConfig = {
-    sender: 'graylog@example.org', // TODO: Default sender should come from the server
+    sender: '', // TODO: Default sender should come from the server. The default should be empty or the address configured in the email server settings
     // eslint-disable-next-line no-template-curly-in-string
     subject: 'Graylog event notification: ${event_definition_title}', // TODO: Default subject should come from the server
     body_template: DEFAULT_BODY_TEMPLATE, // TODO: Default body template should come from the server


### PR DESCRIPTION
This setting should default to empty or the value set in the server email server configuration, to avoid users sending emails to an inexistent email address by mistake. Since default settings live for now in the frontend and there is no easy access to email configuration from there, I decided to leave it empty for now.

Fixes #6159