### PR TITLE
Security update to netty-4.1.39

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <mongodb-driver.version>3.6.4</mongodb-driver.version>
         <mongojack.version>2.10.0</mongojack.version>
         <natty.version>0.13</natty.version>
-        <netty.version>4.1.38.Final</netty.version>
+        <netty.version>4.1.39.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.25.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>3.14.2</okhttp.version>
         <opencsv.version>2.3</opencsv.version>


### PR DESCRIPTION
Includes fixes for CVE-2019-9512, CVE-2019-9514, CVE-2019-9515 and
CVE-2019-9518. (HTTP/2 related issues)

See https://netty.io/news/2019/08/13/4-1-39-Final.html for details.
