### PR TITLE
Add "ij_continuation_indent_size" setting to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,7 @@ insert_final_newline = true
 
 [*.java]
 indent_size = 4
+ij_continuation_indent_size = 8
 trim_trailing_whitespace = true
 
 [*.{js,jsx}]


### PR DESCRIPTION
Since I updated IntelliJ to 2019.2, I noticed changed indentation
behavior on line continuations. Instead of the standard 8 characters we
are using everywhere, I now only get 4 characters of indentation. This
is pretty annoying and also doesn't match the "standard" IntelliJ code
style we are using for years.

It looks like IntelliJ is now handling editorconfig files differently
and now supports vendor specific settings.

This change is adding the "ij_continuation_indent_size" IntelliJ
specific editorconfig setting to restore the old behavior of 8
character indent for line continuations.

Example of "broken" line continuation:

![image](https://user-images.githubusercontent.com/461/62600701-cc8d0800-b8ef-11e9-91dd-4e3cf53d2411.png)

The `.lifecyleStatus()` should have been indented with 8 characters.