### PR TITLE
Place Action Menus bottom to target

### DIFF
--- a/graylog2-web-interface/src/views/components/actions/FieldActions.jsx
+++ b/graylog2-web-interface/src/views/components/actions/FieldActions.jsx
@@ -106,7 +106,7 @@ class FieldActions extends React.Component<Props, State> {
     return (
       <OverlayDropdown show={open}
                        toggle={wrappedElement}
-                       placement="right"
+                       placement="bottom"
                        onToggle={this._onMenuToggle}
                        menuContainer={menuContainer}>
         <div style={{ marginBottom: '10px' }}>

--- a/graylog2-web-interface/src/views/components/actions/ValueActions.jsx
+++ b/graylog2-web-interface/src/views/components/actions/ValueActions.jsx
@@ -123,7 +123,7 @@ class ValueActions extends React.Component<Props, State> {
       <React.Fragment>
         <OverlayDropdown show={open}
                          toggle={element}
-                         placement="right"
+                         placement="bottom"
                          onToggle={this._onMenuToggle}
                          menuContainer={menuContainer}>
           <div className={style.bottomSpacer}>

--- a/graylog2-web-interface/src/views/components/datatable/__snapshots__/DataTableEntry.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/datatable/__snapshots__/DataTableEntry.test.jsx.snap
@@ -160,7 +160,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                     <OverlayDropdown
                       menuContainer={<body />}
                       onToggle={[Function]}
-                      placement="right"
+                      placement="bottom"
                       show={false}
                       toggle={
                         <TypeSpecificValue
@@ -271,7 +271,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                         container={<body />}
                         containerPadding={10}
                         onHide={[Function]}
-                        placement="right"
+                        placement="bottom"
                         rootClose={true}
                         shouldUpdatePosition={true}
                         show={false}
@@ -365,7 +365,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                     <OverlayDropdown
                       menuContainer={<body />}
                       onToggle={[Function]}
-                      placement="right"
+                      placement="bottom"
                       show={false}
                       toggle={
                         <TypeSpecificValue
@@ -494,7 +494,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                         container={<body />}
                         containerPadding={10}
                         onHide={[Function]}
-                        placement="right"
+                        placement="bottom"
                         rootClose={true}
                         shouldUpdatePosition={true}
                         show={false}
@@ -579,7 +579,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                     <OverlayDropdown
                       menuContainer={<body />}
                       onToggle={[Function]}
-                      placement="right"
+                      placement="bottom"
                       show={false}
                       toggle={
                         <TypeSpecificValue
@@ -690,7 +690,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                         container={<body />}
                         containerPadding={10}
                         onHide={[Function]}
-                        placement="right"
+                        placement="bottom"
                         rootClose={true}
                         shouldUpdatePosition={true}
                         show={false}
@@ -784,7 +784,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                     <OverlayDropdown
                       menuContainer={<body />}
                       onToggle={[Function]}
-                      placement="right"
+                      placement="bottom"
                       show={false}
                       toggle={
                         <TypeSpecificValue
@@ -913,7 +913,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                         container={<body />}
                         containerPadding={10}
                         onHide={[Function]}
-                        placement="right"
+                        placement="bottom"
                         rootClose={true}
                         shouldUpdatePosition={true}
                         show={false}
@@ -1010,7 +1010,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                     <OverlayDropdown
                       menuContainer={<body />}
                       onToggle={[Function]}
-                      placement="right"
+                      placement="bottom"
                       show={false}
                       toggle={
                         <TypeSpecificValue
@@ -1139,7 +1139,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                         container={<body />}
                         containerPadding={10}
                         onHide={[Function]}
-                        placement="right"
+                        placement="bottom"
                         rootClose={true}
                         shouldUpdatePosition={true}
                         show={false}
@@ -1227,7 +1227,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                     <OverlayDropdown
                       menuContainer={<body />}
                       onToggle={[Function]}
-                      placement="right"
+                      placement="bottom"
                       show={false}
                       toggle={
                         <TypeSpecificValue
@@ -1338,7 +1338,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                         container={<body />}
                         containerPadding={10}
                         onHide={[Function]}
-                        placement="right"
+                        placement="bottom"
                         rootClose={true}
                         shouldUpdatePosition={true}
                         show={false}
@@ -1435,7 +1435,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                     <OverlayDropdown
                       menuContainer={<body />}
                       onToggle={[Function]}
-                      placement="right"
+                      placement="bottom"
                       show={false}
                       toggle={
                         <TypeSpecificValue
@@ -1564,7 +1564,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                         container={<body />}
                         containerPadding={10}
                         onHide={[Function]}
-                        placement="right"
+                        placement="bottom"
                         rootClose={true}
                         shouldUpdatePosition={true}
                         show={false}
@@ -1661,7 +1661,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                     <OverlayDropdown
                       menuContainer={<body />}
                       onToggle={[Function]}
-                      placement="right"
+                      placement="bottom"
                       show={false}
                       toggle={
                         <TypeSpecificValue
@@ -1790,7 +1790,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                         container={<body />}
                         containerPadding={10}
                         onHide={[Function]}
-                        placement="right"
+                        placement="bottom"
                         rootClose={true}
                         shouldUpdatePosition={true}
                         show={false}
@@ -1878,7 +1878,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                     <OverlayDropdown
                       menuContainer={<body />}
                       onToggle={[Function]}
-                      placement="right"
+                      placement="bottom"
                       show={false}
                       toggle={
                         <TypeSpecificValue
@@ -1989,7 +1989,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                         container={<body />}
                         containerPadding={10}
                         onHide={[Function]}
-                        placement="right"
+                        placement="bottom"
                         rootClose={true}
                         shouldUpdatePosition={true}
                         show={false}
@@ -2086,7 +2086,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                     <OverlayDropdown
                       menuContainer={<body />}
                       onToggle={[Function]}
-                      placement="right"
+                      placement="bottom"
                       show={false}
                       toggle={
                         <TypeSpecificValue
@@ -2215,7 +2215,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                         container={<body />}
                         containerPadding={10}
                         onHide={[Function]}
-                        placement="right"
+                        placement="bottom"
                         rootClose={true}
                         shouldUpdatePosition={true}
                         show={false}


### PR DESCRIPTION
## Description
Prior to this change, when the action menu (either value or field) was
rendered, it was drawn right to the target element. This led to the
problem that it could be rendered outside of the viewport.

This change will render the menu below the target element.
When the menu is still rendered outside the scrollbar grows and you
can scroll to the desired action.

Fixes #6282

## How Has This Been Tested?
Scrolled to the very end and opened the value action. I was still able to scroll to the last
action.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
