### PR TITLE
Authorize Event pages in UI

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/common/HelpPanel.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/common/HelpPanel.jsx
@@ -12,6 +12,7 @@ class HelpPanel extends React.Component {
     collapsible: PropTypes.bool,
     header: PropTypes.node,
     title: PropTypes.string,
+    defaultExpanded: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -21,16 +22,18 @@ class HelpPanel extends React.Component {
     collapsible: false,
     header: undefined,
     title: '',
+    defaultExpanded: false,
   };
 
   render() {
-    const { bsStyle, children, className, collapsible, header, title } = this.props;
+    const { bsStyle, children, className, collapsible, header, title, defaultExpanded } = this.props;
     const defaultHeader = (<h3><i className="fa fa-info-circle" />&emsp;{title}</h3>);
 
     return (
       <Panel bsStyle={bsStyle}
              className={`${styles.helpPanel} ${className}`}
              collapsible={collapsible}
+             defaultExpanded={defaultExpanded}
              header={header || defaultHeader}>
         {children}
       </Panel>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/AddNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/AddNotificationForm.jsx
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import { Button, ButtonToolbar, Col, ControlLabel, FormGroup, HelpBlock, Row } from 'react-bootstrap';
 
 import { Select } from 'components/common';
-import EventNotificationFormContainer from 'components/event-notifications/event-notification-form/EventNotificationFormContainer';
+import EventNotificationFormContainer
+  from 'components/event-notifications/event-notification-form/EventNotificationFormContainer';
 
 import commonStyles from '../common/commonStyles.css';
 
@@ -12,6 +13,11 @@ class AddNotificationForm extends React.Component {
     notifications: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
+    hasCreationPermissions: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    hasCreationPermissions: false,
   };
 
   state = {
@@ -40,8 +46,14 @@ class AddNotificationForm extends React.Component {
   };
 
   formatNotifications = (notifications) => {
+    const { hasCreationPermissions } = this.props;
     const formattedNotifications = notifications.map(n => ({ label: n.title, value: n.id }));
-    formattedNotifications.unshift({ label: 'Create New Notification...', value: 'create' });
+    if (hasCreationPermissions) {
+      formattedNotifications.unshift({
+        label: 'Create New Notification...',
+        value: 'create',
+      });
+    }
     return formattedNotifications;
   };
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventConditionForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventConditionForm.jsx
@@ -14,6 +14,7 @@ import styles from './EventConditionForm.css';
 class EventConditionForm extends React.Component {
   static propTypes = {
     eventDefinition: PropTypes.object.isRequired,
+    currentUser: PropTypes.object.isRequired,
     validation: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
   };

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventConditionForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventConditionForm.jsx
@@ -14,7 +14,8 @@ import styles from './EventConditionForm.css';
 class EventConditionForm extends React.Component {
   static propTypes = {
     eventDefinition: PropTypes.object.isRequired,
-    currentUser: PropTypes.object.isRequired,
+    // eslint-disable-next-line react/no-unused-prop-types
+    currentUser: PropTypes.object.isRequired, // Prop is passed down to pluggable entities
     validation: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
   };

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionForm.jsx
@@ -19,6 +19,7 @@ class EventDefinitionForm extends React.Component {
   static propTypes = {
     action: PropTypes.oneOf(['create', 'edit']),
     eventDefinition: PropTypes.object.isRequired,
+    currentUser: PropTypes.object.isRequired,
     validation: PropTypes.object.isRequired,
     entityTypes: PropTypes.object.isRequired,
     notifications: PropTypes.array.isRequired,
@@ -96,7 +97,16 @@ class EventDefinitionForm extends React.Component {
   };
 
   render() {
-    const { action, entityTypes, eventDefinition, notifications, onChange, validation, defaults } = this.props;
+    const {
+      action,
+      entityTypes,
+      eventDefinition,
+      notifications,
+      onChange,
+      validation,
+      defaults,
+      currentUser,
+    } = this.props;
     const { activeStep } = this.state;
 
     const defaultStepProps = {
@@ -106,6 +116,7 @@ class EventDefinitionForm extends React.Component {
       eventDefinition,
       onChange,
       validation,
+      currentUser,
     };
 
     const eventDefinitionType = this.getConditionPlugin(eventDefinition.config.type);
@@ -137,6 +148,7 @@ class EventDefinitionForm extends React.Component {
         component: (
           <EventDefinitionSummary action={action}
                                   eventDefinition={eventDefinition}
+                                  currentUser={currentUser}
                                   notifications={notifications}
                                   validation={validation} />
         ),

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.jsx
@@ -19,11 +19,13 @@ const { EventDefinitionsActions } = CombinedProvider.get('EventDefinitions');
 const { AvailableEventDefinitionTypesStore } = CombinedProvider.get('AvailableEventDefinitionTypes');
 const { EventNotificationsStore, EventNotificationsActions } = CombinedProvider.get('EventNotifications');
 const { ConfigurationActions } = CombinedProvider.get('Configuration');
+const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
 class EventDefinitionFormContainer extends React.Component {
   static propTypes = {
     action: PropTypes.oneOf(['create', 'edit']),
     eventDefinition: PropTypes.object,
+    currentUser: PropTypes.object,
     entityTypes: PropTypes.object,
     notifications: PropTypes.object.isRequired,
     onEventDefinitionChange: PropTypes.func,
@@ -121,7 +123,7 @@ class EventDefinitionFormContainer extends React.Component {
   };
 
   render() {
-    const { action, entityTypes, notifications } = this.props;
+    const { action, entityTypes, notifications, currentUser } = this.props;
     const { eventDefinition, eventsClusterConfig, validation } = this.state;
     const isLoading = !entityTypes || !notifications.all || !eventsClusterConfig;
 
@@ -134,6 +136,7 @@ class EventDefinitionFormContainer extends React.Component {
     return (
       <EventDefinitionForm action={action}
                            eventDefinition={eventDefinition}
+                           currentUser={currentUser}
                            validation={validation}
                            entityTypes={entityTypes}
                            notifications={notifications.all}
@@ -148,4 +151,9 @@ class EventDefinitionFormContainer extends React.Component {
 export default connect(EventDefinitionFormContainer, {
   entityTypes: AvailableEventDefinitionTypesStore,
   notifications: EventNotificationsStore,
-});
+  currentUser: CurrentUserStore,
+},
+({ currentUser, ...otherProps }) => ({
+  ...otherProps,
+  currentUser: currentUser.currentUser,
+}));

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.jsx
@@ -25,7 +25,7 @@ class EventDefinitionFormContainer extends React.Component {
   static propTypes = {
     action: PropTypes.oneOf(['create', 'edit']),
     eventDefinition: PropTypes.object,
-    currentUser: PropTypes.object,
+    currentUser: PropTypes.object.isRequired,
     entityTypes: PropTypes.object,
     notifications: PropTypes.object.isRequired,
     onEventDefinitionChange: PropTypes.func,

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionSummary.jsx
@@ -8,16 +8,11 @@ import {} from 'moment-duration-format';
 import naturalSort from 'javascript-natural-sort';
 
 import PermissionsMixin from 'util/PermissionsMixin';
-import connect from 'stores/connect';
-import CombinedProvider from 'injection/CombinedProvider';
-
 import EventDefinitionPriorityEnum from 'logic/alerts/EventDefinitionPriorityEnum';
 import EventDefinitionValidationSummary from './EventDefinitionValidationSummary';
 
 import styles from './EventDefinitionSummary.css';
 import commonStyles from '../common/commonStyles.css';
-
-const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
 class EventDefinitionSummary extends React.Component {
   static propTypes = {
@@ -66,9 +61,13 @@ class EventDefinitionSummary extends React.Component {
   };
 
   renderCondition = (config) => {
+    const { currentUser } = this.props;
     const conditionPlugin = this.getPlugin('eventDefinitionTypes', config.type);
     const component = (conditionPlugin.summaryComponent
-      ? React.createElement(conditionPlugin.summaryComponent, { config: config })
+      ? React.createElement(conditionPlugin.summaryComponent, {
+        config: config,
+        currentUser: currentUser,
+      })
       : <p>Condition plugin <em>{config.type}</em> does not provide a summary.</p>
     );
 
@@ -81,6 +80,7 @@ class EventDefinitionSummary extends React.Component {
   };
 
   renderField = (fieldName, config, keys) => {
+    const { currentUser } = this.props;
     if (!config.providers || config.providers.length === 0) {
       return <span key={fieldName}>No field value provider configured.</span>;
     }
@@ -92,6 +92,7 @@ class EventDefinitionSummary extends React.Component {
         config: config,
         keys: keys,
         key: fieldName,
+        currentUser: currentUser,
       })
       : <p key={fieldName}>Provider plugin <em>{provider.type}</em> does not provide a summary.</p>
     );
@@ -229,7 +230,4 @@ class EventDefinitionSummary extends React.Component {
   }
 }
 
-export default connect(EventDefinitionSummary, {
-  currentUser: CurrentUserStore,
-},
-({ currentUser }) => ({ currentUser: currentUser.currentUser }));
+export default EventDefinitionSummary;

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionSummary.jsx
@@ -7,8 +7,6 @@ import moment from 'moment';
 import {} from 'moment-duration-format';
 import naturalSort from 'javascript-natural-sort';
 
-import { IfPermitted } from 'components/common';
-
 import PermissionsMixin from 'util/PermissionsMixin';
 import connect from 'stores/connect';
 import CombinedProvider from 'injection/CombinedProvider';

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldForm.jsx
@@ -32,7 +32,7 @@ class FieldForm extends React.Component {
   static propTypes = {
     fieldName: PropTypes.string,
     config: PropTypes.object,
-    currentUser: PropTypes.object,
+    currentUser: PropTypes.object.isRequired,
     keys: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldForm.jsx
@@ -32,6 +32,7 @@ class FieldForm extends React.Component {
   static propTypes = {
     fieldName: PropTypes.string,
     config: PropTypes.object,
+    currentUser: PropTypes.object,
     keys: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
@@ -139,6 +140,7 @@ class FieldForm extends React.Component {
 
   renderFieldValueProviderForm = () => {
     const { fieldName, config, validation } = this.state;
+    const { currentUser } = this.props;
 
     const providerType = this.getConfigProviderType(config);
     if (!providerType) {
@@ -152,6 +154,7 @@ class FieldForm extends React.Component {
         config: config,
         onChange: this.handleConfigChange,
         validation: validation,
+        currentUser: currentUser,
       })
       : <div>Selected provider is not available.</div>
     );

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldsForm.jsx
@@ -15,6 +15,7 @@ import commonStyles from '../common/commonStyles.css';
 class FieldsForm extends React.Component {
   static propTypes = {
     eventDefinition: PropTypes.object.isRequired,
+    currentUser: PropTypes.object.isRequired,
     validation: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
   };
@@ -61,7 +62,7 @@ class FieldsForm extends React.Component {
   };
 
   render() {
-    const { eventDefinition, validation } = this.props;
+    const { eventDefinition, validation, currentUser } = this.props;
     const { editField, showFieldForm } = this.state;
 
     if (showFieldForm) {
@@ -69,6 +70,7 @@ class FieldsForm extends React.Component {
         <FieldForm keys={eventDefinition.key_spec}
                    fieldName={editField}
                    config={editField ? eventDefinition.field_spec[editField] : undefined}
+                   currentUser={currentUser}
                    onChange={this.addCustomField}
                    onCancel={this.toggleFieldForm} />
       );

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationsForm.jsx
@@ -6,8 +6,6 @@ import lodash from 'lodash';
 
 import Routes from 'routing/Routes';
 import PermissionsMixin from 'util/PermissionsMixin';
-import connect from 'stores/connect';
-import CombinedProvider from 'injection/CombinedProvider';
 
 import AddNotificationForm from './AddNotificationForm';
 import NotificationSettingsForm from './NotificationSettingsForm';
@@ -15,8 +13,6 @@ import NotificationList from './NotificationList';
 
 import styles from './NotificationsForm.css';
 import commonStyles from '../common/commonStyles.css';
-
-const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
 class NotificationsForm extends React.Component {
   static propTypes = {
@@ -103,10 +99,4 @@ class NotificationsForm extends React.Component {
   }
 }
 
-export default connect(NotificationsForm, {
-  currentUser: CurrentUserStore,
-},
-({ currentUser, ...otherProps }) => ({
-  ...otherProps,
-  currentUser: currentUser.currentUser,
-}));
+export default NotificationsForm;

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/LookupTableFieldValueProviderFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/LookupTableFieldValueProviderFormContainer.jsx
@@ -10,7 +10,6 @@ import PermissionsMixin from 'util/PermissionsMixin';
 import LookupTableFieldValueProviderForm from './LookupTableFieldValueProviderForm';
 
 const { LookupTablesStore, LookupTablesActions } = CombinedProvider.get('LookupTables');
-const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
 const LOOKUP_PERMISSIONS = [
   'lookuptables:read',
@@ -64,9 +63,4 @@ class LookupTableFieldValueProviderFormContainer extends React.Component {
 export default connect(LookupTableFieldValueProviderFormContainer, {
   fieldTypes: FieldTypesStore,
   lookupTables: LookupTablesStore,
-  currentUser: CurrentUserStore,
-},
-({ currentUser, ...otherProps }) => ({
-  ...otherProps,
-  currentUser: currentUser.currentUser,
-}));
+});

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/LookupTableFieldValueProviderSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/LookupTableFieldValueProviderSummary.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { IfPermitted } from 'components/common';
+
 import CommonFieldValueProviderSummary from './CommonFieldValueProviderSummary';
 
 class LookupTableFieldValueProviderSummary extends React.Component {
@@ -16,20 +18,22 @@ class LookupTableFieldValueProviderSummary extends React.Component {
 
     return (
       <CommonFieldValueProviderSummary {...this.props}>
-        <React.Fragment>
-          <tr>
-            <td>Value source</td>
-            <td>Lookup Table</td>
-          </tr>
-          <tr>
-            <td>Lookup Table</td>
-            <td>{provider.table_name}</td>
-          </tr>
-          <tr>
-            <td>Lookup Table Key Field</td>
-            <td>{provider.key_field}</td>
-          </tr>
-        </React.Fragment>
+        <IfPermitted permissions="lookuptables:read">
+          <React.Fragment>
+            <tr>
+              <td>Value source</td>
+              <td>Lookup Table</td>
+            </tr>
+            <tr>
+              <td>Lookup Table</td>
+              <td>{provider.table_name}</td>
+            </tr>
+            <tr>
+              <td>Lookup Table Key Field</td>
+              <td>{provider.key_field}</td>
+            </tr>
+          </React.Fragment>
+        </IfPermitted>
       </CommonFieldValueProviderSummary>
     );
   }

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.jsx
@@ -5,12 +5,8 @@ import lodash from 'lodash';
 import { extractDurationAndUnit } from 'components/common/TimeUnitInput';
 import AggregationExpressionParser from 'logic/alerts/AggregationExpressionParser';
 import PermissionsMixin from 'util/PermissionsMixin';
-import connect from 'stores/connect';
-import CombinedProvider from 'injection/CombinedProvider';
 
 import { TIME_UNITS } from './FilterForm';
-
-const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
 class FilterAggregationSummary extends React.Component {
   static propTypes = {
@@ -76,7 +72,4 @@ class FilterAggregationSummary extends React.Component {
   }
 }
 
-export default connect(FilterAggregationSummary, {
-  currentUser: CurrentUserStore,
-},
-({ currentUser }) => ({ currentUser: currentUser.currentUser }));
+export default FilterAggregationSummary;

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterPreview.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterPreview.jsx
@@ -12,12 +12,14 @@ class FilterPreview extends React.Component {
     searchResult: PropTypes.object,
     errors: PropTypes.array,
     isFetchingData: PropTypes.bool,
+    displayPreview: PropTypes.bool,
   };
 
   static defaultProps = {
     searchResult: {},
     errors: [],
     isFetchingData: false,
+    displayPreview: false,
   };
 
   renderMessages = (messages) => {
@@ -52,11 +54,12 @@ class FilterPreview extends React.Component {
   };
 
   render() {
-    const { isFetchingData, searchResult, errors } = this.props;
+    const { isFetchingData, searchResult, errors, displayPreview } = this.props;
 
     return (
       <React.Fragment>
         <HelpPanel collapsible
+                   defaultExpanded={!displayPreview}
                    title="How many Events will Filter & Aggregation create?">
           <p>
             The Filter & Aggregation Condition will generate different number of Events, depending on how it is
@@ -75,14 +78,16 @@ class FilterPreview extends React.Component {
           </ul>
         </HelpPanel>
 
-        <Panel className={styles.filterPreview} header={<h3>Filter Preview</h3>}>
-          {errors.length > 0 ? (
-            <p className="text-danger">{errors[0].description}</p>
-          ) : (
-            isFetchingData ? <Spinner text="Loading filter preview..." /> : this.renderSearchResult(searchResult)
-          )
-          }
-        </Panel>
+        {displayPreview && (
+          <Panel className={styles.filterPreview} header={<h3>Filter Preview</h3>}>
+            {errors.length > 0 ? (
+              <p className="text-danger">{errors[0].description}</p>
+            ) : (
+              isFetchingData ? <Spinner text="Loading filter preview..." /> : this.renderSearchResult(searchResult)
+            )
+            }
+          </Panel>
+        )}
       </React.Fragment>
     );
   }

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
@@ -8,7 +8,15 @@ import {} from 'moment-duration-format';
 
 import Routes from 'routing/Routes';
 
-import { EmptyEntity, EntityList, EntityListItem, PaginatedList, Pluralize, SearchForm } from 'components/common';
+import {
+  EmptyEntity,
+  EntityList,
+  EntityListItem,
+  IfPermitted,
+  PaginatedList,
+  Pluralize,
+  SearchForm,
+} from 'components/common';
 
 import styles from './EventDefinitions.css';
 
@@ -38,9 +46,11 @@ class EventDefinitions extends React.Component {
               Create Event Definitions that are able to search, aggregate or correlate Messages and other
               Events, allowing you to record significant Events in Graylog and alert on them.
             </p>
-            <LinkContainer to={Routes.ALERTS.DEFINITIONS.CREATE}>
-              <Button bsStyle="success">Get Started!</Button>
-            </LinkContainer>
+            <IfPermitted permissions="eventdefinitions:create">
+              <LinkContainer to={Routes.ALERTS.DEFINITIONS.CREATE}>
+                <Button bsStyle="success">Get Started!</Button>
+              </LinkContainer>
+            </IfPermitted>
           </EmptyEntity>
         </Col>
       </Row>
@@ -85,12 +95,16 @@ class EventDefinitions extends React.Component {
     const items = eventDefinitions.map((definition) => {
       const actions = (
         <React.Fragment key={`actions-${definition.id}`}>
-          <LinkContainer to={Routes.ALERTS.DEFINITIONS.edit(definition.id)}>
-            <Button bsStyle="info">Edit</Button>
-          </LinkContainer>
-          <DropdownButton id="more-dropdown" title="More" pullRight>
-            <MenuItem onClick={onDelete(definition)}>Delete</MenuItem>
-          </DropdownButton>
+          <IfPermitted permissions="eventdefinitions:edit">
+            <LinkContainer to={Routes.ALERTS.DEFINITIONS.edit(definition.id)}>
+              <Button bsStyle="info">Edit</Button>
+            </LinkContainer>
+          </IfPermitted>
+          <IfPermitted permissions="eventdefinitions:delete">
+            <DropdownButton id="more-dropdown" title="More" pullRight>
+              <MenuItem onClick={onDelete(definition)}>Delete</MenuItem>
+            </DropdownButton>
+          </IfPermitted>
         </React.Fragment>
       );
 
@@ -110,11 +124,13 @@ class EventDefinitions extends React.Component {
       <React.Fragment>
         <Row>
           <Col md={12}>
-            <div className="pull-right">
-              <LinkContainer to={Routes.ALERTS.DEFINITIONS.CREATE}>
-                <Button bsStyle="success">Create Event Definition</Button>
-              </LinkContainer>
-            </div>
+            <IfPermitted permissions="eventdefinitions:create">
+              <div className="pull-right">
+                <LinkContainer to={Routes.ALERTS.DEFINITIONS.CREATE}>
+                  <Button bsStyle="success">Create Event Definition</Button>
+                </LinkContainer>
+              </div>
+            </IfPermitted>
           </Col>
         </Row>
         <Row>

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
@@ -95,12 +95,12 @@ class EventDefinitions extends React.Component {
     const items = eventDefinitions.map((definition) => {
       const actions = (
         <React.Fragment key={`actions-${definition.id}`}>
-          <IfPermitted permissions="eventdefinitions:edit">
+          <IfPermitted permissions={`eventdefinitions:edit:${definition.id}`}>
             <LinkContainer to={Routes.ALERTS.DEFINITIONS.edit(definition.id)}>
               <Button bsStyle="info">Edit</Button>
             </LinkContainer>
           </IfPermitted>
-          <IfPermitted permissions="eventdefinitions:delete">
+          <IfPermitted permissions={`eventdefinitions:delete:${definition.id}`}>
             <DropdownButton id="more-dropdown" title="More" pullRight>
               <MenuItem onClick={onDelete(definition)}>Delete</MenuItem>
             </DropdownButton>

--- a/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.jsx
@@ -4,7 +4,7 @@ import { Button, Col, DropdownButton, MenuItem, Row } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
-import { EmptyEntity, EntityList, EntityListItem, PaginatedList, SearchForm } from 'components/common';
+import { EmptyEntity, EntityList, EntityListItem, IfPermitted, PaginatedList, SearchForm } from 'components/common';
 
 import Routes from 'routing/Routes';
 
@@ -29,9 +29,11 @@ class EventNotifications extends React.Component {
               Configure Event Notifications that can alert you when an Event occurs. You can also use Notifications
               to integrate Graylog Alerts with an external alerting system you use.
             </p>
-            <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.CREATE}>
-              <Button bsStyle="success">Get Started!</Button>
-            </LinkContainer>
+            <IfPermitted permissions="eventnotifications:create">
+              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.CREATE}>
+                <Button bsStyle="success">Get Started!</Button>
+              </LinkContainer>
+            </IfPermitted>
           </EmptyEntity>
         </Col>
       </Row>
@@ -52,11 +54,15 @@ class EventNotifications extends React.Component {
       const actions = (
         <React.Fragment>
           <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.edit(notification.id)}>
-            <Button bsStyle="info">Edit</Button>
+            <IfPermitted permissions={`eventnotifications:edit:${notification.id}`}>
+              <Button bsStyle="info">Edit</Button>
+            </IfPermitted>
           </LinkContainer>
-          <DropdownButton id={`more-dropdown-${notification.id}`} title="More" pullRight>
-            <MenuItem onClick={onDelete(notification)}>Delete</MenuItem>
-          </DropdownButton>
+          <IfPermitted permissions={`eventnotifications:delete:${notification.id}`}>
+            <DropdownButton id={`more-dropdown-${notification.id}`} title="More" pullRight>
+              <MenuItem onClick={onDelete(notification)}>Delete</MenuItem>
+            </DropdownButton>
+          </IfPermitted>
         </React.Fragment>
       );
 
@@ -83,11 +89,13 @@ class EventNotifications extends React.Component {
       <React.Fragment>
         <Row>
           <Col md={12}>
-            <div className="pull-right">
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.CREATE}>
-                <Button bsStyle="success">Create Notification</Button>
-              </LinkContainer>
-            </div>
+            <IfPermitted permissions="eventnotifications:create">
+              <div className="pull-right">
+                <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.CREATE}>
+                  <Button bsStyle="success">Create Notification</Button>
+                </LinkContainer>
+              </div>
+            </IfPermitted>
           </Col>
         </Row>
         <Row>

--- a/graylog2-web-interface/src/components/events/events/EventDetails.jsx
+++ b/graylog2-web-interface/src/components/events/events/EventDetails.jsx
@@ -7,6 +7,7 @@ import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import { Timestamp } from 'components/common';
 import Routes from 'routing/Routes';
+import PermissionsMixin from 'util/PermissionsMixin';
 
 import EventDefinitionPriorityEnum from 'logic/alerts/EventDefinitionPriorityEnum';
 
@@ -14,6 +15,7 @@ class EventDetails extends React.Component {
   static propTypes = {
     event: PropTypes.object.isRequired,
     eventDefinitionContext: PropTypes.object.isRequired,
+    currentUser: PropTypes.object.isRequired,
   };
 
   getConditionPlugin = (type) => {
@@ -38,6 +40,19 @@ class EventDetails extends React.Component {
     );
   };
 
+  renderLinkToEventDefinition = (event, eventDefinitionContext) => {
+    const { currentUser } = this.props;
+
+    if (!eventDefinitionContext) {
+      return <em>{event.event_definition_id}</em>;
+    }
+
+    return PermissionsMixin.isPermitted(currentUser.permissions,
+      `eventdefinitions:edit:${eventDefinitionContext.id}`)
+      ? <Link to={Routes.ALERTS.DEFINITIONS.edit(eventDefinitionContext.id)}>{eventDefinitionContext.title}</Link>
+      : eventDefinitionContext.title;
+  };
+
   render() {
     const { event, eventDefinitionContext } = this.props;
     const plugin = this.getConditionPlugin(event.event_definition_type);
@@ -58,13 +73,7 @@ class EventDetails extends React.Component {
             </dd>
             <dt>Event Definition</dt>
             <dd>
-              {eventDefinitionContext ? (
-                <Link to={Routes.ALERTS.DEFINITIONS.edit(eventDefinitionContext.id)}>
-                  {eventDefinitionContext.title}
-                </Link>
-              ) : (
-                <em>{event.event_definition_id}</em>
-              )}
+              {this.renderLinkToEventDefinition(event, eventDefinitionContext)}
               &emsp;
               ({plugin.displayName || event.event_definition_type})
             </dd>

--- a/graylog2-web-interface/src/components/events/events/EventsContainer.jsx
+++ b/graylog2-web-interface/src/components/events/events/EventsContainer.jsx
@@ -18,6 +18,7 @@ class EventsContainer extends React.Component {
   static propTypes = {
     events: PropTypes.object.isRequired,
     eventDefinitions: PropTypes.object.isRequired,
+    currentUser: PropTypes.object.isRequired,
     streamId: PropTypes.string,
   };
 

--- a/graylog2-web-interface/src/components/events/events/EventsContainer.jsx
+++ b/graylog2-web-interface/src/components/events/events/EventsContainer.jsx
@@ -12,6 +12,7 @@ import {} from 'components/event-definitions/event-definition-types';
 
 const { EventsStore, EventsActions } = CombinedProvider.get('Events');
 const { EventDefinitionsStore, EventDefinitionsActions } = CombinedProvider.get('EventDefinitions');
+const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
 class EventsContainer extends React.Component {
   static propTypes = {
@@ -100,7 +101,7 @@ class EventsContainer extends React.Component {
   };
 
   render() {
-    const { events, eventDefinitions } = this.props;
+    const { events, eventDefinitions, currentUser } = this.props;
     const isLoading = !events.events || !eventDefinitions.eventDefinitions;
 
     if (isLoading) {
@@ -111,6 +112,7 @@ class EventsContainer extends React.Component {
       <Events events={events.events}
               parameters={events.parameters}
               totalEvents={events.totalEvents}
+              currentUser={currentUser}
               totalEventDefinitions={eventDefinitions.pagination.grandTotal}
               context={events.context}
               onQueryChange={this.handleQueryChange}
@@ -125,4 +127,9 @@ class EventsContainer extends React.Component {
 export default connect(EventsContainer, {
   events: EventsStore,
   eventDefinitions: EventDefinitionsStore,
-});
+  currentUser: CurrentUserStore,
+},
+({ currentUser, ...otherProps }) => ({
+  ...otherProps,
+  currentUser: currentUser.currentUser,
+}));

--- a/graylog2-web-interface/src/pages/CreateEventDefinitionPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateEventDefinitionPage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 
-import { DocumentTitle, PageHeader } from 'components/common';
+import { DocumentTitle, IfPermitted, PageHeader } from 'components/common';
 import EventDefinitionFormContainer
   from 'components/event-definitions/event-definition-form/EventDefinitionFormContainer';
 import DocumentationLink from 'components/support/DocumentationLink';
@@ -47,9 +47,11 @@ class CreateEventDefinitionPage extends React.Component {
               <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
                 <Button bsStyle="info">Event Definitions</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
-                <Button bsStyle="info">Notifications</Button>
-              </LinkContainer>
+              <IfPermitted permissions="eventnotifications:read">
+                <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
+                  <Button bsStyle="info">Notifications</Button>
+                </LinkContainer>
+              </IfPermitted>
             </ButtonToolbar>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/CreateEventDefinitionPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateEventDefinitionPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 
@@ -9,8 +10,18 @@ import DocumentationLink from 'components/support/DocumentationLink';
 
 import Routes from 'routing/Routes';
 import DocsHelper from 'util/DocsHelper';
+import CombinedProvider from 'injection/CombinedProvider';
+import connect from 'stores/connect';
+import PermissionsMixin from 'util/PermissionsMixin';
+import history from 'util/History';
+
+const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
 class CreateEventDefinitionPage extends React.Component {
+  static propTypes = {
+    currentUser: PropTypes.object.isRequired,
+  };
+
   state = {
     eventDefinitionTitle: undefined,
   };
@@ -25,6 +36,12 @@ class CreateEventDefinitionPage extends React.Component {
   render() {
     const { eventDefinitionTitle } = this.state;
     const pageTitle = eventDefinitionTitle ? `New Event Definition "${eventDefinitionTitle}"` : 'New Event Definition';
+
+    const { currentUser } = this.props;
+
+    if (!PermissionsMixin.isPermitted(currentUser.permissions, 'eventdefinitions:create')) {
+      history.push(Routes.NOTFOUND);
+    }
 
     return (
       <DocumentTitle title={pageTitle}>
@@ -68,4 +85,7 @@ class CreateEventDefinitionPage extends React.Component {
   }
 }
 
-export default CreateEventDefinitionPage;
+export default connect(CreateEventDefinitionPage, {
+  currentUser: CurrentUserStore,
+},
+({ currentUser }) => ({ currentUser: currentUser.currentUser }));

--- a/graylog2-web-interface/src/pages/CreateEventDefinitionPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateEventDefinitionPage.jsx
@@ -44,9 +44,11 @@ class CreateEventDefinitionPage extends React.Component {
               <LinkContainer to={Routes.ALERTS.LIST}>
                 <Button bsStyle="info">Alerts & Events</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
-                <Button bsStyle="info">Event Definitions</Button>
-              </LinkContainer>
+              <IfPermitted permissions="eventdefinitions:read">
+                <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
+                  <Button bsStyle="info">Event Definitions</Button>
+                </LinkContainer>
+              </IfPermitted>
               <IfPermitted permissions="eventnotifications:read">
                 <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
                   <Button bsStyle="info">Notifications</Button>

--- a/graylog2-web-interface/src/pages/CreateEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateEventNotificationPage.jsx
@@ -31,9 +31,11 @@ class CreateEventDefinitionPage extends React.Component {
               <LinkContainer to={Routes.ALERTS.LIST}>
                 <Button bsStyle="info">Alerts & Events</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
-                <Button bsStyle="info">Event Definitions</Button>
-              </LinkContainer>
+              <IfPermitted permissions="eventdefinitions:read">
+                <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
+                  <Button bsStyle="info">Event Definitions</Button>
+                </LinkContainer>
+              </IfPermitted>
               <IfPermitted permissions="eventnotifications:read">
                 <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
                   <Button bsStyle="info">Notifications</Button>

--- a/graylog2-web-interface/src/pages/CreateEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateEventNotificationPage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 
-import { DocumentTitle, PageHeader } from 'components/common';
+import { DocumentTitle, IfPermitted, PageHeader } from 'components/common';
 import DocumentationLink from 'components/support/DocumentationLink';
 
 import Routes from 'routing/Routes';
@@ -34,9 +34,11 @@ class CreateEventDefinitionPage extends React.Component {
               <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
                 <Button bsStyle="info">Event Definitions</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
-                <Button bsStyle="info">Notifications</Button>
-              </LinkContainer>
+              <IfPermitted permissions="eventnotifications:read">
+                <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
+                  <Button bsStyle="info">Notifications</Button>
+                </LinkContainer>
+              </IfPermitted>
             </ButtonToolbar>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/CreateEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateEventNotificationPage.jsx
@@ -76,4 +76,3 @@ export default connect(CreateEventDefinitionPage, {
   currentUser: CurrentUserStore,
 },
 ({ currentUser }) => ({ currentUser: currentUser.currentUser }));
-

--- a/graylog2-web-interface/src/pages/CreateEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateEventNotificationPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 
@@ -7,11 +8,27 @@ import DocumentationLink from 'components/support/DocumentationLink';
 
 import Routes from 'routing/Routes';
 import DocsHelper from 'util/DocsHelper';
+import CombinedProvider from 'injection/CombinedProvider';
+import connect from 'stores/connect';
+import PermissionsMixin from 'util/PermissionsMixin';
+import history from 'util/History';
 
 import EventNotificationFormContainer from 'components/event-notifications/event-notification-form/EventNotificationFormContainer';
 
+const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
+
 class CreateEventDefinitionPage extends React.Component {
+  static propTypes = {
+    currentUser: PropTypes.object.isRequired,
+  };
+
   render() {
+    const { currentUser } = this.props;
+
+    if (!PermissionsMixin.isPermitted(currentUser.permissions, 'eventnotifications:create')) {
+      history.push(Routes.NOTFOUND);
+    }
+
     return (
       <DocumentTitle title="New Notification">
         <span>
@@ -55,4 +72,8 @@ class CreateEventDefinitionPage extends React.Component {
   }
 }
 
-export default CreateEventDefinitionPage;
+export default connect(CreateEventDefinitionPage, {
+  currentUser: CurrentUserStore,
+},
+({ currentUser }) => ({ currentUser: currentUser.currentUser }));
+

--- a/graylog2-web-interface/src/pages/EditEventDefinitionPage.jsx
+++ b/graylog2-web-interface/src/pages/EditEventDefinitionPage.jsx
@@ -62,9 +62,11 @@ class EditEventDefinitionPage extends React.Component {
               <LinkContainer to={Routes.ALERTS.LIST}>
                 <Button bsStyle="info">Alerts & Events</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
-                <Button bsStyle="info">Event Definitions</Button>
-              </LinkContainer>
+              <IfPermitted permissions="eventdefinitions:read">
+                <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
+                  <Button bsStyle="info">Event Definitions</Button>
+                </LinkContainer>
+              </IfPermitted>
               <IfPermitted permissions="eventnotifications:read">
                 <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
                   <Button bsStyle="info">Notifications</Button>

--- a/graylog2-web-interface/src/pages/EditEventDefinitionPage.jsx
+++ b/graylog2-web-interface/src/pages/EditEventDefinitionPage.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 
-import { DocumentTitle, PageHeader, Spinner } from 'components/common';
+import { DocumentTitle, IfPermitted, PageHeader, Spinner } from 'components/common';
 import EventDefinitionFormContainer
   from 'components/event-definitions/event-definition-form/EventDefinitionFormContainer';
 import DocumentationLink from 'components/support/DocumentationLink';
@@ -65,9 +65,11 @@ class EditEventDefinitionPage extends React.Component {
               <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
                 <Button bsStyle="info">Event Definitions</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
-                <Button bsStyle="info">Notifications</Button>
-              </LinkContainer>
+              <IfPermitted permissions="eventnotifications:read">
+                <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
+                  <Button bsStyle="info">Notifications</Button>
+                </LinkContainer>
+              </IfPermitted>
             </ButtonToolbar>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/EditEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/EditEventNotificationPage.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 
-import { DocumentTitle, PageHeader, Spinner } from 'components/common';
+import { DocumentTitle, IfPermitted, PageHeader, Spinner } from 'components/common';
 import DocumentationLink from 'components/support/DocumentationLink';
 
 import Routes from 'routing/Routes';
@@ -66,9 +66,11 @@ class EditEventDefinitionPage extends React.Component {
               <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
                 <Button bsStyle="info">Event Definitions</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
-                <Button bsStyle="info">Notifications</Button>
-              </LinkContainer>
+              <IfPermitted permissions="eventnotifications:read">
+                <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
+                  <Button bsStyle="info">Notifications</Button>
+                </LinkContainer>
+              </IfPermitted>
             </ButtonToolbar>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/EditEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/EditEventNotificationPage.jsx
@@ -63,9 +63,11 @@ class EditEventDefinitionPage extends React.Component {
               <LinkContainer to={Routes.ALERTS.LIST}>
                 <Button bsStyle="info">Alerts & Events</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
-                <Button bsStyle="info">Event Definitions</Button>
-              </LinkContainer>
+              <IfPermitted permissions="eventdefinitions:read">
+                <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
+                  <Button bsStyle="info">Event Definitions</Button>
+                </LinkContainer>
+              </IfPermitted>
               <IfPermitted permissions="eventnotifications:read">
                 <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
                   <Button bsStyle="info">Notifications</Button>

--- a/graylog2-web-interface/src/pages/EditEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/EditEventNotificationPage.jsx
@@ -9,14 +9,21 @@ import DocumentationLink from 'components/support/DocumentationLink';
 import Routes from 'routing/Routes';
 import DocsHelper from 'util/DocsHelper';
 import CombinedProvider from 'injection/CombinedProvider';
+import connect from 'stores/connect';
+import PermissionsMixin from 'util/PermissionsMixin';
+import history from 'util/History';
 
 import EventNotificationFormContainer from 'components/event-notifications/event-notification-form/EventNotificationFormContainer';
 
 const { EventNotificationsActions } = CombinedProvider.get('EventNotifications');
+const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
+
+const { isPermitted } = PermissionsMixin;
 
 class EditEventDefinitionPage extends React.Component {
   static propTypes = {
     params: PropTypes.object.isRequired,
+    currentUser: PropTypes.object.isRequired,
   };
 
   state = {
@@ -24,13 +31,21 @@ class EditEventDefinitionPage extends React.Component {
   };
 
   componentDidMount() {
-    const { params } = this.props;
-    EventNotificationsActions.get(params.notificationId)
-      .then(notification => this.setState({ notification: notification }));
+    const { params, currentUser } = this.props;
+
+    if (isPermitted(currentUser.permissions, `eventnotifications:edit:${params.definitionId}`)) {
+      EventNotificationsActions.get(params.notificationId)
+        .then(notification => this.setState({ notification: notification }));
+    }
   }
 
   render() {
     const { notification } = this.state;
+    const { params, currentUser } = this.props;
+
+    if (!isPermitted(currentUser.permissions, `eventnotifications:edit:${params.definitionId}`)) {
+      history.push(Routes.NOTFOUND);
+    }
 
     if (!notification) {
       return (
@@ -87,4 +102,7 @@ class EditEventDefinitionPage extends React.Component {
   }
 }
 
-export default EditEventDefinitionPage;
+export default connect(EditEventDefinitionPage, {
+  currentUser: CurrentUserStore,
+},
+({ currentUser }) => ({ currentUser: currentUser.currentUser }));

--- a/graylog2-web-interface/src/pages/EventDefinitionsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventDefinitionsPage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 
-import { DocumentTitle, PageHeader } from 'components/common';
+import { DocumentTitle, IfPermitted, PageHeader } from 'components/common';
 import DocumentationLink from 'components/support/DocumentationLink';
 import EventDefinitionsContainer from 'components/event-definitions/event-definitions/EventDefinitionsContainer';
 
@@ -32,9 +32,11 @@ class EventDefinitionsPage extends React.Component {
               <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
                 <Button bsStyle="info" className="active">Event Definitions</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
-                <Button bsStyle="info">Notifications</Button>
-              </LinkContainer>
+              <IfPermitted permissions="eventnotifications:read">
+                <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
+                  <Button bsStyle="info">Notifications</Button>
+                </LinkContainer>
+              </IfPermitted>
             </ButtonToolbar>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/EventDefinitionsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventDefinitionsPage.jsx
@@ -29,9 +29,11 @@ class EventDefinitionsPage extends React.Component {
               <LinkContainer to={Routes.ALERTS.LIST}>
                 <Button bsStyle="info">Alerts & Events</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
-                <Button bsStyle="info" className="active">Event Definitions</Button>
-              </LinkContainer>
+              <IfPermitted permissions="eventdefinitions:read">
+                <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
+                  <Button bsStyle="info" className="active">Event Definitions</Button>
+                </LinkContainer>
+              </IfPermitted>
               <IfPermitted permissions="eventnotifications:read">
                 <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
                   <Button bsStyle="info">Notifications</Button>

--- a/graylog2-web-interface/src/pages/EventNotificationsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventNotificationsPage.jsx
@@ -29,9 +29,11 @@ class EventNotificationsPage extends React.Component {
               <LinkContainer to={Routes.ALERTS.LIST}>
                 <Button bsStyle="info">Alerts & Events</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
-                <Button bsStyle="info">Event Definitions</Button>
-              </LinkContainer>
+              <IfPermitted permissions="eventdefinitions:read">
+                <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
+                  <Button bsStyle="info">Event Definitions</Button>
+                </LinkContainer>
+              </IfPermitted>
               <IfPermitted permissions="eventnotifications:read">
                 <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
                   <Button bsStyle="info" className="active">Notifications</Button>

--- a/graylog2-web-interface/src/pages/EventNotificationsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventNotificationsPage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 
-import { DocumentTitle, PageHeader } from 'components/common';
+import { DocumentTitle, IfPermitted, PageHeader } from 'components/common';
 
 import EventNotificationsContainer from 'components/event-notifications/event-notifications/EventNotificationsContainer';
 
@@ -32,9 +32,11 @@ class EventNotificationsPage extends React.Component {
               <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
                 <Button bsStyle="info">Event Definitions</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
-                <Button bsStyle="info" className="active">Notifications</Button>
-              </LinkContainer>
+              <IfPermitted permissions="eventnotifications:read">
+                <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
+                  <Button bsStyle="info" className="active">Notifications</Button>
+                </LinkContainer>
+              </IfPermitted>
             </ButtonToolbar>
           </PageHeader>
 

--- a/graylog2-web-interface/src/pages/EventsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventsPage.jsx
@@ -38,9 +38,11 @@ class EventsPage extends React.Component {
               <LinkContainer to={Routes.ALERTS.LIST}>
                 <Button bsStyle="info" className="active">Alerts & Events</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
-                <Button bsStyle="info">Event Definitions</Button>
-              </LinkContainer>
+              <IfPermitted permissions="eventdefinitions:read">
+                <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
+                  <Button bsStyle="info">Event Definitions</Button>
+                </LinkContainer>
+              </IfPermitted>
               <IfPermitted permissions="eventnotifications:read">
                 <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
                   <Button bsStyle="info">Notifications</Button>

--- a/graylog2-web-interface/src/pages/EventsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventsPage.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Button, ButtonToolbar, Col, Row } from 'react-bootstrap';
 
-import { DocumentTitle, PageHeader } from 'components/common';
+import { DocumentTitle, IfPermitted, PageHeader } from 'components/common';
 import DocumentationLink from 'components/support/DocumentationLink';
 import EventsContainer from 'components/events/events/EventsContainer';
 
@@ -41,9 +41,11 @@ class EventsPage extends React.Component {
               <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
                 <Button bsStyle="info">Event Definitions</Button>
               </LinkContainer>
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
-                <Button bsStyle="info">Notifications</Button>
-              </LinkContainer>
+              <IfPermitted permissions="eventnotifications:read">
+                <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
+                  <Button bsStyle="info">Notifications</Button>
+                </LinkContainer>
+              </IfPermitted>
             </ButtonToolbar>
           </PageHeader>
 


### PR DESCRIPTION
Authorize pages and components in the UI, hiding elements that a user should not see to avoid leaking any information.

These are the permissions that a user must have in order to see all information in the pages:
```
eventdefinitions:*
eventnotifications:*
streams:read
users:list
extendedsearch:create
extendedsearch:use
lookuptables:read
```