### PR TITLE
Disable content pack entity creation for legacy conditions and callbacks

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/ContentPackServiceTest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.graylog.events.legacy.V20190722150700_LegacyAlertConditionMigration;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
 import org.graylog2.alerts.AlertService;
 import org.graylog2.contentpacks.constraints.ConstraintChecker;
@@ -93,6 +94,8 @@ public class ContentPackServiceTest {
     private GrokPatternService patternService;
     @Mock
     private ContentPackInstallationPersistenceService contentPackInstallService;
+    @Mock
+    private V20190722150700_LegacyAlertConditionMigration legacyAlertConditionMigration;
 
     private ContentPackService contentPackService;
     private Set<PluginMetaData> pluginMetaData;
@@ -114,7 +117,7 @@ public class ContentPackServiceTest {
         outputFactories2 = new HashMap<>();
         final Map<ModelType, EntityFacade<?>> entityFacades = ImmutableMap.of(
                 ModelTypes.GROK_PATTERN_V1, new GrokPatternFacade(objectMapper, patternService),
-                ModelTypes.STREAM_V1, new StreamFacade(objectMapper, streamService, streamRuleService, alertService, alarmCallbackConfigurationService, new HashSet<>(), indexSetService),
+                ModelTypes.STREAM_V1, new StreamFacade(objectMapper, streamService, streamRuleService, alertService, alarmCallbackConfigurationService, legacyAlertConditionMigration, indexSetService),
                 ModelTypes.OUTPUT_V1, new OutputFacade(objectMapper, outputService, pluginMetaData, outputFactories, outputFactories2)
         );
 

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/StreamCatalogTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/StreamCatalogTest.java
@@ -24,6 +24,7 @@ import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
 import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
 import org.bson.types.ObjectId;
+import org.graylog.events.legacy.V20190722150700_LegacyAlertConditionMigration;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
 import org.graylog2.alerts.AlertService;
 import org.graylog2.contentpacks.EntityDescriptorIds;
@@ -67,7 +68,6 @@ import org.mockito.junit.MockitoRule;
 
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -100,6 +100,8 @@ public class StreamCatalogTest {
     private NotificationService notificationService;
     @Mock
     private AlarmCallbackConfigurationService alarmCallbackConfigurationService;
+    @Mock
+    private V20190722150700_LegacyAlertConditionMigration legacyAlertConditionMigration;
     private StreamFacade facade;
 
     @Before
@@ -122,7 +124,7 @@ public class StreamCatalogTest {
                 OutputImpl.create("5adf239e4b900a0fdb4e5197", "Title", "Type", "admin", Collections.emptyMap(), new Date(1524654085L), null)
         );
 
-        facade = new StreamFacade(objectMapper, streamService, streamRuleService, alertService, alarmCallbackConfigurationService, new HashSet<>(), indexSetService);
+        facade = new StreamFacade(objectMapper, streamService, streamRuleService, alertService, alarmCallbackConfigurationService, legacyAlertConditionMigration, indexSetService);
     }
 
     @Test


### PR DESCRIPTION
The StreamFacade will continue to create new legacy alert conditions and
alarm callbacks for now but immediately runs the migration to create
event definitions and notifications for them.

Closes #6261
