### PR TITLE
Add refresh button to Events page

### DIFF
--- a/graylog2-web-interface/src/components/common/PaginatedList.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.jsx
@@ -46,8 +46,13 @@ class PaginatedList extends React.Component {
   };
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.activePage !== nextProps.activePage) {
+    const { pageSize, activePage } = this.props;
+
+    if (activePage !== nextProps.activePage) {
       this.setState({ currentPage: nextProps.activePage });
+    }
+    if (pageSize !== nextProps.pageSize) {
+      this.setState({ pageSize: nextProps.pageSize });
     }
   }
 

--- a/graylog2-web-interface/src/components/common/SearchForm.jsx
+++ b/graylog2-web-interface/src/components/common/SearchForm.jsx
@@ -42,9 +42,9 @@ class SearchForm extends React.Component {
     /** bsStyle for search button. */
     searchBsStyle: PropTypes.string,
     /** Text to display in the search button. */
-    searchButtonLabel: PropTypes.string,
+    searchButtonLabel: PropTypes.node,
     /** Text to display in the reset button. */
-    resetButtonLabel: PropTypes.string,
+    resetButtonLabel: PropTypes.node,
     /**
      * Text to display in the search button while the search is loading. This
      * will only be used if `useLoadingState` is true.

--- a/graylog2-web-interface/src/components/common/TimeUnitInput.jsx
+++ b/graylog2-web-interface/src/components/common/TimeUnitInput.jsx
@@ -93,6 +93,8 @@ const TimeUnitInput = createReactClass({
     wrapperClassName: PropTypes.string,
     /** Specifies if the input should render a checkbox. Use this if the enabled state is controlled by another input */
     hideCheckbox: PropTypes.bool,
+    /** Align unit dropdown menu to the right. */
+    pullRight: PropTypes.bool,
   },
 
   getDefaultProps() {
@@ -109,6 +111,7 @@ const TimeUnitInput = createReactClass({
       labelClassName: undefined,
       wrapperClassName: undefined,
       hideCheckbox: false,
+      pullRight: false,
     };
   },
 
@@ -176,7 +179,7 @@ const TimeUnitInput = createReactClass({
 
   render() {
     const { unitOptions } = this.state;
-    const { label, wrapperClassName, help, labelClassName, unit, required, hideCheckbox } = this.props;
+    const { label, wrapperClassName, help, labelClassName, unit, required, hideCheckbox, pullRight } = this.props;
 
     const options = unitOptions.map((o) => {
       return (
@@ -203,6 +206,7 @@ const TimeUnitInput = createReactClass({
             <FormControl type="number" disabled={!this._isChecked()} onChange={this._onUpdate} value={this._getEffectiveValue()} />
             <DropdownButton componentClass={InputGroup.Button}
                             id="input-dropdown-addon"
+                            pullRight={pullRight}
                             title={unitOptions.filter(o => o.value === unit)[0].label}
                             disabled={!this._isChecked()}>
               {options}

--- a/graylog2-web-interface/src/components/events/events/EventDetails.jsx
+++ b/graylog2-web-interface/src/components/events/events/EventDetails.jsx
@@ -23,6 +23,21 @@ class EventDetails extends React.Component {
     return PluginStore.exports('eventDefinitionTypes').find(edt => edt.type === type) || {};
   };
 
+  renderEventFields = (eventFields) => {
+    const fieldNames = Object.keys(eventFields);
+    return (
+      <ul>
+        {fieldNames.map((fieldName) => {
+          return (
+            <React.Fragment key={fieldName}>
+              <li><b>{fieldName}</b> {eventFields[fieldName]}</li>
+            </React.Fragment>
+          );
+        })}
+      </ul>
+    );
+  };
+
   render() {
     const { event, eventDefinitionContext } = this.props;
     const plugin = this.getConditionPlugin(event.event_definition_type);

--- a/graylog2-web-interface/src/components/events/events/EventDetails.jsx
+++ b/graylog2-web-interface/src/components/events/events/EventDetails.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import lodash from 'lodash';
+import { Col, Row } from 'react-bootstrap';
+import { Link } from 'react-router';
+import { PluginStore } from 'graylog-web-plugin/plugin';
+
+import { Timestamp } from 'components/common';
+import Routes from 'routing/Routes';
+
+import EventDefinitionPriorityEnum from 'logic/alerts/EventDefinitionPriorityEnum';
+
+class EventDetails extends React.Component {
+  static propTypes = {
+    event: PropTypes.object.isRequired,
+    eventDefinitionContext: PropTypes.object.isRequired,
+  };
+
+  getConditionPlugin = (type) => {
+    if (type === undefined) {
+      return {};
+    }
+    return PluginStore.exports('eventDefinitionTypes').find(edt => edt.type === type) || {};
+  };
+
+  render() {
+    const { event, eventDefinitionContext } = this.props;
+    const plugin = this.getConditionPlugin(event.event_definition_type);
+
+    return (
+      <Row>
+        <Col md={6}>
+          <dl>
+            <dt>ID</dt>
+            <dd>{event.id}</dd>
+            <dt>Priority</dt>
+            <dd>
+              {lodash.capitalize(EventDefinitionPriorityEnum.properties[event.priority].name)}
+            </dd>
+            <dt>Timestamp</dt>
+            <dd>
+              <Timestamp dateTime={event.timestamp} />
+            </dd>
+            <dt>Event Definition</dt>
+            <dd>
+              {eventDefinitionContext ? (
+                <Link to={Routes.NEXT_ALERTS.DEFINITIONS.edit(eventDefinitionContext.id)}>
+                  {eventDefinitionContext.title}
+                </Link>
+              ) : (
+                <em>{event.event_definition_id}</em>
+              )}
+              &emsp;
+              ({plugin.displayName || event.event_definition_type})
+            </dd>
+          </dl>
+        </Col>
+        <Col md={6}>
+          <dl>
+            {event.timerange_start && event.timerange_end && (
+              <React.Fragment>
+                <dt>Aggregation time range</dt>
+                <dd>
+                  <Timestamp dateTime={event.timerange_start} />
+                  &ensp;&mdash;&ensp;
+                  <Timestamp dateTime={event.timerange_end} />
+                </dd>
+              </React.Fragment>
+            )}
+            <dt>Event Key</dt>
+            <dd>{event.key || 'No Key set for this Event.'}</dd>
+            <dt>Additional Fields</dt>
+            {lodash.isEmpty(event.fields)
+              ? <dd>No additional Fields added to this Event.</dd>
+              : this.renderEventFields(event.fields)}
+          </dl>
+        </Col>
+      </Row>
+    );
+  }
+}
+
+export default EventDetails;

--- a/graylog2-web-interface/src/components/events/events/Events.css
+++ b/graylog2-web-interface/src/components/events/events/Events.css
@@ -2,10 +2,6 @@
     margin-top: 10px;
 }
 
-:local(.inline) {
-    display: inline-block;
-}
-
 :local(.priority) {
     font-size: 1.5em;
     vertical-align: top;

--- a/graylog2-web-interface/src/components/events/events/Events.jsx
+++ b/graylog2-web-interface/src/components/events/events/Events.jsx
@@ -28,6 +28,7 @@ class Events extends React.Component {
     onQueryChange: PropTypes.func.isRequired,
     onAlertFilterChange: PropTypes.func.isRequired,
     onTimeRangeChange: PropTypes.func.isRequired,
+    onSearchReload: PropTypes.func.isRequired,
   };
 
   state = {
@@ -161,6 +162,7 @@ class Events extends React.Component {
       onQueryChange,
       onAlertFilterChange,
       onTimeRangeChange,
+      onSearchReload,
     } = this.props;
 
     const eventList = events.map(e => e.event);
@@ -178,6 +180,7 @@ class Events extends React.Component {
                              onAlertFilterChange={onAlertFilterChange}
                              onTimeRangeChange={onTimeRangeChange}
                              onPageSizeChange={this.handlePageSizeChange}
+                             onSearchReload={onSearchReload}
                              pageSize={parameters.pageSize}
                              pageSizes={[10, 25, 50, 100]} />
             <PaginatedList activePage={parameters.page}

--- a/graylog2-web-interface/src/components/events/events/Events.jsx
+++ b/graylog2-web-interface/src/components/events/events/Events.jsx
@@ -77,21 +77,6 @@ class Events extends React.Component {
     );
   };
 
-  renderEventFields = (eventFields) => {
-    const fieldNames = Object.keys(eventFields);
-    return (
-      <ul>
-        {fieldNames.map((fieldName) => {
-          return (
-            <React.Fragment key={fieldName}>
-              <li><b>{fieldName}</b> {eventFields[fieldName]}</li>
-            </React.Fragment>
-          );
-        })}
-      </ul>
-    );
-  };
-
   renderEvent = (event) => {
     const { context } = this.props;
     const { expanded } = this.state;

--- a/graylog2-web-interface/src/components/events/events/Events.jsx
+++ b/graylog2-web-interface/src/components/events/events/Events.jsx
@@ -1,23 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
-import { Alert, Button, ButtonGroup, Col, Label, OverlayTrigger, Row, Table, Tooltip } from 'react-bootstrap';
+import { Alert, Button, Col, Label, OverlayTrigger, Row, Table, Tooltip } from 'react-bootstrap';
 import { Link } from 'react-router';
 import { LinkContainer } from 'react-router-bootstrap';
 import { PluginStore } from 'graylog-web-plugin/plugin';
-import moment from 'moment';
 
-import { EmptyEntity, PaginatedList, SearchForm, Timestamp, TimeUnitInput } from 'components/common';
-import { extractDurationAndUnit } from 'components/common/TimeUnitInput';
+import { EmptyEntity, PaginatedList, Timestamp } from 'components/common';
 import Routes from 'routing/Routes';
 import DateTime from 'logic/datetimes/DateTime';
 import EventDefinitionPriorityEnum from 'logic/alerts/EventDefinitionPriorityEnum';
 
+import EventsSearchBar from './EventsSearchBar';
+
 import styles from './Events.css';
 
 const HEADERS = ['Description', 'Key', 'Type', 'Event Definition', 'Timestamp'];
-
-const TIME_UNITS = ['DAYS', 'HOURS', 'MINUTES', 'SECONDS'];
 
 class Events extends React.Component {
   static propTypes = {
@@ -42,12 +40,6 @@ class Events extends React.Component {
       const nextExpanded = expanded.includes(eventId) ? lodash.without(expanded, eventId) : expanded.concat([eventId]);
       this.setState({ expanded: nextExpanded });
     };
-  };
-
-  updateSearchTimeRange = (nextValue, nextUnit) => {
-    const { onTimeRangeChange } = this.props;
-    const durationInSeconds = moment.duration(nextValue, nextUnit).asSeconds();
-    onTimeRangeChange('relative', durationInSeconds);
   };
 
   getConditionPlugin = (type) => {
@@ -223,10 +215,8 @@ class Events extends React.Component {
       onPageChange,
       onQueryChange,
       onAlertFilterChange,
+      onTimeRangeChange,
     } = this.props;
-
-    const filterAlerts = parameters.filter.alerts;
-    const timerangeDuration = extractDurationAndUnit(parameters.timerange.range * 1000, TIME_UNITS);
 
     const eventList = events.map(e => e.event);
 
@@ -238,37 +228,10 @@ class Events extends React.Component {
       <React.Fragment>
         <Row>
           <Col md={12}>
-            <div className="form-inline">
-              <SearchForm query={parameters.query}
-                          onSearch={onQueryChange}
-                          onReset={onQueryChange}
-                          searchButtonLabel="Find"
-                          placeholder="Find Events"
-                          queryWidth={300}
-                          topMargin={0}
-                          wrapperClass={styles.inline}
-                          useLoadingState />
-
-              <div className="pull-right">
-                <TimeUnitInput id="event-timerange-selector"
-                               update={this.updateSearchTimeRange}
-                               units={TIME_UNITS}
-                               unit={timerangeDuration.unit}
-                               value={timerangeDuration.duration}
-                               label="In the last"
-                               required />
-              </div>
-            </div>
-          </Col>
-        </Row>
-        <Row>
-          <Col md={12}>
-            <ButtonGroup>
-              <Button active={filterAlerts === 'only'} onClick={onAlertFilterChange('only')}>Alerts</Button>
-              <Button active={filterAlerts === 'exclude'} onClick={onAlertFilterChange('exclude')}>Events</Button>
-              <Button active={filterAlerts === 'include'} onClick={onAlertFilterChange('include')}>Both</Button>
-            </ButtonGroup>
-
+            <EventsSearchBar parameters={parameters}
+                             onQueryChange={onQueryChange}
+                             onAlertFilterChange={onAlertFilterChange}
+                             onTimeRangeChange={onTimeRangeChange} />
             <PaginatedList activePage={parameters.page}
                            pageSize={parameters.pageSize}
                            pageSizes={[10, 25, 50, 100]}

--- a/graylog2-web-interface/src/components/events/events/Events.jsx
+++ b/graylog2-web-interface/src/components/events/events/Events.jsx
@@ -34,6 +34,11 @@ class Events extends React.Component {
     expanded: [],
   };
 
+  handlePageSizeChange = (nextPageSize) => {
+    const { onPageChange } = this.props;
+    onPageChange(1, nextPageSize);
+  };
+
   expandRow = (eventId) => {
     return () => {
       const { expanded } = this.state;
@@ -171,10 +176,13 @@ class Events extends React.Component {
             <EventsSearchBar parameters={parameters}
                              onQueryChange={onQueryChange}
                              onAlertFilterChange={onAlertFilterChange}
-                             onTimeRangeChange={onTimeRangeChange} />
+                             onTimeRangeChange={onTimeRangeChange}
+                             onPageSizeChange={this.handlePageSizeChange}
+                             pageSize={parameters.pageSize}
+                             pageSizes={[10, 25, 50, 100]} />
             <PaginatedList activePage={parameters.page}
                            pageSize={parameters.pageSize}
-                           pageSizes={[10, 25, 50, 100]}
+                           showPageSizeSelect={false}
                            totalItems={totalEvents}
                            onChange={onPageChange}>
               {eventList.length === 0 ? (

--- a/graylog2-web-interface/src/components/events/events/EventsContainer.jsx
+++ b/graylog2-web-interface/src/components/events/events/EventsContainer.jsx
@@ -82,6 +82,12 @@ class EventsContainer extends React.Component {
     });
   };
 
+  handleSearchReload = (callback = () => {}) => {
+    const { events } = this.props;
+    const promise = this.fetchEvents(events.parameters);
+    promise.finally(callback);
+  };
+
   render() {
     const { events, eventDefinitions } = this.props;
     const isLoading = !events.events || !eventDefinitions.eventDefinitions;
@@ -99,7 +105,8 @@ class EventsContainer extends React.Component {
               onQueryChange={this.handleQueryChange}
               onPageChange={this.handlePageChange}
               onAlertFilterChange={this.handleAlertFilterChange}
-              onTimeRangeChange={this.handleTimeRangeChange} />
+              onTimeRangeChange={this.handleTimeRangeChange}
+              onSearchReload={this.handleSearchReload} />
     );
   }
 }

--- a/graylog2-web-interface/src/components/events/events/EventsSearchBar.css
+++ b/graylog2-web-interface/src/components/events/events/EventsSearchBar.css
@@ -1,0 +1,3 @@
+:local(.inline) {
+    display: inline-block;
+}

--- a/graylog2-web-interface/src/components/events/events/EventsSearchBar.css
+++ b/graylog2-web-interface/src/components/events/events/EventsSearchBar.css
@@ -1,3 +1,41 @@
-:local(.inline) {
-    display: inline-block;
+:local(.eventsSearchBar) {
+    display: flex;
+    flex-flow: column nowrap;
+    margin-bottom: 15px;
+}
+
+@media all and (max-width: 768px) {
+    :local(.eventsSearchBar) > div {
+        flex-flow: column nowrap;
+    }
+}
+
+:local(.eventsSearchBar) > div {
+    display: flex;
+    flex-flow: row nowrap;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 10px;
+}
+
+:local(.eventsSearchBar) .form-group {
+    margin-bottom: 0;
+}
+
+:local(.searchForm) {
+    flex: 0 1 45%;
+    margin-right: 10px;
+}
+
+:local(.searchForm) .form-inline {
+    display: flex;
+    flex-flow: row nowrap;
+}
+
+:local(.searchForm) .form-group:first-child {
+    flex: 1 100%;
+}
+
+:local(.searchForm) .form-group:not(:first-child) {
+    margin-right: 5px;
 }

--- a/graylog2-web-interface/src/components/events/events/EventsSearchBar.jsx
+++ b/graylog2-web-interface/src/components/events/events/EventsSearchBar.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, ButtonGroup, Col, Row } from 'react-bootstrap';
+import moment from 'moment';
+
+import { SearchForm, TimeUnitInput } from 'components/common';
+import { extractDurationAndUnit } from 'components/common/TimeUnitInput';
+
+import styles from './EventsSearchBar.css';
+
+const TIME_UNITS = ['DAYS', 'HOURS', 'MINUTES', 'SECONDS'];
+
+class EventsSearchBar extends React.Component {
+  static propTypes = {
+    parameters: PropTypes.object.isRequired,
+    onQueryChange: PropTypes.func.isRequired,
+    onAlertFilterChange: PropTypes.func.isRequired,
+    onTimeRangeChange: PropTypes.func.isRequired,
+  };
+
+  updateSearchTimeRange = (nextValue, nextUnit) => {
+    const { onTimeRangeChange } = this.props;
+    const durationInSeconds = moment.duration(nextValue, nextUnit).asSeconds();
+    onTimeRangeChange('relative', durationInSeconds);
+  };
+
+  render() {
+    const { parameters, onQueryChange, onAlertFilterChange } = this.props;
+
+    const filterAlerts = parameters.filter.alerts;
+    const timerangeDuration = extractDurationAndUnit(parameters.timerange.range * 1000, TIME_UNITS);
+
+    return (
+      <Row>
+        <Col md={12}>
+          <div className="form-inline">
+            <SearchForm query={parameters.query}
+                        onSearch={onQueryChange}
+                        onReset={onQueryChange}
+                        searchButtonLabel="Find"
+                        placeholder="Find Events"
+                        queryWidth={300}
+                        topMargin={0}
+                        wrapperClass={styles.inline}
+                        useLoadingState />
+
+            <div className="pull-right">
+              <TimeUnitInput id="event-timerange-selector"
+                             update={this.updateSearchTimeRange}
+                             units={TIME_UNITS}
+                             unit={timerangeDuration.unit}
+                             value={timerangeDuration.duration}
+                             label="In the last"
+                             required />
+            </div>
+          </div>
+        </Col>
+
+        <Col md={12}>
+          <ButtonGroup>
+            <Button active={filterAlerts === 'only'} onClick={onAlertFilterChange('only')}>Alerts</Button>
+            <Button active={filterAlerts === 'exclude'} onClick={onAlertFilterChange('exclude')}>Events</Button>
+            <Button active={filterAlerts === 'include'} onClick={onAlertFilterChange('include')}>Both</Button>
+          </ButtonGroup>
+        </Col>
+      </Row>
+    );
+  }
+}
+
+export default EventsSearchBar;

--- a/graylog2-web-interface/src/components/events/events/EventsSearchBar.jsx
+++ b/graylog2-web-interface/src/components/events/events/EventsSearchBar.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, ButtonGroup, Col, Row } from 'react-bootstrap';
+import { Button, ButtonGroup, ControlLabel, FormControl, FormGroup } from 'react-bootstrap';
 import moment from 'moment';
 
 import { SearchForm, TimeUnitInput } from 'components/common';
 import { extractDurationAndUnit } from 'components/common/TimeUnitInput';
+import FormsUtils from 'util/FormsUtils';
 
 import styles from './EventsSearchBar.css';
 
@@ -13,9 +14,12 @@ const TIME_UNITS = ['DAYS', 'HOURS', 'MINUTES', 'SECONDS'];
 class EventsSearchBar extends React.Component {
   static propTypes = {
     parameters: PropTypes.object.isRequired,
+    pageSize: PropTypes.number.isRequired,
+    pageSizes: PropTypes.array.isRequired,
     onQueryChange: PropTypes.func.isRequired,
     onAlertFilterChange: PropTypes.func.isRequired,
     onTimeRangeChange: PropTypes.func.isRequired,
+    onPageSizeChange: PropTypes.func.isRequired,
   };
 
   updateSearchTimeRange = (nextValue, nextUnit) => {
@@ -24,8 +28,13 @@ class EventsSearchBar extends React.Component {
     onTimeRangeChange('relative', durationInSeconds);
   };
 
+  handlePageSizeChange = (event) => {
+    const { onPageSizeChange } = this.props;
+    onPageSizeChange(FormsUtils.getValueFromInput(event.target));
+  };
+
   render() {
-    const { parameters, onQueryChange, onAlertFilterChange } = this.props;
+    const { parameters, pageSize, pageSizes, onQueryChange, onAlertFilterChange } = this.props;
 
     const filterAlerts = parameters.filter.alerts;
     const timerangeDuration = extractDurationAndUnit(parameters.timerange.range * 1000, TIME_UNITS);
@@ -62,6 +71,13 @@ class EventsSearchBar extends React.Component {
             <Button active={filterAlerts === 'exclude'} onClick={onAlertFilterChange('exclude')}>Events</Button>
             <Button active={filterAlerts === 'include'} onClick={onAlertFilterChange('include')}>Both</Button>
           </ButtonGroup>
+
+          <FormGroup className="form-inline">
+            <ControlLabel>Show</ControlLabel>
+            <FormControl componentClass="select" bsSize="small" value={pageSize} onChange={this.handlePageSizeChange}>
+              {pageSizes.map(size => <option key={`option-${size}`} value={size}>{size}</option>)}
+            </FormControl>
+          </FormGroup>
         </Col>
       </Row>
     );

--- a/graylog2-web-interface/src/components/events/events/EventsSearchBar.jsx
+++ b/graylog2-web-interface/src/components/events/events/EventsSearchBar.jsx
@@ -40,32 +40,30 @@ class EventsSearchBar extends React.Component {
     const timerangeDuration = extractDurationAndUnit(parameters.timerange.range * 1000, TIME_UNITS);
 
     return (
-      <Row>
-        <Col md={12}>
-          <div className="form-inline">
+      <div className={styles.eventsSearchBar}>
+        <div>
+          <div className={styles.searchForm}>
             <SearchForm query={parameters.query}
                         onSearch={onQueryChange}
-                        onReset={onQueryChange}
-                        searchButtonLabel="Find"
+                        searchButtonLabel={<i className="fa fa-search" />}
+                        loadingLabel=""
                         placeholder="Find Events"
-                        queryWidth={300}
+                        queryWidth="100%"
                         topMargin={0}
-                        wrapperClass={styles.inline}
-                        useLoadingState />
-
-            <div className="pull-right">
-              <TimeUnitInput id="event-timerange-selector"
-                             update={this.updateSearchTimeRange}
-                             units={TIME_UNITS}
-                             unit={timerangeDuration.unit}
-                             value={timerangeDuration.duration}
-                             label="In the last"
-                             required />
-            </div>
+                        useLoadingState>
+              <Button><i className="fa fa-refresh" /></Button>
+            </SearchForm>
           </div>
-        </Col>
 
-        <Col md={12}>
+          <TimeUnitInput id="event-timerange-selector"
+                         update={this.updateSearchTimeRange}
+                         units={TIME_UNITS}
+                         unit={timerangeDuration.unit}
+                         value={timerangeDuration.duration}
+                         pullRight
+                         required />
+        </div>
+        <div>
           <ButtonGroup>
             <Button active={filterAlerts === 'only'} onClick={onAlertFilterChange('only')}>Alerts</Button>
             <Button active={filterAlerts === 'exclude'} onClick={onAlertFilterChange('exclude')}>Events</Button>
@@ -78,8 +76,8 @@ class EventsSearchBar extends React.Component {
               {pageSizes.map(size => <option key={`option-${size}`} value={size}>{size}</option>)}
             </FormControl>
           </FormGroup>
-        </Col>
-      </Row>
+        </div>
+      </div>
     );
   }
 }

--- a/graylog2-web-interface/src/components/events/events/EventsSearchBar.jsx
+++ b/graylog2-web-interface/src/components/events/events/EventsSearchBar.jsx
@@ -20,6 +20,11 @@ class EventsSearchBar extends React.Component {
     onAlertFilterChange: PropTypes.func.isRequired,
     onTimeRangeChange: PropTypes.func.isRequired,
     onPageSizeChange: PropTypes.func.isRequired,
+    onSearchReload: PropTypes.func.isRequired,
+  };
+
+  state = {
+    isReloadingResults: false,
   };
 
   updateSearchTimeRange = (nextValue, nextUnit) => {
@@ -33,8 +38,19 @@ class EventsSearchBar extends React.Component {
     onPageSizeChange(FormsUtils.getValueFromInput(event.target));
   };
 
+  resetLoadingState = () => {
+    this.setState({ isReloadingResults: false });
+  };
+
+  handleSearchReload = () => {
+    this.setState({ isReloadingResults: true });
+    const { onSearchReload } = this.props;
+    onSearchReload(this.resetLoadingState);
+  };
+
   render() {
     const { parameters, pageSize, pageSizes, onQueryChange, onAlertFilterChange } = this.props;
+    const { isReloadingResults } = this.state;
 
     const filterAlerts = parameters.filter.alerts;
     const timerangeDuration = extractDurationAndUnit(parameters.timerange.range * 1000, TIME_UNITS);
@@ -51,7 +67,9 @@ class EventsSearchBar extends React.Component {
                         queryWidth="100%"
                         topMargin={0}
                         useLoadingState>
-              <Button><i className="fa fa-refresh" /></Button>
+              <Button onClick={this.handleSearchReload} disabled={isReloadingResults}>
+                <i className={`fa fa-refresh ${isReloadingResults ? 'fa-spin' : ''}`} />
+              </Button>
             </SearchForm>
           </div>
 


### PR DESCRIPTION
This PR adds the functionality to manually refresh the Alert/Event list.
It additionally refactor the `Events` component to make it more modular and improves the overall styling of the Event search controls.

![Screenshot 2019-07-29 at 16 58 44](https://user-images.githubusercontent.com/716185/62058706-258adb00-b222-11e9-9f88-8b00b16e59b8.png)

Fixes #6154