### PR TITLE
Remove ability to add parameters to long typed fields

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/AggregationEventProcessorConfigEntity.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/entities/AggregationEventProcessorConfigEntity.java
@@ -73,10 +73,10 @@ public abstract class AggregationEventProcessorConfigEntity implements EventProc
     public abstract Optional<AggregationConditions> conditions();
 
     @JsonProperty(FIELD_SEARCH_WITHIN_MS)
-    public abstract ValueReference searchWithinMs();
+    public abstract long searchWithinMs();
 
     @JsonProperty(FIELD_EXECUTE_EVERY_MS)
-    public abstract ValueReference executeEveryMs();
+    public abstract long executeEveryMs();
 
     public static Builder builder() {
         return Builder.create();
@@ -109,10 +109,10 @@ public abstract class AggregationEventProcessorConfigEntity implements EventProc
         public abstract Builder conditions(@Nullable AggregationConditions conditions);
 
         @JsonProperty(FIELD_SEARCH_WITHIN_MS)
-        public abstract Builder searchWithinMs(ValueReference searchWithinMs);
+        public abstract Builder searchWithinMs(long searchWithinMs);
 
         @JsonProperty(FIELD_EXECUTE_EVERY_MS)
-        public abstract Builder executeEveryMs(ValueReference executeEveryMs);
+        public abstract Builder executeEveryMs(long executeEveryMs);
 
         public abstract AggregationEventProcessorConfigEntity build();
     }
@@ -143,8 +143,8 @@ public abstract class AggregationEventProcessorConfigEntity implements EventProc
                 .groupBy(groupBy())
                 .series(series())
                 .conditions(conditions().orElse(null))
-                .executeEveryMs(executeEveryMs().asLong(parameters))
-                .searchWithinMs(searchWithinMs().asLong(parameters))
+                .executeEveryMs(executeEveryMs())
+                .searchWithinMs(searchWithinMs())
                 .build();
     }
 

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessorConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessorConfig.java
@@ -201,8 +201,8 @@ public abstract class AggregationEventProcessorConfig implements EventProcessorC
             .groupBy(groupBy())
             .series(series())
             .conditions(conditions().orElse(null))
-            .executeEveryMs(ValueReference.of(executeEveryMs()))
-            .searchWithinMs(ValueReference.of(searchWithinMs()))
+            .executeEveryMs(executeEveryMs())
+            .searchWithinMs(searchWithinMs())
             .build();
     }
 

--- a/graylog2-server/src/test/java/org/graylog/events/contentpack/facade/EventDefinitionFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/contentpack/facade/EventDefinitionFacadeTest.java
@@ -168,8 +168,8 @@ public class EventDefinitionFacadeTest {
                 .groupBy(ImmutableList.of("project"))
                 .series(ImmutableList.of(serie))
                 .conditions(condition)
-                .executeEveryMs(ValueReference.of(122200000L))
-                .searchWithinMs(ValueReference.of(1231312123L))
+                .executeEveryMs(122200000L)
+                .searchWithinMs(1231312123L)
                 .build();
 
         final EventDefinitionEntity eventDefinitionEntity = EventDefinitionEntity.builder()


### PR DESCRIPTION
## Description
Prior to this change, there was a problem assigning a parameter to a
long typed field of event definition config. The web ui does not
really support long values yet.

This change will replace the ValueRefrence type of the fields
with long.

## How Has This Been Tested?
Created a content pack and tried to add a parameter to disabled fields.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
