### PR TITLE
Migrate Legacy Alerts and Notifications without title

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/legacy/LegacyAlertConditionMigrator.java
+++ b/graylog2-server/src/main/java/org/graylog/events/legacy/LegacyAlertConditionMigrator.java
@@ -188,7 +188,7 @@ public class LegacyAlertConditionMigrator {
                 .build();
 
         final NotificationDto dto = NotificationDto.builder()
-                .title(title)
+                .title(firstNonNull(title, "Untitled"))
                 .description("Migrated legacy alarm callback")
                 .config(config)
                 .build();
@@ -416,7 +416,7 @@ public class LegacyAlertConditionMigrator {
                     .collect(ImmutableList.toImmutableList());
 
             return EventDefinitionDto.builder()
-                    .title(title)
+                    .title(firstNonNull(title, "Untitled"))
                     .description("Migrated message count alert condition")
                     .config(config)
                     .alert(true)

--- a/graylog2-server/src/test/resources/org/graylog/events/legacy/legacy-alert-conditions.json
+++ b/graylog2-server/src/test/resources/org/graylog/events/legacy/legacy-alert-conditions.json
@@ -213,6 +213,22 @@
           "created_at": {
             "$date": "2019-01-01T00:00:00.000Z"
           }
+        },
+        {
+          "id" : "00000000-0000-0000-0000-000000000010",
+          "type" : "field_content_value",
+          "parameters" : {
+            "backlog" : 0,
+            "repeat_notifications" : false,
+            "field" : "test_field_3",
+            "query" : "foo:bar",
+            "grace" : 0,
+            "value" : "foo"
+          },
+          "creator_user_id" : "admin",
+          "created_at": {
+            "$date": "2019-01-01T00:00:00.000Z"
+          }
         }
       ],
       "description" : "A test stream.",
@@ -290,6 +306,20 @@
         "$date": "2019-01-01T00:00:00.000Z"
       },
       "creator_user_id" : "jane"
+    },
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0004"
+      },
+      "stream_id" : "54e3deadbeefdeadbeef0001",
+      "type" : "org.graylog2.alarmcallbacks.HTTPAlarmCallback",
+      "configuration" : {
+        "url" : "http://localhost:11000/"
+      },
+      "created_at": {
+        "$date": "2019-01-01T00:00:00.000Z"
+      },
+      "creator_user_id" : "admin"
     }
   ]
 }


### PR DESCRIPTION
Use default title when `AlarmCallback` or `AlertCondition` title is `null`.

Fixes #6241
