### PR TITLE
Implement new getPackageName function for versionConstraints

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/facade/EventDefinitionFacade.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/facade/EventDefinitionFacade.java
@@ -95,8 +95,7 @@ public class EventDefinitionFacade implements EntityFacade<EventDefinitionDto> {
     }
 
     private ImmutableSet<Constraint> versionConstraints(EventDefinitionDto eventDefinitionDto) {
-        // The report facade is in the enterprise plugin so we need to add a constraint for that
-        final String packageName = eventDefinitionDto.config().getPackageName();
+        final String packageName = eventDefinitionDto.config().getContentPackPluginPackage();
         return pluginMetaData.stream()
                 .filter(metaData -> packageName.equals(metaData.getClass().getCanonicalName()))
                 .map(PluginVersionConstraint::of)

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackable.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackable.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.contentpacks;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.graph.MutableGraph;
 import org.graylog2.contentpacks.model.entities.EntityDescriptor;
 
@@ -23,5 +24,10 @@ public interface ContentPackable<T> {
     T toContentPackEntity(EntityDescriptorIds entityDescriptorIds);
     default void resolveNativeEntity(EntityDescriptor entityDescriptor,
                                      MutableGraph<EntityDescriptor> mutableGraph) {
+    }
+
+    @JsonIgnore
+    default String getPackageName() {
+        return this.getClass().getPackage().getName();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackable.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPackable.java
@@ -27,7 +27,7 @@ public interface ContentPackable<T> {
     }
 
     @JsonIgnore
-    default String getPackageName() {
+    default String getContentPackPluginPackage() {
         return this.getClass().getPackage().getName();
     }
 }


### PR DESCRIPTION
Prior to this change, the correlation config did not add its enterprise
plugin constraint to the constraints list.

This change adds a new function to the ContentPackable constraint:
getPackageName.

This is necessary since the package name of CorrelationConfig is
graylog.plugins.events but we need graylog.plugin.enterprise since
it is the name of the constraint.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
