### PR TITLE
Adjust UI for new alerting

### DIFF
--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionsComponent.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionsComponent.jsx
@@ -56,7 +56,7 @@ const AlertConditionsComponent = createReactClass({
     return (
       <div>
         <div className="pull-right">
-          <LinkContainer to={Routes.ALERTS.NEW_CONDITION}>
+          <LinkContainer to={Routes.LEGACY_ALERTS.NEW_CONDITION}>
             <Button bsStyle="success">Add new condition</Button>
           </LinkContainer>
         </div>

--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotificationsComponent.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotificationsComponent.jsx
@@ -55,7 +55,7 @@ const AlertNotificationsComponent = createReactClass({
     return (
       <div>
         <div className="pull-right">
-          <LinkContainer to={Routes.ALERTS.NEW_NOTIFICATION}>
+          <LinkContainer to={Routes.LEGACY_ALERTS.NEW_NOTIFICATION}>
             <Button bsStyle="success">Add new notification</Button>
           </LinkContainer>
         </div>

--- a/graylog2-web-interface/src/components/alerts/AlertsHeaderToolbar.jsx
+++ b/graylog2-web-interface/src/components/alerts/AlertsHeaderToolbar.jsx
@@ -19,14 +19,14 @@ class AlertsHeaderToolbar extends React.Component {
 
     return (
       <ButtonToolbar>
-        <LinkContainer to={Routes.ALERTS.LIST}>
-          <Button bsStyle="info" className={this._isActive(active, Routes.ALERTS.LIST)}>Alerts</Button>
+        <LinkContainer to={Routes.LEGACY_ALERTS.LIST}>
+          <Button bsStyle="info" className={this._isActive(active, Routes.LEGACY_ALERTS.LIST)}>Alerts</Button>
         </LinkContainer>
-        <LinkContainer to={Routes.ALERTS.CONDITIONS}>
-          <Button bsStyle="info" className={this._isActive(active, Routes.ALERTS.CONDITIONS)}>Conditions</Button>
+        <LinkContainer to={Routes.LEGACY_ALERTS.CONDITIONS}>
+          <Button bsStyle="info" className={this._isActive(active, Routes.LEGACY_ALERTS.CONDITIONS)}>Conditions</Button>
         </LinkContainer>
-        <LinkContainer to={Routes.ALERTS.NOTIFICATIONS}>
-          <Button bsStyle="info" className={this._isActive(active, Routes.ALERTS.NOTIFICATIONS)}>Notifications</Button>
+        <LinkContainer to={Routes.LEGACY_ALERTS.NOTIFICATIONS}>
+          <Button bsStyle="info" className={this._isActive(active, Routes.LEGACY_ALERTS.NOTIFICATIONS)}>Notifications</Button>
         </LinkContainer>
       </ButtonToolbar>
     );

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.jsx
@@ -90,7 +90,7 @@ class EventDefinitionFormContainer extends React.Component {
     if (action === 'create') {
       EventDefinitionsActions.create(eventDefinition)
         .then(
-          () => history.push(Routes.NEXT_ALERTS.DEFINITIONS.LIST),
+          () => history.push(Routes.ALERTS.DEFINITIONS.LIST),
           (errorResponse) => {
             const { body } = errorResponse.additional;
             if (errorResponse.status === 400 && body && body.failed) {
@@ -101,7 +101,7 @@ class EventDefinitionFormContainer extends React.Component {
     } else {
       EventDefinitionsActions.update(eventDefinition.id, eventDefinition)
         .then(
-          () => history.push(Routes.NEXT_ALERTS.DEFINITIONS.LIST),
+          () => history.push(Routes.ALERTS.DEFINITIONS.LIST),
           (errorResponse) => {
             const { body } = errorResponse.additional;
             if (errorResponse.status === 400 && body && body.failed) {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationsForm.jsx
@@ -62,7 +62,7 @@ class NotificationsForm extends React.Component {
       <Row>
         <Col md={6} lg={5}>
           <span className={styles.manageNotifications}>
-            <LinkContainer to={Routes.NEXT_ALERTS.NOTIFICATIONS.LIST} target="_blank">
+            <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST} target="_blank">
               <Button bsStyle="link" bsSize="small">Manage Notifications <i className="fa fa-external-link" /></Button>
             </LinkContainer>
           </span>

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
@@ -38,7 +38,7 @@ class EventDefinitions extends React.Component {
               Create Event Definitions that are able to search, aggregate or correlate Messages and other
               Events, allowing you to record significant Events in Graylog and alert on them.
             </p>
-            <LinkContainer to={Routes.NEXT_ALERTS.DEFINITIONS.CREATE}>
+            <LinkContainer to={Routes.ALERTS.DEFINITIONS.CREATE}>
               <Button bsStyle="success">Get Started!</Button>
             </LinkContainer>
           </EmptyEntity>
@@ -85,7 +85,7 @@ class EventDefinitions extends React.Component {
     const items = eventDefinitions.map((definition) => {
       const actions = (
         <React.Fragment key={`actions-${definition.id}`}>
-          <LinkContainer to={Routes.NEXT_ALERTS.DEFINITIONS.edit(definition.id)}>
+          <LinkContainer to={Routes.ALERTS.DEFINITIONS.edit(definition.id)}>
             <Button bsStyle="info">Edit</Button>
           </LinkContainer>
           <DropdownButton id="more-dropdown" title="More" pullRight>
@@ -111,7 +111,7 @@ class EventDefinitions extends React.Component {
         <Row>
           <Col md={12}>
             <div className="pull-right">
-              <LinkContainer to={Routes.NEXT_ALERTS.DEFINITIONS.CREATE}>
+              <LinkContainer to={Routes.ALERTS.DEFINITIONS.CREATE}>
                 <Button bsStyle="success">Create Event Definition</Button>
               </LinkContainer>
             </div>

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationFormContainer.jsx
@@ -71,7 +71,7 @@ class EventNotificationFormContainer extends React.Component {
       promise.then(
         () => {
           if (!embedded) {
-            history.push(Routes.NEXT_ALERTS.NOTIFICATIONS.LIST);
+            history.push(Routes.ALERTS.NOTIFICATIONS.LIST);
           }
         },
         (errorResponse) => {
@@ -86,7 +86,7 @@ class EventNotificationFormContainer extends React.Component {
       promise.then(
         () => {
           if (!embedded) {
-            history.push(Routes.NEXT_ALERTS.NOTIFICATIONS.LIST);
+            history.push(Routes.ALERTS.NOTIFICATIONS.LIST);
           }
         },
         (errorResponse) => {

--- a/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.jsx
@@ -29,7 +29,7 @@ class EventNotifications extends React.Component {
               Configure Event Notifications that can alert you when an Event occurs. You can also use Notifications
               to integrate Graylog Alerts with an external alerting system you use.
             </p>
-            <LinkContainer to={Routes.NEXT_ALERTS.NOTIFICATIONS.CREATE}>
+            <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.CREATE}>
               <Button bsStyle="success">Get Started!</Button>
             </LinkContainer>
           </EmptyEntity>
@@ -51,7 +51,7 @@ class EventNotifications extends React.Component {
     return notifications.map((notification) => {
       const actions = (
         <React.Fragment>
-          <LinkContainer to={Routes.NEXT_ALERTS.NOTIFICATIONS.edit(notification.id)}>
+          <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.edit(notification.id)}>
             <Button bsStyle="info">Edit</Button>
           </LinkContainer>
           <DropdownButton id={`more-dropdown-${notification.id}`} title="More" pullRight>
@@ -84,7 +84,7 @@ class EventNotifications extends React.Component {
         <Row>
           <Col md={12}>
             <div className="pull-right">
-              <LinkContainer to={Routes.NEXT_ALERTS.NOTIFICATIONS.CREATE}>
+              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.CREATE}>
                 <Button bsStyle="success">Create Notification</Button>
               </LinkContainer>
             </div>

--- a/graylog2-web-interface/src/components/events/events/EventDetails.jsx
+++ b/graylog2-web-interface/src/components/events/events/EventDetails.jsx
@@ -59,7 +59,7 @@ class EventDetails extends React.Component {
             <dt>Event Definition</dt>
             <dd>
               {eventDefinitionContext ? (
-                <Link to={Routes.NEXT_ALERTS.DEFINITIONS.edit(eventDefinitionContext.id)}>
+                <Link to={Routes.ALERTS.DEFINITIONS.edit(eventDefinitionContext.id)}>
                   {eventDefinitionContext.title}
                 </Link>
               ) : (

--- a/graylog2-web-interface/src/components/events/events/Events.jsx
+++ b/graylog2-web-interface/src/components/events/events/Events.jsx
@@ -99,7 +99,7 @@ class Events extends React.Component {
           <td>{event.alert ? <Label bsStyle="warning">Alert</Label> : <Label bsStyle="info">Event</Label>}</td>
           <td>
             {eventDefinitionContext ? (
-              <Link to={Routes.NEXT_ALERTS.DEFINITIONS.edit(eventDefinitionContext.id)}>
+              <Link to={Routes.ALERTS.DEFINITIONS.edit(eventDefinitionContext.id)}>
                 {eventDefinitionContext.title}
               </Link>
             ) : (
@@ -128,7 +128,7 @@ class Events extends React.Component {
               Create Event Definitions that are able to search, aggregate or correlate Messages and other
               Events, allowing you to record significant Events in Graylog and alert on them.
             </p>
-            <LinkContainer to={Routes.NEXT_ALERTS.DEFINITIONS.CREATE}>
+            <LinkContainer to={Routes.ALERTS.DEFINITIONS.CREATE}>
               <Button bsStyle="success">Get Started!</Button>
             </LinkContainer>
           </EmptyEntity>

--- a/graylog2-web-interface/src/components/events/events/Events.jsx
+++ b/graylog2-web-interface/src/components/events/events/Events.jsx
@@ -156,6 +156,9 @@ class Events extends React.Component {
       return this.renderEmptyContent();
     }
 
+    const filter = parameters.filter.alerts;
+    const entity = (filter === 'only' ? 'Alerts' : (filter === 'exclude' ? 'Events' : 'Alerts & Events'));
+
     return (
       <React.Fragment>
         <Row>
@@ -174,7 +177,7 @@ class Events extends React.Component {
                            totalItems={totalEvents}
                            onChange={onPageChange}>
               {eventList.length === 0 ? (
-                <Alert bsStyle="info">No Events found for the current search criteria.</Alert>
+                <Alert bsStyle="info">No {entity} found for the current search criteria.</Alert>
               ) : (
                 <Table id="events-table" className={styles.eventsTable}>
                   <thead>

--- a/graylog2-web-interface/src/components/events/events/EventsContainer.jsx
+++ b/graylog2-web-interface/src/components/events/events/EventsContainer.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import lodash from 'lodash';
 
 import { Spinner } from 'components/common';
 
@@ -17,10 +18,21 @@ class EventsContainer extends React.Component {
   static propTypes = {
     events: PropTypes.object.isRequired,
     eventDefinitions: PropTypes.object.isRequired,
+    streamId: PropTypes.string,
+  };
+
+  static defaultProps = {
+    streamId: '',
   };
 
   componentDidMount() {
-    this.fetchEvents({});
+    const { streamId } = this.props;
+    const params = {};
+    if (streamId) {
+      params.query = `source_streams:${streamId}`;
+    }
+
+    this.fetchEvents(params);
     this.fetchEventDefinitions();
   }
 

--- a/graylog2-web-interface/src/components/events/events/EventsContainer.jsx
+++ b/graylog2-web-interface/src/components/events/events/EventsContainer.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import lodash from 'lodash';
 
 import { Spinner } from 'components/common';
 

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -98,7 +98,7 @@ const Navigation = ({ permissions, fullName, location, loginName }) => {
             <NavItem>Streams</NavItem>
           </LinkContainer>
 
-          <LinkContainer to={Routes.ALERTS.LIST}>
+          <LinkContainer to={Routes.LEGACY_ALERTS.LIST}>
             <NavItem>Alerts</NavItem>
           </LinkContainer>
 

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -98,12 +98,8 @@ const Navigation = ({ permissions, fullName, location, loginName }) => {
             <NavItem>Streams</NavItem>
           </LinkContainer>
 
-          <LinkContainer to={Routes.LEGACY_ALERTS.LIST}>
-            <NavItem>Alerts</NavItem>
-          </LinkContainer>
-
           <LinkContainer to={Routes.ALERTS.LIST}>
-            <NavItem>Events</NavItem>
+            <NavItem>Alerts</NavItem>
           </LinkContainer>
 
           <LinkContainer to={Routes.DASHBOARDS}>

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -102,7 +102,7 @@ const Navigation = ({ permissions, fullName, location, loginName }) => {
             <NavItem>Alerts</NavItem>
           </LinkContainer>
 
-          <LinkContainer to={Routes.NEXT_ALERTS.LIST}>
+          <LinkContainer to={Routes.ALERTS.LIST}>
             <NavItem>Events</NavItem>
           </LinkContainer>
 

--- a/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
@@ -148,9 +148,9 @@ describe('Navigation', () => {
     };
     it.each`
     permissions                    | count | links
-    ${[]}                          | ${5}  | ${['Streams', 'Alerts', 'Dashboards']}
-    ${['searches:absolute', 'searches:relative', 'searches:keyword']} | ${6}  | ${['Search']}
-    ${['sources:read']}            | ${6}  | ${['Sources']}
+    ${[]}                          | ${4}  | ${['Streams', 'Alerts', 'Dashboards']}
+    ${['searches:absolute', 'searches:relative', 'searches:keyword']} | ${5}  | ${['Search']}
+    ${['sources:read']}            | ${5}  | ${['Sources']}
   `('shows $links for user with $permissions permissions', verifyPermissions);
   });
 });

--- a/graylog2-web-interface/src/pages/AlertConditionsPage.jsx
+++ b/graylog2-web-interface/src/pages/AlertConditionsPage.jsx
@@ -34,7 +34,7 @@ const AlertConditionsPage = createReactClass({
             </span>
 
             <span>
-              <AlertsHeaderToolbar active={Routes.ALERTS.CONDITIONS} />
+              <AlertsHeaderToolbar active={Routes.LEGACY_ALERTS.CONDITIONS} />
             </span>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/AlertNotificationsPage.jsx
+++ b/graylog2-web-interface/src/pages/AlertNotificationsPage.jsx
@@ -31,7 +31,7 @@ const AlertNotificationsPage = createReactClass({
             </span>
 
             <span>
-              <AlertsHeaderToolbar active={Routes.ALERTS.NOTIFICATIONS} />
+              <AlertsHeaderToolbar active={Routes.LEGACY_ALERTS.NOTIFICATIONS} />
             </span>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/AlertsPage.jsx
+++ b/graylog2-web-interface/src/pages/AlertsPage.jsx
@@ -34,7 +34,7 @@ const AlertsPage = createReactClass({
             </span>
 
             <span>
-              <AlertsHeaderToolbar active={Routes.ALERTS.LIST} />
+              <AlertsHeaderToolbar active={Routes.LEGACY_ALERTS.LIST} />
             </span>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/CreateEventDefinitionPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateEventDefinitionPage.jsx
@@ -42,7 +42,7 @@ class CreateEventDefinitionPage extends React.Component {
 
             <ButtonToolbar>
               <LinkContainer to={Routes.ALERTS.LIST}>
-                <Button bsStyle="info">Events</Button>
+                <Button bsStyle="info">Alerts & Events</Button>
               </LinkContainer>
               <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
                 <Button bsStyle="info">Event Definitions</Button>

--- a/graylog2-web-interface/src/pages/CreateEventDefinitionPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateEventDefinitionPage.jsx
@@ -41,13 +41,13 @@ class CreateEventDefinitionPage extends React.Component {
             </span>
 
             <ButtonToolbar>
-              <LinkContainer to={Routes.NEXT_ALERTS.LIST}>
+              <LinkContainer to={Routes.ALERTS.LIST}>
                 <Button bsStyle="info">Events</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.NEXT_ALERTS.DEFINITIONS.LIST}>
+              <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
                 <Button bsStyle="info">Event Definitions</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.NEXT_ALERTS.NOTIFICATIONS.LIST}>
+              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
                 <Button bsStyle="info">Notifications</Button>
               </LinkContainer>
             </ButtonToolbar>

--- a/graylog2-web-interface/src/pages/CreateEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateEventNotificationPage.jsx
@@ -29,7 +29,7 @@ class CreateEventDefinitionPage extends React.Component {
 
             <ButtonToolbar>
               <LinkContainer to={Routes.ALERTS.LIST}>
-                <Button bsStyle="info">Events</Button>
+                <Button bsStyle="info">Alerts & Events</Button>
               </LinkContainer>
               <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
                 <Button bsStyle="info">Event Definitions</Button>

--- a/graylog2-web-interface/src/pages/CreateEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateEventNotificationPage.jsx
@@ -28,13 +28,13 @@ class CreateEventDefinitionPage extends React.Component {
             </span>
 
             <ButtonToolbar>
-              <LinkContainer to={Routes.NEXT_ALERTS.LIST}>
+              <LinkContainer to={Routes.ALERTS.LIST}>
                 <Button bsStyle="info">Events</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.NEXT_ALERTS.DEFINITIONS.LIST}>
+              <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
                 <Button bsStyle="info">Event Definitions</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.NEXT_ALERTS.NOTIFICATIONS.LIST}>
+              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
                 <Button bsStyle="info">Notifications</Button>
               </LinkContainer>
             </ButtonToolbar>

--- a/graylog2-web-interface/src/pages/EditAlertConditionPage.jsx
+++ b/graylog2-web-interface/src/pages/EditAlertConditionPage.jsx
@@ -48,7 +48,7 @@ const EditAlertConditionPage = createReactClass({
   },
 
   _handleDelete() {
-    history.push(Routes.ALERTS.CONDITIONS);
+    history.push(Routes.LEGACY_ALERTS.CONDITIONS);
   },
 
   _isLoading() {
@@ -79,7 +79,7 @@ const EditAlertConditionPage = createReactClass({
             </span>
 
             <span>
-              <AlertsHeaderToolbar active={Routes.ALERTS.CONDITIONS} />
+              <AlertsHeaderToolbar active={Routes.LEGACY_ALERTS.CONDITIONS} />
             </span>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/EditEventDefinitionPage.jsx
+++ b/graylog2-web-interface/src/pages/EditEventDefinitionPage.jsx
@@ -59,13 +59,13 @@ class EditEventDefinitionPage extends React.Component {
             </span>
 
             <ButtonToolbar>
-              <LinkContainer to={Routes.NEXT_ALERTS.LIST}>
+              <LinkContainer to={Routes.ALERTS.LIST}>
                 <Button bsStyle="info">Events</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.NEXT_ALERTS.DEFINITIONS.LIST}>
+              <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
                 <Button bsStyle="info">Event Definitions</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.NEXT_ALERTS.NOTIFICATIONS.LIST}>
+              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
                 <Button bsStyle="info">Notifications</Button>
               </LinkContainer>
             </ButtonToolbar>

--- a/graylog2-web-interface/src/pages/EditEventDefinitionPage.jsx
+++ b/graylog2-web-interface/src/pages/EditEventDefinitionPage.jsx
@@ -60,7 +60,7 @@ class EditEventDefinitionPage extends React.Component {
 
             <ButtonToolbar>
               <LinkContainer to={Routes.ALERTS.LIST}>
-                <Button bsStyle="info">Events</Button>
+                <Button bsStyle="info">Alerts & Events</Button>
               </LinkContainer>
               <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
                 <Button bsStyle="info">Event Definitions</Button>

--- a/graylog2-web-interface/src/pages/EditEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/EditEventNotificationPage.jsx
@@ -60,13 +60,13 @@ class EditEventDefinitionPage extends React.Component {
             </span>
 
             <ButtonToolbar>
-              <LinkContainer to={Routes.NEXT_ALERTS.LIST}>
+              <LinkContainer to={Routes.ALERTS.LIST}>
                 <Button bsStyle="info">Events</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.NEXT_ALERTS.DEFINITIONS.LIST}>
+              <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
                 <Button bsStyle="info">Event Definitions</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.NEXT_ALERTS.NOTIFICATIONS.LIST}>
+              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
                 <Button bsStyle="info">Notifications</Button>
               </LinkContainer>
             </ButtonToolbar>

--- a/graylog2-web-interface/src/pages/EditEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/EditEventNotificationPage.jsx
@@ -61,7 +61,7 @@ class EditEventDefinitionPage extends React.Component {
 
             <ButtonToolbar>
               <LinkContainer to={Routes.ALERTS.LIST}>
-                <Button bsStyle="info">Events</Button>
+                <Button bsStyle="info">Alerts & Events</Button>
               </LinkContainer>
               <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
                 <Button bsStyle="info">Event Definitions</Button>

--- a/graylog2-web-interface/src/pages/EventDefinitionsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventDefinitionsPage.jsx
@@ -26,13 +26,13 @@ class EventDefinitionsPage extends React.Component {
             </span>
 
             <ButtonToolbar>
-              <LinkContainer to={Routes.NEXT_ALERTS.LIST}>
+              <LinkContainer to={Routes.ALERTS.LIST}>
                 <Button bsStyle="info">Events</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.NEXT_ALERTS.DEFINITIONS.LIST}>
+              <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
                 <Button bsStyle="info" className="active">Event Definitions</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.NEXT_ALERTS.NOTIFICATIONS.LIST}>
+              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
                 <Button bsStyle="info">Notifications</Button>
               </LinkContainer>
             </ButtonToolbar>

--- a/graylog2-web-interface/src/pages/EventDefinitionsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventDefinitionsPage.jsx
@@ -27,7 +27,7 @@ class EventDefinitionsPage extends React.Component {
 
             <ButtonToolbar>
               <LinkContainer to={Routes.ALERTS.LIST}>
-                <Button bsStyle="info">Events</Button>
+                <Button bsStyle="info">Alerts & Events</Button>
               </LinkContainer>
               <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
                 <Button bsStyle="info" className="active">Event Definitions</Button>

--- a/graylog2-web-interface/src/pages/EventNotificationsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventNotificationsPage.jsx
@@ -27,7 +27,7 @@ class EventNotificationsPage extends React.Component {
 
             <ButtonToolbar>
               <LinkContainer to={Routes.ALERTS.LIST}>
-                <Button bsStyle="info">Events</Button>
+                <Button bsStyle="info">Alerts & Events</Button>
               </LinkContainer>
               <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
                 <Button bsStyle="info">Event Definitions</Button>

--- a/graylog2-web-interface/src/pages/EventNotificationsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventNotificationsPage.jsx
@@ -26,13 +26,13 @@ class EventNotificationsPage extends React.Component {
             </span>
 
             <ButtonToolbar>
-              <LinkContainer to={Routes.NEXT_ALERTS.LIST}>
+              <LinkContainer to={Routes.ALERTS.LIST}>
                 <Button bsStyle="info">Events</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.NEXT_ALERTS.DEFINITIONS.LIST}>
+              <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
                 <Button bsStyle="info">Event Definitions</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.NEXT_ALERTS.NOTIFICATIONS.LIST}>
+              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
                 <Button bsStyle="info" className="active">Notifications</Button>
               </LinkContainer>
             </ButtonToolbar>

--- a/graylog2-web-interface/src/pages/EventsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventsPage.jsx
@@ -18,8 +18,8 @@ class EventsPage extends React.Component {
         <span>
           <PageHeader title="Alerts & Events">
             <span>
-              Events are generated when Event Definitions you define are satisfied. Alerts also trigger
-              Notifications, being meant to capture relevant Events that may require your attention.
+              Define Events through different conditions. Add Notifications to Events that require your attention
+              to create Alerts.
             </span>
 
             <span>

--- a/graylog2-web-interface/src/pages/EventsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventsPage.jsx
@@ -14,9 +14,9 @@ class EventsPage extends React.Component {
 
   render() {
     return (
-      <DocumentTitle title="Events">
+      <DocumentTitle title="Alerts & Events">
         <span>
-          <PageHeader title="Events">
+          <PageHeader title="Alerts & Events">
             <span>
               Events are generated when Event Definitions you define are satisfied. Alerts also trigger
               Notifications, being meant to capture relevant Events that may require your attention.
@@ -30,7 +30,7 @@ class EventsPage extends React.Component {
 
             <ButtonToolbar>
               <LinkContainer to={Routes.ALERTS.LIST}>
-                <Button bsStyle="info" className="active">Events</Button>
+                <Button bsStyle="info" className="active">Alerts & Events</Button>
               </LinkContainer>
               <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
                 <Button bsStyle="info">Event Definitions</Button>

--- a/graylog2-web-interface/src/pages/EventsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventsPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 
@@ -10,9 +11,14 @@ import DocsHelper from 'util/DocsHelper';
 import Routes from 'routing/Routes';
 
 class EventsPage extends React.Component {
-  static propTypes = {};
+  static propTypes = {
+    location: PropTypes.object.isRequired,
+  };
 
   render() {
+    const { location } = this.props;
+    const filteredSourceStream = location.query.stream_id;
+
     return (
       <DocumentTitle title="Alerts & Events">
         <span>
@@ -43,7 +49,7 @@ class EventsPage extends React.Component {
 
           <Row className="content">
             <Col md={12}>
-              <EventsContainer />
+              <EventsContainer key={filteredSourceStream} streamId={filteredSourceStream} />
             </Col>
           </Row>
         </span>

--- a/graylog2-web-interface/src/pages/EventsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventsPage.jsx
@@ -29,13 +29,13 @@ class EventsPage extends React.Component {
             </span>
 
             <ButtonToolbar>
-              <LinkContainer to={Routes.NEXT_ALERTS.LIST}>
+              <LinkContainer to={Routes.ALERTS.LIST}>
                 <Button bsStyle="info" className="active">Events</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.NEXT_ALERTS.DEFINITIONS.LIST}>
+              <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
                 <Button bsStyle="info">Event Definitions</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.NEXT_ALERTS.NOTIFICATIONS.LIST}>
+              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
                 <Button bsStyle="info">Notifications</Button>
               </LinkContainer>
             </ButtonToolbar>

--- a/graylog2-web-interface/src/pages/NewAlertConditionPage.jsx
+++ b/graylog2-web-interface/src/pages/NewAlertConditionPage.jsx
@@ -40,7 +40,7 @@ const NewAlertConditionPage = createReactClass({
             </span>
 
             <span>
-              <AlertsHeaderToolbar active={Routes.ALERTS.CONDITIONS} />
+              <AlertsHeaderToolbar active={Routes.LEGACY_ALERTS.CONDITIONS} />
             </span>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/NewAlertNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/NewAlertNotificationPage.jsx
@@ -36,7 +36,7 @@ const NewAlertNotificationPage = createReactClass({
             </span>
 
             <span>
-              <AlertsHeaderToolbar active={Routes.ALERTS.NOTIFICATIONS} />
+              <AlertsHeaderToolbar active={Routes.LEGACY_ALERTS.NOTIFICATIONS} />
             </span>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/ShowAlertPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowAlertPage.jsx
@@ -131,7 +131,7 @@ const ShowAlertPage = createReactClass({
 
             <span>
               <ButtonToolbar>
-                <LinkContainer to={Routes.ALERTS.LIST}>
+                <LinkContainer to={Routes.LEGACY_ALERTS.LIST}>
                   <Button bsStyle="info" className="active">Alerts</Button>
                 </LinkContainer>
                 <OverlayElement overlay={conditionDetailsTooltip}

--- a/graylog2-web-interface/src/pages/StreamAlertsOverviewPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamAlertsOverviewPage.jsx
@@ -53,13 +53,13 @@ class StreamAlertsOverviewPage extends React.Component {
               <LinkContainer to={Routes.STREAMS}>
                 <Button bsStyle="info">Streams</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.ALERTS.LIST}>
+              <LinkContainer to={Routes.LEGACY_ALERTS.LIST}>
                 <Button bsStyle="info">All Alerts</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.ALERTS.CONDITIONS}>
+              <LinkContainer to={Routes.LEGACY_ALERTS.CONDITIONS}>
                 <Button bsStyle="info">All Conditions</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS}>
+              <LinkContainer to={Routes.LEGACY_ALERTS.NOTIFICATIONS}>
                 <Button bsStyle="info">All Notifications</Button>
               </LinkContainer>
             </ButtonToolbar>

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -120,13 +120,13 @@ const AppRouter = () => {
             <Route path={Routes.LEGACY_ALERTS.NEW_CONDITION} component={NewAlertConditionPage} />
             <Route path={Routes.LEGACY_ALERTS.NOTIFICATIONS} component={AlertNotificationsPage} />
             <Route path={Routes.LEGACY_ALERTS.NEW_NOTIFICATION} component={NewAlertNotificationPage} />
-            <Route path={Routes.NEXT_ALERTS.LIST} component={EventsPage} />
-            <Route path={Routes.NEXT_ALERTS.DEFINITIONS.LIST} component={EventDefinitionsPage} />
-            <Route path={Routes.NEXT_ALERTS.DEFINITIONS.CREATE} component={CreateEventDefinitionPage} />
-            <Route path={Routes.NEXT_ALERTS.DEFINITIONS.edit(':definitionId')} component={EditEventDefinitionPage} />
-            <Route path={Routes.NEXT_ALERTS.NOTIFICATIONS.LIST} component={EventNotificationsPage} />
-            <Route path={Routes.NEXT_ALERTS.NOTIFICATIONS.CREATE} component={CreateEventNotificationPage} />
-            <Route path={Routes.NEXT_ALERTS.NOTIFICATIONS.edit(':notificationId')} component={EditEventNotificationPage} />
+            <Route path={Routes.ALERTS.LIST} component={EventsPage} />
+            <Route path={Routes.ALERTS.DEFINITIONS.LIST} component={EventDefinitionsPage} />
+            <Route path={Routes.ALERTS.DEFINITIONS.CREATE} component={CreateEventDefinitionPage} />
+            <Route path={Routes.ALERTS.DEFINITIONS.edit(':definitionId')} component={EditEventDefinitionPage} />
+            <Route path={Routes.ALERTS.NOTIFICATIONS.LIST} component={EventNotificationsPage} />
+            <Route path={Routes.ALERTS.NOTIFICATIONS.CREATE} component={CreateEventNotificationPage} />
+            <Route path={Routes.ALERTS.NOTIFICATIONS.edit(':notificationId')} component={EditEventNotificationPage} />
             <Route path={Routes.show_alert_condition(':streamId', ':conditionId')} component={EditAlertConditionPage} />
             <Route path={Routes.show_alert(':alertId')} component={ShowAlertPage} />
             <Route path={Routes.DASHBOARDS} component={DashboardsPage} />

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -115,11 +115,11 @@ const AppRouter = () => {
             <Route path={Routes.stream_edit(':streamId')} component={StreamEditPage} />
             <Route path={Routes.stream_outputs(':streamId')} component={StreamOutputsPage} />
             <Route path={Routes.stream_alerts(':streamId')} component={StreamAlertsOverviewPage} />
-            <Route path={Routes.ALERTS.LIST} component={AlertsPage} />
-            <Route path={Routes.ALERTS.CONDITIONS} component={AlertConditionsPage} />
-            <Route path={Routes.ALERTS.NEW_CONDITION} component={NewAlertConditionPage} />
-            <Route path={Routes.ALERTS.NOTIFICATIONS} component={AlertNotificationsPage} />
-            <Route path={Routes.ALERTS.NEW_NOTIFICATION} component={NewAlertNotificationPage} />
+            <Route path={Routes.LEGACY_ALERTS.LIST} component={AlertsPage} />
+            <Route path={Routes.LEGACY_ALERTS.CONDITIONS} component={AlertConditionsPage} />
+            <Route path={Routes.LEGACY_ALERTS.NEW_CONDITION} component={NewAlertConditionPage} />
+            <Route path={Routes.LEGACY_ALERTS.NOTIFICATIONS} component={AlertNotificationsPage} />
+            <Route path={Routes.LEGACY_ALERTS.NEW_NOTIFICATION} component={NewAlertNotificationPage} />
             <Route path={Routes.NEXT_ALERTS.LIST} component={EventsPage} />
             <Route path={Routes.NEXT_ALERTS.DEFINITIONS.LIST} component={EventDefinitionsPage} />
             <Route path={Routes.NEXT_ALERTS.DEFINITIONS.CREATE} component={CreateEventDefinitionPage} />

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -53,17 +53,17 @@ const Routes = {
     NOTIFICATIONS: '/legacy/alerts/notifications',
     NEW_NOTIFICATION: '/legacy/alerts/notifications/new',
   },
-  NEXT_ALERTS: {
-    LIST: '/next/alerts',
+  ALERTS: {
+    LIST: '/alerts',
     DEFINITIONS: {
-      LIST: '/next/alerts/definitions',
-      CREATE: '/next/alerts/definitions/new',
-      edit: definitionId => `/next/alerts/definitions/${definitionId}`,
+      LIST: '/alerts/definitions',
+      CREATE: '/alerts/definitions/new',
+      edit: definitionId => `/alerts/definitions/${definitionId}`,
     },
     NOTIFICATIONS: {
-      LIST: '/next/alerts/notifications',
-      CREATE: '/next/alerts/notifications/new',
-      edit: notificationId => `/next/alerts/notifications/${notificationId}`,
+      LIST: '/alerts/notifications',
+      CREATE: '/alerts/notifications/new',
+      edit: notificationId => `/alerts/notifications/${notificationId}`,
     },
   },
   SOURCES: '/sources',

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -198,7 +198,7 @@ const Routes = {
   stream_search: (streamId, query, timeRange, resolution) => {
     return Routes._common_search_url(`${Routes.STREAMS}/${streamId}/search`, query, timeRange, resolution);
   },
-  stream_alerts: streamId => `/streams/${streamId}/alerts`,
+  stream_alerts: streamId => `/alerts/?stream_id=${streamId}`,
 
   legacy_stream_search: streamId => `/streams/${streamId}/messages`,
   show_alert: alertId => `${Routes.LEGACY_ALERTS.LIST}/${alertId}`,

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -46,12 +46,12 @@ const Routes = {
   NOTFOUND: '/notfound',
   SEARCH: '/search',
   STREAMS: '/streams',
-  ALERTS: {
-    LIST: '/alerts',
-    CONDITIONS: '/alerts/conditions',
-    NEW_CONDITION: '/alerts/conditions/new',
-    NOTIFICATIONS: '/alerts/notifications',
-    NEW_NOTIFICATION: '/alerts/notifications/new',
+  LEGACY_ALERTS: {
+    LIST: '/legacy/alerts',
+    CONDITIONS: '/legacy/alerts/conditions',
+    NEW_CONDITION: '/legacy/alerts/conditions/new',
+    NOTIFICATIONS: '/legacy/alerts/notifications',
+    NEW_NOTIFICATION: '/legacy/alerts/notifications/new',
   },
   NEXT_ALERTS: {
     LIST: '/next/alerts',
@@ -201,10 +201,10 @@ const Routes = {
   stream_alerts: streamId => `/streams/${streamId}/alerts`,
 
   legacy_stream_search: streamId => `/streams/${streamId}/messages`,
-  show_alert: alertId => `${Routes.ALERTS.LIST}/${alertId}`,
-  show_alert_condition: (streamId, conditionId) => `${Routes.ALERTS.CONDITIONS}/${streamId}/${conditionId}`,
-  new_alert_condition_for_stream: streamId => `${Routes.ALERTS.NEW_CONDITION}?stream_id=${streamId}`,
-  new_alert_notification_for_stream: streamId => `${Routes.ALERTS.NEW_NOTIFICATION}?stream_id=${streamId}`,
+  show_alert: alertId => `${Routes.LEGACY_ALERTS.LIST}/${alertId}`,
+  show_alert_condition: (streamId, conditionId) => `${Routes.LEGACY_ALERTS.CONDITIONS}/${streamId}/${conditionId}`,
+  new_alert_condition_for_stream: streamId => `${Routes.LEGACY_ALERTS.NEW_CONDITION}?stream_id=${streamId}`,
+  new_alert_notification_for_stream: streamId => `${Routes.LEGACY_ALERTS.NEW_NOTIFICATION}?stream_id=${streamId}`,
 
   dashboard_show: dashboardId => `/dashboards/${dashboardId}`,
 


### PR DESCRIPTION
This PR takes care of preparing the move to the new alerting:

- Updates navigation menu to link Alerts to the new product
- Prefixes legacy alerting URLs to `/legacy/alerts`, so they are still accessible in case they are necessary
- Removes prefix from new Alerting/Events URLs
- Adds a filter in Alerts page to filter Events/Alerts for a stream
- Updates the "Manage Alerts" button in the Streams page to go to Alerts with a filter set for that particular Stream

Fixes #6108