### PR TITLE
Avoid logging excessive exceptions in ProxiedResource

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
@@ -83,7 +83,11 @@ public abstract class ProxiedResource extends RestResource {
                                     return Optional.<FinalResponseType>empty();
                                 }
                             } catch (IOException e) {
-                                LOG.warn("Unable to call {} on node <{}>", call.request().url(), node, e);
+                                if (LOG.isDebugEnabled()) {
+                                    LOG.warn("Unable to call {} on node <{}>", call.request().url(), node, e);
+                                } else {
+                                    LOG.warn("Unable to call {} on node <{}>: {}", call.request().url(), node, e.getMessage());
+                                }
                                 return Optional.<FinalResponseType>empty();
                             }
                         }))


### PR DESCRIPTION
Connection errors in ProxiedResource can happen if other nodes in the cluster are restarting. Only log the stack trace if `DEBUG` is enabled for the logger. Otherwise log a one-line message.

<details>
  <summary>Example stack trace</summary>

```
2019-07-31 23:37:03,022 WARN : org.graylog2.shared.rest.resources.ProxiedResource - Unable to call http://127.0.0.1:9010/api/system/metrics/multiple on node <38fe132d-0a9a-4194-ae18-73d9fd1e134c>
java.net.ConnectException: Failed to connect to /127.0.0.1:9010
	at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.java:265) ~[okhttp-3.14.2.jar:?]
	at okhttp3.internal.connection.RealConnection.connect(RealConnection.java:183) ~[okhttp-3.14.2.jar:?]
	at okhttp3.internal.connection.ExchangeFinder.findConnection(ExchangeFinder.java:224) ~[okhttp-3.14.2.jar:?]
	at okhttp3.internal.connection.ExchangeFinder.findHealthyConnection(ExchangeFinder.java:108) ~[okhttp-3.14.2.jar:?]
	at okhttp3.internal.connection.ExchangeFinder.find(ExchangeFinder.java:88) ~[okhttp-3.14.2.jar:?]
	at okhttp3.internal.connection.Transmitter.newExchange(Transmitter.java:169) ~[okhttp-3.14.2.jar:?]
	at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.java:41) ~[okhttp-3.14.2.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[okhttp-3.14.2.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[okhttp-3.14.2.jar:?]
	at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.java:94) ~[okhttp-3.14.2.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[okhttp-3.14.2.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[okhttp-3.14.2.jar:?]
	at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.java:93) ~[okhttp-3.14.2.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[okhttp-3.14.2.jar:?]
	at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.java:88) ~[okhttp-3.14.2.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[okhttp-3.14.2.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[okhttp-3.14.2.jar:?]
	at org.graylog2.rest.RemoteInterfaceProvider.lambda$get$0(RemoteInterfaceProvider.java:61) ~[classes/:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:142) ~[okhttp-3.14.2.jar:?]
	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:117) ~[okhttp-3.14.2.jar:?]
	at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.java:221) ~[okhttp-3.14.2.jar:?]
	at okhttp3.RealCall.execute(RealCall.java:81) ~[okhttp-3.14.2.jar:?]
	at retrofit2.OkHttpCall.execute(OkHttpCall.java:188) ~[retrofit-2.6.0.jar:?]
	at org.graylog2.shared.rest.resources.ProxiedResource.lambda$null$0(ProxiedResource.java:78) ~[classes/:?]
	at java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:266) [?:1.8.0_222]
	at java.util.concurrent.FutureTask.run(FutureTask.java) [?:1.8.0_222]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:1.8.0_222]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:1.8.0_222]
	at java.lang.Thread.run(Thread.java:748) [?:1.8.0_222]
Caused by: java.net.ConnectException: Connection refused (Connection refused)
	at java.net.PlainSocketImpl.socketConnect(Native Method) ~[?:1.8.0_222]
	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350) ~[?:1.8.0_222]
	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206) ~[?:1.8.0_222]
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188) ~[?:1.8.0_222]
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392) ~[?:1.8.0_222]
	at java.net.Socket.connect(Socket.java:589) ~[?:1.8.0_222]
	at okhttp3.internal.platform.Platform.connectSocket(Platform.java:130) ~[okhttp-3.14.2.jar:?]
	at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.java:263) ~[okhttp-3.14.2.jar:?]
	... 28 more
```

</details>

With this PR it looks like the following. (multiple messages)

```
2019-07-31 23:58:08,707 WARN : org.graylog2.shared.rest.resources.ProxiedResource - Unable to call http://127.0.0.1:9010/api/system/metrics/multiple on node <38fe132d-0a9a-4194-ae18-73d9fd1e134c>: Failed to connect to /127.0.0.1:9010
2019-07-31 23:58:09,021 WARN : org.graylog2.shared.rest.resources.ProxiedResource - Unable to call http://127.0.0.1:9010/api/system/metrics/multiple on node <38fe132d-0a9a-4194-ae18-73d9fd1e134c>: Failed to connect to /127.0.0.1:9010
2019-07-31 23:58:09,479 WARN : org.graylog2.shared.rest.resources.ProxiedResource - Unable to call http://127.0.0.1:9010/api/system/inputstates on node <38fe132d-0a9a-4194-ae18-73d9fd1e134c>: Failed to connect to /127.0.0.1:9010
2019-07-31 23:58:10,471 WARN : org.graylog2.shared.rest.resources.ProxiedResource - Unable to call http://127.0.0.1:9010/api/system/metrics/multiple on node <38fe132d-0a9a-4194-ae18-73d9fd1e134c>: Failed to connect to /127.0.0.1:9010
2019-07-31 23:58:18,468 WARN : org.graylog2.shared.rest.resources.ProxiedResource - Unable to call http://127.0.0.1:9010/api/system/metrics/multiple on node <38fe132d-0a9a-4194-ae18-73d9fd1e134c>: Failed to connect to /127.0.0.1:9010
2019-07-31 23:58:19,016 WARN : org.graylog2.shared.rest.resources.ProxiedResource - Unable to call http://127.0.0.1:9010/api/system/metrics/multiple on node <38fe132d-0a9a-4194-ae18-73d9fd1e134c>: Failed to connect to /127.0.0.1:9010
```