### PR TITLE
Improve Event processor exceptions

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
@@ -154,7 +154,7 @@ public class AggregationEventProcessor implements EventProcessor {
             try {
                 moreSearch.scrollQuery(config.query(), config.streams(), timeRange, Math.min(500, Ints.saturatedCast(limit)), callback);
             } catch (NotFoundException e) {
-                throw new EventProcessorException("Couldn't find one or more streams.", true, eventDefinition, e);
+                throw new EventProcessorException("Failed to load all streams.", false, eventDefinition, e);
             }
         }
 
@@ -197,7 +197,7 @@ public class AggregationEventProcessor implements EventProcessor {
         try {
             moreSearch.scrollQuery(config.query(), streams, parameters.timerange(), parameters.batchSize(), callback);
         } catch(NotFoundException e) {
-            throw new EventProcessorException("Couldn't find one or more streams.", true, eventDefinition, e);
+            throw new EventProcessorException("Failed to load all streams.", false, eventDefinition, e);
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
@@ -39,7 +39,6 @@ import org.graylog.events.processor.EventProcessorException;
 import org.graylog.events.processor.EventProcessorParameters;
 import org.graylog.events.processor.EventProcessorPreconditionException;
 import org.graylog.events.search.MoreSearch;
-import org.graylog2.database.NotFoundException;
 import org.graylog2.indexer.messages.Messages;
 import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.plugin.Message;
@@ -151,11 +150,7 @@ public class AggregationEventProcessor implements EventProcessor {
                 messageConsumer.accept(summaries);
             };
             final TimeRange timeRange = AbsoluteRange.create(event.getTimerangeStart(), event.getTimerangeEnd());
-            try {
-                moreSearch.scrollQuery(config.query(), config.streams(), timeRange, Math.min(500, Ints.saturatedCast(limit)), callback);
-            } catch (NotFoundException e) {
-                throw new EventProcessorException("Failed to load all streams.", false, eventDefinition, e);
-            }
+            moreSearch.scrollQuery(config.query(), config.streams(), timeRange, Math.min(500, Ints.saturatedCast(limit)), callback);
         }
 
     }
@@ -194,11 +189,7 @@ public class AggregationEventProcessor implements EventProcessor {
             eventsConsumer.accept(eventsWithContext.build());
         };
 
-        try {
-            moreSearch.scrollQuery(config.query(), streams, parameters.timerange(), parameters.batchSize(), callback);
-        } catch(NotFoundException e) {
-            throw new EventProcessorException("Failed to load all streams.", false, eventDefinition, e);
-        }
+        moreSearch.scrollQuery(config.query(), streams, parameters.timerange(), parameters.batchSize(), callback);
     }
 
     private void aggregatedSearch(EventFactory eventFactory, AggregationEventProcessorParameters parameters,

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
@@ -39,6 +39,7 @@ import org.graylog.events.processor.EventProcessorException;
 import org.graylog.events.processor.EventProcessorParameters;
 import org.graylog.events.processor.EventProcessorPreconditionException;
 import org.graylog.events.search.MoreSearch;
+import org.graylog2.database.NotFoundException;
 import org.graylog2.indexer.messages.Messages;
 import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.plugin.Message;
@@ -105,8 +106,6 @@ public class AggregationEventProcessor implements EventProcessor {
 
         LOG.debug("Creating events for config={} parameters={}", config, parameters);
 
-        // TODO: This needs error handling!
-
         // The absence of a series indicates that the user doesn't want to do an aggregation but create events from
         // a simple search query. (one message -> one event)
         if (config.series().isEmpty()) {
@@ -152,7 +151,11 @@ public class AggregationEventProcessor implements EventProcessor {
                 messageConsumer.accept(summaries);
             };
             final TimeRange timeRange = AbsoluteRange.create(event.getTimerangeStart(), event.getTimerangeEnd());
-            moreSearch.scrollQuery(config.query(), config.streams(), timeRange, Math.min(500, Ints.saturatedCast(limit)), callback);
+            try {
+                moreSearch.scrollQuery(config.query(), config.streams(), timeRange, Math.min(500, Ints.saturatedCast(limit)), callback);
+            } catch (NotFoundException e) {
+                throw new EventProcessorException("Couldn't find one or more streams.", true, eventDefinition, e);
+            }
         }
 
     }
@@ -191,17 +194,21 @@ public class AggregationEventProcessor implements EventProcessor {
             eventsConsumer.accept(eventsWithContext.build());
         };
 
-        moreSearch.scrollQuery(config.query(), streams, parameters.timerange(), parameters.batchSize(), callback);
+        try {
+            moreSearch.scrollQuery(config.query(), streams, parameters.timerange(), parameters.batchSize(), callback);
+        } catch(NotFoundException e) {
+            throw new EventProcessorException("Couldn't find one or more streams.", true, eventDefinition, e);
+        }
     }
 
     private void aggregatedSearch(EventFactory eventFactory, AggregationEventProcessorParameters parameters,
                                   EventConsumer<List<EventWithContext>> eventsConsumer) throws EventProcessorException {
         final String owner = "event-processor-" + AggregationEventProcessorConfig.TYPE_NAME + "-" + eventDefinition.id();
-        final AggregationSearch search = aggregationSearchFactory.create(config, parameters, owner);
+        final AggregationSearch search = aggregationSearchFactory.create(config, parameters, owner, eventDefinition);
         final AggregationResult result = search.doSearch();
 
         if (result.keyResults().isEmpty()) {
-            LOG.debug("Empty result set");
+            LOG.debug("Aggregated search returned empty result set.");
             return;
         }
 

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationSearch.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationSearch.java
@@ -16,12 +16,16 @@
  */
 package org.graylog.events.processor.aggregation;
 
+import org.graylog.events.processor.EventDefinition;
+import org.graylog.events.processor.EventProcessorException;
+
 public interface AggregationSearch {
     interface Factory {
         AggregationSearch create(AggregationEventProcessorConfig config,
                                  AggregationEventProcessorParameters parameters,
-                                 String searchOwner);
+                                 String searchOwner,
+                                 EventDefinition eventDefinition);
     }
 
-    AggregationResult doSearch();
+    AggregationResult doSearch() throws EventProcessorException;
 }

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/PivotAggregationSearch.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/PivotAggregationSearch.java
@@ -122,9 +122,9 @@ public class PivotAggregationSearch implements AggregationSearch {
             });
 
             if (errors.size() > 1) {
-                throw new EventProcessorException("Pivot search failed with multiple errors.", true, eventDefinition);
+                throw new EventProcessorException("Pivot search failed with multiple errors.", false, eventDefinition);
             } else {
-                throw new EventProcessorException(errors.iterator().next().description(), true, eventDefinition);
+                throw new EventProcessorException(errors.iterator().next().description(), false, eventDefinition);
             }
         }
 
@@ -294,11 +294,11 @@ public class PivotAggregationSearch implements AggregationSearch {
                 configurationProvider.get().eventsSearchTimeout(),
                 TimeUnit.MILLISECONDS);
         } catch (ExecutionException e) {
-            throw new EventProcessorException("Error executing search job: " + e.getMessage(), true, eventDefinition, e);
+            throw new EventProcessorException("Error executing search job: " + e.getMessage(), false, eventDefinition, e);
         } catch (TimeoutException e) {
             throw new EventProcessorException("Timeout while executing search job.", false, eventDefinition, e);
         } catch (Exception e) {
-            throw new EventProcessorException("Unhandled exception in search job.", true, eventDefinition, e);
+            throw new EventProcessorException("Unhandled exception in search job.", false, eventDefinition, e);
         }
 
         return searchJob;

--- a/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorTest.java
@@ -338,7 +338,7 @@ public class AggregationEventProcessorTest {
                 eq(parameters.batchSize()),
                 any(MoreSearch.ScrollCallback.class)
         );
-        verify(searchFactory, never()).create(eq(config), eq(parameters), any(String.class));
+        verify(searchFactory, never()).create(eq(config), eq(parameters), any(String.class), eq(eventDefinitionDto));
     }
 
     @Test
@@ -398,7 +398,7 @@ public class AggregationEventProcessorTest {
                 .isInstanceOf(EventProcessorPreconditionException.class);
 
         verify(stateService, never()).setState(any(String.class), any(DateTime.class), any(DateTime.class));
-        verify(searchFactory, never()).create(any(), any(), any());
+        verify(searchFactory, never()).create(any(), any(), any(), any());
         verify(moreSearch, never()).scrollQuery(
                 eq(config.query()),
                 eq(config.streams()),

--- a/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/PivotAggregationSearchTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/PivotAggregationSearchTest.java
@@ -19,6 +19,7 @@ package org.graylog.events.processor.aggregation;
 import com.google.common.collect.ImmutableList;
 import org.graylog.events.EventsConfigurationTestProvider;
 import org.graylog.events.processor.EventDefinition;
+import org.graylog.events.search.MoreSearch;
 import org.graylog.plugins.views.search.db.SearchJobService;
 import org.graylog.plugins.views.search.engine.QueryEngine;
 import org.graylog.plugins.views.search.searchtypes.pivot.PivotResult;
@@ -44,6 +45,8 @@ public class PivotAggregationSearchTest {
     private QueryEngine queryEngine;
     @Mock
     private EventDefinition eventDefinition;
+    @Mock
+    private MoreSearch moreSearch;
 
     @Test
     public void testExtractValuesWithGroupBy() throws Exception {
@@ -66,13 +69,14 @@ public class PivotAggregationSearchTest {
                 .build();
 
         final PivotAggregationSearch pivotAggregationSearch = new PivotAggregationSearch(
-            config,
-            parameters,
-            "test",
-            eventDefinition,
-            searchJobService,
-            queryEngine,
-            EventsConfigurationTestProvider.create());
+                config,
+                parameters,
+                "test",
+                eventDefinition,
+                searchJobService,
+                queryEngine,
+                EventsConfigurationTestProvider.create(),
+                moreSearch);
 
         final PivotResult pivotResult = PivotResult.builder()
                 .id("test")
@@ -156,13 +160,14 @@ public class PivotAggregationSearchTest {
                 .build();
 
         final PivotAggregationSearch pivotAggregationSearch = new PivotAggregationSearch(
-            config,
-            parameters,
-            "test",
-            eventDefinition,
-            searchJobService,
-            queryEngine,
-            EventsConfigurationTestProvider.create());
+                config,
+                parameters,
+                "test",
+                eventDefinition,
+                searchJobService,
+                queryEngine,
+                EventsConfigurationTestProvider.create(),
+                moreSearch);
 
         final PivotResult pivotResult = PivotResult.builder()
                 .id("test")
@@ -218,13 +223,14 @@ public class PivotAggregationSearchTest {
                 .build();
 
         final PivotAggregationSearch pivotAggregationSearch = new PivotAggregationSearch(
-            config,
-            parameters,
-            "test",
-            eventDefinition,
-            searchJobService,
-            queryEngine,
-            EventsConfigurationTestProvider.create());
+                config,
+                parameters,
+                "test",
+                eventDefinition,
+                searchJobService,
+                queryEngine,
+                EventsConfigurationTestProvider.create(),
+                moreSearch);
 
         final PivotResult pivotResult = PivotResult.builder()
                 .id("test")

--- a/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/PivotAggregationSearchTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/PivotAggregationSearchTest.java
@@ -18,6 +18,7 @@ package org.graylog.events.processor.aggregation;
 
 import com.google.common.collect.ImmutableList;
 import org.graylog.events.EventsConfigurationTestProvider;
+import org.graylog.events.processor.EventDefinition;
 import org.graylog.plugins.views.search.db.SearchJobService;
 import org.graylog.plugins.views.search.engine.QueryEngine;
 import org.graylog.plugins.views.search.searchtypes.pivot.PivotResult;
@@ -41,6 +42,8 @@ public class PivotAggregationSearchTest {
     private SearchJobService searchJobService;
     @Mock
     private QueryEngine queryEngine;
+    @Mock
+    private EventDefinition eventDefinition;
 
     @Test
     public void testExtractValuesWithGroupBy() throws Exception {
@@ -66,6 +69,7 @@ public class PivotAggregationSearchTest {
             config,
             parameters,
             "test",
+            eventDefinition,
             searchJobService,
             queryEngine,
             EventsConfigurationTestProvider.create());
@@ -155,6 +159,7 @@ public class PivotAggregationSearchTest {
             config,
             parameters,
             "test",
+            eventDefinition,
             searchJobService,
             queryEngine,
             EventsConfigurationTestProvider.create());
@@ -216,6 +221,7 @@ public class PivotAggregationSearchTest {
             config,
             parameters,
             "test",
+            eventDefinition,
             searchJobService,
             queryEngine,
             EventsConfigurationTestProvider.create());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR let the AggregationEventProcessor only throw EventProcessorExceptions to handle failed searches in a better way. Also searches on removed streams should now be handled so that the processor still works on the remaining streams.

Fixes: https://github.com/Graylog2/graylog-plugin-enterprise/issues/1062

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
