### PR TITLE
Fix bytes formatting after numeral major update.

### DIFF
--- a/graylog2-web-interface/src/components/cluster/TrafficGraph.jsx
+++ b/graylog2-web-interface/src/components/cluster/TrafficGraph.jsx
@@ -5,7 +5,6 @@ import HistogramVisualization from 'components/visualizations/HistogramVisualiza
 import _ from 'lodash';
 import moment from 'moment';
 import crossfilter from 'crossfilter';
-import numeral from 'numeral';
 import DateTime from 'logic/datetimes/DateTime';
 import NumberUtils from 'util/NumberUtils';
 

--- a/graylog2-web-interface/src/components/cluster/TrafficGraph.jsx
+++ b/graylog2-web-interface/src/components/cluster/TrafficGraph.jsx
@@ -7,6 +7,7 @@ import moment from 'moment';
 import crossfilter from 'crossfilter';
 import numeral from 'numeral';
 import DateTime from 'logic/datetimes/DateTime';
+import NumberUtils from 'util/NumberUtils';
 
 class TrafficGraph extends React.Component {
   static propTypes = {
@@ -48,7 +49,7 @@ class TrafficGraph extends React.Component {
                               width={this.props.width}
                               interactive
                               keyTitleRenderer={d => `<span class="date">${new DateTime(d.x).toString(DateTime.Formats.DATE)}</span>`}
-                              valueTitleRenderer={d => `${numeral(d.y).format('0.00b')}`}
+                              valueTitleRenderer={d => `${NumberUtils.formatBytes(d.y)}`}
                               computationTimeRange={{ from: this.props.from, to: this.props.to }} />
     );
   }

--- a/graylog2-web-interface/src/util/NumberUtils.js
+++ b/graylog2-web-interface/src/util/NumberUtils.js
@@ -42,7 +42,7 @@ const NumberUtils = {
 
     let formattedNumber;
     try {
-      formattedNumber = numeral(this.normalizeNumber(number)).format('0.0b');
+      formattedNumber = numeral(this.normalizeNumber(number)).format('0.0ib');
     } catch (e) {
       formattedNumber = number;
     }


### PR DESCRIPTION
Numeral 2.0 changed the "b" format modifier and we now have to use "ib"
to get the Graylog 3.0 (and earlier) behavior.

Relevant changelog entry:

> Breaking change / Feature: Bytes are now formatted as: b (base 1000) and ib (base 1024)

Switch TrafficGraph.jsx to use NumberUtils instead of using numeral
directly.

Fixes #6175