### PR TITLE
Fix error for missing legacy notification plugins in Event Definition form

### DIFF
--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/CommonNotificationSummary.css
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/CommonNotificationSummary.css
@@ -1,3 +1,4 @@
 :local(.fixedTable) {
     table-layout: fixed;
+    overflow-wrap: break-word;
 }

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationCommonStyles.css
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationCommonStyles.css
@@ -1,3 +1,4 @@
 :local(.legacyNotificationAlert) {
     margin-bottom: 15px;
+    overflow-wrap: break-word;
 }

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationForm.jsx
@@ -6,7 +6,7 @@ import lodash from 'lodash';
 import { Select } from 'components/common';
 import { ConfigurationFormField } from 'components/configurationforms';
 
-import styles from './LegacyNotificationForm.css';
+import commonStyles from './LegacyNotificationCommonStyles.css';
 
 class LegacyNotificationForm extends React.Component {
   static propTypes = {
@@ -94,7 +94,7 @@ class LegacyNotificationForm extends React.Component {
       content = this.renderNotificationForm(config, typeData);
     } else if (callbackType) {
       content = (
-        <Alert bsStyle="danger" className={styles.legacyNotificationAlert}>
+        <Alert bsStyle="danger" className={commonStyles.legacyNotificationAlert}>
           Unknown legacy alarm callback type: <strong>{callbackType}</strong> Please make sure the plugin is installed.
         </Alert>
       );
@@ -118,7 +118,7 @@ class LegacyNotificationForm extends React.Component {
           </FormGroup>
         </fieldset>
 
-        <Alert bsStyle="danger" className={styles.legacyNotificationAlert}>
+        <Alert bsStyle="danger" className={commonStyles.legacyNotificationAlert}>
           Legacy alarm callbacks are deprecated. Please switch to the new notification types as soon as possible!
         </Alert>
 

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationSummary.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationSummary.jsx
@@ -15,21 +15,36 @@ class LegacyNotificationSummary extends React.Component {
     const { notification, legacyTypes } = this.props;
     const configurationValues = notification.config.configuration;
     const callbackType = notification.config.callback_type;
-    const typeConfiguration = legacyTypes[callbackType].configuration;
+    const typeData = legacyTypes[callbackType];
 
-    const summaryFields = Object.entries(typeConfiguration).map(([key, value]) => {
-      return (
-        <tr key={key}>
-          <td>{value.human_name}</td>
-          <td>{configurationValues[key]}</td>
+    let content;
+    if (typeData) {
+      const typeConfiguration = typeData.configuration;
+
+      content = Object.entries(typeConfiguration)
+        .map(([key, value]) => {
+          return (
+            <tr key={key}>
+              <td>{value.human_name}</td>
+              <td>{configurationValues[key]}</td>
+            </tr>
+          );
+        });
+    } else {
+      content = (
+        <tr className="danger">
+          <td>Type</td>
+          <td>
+            Unknown legacy alarm callback type: <strong>{callbackType}</strong> Please make sure the plugin is installed.
+          </td>
         </tr>
       );
-    });
+    }
 
     return (
       <CommonNotificationSummary {...this.props}>
         <React.Fragment>
-          {summaryFields}
+          {content}
         </React.Fragment>
       </CommonNotificationSummary>
     );

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationSummary.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationSummary.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Alert } from 'react-bootstrap';
 
 import CommonNotificationSummary from './CommonNotificationSummary';
+import commonStyles from './LegacyNotificationCommonStyles.css';
 
 class LegacyNotificationSummary extends React.Component {
   static propTypes = {
@@ -35,18 +37,27 @@ class LegacyNotificationSummary extends React.Component {
         <tr className="danger">
           <td>Type</td>
           <td>
-            Unknown legacy alarm callback type: <strong>{callbackType}</strong> Please make sure the plugin is installed.
+            Unknown legacy alarm callback type: <code>{callbackType}</code>.
+            Please make sure the plugin is installed.
           </td>
         </tr>
       );
     }
 
     return (
-      <CommonNotificationSummary {...this.props}>
-        <React.Fragment>
-          {content}
-        </React.Fragment>
-      </CommonNotificationSummary>
+      <React.Fragment>
+        {!typeData && (
+          <Alert bsStyle="danger" className={commonStyles.legacyNotificationAlert}>
+            Error in {notification.title || 'Legacy Alarm Callback'}: Unknown type <code>{callbackType}</code>,
+            please ensure the plugin is installed.
+          </Alert>
+        )}
+        <CommonNotificationSummary {...this.props}>
+          <React.Fragment>
+            {content}
+          </React.Fragment>
+        </CommonNotificationSummary>
+      </React.Fragment>
     );
   }
 }


### PR DESCRIPTION
When selecting a notification from a removed legacy alarm callback plugin in the Event Definition form, going to the summary step results in an error.

This commit fixes the issue by checking if the configuration is defined before accessing it and displaying a message like in #6199.
