### PR TITLE
Security update to jackson-databind 2.8.11.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <HdrHistogram.version>2.1.10</HdrHistogram.version>
         <hibernate-validator.version>6.0.13.Final</hibernate-validator.version>
         <hk2.version>2.5.0-b32</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->
-        <jackson.version>2.8.11.20181123</jackson.version>
+        <jackson.version>2.8.11.20190726</jackson.version>
         <jadconfig.version>0.13.0</jadconfig.version>
         <java-semver.version>0.9.0</java-semver.version>
         <javapoet.version>1.11.1</javapoet.version>


### PR DESCRIPTION
Includes fixes for CVE-2019-12086, CVE-2019-12384, CVE-2019-12814,
CVE-2019-14379 and CVE-2019-14439.

See https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.8 for details.

Update to the latest bom for 2.8 which includes the 2.8.11.4 version of
jackson-databind.
