### PR TITLE
Adding type field to view DTO to discriminate searches & dashboards.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewDTO.java
@@ -38,7 +38,13 @@ import java.util.Set;
 @JsonDeserialize(builder = ViewDTO.Builder.class)
 @WithBeanGetter
 public abstract class ViewDTO {
+    public enum Type {
+        SEARCH,
+        DASHBOARD
+    }
+
     public static final String FIELD_ID = "id";
+    public static final String FIELD_TYPE = "type";
     public static final String FIELD_TITLE = "title";
     public static final String FIELD_SUMMARY = "summary";
     public static final String FIELD_DESCRIPTION = "description";
@@ -57,6 +63,9 @@ public abstract class ViewDTO {
     @Nullable
     @JsonProperty(FIELD_ID)
     public abstract String id();
+
+    @JsonProperty(FIELD_TYPE)
+    public abstract Type type();
 
     @JsonProperty(FIELD_TITLE)
     @NotBlank
@@ -104,6 +113,9 @@ public abstract class ViewDTO {
         @JsonProperty(FIELD_ID)
         public abstract Builder id(String id);
 
+        @JsonProperty(FIELD_TYPE)
+        public abstract Builder type(Type type);
+
         @JsonProperty(FIELD_TITLE)
         public abstract Builder title(String title);
 
@@ -143,6 +155,7 @@ public abstract class ViewDTO {
         @JsonCreator
         public static Builder create() {
             return new AutoValue_ViewDTO.Builder()
+                    .type(Type.DASHBOARD)
                     .summary("")
                     .description("")
                     .properties(ImmutableSet.of())


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This change is adding a `type` field to `ViewDTO` objects defining if
this view is a search or a dashboard. The decision to add a type field
instead of separate classes is based on the following aspects:

  * There are very little differences between searches and dashboards:
    * Searches do allow only a single Query
    * Dashboards contain a list of widgets being shown in display mode

  * AutoValue does not allow/discourages inheritance for value classes

  * Creating two distinct classes without sharing attributes would
result in mostly duplicated code and the necessity to update both
classes for changes to prevent subtle bugs

  * Turning a search into a dashboard is required in future use cases.
Doing this with a single class that differs only in the value of the
`type` attributes allows to just clone/copy an object and mutate the
`type` value of the object instead of transforming it (and again, ensure
that all attributes are picked up)

For now, both types are kept in the same collection (`views`), but this
not a strict requirement and can be changed if necessary.