### PR TITLE
 Fix issue showing unknown legacy type warning when creating notification

### DIFF
--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationForm.jsx
@@ -77,18 +77,21 @@ class LegacyNotificationForm extends React.Component {
     );
   }
 
-  renderMissingPlugin(pluginType) {
-    return (
-      <Alert bsStyle="danger" className={styles.legacyNotificationAlert}>
-        Unknown legacy alarm callback type: <strong>{pluginType}</strong> Please make sure the plugin is installed.
-      </Alert>
-    );
-  }
-
   render() {
     const { config, legacyTypes } = this.props;
     const callbackType = config.callback_type;
     const typeData = legacyTypes[callbackType];
+
+    let content;
+    if (typeData) {
+      content = this.renderNotificationForm(config, typeData);
+    } else {
+      content = (
+        <Alert bsStyle="danger" className={styles.legacyNotificationAlert}>
+          Unknown legacy alarm callback type: <strong>{callbackType}</strong> Please make sure the plugin is installed.
+        </Alert>
+      );
+    }
 
     return (
       <React.Fragment>
@@ -109,7 +112,7 @@ class LegacyNotificationForm extends React.Component {
           Legacy alarm callbacks are deprecated. Please switch to the new notification types as soon as possible!
         </Alert>
 
-        {typeData ? this.renderNotificationForm(config, typeData) : this.renderMissingPlugin(callbackType)}
+        {content}
       </React.Fragment>
     );
   }

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationForm.jsx
@@ -85,7 +85,7 @@ class LegacyNotificationForm extends React.Component {
     let content;
     if (typeData) {
       content = this.renderNotificationForm(config, typeData);
-    } else {
+    } else if (callbackType) {
       content = (
         <Alert bsStyle="danger" className={styles.legacyNotificationAlert}>
           Unknown legacy alarm callback type: <strong>{callbackType}</strong> Please make sure the plugin is installed.


### PR DESCRIPTION
Only show the warning if a legacy type has been selected but that type cannot be found.

Fixes #6218 