### PR TITLE
Cleanup stale job trigger on server startup

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/scheduler/JobExecutionEngine.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/JobExecutionEngine.java
@@ -73,9 +73,9 @@ public class JobExecutionEngine {
     private void cleanup() {
         // The cleanup should only run once before starting job processing to avoid damaging any state.
         if (shouldCleanup.getAndSet(false)) {
-            final int releasedTrigger = jobTriggerService.forceReleaseOwnedTriggers();
-            if (releasedTrigger > 0) {
-                LOG.warn("Force-released {} stale job trigger after an unclean job scheduler shutdown", releasedTrigger);
+            final int releasedTriggers = jobTriggerService.forceReleaseOwnedTriggers();
+            if (releasedTriggers > 0) {
+                LOG.warn("Force-released {} stale job triggers after an unclean job scheduler shutdown", releasedTriggers);
             }
         }
     }

--- a/graylog2-server/src/test/resources/org/graylog/scheduler/stale-job-triggers.json
+++ b/graylog2-server/src/test/resources/org/graylog/scheduler/stale-job-triggers.json
@@ -1,0 +1,185 @@
+{
+  "scheduler_triggers": [
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0000"
+      },
+      "job_definition_id": "54e3deadbeefdeadbeefaff3",
+      "start_time": {
+        "$date": "2019-01-01T00:00:00.000Z"
+      },
+      "next_time": {
+        "$date": "2019-01-01T02:00:00.000Z"
+      },
+      "created_at": {
+        "$date": "2019-01-01T00:00:00.000Z"
+      },
+      "updated_at": {
+        "$date": "2019-01-01T00:00:00.000Z"
+      },
+      "status": "runnable",
+      "lock": {
+        "owner": null,
+        "clock": 0,
+        "progress": 0
+      },
+      "schedule": {
+        "type": "interval",
+        "interval": 1,
+        "unit": "SECONDS"
+      },
+      "data": null
+    },
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0001"
+      },
+      "job_definition_id": "54e3deadbeefdeadbeefaff3",
+      "start_time": {
+        "$date": "2019-01-01T00:00:00.000Z"
+      },
+      "end_time": {
+        "$date": "2019-01-31T00:00:00.000Z"
+      },
+      "next_time": {
+        "$date": "2019-01-01T03:00:00.000Z"
+      },
+      "created_at": {
+        "$date": "2019-01-01T00:00:00.000Z"
+      },
+      "updated_at": {
+        "$date": "2019-01-01T00:00:00.000Z"
+      },
+      "status": "running",
+      "lock": {
+        "owner": "node-1",
+        "last_lock_time": null,
+        "clock": 0,
+        "progress": 0
+      },
+      "schedule": {
+        "type": "interval",
+        "interval": 1,
+        "unit": "SECONDS"
+      },
+      "data": {
+        "type": "__test_job_trigger_data__",
+        "map": {
+          "hello": "world"
+        }
+      }
+    },
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0002"
+      },
+      "job_definition_id": "54e3deadbeefdeadbeefaff4",
+      "start_time": {
+        "$date": "2019-01-01T00:00:00.000Z"
+      },
+      "next_time": {
+        "$date": "2019-01-01T00:00:00.000Z"
+      },
+      "created_at": {
+        "$date": "2019-01-01T00:00:00.000Z"
+      },
+      "updated_at": {
+        "$date": "2019-01-01T00:00:00.000Z"
+      },
+      "triggered_at": {
+        "$date": "2019-01-01T01:00:00.000Z"
+      },
+      "status": "running",
+      "lock": {
+        "owner": "node-2",
+        "last_lock_time": {
+          "$date": "2019-01-01T01:00:00.000Z"
+        },
+        "clock": 5,
+        "progress": 80
+      },
+      "schedule": {
+        "type": "interval",
+        "interval": 1,
+        "unit": "SECONDS"
+      },
+      "data": {
+        "type": "__test_job_trigger_data__",
+        "map": {
+          "hello": "world"
+        }
+      }
+    },
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0003"
+      },
+      "job_definition_id": "54e3deadbeefdeadbeefaff5",
+      "start_time": {
+        "$date": "2019-01-01T00:00:00.000Z"
+      },
+      "next_time": {
+        "$date": "2019-01-01T00:00:00.000Z"
+      },
+      "created_at": {
+        "$date": "2019-01-01T00:00:00.000Z"
+      },
+      "updated_at": {
+        "$date": "2019-01-01T00:00:00.000Z"
+      },
+      "triggered_at": {
+        "$date": "2019-01-01T01:00:00.000Z"
+      },
+      "status": "complete",
+      "lock": {
+        "owner": null,
+        "last_lock_time": null,
+        "clock": 0,
+        "progress": 0
+      },
+      "schedule": {
+        "type": "once"
+      },
+      "data": null
+    },
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0004"
+      },
+      "job_definition_id": "54e3deadbeefdeadbeefaff3",
+      "start_time": {
+        "$date": "2019-01-01T00:00:00.000Z"
+      },
+      "end_time": {
+        "$date": "2019-01-31T00:00:00.000Z"
+      },
+      "next_time": {
+        "$date": "2019-01-01T03:00:00.000Z"
+      },
+      "created_at": {
+        "$date": "2019-01-01T00:00:00.000Z"
+      },
+      "updated_at": {
+        "$date": "2019-01-01T00:00:00.000Z"
+      },
+      "status": "running",
+      "lock": {
+        "owner": "node-1",
+        "last_lock_time": null,
+        "clock": 0,
+        "progress": 0
+      },
+      "schedule": {
+        "type": "interval",
+        "interval": 1,
+        "unit": "SECONDS"
+      },
+      "data": {
+        "type": "__test_job_trigger_data__",
+        "map": {
+          "hello": "world"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This will only cleanup trigger that are owned by the calling server
node. It will fix stale job trigger after an unclean JVM or server
shutdown.

Closes Graylog2/graylog-plugin-enterprise#1139