### PR TITLE
Fix error when opening legacy notifications and the plugin is missing

### DIFF
--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationForm.jsx
@@ -77,9 +77,18 @@ class LegacyNotificationForm extends React.Component {
     );
   }
 
+  renderMissingPlugin(pluginType) {
+    return (
+      <Alert bsStyle="danger" className={styles.legacyNotificationAlert}>
+        Unknown legacy alarm callback type: <strong>{pluginType}</strong> Please make sure the plugin is installed.
+      </Alert>
+    );
+  }
+
   render() {
     const { config, legacyTypes } = this.props;
     const callbackType = config.callback_type;
+    const typeData = legacyTypes[callbackType];
 
     return (
       <React.Fragment>
@@ -100,7 +109,7 @@ class LegacyNotificationForm extends React.Component {
           Legacy alarm callbacks are deprecated. Please switch to the new notification types as soon as possible!
         </Alert>
 
-        {callbackType && this.renderNotificationForm(config, legacyTypes[callbackType])}
+        {typeData ? this.renderNotificationForm(config, typeData) : this.renderMissingPlugin(callbackType)}
       </React.Fragment>
     );
   }


### PR DESCRIPTION
If users open an existing legacy notification where the plugin is
missing, the UI throws an error. This fixes it by checking if the plugin
type exists and showing a warning if it's missing.

## Before

![image](https://user-images.githubusercontent.com/461/61963945-1101d500-afcd-11e9-81e2-9dfb158b01c3.png)

## After

![image](https://user-images.githubusercontent.com/461/61963961-19f2a680-afcd-11e9-9a1e-42f058c6d933.png)
