### PR TITLE
Prevent closing of UDP channel in input for messages with bogus GELF header.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/EnvelopeMessageAggregationHandler.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/EnvelopeMessageAggregationHandler.java
@@ -59,4 +59,10 @@ public class EnvelopeMessageAggregationHandler extends SimpleChannelInboundHandl
             LOG.debug("Message chunk was not valid and discarded.");
         }
     }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable e) throws Exception {
+        LOG.error("Caught exception while decoding type of GELF packet: {}", e.getMessage());
+        invalidChunksMeter.mark();
+    }
 }


### PR DESCRIPTION
## Description
## Motivation and Context

Before this change, whenever a UDP message came in with a 0 or 1 byte header (smaller than the 2 byte GELF header), the thread handling this message throws an exception in `GELFMessage#getGELFType` which is caught in `EnvelopeMessageHandler#exceptionCaught`. In there, the channel is closed. This is correct for a TCP-based input, as the corresponding TCP-connection would be closed, as each channel corresponds to a TCP connection. This is not the case for UDP pipelines. Closing a channel of a UDP pipeline leads to the handler/thread losing the overall connection to the socket multiplexing. If this happens for a number of times equaling the number of working threads, the whole input stops processing any UDP messages as there is no thread left which is able to receive channel events.

This change adds `EnvelopeMessageAggregationHandler#exceptionCaught` which is only logging the exception and increasing the counter for invalid GELF chunks, without propagating the exception to other handlers (preventing the channel closure).

A remaining issue is that for UDP messages with no/invalid GELF headers, the `EnvelopeMessageAggregationHandler#channelRead0` is called four times, for correct messages only once. The first three times it is called with a single byte buffer, the last time with a buffer containing the complete message. It is unclear to me why this happens and leads to the exception being logged four times, but this seems to be still way better than causing situations where the complete input ceases to work.  Any insight how to fix this is welcome.  

Fixes #5701.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Send 12 messages (actual count depends on the number of configured threads) with no header to the GELF UDP port, e.g. like this:
  ```
        for i in `seq 1 12`; do nc -vzu localhost 12201; done
  ```
- Send proper GELF UDP message:
  ```
    echo '{"version": "1.1","host":"example.org","short_message":"A short message that helps you identify what is going on","full_message":"Backtrace here\n\nmore stuff","level":1,"_user_id":9001,"_some_info":"foo","_some_env_var":"bar"}' | gzip | nc -u -w 1 localhost 12201
  ```
- Ensure that message was processed and indexed


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.