### PR TITLE
Hide unsupported Streams from Filter Select

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationFormContainer.jsx
@@ -11,6 +11,13 @@ import FilterAggregationForm from './FilterAggregationForm';
 
 const { StreamsStore } = CombinedProvider.get('Streams');
 
+// We currently don't support creating Events from these Streams, since they also contain Events
+// and it's not possible to access custom Fields defined in them.
+const HIDDEN_STREAMS = [
+  '000000000000000000000002',
+  '000000000000000000000003',
+];
+
 class FilterAggregationFormContainer extends React.Component {
   static propTypes = {
     action: PropTypes.oneOf(['create', 'edit']).isRequired,
@@ -25,7 +32,10 @@ class FilterAggregationFormContainer extends React.Component {
   };
 
   componentDidMount() {
-    StreamsStore.load(streams => this.setState({ availableStreams: streams }));
+    StreamsStore.load((streams) => {
+      const filteredStreams = streams.filter(s => !HIDDEN_STREAMS.includes(s.id));
+      this.setState({ availableStreams: filteredStreams });
+    });
   }
 
   render() {


### PR DESCRIPTION
While this is something we want to allow in the future, it's currently not possible to use the nested custom fields of an event in fields for aggregation grouping and aggregation series fields.

Fixes #6236