### PR TITLE
Fix wizard layot design for content packs

### DIFF
--- a/graylog2-web-interface/src/components/common/Wizard.jsx
+++ b/graylog2-web-interface/src/components/common/Wizard.jsx
@@ -214,7 +214,14 @@ class Wizard extends React.Component {
 
   render() {
     const { steps, horizontal, containerClassName, children } = this.props;
-    const leftComponentCols = children ? 7 : 12; // Use all available width if no preview will be rendered
+    let leftComponentCols;
+
+    if (children) {
+      leftComponentCols = 7;
+    } else {
+      leftComponentCols = horizontal ? 12 : 10;
+    }
+
     const rightComponentCols = horizontal ? 5 : 3; // If horizontal, use more space for this component
     return (
       <Row className={containerClassName}>

--- a/graylog2-web-interface/src/components/common/__snapshots__/Wizard.test.jsx.snap
+++ b/graylog2-web-interface/src/components/common/__snapshots__/Wizard.test.jsx.snap
@@ -271,7 +271,7 @@ exports[`<Wizard /> should render with 3 steps 1`] = `
     </div>
   </div>
   <div
-    className="col-md-12"
+    className="col-md-10"
   >
     <div>
       Component1


### PR DESCRIPTION
Prior to this change, the preview page was to wide, which resulted
in a broken view.

This change will only make the lefComponentCols 12 wide if
it is horizontal.

Fixes #6197

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
