### PR TITLE
Add Notification to content packs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/EventsModule.java
+++ b/graylog2-server/src/main/java/org/graylog/events/EventsModule.java
@@ -19,7 +19,12 @@ package org.graylog.events;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import org.graylog.events.audit.EventsAuditEventTypes;
 import org.graylog.events.contentpack.entities.AggregationEventProcessorConfigEntity;
+import org.graylog.events.contentpack.entities.EmailEventNotificationConfigEntity;
+import org.graylog.events.contentpack.entities.EventNotificationConfigEntity;
+import org.graylog.events.contentpack.entities.HttpEventNotificationConfigEntity;
+import org.graylog.events.contentpack.entities.LegacyAlarmCallbackEventNotificationConfigEntity;
 import org.graylog.events.contentpack.facade.EventDefinitionFacade;
+import org.graylog.events.contentpack.facade.NotificationFacade;
 import org.graylog.events.fields.EventFieldSpecEngine;
 import org.graylog.events.fields.providers.LookupTableFieldValueProvider;
 import org.graylog.events.fields.providers.TemplateFieldValueProvider;
@@ -79,12 +84,19 @@ public class EventsModule extends PluginModule {
         addPeriodical(EventNotificationStatusCleanUp.class);
 
         addEntityFacade(ModelTypes.EVENT_DEFINITION_V1, EventDefinitionFacade.class);
+        addEntityFacade(ModelTypes.NOTIFICATION_V1, NotificationFacade.class);
 
         addMigration(V20190722150700_LegacyAlertConditionMigration.class);
         addAuditEventTypes(EventsAuditEventTypes.class);
 
         registerJacksonSubtype(AggregationEventProcessorConfigEntity.class,
             AggregationEventProcessorConfigEntity.TYPE_NAME);
+        registerJacksonSubtype(HttpEventNotificationConfigEntity.class,
+            HttpEventNotificationConfigEntity.TYPE_NAME);
+        registerJacksonSubtype(EmailEventNotificationConfigEntity.class,
+            EmailEventNotificationConfigEntity.TYPE_NAME);
+        registerJacksonSubtype(LegacyAlarmCallbackEventNotificationConfigEntity.class,
+            LegacyAlarmCallbackEventNotificationConfigEntity.TYPE_NAME);
 
         addEventProcessor(AggregationEventProcessorConfig.TYPE_NAME,
                 AggregationEventProcessor.class,

--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/EmailEventNotificationConfigEntity.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/EmailEventNotificationConfigEntity.java
@@ -20,12 +20,15 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import org.graylog.events.notifications.EventNotificationConfig;
+import org.graylog.events.notifications.types.EmailEventNotificationConfig;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.mongojack.Id;
 import org.mongojack.ObjectId;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
+import java.util.Map;
 import java.util.Set;
 
 @AutoValue
@@ -85,5 +88,16 @@ public abstract class EmailEventNotificationConfigEntity implements EventNotific
         public abstract Builder userRecipients(Set<String> userRecipients);
 
         public abstract EmailEventNotificationConfigEntity build();
+    }
+
+    @Override
+    public EventNotificationConfig toNativeEntity(Map<String, ValueReference> parameters) {
+        return EmailEventNotificationConfig.builder()
+            .sender(sender().asString(parameters))
+            .subject(subject().asString(parameters))
+            .bodyTemplate(bodyTemplate().asString())
+            .emailRecipients(emailRecipients())
+            .userRecipients(userRecipients())
+            .build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/EmailEventNotificationConfigEntity.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/EmailEventNotificationConfigEntity.java
@@ -1,0 +1,89 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.events.contentpack.entities;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import org.graylog2.contentpacks.model.entities.references.ValueReference;
+import org.mongojack.Id;
+import org.mongojack.ObjectId;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotBlank;
+import java.util.Set;
+
+@AutoValue
+@JsonDeserialize(builder = EmailEventNotificationConfigEntity.Builder.class)
+public abstract class EmailEventNotificationConfigEntity implements EventNotificationConfigEntity {
+
+    public static final String TYPE_NAME = "email-notification-v1";
+    private static final String FIELD_SENDER = "sender";
+    private static final String FIELD_SUBJECT = "subject";
+    private static final String FIELD_BODY_TEMPLATE = "body_template";
+    private static final String FIELD_EMAIL_RECIPIENTS = "email_recipients";
+    private static final String FIELD_USER_RECIPIENTS = "user_recipients";
+
+    @JsonProperty(FIELD_SENDER)
+    public abstract ValueReference sender();
+
+    @JsonProperty(FIELD_SUBJECT)
+    public abstract ValueReference subject();
+
+    @JsonProperty(FIELD_BODY_TEMPLATE)
+    public abstract ValueReference bodyTemplate();
+
+    @JsonProperty(FIELD_EMAIL_RECIPIENTS)
+    public abstract Set<String> emailRecipients();
+
+    @JsonProperty(FIELD_USER_RECIPIENTS)
+    public abstract Set<String> userRecipients();
+
+    public static Builder builder() {
+        return Builder.create();
+    }
+
+    public abstract Builder toBuilder();
+
+    @AutoValue.Builder
+    public static abstract class Builder implements EventNotificationConfigEntity.Builder<Builder> {
+
+        @JsonCreator
+        public static Builder create() {
+            return new AutoValue_EmailEventNotificationConfigEntity.Builder()
+                .type(TYPE_NAME);
+        }
+
+        @JsonProperty(FIELD_SENDER)
+        public abstract Builder sender(ValueReference sender);
+
+        @JsonProperty(FIELD_SUBJECT)
+        public abstract Builder subject(ValueReference subject);
+
+        @JsonProperty(FIELD_BODY_TEMPLATE)
+        public abstract Builder bodyTemplate(ValueReference bodyTemplate);
+
+        @JsonProperty(FIELD_EMAIL_RECIPIENTS)
+        public abstract Builder emailRecipients(Set<String> emailRecipients);
+
+        @JsonProperty(FIELD_USER_RECIPIENTS)
+        public abstract Builder userRecipients(Set<String> userRecipients);
+
+        public abstract EmailEventNotificationConfigEntity build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/EventNotificationConfigEntity.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/EventNotificationConfigEntity.java
@@ -18,13 +18,15 @@ package org.graylog.events.contentpack.entities;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.graylog.events.notifications.EventNotificationConfig;
+import org.graylog2.contentpacks.NativeEntityConverter;
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.EXISTING_PROPERTY,
     property = org.graylog.events.notifications.EventNotificationConfig.TYPE_FIELD,
     visible = true)
-public interface EventNotificationConfigEntity {
+public interface EventNotificationConfigEntity extends NativeEntityConverter<EventNotificationConfig> {
     String TYPE_FIELD = "type";
 
     @JsonProperty(TYPE_FIELD)

--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/EventNotificationConfigEntity.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/EventNotificationConfigEntity.java
@@ -1,0 +1,40 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.events.contentpack.entities;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = org.graylog.events.notifications.EventNotificationConfig.TYPE_FIELD,
+    visible = true)
+public interface EventNotificationConfigEntity {
+    String TYPE_FIELD = "type";
+
+    @JsonProperty(TYPE_FIELD)
+    String type();
+
+    interface Builder<SELF> {
+        @JsonProperty(TYPE_FIELD)
+        SELF type(String type);
+    }
+}
+
+
+

--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/HttpEventNotificationConfigEntity.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/HttpEventNotificationConfigEntity.java
@@ -1,0 +1,56 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.events.contentpack.entities;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import org.graylog2.contentpacks.model.entities.references.ValueReference;
+
+@AutoValue
+@JsonDeserialize(builder = HttpEventNotificationConfigEntity.Builder.class)
+public abstract class HttpEventNotificationConfigEntity implements EventNotificationConfigEntity {
+
+    public static final String TYPE_NAME = "http-notification-v1";
+
+    private static final String FIELD_URL = "url";
+
+    @JsonProperty(FIELD_URL)
+    public abstract ValueReference url();
+
+    public static Builder builder() {
+        return Builder.create();
+    }
+
+    public abstract Builder toBuilder();
+
+    @AutoValue.Builder
+    public static abstract class Builder implements EventNotificationConfigEntity.Builder<Builder> {
+
+        @JsonCreator
+        public static Builder create() {
+            return new AutoValue_HttpEventNotificationConfigEntity.Builder()
+                    .type(TYPE_NAME);
+        }
+
+        @JsonProperty(FIELD_URL)
+        public abstract Builder url(ValueReference url);
+
+        public abstract HttpEventNotificationConfigEntity build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/HttpEventNotificationConfigEntity.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/HttpEventNotificationConfigEntity.java
@@ -20,7 +20,11 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import org.graylog.events.notifications.EventNotificationConfig;
+import org.graylog.events.notifications.types.HTTPEventNotificationConfig;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
+
+import java.util.Map;
 
 @AutoValue
 @JsonDeserialize(builder = HttpEventNotificationConfigEntity.Builder.class)
@@ -52,5 +56,12 @@ public abstract class HttpEventNotificationConfigEntity implements EventNotifica
         public abstract Builder url(ValueReference url);
 
         public abstract HttpEventNotificationConfigEntity build();
+    }
+
+    @Override
+    public EventNotificationConfig toNativeEntity(Map<String, ValueReference> parameters) {
+        return HTTPEventNotificationConfig.builder()
+            .url(url().asString(parameters))
+            .build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/LegacyAlarmCallbackEventNotificationConfigEntity.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/LegacyAlarmCallbackEventNotificationConfigEntity.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import org.graylog.events.legacy.LegacyAlarmCallbackEventNotificationConfig;
+import org.graylog.events.notifications.EventNotificationConfig;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
 
 import java.util.Map;
@@ -61,5 +63,13 @@ public abstract class LegacyAlarmCallbackEventNotificationConfigEntity implement
 
 
         public abstract LegacyAlarmCallbackEventNotificationConfigEntity build();
+    }
+
+    @Override
+    public EventNotificationConfig toNativeEntity(Map<String, ValueReference> parameters) {
+        return LegacyAlarmCallbackEventNotificationConfig.builder()
+            .callbackType(callbackType().asString(parameters))
+            .configuration(configuration())
+            .build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/LegacyAlarmCallbackEventNotificationConfigEntity.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/LegacyAlarmCallbackEventNotificationConfigEntity.java
@@ -1,0 +1,65 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.events.contentpack.entities;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import org.graylog2.contentpacks.model.entities.references.ValueReference;
+
+import java.util.Map;
+
+@AutoValue
+@JsonDeserialize(builder = LegacyAlarmCallbackEventNotificationConfigEntity.Builder.class)
+public abstract class LegacyAlarmCallbackEventNotificationConfigEntity implements EventNotificationConfigEntity {
+    public static final String TYPE_NAME = "legacy-alarm-callback-notification-v1";
+
+    private static final String FIELD_CALLBACK_TYPE = "callback_type";
+    private static final String FIELD_CONFIGURATION = "configuration";
+
+    @JsonProperty(FIELD_CALLBACK_TYPE)
+    public abstract ValueReference callbackType();
+
+    @JsonProperty(FIELD_CONFIGURATION)
+    public abstract Map<String, Object> configuration();
+
+    public static Builder builder() {
+        return Builder.create();
+    }
+
+    public abstract Builder toBuilder();
+
+    @AutoValue.Builder
+    public static abstract class Builder implements EventNotificationConfigEntity.Builder<Builder> {
+
+        @JsonCreator
+        public static Builder create() {
+            return new AutoValue_LegacyAlarmCallbackEventNotificationConfigEntity.Builder()
+                .type(TYPE_NAME);
+        }
+
+        @JsonProperty(FIELD_CALLBACK_TYPE)
+        public abstract Builder callbackType(ValueReference callbackType);
+
+        @JsonProperty(FIELD_CONFIGURATION)
+        public abstract Builder configuration(Map<String, Object> configuration);
+
+
+        public abstract LegacyAlarmCallbackEventNotificationConfigEntity build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/NotificationEntity.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/NotificationEntity.java
@@ -20,11 +20,15 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import org.graylog.events.notifications.NotificationDto;
+import org.graylog2.contentpacks.NativeEntityConverter;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
+
+import java.util.Map;
 
 @AutoValue
 @JsonDeserialize(builder = NotificationEntity.Builder.class)
-public abstract class NotificationEntity {
+public abstract class NotificationEntity implements NativeEntityConverter<NotificationDto> {
 
     public static final String FIELD_TITLE = "title";
     public static final String FIELD_DESCRIPTION = "description";
@@ -63,5 +67,14 @@ public abstract class NotificationEntity {
         public abstract Builder config(EventNotificationConfigEntity config);
 
         public abstract NotificationEntity build();
+    }
+
+    @Override
+    public NotificationDto toNativeEntity(Map<String, ValueReference> parameters) {
+        return NotificationDto.builder()
+            .description(description().asString(parameters))
+            .title(title().asString(parameters))
+            .config(config().toNativeEntity(parameters))
+            .build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/NotificationEntity.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/NotificationEntity.java
@@ -1,0 +1,67 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.events.contentpack.entities;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import org.graylog2.contentpacks.model.entities.references.ValueReference;
+
+@AutoValue
+@JsonDeserialize(builder = NotificationEntity.Builder.class)
+public abstract class NotificationEntity {
+
+    public static final String FIELD_TITLE = "title";
+    public static final String FIELD_DESCRIPTION = "description";
+    private static final String FIELD_CONFIG = "config";
+
+    public static Builder builder() {
+        return Builder.create();
+    }
+
+    @JsonProperty(FIELD_TITLE)
+    public abstract ValueReference title();
+
+    @JsonProperty(FIELD_DESCRIPTION)
+    public abstract ValueReference description();
+
+    @JsonProperty(FIELD_CONFIG)
+    public abstract EventNotificationConfigEntity config();
+
+    public abstract Builder toBuilder();
+
+    @AutoValue.Builder
+    public static abstract class Builder {
+
+        @JsonCreator
+        public static Builder create() {
+            return new AutoValue_NotificationEntity.Builder();
+        }
+
+        @JsonProperty(FIELD_TITLE)
+        public abstract Builder title(ValueReference title);
+
+        @JsonProperty(FIELD_DESCRIPTION)
+        public abstract Builder description(ValueReference description);
+
+        @JsonProperty(FIELD_CONFIG)
+        public abstract Builder config(EventNotificationConfigEntity config);
+
+        public abstract NotificationEntity build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/facade/NotificationFacade.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/facade/NotificationFacade.java
@@ -1,0 +1,100 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.events.contentpack.facade;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog.events.contentpack.entities.NotificationEntity;
+import org.graylog.events.notifications.DBNotificationService;
+import org.graylog.events.notifications.NotificationDto;
+import org.graylog2.contentpacks.EntityDescriptorIds;
+import org.graylog2.contentpacks.facades.EntityFacade;
+import org.graylog2.contentpacks.model.ModelId;
+import org.graylog2.contentpacks.model.ModelTypes;
+import org.graylog2.contentpacks.model.entities.Entity;
+import org.graylog2.contentpacks.model.entities.EntityDescriptor;
+import org.graylog2.contentpacks.model.entities.EntityExcerpt;
+import org.graylog2.contentpacks.model.entities.EntityV1;
+import org.graylog2.contentpacks.model.entities.NativeEntity;
+import org.graylog2.contentpacks.model.entities.NativeEntityDescriptor;
+import org.graylog2.contentpacks.model.entities.references.ValueReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public class NotificationFacade implements EntityFacade<NotificationDto> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NotificationFacade.class);
+
+    private final ObjectMapper objectMapper;
+    private final DBNotificationService notificationService;
+
+    @Inject
+    public NotificationFacade(ObjectMapper objectMapper,
+                              DBNotificationService notificationService) {
+        this.objectMapper = objectMapper;
+        this.notificationService = notificationService;
+    }
+
+    @Override
+    public Optional<Entity> exportEntity(EntityDescriptor entityDescriptor, EntityDescriptorIds entityDescriptorIds) {
+        final ModelId modelId = entityDescriptor.id();
+        final Optional<NotificationDto> notificationDto = notificationService.get(modelId.id());
+        if (!notificationDto.isPresent()) {
+            LOG.debug("Couldn't find notification {}", entityDescriptor);
+            return Optional.empty();
+        }
+
+        final NotificationEntity entity = (NotificationEntity) notificationDto.get().toContentPackEntity();
+        final JsonNode data = objectMapper.convertValue(entity, JsonNode.class);
+        return Optional.of(
+            EntityV1.builder()
+                .id(ModelId.of(entityDescriptorIds.getOrThrow(notificationDto.get().id(), ModelTypes.NOTIFICATION_V1)))
+                .type(ModelTypes.NOTIFICATION_V1)
+                .data(data)
+                .build());
+    }
+
+    @Override
+    public NativeEntity<NotificationDto> createNativeEntity(Entity entity, Map<String, ValueReference> parameters, Map<EntityDescriptor, Object> nativeEntities, String username) {
+        return null;
+    }
+
+    @Override
+    public Optional<NativeEntity<NotificationDto>> loadNativeEntity(NativeEntityDescriptor nativeEntityDescriptor) {
+        return Optional.empty();
+    }
+
+    @Override
+    public void delete(NotificationDto nativeEntity) {
+
+    }
+
+    @Override
+    public EntityExcerpt createExcerpt(NotificationDto nativeEntity) {
+        return null;
+    }
+
+    @Override
+    public Set<EntityExcerpt> listEntityExcerpts() {
+        return null;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/events/legacy/LegacyAlarmCallbackEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/legacy/LegacyAlarmCallbackEventNotificationConfig.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import org.graylog.events.contentpack.entities.EventNotificationConfigEntity;
 import org.graylog.events.contentpack.entities.LegacyAlarmCallbackEventNotificationConfigEntity;
 import org.graylog.events.event.EventDto;
 import org.graylog.events.notifications.EventNotificationConfig;
@@ -85,7 +86,7 @@ public abstract class LegacyAlarmCallbackEventNotificationConfig implements Even
     }
 
     @Override
-    public Object toContentPackEntity() {
+    public EventNotificationConfigEntity toContentPackEntity() {
         return LegacyAlarmCallbackEventNotificationConfigEntity.builder()
             .callbackType(ValueReference.of(callbackType()))
             .configuration(configuration())

--- a/graylog2-server/src/main/java/org/graylog/events/legacy/LegacyAlarmCallbackEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/legacy/LegacyAlarmCallbackEventNotificationConfig.java
@@ -22,10 +22,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import org.graylog.events.contentpack.entities.LegacyAlarmCallbackEventNotificationConfigEntity;
 import org.graylog.events.event.EventDto;
 import org.graylog.events.notifications.EventNotificationConfig;
 import org.graylog.events.notifications.EventNotificationExecutionJob;
 import org.graylog.scheduler.JobTriggerData;
+import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.plugin.rest.ValidationResult;
 
 import java.util.Map;
@@ -80,5 +82,13 @@ public abstract class LegacyAlarmCallbackEventNotificationConfig implements Even
         public abstract Builder configuration(Map<String, Object> configuration);
 
         public abstract LegacyAlarmCallbackEventNotificationConfig build();
+    }
+
+    @Override
+    public Object toContentPackEntity() {
+        return LegacyAlarmCallbackEventNotificationConfigEntity.builder()
+            .callbackType(ValueReference.of(callbackType()))
+            .configuration(configuration())
+            .build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/EventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/EventNotificationConfig.java
@@ -19,10 +19,11 @@ package org.graylog.events.notifications;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.graylog.events.contentpack.entities.EventNotificationConfigEntity;
 import org.graylog.events.event.EventDto;
 import org.graylog.scheduler.JobTriggerData;
-import org.graylog2.plugin.rest.ValidationResult;
 import org.graylog2.contentpacks.ContentPackable;
+import org.graylog2.plugin.rest.ValidationResult;
 
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
@@ -30,7 +31,7 @@ import org.graylog2.contentpacks.ContentPackable;
         property = EventNotificationConfig.TYPE_FIELD,
         visible = true,
         defaultImpl = EventNotificationConfig.FallbackNotificationConfig.class)
-public interface EventNotificationConfig extends ContentPackable<EventNotificationConfig> {
+public interface EventNotificationConfig extends ContentPackable<EventNotificationConfigEntity> {
     String FIELD_NOTIFICATION_ID = "notification_id";
     String TYPE_FIELD = "type";
 
@@ -65,7 +66,7 @@ public interface EventNotificationConfig extends ContentPackable<EventNotificati
         }
 
         @Override
-        public Object toContentPackEntity() {
+        public EventNotificationConfigEntity toContentPackEntity() {
             return null;
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/EventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/EventNotificationConfig.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.graylog.events.event.EventDto;
 import org.graylog.scheduler.JobTriggerData;
 import org.graylog2.plugin.rest.ValidationResult;
+import org.graylog2.contentpacks.ContentPackable;
 
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
@@ -29,7 +30,7 @@ import org.graylog2.plugin.rest.ValidationResult;
         property = EventNotificationConfig.TYPE_FIELD,
         visible = true,
         defaultImpl = EventNotificationConfig.FallbackNotificationConfig.class)
-public interface EventNotificationConfig {
+public interface EventNotificationConfig extends ContentPackable<EventNotificationConfig> {
     String FIELD_NOTIFICATION_ID = "notification_id";
     String TYPE_FIELD = "type";
 
@@ -60,6 +61,11 @@ public interface EventNotificationConfig {
 
         @Override
         public JobTriggerData toJobTriggerData(EventDto dto) {
+            return null;
+        }
+
+        @Override
+        public Object toContentPackEntity() {
             return null;
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationDto.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationDto.java
@@ -21,6 +21,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import org.graylog.events.contentpack.entities.EventNotificationConfigEntity;
+import org.graylog.events.contentpack.entities.NotificationEntity;
+import org.graylog2.contentpacks.ContentPackable;
+import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.plugin.rest.ValidationResult;
 import org.mongojack.Id;
 import org.mongojack.ObjectId;
@@ -29,7 +33,7 @@ import javax.annotation.Nullable;
 
 @AutoValue
 @JsonDeserialize(builder = NotificationDto.Builder.class)
-public abstract class NotificationDto {
+public abstract class NotificationDto implements ContentPackable {
     public static final String FIELD_ID = "id";
     public static final String FIELD_TITLE = "title";
     public static final String FIELD_DESCRIPTION = "description";
@@ -97,4 +101,13 @@ public abstract class NotificationDto {
         public abstract NotificationDto build();
     }
 
+    @Override
+    public Object toContentPackEntity() {
+        final EventNotificationConfigEntity config = (EventNotificationConfigEntity) config().toContentPackEntity();
+        return NotificationEntity.builder()
+            .description(ValueReference.of(description()))
+            .title(ValueReference.of(title()))
+            .config(config)
+            .build();
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationDto.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationDto.java
@@ -103,7 +103,7 @@ public abstract class NotificationDto implements ContentPackable {
 
     @Override
     public Object toContentPackEntity() {
-        final EventNotificationConfigEntity config = (EventNotificationConfigEntity) config().toContentPackEntity();
+        final EventNotificationConfigEntity config = config().toContentPackEntity();
         return NotificationEntity.builder()
             .description(ValueReference.of(description()))
             .title(ValueReference.of(title()))

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailEventNotificationConfig.java
@@ -97,6 +97,10 @@ public abstract class EmailEventNotificationConfig implements EventNotificationC
         return EventNotificationExecutionJob.Data.builder().eventDto(dto).build();
     }
 
+    public static Builder builder() {
+        return Builder.create();
+    }
+
     @JsonIgnore
     public ValidationResult validate() {
         final ValidationResult validation = new ValidationResult();

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailEventNotificationConfig.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 import org.graylog.events.contentpack.entities.EmailEventNotificationConfigEntity;
+import org.graylog.events.contentpack.entities.EventNotificationConfigEntity;
 import org.graylog.events.event.EventDto;
 import org.graylog.events.notifications.EventNotificationConfig;
 import org.graylog.events.notifications.EventNotificationExecutionJob;
@@ -153,7 +154,7 @@ public abstract class EmailEventNotificationConfig implements EventNotificationC
     }
 
     @Override
-    public Object toContentPackEntity() {
+    public EventNotificationConfigEntity toContentPackEntity() {
         return EmailEventNotificationConfigEntity.builder()
             .sender(ValueReference.of(sender()))
             .subject(ValueReference.of(subject()))

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailEventNotificationConfig.java
@@ -23,10 +23,12 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
+import org.graylog.events.contentpack.entities.EmailEventNotificationConfigEntity;
 import org.graylog.events.event.EventDto;
 import org.graylog.events.notifications.EventNotificationConfig;
 import org.graylog.events.notifications.EventNotificationExecutionJob;
 import org.graylog.scheduler.JobTriggerData;
+import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.plugin.rest.ValidationResult;
 
 import javax.validation.constraints.NotBlank;
@@ -144,5 +146,16 @@ public abstract class EmailEventNotificationConfig implements EventNotificationC
         public abstract Builder userRecipients(Set<String> userRecipients);
 
         public abstract EmailEventNotificationConfig build();
+    }
+
+    @Override
+    public Object toContentPackEntity() {
+        return EmailEventNotificationConfigEntity.builder()
+            .sender(ValueReference.of(sender()))
+            .subject(ValueReference.of(subject()))
+            .bodyTemplate(ValueReference.of(bodyTemplate()))
+            .emailRecipients(emailRecipients())
+            .userRecipients(userRecipients())
+            .build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
@@ -22,10 +22,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import org.graylog.events.contentpack.entities.HttpEventNotificationConfigEntity;
 import org.graylog.events.event.EventDto;
 import org.graylog.events.notifications.EventNotificationConfig;
 import org.graylog.events.notifications.EventNotificationExecutionJob;
 import org.graylog.scheduler.JobTriggerData;
+import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.plugin.rest.ValidationResult;
 
 @AutoValue
@@ -67,5 +69,12 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
         public abstract Builder url(String url);
 
         public abstract HTTPEventNotificationConfig build();
+    }
+
+    @Override
+    public Object toContentPackEntity() {
+       return HttpEventNotificationConfigEntity.builder()
+           .url(ValueReference.of(url()))
+           .build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import org.graylog.events.contentpack.entities.EventNotificationConfigEntity;
 import org.graylog.events.contentpack.entities.HttpEventNotificationConfigEntity;
 import org.graylog.events.event.EventDto;
 import org.graylog.events.notifications.EventNotificationConfig;
@@ -76,7 +77,7 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
     }
 
     @Override
-    public Object toContentPackEntity() {
+    public EventNotificationConfigEntity toContentPackEntity() {
        return HttpEventNotificationConfigEntity.builder()
            .url(ValueReference.of(url()))
            .build();

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotificationConfig.java
@@ -46,6 +46,10 @@ public abstract class HTTPEventNotificationConfig implements EventNotificationCo
         return EventNotificationExecutionJob.Data.builder().eventDto(dto).build();
     }
 
+    public static Builder builder() {
+        return Builder.create();
+    }
+
     @JsonIgnore
     public ValidationResult validate() {
         final ValidationResult validation = new ValidationResult();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ModelTypes.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/ModelTypes.java
@@ -31,4 +31,5 @@ public interface ModelTypes {
     ModelType ROOT = ModelType.of("virtual-root", "1");
     ModelType STREAM_V1 = ModelType.of("stream", "1");
     ModelType EVENT_DEFINITION_V1 = ModelType.of("event_definition", "1");
+    ModelType NOTIFICATION_V1 = ModelType.of("notification", "1");
 }


### PR DESCRIPTION
## Description
Implement a NotificationFacade and its needed Entities.

## Motivation and Context
EventDefinitions are only use full if the create Alerts with Notifications.

## How Has This Been Tested?
- Exported, Imported and Installed an Content Pack containing a Notification.

## Still Open
- There are still problem with parameters
- Notification should be a dependency to EventDefinition

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
