### PR TITLE
Dont throw exception on misconfigured email notification

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailSender.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailSender.java
@@ -180,9 +180,10 @@ public class EmailSender {
 
         if (emailRecipients.isEmpty()) {
             if (!emailConfig.isEnabled()) {
-                throw new ConfigurationError("Email transport is not enabled in server configuration file!");
+                LOG.debug("Email transport is not enabled in server configuration file!");
             }
-            throw new ConfigurationError("Cannot send emails: empty recipient list.");
+            LOG.debug("Cannot send emails: empty recipient list.");
+            return;
         }
 
         final Set<String> recipientsSet = emailRecipients.getEmailRecipients();

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailSender.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailSender.java
@@ -178,10 +178,12 @@ public class EmailSender {
                 new ArrayList<>(notificationConfig.emailRecipients())
         );
 
+        if (!emailConfig.isEnabled()) {
+            LOG.debug("Email transport is not enabled in server configuration file!");
+            return;
+        }
+
         if (emailRecipients.isEmpty()) {
-            if (!emailConfig.isEnabled()) {
-                LOG.debug("Email transport is not enabled in server configuration file!");
-            }
             LOG.debug("Cannot send emails: empty recipient list.");
             return;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR reduces exceptions in cases of an empty Email receiver list. The lists are already validated in the frontend and the API. So this case indicates a broken setup and we should not retry to send the notification.

Fixes: https://github.com/Graylog2/graylog2-server/issues/6163


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
