### PR TITLE
Render query bar and widget filter icon if current view is dashboard.

### DIFF
--- a/graylog2-web-interface/src/views/Constants.js
+++ b/graylog2-web-interface/src/views/Constants.js
@@ -11,6 +11,7 @@ export const DEFAULT_HIGHLIGHT_COLOR = '#ffec3d';
 export const DEFAULT_CUSTOM_HIGHLIGHT_RANGE = chroma.scale(['lightyellow', 'lightgreen', 'lightblue', 'red']).mode('lch').colors(40);
 
 export const dashboardsPath = '/dashboards';
+export const newDashboardsPath = '/dashboards/new';
 export const extendedSearchPath = '/extendedsearch';
 export const viewsPath = '/views';
 export const showViewsPath = `${dashboardsPath}/:viewId`;

--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -59,7 +59,8 @@ import OperatorCompletion from 'views/components/searchbar/completions/OperatorC
 import requirementsProvided from 'views/hooks/RequirementsProvided';
 import type { ValueActionHandlerConditionProps } from 'views/logic/valueactions/ValueActionHandler';
 import type { FieldActionHandlerConditionProps } from 'views/logic/fieldactions/FieldActionHandler';
-import { dashboardsPath, extendedSearchPath, showViewsPath, viewsPath } from 'views/Constants';
+import { dashboardsPath, extendedSearchPath, newDashboardsPath, showViewsPath, viewsPath } from 'views/Constants';
+import NewDashboardPage from 'views/pages/NewDashboardPage';
 import StreamSearchPage from './pages/StreamSearchPage';
 
 Widget.registerSubtype(AggregationWidget.type, AggregationWidget);
@@ -80,6 +81,7 @@ export default {
   routes: [
     { path: extendedSearchPath, component: NewSearchPage, permissions: Permissions.ExtendedSearch.Use },
     { path: viewsPath, component: ViewManagementPage, permissions: Permissions.View.Use },
+    { path: newDashboardsPath, component: NewDashboardPage },
     { path: showViewsPath, component: ShowViewPage },
     { path: Routes.stream_search(':streamId'), component: StreamSearchPage },
     { path: dashboardsPath, component: DashboardsPage },

--- a/graylog2-web-interface/src/views/components/contexts/ViewTypeContext.jsx
+++ b/graylog2-web-interface/src/views/components/contexts/ViewTypeContext.jsx
@@ -1,0 +1,8 @@
+// @flow strict
+import * as React from 'react';
+import type { ViewType } from 'views/logic/views/View';
+import View from 'views/logic/views/View';
+
+const ViewTypeContext = React.createContext<ViewType>(View.Type.Dashboard);
+
+export default ViewTypeContext;

--- a/graylog2-web-interface/src/views/components/dashboard/IfDashboard.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/IfDashboard.jsx
@@ -8,7 +8,7 @@ type Props = {
 };
 const IfDashboard = ({ children }: Props) => (
   <ViewTypeContext.Consumer>
-    {(viewType) => viewType === View.Type.Dashboard ? children : null}
+    {viewType => ((viewType === View.Type.Dashboard) ? children : null)}
   </ViewTypeContext.Consumer>
 );
 

--- a/graylog2-web-interface/src/views/components/dashboard/IfDashboard.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/IfDashboard.jsx
@@ -1,0 +1,15 @@
+// @flow strict
+import * as React from 'react';
+import View from 'views/logic/views/View';
+import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
+
+type Props = {
+  children: React.Node,
+};
+const IfDashboard = ({ children }: Props) => (
+  <ViewTypeContext.Consumer>
+    {(viewType) => viewType === View.Type.Dashboard ? children : null}
+  </ViewTypeContext.Consumer>
+);
+
+export default IfDashboard;

--- a/graylog2-web-interface/src/views/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.jsx
@@ -54,8 +54,11 @@ class Widget extends React.Component<Props, State> {
   static propTypes = {
     id: PropTypes.string.isRequired,
     widget: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      type: PropTypes.string.isRequired,
       computationTimeRange: PropTypes.object,
       config: PropTypes.object.isRequired,
+      filter: PropTypes.string,
     }).isRequired,
     data: PropTypes.any,
     editing: PropTypes.bool,
@@ -168,6 +171,7 @@ class Widget extends React.Component<Props, State> {
     return <LoadingWidget />;
   };
 
+  // TODO: Clean up different code paths for normal/edit modes
   render() {
     const { id, widget, fields, onSizeChange, title, position, onPositionsChange } = this.props;
     const { editing } = this.state;

--- a/graylog2-web-interface/src/views/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.jsx
@@ -29,6 +29,7 @@ import ErrorWidget from './ErrorWidget';
 import { WidgetErrorsList } from './WidgetPropTypes';
 import SaveOrCancelButtons from './SaveOrCancelButtons';
 import WidgetColorContext from './WidgetColorContext';
+import IfDashboard from '../dashboard/IfDashboard';
 
 type Props = {
   id: string,
@@ -187,9 +188,11 @@ class Widget extends React.Component<Props, State> {
                             hideDragHandle
                             onRename={newTitle => TitlesActions.set('widget', id, newTitle)}
                             editing={editing}>
-                <WidgetFilterMenu onChange={newFilter => WidgetActions.filter(id, newFilter)} value={filter}>
-                  <i className={`fa fa-filter ${styles.widgetActionDropdownCaret} ${filter ? styles.filterSet : styles.filterNotSet}`} />
-                </WidgetFilterMenu>
+                <IfDashboard>
+                  <WidgetFilterMenu onChange={newFilter => WidgetActions.filter(id, newFilter)} value={filter}>
+                    <i className={`fa fa-filter ${styles.widgetActionDropdownCaret} ${filter ? styles.filterSet : styles.filterNotSet}`} />
+                  </WidgetFilterMenu>
+                </IfDashboard>
               </WidgetHeader>
               <EditComponent config={config}
                              fields={fields}
@@ -215,10 +218,12 @@ class Widget extends React.Component<Props, State> {
                                        widgetType={widget.type}
                                        onStretch={onPositionsChange}
                                        position={position} />
-              {' '}
-              <WidgetFilterMenu onChange={newFilter => WidgetActions.filter(id, newFilter)} value={filter}>
-                <i className={`fa fa-filter ${styles.widgetActionDropdownCaret} ${filter ? styles.filterSet : styles.filterNotSet}`} />
-              </WidgetFilterMenu>
+              <IfDashboard>
+                {' '}
+                <WidgetFilterMenu onChange={newFilter => WidgetActions.filter(id, newFilter)} value={filter}>
+                  <i className={`fa fa-filter ${styles.widgetActionDropdownCaret} ${filter ? styles.filterSet : styles.filterNotSet}`} />
+                </WidgetFilterMenu>
+              </IfDashboard>
               {' '}
               <WidgetActionDropdown>
                 <MenuItem onSelect={this._onToggleEdit}>Edit</MenuItem>

--- a/graylog2-web-interface/src/views/hooks/__snapshots__/RequirementsProvided.test.jsx.snap
+++ b/graylog2-web-interface/src/views/hooks/__snapshots__/RequirementsProvided.test.jsx.snap
@@ -26,6 +26,7 @@ exports[`RequirementsProvided throws Component if not all requirements are provi
         "state": undefined,
         "summary": undefined,
         "title": undefined,
+        "type": undefined,
       }
     }
   >

--- a/graylog2-web-interface/src/views/logic/views/View.js
+++ b/graylog2-web-interface/src/views/logic/views/View.js
@@ -151,10 +151,11 @@ export default class View {
   }
 
   toJSON() {
-    const { id, title, summary, description, search, properties, state, createdAt, owner } = this._value;
+    const { id, type, title, summary, description, search, properties, state, createdAt, owner } = this._value;
 
     return {
       id,
+      type,
       title,
       summary,
       description,

--- a/graylog2-web-interface/src/views/logic/views/View.js
+++ b/graylog2-web-interface/src/views/logic/views/View.js
@@ -14,8 +14,11 @@ export type PluginMetadata = {
 };
 export type Requirements = { [string]: PluginMetadata };
 
+export type ViewType = 'SEARCH' | 'DASHBOARD';
+
 type InternalState = {
   id: string,
+  type: ViewType,
   title: string,
   summary: string,
   description: string,
@@ -30,6 +33,7 @@ type InternalState = {
 export type WidgetMapping = Immutable.Map<string, string>;
 export type ViewJson = {
   id: string,
+  type: ViewType,
   title: string,
   summary: string,
   description: string,
@@ -42,9 +46,15 @@ export type ViewJson = {
 };
 
 export default class View {
+  static Type: { [string]: ViewType } = {
+    Search: 'SEARCH',
+    Dashboard: 'DASHBOARD',
+  };
+
   _value: InternalState;
 
   constructor(id: string,
+    type: ViewType,
     title: string,
     summary: string,
     description: string,
@@ -56,6 +66,7 @@ export default class View {
     requires: Requirements) {
     this._value = {
       id,
+      type,
       title,
       summary,
       description,
@@ -75,6 +86,10 @@ export default class View {
 
   get id(): string {
     return this._value.id;
+  }
+
+  get type(): ViewType {
+    return this._value.type;
   }
 
   get title(): string {
@@ -153,11 +168,12 @@ export default class View {
 
   static fromJSON(value: ViewJson): View {
     // eslint-disable-next-line camelcase
-    const { id, title, summary, description, properties, state, created_at, owner, requires } = value;
+    const { id, type, title, summary, description, properties, state, created_at, owner, requires } = value;
     const viewState: Immutable.Map<QueryId, ViewState> = Immutable.Map(state).map(ViewState.fromJSON);
     return View.create()
       .toBuilder()
       .id(id)
+      .type(type)
       .title(title)
       .summary(summary)
       .description(description)
@@ -185,6 +201,10 @@ class Builder {
 
   id(value: string): Builder {
     return new Builder(this.value.set('id', value));
+  }
+
+  type(value: ViewType): Builder {
+    return new Builder(this.value.set('type', value));
   }
 
   newId(): Builder {
@@ -228,7 +248,7 @@ class Builder {
   }
 
   build(): View {
-    const { id, title, summary, description, search, properties, state, createdAt, owner, requires } = this.value.toObject();
-    return new View(id, title, summary, description, search, properties, state, createdAt, owner, requires);
+    const { id, type, title, summary, description, search, properties, state, createdAt, owner, requires } = this.value.toObject();
+    return new View(id, type, title, summary, description, search, properties, state, createdAt, owner, requires);
   }
 }

--- a/graylog2-web-interface/src/views/pages/DashboardsPage.jsx
+++ b/graylog2-web-interface/src/views/pages/DashboardsPage.jsx
@@ -51,7 +51,7 @@ const DashboardsPage = ({ dashboards: { list, pagination } }: Props) => {
           </span>
 
           <span>
-            <LinkContainer to={Routes.EXTENDEDSEARCH}>
+            <LinkContainer to={Routes.pluginRoute('DASHBOARDS_NEW')}>
               <Button bsStyle="success" bsSize="lg">Create new dashboard</Button>
             </LinkContainer>
           </span>

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -25,6 +25,7 @@ import QueryBarElements from 'views/components/QueryBarElements';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import WindowLeaveMessage from 'views/components/common/WindowLeaveMessage';
 import withPluginEntities from 'views/logic/withPluginEntities';
+import IfDashboard from 'views/components/dashboard/IfDashboard';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import style from '!style/useable!css!./ExtendedSearchPage.css';
@@ -85,6 +86,10 @@ const ExtendedSearchPage = ({ executionState, route, searchRefreshHooks }) => {
       <WindowLeaveMessage route={route} />
       <HeaderElements />
       <Row id="main-row">
+        <QueryBar />
+        <IfDashboard>
+          <QueryBar />
+        </IfDashboard>
         <SearchBarWithStatus onExecute={refreshIfNotUndeclared} />
 
         <QueryBarElements />

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -86,7 +86,6 @@ const ExtendedSearchPage = ({ executionState, route, searchRefreshHooks }) => {
       <WindowLeaveMessage route={route} />
       <HeaderElements />
       <Row id="main-row">
-        <QueryBar />
         <IfDashboard>
           <QueryBar />
         </IfDashboard>

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -26,6 +26,7 @@ import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import WindowLeaveMessage from 'views/components/common/WindowLeaveMessage';
 import withPluginEntities from 'views/logic/withPluginEntities';
 import IfDashboard from 'views/components/dashboard/IfDashboard';
+import QueryBar from 'views/components/QueryBar';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import style from '!style/useable!css!./ExtendedSearchPage.css';

--- a/graylog2-web-interface/src/views/pages/NewDashboardPage.jsx
+++ b/graylog2-web-interface/src/views/pages/NewDashboardPage.jsx
@@ -1,0 +1,33 @@
+// @flow strict
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import Spinner from 'components/common/Spinner';
+
+import { ViewActions } from 'views/stores/ViewStore';
+import View from 'views/logic/views/View';
+import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
+import ExtendedSearchPage from './ExtendedSearchPage';
+
+type Props = {
+  route: {},
+};
+const NewDashboardPage = ({ route }: Props) => {
+  const [loaded, setLoaded] = useState(false);
+  useEffect(() => {
+    ViewActions.create().then(() => setLoaded(true));
+  }, []);
+
+  return loaded
+    ? (
+      <ViewTypeContext.Provider value={View.Type.Dashboard}>
+        <ExtendedSearchPage route={route} />
+      </ViewTypeContext.Provider>
+    )
+    : <Spinner />;
+};
+
+NewDashboardPage.propTypes = {
+  route: PropTypes.object.isRequired,
+};
+
+export default NewDashboardPage;

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 
 import { Spinner } from 'components/common';
 import { ViewActions } from 'views/stores/ViewStore';
+import View from 'views/logic/views/View';
+import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
 import ExtendedSearchPage from './ExtendedSearchPage';
 
 type Props = {
@@ -34,7 +36,11 @@ export default class NewSearchPage extends React.Component<Props, State> {
     const { loaded } = this.state;
     if (loaded) {
       const { route } = this.props;
-      return <ExtendedSearchPage route={route} />;
+      return (
+        <ViewTypeContext.Provider value={View.Type.Search}>
+          <ExtendedSearchPage route={route} />
+        </ViewTypeContext.Provider>
+      );
     }
     return <Spinner />;
   }

--- a/graylog2-web-interface/src/views/pages/ShowViewPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/ShowViewPage.test.jsx
@@ -37,6 +37,7 @@ jest.mock('./ExtendedSearchPage', () => 'extended-search-page');
 describe('ShowViewPage', () => {
   const viewJson = {
     id: 'foo',
+    type: 'DASHBOARD',
     title: 'Foo',
     summary: 'summary',
     description: 'Foo',

--- a/graylog2-web-interface/src/views/stores/StoreTypes.js
+++ b/graylog2-web-interface/src/views/stores/StoreTypes.js
@@ -6,10 +6,10 @@ type ExtractResultType = <R>((...any) => Promise<R>) => R;
 export type ListenableAction<R> = R & {
   $call: R,
   // eslint-disable-next-line no-undef
-  listen: (($Call<ExtractResultType, R>) => void) => () => void,
+  listen: (($Call<ExtractResultType, R>) => *) => () => void,
   completed: {
     // eslint-disable-next-line no-undef
-    listen: (($Call<ExtractResultType, R>) => void) => () => void,
+    listen: (($Call<ExtractResultType, R>) => *) => () => void,
   },
   // eslint-disable-next-line no-undef
   promise: (Promise<$Call<ExtractResultType, R>>) => void,

--- a/graylog2-web-interface/src/views/test/ViewFixtures.js
+++ b/graylog2-web-interface/src/views/test/ViewFixtures.js
@@ -3,7 +3,6 @@
 import View from 'views/logic/views/View';
 import type { ViewJson } from 'views/logic/views/View';
 import Search from 'views/logic/search/Search';
-import DashboardState from '../logic/views/DashboardState';
 
 const simpleView = (): View => View.builder()
   .id('foo')
@@ -11,7 +10,6 @@ const simpleView = (): View => View.builder()
   .summary('summary')
   .description('Foo')
   .search(Search.create().toBuilder().id('foosearch').build())
-  .dashboardState(DashboardState.create())
   .properties({})
   .state({})
   .createdAt(new Date())

--- a/graylog2-web-interface/src/views/test/ViewFixtures.js
+++ b/graylog2-web-interface/src/views/test/ViewFixtures.js
@@ -6,6 +6,7 @@ import Search from 'views/logic/search/Search';
 
 const simpleView = (): View => View.builder()
   .id('foo')
+  .type(View.Type.Dashboard)
   .title('Foo')
   .summary('summary')
   .description('Foo')


### PR DESCRIPTION
## Description

This change is conditionally rendering the query bar and widget filter icon if the current view is a dashboard. For this, the PR does:

  * Add a `ViewTypeContext` React context providing current view type
  * Add a `IfDashboard` component for conditional rendering of children
if current view is a dashboard
  * Conditionally render the affected elements

![SearchAndDashboardModes](https://user-images.githubusercontent.com/41929/62783688-34447e00-babd-11e9-9f44-f2a494f99c79.gif)

**Note:**

Requires #6268, #6270, #6271 to be merged before.