### PR TITLE
Fix retrieval of registered plugin routes.

### DIFF
--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -264,8 +264,7 @@ defaultExport.pluginRoute = (routeKey) => {
   });
   const route = (AppConfig.gl2AppPathPrefix() ? qualifyUrls(pluginRoutes, AppConfig.gl2AppPathPrefix()) : pluginRoutes)[routeKey];
   if (!route) {
-    // eslint-disable-next-line no-console
-    console.error(`Could not find plugin route '${routeKey}'.`);
+    throw new Error(`Could not find plugin route '${routeKey}'.`);
   }
 
   return route;

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -2,45 +2,6 @@ import AppConfig from 'util/AppConfig';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import URI from 'urijs';
 
-/*
- * Global registry of plugin routes. Route names are generated automatically from the route path, by removing
- * any colons, replacing slashes with underscores, and making the string uppercase. Below there is an example of how
- * to access the routes.
- *
- * Plugin register example:
- * routes: [
- *           { path: '/system/pipelines', component: Foo },
- *           { path: '/system/pipelines/:pipelineId', component: Bar },
- * ]
- *
- * Using routes on plugin components:
- * <LinkContainer to={Routes.pluginRoutes('SYSTEM_PIPELINES')}>...</LinkContainer>
- * <LinkContainer to={Routes.pluginRoutes('SYSTEM_PIPELINES_PIPELINEID')(123)}>...</LinkContainer>
- *
- */
-const pluginRoutes = {};
-PluginStore.exports('routes').forEach((pluginRoute) => {
-  const uri = new URI(pluginRoute.path);
-  const segments = uri.segment();
-  const key = segments.map(segment => segment.replace(':', '')).join('_').toUpperCase();
-  const paramNames = segments.filter(segment => segment.startsWith(':'));
-
-  if (paramNames.length > 0) {
-    pluginRoutes[key] = (...paramValues) => {
-      paramNames.forEach((param, idx) => {
-        const value = String(paramValues[idx]);
-        uri.segment(segments.indexOf(param), value);
-      });
-
-      return uri.pathname();
-    };
-
-    return;
-  }
-
-  pluginRoutes[key] = pluginRoute.path;
-});
-
 const Routes = {
   STARTPAGE: '/',
   NOTFOUND: '/notfound',
@@ -261,14 +222,50 @@ const qualifyUrls = (routes, appPrefix) => {
 };
 
 const defaultExport = AppConfig.gl2AppPathPrefix() ? qualifyUrls(Routes, AppConfig.gl2AppPathPrefix()) : Routes;
-window.pluginRoutes = AppConfig.gl2AppPathPrefix() ? qualifyUrls(pluginRoutes, AppConfig.gl2AppPathPrefix()) : pluginRoutes;
 
-// Plugin routes need to be prefixed separately, so we add them to the Routes object just at the end.
-defaultExport.pluginRoute = (key) => {
-  const route = window.pluginRoutes[key];
+/*
+ * Global registry of plugin routes. Route names are generated automatically from the route path, by removing
+ * any colons, replacing slashes with underscores, and making the string uppercase. Below there is an example of how
+ * to access the routes.
+ *
+ * Plugin register example:
+ * routes: [
+ *           { path: '/system/pipelines', component: Foo },
+ *           { path: '/system/pipelines/:pipelineId', component: Bar },
+ * ]
+ *
+ * Using routes on plugin components:
+ * <LinkContainer to={Routes.pluginRoutes('SYSTEM_PIPELINES')}>...</LinkContainer>
+ * <LinkContainer to={Routes.pluginRoutes('SYSTEM_PIPELINES_PIPELINEID')(123)}>...</LinkContainer>
+ *
+ */
+defaultExport.pluginRoute = (routeKey) => {
+  const pluginRoutes = {};
+  PluginStore.exports('routes').forEach((pluginRoute) => {
+    const uri = new URI(pluginRoute.path);
+    const segments = uri.segment();
+    const key = segments.map(segment => segment.replace(':', '')).join('_').toUpperCase();
+    const paramNames = segments.filter(segment => segment.startsWith(':'));
+
+    if (paramNames.length > 0) {
+      pluginRoutes[key] = (...paramValues) => {
+        paramNames.forEach((param, idx) => {
+          const value = String(paramValues[idx]);
+          uri.segment(segments.indexOf(param), value);
+        });
+
+        return uri.pathname();
+      };
+
+      return;
+    }
+
+    pluginRoutes[key] = pluginRoute.path;
+  });
+  const route = (AppConfig.gl2AppPathPrefix() ? qualifyUrls(pluginRoutes, AppConfig.gl2AppPathPrefix()) : pluginRoutes)[routeKey];
   if (!route) {
     // eslint-disable-next-line no-console
-    console.error(`Could not find plugin route '${key}'.`);
+    console.error(`Could not find plugin route '${routeKey}'.`);
   }
 
   return route;


### PR DESCRIPTION
## Description

Before this change, retrieval of plugin routes using `Routes.pluginRoute('...')` had the following issue:

  1. Plugin routes were retrieved once and then stored in `window.pluginRoutes`
  2. Every consumer (core or any plugin) needs to import `Routes.jsx` to be able to retrieve a plugin route
  3. When the file is imported from a different scope (e.g. core vs plugin, or plugin1 vs. plugin2), the file is evaluated again, performing 1. again.

This means that the contents of `window.pluginRoutes` could be different depending on when an where the module is imported. This could lead to a scenario of:

  * Plugin A requires a plugin route of Plugin B at runtime.
  * If Plugin B was not loaded before Plugin A, `window.pluginRoutes` does not contain Plugin B's routes if it was only imported from Plugin A (earlier), although they are available at runtime (the actual route retrieval)

Or:

  * Plugin/Core imports _something_ that imports `Routes.jsx` down the chain
  * Afterwards bindings containing routes are registered in `PluginStore`
  * Due to `import` hoisting, the import will always take place before route registration

This change is fixing this behavior by not caching the plugin routes, but iterating over all `route` exports in the `PluginStore` and retrieving the matching route from there, always returning accurate results.