### PR TITLE
Fix rendering of LDAP page

### DIFF
--- a/graylog2-web-interface/src/components/ldap/LdapComponent.jsx
+++ b/graylog2-web-interface/src/components/ldap/LdapComponent.jsx
@@ -293,6 +293,11 @@ const LdapComponent = createReactClass({
                disabled={disabled} />
       );
 
+    const additionalDefaultGroups = this.state.ldapSettings.additional_default_groups;
+    const additionalDefaultGroupsString = Array.isArray(additionalDefaultGroups)
+      ? additionalDefaultGroups.join(',')
+      : additionalDefaultGroups;
+
     return (
       <Row>
         <Col lg={8}>
@@ -529,7 +534,7 @@ const LdapComponent = createReactClass({
                      help={help.ADDITIONAL_GROUPS}>
                 <MultiSelect options={rolesOptions}
                              disabled={disabled}
-                             value={this.state.ldapSettings.additional_default_groups}
+                             value={additionalDefaultGroupsString}
                              onChange={roles => this._setAdditionalDefaultGroups(roles)}
                              placeholder="Choose additional roles..." />
               </Input>

--- a/graylog2-web-interface/src/components/ldap/LdapComponent.jsx
+++ b/graylog2-web-interface/src/components/ldap/LdapComponent.jsx
@@ -8,7 +8,7 @@ import naturalSort from 'javascript-natural-sort';
 
 import { Input, InputWrapper } from 'components/bootstrap';
 import { FormGroup, ControlLabel } from 'react-bootstrap';
-import { MultiSelect, Spinner } from 'components/common';
+import { MultiSelect, Select, Spinner } from 'components/common';
 import ObjectUtils from 'util/ObjectUtils';
 
 import StoreProvider from 'injection/StoreProvider';
@@ -510,12 +510,11 @@ const LdapComponent = createReactClass({
                      wrapperClassName="col-sm-9"
                      label="Default User Role"
                      help={help.defaultGroup(this._onShowGroups)}>
-                <MultiSelect options={rolesOptions}
-                             disabled={disabled}
-                             multi={false}
-                             value={this.state.ldapSettings.default_group}
-                             onChange={role => this._setSetting('default_group', role)}
-                             placeholder="Choose a default role" />
+                <Select options={rolesOptions}
+                        disabled={disabled}
+                        value={this.state.ldapSettings.default_group}
+                        onChange={role => this._setSetting('default_group', role)}
+                        placeholder="Choose a default role" />
               </Input>
 
               <Row>


### PR DESCRIPTION
This PR fixes the issue by converting the array into a string and passing that down to `MultiSelect`. 

It also replaces a "fake" `MultiSelect` component with `Select`.

Fixes #6247