### PR TITLE
Validate forms

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/legacy/LegacyAlarmCallbackEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/legacy/LegacyAlarmCallbackEventNotificationConfig.java
@@ -26,6 +26,7 @@ import org.graylog.events.event.EventDto;
 import org.graylog.events.notifications.EventNotificationConfig;
 import org.graylog.events.notifications.EventNotificationExecutionJob;
 import org.graylog.scheduler.JobTriggerData;
+import org.graylog2.plugin.rest.ValidationResult;
 
 import java.util.Map;
 
@@ -51,6 +52,17 @@ public abstract class LegacyAlarmCallbackEventNotificationConfig implements Even
 
     public static Builder builder() {
         return Builder.create();
+    }
+
+    @JsonIgnore
+    public ValidationResult validate() {
+        final ValidationResult validation = new ValidationResult();
+
+        if (callbackType().isEmpty()) {
+            validation.addError(FIELD_CALLBACK_TYPE, "Legacy Notification callback type cannot be empty.");
+        }
+
+        return validation;
     }
 
     @AutoValue.Builder

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/EventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/EventNotificationConfig.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.graylog.events.event.EventDto;
 import org.graylog.scheduler.JobTriggerData;
+import org.graylog2.plugin.rest.ValidationResult;
 
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
@@ -43,9 +44,17 @@ public interface EventNotificationConfig {
     @JsonIgnore
     JobTriggerData toJobTriggerData(EventDto dto);
 
+    @JsonIgnore
+    ValidationResult validate();
+
     class FallbackNotificationConfig implements EventNotificationConfig {
         @Override
         public String type() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ValidationResult validate() {
             throw new UnsupportedOperationException();
         }
 

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationDto.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationDto.java
@@ -17,9 +17,11 @@
 package org.graylog.events.notifications;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import org.graylog2.plugin.rest.ValidationResult;
 import org.mongojack.Id;
 import org.mongojack.ObjectId;
 
@@ -53,6 +55,23 @@ public abstract class NotificationDto {
     }
 
     public abstract Builder toBuilder();
+
+    @JsonIgnore
+    public ValidationResult validate() {
+        final ValidationResult validation = new ValidationResult();
+
+        if (title().isEmpty()) {
+            validation.addError(FIELD_TITLE, "Notification title cannot be empty.");
+        }
+
+        try {
+            validation.addAll(config().validate());
+        } catch (UnsupportedOperationException e) {
+            validation.addError(FIELD_CONFIG, "Notification config type cannot be empty.");
+        }
+
+        return validation;
+    }
 
     @AutoValue.Builder
     public static abstract class Builder {

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailEventNotificationConfig.java
@@ -27,6 +27,7 @@ import org.graylog.events.event.EventDto;
 import org.graylog.events.notifications.EventNotificationConfig;
 import org.graylog.events.notifications.EventNotificationExecutionJob;
 import org.graylog.scheduler.JobTriggerData;
+import org.graylog2.plugin.rest.ValidationResult;
 
 import javax.validation.constraints.NotBlank;
 import java.util.Set;
@@ -92,6 +93,26 @@ public abstract class EmailEventNotificationConfig implements EventNotificationC
     @JsonIgnore
     public JobTriggerData toJobTriggerData(EventDto dto) {
         return EventNotificationExecutionJob.Data.builder().eventDto(dto).build();
+    }
+
+    @JsonIgnore
+    public ValidationResult validate() {
+        final ValidationResult validation = new ValidationResult();
+
+        if (sender().isEmpty()) {
+            validation.addError(FIELD_SENDER, "Email Notification sender cannot be empty.");
+        }
+        if (subject().isEmpty()) {
+            validation.addError(FIELD_SUBJECT, "Email Notification subject cannot be empty.");
+        }
+        if (bodyTemplate().isEmpty()) {
+            validation.addError(FIELD_BODY_TEMPLATE, "Email Notification body template cannot be empty.");
+        }
+        if (emailRecipients().isEmpty() && userRecipients().isEmpty()) {
+            validation.addError("recipients", "Email Notification must have email recipients or user recipients.");
+        }
+
+        return validation;
     }
 
     @AutoValue.Builder

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
@@ -26,6 +26,7 @@ import org.graylog.events.event.EventDto;
 import org.graylog.events.notifications.EventNotificationConfig;
 import org.graylog.events.notifications.EventNotificationExecutionJob;
 import org.graylog.scheduler.JobTriggerData;
+import org.graylog2.plugin.rest.ValidationResult;
 
 @AutoValue
 @JsonTypeName(HTTPEventNotificationConfig.TYPE_NAME)
@@ -41,6 +42,17 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
     @JsonIgnore
     public JobTriggerData toJobTriggerData(EventDto dto) {
         return EventNotificationExecutionJob.Data.builder().eventDto(dto).build();
+    }
+
+    @JsonIgnore
+    public ValidationResult validate() {
+        final ValidationResult validation = new ValidationResult();
+
+        if (url().isEmpty()) {
+            validation.addError(FIELD_URL, "HTTP Notification url cannot be empty.");
+        }
+
+        return validation;
     }
 
     @AutoValue.Builder

--- a/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionDto.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionDto.java
@@ -17,6 +17,7 @@
 package org.graylog.events.processor;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
@@ -28,11 +29,14 @@ import org.graylog.events.notifications.EventNotificationHandler;
 import org.graylog.events.notifications.EventNotificationSettings;
 import org.graylog.events.processor.storage.EventStorageHandler;
 import org.graylog.events.processor.storage.PersistToStreamsStorageHandler;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.rest.ValidationResult;
 import org.mongojack.Id;
 import org.mongojack.ObjectId;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @AutoValue
@@ -103,6 +107,35 @@ public abstract class EventDefinitionDto implements EventDefinition {
     }
 
     public abstract Builder toBuilder();
+
+    @JsonIgnore
+    public ValidationResult validate() {
+        final ValidationResult validation = new ValidationResult();
+
+        if (title().isEmpty()) {
+            validation.addError(FIELD_TITLE, "Event Definition title cannot be empty.");
+        }
+
+        try {
+            validation.addAll(config().validate());
+        } catch (UnsupportedOperationException e) {
+            validation.addError(FIELD_CONFIG, "Event Definition config type cannot be empty.");
+        }
+
+        for (Map.Entry<String, EventFieldSpec> fieldSpecEntry : fieldSpec().entrySet()) {
+            final String fieldName = fieldSpecEntry.getKey();
+            if (!Message.validKey(fieldName)) {
+                validation.addError(FIELD_FIELD_SPEC,
+                    "Event Definition field_spec contains invalid message field \"" + fieldName + "\"");
+            }
+        }
+
+        if (keySpec().stream().anyMatch(key -> !fieldSpec().containsKey(key))) {
+            validation.addError(FIELD_KEY_SPEC, "Event Definition key_spec can only contain fields defined in field_spec.");
+        }
+
+        return validation;
+    }
 
     @AutoValue.Builder
     public static abstract class Builder {

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessorConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessorConfig.java
@@ -77,6 +77,8 @@ public abstract class AggregationEventProcessorConfig implements EventProcessorC
         return Builder.create();
     }
 
+    public abstract Builder toBuilder();
+
     @Override
     public Optional<EventProcessorSchedulerConfig> toJobSchedulerConfig(EventDefinition eventDefinition, JobSchedulerClock clock) {
         final DateTime now = clock.nowUTC();
@@ -132,8 +134,33 @@ public abstract class AggregationEventProcessorConfig implements EventProcessorC
         public abstract AggregationEventProcessorConfig build();
     }
 
+    private boolean isConditionsEmpty() {
+        return !conditions().isPresent() || !conditions().get().expression().isPresent();
+    }
+
     @Override
     public ValidationResult validate() {
-        return new ValidationResult();
+        final ValidationResult validationResult = new ValidationResult();
+
+        if (searchWithinMs() <= 0) {
+            validationResult.addError(FIELD_SEARCH_WITHIN_MS,
+                "Filter & Aggregation search_within_ms must be greater than 0.");
+        }
+        if (executeEveryMs() <= 0) {
+            validationResult.addError(FIELD_EXECUTE_EVERY_MS,
+                "Filter & Aggregation execute_every_ms must be greater than 0.");
+        }
+        if (!groupBy().isEmpty() && (series().isEmpty() || isConditionsEmpty())) {
+            validationResult.addError(FIELD_SERIES, "Aggregation with group_by must also contain series");
+            validationResult.addError(FIELD_CONDITIONS, "Aggregation with group_by must also contain conditions");
+        }
+        if (series().isEmpty() && !isConditionsEmpty()) {
+            validationResult.addError(FIELD_SERIES, "Aggregation with conditions must also contain series");
+        }
+        if (!series().isEmpty() && isConditionsEmpty()) {
+            validationResult.addError(FIELD_CONDITIONS, "Aggregation with series must also contain conditions");
+        }
+
+        return validationResult;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
@@ -117,7 +117,7 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
     @AuditEvent(type = EventsAuditEventTypes.EVENT_DEFINITION_CREATE)
     @RequiresPermissions(RestPermissions.EVENT_DEFINITIONS_CREATE)
     public Response create(EventDefinitionDto dto) {
-        final ValidationResult result = dto.config().validate();
+        final ValidationResult result = dto.validate();
         if (result.failed()) {
             return Response.status(Response.Status.BAD_REQUEST).entity(result).build();
         }
@@ -134,7 +134,7 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
         dbService.get(definitionId)
                 .orElseThrow(() -> new NotFoundException("Event definition <" + definitionId + "> doesn't exist"));
 
-        final ValidationResult result = dto.config().validate();
+        final ValidationResult result = dto.validate();
         if (!definitionId.equals(dto.id())) {
             result.addError("id", "Event definition IDs don't match");
         }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/rest/ValidationResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/rest/ValidationResult.java
@@ -39,6 +39,10 @@ public class ValidationResult {
         errors.putAll(extraErrors);
     }
 
+    public void addAll(ValidationResult validationResult) {
+        errors.putAll(validationResult.errors);
+    }
+
     @JsonProperty("failed")
     public boolean failed() {
         return !errors.isEmpty();

--- a/graylog2-server/src/test/java/org/graylog/events/notifications/NotificationDtoTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/notifications/NotificationDtoTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.events.notifications;
 
 import com.google.common.collect.Sets;

--- a/graylog2-server/src/test/java/org/graylog/events/notifications/NotificationDtoTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/notifications/NotificationDtoTest.java
@@ -1,0 +1,132 @@
+package org.graylog.events.notifications;
+
+import com.google.common.collect.Sets;
+import org.graylog.events.legacy.LegacyAlarmCallbackEventNotificationConfig;
+import org.graylog.events.notifications.types.EmailEventNotificationConfig;
+import org.graylog.events.notifications.types.HTTPEventNotificationConfig;
+import org.graylog2.plugin.rest.ValidationResult;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NotificationDtoTest {
+    private NotificationDto getHttpNotification() {
+        return NotificationDto.builder()
+                .title("Foobar")
+                .description("")
+                .config(HTTPEventNotificationConfig.Builder.create()
+                        .url("http://localhost")
+                        .build())
+                .build();
+    }
+
+    private NotificationDto getEmailNotification() {
+        return NotificationDto.builder()
+                .title("Foobar")
+                .description("")
+                .config(EmailEventNotificationConfig.Builder.create()
+                        .sender("foo@graylog.org")
+                        .subject("foo")
+                        .bodyTemplate("bar")
+                        .emailRecipients(Sets.newHashSet("foo@graylog.org"))
+                        .build())
+                .build();
+    }
+
+    private NotificationDto getLegacyNotification() {
+        return NotificationDto.builder()
+                .title("Foobar")
+                .description("")
+                .config(LegacyAlarmCallbackEventNotificationConfig.Builder.create()
+                        .callbackType("foo")
+                        .configuration(new HashMap<>())
+                        .build())
+                .build();
+    }
+
+    @Test
+    public void testValidateWithEmptyTitle() {
+        final NotificationDto invalidNotification = getHttpNotification().toBuilder().title("").build();
+        final ValidationResult validationResult = invalidNotification.validate();
+        assertThat(validationResult.failed()).isTrue();
+        assertThat(validationResult.getErrors()).containsOnlyKeys("title");
+    }
+
+    @Test
+    public void testValidateWithEmptyConfig() {
+        final NotificationDto invalidNotification = NotificationDto.builder()
+                .title("Foo")
+                .description("")
+                .config(new EventNotificationConfig.FallbackNotificationConfig())
+                .build();
+        final ValidationResult validationResult = invalidNotification.validate();
+        assertThat(validationResult.failed()).isTrue();
+        assertThat(validationResult.getErrors()).containsOnlyKeys("config");
+    }
+
+    @Test
+    public void testValidateHttpWithEmptyConfigParameters() {
+        final HTTPEventNotificationConfig emptyConfig = HTTPEventNotificationConfig.Builder.create()
+                .url("")
+                .build();
+        final NotificationDto emptyNotification = getHttpNotification().toBuilder().config(emptyConfig).build();
+        final ValidationResult validationResult = emptyNotification.validate();
+        assertThat(validationResult.failed()).isTrue();
+        assertThat(validationResult.getErrors()).containsOnlyKeys("url");
+    }
+
+    @Test
+    public void testValidateEmailWithEmptyConfigParameters() {
+        final EmailEventNotificationConfig emptyConfig = EmailEventNotificationConfig.Builder.create()
+                .sender("")
+                .subject("")
+                .bodyTemplate("")
+                .build();
+        final NotificationDto emptyNotification = getEmailNotification().toBuilder().config(emptyConfig).build();
+        final ValidationResult validationResult = emptyNotification.validate();
+        assertThat(validationResult.failed()).isTrue();
+        assertThat(validationResult.getErrors().size()).isEqualTo(4);
+        assertThat(validationResult.getErrors()).containsOnlyKeys("subject", "sender", "body_template", "recipients");
+    }
+
+    @Test
+    public void testValidateLegacyWithEmptyConfigParameters() {
+        final LegacyAlarmCallbackEventNotificationConfig emptyConfig = LegacyAlarmCallbackEventNotificationConfig.Builder.create()
+                .callbackType("")
+                .configuration(new HashMap<>())
+                .build();
+        final NotificationDto emptyNotification = getLegacyNotification().toBuilder().config(emptyConfig).build();
+        final ValidationResult validationResult = emptyNotification.validate();
+        assertThat(validationResult.failed()).isTrue();
+        assertThat(validationResult.getErrors()).containsOnlyKeys("callback_type");
+    }
+
+    @Test
+    public void testValidHttpNotification() {
+        final NotificationDto validNotification = getHttpNotification();
+
+        final ValidationResult validationResult = validNotification.validate();
+        assertThat(validationResult.failed()).isFalse();
+        assertThat(validationResult.getErrors().size()).isEqualTo(0);
+    }
+
+    @Test
+    public void testValidEmailNotification() {
+        final NotificationDto validNotification = getEmailNotification();
+
+        final ValidationResult validationResult = validNotification.validate();
+        assertThat(validationResult.failed()).isFalse();
+        assertThat(validationResult.getErrors().size()).isEqualTo(0);
+    }
+
+    @Test
+    public void testValidLegacyNotification() {
+        final NotificationDto validNotification = getLegacyNotification();
+
+        final ValidationResult validationResult = validNotification.validate();
+        assertThat(validationResult.failed()).isFalse();
+        assertThat(validationResult.getErrors().size()).isEqualTo(0);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/events/processor/EventDefinitionDtoTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/EventDefinitionDtoTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.events.processor;
 
 import com.google.common.collect.ImmutableList;

--- a/graylog2-server/src/test/java/org/graylog/events/processor/EventDefinitionDtoTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/EventDefinitionDtoTest.java
@@ -1,0 +1,117 @@
+package org.graylog.events.processor;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.graylog.events.fields.EventFieldSpec;
+import org.graylog.events.notifications.EventNotificationSettings;
+import org.graylog.events.processor.aggregation.AggregationEventProcessorConfig;
+import org.graylog2.plugin.rest.ValidationResult;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class EventDefinitionDtoTest {
+    private EventDefinitionDto testSubject;
+
+    @Before
+    public void setUp() throws Exception {
+        final AggregationEventProcessorConfig configMock = mock(AggregationEventProcessorConfig.class);
+        when(configMock.validate()).thenReturn(new ValidationResult());
+
+        testSubject = EventDefinitionDto.builder()
+            .title("foo")
+            .description("bar")
+            .priority(1)
+            .alert(false)
+            .config(configMock)
+            .keySpec(ImmutableList.<String>builder().build())
+            .notificationSettings(EventNotificationSettings.withGracePeriod(0))
+            .build();
+    }
+
+    @Test
+    public void testValidateWithEmptyTitle() {
+        final EventDefinitionDto invalidEventDefinition = testSubject.toBuilder()
+            .title("")
+            .build();
+        final ValidationResult validationResult = invalidEventDefinition.validate();
+        assertThat(validationResult.failed()).isTrue();
+        assertThat(validationResult.getErrors()).containsOnlyKeys("title");
+    }
+
+    @Test
+    public void testValidateWithEmptyConfigType() {
+        final EventDefinitionDto invalidEventDefinition = testSubject.toBuilder()
+            .config(new EventProcessorConfig.FallbackConfig())
+            .build();
+        final ValidationResult validationResult = invalidEventDefinition.validate();
+        assertThat(validationResult.failed()).isTrue();
+        assertThat(validationResult.getErrors()).containsOnlyKeys("config");
+    }
+
+    @Test
+    public void testValidateWithInvalidConfig() {
+        final AggregationEventProcessorConfig configMock = mock(AggregationEventProcessorConfig.class);
+        final ValidationResult mockedValidationResult = new ValidationResult();
+        mockedValidationResult.addError("foo", "bar");
+        when(configMock.validate()).thenReturn(mockedValidationResult);
+
+        final EventDefinitionDto invalidEventDefinition = testSubject.toBuilder()
+            .config(configMock)
+            .build();
+        final ValidationResult validationResult = invalidEventDefinition.validate();
+        assertThat(validationResult.failed()).isTrue();
+        assertThat(validationResult.getErrors()).containsOnlyKeys("foo");
+    }
+
+    @Test
+    public void testValidateWithInvalidFieldName() {
+        final EventFieldSpec fieldSpecMock = mock(EventFieldSpec.class);
+        final EventDefinitionDto invalidEventDefinition = testSubject.toBuilder()
+            .fieldSpec(ImmutableMap.of("foo\\bar", fieldSpecMock, "$yo&^a", fieldSpecMock))
+            .build();
+        final ValidationResult validationResult = invalidEventDefinition.validate();
+        assertThat(validationResult.failed()).isTrue();
+        assertThat(validationResult.getErrors()).containsOnlyKeys("field_spec");
+        final List<String> fieldValidation = (List<String>) validationResult.getErrors().get("field_spec");
+        assertThat(fieldValidation.size()).isEqualTo(2);
+        assertThat(fieldValidation.get(0)).contains("foo\\bar");
+        assertThat(fieldValidation.get(1)).contains("$yo&^a");
+    }
+
+    @Test
+    public void testValidateWithKeySpecNotInFieldSpec() {
+        final EventFieldSpec fieldSpecMock = mock(EventFieldSpec.class);
+        final EventDefinitionDto invalidEventDefinition = testSubject.toBuilder()
+            .fieldSpec(ImmutableMap.of("bar", fieldSpecMock, "baz", fieldSpecMock))
+            .keySpec(ImmutableList.of("foo"))
+            .build();
+        final ValidationResult validationResult = invalidEventDefinition.validate();
+        assertThat(validationResult.failed()).isTrue();
+        assertThat(validationResult.getErrors()).containsOnlyKeys("key_spec");
+    }
+
+    @Test
+    public void testValidEventDefinition() {
+        final ValidationResult validationResult = testSubject.validate();
+        assertThat(validationResult.failed()).isFalse();
+        assertThat(validationResult.getErrors().size()).isEqualTo(0);
+    }
+
+    @Test
+    public void testValidEventDefinitionWithKeySpecInFieldSpec() {
+        final EventFieldSpec fieldSpecMock = mock(EventFieldSpec.class);
+        final EventDefinitionDto invalidEventDefinition = testSubject.toBuilder()
+            .fieldSpec(ImmutableMap.of("foo", fieldSpecMock, "bar", fieldSpecMock))
+            .keySpec(ImmutableList.of("foo", "bar"))
+            .build();
+        final ValidationResult validationResult = invalidEventDefinition.validate();
+        assertThat(validationResult.failed()).isFalse();
+        assertThat(validationResult.getErrors().size()).isEqualTo(0);
+    }
+}

--- a/graylog2-web-interface/src/components/event-definitions/common/commonStyles.css
+++ b/graylog2-web-interface/src/components/event-definitions/common/commonStyles.css
@@ -6,3 +6,17 @@
 :local(.fixedTable) {
     table-layout: fixed;
 }
+
+:local(.validationSummary).alert {
+    margin-bottom: 10px;
+}
+
+:local(.validationSummary) h4 {
+    font-size: 16px;
+    margin-bottom: 0.5em;
+}
+
+:local(.validationSummary) ul {
+    list-style: disc;
+    margin: 0.5em 0;
+}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventConditionForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventConditionForm.jsx
@@ -14,6 +14,7 @@ import styles from './EventConditionForm.css';
 class EventConditionForm extends React.Component {
   static propTypes = {
     eventDefinition: PropTypes.object.isRequired,
+    validation: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
   };
 
@@ -68,7 +69,7 @@ class EventConditionForm extends React.Component {
   };
 
   render() {
-    const { eventDefinition } = this.props;
+    const { eventDefinition, validation } = this.props;
     const eventDefinitionType = this.getConditionPlugin(eventDefinition.config.type);
 
     const eventDefinitionTypeComponent = eventDefinitionType.formComponent
@@ -88,7 +89,7 @@ class EventConditionForm extends React.Component {
             Conditions, making it possible to build powerful Conditions based on others.
           </p>
 
-          <FormGroup controlId="event-definition-priority">
+          <FormGroup controlId="event-definition-priority" validationState={validation.errors.config ? 'error' : null}>
             <ControlLabel>Condition Type</ControlLabel>
             <Select placeholder="Select a Condition Type"
                     options={this.formattedEventDefinitionTypes()}
@@ -96,7 +97,9 @@ class EventConditionForm extends React.Component {
                     onChange={this.handleEventDefinitionTypeChange}
                     clearable={false}
                     required />
-            <HelpBlock>Choose the type of Condition for this Event.</HelpBlock>
+            <HelpBlock>
+              {lodash.get(validation, 'errors.config[0]', 'Choose the type of Condition for this Event.')}
+            </HelpBlock>
           </FormGroup>
         </Col>
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionForm.jsx
@@ -19,6 +19,7 @@ class EventDefinitionForm extends React.Component {
   static propTypes = {
     action: PropTypes.oneOf(['create', 'edit']),
     eventDefinition: PropTypes.object.isRequired,
+    validation: PropTypes.object.isRequired,
     entityTypes: PropTypes.object.isRequired,
     notifications: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired,
@@ -94,7 +95,7 @@ class EventDefinitionForm extends React.Component {
   };
 
   render() {
-    const { action, entityTypes, eventDefinition, notifications, onChange } = this.props;
+    const { action, entityTypes, eventDefinition, notifications, onChange, validation } = this.props;
     const { activeStep } = this.state;
 
     const defaultStepProps = {
@@ -103,6 +104,7 @@ class EventDefinitionForm extends React.Component {
       entityTypes,
       eventDefinition,
       onChange,
+      validation,
     };
 
     const eventDefinitionType = this.getConditionPlugin(eventDefinition.config.type);
@@ -132,7 +134,10 @@ class EventDefinitionForm extends React.Component {
         key: STEP_KEYS[4],
         title: 'Summary',
         component: (
-          <EventDefinitionSummary action={action} eventDefinition={eventDefinition} notifications={notifications} />
+          <EventDefinitionSummary action={action}
+                                  eventDefinition={eventDefinition}
+                                  notifications={notifications}
+                                  validation={validation} />
         ),
       },
     ];

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.jsx
@@ -53,6 +53,9 @@ class EventDefinitionFormContainer extends React.Component {
 
     this.state = {
       eventDefinition: props.eventDefinition,
+      validation: {
+        errors: {},
+      },
     };
   }
 
@@ -86,16 +89,32 @@ class EventDefinitionFormContainer extends React.Component {
 
     if (action === 'create') {
       EventDefinitionsActions.create(eventDefinition)
-        .then(() => history.push(Routes.NEXT_ALERTS.DEFINITIONS.LIST));
+        .then(
+          () => history.push(Routes.NEXT_ALERTS.DEFINITIONS.LIST),
+          (errorResponse) => {
+            const { body } = errorResponse.additional;
+            if (errorResponse.status === 400 && body && body.failed) {
+              this.setState({ validation: body });
+            }
+          },
+        );
     } else {
       EventDefinitionsActions.update(eventDefinition.id, eventDefinition)
-        .then(() => history.push(Routes.NEXT_ALERTS.DEFINITIONS.LIST));
+        .then(
+          () => history.push(Routes.NEXT_ALERTS.DEFINITIONS.LIST),
+          (errorResponse) => {
+            const { body } = errorResponse.additional;
+            if (errorResponse.status === 400 && body && body.failed) {
+              this.setState({ validation: body });
+            }
+          },
+        );
     }
   };
 
   render() {
     const { action, entityTypes, notifications } = this.props;
-    const { eventDefinition } = this.state;
+    const { eventDefinition, validation } = this.state;
     const isLoading = !entityTypes || !notifications.all;
 
     if (isLoading) {
@@ -105,6 +124,7 @@ class EventDefinitionFormContainer extends React.Component {
     return (
       <EventDefinitionForm action={action}
                            eventDefinition={eventDefinition}
+                           validation={validation}
                            entityTypes={entityTypes}
                            notifications={notifications.all}
                            onChange={this.handleChange}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionSummary.jsx
@@ -8,6 +8,7 @@ import {} from 'moment-duration-format';
 import naturalSort from 'javascript-natural-sort';
 
 import EventDefinitionPriorityEnum from 'logic/alerts/EventDefinitionPriorityEnum';
+import EventDefinitionValidationSummary from './EventDefinitionValidationSummary';
 
 import styles from './EventDefinitionSummary.css';
 import commonStyles from '../common/commonStyles.css';
@@ -16,6 +17,7 @@ class EventDefinitionSummary extends React.Component {
   static propTypes = {
     eventDefinition: PropTypes.object.isRequired,
     notifications: PropTypes.array.isRequired,
+    validation: PropTypes.object.isRequired,
   };
 
   renderDetails = (eventDefinition) => {
@@ -169,11 +171,13 @@ class EventDefinitionSummary extends React.Component {
   };
 
   render() {
-    const { eventDefinition } = this.props;
+    const { eventDefinition, validation } = this.props;
+
     return (
       <Row className={styles.eventSummary}>
         <Col md={12}>
           <h2 className={commonStyles.title}>Event Summary</h2>
+          <EventDefinitionValidationSummary validation={validation} />
           <Row>
             <Col md={5}>
               {this.renderDetails(eventDefinition)}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionSummary.jsx
@@ -20,6 +20,21 @@ class EventDefinitionSummary extends React.Component {
     validation: PropTypes.object.isRequired,
   };
 
+  state = {
+    showValidation: false,
+  };
+
+  componentDidUpdate() {
+    this.showValidation();
+  }
+
+  showValidation = () => {
+    const { showValidation } = this.state;
+    if (!showValidation) {
+      this.setState({ showValidation: true });
+    }
+  };
+
   renderDetails = (eventDefinition) => {
     return (
       <React.Fragment>
@@ -172,12 +187,13 @@ class EventDefinitionSummary extends React.Component {
 
   render() {
     const { eventDefinition, validation } = this.props;
+    const { showValidation } = this.state;
 
     return (
       <Row className={styles.eventSummary}>
         <Col md={12}>
           <h2 className={commonStyles.title}>Event Summary</h2>
-          <EventDefinitionValidationSummary validation={validation} />
+          {showValidation && <EventDefinitionValidationSummary validation={validation} />}
           <Row>
             <Col md={5}>
               {this.renderDetails(eventDefinition)}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionValidationSummary.css
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionValidationSummary.css
@@ -1,0 +1,9 @@
+:local(.validationSummary) h4 {
+    font-size: 16px;
+    margin-bottom: 0.5em;
+}
+
+:local(.validationSummary) ul {
+    list-style: disc;
+    margin: 0.5em 0;
+}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionValidationSummary.css
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionValidationSummary.css
@@ -1,9 +1,0 @@
-:local(.validationSummary) h4 {
-    font-size: 16px;
-    margin-bottom: 0.5em;
-}
-
-:local(.validationSummary) ul {
-    list-style: disc;
-    margin: 0.5em 0;
-}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionValidationSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionValidationSummary.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Alert, Col, Row } from 'react-bootstrap';
+
+import styles from './EventDefinitionValidationSummary.css';
+
+class EventDefinitionValidationSummary extends React.Component {
+  static propTypes = {
+    validation: PropTypes.object.isRequired,
+  };
+
+  render() {
+    const { validation } = this.props;
+    const fieldsWithErrors = Object.keys(validation.errors);
+    if (fieldsWithErrors.length === 0) {
+      return null;
+    }
+
+    return (
+      <Row>
+        <Col md={12}>
+          <Alert bsStyle="danger" className={styles.validationSummary}>
+            <h4>We found some errors!</h4>
+            <p>Please correct the following errors before saving this Event Definition:</p>
+            <ul>
+              {fieldsWithErrors.map((field) => {
+                return validation.errors[field].map(error => <li key={`${field}-${error}`}>{error}</li>);
+              })}
+            </ul>
+          </Alert>
+        </Col>
+      </Row>
+    );
+  }
+}
+
+export default EventDefinitionValidationSummary;

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionValidationSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionValidationSummary.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Alert, Col, Row } from 'react-bootstrap';
 
-import styles from './EventDefinitionValidationSummary.css';
+import commonStyles from '../common/commonStyles.css';
 
 class EventDefinitionValidationSummary extends React.Component {
   static propTypes = {
@@ -19,12 +19,15 @@ class EventDefinitionValidationSummary extends React.Component {
     return (
       <Row>
         <Col md={12}>
-          <Alert bsStyle="danger" className={styles.validationSummary}>
+          <Alert bsStyle="danger" className={commonStyles.validationSummary}>
             <h4>We found some errors!</h4>
             <p>Please correct the following errors before saving this Event Definition:</p>
             <ul>
               {fieldsWithErrors.map((field) => {
-                return validation.errors[field].map(error => <li key={`${field}-${error}`}>{error}</li>);
+                return validation.errors[field].map((error) => {
+                  const effectiveError = (field === 'config' ? error.replace('config', 'condition') : error);
+                  return <li key={`${field}-${effectiveError}`}>{effectiveError}</li>;
+                });
               })}
             </ul>
           </Alert>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDetailsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDetailsForm.jsx
@@ -16,6 +16,7 @@ const priorityOptions = lodash.map(EventDefinitionPriorityEnum.properties, (valu
 class EventDetailsForm extends React.Component {
   static propTypes = {
     eventDefinition: PropTypes.object.isRequired,
+    validation: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
   };
 
@@ -31,7 +32,7 @@ class EventDetailsForm extends React.Component {
   };
 
   render() {
-    const { eventDefinition } = this.props;
+    const { eventDefinition, validation } = this.props;
 
     return (
       <Row>
@@ -42,7 +43,8 @@ class EventDetailsForm extends React.Component {
                    name="title"
                    label="Title"
                    type="text"
-                   help="Title for this Event Definition, Events and Alerts created from it."
+                   bsStyle={validation.errors.title ? 'error' : null}
+                   help={lodash.get(validation, 'errors.title[0]', 'Title for this Event Definition, Events and Alerts created from it.')}
                    value={eventDefinition.title}
                    onChange={this.handleChange}
                    required />

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsForm.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
-import { Button, Col, OverlayTrigger, Row } from 'react-bootstrap';
+import { Alert, Button, Col, OverlayTrigger, Row } from 'react-bootstrap';
 
 import EventKeyHelpPopover from 'components/event-definitions/common/EventKeyHelpPopover';
 import FieldForm from './FieldForm';
@@ -15,6 +15,7 @@ import commonStyles from '../common/commonStyles.css';
 class FieldsForm extends React.Component {
   static propTypes = {
     eventDefinition: PropTypes.object.isRequired,
+    validation: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
   };
 
@@ -60,7 +61,7 @@ class FieldsForm extends React.Component {
   };
 
   render() {
-    const { eventDefinition } = this.props;
+    const { eventDefinition, validation } = this.props;
     const { editField, showFieldForm } = this.state;
 
     if (showFieldForm) {
@@ -73,10 +74,27 @@ class FieldsForm extends React.Component {
       );
     }
 
+    const fieldErrors = lodash.get(validation, 'errors.field_spec', []);
+    const keyErrors = lodash.get(validation, 'errors.key_spec', []);
+    const errors = [...fieldErrors, ...keyErrors];
+
     return (
       <Row>
         <Col md={12}>
           <h2 className={commonStyles.title}>Event Fields</h2>
+
+          {errors.length > 0 && (
+            <Alert bsStyle="danger" className={commonStyles.validationSummary}>
+              <h4>Fields with errors</h4>
+              <p>Please correct the following errors before saving this Event Definition:</p>
+              <ul>
+                {errors.map((error) => {
+                  return <li key={error}>{error}</li>;
+                })}
+              </ul>
+            </Alert>
+          )}
+
           {Object.keys(eventDefinition.field_spec).length > 0 && (
             <dl>
               <dt>
@@ -91,6 +109,7 @@ class FieldsForm extends React.Component {
             </dl>
           )}
           <FieldsList fields={eventDefinition.field_spec}
+                      validation={validation}
                       keys={eventDefinition.key_spec}
                       onAddFieldClick={this.toggleFieldForm}
                       onEditFieldClick={this.toggleFieldForm}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/LookupTableFieldValueProviderForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/LookupTableFieldValueProviderForm.jsx
@@ -11,6 +11,7 @@ class LookupTableFieldValueProviderForm extends React.Component {
   static propTypes = {
     allFieldTypes: PropTypes.array.isRequired,
     config: PropTypes.object.isRequired,
+    validation: PropTypes.object.isRequired,
     lookupTables: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired,
   };
@@ -21,6 +22,11 @@ class LookupTableFieldValueProviderForm extends React.Component {
     table_name: '',
     key_field: '',
   };
+
+  static requiredFields = [
+    'table_name',
+    'key_field',
+  ];
 
   formatMessageFields = lodash.memoize(
     (fieldTypes) => {
@@ -61,13 +67,13 @@ class LookupTableFieldValueProviderForm extends React.Component {
   };
 
   render() {
-    const { allFieldTypes, config, lookupTables } = this.props;
+    const { allFieldTypes, config, lookupTables, validation } = this.props;
     const provider = config.providers.find(p => p.type === LookupTableFieldValueProviderForm.type);
 
     return (
       <Row className="row-sm">
         <Col md={7} lg={6}>
-          <FormGroup controlId="lookup-provider-table">
+          <FormGroup controlId="lookup-provider-table" validationState={validation.errors.table_name ? 'error' : null}>
             <ControlLabel>Select Lookup Table</ControlLabel>
             <Select name="event-field-table-name"
                     placeholder="Select Lookup Table"
@@ -76,10 +82,12 @@ class LookupTableFieldValueProviderForm extends React.Component {
                     value={provider.table_name}
                     matchProp="label"
                     required />
-            <HelpBlock>Select the Lookup Table Graylog should use to get the value.</HelpBlock>
+            <HelpBlock>
+              {validation.errors.table_name || 'Select the Lookup Table Graylog should use to get the value.'}
+            </HelpBlock>
           </FormGroup>
 
-          <FormGroup controlId="lookup-provider-table">
+          <FormGroup controlId="lookup-provider-table" validationState={validation.errors.key_field ? 'error' : null}>
             <ControlLabel>Lookup Table Key Field</ControlLabel>
             <Select name="lookup-provider-key"
                     placeholder="Select Field"
@@ -89,7 +97,9 @@ class LookupTableFieldValueProviderForm extends React.Component {
                     matchProp="label"
                     allowCreate
                     required />
-            <HelpBlock>Message Field name whose value will be used as Lookup Table Key.</HelpBlock>
+            <HelpBlock>
+              {validation.errors.key_field || 'Message Field name whose value will be used as Lookup Table Key.'}
+            </HelpBlock>
           </FormGroup>
         </Col>
       </Row>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/LookupTableFieldValueProviderForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/LookupTableFieldValueProviderForm.jsx
@@ -17,6 +17,11 @@ class LookupTableFieldValueProviderForm extends React.Component {
 
   static type = 'lookup-v1';
 
+  static defaultConfig = {
+    table_name: '',
+    key_field: '',
+  };
+
   formatMessageFields = lodash.memoize(
     (fieldTypes) => {
       return fieldTypes

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/LookupTableFieldValueProviderFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/LookupTableFieldValueProviderFormContainer.jsx
@@ -12,6 +12,7 @@ const { LookupTablesStore, LookupTablesActions } = CombinedProvider.get('LookupT
 class LookupTableFieldValueProviderFormContainer extends React.Component {
   static propTypes = {
     config: PropTypes.object.isRequired,
+    validation: PropTypes.object.isRequired,
     fieldTypes: PropTypes.object.isRequired,
     lookupTables: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/TemplateFieldValueProviderForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/TemplateFieldValueProviderForm.jsx
@@ -12,6 +12,7 @@ import TemplateFieldValueProviderPreview from './TemplateFieldValueProviderPrevi
 class TemplateFieldValueProviderForm extends React.Component {
   static propTypes = {
     config: PropTypes.object.isRequired,
+    validation: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
   };
 
@@ -20,6 +21,10 @@ class TemplateFieldValueProviderForm extends React.Component {
   static defaultConfig = {
     template: '',
   };
+
+  static requiredFields = [
+    'template',
+  ];
 
   handleChange = (event) => {
     const { config, onChange } = this.props;
@@ -32,7 +37,7 @@ class TemplateFieldValueProviderForm extends React.Component {
   };
 
   render() {
-    const { config } = this.props;
+    const { config, validation } = this.props;
     const provider = config.providers.find(p => p.type === TemplateFieldValueProviderForm.type);
 
     const helpText = (
@@ -54,7 +59,8 @@ class TemplateFieldValueProviderForm extends React.Component {
                  label="Template"
                  onChange={this.handleChange}
                  value={provider.template || ''}
-                 help={helpText} />
+                 bsStyle={validation.errors.template ? 'error' : null}
+                 help={validation.errors.template || helpText} />
 
           <FormGroup>
             <Checkbox id="lookup-message-require-values"

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/TemplateFieldValueProviderForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/TemplateFieldValueProviderForm.jsx
@@ -17,6 +17,10 @@ class TemplateFieldValueProviderForm extends React.Component {
 
   static type = 'template-v1';
 
+  static defaultConfig = {
+    template: '',
+  };
+
   handleChange = (event) => {
     const { config, onChange } = this.props;
     const { name } = event.target;

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/index.js
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/index.js
@@ -14,6 +14,7 @@ PluginStore.register(new PluginManifest({}, {
       formComponent: TemplateFieldValueProviderForm,
       summaryComponent: TemplateFieldValueProviderSummary,
       defaultConfig: TemplateFieldValueProviderForm.defaultConfig,
+      requiredFields: TemplateFieldValueProviderForm.requiredFields,
     },
     {
       type: LookupTableFieldValueProviderForm.type,
@@ -21,6 +22,7 @@ PluginStore.register(new PluginManifest({}, {
       formComponent: LookupTableFieldValueProviderFormContainer,
       summaryComponent: LookupTableFieldValueProviderSummary,
       defaultConfig: LookupTableFieldValueProviderForm.defaultConfig,
+      requiredFields: LookupTableFieldValueProviderForm.requiredFields,
     },
   ],
 }));

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/index.js
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/index.js
@@ -13,12 +13,14 @@ PluginStore.register(new PluginManifest({}, {
       displayName: 'Template',
       formComponent: TemplateFieldValueProviderForm,
       summaryComponent: TemplateFieldValueProviderSummary,
+      defaultConfig: TemplateFieldValueProviderForm.defaultConfig,
     },
     {
       type: LookupTableFieldValueProviderForm.type,
       displayName: 'Lookup Table',
       formComponent: LookupTableFieldValueProviderFormContainer,
       summaryComponent: LookupTableFieldValueProviderSummary,
+      defaultConfig: LookupTableFieldValueProviderForm.defaultConfig,
     },
   ],
 }));

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationForm.jsx
@@ -16,6 +16,7 @@ import commonStyles from '../common/commonStyles.css';
 class AggregationForm extends React.Component {
   static propTypes = {
     eventDefinition: PropTypes.object.isRequired,
+    validation: PropTypes.object.isRequired,
     allFieldTypes: PropTypes.array.isRequired,
     aggregationFunctions: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired,
@@ -107,7 +108,7 @@ class AggregationForm extends React.Component {
   };
 
   render() {
-    const { allFieldTypes, aggregationFunctions, eventDefinition } = this.props;
+    const { allFieldTypes, aggregationFunctions, eventDefinition, validation } = this.props;
     const formattedFields = this.formatFields(allFieldTypes);
     const series = this.getSeries(eventDefinition.config) || {};
     const expressionResults = AggregationExpressionParser.parseExpression(eventDefinition.config.conditions);
@@ -144,7 +145,7 @@ class AggregationForm extends React.Component {
         <h3 className={commonStyles.title}>Create Events for Definition</h3>
         <Row className="row-sm">
           <Col md={6}>
-            <FormGroup controlId="aggregation-function">
+            <FormGroup controlId="aggregation-function" validationState={validation.errors.series ? 'error' : null}>
               <ControlLabel>If</ControlLabel>
               <Row className="row-sm">
                 <Col md={6}>
@@ -165,10 +166,13 @@ class AggregationForm extends React.Component {
                           allowCreate />
                 </Col>
               </Row>
+              {validation.errors.series && (
+                <HelpBlock>{lodash.get(validation, 'errors.series[0]')}</HelpBlock>
+              )}
             </FormGroup>
           </Col>
           <Col md={3}>
-            <FormGroup controlId="aggregation-condition">
+            <FormGroup controlId="aggregation-condition" validationState={validation.errors.conditions ? 'error' : null}>
               <ControlLabel>Is</ControlLabel>
               <Select id="aggregation-condition"
                       matchProp="label"
@@ -182,6 +186,9 @@ class AggregationForm extends React.Component {
                         { label: '=', value: '==' },
                       ]}
                       value={expressionResults.operator} />
+              {validation.errors.conditions && (
+                <HelpBlock>{lodash.get(validation, 'errors.conditions[0]')}</HelpBlock>
+              )}
             </FormGroup>
           </Col>
           <Col md={3}>
@@ -190,6 +197,8 @@ class AggregationForm extends React.Component {
                    label="Threshold"
                    type="number"
                    value={lodash.defaultTo(expressionResults.value, 0)}
+                   bsStyle={validation.errors.conditions ? 'error' : null}
+                   help={lodash.get(validation, 'errors.conditions[0]', null)}
                    onChange={this.handleExpressionThresholdChange} />
           </Col>
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.jsx
@@ -29,6 +29,7 @@ const initialAggregationConfig = {
 class FilterAggregationForm extends React.Component {
   static propTypes = {
     eventDefinition: PropTypes.object.isRequired,
+    validation: PropTypes.object.isRequired,
     allFieldTypes: PropTypes.array.isRequired,
     entityTypes: PropTypes.object.isRequired,
     streams: PropTypes.array.isRequired,
@@ -96,13 +97,16 @@ class FilterAggregationForm extends React.Component {
 
   render() {
     const { conditionType } = this.state;
-    const { allFieldTypes, entityTypes, eventDefinition, streams } = this.props;
+    const { allFieldTypes, entityTypes, eventDefinition, streams, validation } = this.props;
 
     return (
       <React.Fragment>
         <Row>
           <Col md={7} lg={6}>
-            <FilterForm eventDefinition={eventDefinition} streams={streams} onChange={this.propagateChange} />
+            <FilterForm eventDefinition={eventDefinition}
+                        validation={validation}
+                        streams={streams}
+                        onChange={this.propagateChange} />
 
             <FormGroup>
               <ControlLabel>Create Events for Definition if...</ControlLabel>
@@ -130,6 +134,7 @@ class FilterAggregationForm extends React.Component {
           <Row>
             <Col md={12}>
               <AggregationForm eventDefinition={eventDefinition}
+                               validation={validation}
                                allFieldTypes={allFieldTypes}
                                aggregationFunctions={entityTypes.aggregation_functions}
                                onChange={this.propagateChange} />

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationFormContainer.jsx
@@ -14,6 +14,7 @@ const { StreamsStore } = CombinedProvider.get('Streams');
 class FilterAggregationFormContainer extends React.Component {
   static propTypes = {
     action: PropTypes.oneOf(['create', 'edit']).isRequired,
+    validation: PropTypes.object.isRequired,
     eventDefinition: PropTypes.object.isRequired,
     fieldTypes: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.jsx
@@ -56,7 +56,10 @@ class FilterAggregationSummary extends React.Component {
             <dt>Group by Field(s)</dt>
             <dd>{groupBy && groupBy.length > 0 ? groupBy.join(', ') : 'No Group by configured'}</dd>
             <dt>Create Events if</dt>
-            <dd><em>{series[0].function}({series[0].field})</em> {expressionResults.operator} {expressionResults.value}</dd>
+            <dd>
+              {series[0] ? <em>{series[0].function}({series[0].field})</em> : <span>No series selected</span>}
+              {' '}{expressionResults.operator} {expressionResults.value}
+            </dd>
           </React.Fragment>
         )}
       </dl>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
@@ -18,6 +18,7 @@ export const TIME_UNITS = ['HOURS', 'MINUTES', 'SECONDS'];
 class FilterForm extends React.Component {
   static propTypes = {
     eventDefinition: PropTypes.object.isRequired,
+    validation: PropTypes.object.isRequired,
     streams: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired,
   };
@@ -46,7 +47,7 @@ class FilterForm extends React.Component {
   };
 
   render() {
-    const { eventDefinition, streams } = this.props;
+    const { eventDefinition, streams, validation } = this.props;
     const formattedStreams = streams
       .map(stream => ({ label: stream.title, value: stream.id }))
       .sort((s1, s2) => naturalSortIgnoreCase(s1.label, s2.label));
@@ -76,22 +77,28 @@ class FilterForm extends React.Component {
           <HelpBlock>Select streams the search should include. Searches in all streams if empty.</HelpBlock>
         </FormGroup>
 
-        <FormGroup controlId="search-within">
+        <FormGroup controlId="search-within" validationState={validation.errors.search_within_ms ? 'error' : null}>
           <TimeUnitInput label="Search within the last"
                          update={this.handleTimeRangeChange('search_within_ms')}
                          value={searchWithin.duration}
                          unit={searchWithin.unit}
                          units={TIME_UNITS}
                          required />
+          {validation.errors.search_within_ms && (
+            <HelpBlock>{lodash.get(validation, 'errors.search_within_ms[0]')}</HelpBlock>
+          )}
         </FormGroup>
 
-        <FormGroup controlId="execute-every">
+        <FormGroup controlId="execute-every" validationState={validation.errors.execute_every_ms ? 'error' : null}>
           <TimeUnitInput label="Execute search every"
                          update={this.handleTimeRangeChange('execute_every_ms')}
                          value={executeEvery.duration}
                          unit={executeEvery.unit}
                          units={TIME_UNITS}
                          required />
+          {validation.errors.execute_every_ms && (
+            <HelpBlock>{lodash.get(validation, 'errors.execute_every_ms[0]')}</HelpBlock>
+          )}
         </FormGroup>
       </fieldset>
     );

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
@@ -12,6 +12,7 @@ class EventNotificationForm extends React.Component {
   static propTypes = {
     action: PropTypes.oneOf(['create', 'edit']),
     notification: PropTypes.object.isRequired,
+    validation: PropTypes.object.isRequired,
     formId: PropTypes.string,
     embedded: PropTypes.bool.isRequired,
     onChange: PropTypes.func.isRequired,
@@ -61,13 +62,14 @@ class EventNotificationForm extends React.Component {
   };
 
   render() {
-    const { action, embedded, formId, notification, onCancel } = this.props;
+    const { action, embedded, formId, notification, onCancel, validation } = this.props;
 
     const notificationPlugin = this.getNotificationPlugin(notification.config.type);
     const notificationFormComponent = notificationPlugin.formComponent
       ? React.createElement(notificationPlugin.formComponent, {
         config: notification.config,
         onChange: this.handleConfigChange,
+        validation: validation,
       })
       : null;
 
@@ -79,7 +81,8 @@ class EventNotificationForm extends React.Component {
                    name="title"
                    label="Title"
                    type="text"
-                   help="Title for this Notification."
+                   bsStyle={validation.errors.title ? 'error' : null}
+                   help={validation.errors.title || 'Title for this Notification.'}
                    value={notification.title}
                    onChange={this.handleChange}
                    required />
@@ -93,7 +96,7 @@ class EventNotificationForm extends React.Component {
                    onChange={this.handleChange}
                    rows={2} />
 
-            <FormGroup controlId="notification-type">
+            <FormGroup controlId="notification-type" validationState={validation.errors.config ? 'error' : null}>
               <ControlLabel>Notification Type</ControlLabel>
               <Select id="notification-type"
                       options={this.formattedEventNotificationTypes()}
@@ -101,7 +104,9 @@ class EventNotificationForm extends React.Component {
                       onChange={this.handleTypeChange}
                       clearable={false}
                       required />
-              <HelpBlock>Choose the type of Notification to create.</HelpBlock>
+              <HelpBlock>
+                {validation.errors.config || 'Choose the type of Notification to create.'}
+              </HelpBlock>
             </FormGroup>
 
             {notificationFormComponent}

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, ButtonToolbar, Col, ControlLabel, FormGroup, HelpBlock, Row } from 'react-bootstrap';
 import { PluginStore } from 'graylog-web-plugin/plugin';
+import lodash from 'lodash';
 
 import { Select } from 'components/common';
 import { Input } from 'components/bootstrap';
@@ -82,7 +83,7 @@ class EventNotificationForm extends React.Component {
                    label="Title"
                    type="text"
                    bsStyle={validation.errors.title ? 'error' : null}
-                   help={validation.errors.title || 'Title for this Notification.'}
+                   help={lodash.get(validation, 'errors.title[0]', 'Title for this Notification.')}
                    value={notification.title}
                    onChange={this.handleChange}
                    required />
@@ -105,7 +106,7 @@ class EventNotificationForm extends React.Component {
                       clearable={false}
                       required />
               <HelpBlock>
-                {validation.errors.config || 'Choose the type of Notification to create.'}
+                {lodash.get(validation, 'errors.config[0]', 'Choose the type of Notification to create.')}
               </HelpBlock>
             </FormGroup>
 

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationFormContainer.jsx
@@ -42,6 +42,9 @@ class EventNotificationFormContainer extends React.Component {
 
     this.state = {
       notification: props.notification,
+      validation: {
+        errors: {},
+      },
     };
   }
 
@@ -65,18 +68,34 @@ class EventNotificationFormContainer extends React.Component {
     let promise;
     if (action === 'create') {
       promise = EventNotificationsActions.create(notification);
-      promise.then(() => {
-        if (!embedded) {
-          history.push(Routes.NEXT_ALERTS.NOTIFICATIONS.LIST);
-        }
-      });
+      promise.then(
+        () => {
+          if (!embedded) {
+            history.push(Routes.NEXT_ALERTS.NOTIFICATIONS.LIST);
+          }
+        },
+        (errorResponse) => {
+          const { body } = errorResponse.additional;
+          if (errorResponse.status === 400 && body && body.failed) {
+            this.setState({ validation: body });
+          }
+        },
+      );
     } else {
       promise = EventNotificationsActions.update(notification.id, notification);
-      promise.then(() => {
-        if (!embedded) {
-          history.push(Routes.NEXT_ALERTS.NOTIFICATIONS.LIST);
-        }
-      });
+      promise.then(
+        () => {
+          if (!embedded) {
+            history.push(Routes.NEXT_ALERTS.NOTIFICATIONS.LIST);
+          }
+        },
+        (errorResponse) => {
+          const { body } = errorResponse.additional;
+          if (errorResponse.status === 400 && body && body.failed) {
+            this.setState({ validation: body });
+          }
+        },
+      );
     }
 
     onSubmit(promise);
@@ -84,11 +103,12 @@ class EventNotificationFormContainer extends React.Component {
 
   render() {
     const { action, embedded, formId } = this.props;
-    const { notification } = this.state;
+    const { notification, validation } = this.state;
 
     return (
       <EventNotificationForm action={action}
                              notification={notification}
+                             validation={validation}
                              formId={formId}
                              embedded={embedded}
                              onChange={this.handleChange}

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
@@ -85,7 +85,7 @@ class EmailNotificationForm extends React.Component {
                label="Sender"
                type="text"
                bsStyle={validation.errors.sender ? 'error' : null}
-               help={validation.errors.sender || 'The email address that should be used as the notification sender.'}
+               help={lodash.get(validation, 'errors.sender[0]', 'The email address that should be used as the notification sender.')}
                value={config.sender || ''}
                onChange={this.handleChange}
                required />
@@ -94,7 +94,7 @@ class EmailNotificationForm extends React.Component {
                label="Subject"
                type="text"
                bsStyle={validation.errors.subject ? 'error' : null}
-               help={validation.errors.subject || 'The subject that should be used for the email notification.'}
+               help={lodash.get(validation, 'errors.subject[0]', 'The subject that should be used for the email notification.')}
                value={config.subject || ''}
                onChange={this.handleChange}
                required />
@@ -107,7 +107,7 @@ class EmailNotificationForm extends React.Component {
                        options={this.formatUsers(users)}
                        onChange={this.handleRecipientsChange('user_recipients')} />
           <HelpBlock>
-            {validation.errors.recipients || 'Select Graylog users that will receive this Notification.'}
+            {lodash.get(validation, 'errors.recipients[0]', 'Select Graylog users that will receive this Notification.')}
           </HelpBlock>
         </FormGroup>
 
@@ -122,7 +122,7 @@ class EmailNotificationForm extends React.Component {
                        onChange={this.handleRecipientsChange('email_recipients')}
                        allowCreate />
           <HelpBlock>
-            {validation.errors.recipients || 'Add email addresses that will receive this Notification.'}
+            {lodash.get(validation, 'errors.recipients[0]', 'Add email addresses that will receive this Notification.')}
           </HelpBlock>
         </FormGroup>
         <FormGroup controlId="notification-body-template"
@@ -134,7 +134,7 @@ class EmailNotificationForm extends React.Component {
                             value={config.body_template || ''}
                             onChange={this.handleBodyTemplateChange} />
           <HelpBlock>
-            {validation.errors.body_template || 'The template that will be used to generate the email body.'}
+            {lodash.get(validation, 'errors.body_template[0]', 'The template that will be used to generate the email body.')}
           </HelpBlock>
         </FormGroup>
       </React.Fragment>

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
@@ -37,6 +37,7 @@ Last messages accounting for this alert:
 class EmailNotificationForm extends React.Component {
   static propTypes = {
     config: PropTypes.object.isRequired,
+    validation: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
     users: PropTypes.array.isRequired,
   };
@@ -75,7 +76,7 @@ class EmailNotificationForm extends React.Component {
   };
 
   render() {
-    const { config, users } = this.props;
+    const { config, users, validation } = this.props;
 
     return (
       <React.Fragment>
@@ -83,7 +84,8 @@ class EmailNotificationForm extends React.Component {
                name="sender"
                label="Sender"
                type="text"
-               help="The email address that should be used as the notification sender."
+               bsStyle={validation.errors.sender ? 'error' : null}
+               help={validation.errors.sender || 'The email address that should be used as the notification sender.'}
                value={config.sender || ''}
                onChange={this.handleChange}
                required />
@@ -91,21 +93,26 @@ class EmailNotificationForm extends React.Component {
                name="subject"
                label="Subject"
                type="text"
-               help="The subject that should be used for the email notification."
+               bsStyle={validation.errors.subject ? 'error' : null}
+               help={validation.errors.subject || 'The subject that should be used for the email notification.'}
                value={config.subject || ''}
                onChange={this.handleChange}
                required />
-        <FormGroup id="notification-user-recipients">
+        <FormGroup controlId="notification-user-recipients"
+                   validationState={validation.errors.recipients ? 'error' : null}>
           <ControlLabel>User recipient(s) <small className="text-muted">(Optional)</small></ControlLabel>
           <MultiSelect id="notification-user-recipients"
                        value={Array.isArray(config.user_recipients) ? config.user_recipients.join(',') : ''}
                        placeholder="Select user(s)..."
                        options={this.formatUsers(users)}
                        onChange={this.handleRecipientsChange('user_recipients')} />
-          <HelpBlock>Select Graylog users that will receive this Notification.</HelpBlock>
+          <HelpBlock>
+            {validation.errors.recipients || 'Select Graylog users that will receive this Notification.'}
+          </HelpBlock>
         </FormGroup>
 
-        <FormGroup id="notification-email-recipients">
+        <FormGroup controlId="notification-email-recipients"
+                   validationState={validation.errors.recipients ? 'error' : null}>
           <ControlLabel>Email recipient(s) <small className="text-muted">(Optional)</small></ControlLabel>
           <MultiSelect id="notification-email-recipients"
                        value={Array.isArray(config.email_recipients) ? config.email_recipients.join(',') : ''}
@@ -114,16 +121,21 @@ class EmailNotificationForm extends React.Component {
                        options={[]}
                        onChange={this.handleRecipientsChange('email_recipients')}
                        allowCreate />
-          <HelpBlock>Add email addresses that will receive this Notification.</HelpBlock>
+          <HelpBlock>
+            {validation.errors.recipients || 'Add email addresses that will receive this Notification.'}
+          </HelpBlock>
         </FormGroup>
-        <FormGroup controlId="notification-body-template">
+        <FormGroup controlId="notification-body-template"
+                   validationState={validation.errors.body_template ? 'error' : null}>
           <ControlLabel>Body Template</ControlLabel>
           <SourceCodeEditor id="notification-body-template"
                             mode="text"
                             theme="light"
                             value={config.body_template || ''}
                             onChange={this.handleBodyTemplateChange} />
-          <HelpBlock>The template that will be used to generate the email body.</HelpBlock>
+          <HelpBlock>
+            {validation.errors.body_template || 'The template that will be used to generate the email body.'}
+          </HelpBlock>
         </FormGroup>
       </React.Fragment>
     );

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationFormContainer.jsx
@@ -16,6 +16,7 @@ class EmailNotificationFormContainer extends React.Component {
   static propTypes = {
     currentUser: PropTypes.object.isRequired,
     config: PropTypes.object.isRequired,
+    validation: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
   };
 

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
@@ -38,7 +38,7 @@ class HttpNotificationForm extends React.Component {
                label="URL"
                type="text"
                bsStyle={validation.errors.url ? 'error' : null}
-               help={validation.errors.url || 'The URL to POST to when an Event occurs.'}
+               help={lodash.get(validation, 'errors.url[0]', 'The URL to POST to when an Event occurs.')}
                value={config.url || ''}
                onChange={this.handleChange}
                required />

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/HttpNotificationForm.jsx
@@ -8,6 +8,7 @@ import FormsUtils from 'util/FormsUtils';
 class HttpNotificationForm extends React.Component {
   static propTypes = {
     config: PropTypes.object.isRequired,
+    validation: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
   };
 
@@ -28,7 +29,7 @@ class HttpNotificationForm extends React.Component {
   };
 
   render() {
-    const { config } = this.props;
+    const { config, validation } = this.props;
 
     return (
       <React.Fragment>
@@ -36,7 +37,8 @@ class HttpNotificationForm extends React.Component {
                name="url"
                label="URL"
                type="text"
-               help="The URL to POST to when an Event occurs."
+               bsStyle={validation.errors.url ? 'error' : null}
+               help={validation.errors.url || 'The URL to POST to when an Event occurs.'}
                value={config.url || ''}
                onChange={this.handleChange}
                required />

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationForm.jsx
@@ -10,6 +10,7 @@ import styles from './LegacyNotificationForm.css';
 class LegacyNotificationForm extends React.Component {
   static propTypes = {
     config: PropTypes.object.isRequired,
+    validation: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
     legacyTypes: PropTypes.object.isRequired,
   };
@@ -91,14 +92,15 @@ class LegacyNotificationForm extends React.Component {
   }
 
   render() {
-    const { config, legacyTypes } = this.props;
+    const { config, legacyTypes, validation } = this.props;
     const callbackType = config.callback_type;
     const typeData = legacyTypes[callbackType];
 
     return (
       <React.Fragment>
         <fieldset>
-          <FormGroup controlId="notification-legacy-select">
+          <FormGroup controlId="notification-legacy-select"
+                     validationState={validation.errors.callback_type ? 'error' : null}>
             <ControlLabel>Choose Legacy Notification</ControlLabel>
             <Select id="notification-legacy-select"
                     matchProp="label"
@@ -106,7 +108,9 @@ class LegacyNotificationForm extends React.Component {
                     onChange={this.handleSelectNotificationChange}
                     options={this.formatLegacyTypes(legacyTypes)}
                     value={callbackType} />
-            <HelpBlock>Select a Legacy Notification to use on this Event Definition.</HelpBlock>
+            <HelpBlock>
+              {validation.errors.callback_type || 'Select a Legacy Notification to use on this Event Definition.'}
+            </HelpBlock>
           </FormGroup>
         </fieldset>
 

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationForm.jsx
@@ -14,6 +14,11 @@ class LegacyNotificationForm extends React.Component {
     legacyTypes: PropTypes.object.isRequired,
   };
 
+  static defaultConfig = {
+    callback_type: '',
+    configuration: {},
+  };
+
   propagateMultiChange = (newValues) => {
     const { config, onChange } = this.props;
     const nextConfig = Object.assign({}, config, newValues);

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationForm.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Alert, ControlLabel, FormGroup, HelpBlock } from 'react-bootstrap';
+import lodash from 'lodash';
 
 import { Select } from 'components/common';
 import { ConfigurationFormField } from 'components/configurationforms';
@@ -109,7 +110,7 @@ class LegacyNotificationForm extends React.Component {
                     options={this.formatLegacyTypes(legacyTypes)}
                     value={callbackType} />
             <HelpBlock>
-              {validation.errors.callback_type || 'Select a Legacy Notification to use on this Event Definition.'}
+              {lodash.get(validation, 'errors.callback_type[0]', 'Select a Legacy Notification to use on this Event Definition.')}
             </HelpBlock>
           </FormGroup>
         </fieldset>

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationFormContainer.jsx
@@ -13,6 +13,7 @@ const { EventNotificationsStore, EventNotificationsActions } = CombinedProvider.
 class LegacyNotificationFormContainer extends React.Component {
   static propTypes = {
     config: PropTypes.object.isRequired,
+    validation: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
     notifications: PropTypes.object.isRequired,
   };

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/index.js
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/index.js
@@ -5,6 +5,7 @@ import EmailNotificationForm from './EmailNotificationForm';
 import EmailNotificationSummary from './EmailNotificationSummary';
 import HttpNotificationForm from './HttpNotificationForm';
 import HttpNotificationSummary from './HttpNotificationSummary';
+import LegacyNotificationForm from './LegacyNotificationForm';
 import LegacyNotificationFormContainer from './LegacyNotificationFormContainer';
 import LegacyNotificationSummaryContainer from './LegacyNotificationSummaryContainer';
 
@@ -29,6 +30,7 @@ PluginStore.register(new PluginManifest({}, {
       displayName: 'Legacy Alarm Callbacks',
       formComponent: LegacyNotificationFormContainer,
       summaryComponent: LegacyNotificationSummaryContainer,
+      defaultConfig: LegacyNotificationForm.defaultConfig,
     },
   ],
 }));

--- a/graylog2-web-interface/src/stores/event-definitions/EventDefinitionsStore.js
+++ b/graylog2-web-interface/src/stores/event-definitions/EventDefinitionsStore.js
@@ -120,8 +120,10 @@ const EventDefinitionsStore = Reflux.createStore({
         return response;
       },
       (error) => {
-        UserNotification.error(`Creating Event Definition "${eventDefinition.title}" failed with status: ${error}`,
+        if (error.status !== 400 || !error.additional.body || !error.additional.body.failed) {
+          UserNotification.error(`Creating Event Definition "${eventDefinition.title}" failed with status: ${error}`,
           'Could not save Event Definition');
+        }
       },
     );
     EventDefinitionsActions.create.promise(promise);
@@ -138,8 +140,10 @@ const EventDefinitionsStore = Reflux.createStore({
         return response;
       },
       (error) => {
-        UserNotification.error(`Updating Event Definition "${eventDefinition.title}" failed with status: ${error}`,
-          'Could not update Event Definition');
+        if (error.status !== 400 || !error.additional.body || !error.additional.body.failed) {
+          UserNotification.error(`Updating Event Definition "${eventDefinition.title}" failed with status: ${error}`,
+            'Could not update Event Definition');
+        }
       },
     );
     EventDefinitionsActions.update.promise(promise);

--- a/graylog2-web-interface/src/stores/event-definitions/EventDefinitionsStore.js
+++ b/graylog2-web-interface/src/stores/event-definitions/EventDefinitionsStore.js
@@ -122,7 +122,7 @@ const EventDefinitionsStore = Reflux.createStore({
       (error) => {
         if (error.status !== 400 || !error.additional.body || !error.additional.body.failed) {
           UserNotification.error(`Creating Event Definition "${eventDefinition.title}" failed with status: ${error}`,
-          'Could not save Event Definition');
+            'Could not save Event Definition');
         }
       },
     );

--- a/graylog2-web-interface/src/stores/event-notifications/EventNotificationsStore.js
+++ b/graylog2-web-interface/src/stores/event-notifications/EventNotificationsStore.js
@@ -116,8 +116,10 @@ const EventNotificationsStore = Reflux.createStore({
         return response;
       },
       (error) => {
-        UserNotification.error(`Creating Notification "${notification.title}" failed with status: ${error}`,
-          'Could not save Notification');
+        if (error.status !== 400 || !error.additional.body || !error.additional.body.failed) {
+          UserNotification.error(`Creating Notification "${notification.title}" failed with status: ${error}`,
+            'Could not save Notification');
+        }
       },
     );
     EventNotificationsActions.create.promise(promise);
@@ -132,8 +134,10 @@ const EventNotificationsStore = Reflux.createStore({
         return response;
       },
       (error) => {
-        UserNotification.error(`Updating Notification "${notification.title}" failed with status: ${error}`,
-          'Could not update Notification');
+        if (error.status !== 400 || !error.additional.body || !error.additional.body.failed) {
+          UserNotification.error(`Updating Notification "${notification.title}" failed with status: ${error}`,
+            'Could not update Notification');
+        }
       },
     );
     EventNotificationsActions.update.promise(promise);


### PR DESCRIPTION
This PR adds some validations to Event Definitions and Notifications:

- Both entities will be validated when creating or updating them
- When an entity with validation errors is detected, a `ValidationResult` is returned in the response with information about the detected errors
- The frontend code do basic HTML5 validation when possible, and rely on backend validation for the rest
-  Validation errors are displayed inline when possible

So far validation only occurs before the entity is persisted, so in the Event Definition wizard there is no validation on step change. Submitting the form and going back to any step will display validation errors when they happen, though.

Not each validation is detected yet, but we can extend that when we have more time for it.

Fixes #6192, #6217, and partially #6153 
