### PR TITLE
Change JobSchedulerConfig interface

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/scheduler/DefaultJobSchedulerConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/DefaultJobSchedulerConfig.java
@@ -40,13 +40,18 @@ public class DefaultJobSchedulerConfig implements JobSchedulerConfig {
     }
 
     @Override
-    public boolean canRun() {
+    public boolean canStart() {
         try {
             return nodeService.byNodeId(nodeId).isMaster();
         } catch (NodeNotFoundException e) {
             LOG.error("Couldn't find current node <{}> in the database", nodeId.toString(), e);
             return false;
         }
+    }
+
+    @Override
+    public boolean canExecute() {
+        return true;
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/scheduler/JobSchedulerConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/JobSchedulerConfig.java
@@ -21,11 +21,19 @@ package org.graylog.scheduler;
  */
 public interface JobSchedulerConfig {
     /**
-     * Determines if the scheduler is can start.
+     * Determines if the scheduler can start.
      *
      * @return true if the scheduler can be started, false otherwise
      */
-    boolean canRun();
+    boolean canStart();
+
+    /**
+     * Determines if the scheduler can execute the next loop iteration.
+     * This method will be called at the beginning of each scheduler loop iteration so it should be fast!
+     *
+     * @return true if scheduler can execute next loop iteration
+     */
+    boolean canExecute();
 
     /**
      * The number of worker threads to start.

--- a/graylog2-server/src/main/java/org/graylog/scheduler/JobSchedulerService.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/JobSchedulerService.java
@@ -50,8 +50,14 @@ public class JobSchedulerService extends AbstractExecutionThreadService {
 
     @Override
     protected void run() throws Exception {
-        if (schedulerConfig.canRun()) {
+        if (schedulerConfig.canStart()) {
             while (isRunning()) {
+                if (!schedulerConfig.canExecute()) {
+                    LOG.info("Couldn't execute next scheduler loop iteration. Waiting and trying again.");
+                    clock.sleepUninterruptibly(1, TimeUnit.SECONDS);
+                    continue;
+                }
+
                 LOG.debug("Starting scheduler loop iteration");
                 try {
                     if (!jobExecutionEngine.execute() && isRunning()) {


### PR DESCRIPTION
- Rename "canRun" to "canStart"
- Add "canExecute"

Also don't run scheduler loop if "canExecute" returns false. In that
case sleep for a while and retry.

(Tests will fail because of missing changes in plugins.)