### PR TITLE
Don't block server shutdown in FakeHttpMessageInput

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/RandomMessageTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/RandomMessageTransport.java
@@ -38,8 +38,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Random;
 
-import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.graylog2.inputs.random.generators.FakeHttpRawMessageGenerator.rateDeviation;
 
 public class RandomMessageTransport extends GeneratorTransport {
@@ -74,10 +72,11 @@ public class RandomMessageTransport extends GeneratorTransport {
 
             final RawMessage raw = new RawMessage(payload);
 
-            sleepUninterruptibly(rateDeviation(sleepMs, maxSleepDeviation, rand), MILLISECONDS);
+            Thread.sleep(rateDeviation(sleepMs, maxSleepDeviation, rand));
             return raw;
         } catch (JsonProcessingException e) {
             log.error("Unable to serialize generator state", e);
+        } catch (InterruptedException ignored) {
         }
         return null;
     }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/GeneratorTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/GeneratorTransport.java
@@ -47,6 +47,8 @@ public abstract class GeneratorTransport extends ThrottleableTransport {
     @Override
     public void doLaunch(final MessageInput input) throws MisfireException {
         generatorService = new AbstractExecutionThreadService() {
+            Thread runThread;
+
             @Override
             protected void run() throws Exception {
                 while (isRunning()) {
@@ -59,6 +61,16 @@ public abstract class GeneratorTransport extends ThrottleableTransport {
                         input.processRawMessage(rawMessage);
                     }
                 }
+            }
+
+            @Override
+            protected void startUp() throws Exception {
+                runThread = Thread.currentThread();
+            }
+
+            @Override
+            protected void triggerShutdown() {
+                runThread.interrupt();
             }
         };
 


### PR DESCRIPTION
A long sleep time for the Random HTTP message generator
will prevent the server from shutting down.

Excplicitely interrupt the AbstractExecutionThreadService runThread
to abort the sleep.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)

