### PR TITLE
Replace stream search with new extended search.

### DIFF
--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -81,7 +81,6 @@ import {
   StreamAlertsOverviewPage,
   StreamEditPage,
   StreamOutputsPage,
-  StreamSearchPage,
   StreamsPage,
   SystemOutputsPage,
   SystemOverviewPage,
@@ -105,11 +104,10 @@ const AppRouter = () => {
           <Route component={AppWithSearchBar}>
             <Route path={Routes.message_show(':index', ':messageId')} component={ShowMessagePage} />
             <Route path={Routes.SOURCES} component={SourcesPage} />
-            <Route path={Routes.stream_search(':streamId')} component={StreamSearchPage} />
-            <Redirect from={Routes.legacy_stream_search(':streamId')} to={Routes.stream_search(':streamId')} />
           </Route>
           <Route component={AppWithoutSearchBar}>
             <Route path={Routes.SEARCH} component={DelegatedSearchPage} />
+            <Redirect from={Routes.legacy_stream_search(':streamId')} to={Routes.stream_search(':streamId')} />
             <Route path={Routes.GETTING_STARTED} component={GettingStartedPage} />
             <Route path={Routes.STREAMS} component={StreamsPage} />
             <Route path={Routes.stream_edit(':streamId')} component={StreamEditPage} />

--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -1,4 +1,5 @@
 // @flow strict
+import Routes from 'routing/Routes';
 import * as Permissions from 'views/Permissions';
 
 import { MessageListHandler } from 'views/logic/searchtypes';
@@ -59,6 +60,7 @@ import requirementsProvided from './hooks/RequirementsProvided';
 import type { ValueActionHandlerConditionProps } from './logic/valueactions/ValueActionHandler';
 import type { FieldActionHandlerConditionProps } from './logic/fieldactions/FieldActionHandler';
 import { extendedSearchPath, showViewsPath, viewsPath } from './Constants';
+import StreamSearchPage from './pages/StreamSearchPage';
 
 Widget.registerSubtype(AggregationWidget.type, AggregationWidget);
 Widget.registerSubtype(MessagesWidget.type, MessagesWidget);
@@ -79,6 +81,7 @@ export default {
     { path: extendedSearchPath, component: NewSearchPage, permissions: Permissions.ExtendedSearch.Use },
     { path: viewsPath, component: ViewManagementPage, permissions: Permissions.View.Use },
     { path: showViewsPath, component: ShowViewPage },
+    { path: Routes.stream_search(':streamId'), component: StreamSearchPage },
   ],
   enterpriseWidgets: [
     {

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.jsx
@@ -1,0 +1,25 @@
+// @flow strict
+import React, { useEffect, useState } from 'react';
+
+import { ViewActions } from 'views/stores/ViewStore';
+import { QueryFiltersActions } from 'views/stores/QueryFiltersStore';
+import Spinner from 'components/common/Spinner';
+import ExtendedSearchPage from './ExtendedSearchPage';
+
+type Props = {
+  params: {
+    streamId: string,
+  },
+  route: {}
+};
+
+export default ({ params: { streamId }, route }: Props) => {
+  const [loaded, setLoaded] = useState(false);
+  useEffect(() => {
+    ViewActions.create()
+      .then(({ activeQuery }) => QueryFiltersActions.streams(activeQuery, [streamId]))
+      .then(() => setLoaded(true));
+  }, []);
+
+  return loaded ? <ExtendedSearchPage route={route} /> : <Spinner />;
+};

--- a/graylog2-web-interface/src/views/stores/QueryFiltersStore.js
+++ b/graylog2-web-interface/src/views/stores/QueryFiltersStore.js
@@ -23,9 +23,9 @@ const _filtersForQuery = (streams) => {
 
 export const QueryFiltersActions = singletonActions(
   'views.QueryFilters',
-  () => Reflux.createActions([
-    'streams',
-  ]),
+  () => Reflux.createActions({
+    streams: { asyncResult: true },
+  }),
 );
 
 export const QueryFiltersStore = singletonStore(
@@ -53,7 +53,9 @@ export const QueryFiltersStore = singletonStore(
     streams(queryId, streams) {
       const streamFilter = _filtersForQuery(streams);
       const newQuery = this.queries.get(queryId).toBuilder().filter(streamFilter).build();
-      QueriesActions.update(queryId, newQuery);
+      const promise = QueriesActions.update(queryId, newQuery);
+      QueryFiltersActions.streams.promise(promise);
+      return promise;
     },
 
     _state() {


### PR DESCRIPTION
## Description

This change is replacing the current stream search with the new views-based extended search. That means that a user going to `Streams` and selecting a stream for search will create a new extended search, having the selected stream preconfigured in the stream filter. From then on, the extended search behaves as any other extended search, which means that this stream can be removed again from the filter or additional streams can be added.

**Note:**

Requires #6268 to be merged before.