### PR TITLE
Sort entities in alerting forms

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/LookupTableFieldValueProviderForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/field-value-providers/LookupTableFieldValueProviderForm.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Col, ControlLabel, FormGroup, HelpBlock, Row } from 'react-bootstrap';
 import lodash from 'lodash';
-import naturalSort from 'javascript-natural-sort';
 
 import { Select } from 'components/common';
 import FormsUtils from 'util/FormsUtils';
+import { naturalSortIgnoreCase } from 'util/SortUtils';
 
 class LookupTableFieldValueProviderForm extends React.Component {
   static propTypes = {
@@ -31,7 +31,7 @@ class LookupTableFieldValueProviderForm extends React.Component {
   formatMessageFields = lodash.memoize(
     (fieldTypes) => {
       return fieldTypes
-        .sort((ftA, ftB) => naturalSort(ftA.name, ftB.name))
+        .sort((ftA, ftB) => naturalSortIgnoreCase(ftA.name, ftB.name))
         .map((fieldType) => {
           return {
             label: `${fieldType.name} – ${fieldType.value.type.type}`,
@@ -63,7 +63,9 @@ class LookupTableFieldValueProviderForm extends React.Component {
   };
 
   formatLookupTables = (lookupTables) => {
-    return lookupTables.map(table => ({ label: table.title, value: table.name }));
+    return lookupTables
+      .sort((lt1, lt2) => naturalSortIgnoreCase(lt1.title, lt2.title))
+      .map(table => ({ label: table.title, value: table.name }));
   };
 
   render() {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationForm.jsx
@@ -10,6 +10,7 @@ import { Input } from 'components/bootstrap';
 
 import FormsUtils from 'util/FormsUtils';
 import AggregationExpressionParser from 'logic/alerts/AggregationExpressionParser';
+import { naturalSortIgnoreCase } from 'util/SortUtils';
 
 import commonStyles from '../common/commonStyles.css';
 
@@ -25,12 +26,14 @@ class AggregationForm extends React.Component {
   // Memoize function to only format fields when they change. Use joined fieldNames as cache key.
   formatFields = lodash.memoize(
     (fieldTypes) => {
-      return fieldTypes.map((fieldType) => {
-        return {
-          label: `${fieldType.name} – ${fieldType.value.type.type}`,
-          value: fieldType.name,
-        };
-      });
+      return fieldTypes
+        .sort((ftA, ftB) => naturalSortIgnoreCase(ftA.name, ftB.name))
+        .map((fieldType) => {
+          return {
+            label: `${fieldType.name} – ${fieldType.value.type.type}`,
+            value: fieldType.name,
+          };
+        });
     },
     fieldTypes => fieldTypes.map(ft => ft.name).join('-'),
   );


### PR DESCRIPTION
This PR ensures lists of Fields and Lookup Tables are sorted. Other entities are sorted in the frontend or API already.

Refs #6155