### PR TITLE
Replacing existing search page with extended search, removing query bar.

### DIFF
--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -103,13 +103,13 @@ const AppRouter = () => {
         <Route component={AppWithGlobalNotifications}>
           <IndexRoute component={StartPage} />
           <Route component={AppWithSearchBar}>
-            <Route path={Routes.SEARCH} component={DelegatedSearchPage} />
             <Route path={Routes.message_show(':index', ':messageId')} component={ShowMessagePage} />
             <Route path={Routes.SOURCES} component={SourcesPage} />
             <Route path={Routes.stream_search(':streamId')} component={StreamSearchPage} />
             <Redirect from={Routes.legacy_stream_search(':streamId')} to={Routes.stream_search(':streamId')} />
           </Route>
           <Route component={AppWithoutSearchBar}>
+            <Route path={Routes.SEARCH} component={DelegatedSearchPage} />
             <Route path={Routes.GETTING_STARTED} component={GettingStartedPage} />
             <Route path={Routes.STREAMS} component={StreamsPage} />
             <Route path={Routes.stream_edit(':streamId')} component={StreamEditPage} />

--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -73,7 +73,7 @@ ViewSharing.registerSubtype(SpecificUsers.Type, SpecificUsers);
 
 export default {
   pages: {
-    // search: { component: ExtendedSearchPage },
+    search: { component: NewSearchPage },
   },
   routes: [
     { path: extendedSearchPath, component: NewSearchPage, permissions: Permissions.ExtendedSearch.Use },

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -6,7 +6,6 @@ import { Row } from 'react-bootstrap';
 import * as Immutable from 'immutable';
 
 import connect from 'stores/connect';
-import QueryBar from 'views/components/QueryBar';
 import SearchBarWithStatus from 'views/components/SearchBarWithStatus';
 import SearchResult from 'views/components/SearchResult';
 import type {

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -97,7 +97,6 @@ const ExtendedSearchPage = createReactClass({
         <WindowLeaveMessage route={route} />
         <HeaderElements />
         <Row id="main-row">
-          <QueryBar />
           <SearchBarWithStatus onExecute={this._refreshIfNotUndeclared} />
 
           <QueryBarElements />


### PR DESCRIPTION
## Description

This change prepares the search page for replacement with the views-based search page by registering the new extended search as the default search.

Additionally, it removes the query bar from the extended search, as the search replacement is supposed to have only a single query to resemble the existing search more closely.