### PR TITLE
Remove notification action from event definition on notification delete

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/processor/DBEventDefinitionService.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/DBEventDefinitionService.java
@@ -16,15 +16,20 @@
  */
 package org.graylog.events.processor;
 
+import com.google.common.collect.ImmutableList;
+import org.graylog.events.notifications.EventNotificationConfig;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.database.PaginatedDbService;
 import org.graylog2.database.PaginatedList;
 import org.graylog2.search.SearchQuery;
+import org.mongojack.DBQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.util.List;
+import java.util.Locale;
 import java.util.function.Predicate;
 
 public class DBEventDefinitionService extends PaginatedDbService<EventDefinitionDto> {
@@ -56,5 +61,18 @@ public class DBEventDefinitionService extends PaginatedDbService<EventDefinition
             LOG.error("Couldn't delete event processor state for <{}>", id, e);
         }
         return super.delete(id);
+    }
+
+    /**
+     * Returns the list of event definitions that is using the given notification ID.
+     *
+     * @param notificationId the notification ID
+     * @return the event definitions with the given notification ID
+     */
+    public List<EventDefinitionDto> getByNotificationId(String notificationId) {
+        final String field = String.format(Locale.US, "%s.%s",
+            EventDefinitionDto.FIELD_NOTIFICATIONS,
+            EventNotificationConfig.FIELD_NOTIFICATION_ID);
+        return ImmutableList.copyOf((db.find(DBQuery.is(field, notificationId)).iterator()));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionDto.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionDto.java
@@ -50,13 +50,13 @@ public abstract class EventDefinitionDto implements EventDefinition, ContentPack
     public static final String FIELD_ID = "id";
     public static final String FIELD_TITLE = "title";
     public static final String FIELD_DESCRIPTION = "description";
+    public static final String FIELD_NOTIFICATIONS = "notifications";
     private static final String FIELD_PRIORITY = "priority";
     private static final String FIELD_ALERT = "alert";
     private static final String FIELD_CONFIG = "config";
     private static final String FIELD_FIELD_SPEC = "field_spec";
     private static final String FIELD_KEY_SPEC = "key_spec";
     private static final String FIELD_NOTIFICATION_SETTINGS = "notification_settings";
-    private static final String FIELD_NOTIFICATIONS = "notifications";
     private static final String FIELD_STORAGE = "storage";
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog/events/legacy/LegacyAlertConditionMigratorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/legacy/LegacyAlertConditionMigratorTest.java
@@ -105,7 +105,7 @@ public class LegacyAlertConditionMigratorTest {
 
         this.eventDefinitionService = new DBEventDefinitionService(mongoConnection, mongoJackObjectMapperProvider, mock(DBEventProcessorStateService.class));
         this.eventDefinitionHandler = spy(new EventDefinitionHandler(eventDefinitionService, jobDefinitionService, jobTriggerService, clock));
-        this.notificationResourceHandler = spy(new NotificationResourceHandler(notificationService, jobDefinitionService, jobTriggerService));
+        this.notificationResourceHandler = spy(new NotificationResourceHandler(notificationService, jobDefinitionService, eventDefinitionService));
         this.migrator = new LegacyAlertConditionMigrator(mongoConnection, eventDefinitionHandler, notificationResourceHandler, notificationService, CHECK_INTERVAL);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When a notification definition is deleted we need to clean up all events which make use of it.

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/1119

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
