### PR TITLE
More Events UI improvements

### DIFF
--- a/graylog2-web-interface/src/components/common/ConfirmLeaveDialog.jsx
+++ b/graylog2-web-interface/src/components/common/ConfirmLeaveDialog.jsx
@@ -5,7 +5,7 @@ import { withRouter } from 'react-router';
 import AppConfig from 'util/AppConfig';
 
 /**
- * This component should be conditionally rendered if you have a form that is in a "dirty" state. It will confirm with the user that they want to naviage away, refresh, or in any way unload the component.
+ * This component should be conditionally rendered if you have a form that is in a "dirty" state. It will confirm with the user that they want to navigate away, refresh, or in any way unload the component.
  */
 const ConfirmLeaveDialog = ({ question, router, route }) => {
   const handleLeavePage = (e) => {

--- a/graylog2-web-interface/src/components/common/TimeUnitInput.jsx
+++ b/graylog2-web-interface/src/components/common/TimeUnitInput.jsx
@@ -95,6 +95,8 @@ const TimeUnitInput = createReactClass({
     hideCheckbox: PropTypes.bool,
     /** Align unit dropdown menu to the right. */
     pullRight: PropTypes.bool,
+    /** Lets the user clear the numeric input. */
+    clearable: PropTypes.bool,
   },
 
   getDefaultProps() {
@@ -112,6 +114,7 @@ const TimeUnitInput = createReactClass({
       wrapperClassName: undefined,
       hideCheckbox: false,
       pullRight: false,
+      clearable: false,
     };
   },
 
@@ -131,8 +134,8 @@ const TimeUnitInput = createReactClass({
   },
 
   _getEffectiveValue() {
-    const { defaultValue, value } = this.props;
-    return lodash.defaultTo(value, defaultValue);
+    const { defaultValue, value, clearable } = this.props;
+    return clearable ? value : lodash.defaultTo(value, defaultValue);
   },
 
   _getUnitOptions(units) {
@@ -168,8 +171,13 @@ const TimeUnitInput = createReactClass({
   },
 
   _onUpdate(e) {
-    const { defaultValue } = this.props;
-    const value = lodash.defaultTo(FormsUtils.getValueFromInput(e.target), defaultValue);
+    const { defaultValue, clearable } = this.props;
+    let value;
+    if (clearable) {
+      value = FormsUtils.getValueFromInput(e.target);
+    } else {
+      value = lodash.defaultTo(FormsUtils.getValueFromInput(e.target), defaultValue);
+    }
     this._propagateInput({ value: value });
   },
 
@@ -203,7 +211,7 @@ const TimeUnitInput = createReactClass({
         <InputWrapper className={wrapperClassName}>
           <InputGroup>
             {(!required && !hideCheckbox) && checkbox}
-            <FormControl type="number" disabled={!this._isChecked()} onChange={this._onUpdate} value={this._getEffectiveValue()} />
+            <FormControl type="number" disabled={!this._isChecked()} onChange={this._onUpdate} value={lodash.defaultTo(this._getEffectiveValue(), '')} />
             <DropdownButton componentClass={InputGroup.Button}
                             id="input-dropdown-addon"
                             pullRight={pullRight}

--- a/graylog2-web-interface/src/components/common/TimeUnitInput.test.jsx
+++ b/graylog2-web-interface/src/components/common/TimeUnitInput.test.jsx
@@ -44,7 +44,7 @@ describe('<TimeUnitInput />', () => {
     expect(checkbox.prop('checked')).toBe(true);
     expect(wrapper.find('input[type="number"]').prop('value')).toBe(1);
     expect(wrapper.find('li.active a').prop('children')).toBe('days');
-    wrapper.find('input[type="number"]').simulate('change', { target: { value: 42 } });
+    wrapper.find('input[type="number"]').simulate('change', { target: { value: 42, type: 'number' } });
   });
 
   it('should use values before default values', () => {
@@ -70,7 +70,7 @@ describe('<TimeUnitInput />', () => {
 
     const wrapper = mount(<TimeUnitInput update={onUpdate} required enabled={false} defaultEnabled={false} />);
     expect(wrapper.find('input[type="checkbox"]').length).toBe(0);
-    wrapper.find('input[type="number"]').simulate('change', { target: { value: 42 } });
+    wrapper.find('input[type="number"]').simulate('change', { target: { value: 42, type: 'number' } });
   });
 
   it('should disable all inputs when disabled', () => {
@@ -94,5 +94,62 @@ describe('<TimeUnitInput />', () => {
     expect(wrapper.find('input[type="checkbox"]').length).toBe(0);
     expect(wrapper.find('input[type="number"]').getDOMNode().disabled).toBeTruthy();
     expect(wrapper.find('button.dropdown-toggle').getDOMNode().disabled).toBeTruthy();
+  });
+
+  it('should use default value when clearing the input', () => {
+    const handleUpdate = (value, unit, checked) => {
+      expect(value).toBe(42);
+      expect(unit).toBe('SECONDS');
+      expect(checked).toBe(true);
+    };
+
+    const wrapper = mount(<TimeUnitInput update={handleUpdate} defaultEnabled value={9} defaultValue={42} />);
+    wrapper.find('input[type="number"]').simulate('change', { target: { value: '', type: 'number' } });
+  });
+
+  it('should use default value when input receives some text', () => {
+    const handleUpdate = (value, unit, checked) => {
+      expect(value).toBe(42);
+      expect(unit).toBe('SECONDS');
+      expect(checked).toBe(true);
+    };
+
+    const wrapper = mount(<TimeUnitInput update={handleUpdate} defaultEnabled value={9} defaultValue={42} />);
+    wrapper.find('input[type="number"]').simulate('change', { target: { value: 'adsasd', type: 'number' } });
+  });
+
+  describe('when clearable is set', () => {
+    it('should use undefined when clearing input', () => {
+      const handleUpdate = (value, unit, checked) => {
+        expect(value).toBe(undefined);
+        expect(unit).toBe('SECONDS');
+        expect(checked).toBe(true);
+      };
+
+      const wrapper = mount(
+        <TimeUnitInput update={handleUpdate} defaultEnabled clearable value={9} defaultValue={42} />,
+      );
+      wrapper.find('input[type="number"]').simulate('change', { target: { value: '', type: 'number' } });
+    });
+
+    it('should use undefined when input receives some text', () => {
+      const handleUpdate = (value, unit, checked) => {
+        expect(value).toBe(undefined);
+        expect(unit).toBe('SECONDS');
+        expect(checked).toBe(true);
+      };
+
+      const wrapper = mount(
+        <TimeUnitInput update={handleUpdate} defaultEnabled clearable value={9} defaultValue={42} />,
+      );
+      wrapper.find('input[type="number"]').simulate('change', { target: { value: 'adsasd', type: 'number' } });
+    });
+
+    it('should render empty string when value is undefined', () => {
+      const wrapper = mount(
+        <TimeUnitInput update={() => {}} defaultEnabled clearable value={undefined} defaultValue={42} />,
+      );
+      expect(wrapper.find('input[type="number"]').prop('value')).toBe('');
+    });
   });
 });

--- a/graylog2-web-interface/src/components/common/index.jsx
+++ b/graylog2-web-interface/src/components/common/index.jsx
@@ -5,6 +5,7 @@ const SourceCodeEditor = loadAsync(() => import('./SourceCodeEditor'));
 export { default as ClipboardButton } from './ClipboardButton';
 export { default as ColorPicker } from './ColorPicker';
 export { default as ColorPickerPopover } from './ColorPickerPopover';
+export { default as ConfirmLeaveDialog } from './ConfirmLeaveDialog';
 export { default as ContentPackMarker } from './ContentPackMarker';
 export { default as ControlledTableList } from './ControlledTableList';
 export { default as DataTable } from './DataTable';

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldForm.jsx
@@ -68,7 +68,7 @@ class FieldForm extends React.Component {
   };
 
   validate = () => {
-    const { config } = this.state;
+    const { isKey, keyPosition, config } = this.state;
     const errors = {};
 
     const providerType = this.getConfigProviderType(config);
@@ -83,6 +83,10 @@ class FieldForm extends React.Component {
         errors[requiredField] = 'Field cannot be empty.';
       }
     });
+
+    if (isKey && (!lodash.isNumber(keyPosition) || Number(keyPosition) < 1)) {
+      errors.key_position = 'Field must be a positive number.';
+    }
 
     pluginRequiredFields.forEach((requiredField) => {
       if (!lodash.get(config, `providers[0].${requiredField}`)) {
@@ -129,7 +133,7 @@ class FieldForm extends React.Component {
   };
 
   handleKeySortChange = (event) => {
-    const nextPosition = FormsUtils.getValueFromInput(event.target);
+    const nextPosition = event.target.value === '' ? '' : FormsUtils.getValueFromInput(event.target);
     this.setState({ keyPosition: nextPosition });
   };
 
@@ -186,7 +190,7 @@ class FieldForm extends React.Component {
                  help={validation.errors.fieldName || 'Name for this Field.'}
                  required />
 
-          <FormGroup>
+          <FormGroup validationState={validation.errors.key_position ? 'error' : null}>
             <ControlLabel>
               Use Field as Event Key&emsp;
               <OverlayTrigger placement="right" trigger="click" overlay={<EventKeyHelpPopover id="key-popover" />}>
@@ -204,7 +208,9 @@ class FieldForm extends React.Component {
                            onChange={this.handleKeySortChange}
                            disabled={!isKey} />
             </InputGroup>
-            <HelpBlock>Indicates if this Field should be a Key and its order.</HelpBlock>
+            <HelpBlock>
+              {validation.errors.key_position || 'Indicates if this Field should be a Key and its order.'}
+            </HelpBlock>
           </FormGroup>
 
           <FormGroup>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationSettingsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationSettingsForm.jsx
@@ -57,11 +57,11 @@ class NotificationSettingsForm extends React.Component {
     this.setState(stateUpdate);
   };
 
-  handleChange = (event) => {
+  handleBacklogSizeChange = (event) => {
     const { name } = event.target;
-    const value = FormsUtils.getValueFromInput(event.target);
+    const value = event.target.value === '' ? '' : FormsUtils.getValueFromInput(event.target);
     this.setState({ [lodash.camelCase(name)]: value });
-    this.propagateChanges(name, value);
+    this.propagateChanges(name, lodash.max([Number(value), 0]));
   };
 
   toggleBacklogSize = () => {
@@ -112,7 +112,7 @@ class NotificationSettingsForm extends React.Component {
               <FormControl type="number"
                            id="backlog_size"
                            name="backlog_size"
-                           onChange={this.handleChange}
+                           onChange={this.handleBacklogSizeChange}
                            value={backlogSize}
                            disabled={!isBacklogSizeEnabled} />
             </InputGroup>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationSettingsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationSettingsForm.jsx
@@ -22,12 +22,15 @@ class NotificationSettingsForm extends React.Component {
   constructor(props) {
     super(props);
 
-    const { backlog_size: backlogSize } = props.eventDefinition.notification_settings;
+    const { backlog_size: backlogSize, grace_period_ms: gracePeriodMs } = props.eventDefinition.notification_settings;
+
+    const gracePeriod = extractDurationAndUnit(gracePeriodMs, TIME_UNITS);
     const defaultBacklogSize = props.defaults.default_backlog_size;
     const effectiveBacklogSize = lodash.defaultTo(backlogSize, defaultBacklogSize);
 
     this.state = {
-      lastEnabledGracePeriod: undefined,
+      gracePeriodDuration: gracePeriod.duration,
+      gracePeriodUnit: gracePeriod.unit,
       isBacklogSizeEnabled: (backlogSize === null ? false : (effectiveBacklogSize > 0)),
       backlogSize: effectiveBacklogSize,
     };
@@ -41,20 +44,9 @@ class NotificationSettingsForm extends React.Component {
   };
 
   handleGracePeriodChange = (nextValue, nextUnit, enabled) => {
-    const durationInMs = enabled ? moment.duration(nextValue, nextUnit).asMilliseconds() : 0;
+    const durationInMs = enabled ? moment.duration(lodash.max([nextValue, 0]), nextUnit).asMilliseconds() : 0;
     this.propagateChanges('grace_period_ms', durationInMs);
-
-    // Update last enabled grace period in state to display, to display the previous value when input is disabled.
-    const stateUpdate = {};
-    if (enabled) {
-      stateUpdate.lastEnabledGracePeriod = undefined;
-    } else {
-      stateUpdate.lastEnabledGracePeriod = {
-        duration: nextValue,
-        unit: nextUnit,
-      };
-    }
-    this.setState(stateUpdate);
+    this.setState({ gracePeriodDuration: nextValue, gracePeriodUnit: nextUnit });
   };
 
   handleBacklogSizeChange = (event) => {
@@ -72,16 +64,11 @@ class NotificationSettingsForm extends React.Component {
 
   render() {
     const { eventDefinition } = this.props;
-    const { lastEnabledGracePeriod, isBacklogSizeEnabled, backlogSize } = this.state;
+    const { gracePeriodDuration, gracePeriodUnit, isBacklogSizeEnabled, backlogSize } = this.state;
 
     if (eventDefinition.notifications.length === 0) {
       return null;
     }
-
-    // Display old grace period to avoid input resetting to null when input is disabled.
-    const gracePeriod = (lastEnabledGracePeriod === undefined
-      ? extractDurationAndUnit(eventDefinition.notification_settings.grace_period_ms, TIME_UNITS)
-      : lastEnabledGracePeriod);
 
     return (
       <React.Fragment>
@@ -90,10 +77,11 @@ class NotificationSettingsForm extends React.Component {
           <FormGroup controlId="grace-period">
             <TimeUnitInput label="Grace Period"
                            update={this.handleGracePeriodChange}
-                           defaultEnabled={gracePeriod.duration !== 0}
-                           value={gracePeriod.duration}
-                           unit={gracePeriod.unit}
-                           units={TIME_UNITS} />
+                           defaultEnabled={gracePeriodDuration !== 0}
+                           value={gracePeriodDuration}
+                           unit={gracePeriodUnit}
+                           units={TIME_UNITS}
+                           clearable />
             <HelpBlock>
               Time to wait after a Notification is sent, to send another Notification.
               Events with keys have different grace periods for each key.

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/TemplateFieldValueProviderPreview.css
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/TemplateFieldValueProviderPreview.css
@@ -1,11 +1,5 @@
-:local(.templatePreview) {
-    border: 1px solid #333;
-    border-radius: 2px;
+:local(.templatePreview) .panel-body {
     padding: 20px 10px;
-}
-
-:local(.templatePreview) h3 {
-    margin-bottom: 5px;
 }
 
 :local(.templatePreview) ul {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/TemplateFieldValueProviderPreview.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/TemplateFieldValueProviderPreview.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Panel } from 'react-bootstrap';
 
 import styles from './TemplateFieldValueProviderPreview.css';
 
@@ -7,8 +8,7 @@ class TemplateFieldValueProviderPreview extends React.Component {
 
   render() {
     return (
-      <div className={styles.templatePreview}>
-        <h3>Available Fields in Template</h3>
+      <Panel className={styles.templatePreview} header={<h3>Available Fields in Template</h3>}>
         <p>
           Graylog lets you enrich generated Events with dynamic values. You can access Fields from the Event context{' '}
           {/* eslint-disable-next-line no-template-curly-in-string */}
@@ -21,7 +21,7 @@ class TemplateFieldValueProviderPreview extends React.Component {
           <li><b>Aggregation:</b> Fields set in Group By with their original names</li>
           <li><b>Correlation:</b> All Fields in the last matched and non-negated Event</li>
         </ul>
-      </div>
+      </Panel>
     );
   }
 }

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationFormContainer.jsx
@@ -4,12 +4,10 @@ import PropTypes from 'prop-types';
 import { Spinner } from 'components/common';
 
 import connect from 'stores/connect';
-import CombinedProvider from 'injection/CombinedProvider';
 import { FieldTypesStore } from 'views/stores/FieldTypesStore';
 
 import FilterAggregationForm from './FilterAggregationForm';
-
-const { StreamsStore } = CombinedProvider.get('Streams');
+import withStreams from './withStreams';
 
 // We currently don't support creating Events from these Streams, since they also contain Events
 // and it's not possible to access custom Fields defined in them.
@@ -27,34 +25,18 @@ class FilterAggregationFormContainer extends React.Component {
     onChange: PropTypes.func.isRequired,
   };
 
-  state = {
-    availableStreams: undefined,
-  };
-
-  componentDidMount() {
-    StreamsStore.load((streams) => {
-      const filteredStreams = streams.filter(s => !HIDDEN_STREAMS.includes(s.id));
-      this.setState({ availableStreams: filteredStreams });
-    });
-  }
-
   render() {
     const { fieldTypes, ...otherProps } = this.props;
-    const { availableStreams } = this.state;
-    const isLoading = typeof fieldTypes.all !== 'object' || !availableStreams;
+    const isLoading = typeof fieldTypes.all !== 'object';
 
     if (isLoading) {
       return <Spinner text="Loading Filter & Aggregation Information..." />;
     }
 
-    return (
-      <FilterAggregationForm allFieldTypes={fieldTypes.all.toJS()}
-                             streams={availableStreams}
-                             {...otherProps} />
-    );
+    return <FilterAggregationForm allFieldTypes={fieldTypes.all.toJS()} {...otherProps} />;
   }
 }
 
-export default connect(FilterAggregationFormContainer, {
+export default connect(withStreams(FilterAggregationFormContainer, HIDDEN_STREAMS), {
   fieldTypes: FieldTypesStore,
 });

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.css
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.css
@@ -1,0 +1,3 @@
+:local(.streamList) span:not(:last-child)::after {
+    content: ', ';
+}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
@@ -23,6 +23,24 @@ class FilterForm extends React.Component {
     onChange: PropTypes.func.isRequired,
   };
 
+  formatStreamIds = lodash.memoize(
+    (streamIds) => {
+      const { streams } = this.props;
+
+      return streamIds
+        .map(streamId => streams.find(s => s.id === streamId) || streamId)
+        .map((streamOrId) => {
+          const stream = (typeof streamOrId === 'object' ? streamOrId : { title: streamOrId, id: streamOrId });
+          return {
+            label: stream.title,
+            value: stream.id,
+          };
+        })
+        .sort((s1, s2) => naturalSortIgnoreCase(s1.label, s2.label));
+    },
+    streamIds => streamIds.join('-'),
+  );
+
   propagateChange = (key, value) => {
     const { eventDefinition, onChange } = this.props;
     const config = lodash.cloneDeep(eventDefinition.config);
@@ -51,14 +69,7 @@ class FilterForm extends React.Component {
 
     // Ensure deleted streams are still displayed in select
     const allStreamIds = lodash.union(streams.map(s => s.id), lodash.defaultTo(eventDefinition.config.streams, []));
-
-    const formattedStreams = allStreamIds
-      .map(streamId => streams.find(s => s.id === streamId) || streamId)
-      .map((streamOrId) => {
-        const stream = (typeof streamOrId === 'object' ? streamOrId : { title: streamOrId, id: streamOrId });
-        return { label: stream.title, value: stream.id };
-      })
-      .sort((s1, s2) => naturalSortIgnoreCase(s1.label, s2.label));
+    const formattedStreams = this.formatStreamIds(allStreamIds);
 
     const searchWithin = extractDurationAndUnit(eventDefinition.config.search_within_ms, TIME_UNITS);
     const executeEvery = extractDurationAndUnit(eventDefinition.config.execute_every_ms, TIME_UNITS);

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
@@ -48,8 +48,16 @@ class FilterForm extends React.Component {
 
   render() {
     const { eventDefinition, streams, validation } = this.props;
-    const formattedStreams = streams
-      .map(stream => ({ label: stream.title, value: stream.id }))
+
+    // Ensure deleted streams are still displayed in select
+    const allStreamIds = lodash.union(streams.map(s => s.id), lodash.defaultTo(eventDefinition.config.streams, []));
+
+    const formattedStreams = allStreamIds
+      .map(streamId => streams.find(s => s.id === streamId) || streamId)
+      .map((streamOrId) => {
+        const stream = (typeof streamOrId === 'object' ? streamOrId : { title: streamOrId, id: streamOrId });
+        return { label: stream.title, value: stream.id };
+      })
       .sort((s1, s2) => naturalSortIgnoreCase(s1.label, s2.label));
 
     const searchWithin = extractDurationAndUnit(eventDefinition.config.search_within_ms, TIME_UNITS);

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterPreview.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterPreview.jsx
@@ -23,9 +23,9 @@ class FilterPreview extends React.Component {
   };
 
   renderMessages = (messages) => {
-    return messages.map(({ message }) => {
+    return messages.map(({ index, message }) => {
       return (
-        <tr key={message._id}>
+        <tr key={`${index}-${message._id}`}>
           <td>{message.timestamp}</td>
           <td>{message.message}</td>
         </tr>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/withStreams.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/withStreams.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import { Spinner } from 'components/common';
+import CombinedProvider from 'injection/CombinedProvider';
+
+const { StreamsStore } = CombinedProvider.get('Streams');
+
+export default function withStreams(WrappedComponent, hiddenStreams = []) {
+  const wrappedComponentName = WrappedComponent.displayName || WrappedComponent.name || 'Component';
+  class WithStreams extends React.Component {
+    state = {
+      streams: undefined,
+    };
+
+    componentDidMount() {
+      StreamsStore.load((streams) => {
+        let filteredStreams = streams;
+        if (hiddenStreams.length !== 0) {
+          filteredStreams = streams.filter(s => !hiddenStreams.includes(s.id));
+        }
+        this.setState({ streams: filteredStreams });
+      });
+    }
+
+    render() {
+      const { streams } = this.state;
+
+      if (!streams) {
+        return <Spinner text="Loading Streams Information..." />;
+      }
+
+      return <WrappedComponent streams={streams} {...this.props} />;
+    }
+  }
+
+  WithStreams.displayName = `withStreams(${wrappedComponentName})`;
+
+  return WithStreams;
+}

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.css
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.css
@@ -5,3 +5,7 @@
 :local(.inline) {
     display: inline-block;
 }
+
+:local(.createButton) {
+    margin-left: 5px;
+}

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
@@ -121,42 +121,35 @@ class EventDefinitions extends React.Component {
     });
 
     return (
-      <React.Fragment>
-        <Row>
-          <Col md={12}>
+      <Row>
+        <Col md={12}>
+          <SearchForm query={query}
+                      onSearch={onQueryChange}
+                      onReset={onQueryChange}
+                      searchButtonLabel="Find"
+                      placeholder="Find Event Definitions"
+                      wrapperClass={styles.inline}
+                      queryWidth={200}
+                      topMargin={0}
+                      useLoadingState>
             <IfPermitted permissions="eventdefinitions:create">
-              <div className="pull-right">
-                <LinkContainer to={Routes.ALERTS.DEFINITIONS.CREATE}>
-                  <Button bsStyle="success">Create Event Definition</Button>
-                </LinkContainer>
-              </div>
+              <LinkContainer to={Routes.ALERTS.DEFINITIONS.CREATE}>
+                <Button bsStyle="success" className={styles.createButton}>Create Event Definition</Button>
+              </LinkContainer>
             </IfPermitted>
-          </Col>
-        </Row>
-        <Row>
-          <Col md={12}>
-            <SearchForm query={query}
-                        onSearch={onQueryChange}
-                        onReset={onQueryChange}
-                        searchButtonLabel="Find"
-                        placeholder="Find Event Definitions"
-                        wrapperClass={styles.inline}
-                        queryWidth={200}
-                        topMargin={0}
-                        useLoadingState />
+          </SearchForm>
 
-            <PaginatedList activePage={pagination.page}
-                           pageSize={pagination.pageSize}
-                           pageSizes={[10, 25, 50]}
-                           totalItems={pagination.total}
-                           onChange={onPageChange}>
-              <div className={styles.definitionList}>
-                <EntityList items={items} />
-              </div>
-            </PaginatedList>
-          </Col>
-        </Row>
-      </React.Fragment>
+          <PaginatedList activePage={pagination.page}
+                         pageSize={pagination.pageSize}
+                         pageSizes={[10, 25, 50]}
+                         totalItems={pagination.total}
+                         onChange={onPageChange}>
+            <div className={styles.definitionList}>
+              <EntityList items={items} />
+            </div>
+          </PaginatedList>
+        </Col>
+      </Row>
     );
   }
 }

--- a/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.css
+++ b/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.css
@@ -5,3 +5,7 @@
 :local(.inline) {
     display: inline-block;
 }
+
+:local(.createButton) {
+    margin-left: 5px;
+}

--- a/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.jsx
@@ -86,42 +86,35 @@ class EventNotifications extends React.Component {
     }
 
     return (
-      <React.Fragment>
-        <Row>
-          <Col md={12}>
+      <Row>
+        <Col md={12}>
+          <SearchForm query={query}
+                      onSearch={onQueryChange}
+                      onReset={onQueryChange}
+                      searchButtonLabel="Find"
+                      placeholder="Find Notifications"
+                      wrapperClass={styles.inline}
+                      queryWidth={200}
+                      topMargin={0}
+                      useLoadingState>
             <IfPermitted permissions="eventnotifications:create">
-              <div className="pull-right">
-                <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.CREATE}>
-                  <Button bsStyle="success">Create Notification</Button>
-                </LinkContainer>
-              </div>
+              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.CREATE}>
+                <Button bsStyle="success" className={styles.createButton}>Create Notification</Button>
+              </LinkContainer>
             </IfPermitted>
-          </Col>
-        </Row>
-        <Row>
-          <Col md={12}>
-            <SearchForm query={query}
-                        onSearch={onQueryChange}
-                        onReset={onQueryChange}
-                        searchButtonLabel="Find"
-                        placeholder="Find Notifications"
-                        wrapperClass={styles.inline}
-                        queryWidth={200}
-                        topMargin={0}
-                        useLoadingState />
+          </SearchForm>
 
-            <PaginatedList activePage={pagination.page}
-                           pageSize={pagination.pageSize}
-                           pageSizes={[10, 25, 50]}
-                           totalItems={pagination.total}
-                           onChange={onPageChange}>
-              <div className={styles.notificationList}>
-                <EntityList items={this.formatNotification(notifications)} />
-              </div>
-            </PaginatedList>
-          </Col>
-        </Row>
-      </React.Fragment>
+          <PaginatedList activePage={pagination.page}
+                         pageSize={pagination.pageSize}
+                         pageSizes={[10, 25, 50]}
+                         totalItems={pagination.total}
+                         onChange={onPageChange}>
+            <div className={styles.notificationList}>
+              <EntityList items={this.formatNotification(notifications)} />
+            </div>
+          </PaginatedList>
+        </Col>
+      </Row>
     );
   }
 }

--- a/graylog2-web-interface/src/components/events/events/EventsSearchBar.jsx
+++ b/graylog2-web-interface/src/components/events/events/EventsSearchBar.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, ButtonGroup, ControlLabel, FormControl, FormGroup } from 'react-bootstrap';
 import moment from 'moment';
+import lodash from 'lodash';
 
 import { SearchForm, TimeUnitInput } from 'components/common';
 import { extractDurationAndUnit } from 'components/common/TimeUnitInput';
@@ -23,14 +24,23 @@ class EventsSearchBar extends React.Component {
     onSearchReload: PropTypes.func.isRequired,
   };
 
-  state = {
-    isReloadingResults: false,
-  };
+  constructor(props) {
+    super(props);
+
+    const timerangeDuration = extractDurationAndUnit(props.parameters.timerange.range * 1000, TIME_UNITS);
+
+    this.state = {
+      isReloadingResults: false,
+      timeRangeDuration: timerangeDuration.duration,
+      timeRangeUnit: timerangeDuration.unit,
+    };
+  }
 
   updateSearchTimeRange = (nextValue, nextUnit) => {
     const { onTimeRangeChange } = this.props;
-    const durationInSeconds = moment.duration(nextValue, nextUnit).asSeconds();
+    const durationInSeconds = moment.duration(lodash.max([nextValue, 1]), nextUnit).asSeconds();
     onTimeRangeChange('relative', durationInSeconds);
+    this.setState({ timeRangeDuration: nextValue, timeRangeUnit: nextUnit });
   };
 
   handlePageSizeChange = (event) => {
@@ -50,10 +60,9 @@ class EventsSearchBar extends React.Component {
 
   render() {
     const { parameters, pageSize, pageSizes, onQueryChange, onAlertFilterChange } = this.props;
-    const { isReloadingResults } = this.state;
+    const { isReloadingResults, timeRangeUnit, timeRangeDuration } = this.state;
 
     const filterAlerts = parameters.filter.alerts;
-    const timerangeDuration = extractDurationAndUnit(parameters.timerange.range * 1000, TIME_UNITS);
 
     return (
       <div className={styles.eventsSearchBar}>
@@ -76,8 +85,9 @@ class EventsSearchBar extends React.Component {
           <TimeUnitInput id="event-timerange-selector"
                          update={this.updateSearchTimeRange}
                          units={TIME_UNITS}
-                         unit={timerangeDuration.unit}
-                         value={timerangeDuration.duration}
+                         unit={timeRangeUnit}
+                         value={timeRangeDuration}
+                         clearable
                          pullRight
                          required />
         </div>

--- a/graylog2-web-interface/src/pages/CreateEventDefinitionPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateEventDefinitionPage.jsx
@@ -20,6 +20,7 @@ const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 class CreateEventDefinitionPage extends React.Component {
   static propTypes = {
     currentUser: PropTypes.object.isRequired,
+    route: PropTypes.object.isRequired,
   };
 
   state = {
@@ -37,7 +38,7 @@ class CreateEventDefinitionPage extends React.Component {
     const { eventDefinitionTitle } = this.state;
     const pageTitle = eventDefinitionTitle ? `New Event Definition "${eventDefinitionTitle}"` : 'New Event Definition';
 
-    const { currentUser } = this.props;
+    const { currentUser, route } = this.props;
 
     if (!PermissionsMixin.isPermitted(currentUser.permissions, 'eventdefinitions:create')) {
       history.push(Routes.NOTFOUND);
@@ -76,7 +77,9 @@ class CreateEventDefinitionPage extends React.Component {
 
           <Row className="content">
             <Col md={12}>
-              <EventDefinitionFormContainer action="create" onEventDefinitionChange={this.handleEventDefinitionChange} />
+              <EventDefinitionFormContainer action="create"
+                                            onEventDefinitionChange={this.handleEventDefinitionChange}
+                                            route={route} />
             </Col>
           </Row>
         </span>

--- a/graylog2-web-interface/src/pages/CreateEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateEventNotificationPage.jsx
@@ -20,10 +20,11 @@ const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 class CreateEventDefinitionPage extends React.Component {
   static propTypes = {
     currentUser: PropTypes.object.isRequired,
+    route: PropTypes.object.isRequired,
   };
 
   render() {
-    const { currentUser } = this.props;
+    const { currentUser, route } = this.props;
 
     if (!PermissionsMixin.isPermitted(currentUser.permissions, 'eventnotifications:create')) {
       history.push(Routes.NOTFOUND);
@@ -63,7 +64,7 @@ class CreateEventDefinitionPage extends React.Component {
 
           <Row className="content">
             <Col md={12}>
-              <EventNotificationFormContainer action="create" />
+              <EventNotificationFormContainer action="create" route={route} />
             </Col>
           </Row>
         </span>

--- a/graylog2-web-interface/src/pages/EditEventDefinitionPage.jsx
+++ b/graylog2-web-interface/src/pages/EditEventDefinitionPage.jsx
@@ -24,6 +24,7 @@ class EditEventDefinitionPage extends React.Component {
   static propTypes = {
     params: PropTypes.object.isRequired,
     currentUser: PropTypes.object.isRequired,
+    route: PropTypes.object.isRequired,
   };
 
   state = {
@@ -40,7 +41,7 @@ class EditEventDefinitionPage extends React.Component {
   }
 
   render() {
-    const { params, currentUser } = this.props;
+    const { params, currentUser, route } = this.props;
     const { eventDefinition } = this.state;
 
     if (!isPermitted(currentUser.permissions, `eventdefinitions:edit:${params.definitionId}`)) {
@@ -92,7 +93,7 @@ class EditEventDefinitionPage extends React.Component {
 
           <Row className="content">
             <Col md={12}>
-              <EventDefinitionFormContainer action="edit" eventDefinition={eventDefinition} />
+              <EventDefinitionFormContainer action="edit" eventDefinition={eventDefinition} route={route} />
             </Col>
           </Row>
         </span>

--- a/graylog2-web-interface/src/pages/EditEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/EditEventNotificationPage.jsx
@@ -24,6 +24,7 @@ class EditEventDefinitionPage extends React.Component {
   static propTypes = {
     params: PropTypes.object.isRequired,
     currentUser: PropTypes.object.isRequired,
+    route: PropTypes.object.isRequired,
   };
 
   state = {
@@ -41,7 +42,7 @@ class EditEventDefinitionPage extends React.Component {
 
   render() {
     const { notification } = this.state;
-    const { params, currentUser } = this.props;
+    const { params, currentUser, route } = this.props;
 
     if (!isPermitted(currentUser.permissions, `eventnotifications:edit:${params.definitionId}`)) {
       history.push(Routes.NOTFOUND);
@@ -93,7 +94,7 @@ class EditEventDefinitionPage extends React.Component {
 
           <Row className="content">
             <Col md={12}>
-              <EventNotificationFormContainer action="edit" notification={notification} />
+              <EventNotificationFormContainer action="edit" notification={notification} route={route} />
             </Col>
           </Row>
         </span>

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -58,12 +58,12 @@ const Routes = {
     DEFINITIONS: {
       LIST: '/alerts/definitions',
       CREATE: '/alerts/definitions/new',
-      edit: definitionId => `/alerts/definitions/${definitionId}`,
+      edit: definitionId => `/alerts/definitions/${definitionId}/edit`,
     },
     NOTIFICATIONS: {
       LIST: '/alerts/notifications',
       CREATE: '/alerts/notifications/new',
-      edit: notificationId => `/alerts/notifications/${notificationId}`,
+      edit: notificationId => `/alerts/notifications/${notificationId}/edit`,
     },
   },
   SOURCES: '/sources',


### PR DESCRIPTION
These PR contains more improvements from #6155, namely:

- Add confirmations before leaving Event Definition and Notification forms (must run in production to be seen)
- Change position of create buttons to reduce amount of empty space in Event Definition list and Notification list
- Style template preview as other previews
- Allow clearing number inputs
- Allow clearing `TimeUnitInput`s
- Display deleted streams in Filter & Aggregation
- Display stream names in Filter & Aggregation summary
- Use more consistent URL for edit pages