### PR TITLE
Improve processing status handling to avoid blocking event processing

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/processor/EventProcessorDependencyCheck.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/EventProcessorDependencyCheck.java
@@ -66,6 +66,8 @@ public class EventProcessorDependencyCheck {
      * @return true if messages up to the given latestTimestamp have already been indexed, false otherwise
      */
     public boolean hasMessagesIndexedUpTo(DateTime latestTimestamp) {
+        // If there is no timestamp returned, there is no node in the cluster that is processing any messages.
+        // In that case we return false because there is nothing to process.
         return processingStatusService.earliestPostIndexingTimestamp()
                 .map(latestPostIndexTimestamp -> latestPostIndexTimestamp.isAfter(latestTimestamp) || latestPostIndexTimestamp.isEqual(latestTimestamp))
                 .orElse(false);

--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
@@ -109,10 +109,10 @@ public class KafkaJournal extends AbstractIdleService implements Journal {
     public static final int THRESHOLD_THROTTLING_DISABLED = -1;
 
     // Metric names, which should be used twice (once in metric startup and once in metric teardown).
-    private static final String METER_WRITTEN_MESSAGES = "writtenMessages";
-    private static final String METER_READ_MESSAGES = "readMessages";
+    public static final String METER_WRITTEN_MESSAGES = "writtenMessages";
+    public static final String METER_READ_MESSAGES = "readMessages";
     private static final String METER_WRITE_DISCARDED_MESSAGES = "writeDiscardedMessages";
-    private static final String GAUGE_UNCOMMITTED_MESSAGES = "uncommittedMessages";
+    public static final String GAUGE_UNCOMMITTED_MESSAGES = "uncommittedMessages";
     private static final String TIMER_WRITE_TIME = "writeTime";
     private static final String TIMER_READ_TIME = "readTime";
     private static final String METRIC_NAME_SIZE = "size";

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/InMemoryProcessingStatusRecorder.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/InMemoryProcessingStatusRecorder.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.system.processing;
 
+import org.graylog2.plugin.lifecycles.Lifecycle;
 import org.joda.time.DateTime;
 
 import javax.inject.Singleton;
@@ -31,6 +32,11 @@ public class InMemoryProcessingStatusRecorder implements ProcessingStatusRecorde
     private final AtomicReference<DateTime> ingestReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
     private final AtomicReference<DateTime> postProcessingReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
     private final AtomicReference<DateTime> postIndexReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
+
+    @Override
+    public Lifecycle getNodeLifecycleStatus() {
+        return Lifecycle.RUNNING;
+    }
 
     @Override
     public DateTime getIngestReceiveTime() {

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/InMemoryProcessingStatusRecorder.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/InMemoryProcessingStatusRecorder.java
@@ -16,10 +16,13 @@
  */
 package org.graylog2.system.processing;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.AtomicDouble;
 import org.graylog2.plugin.lifecycles.Lifecycle;
 import org.joda.time.DateTime;
 
 import javax.inject.Singleton;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.joda.time.DateTimeZone.UTC;
@@ -32,6 +35,13 @@ public class InMemoryProcessingStatusRecorder implements ProcessingStatusRecorde
     private final AtomicReference<DateTime> ingestReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
     private final AtomicReference<DateTime> postProcessingReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
     private final AtomicReference<DateTime> postIndexReceiveTime = new AtomicReference<>(new DateTime(0L, UTC));
+
+    @VisibleForTesting
+    final AtomicLong uncommittedMessages = new AtomicLong(0);
+    @VisibleForTesting
+    final AtomicDouble readMessages1m = new AtomicDouble(0);
+    @VisibleForTesting
+    final AtomicDouble writtenMessages1m = new AtomicDouble(0);
 
     @Override
     public Lifecycle getNodeLifecycleStatus() {
@@ -51,6 +61,21 @@ public class InMemoryProcessingStatusRecorder implements ProcessingStatusRecorde
     @Override
     public DateTime getPostIndexingReceiveTime() {
         return postIndexReceiveTime.get();
+    }
+
+    @Override
+    public long getJournalInfoUncommittedEntries() {
+        return uncommittedMessages.get();
+    }
+
+    @Override
+    public double getJournalInfoReadMessages1mRate() {
+        return readMessages1m.get();
+    }
+
+    @Override
+    public double getJournalInfoWrittenMessages1mRate() {
+        return writtenMessages1m.get();
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/MongoDBProcessingStatusRecorderService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/MongoDBProcessingStatusRecorderService.java
@@ -20,6 +20,7 @@ import com.github.joschi.jadconfig.util.Duration;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import com.google.common.util.concurrent.AbstractIdleService;
+import org.graylog2.plugin.ServerStatus;
 import org.graylog2.plugin.lifecycles.Lifecycle;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
@@ -48,6 +49,7 @@ public class MongoDBProcessingStatusRecorderService extends AbstractIdleService 
 
     private final DBProcessingStatusService dbService;
     private final EventBus eventBus;
+    private final ServerStatus serverStatus;
     private final Duration persistInterval;
     private final ScheduledExecutorService scheduler;
     private final AtomicBoolean inShutdown = new AtomicBoolean(false);
@@ -56,10 +58,12 @@ public class MongoDBProcessingStatusRecorderService extends AbstractIdleService 
     @Inject
     public MongoDBProcessingStatusRecorderService(DBProcessingStatusService dbService,
                                                   EventBus eventBus,
+                                                  ServerStatus serverStatus,
                                                   @Named(ProcessingStatusConfig.PERSIST_INTERVAL) Duration persistInterval,
                                                   @Named("daemonScheduler") ScheduledExecutorService scheduler) {
         this.dbService = dbService;
         this.eventBus = eventBus;
+        this.serverStatus = serverStatus;
         this.persistInterval = persistInterval;
         this.scheduler = scheduler;
     }
@@ -117,6 +121,11 @@ public class MongoDBProcessingStatusRecorderService extends AbstractIdleService 
         } catch (Exception e) {
             LOG.error("Couldn't persist processing status", e);
         }
+    }
+
+    @Override
+    public Lifecycle getNodeLifecycleStatus() {
+        return serverStatus.getLifecycle();
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusConfig.java
@@ -23,13 +23,22 @@ import com.github.joschi.jadconfig.util.Duration;
 import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
 
 public class ProcessingStatusConfig {
-    public static final String PERSIST_INTERVAL = "processing_status_persist_interval";
+    private static final String PREFIX = "processing_status_";
+    public static final String PERSIST_INTERVAL = PREFIX + "persist_interval";
+    public static final String EXCLUDE_THRESHOLD = PREFIX + "exclude_threshold";
 
     @Parameter(value = PERSIST_INTERVAL, validators = {PositiveDurationValidator.class, Minimum1SecondValidator.class})
     private Duration processingStatusPersistInterval = Duration.seconds(1);
 
+    @Parameter(value = EXCLUDE_THRESHOLD, validators = {PositiveDurationValidator.class, Minimum1SecondValidator.class})
+    private Duration excludeThreshold = Duration.minutes(1);
+
     public Duration getProcessingStatusPersistInterval() {
         return processingStatusPersistInterval;
+    }
+
+    public Duration getExcludeThreshold() {
+        return excludeThreshold;
     }
 
     public static class Minimum1SecondValidator implements Validator<Duration> {

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusConfig.java
@@ -21,24 +21,34 @@ import com.github.joschi.jadconfig.ValidationException;
 import com.github.joschi.jadconfig.Validator;
 import com.github.joschi.jadconfig.util.Duration;
 import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
+import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 
+@SuppressWarnings({"unused", "FieldCanBeLocal"})
 public class ProcessingStatusConfig {
     private static final String PREFIX = "processing_status_";
-    public static final String PERSIST_INTERVAL = PREFIX + "persist_interval";
-    public static final String EXCLUDE_THRESHOLD = PREFIX + "exclude_threshold";
+    static final String PERSIST_INTERVAL = PREFIX + "persist_interval";
+    static final String UPDATE_THRESHOLD = PREFIX + "update_threshold";
+    static final String JOURNAL_WRITE_RATE_THRESHOLD = PREFIX + "journal_write_rate_threshold";
 
     @Parameter(value = PERSIST_INTERVAL, validators = {PositiveDurationValidator.class, Minimum1SecondValidator.class})
     private Duration processingStatusPersistInterval = Duration.seconds(1);
 
-    @Parameter(value = EXCLUDE_THRESHOLD, validators = {PositiveDurationValidator.class, Minimum1SecondValidator.class})
-    private Duration excludeThreshold = Duration.minutes(1);
+    @Parameter(value = UPDATE_THRESHOLD, validators = {PositiveDurationValidator.class, Minimum1SecondValidator.class})
+    private Duration updateThreshold = Duration.minutes(1);
+
+    @Parameter(value = JOURNAL_WRITE_RATE_THRESHOLD, validators = PositiveIntegerValidator.class)
+    private int journalWriteRateThreshold = 1;
 
     public Duration getProcessingStatusPersistInterval() {
         return processingStatusPersistInterval;
     }
 
-    public Duration getExcludeThreshold() {
-        return excludeThreshold;
+    public Duration getUpdateThreshold() {
+        return updateThreshold;
+    }
+
+    public int getJournalWriteRateThreshold() {
+        return journalWriteRateThreshold;
     }
 
     public static class Minimum1SecondValidator implements Validator<Duration> {

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusDto.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusDto.java
@@ -159,9 +159,9 @@ public abstract class ProcessingStatusDto {
     @AutoValue
     @JsonDeserialize(builder = JournalInfo.Builder.class)
     public static abstract class JournalInfo {
-        private static final String FIELD_UNCOMMITTED_ENTRIES = "uncommitted_entries";
+        static final String FIELD_UNCOMMITTED_ENTRIES = "uncommitted_entries";
         private static final String FIELD_READ_MESSAGES_1M_RATE = "read_messages_1m_rate";
-        private static final String FIELD_WRITTEN_MESSAGES_1M_RATE = "written_messages_1m_rate";
+        static final String FIELD_WRITTEN_MESSAGES_1M_RATE = "written_messages_1m_rate";
 
         @JsonProperty(FIELD_UNCOMMITTED_ENTRIES)
         public abstract long uncommittedEntries();

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusRecorder.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusRecorder.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.system.processing;
 
+import org.graylog2.plugin.lifecycles.Lifecycle;
 import org.joda.time.DateTime;
 
 /**
@@ -51,4 +52,11 @@ public interface ProcessingStatusRecorder {
     void updatePostIndexingReceiveTime(DateTime newTimestamp);
 
     DateTime getPostIndexingReceiveTime();
+
+    /**
+     * Returns the node {@link Lifecycle} status for the node.
+     *
+     * @return the node lifecycle status
+     */
+    Lifecycle getNodeLifecycleStatus();
 }

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusRecorder.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusRecorder.java
@@ -59,4 +59,10 @@ public interface ProcessingStatusRecorder {
      * @return the node lifecycle status
      */
     Lifecycle getNodeLifecycleStatus();
+
+    long getJournalInfoUncommittedEntries();
+
+    double getJournalInfoReadMessages1mRate();
+
+    double getJournalInfoWrittenMessages1mRate();
 }

--- a/graylog2-server/src/test/java/org/graylog2/system/processing/DBProcessingStatusServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/system/processing/DBProcessingStatusServiceTest.java
@@ -94,6 +94,12 @@ public class DBProcessingStatusServiceTest {
                 assertThat(receiveTimes.postProcessing()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:02:00.000Z"));
                 assertThat(receiveTimes.postIndexing()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:01:00.000Z"));
             });
+
+            assertThat(dto.inputJournal()).satisfies(inputJournal -> {
+                assertThat(inputJournal.uncommittedEntries()).isEqualTo(0);
+                assertThat(inputJournal.readMessages1mRate()).isEqualTo(12.0d);
+                assertThat(inputJournal.writtenMessages1mRate()).isEqualTo(12.0d);
+            });
         });
 
         assertThat(dbService.all().get(1)).satisfies(dto -> {
@@ -106,6 +112,12 @@ public class DBProcessingStatusServiceTest {
                 assertThat(receiveTimes.ingest()).isEqualByComparingTo(DateTime.parse("2019-01-01T01:03:00.000Z"));
                 assertThat(receiveTimes.postProcessing()).isEqualByComparingTo(DateTime.parse("2019-01-01T01:02:00.000Z"));
                 assertThat(receiveTimes.postIndexing()).isEqualByComparingTo(DateTime.parse("2019-01-01T02:01:00.000Z"));
+            });
+
+            assertThat(dto.inputJournal()).satisfies(inputJournal -> {
+                assertThat(inputJournal.uncommittedEntries()).isEqualTo(0);
+                assertThat(inputJournal.readMessages1mRate()).isEqualTo(0);
+                assertThat(inputJournal.writtenMessages1mRate()).isEqualTo(0);
             });
         });
 
@@ -120,6 +132,12 @@ public class DBProcessingStatusServiceTest {
                 assertThat(receiveTimes.postProcessing()).isEqualByComparingTo(DateTime.parse("2019-01-01T02:02:00.000Z"));
                 assertThat(receiveTimes.postIndexing()).isEqualByComparingTo(DateTime.parse("2019-01-01T01:01:00.000Z"));
             });
+
+            assertThat(dto.inputJournal()).satisfies(inputJournal -> {
+                assertThat(inputJournal.uncommittedEntries()).isEqualTo(42);
+                assertThat(inputJournal.readMessages1mRate()).isEqualTo(2.0d);
+                assertThat(inputJournal.writtenMessages1mRate()).isEqualTo(4.0d);
+            });
         });
     }
 
@@ -133,6 +151,10 @@ public class DBProcessingStatusServiceTest {
         statusRecorder.updatePostProcessingReceiveTime(now.minusSeconds(1));
         statusRecorder.updatePostIndexingReceiveTime(now.minusSeconds(2));
 
+        statusRecorder.uncommittedMessages.set(123);
+        statusRecorder.readMessages1m.set(1);
+        statusRecorder.writtenMessages1m.set(2);
+
         assertThat(dbService.save(statusRecorder, now)).satisfies(dto -> {
             assertThat(dto.id()).isNotBlank();
             assertThat(dto.nodeId()).isEqualTo(NODE_ID);
@@ -143,6 +165,12 @@ public class DBProcessingStatusServiceTest {
                 assertThat(receiveTimes.ingest()).isEqualByComparingTo(now);
                 assertThat(receiveTimes.postProcessing()).isEqualByComparingTo(now.minusSeconds(1));
                 assertThat(receiveTimes.postIndexing()).isEqualByComparingTo(now.minusSeconds(2));
+            });
+
+            assertThat(dto.inputJournal()).satisfies(inputJournal -> {
+                assertThat(inputJournal.uncommittedEntries()).isEqualTo(123);
+                assertThat(inputJournal.readMessages1mRate()).isEqualTo(1.0d);
+                assertThat(inputJournal.writtenMessages1mRate()).isEqualTo(2.0d);
             });
         });
 
@@ -166,6 +194,12 @@ public class DBProcessingStatusServiceTest {
                 assertThat(receiveTimes.ingest()).isEqualByComparingTo(tomorrow);
                 assertThat(receiveTimes.postProcessing()).isEqualByComparingTo(tomorrow.minusSeconds(1));
                 assertThat(receiveTimes.postIndexing()).isEqualByComparingTo(tomorrow.minusSeconds(2));
+            });
+
+            assertThat(dto.inputJournal()).satisfies(inputJournal -> {
+                assertThat(inputJournal.uncommittedEntries()).isEqualTo(123);
+                assertThat(inputJournal.readMessages1mRate()).isEqualTo(1.0d);
+                assertThat(inputJournal.writtenMessages1mRate()).isEqualTo(2.0d);
             });
         });
 

--- a/graylog2-server/src/test/java/org/graylog2/system/processing/DBProcessingStatusServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/system/processing/DBProcessingStatusServiceTest.java
@@ -25,6 +25,7 @@ import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.cluster.Node;
 import org.graylog2.cluster.NodeService;
 import org.graylog2.database.MongoConnectionRule;
+import org.graylog2.plugin.lifecycles.Lifecycle;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.joda.time.DateTime;
@@ -86,6 +87,7 @@ public class DBProcessingStatusServiceTest {
             assertThat(dto.id()).isEqualTo("54e3deadbeefdeadbeef0000");
             assertThat(dto.nodeId()).isEqualTo("abc-123");
             assertThat(dto.updatedAt()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:03:00.000Z"));
+            assertThat(dto.nodeLifecycleStatus()).isEqualTo(Lifecycle.RUNNING);
 
             assertThat(dto.receiveTimes()).satisfies(receiveTimes -> {
                 assertThat(receiveTimes.ingest()).isEqualByComparingTo(DateTime.parse("2019-01-01T00:03:00.000Z"));
@@ -98,6 +100,7 @@ public class DBProcessingStatusServiceTest {
             assertThat(dto.id()).isEqualTo("54e3deadbeefdeadbeef0001");
             assertThat(dto.nodeId()).isEqualTo("abc-456");
             assertThat(dto.updatedAt()).isEqualByComparingTo(DateTime.parse("2019-01-01T01:03:00.000Z"));
+            assertThat(dto.nodeLifecycleStatus()).isEqualTo(Lifecycle.RUNNING);
 
             assertThat(dto.receiveTimes()).satisfies(receiveTimes -> {
                 assertThat(receiveTimes.ingest()).isEqualByComparingTo(DateTime.parse("2019-01-01T01:03:00.000Z"));
@@ -110,6 +113,7 @@ public class DBProcessingStatusServiceTest {
             assertThat(dto.id()).isEqualTo("54e3deadbeefdeadbeef0002");
             assertThat(dto.nodeId()).isEqualTo("abc-789");
             assertThat(dto.updatedAt()).isEqualByComparingTo(DateTime.parse("2019-01-01T02:03:00.000Z"));
+            assertThat(dto.nodeLifecycleStatus()).isEqualTo(Lifecycle.STARTING);
 
             assertThat(dto.receiveTimes()).satisfies(receiveTimes -> {
                 assertThat(receiveTimes.ingest()).isEqualByComparingTo(DateTime.parse("2019-01-01T02:03:00.000Z"));
@@ -133,6 +137,7 @@ public class DBProcessingStatusServiceTest {
             assertThat(dto.id()).isNotBlank();
             assertThat(dto.nodeId()).isEqualTo(NODE_ID);
             assertThat(dto.updatedAt()).isEqualByComparingTo(now);
+            assertThat(dto.nodeLifecycleStatus()).isEqualTo(Lifecycle.RUNNING);
 
             assertThat(dto.receiveTimes()).satisfies(receiveTimes -> {
                 assertThat(receiveTimes.ingest()).isEqualByComparingTo(now);
@@ -155,6 +160,7 @@ public class DBProcessingStatusServiceTest {
             assertThat(dto.id()).isNotBlank();
             assertThat(dto.nodeId()).isEqualTo(NODE_ID);
             assertThat(dto.updatedAt()).isEqualByComparingTo(tomorrow);
+            assertThat(dto.nodeLifecycleStatus()).isEqualTo(Lifecycle.RUNNING);
 
             assertThat(dto.receiveTimes()).satisfies(receiveTimes -> {
                 assertThat(receiveTimes.ingest()).isEqualByComparingTo(tomorrow);

--- a/graylog2-server/src/test/resources/org/graylog2/system/processing/processing-status-node-selection-test.json
+++ b/graylog2-server/src/test/resources/org/graylog2/system/processing/processing-status-node-selection-test.json
@@ -1,0 +1,108 @@
+{
+  "processing_status": [
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0000"
+      },
+      "node_id": "abc-123",
+      "node_lifecycle_status": "RUNNING",
+      "updated_at": {
+        "$date": "2019-01-01T00:03:00.000Z"
+      },
+      "receive_times": {
+        "ingest": {
+          "$date": "2019-01-01T00:03:00.000Z"
+        },
+        "post_processing": {
+          "$date": "2019-01-01T00:03:00.000Z"
+        },
+        "post_indexing": {
+          "$date": "2019-01-01T00:03:00.000Z"
+        }
+      },
+      "input_journal": {
+        "uncommitted_entries": 2,
+        "read_messages_1m_rate": 14.0,
+        "written_messages_1m_rate": 12.0
+      }
+    },
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0001"
+      },
+      "node_id": "abc-456",
+      "node_lifecycle_status": "RUNNING",
+      "updated_at": {
+        "$date": "2019-01-01T00:03:00.000Z"
+      },
+      "receive_times": {
+        "ingest": {
+          "$date": "2019-01-01T00:02:00.000Z"
+        },
+        "post_processing": {
+          "$date": "2019-01-01T00:02:00.000Z"
+        },
+        "post_indexing": {
+          "$date": "2019-01-01T00:02:00.000Z"
+        }
+      },
+      "input_journal": {
+        "uncommitted_entries": 23,
+        "read_messages_1m_rate": 0.0,
+        "written_messages_1m_rate": 0.0
+      }
+    },
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0002"
+      },
+      "node_id": "abc-678",
+      "node_lifecycle_status": "RUNNING",
+      "updated_at": {
+        "$date": "2019-01-01T00:03:00.000Z"
+      },
+      "receive_times": {
+        "ingest": {
+          "$date": "2019-01-01T00:02:00.000Z"
+        },
+        "post_processing": {
+          "$date": "2019-01-01T00:02:00.000Z"
+        },
+        "post_indexing": {
+          "$date": "2019-01-01T00:02:00.000Z"
+        }
+      },
+      "input_journal": {
+        "uncommitted_entries": 0,
+        "read_messages_1m_rate": 0.0,
+        "written_messages_1m_rate": 1.0
+      }
+    },
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0003"
+      },
+      "node_id": "abc-000",
+      "node_lifecycle_status": "RUNNING",
+      "updated_at": {
+        "$date": "2019-01-01T00:03:00.000Z"
+      },
+      "receive_times": {
+        "ingest": {
+          "$date": "2019-01-01T00:02:00.000Z"
+        },
+        "post_processing": {
+          "$date": "2019-01-01T00:02:00.000Z"
+        },
+        "post_indexing": {
+          "$date": "2019-01-01T00:02:00.000Z"
+        }
+      },
+      "input_journal": {
+        "uncommitted_entries": 0,
+        "read_messages_1m_rate": 0.0,
+        "written_messages_1m_rate": 0.0
+      }
+    }
+  ]
+}

--- a/graylog2-server/src/test/resources/org/graylog2/system/processing/processing-status.json
+++ b/graylog2-server/src/test/resources/org/graylog2/system/processing/processing-status.json
@@ -19,6 +19,11 @@
         "post_indexing": {
           "$date": "2019-01-01T00:01:00.000Z"
         }
+      },
+      "input_journal": {
+        "uncommitted_entries": 0,
+        "read_messages_1m_rate": 12,
+        "written_messages_1m_rate": 12
       }
     },
     {
@@ -60,6 +65,11 @@
         "post_indexing": {
           "$date": "2019-01-01T01:01:00.000Z"
         }
+      },
+      "input_journal": {
+        "uncommitted_entries": 42,
+        "read_messages_1m_rate": 2,
+        "written_messages_1m_rate": 4
       }
     }
   ]

--- a/graylog2-server/src/test/resources/org/graylog2/system/processing/processing-status.json
+++ b/graylog2-server/src/test/resources/org/graylog2/system/processing/processing-status.json
@@ -7,7 +7,7 @@
       "node_id": "abc-123",
       "node_lifecycle_status": "RUNNING",
       "updated_at": {
-        "$date": "2019-01-01T00:03:00.000Z"
+        "$date": "2019-01-01T00:01:00.000Z"
       },
       "receive_times": {
         "ingest": {
@@ -32,7 +32,7 @@
       },
       "node_id": "abc-456",
       "updated_at": {
-        "$date": "2019-01-01T01:03:00.000Z"
+        "$date": "2019-01-01T02:01:00.000Z"
       },
       "receive_times": {
         "ingest": {
@@ -53,7 +53,7 @@
       "node_id": "abc-789",
       "node_lifecycle_status": "STARTING",
       "updated_at": {
-        "$date": "2019-01-01T02:03:00.000Z"
+        "$date": "2019-01-01T01:01:00.000Z"
       },
       "receive_times": {
         "ingest": {

--- a/graylog2-server/src/test/resources/org/graylog2/system/processing/processing-status.json
+++ b/graylog2-server/src/test/resources/org/graylog2/system/processing/processing-status.json
@@ -5,6 +5,7 @@
         "$oid": "54e3deadbeefdeadbeef0000"
       },
       "node_id": "abc-123",
+      "node_lifecycle_status": "RUNNING",
       "updated_at": {
         "$date": "2019-01-01T00:03:00.000Z"
       },
@@ -45,6 +46,7 @@
         "$oid": "54e3deadbeefdeadbeef0002"
       },
       "node_id": "abc-789",
+      "node_lifecycle_status": "STARTING",
       "updated_at": {
         "$date": "2019-01-01T02:03:00.000Z"
       },

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -638,3 +638,8 @@ proxied_requests_thread_pool_size = 32
 # often the data is written to the database.
 # Default: 1s (cannot be less than 1s)
 #processing_status_persist_interval = 1s
+
+# Configures the threshold for detecting outdated processing status records. Any records that haven't been updated
+# in the configured threshold will be ignored.
+# Default: 1m (one minute)
+#processing_status_exclude_threshold = 1m

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -642,4 +642,9 @@ proxied_requests_thread_pool_size = 32
 # Configures the threshold for detecting outdated processing status records. Any records that haven't been updated
 # in the configured threshold will be ignored.
 # Default: 1m (one minute)
-#processing_status_exclude_threshold = 1m
+#processing_status_update_threshold = 1m
+
+# Configures the journal write rate threshold for selecting processing status records. Any records that have a lower
+# one minute rate than the configured value might be ignored. (dependent on number of messages in the journal)
+# Default: 1
+#processing_status_journal_write_rate_threshold = 1


### PR DESCRIPTION
Previously we did the processing status record selection based on the
active node list in the cluster. Since that system is pretty aggressive
removing nodes from the database, we needed something else.

Another problem was that nodes which didn't receive any log messages
but are part of the cluster and update their processing status records,
would be included in the earliest post-indexing timestamp computation.
Since these inactive nodes wouldn't receive any log messages, the
timestamp would always be very old and the events system wouldn't
run any jobs. (See #6228)

We are now choosing processing status records where:

- the "updated_at" timestamp has been updated recently (configurable)
- and either the 1 minute journal write rate is larger than a threshold
  (configurable)
- or the number of uncommitted journal entries is not zero

That means status records that haven't been updated recently or
indicate that a node doesn't receive any data (journal writes) and
that have no messages in the journal will be ignored.

Closes #6228