### PR TITLE
Reset loading state when loading field statistics fails

### DIFF
--- a/graylog2-web-interface/src/components/field-analyzers/FieldStatistics.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/FieldStatistics.jsx
@@ -89,23 +89,25 @@ const FieldStatistics = createReactClass({
     if (this.isMounted) {
       this.setState({ statsLoadPending: statsLoadPending.set(field, true) });
       const promise = FieldStatisticsStore.getFieldStatistics(field);
-      promise.then((statistics) => {
-        this.setState({
-          fieldStatistics: fieldStatistics.set(field, statistics),
-          statsLoadPending: statsLoadPending.set(field, false),
-        });
-      }).catch((error) => {
-        // if the field has no statistics to display, remove it from the set of fields (which will cause the component to not render)
-        if (error.additional && error.additional.status === 400) {
+      promise.then(
+        (statistics) => {
           this.setState({
-            fieldStatistics: fieldStatistics.delete(field),
+            fieldStatistics: fieldStatistics.set(field, statistics),
             statsLoadPending: statsLoadPending.delete(field),
           });
-        } else {
-          UserNotification.error(`Loading field statistics failed with status: ${error}`,
-            'Could not load field statistics');
-        }
-      });
+        },
+        (error) => {
+          // If the field has no statistics to display, remove it from the set of fields
+          if (error.additional && error.additional.status === 400) {
+            this.setState({ fieldStatistics: fieldStatistics.delete(field) });
+          } else {
+            UserNotification.error(`Loading field statistics failed with status: ${error}`,
+              'Could not load field statistics');
+          }
+          // Reset loading state for the field after failure
+          this.setState({ statsLoadPending: statsLoadPending.delete(field) });
+        },
+      );
     }
   },
 

--- a/graylog2-web-interface/src/components/field-analyzers/FieldStatistics.jsx
+++ b/graylog2-web-interface/src/components/field-analyzers/FieldStatistics.jsx
@@ -203,7 +203,10 @@ const FieldStatistics = createReactClass({
               <Button bsSize="small" onClick={() => this._resetStatus()}><Icon name="close" /></Button>
             </AddToDashboardMenu>
           </div>
-          <h1>Field Statistics</h1>
+          <h1>
+            Field Statistics{' '}
+            {!statsLoadPending.isEmpty() && <Icon name="spinner" spin />}
+          </h1>
 
           <div className="table-responsive">
             <table className="table table-striped table-bordered table-hover table-condensed">


### PR DESCRIPTION
This PR resets the loading state when fetching statistics for a field fails.

@mehrenreich I added you to the reviewers in case you want to take a look as well :)

Refs #5836