### PR TITLE
Avoid using `Stream#peek` for counting items in paginated result set.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/database/PaginatedDbService.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/PaginatedDbService.java
@@ -152,9 +152,10 @@ public abstract class PaginatedDbService<DTO> {
                                                                      DBSort.SortBuilder sort,
                                                                      int page,
                                                                      int perPage) {
+        // Calculate the total amount of items matching the query/filter, but before pagination
         final long total = streamQueryWithSort(query, sort).filter(filter).count();
 
-        // Then use that filtered stream and only collect the entries according to page and perPage
+        // Then create another filtered stream and only collect the entries according to page and perPage
         Stream<DTO> resultStream = streamQueryWithSort(query, sort).filter(filter);
         if (perPage > 0) {
             resultStream = resultStream.skip(perPage * Math.max(0, page - 1)).limit(perPage);


### PR DESCRIPTION
## Description
## Motivation and Context

Before this change, in `PaginatedDbService#findPaginatedWithQueryFilterAndSort` a single stream was used to filter (based on the query), paginate (based on page size and page number) and determine the number of total items (before pagination). The latter is performed using `Stream#peek`, which has the following characteristics:

  1. The docs say: `This method exists mainly to support debugging, where you want to see the elements as they flow past a certain point in a pipeline`
  2. `peek` is an intermediate operation on a stream, which means that
    a) it's actual execution is driven by the terminal operation of the stream
    b) it has the benefit in this case that a single stream execution is able to perform multiple tasks

The code before this PR relies on `peek` being executed for each item on the stream before pagination (`skip`/`limit`) is performed. This is the case for OracleJDK up to and including 1.8.0_202.  

Unfortunately OpenJDK (tested with `1.8.0_222`) is performing an optimization, where the actual stream execution is determined by the terminal operation (see 2a) and `peek` only sees items after filtering _and_ pagination (`Streams are lazy; computation on the source data is only performed when the terminal operation is initiated, and source elements are consumed only as needed.`).

Therefore, this change is replacing the usage of `peek` with a simpler variant, which is using two separate stream instantiations for counting the total items and the actual pagination.

Fixes #6254.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.