### PR TITLE
Adding settings class for display mode to view/query state class.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/DisplayModeSettings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/DisplayModeSettings.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.views.search.views;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/DisplayModeSettings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/DisplayModeSettings.java
@@ -1,0 +1,38 @@
+package org.graylog.plugins.views.search.views;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+
+import java.util.Collections;
+import java.util.Map;
+
+@AutoValue
+@JsonAutoDetect
+@JsonDeserialize(builder = DisplayModeSettings.Builder.class)
+public abstract class DisplayModeSettings {
+    private static final String FIELD_POSITIONS = "positions";
+
+    @JsonProperty(FIELD_POSITIONS)
+    public abstract Map<String, WidgetPositionDTO> positions();
+
+    public static DisplayModeSettings empty() {
+        return Builder.create().build();
+    }
+
+    @AutoValue.Builder
+    public static abstract class Builder {
+        @JsonProperty(FIELD_POSITIONS)
+        public abstract Builder positions(Map<String, WidgetPositionDTO> positions);
+
+        public abstract DisplayModeSettings build();
+
+        @JsonCreator
+        public static Builder create() {
+            return new AutoValue_DisplayModeSettings.Builder()
+                    .positions(Collections.emptyMap());
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewStateDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewStateDTO.java
@@ -38,6 +38,7 @@ public abstract class ViewStateDTO {
     static final String FIELD_WIDGET_MAPPING = "widget_mapping";
     static final String FIELD_WIDGET_POSITIONS = "positions";
     static final String FIELD_FORMATTING = "formatting";
+    static final String FIELD_DISPLAY_MODE_SETTINGS = "display_mode_settings";
 
     @JsonProperty(FIELD_SELECTED_FIELDS)
     public abstract Set<String> fields();
@@ -61,6 +62,9 @@ public abstract class ViewStateDTO {
     @JsonProperty(FIELD_FORMATTING)
     @Nullable
     public abstract FormattingSettings formatting();
+
+    @JsonProperty(FIELD_DISPLAY_MODE_SETTINGS)
+    public abstract DisplayModeSettings displayModeSettings();
 
     @AutoValue.Builder
     public static abstract class Builder {
@@ -86,11 +90,16 @@ public abstract class ViewStateDTO {
         @JsonProperty(FIELD_FORMATTING)
         public abstract Builder formatting(FormattingSettings formattingSettings);
 
+        @JsonProperty(FIELD_DISPLAY_MODE_SETTINGS)
+        public abstract Builder displayModeSettings(DisplayModeSettings displayModeSettings);
+
         public abstract ViewStateDTO build();
 
         @JsonCreator
         public static Builder create() {
-            return new AutoValue_ViewStateDTO.Builder().titles(Collections.emptyMap());
+            return new AutoValue_ViewStateDTO.Builder()
+                    .titles(Collections.emptyMap())
+                    .displayModeSettings(DisplayModeSettings.empty());
         }
     }
 }


### PR DESCRIPTION
## Description

This change is adding a `DisplayModeSettings` class which keeps track of widgets being shown in the display mode of a dashboard by recording their positions.

**Note:**

Requires #6266 to be merged before.