### PR TITLE
Issue-5941 Add Rest resource to compare LDAP system password

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/audit/AuditEventTypes.java
+++ b/graylog2-server/src/main/java/org/graylog2/audit/AuditEventTypes.java
@@ -79,6 +79,7 @@ public class AuditEventTypes implements PluginAuditEventTypes {
     public static final String LDAP_CONFIGURATION_DELETE = PREFIX + "ldap_configuration:delete";
     public static final String LDAP_CONFIGURATION_UPDATE = PREFIX + "ldap_configuration:update";
     public static final String LDAP_GROUP_MAPPING_UPDATE = PREFIX + "ldap_group_mapping:update";
+    public static final String LDAP_SYSTEM_PASSWORD_VALIDATE = PREFIX + "ldap_system_password:validate";
     public static final String LOAD_BALANCER_STATUS_UPDATE = PREFIX + "load_balancer_status:update";
     public static final String LOG_LEVEL_UPDATE = PREFIX + "log_level:update";
     public static final String LOOKUP_ADAPTER_CREATE = PREFIX + "lut_adapter:create";
@@ -205,6 +206,7 @@ public class AuditEventTypes implements PluginAuditEventTypes {
             .add(LDAP_CONFIGURATION_DELETE)
             .add(LDAP_CONFIGURATION_UPDATE)
             .add(LDAP_GROUP_MAPPING_UPDATE)
+            .add(LDAP_SYSTEM_PASSWORD_VALIDATE)
             .add(LOAD_BALANCER_STATUS_UPDATE)
             .add(LOG_LEVEL_UPDATE)
             .add(LOOKUP_ADAPTER_CREATE)

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/ldap/requests/LdapSystemPasswordValidationRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/ldap/requests/LdapSystemPasswordValidationRequest.java
@@ -1,0 +1,36 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.models.system.ldap.requests;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+
+@JsonAutoDetect
+@AutoValue
+@WithBeanGetter
+public abstract class LdapSystemPasswordValidationRequest {
+    @JsonProperty
+    public abstract String systemPassword();
+
+    @JsonCreator
+    public static LdapSystemPasswordValidationRequest create(@JsonProperty("system_password") String systemPassword) {
+        return new AutoValue_LdapSystemPasswordValidationRequest(systemPassword);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/ldap/responses/LdapSystemPasswordValidationResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/ldap/responses/LdapSystemPasswordValidationResponse.java
@@ -1,0 +1,36 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.models.system.ldap.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+
+@JsonAutoDetect
+@AutoValue
+@WithBeanGetter
+public abstract class LdapSystemPasswordValidationResponse {
+    @JsonProperty
+    public abstract boolean systemPasswordMatches();
+
+    @JsonCreator
+    public static LdapSystemPasswordValidationResponse create(@JsonProperty("system_password_matches") boolean enabled) {
+        return new AutoValue_LdapSystemPasswordValidationResponse(enabled);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ldap/LdapResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ldap/LdapResource.java
@@ -340,6 +340,7 @@ public class LdapResource extends RestResource {
     @Path("/validate")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
+    @AuditEvent(type = AuditEventTypes.LDAP_SYSTEM_PASSWORD_VALIDATE)
     public LdapSystemPasswordValidationResponse validateSystemPassword(LdapSystemPasswordValidationRequest request)
             throws BadRequestException {
         final LdapSettings ldapSettings = ldapSettingsService.load();

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/ldap/LdapResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/ldap/LdapResourceTest.java
@@ -1,0 +1,114 @@
+package org.graylog2.rest.resources.system.ldap;
+
+import org.graylog2.rest.models.system.ldap.requests.LdapSystemPasswordValidationRequest;
+import org.graylog2.rest.models.system.ldap.responses.LdapSystemPasswordValidationResponse;
+import org.graylog2.security.ldap.LdapConnector;
+import org.graylog2.security.ldap.LdapSettingsImpl;
+import org.graylog2.security.ldap.LdapSettingsService;
+import org.graylog2.shared.bindings.GuiceInjectorHolder;
+import org.graylog2.shared.security.ldap.LdapSettings;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import javax.ws.rs.BadRequestException;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LdapResourceTest {
+
+    private static String VALID_PASSWORD = "1234";
+    private static String INVALID_PASSWORD = "4321";
+
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    @Mock
+    private LdapSettingsService ldapSettingsService;
+
+    @Mock
+    private LdapSettingsImpl.Factory ldapSettingsFactory;
+
+    @Mock
+    private LdapConnector ldapConnector;
+
+    private LdapResource resource;
+
+    public LdapResourceTest(){
+        GuiceInjectorHolder.createInjector(Collections.emptyList());
+    }
+
+    @Before
+    public void setUp() {
+        this.resource = new LdapResource(this.ldapSettingsService, this.ldapSettingsFactory, this.ldapConnector);
+    }
+
+    @Test
+    public void testValidateSystemPasswordThrowsExceptionIfLdapIsNotConfigured() throws BadRequestException {
+        when(this.ldapSettingsService.load()).thenReturn(null);
+        LdapSystemPasswordValidationRequest request = this.buildRequest(VALID_PASSWORD);
+
+        expectedException.expect(BadRequestException.class);
+
+        this.resource.validateSystemPassword(request);
+    }
+
+    @Test
+    public void testValidateSystemPasswordThrowsExceptionIfLdapIsDisabled() throws BadRequestException {
+        LdapSettings disabledLdapSettings = this.getLdapSettings(false, VALID_PASSWORD);
+        when(this.ldapSettingsService.load()).thenReturn(disabledLdapSettings);
+        LdapSystemPasswordValidationRequest request = this.buildRequest(VALID_PASSWORD);
+
+        expectedException.expect(BadRequestException.class);
+
+        this.resource.validateSystemPassword(request);
+    }
+
+    @Test
+    public void testValidateSystemPasswordWithValidPassword() throws BadRequestException {
+        LdapSettings enabledLdapSettings = this.getLdapSettings(true, VALID_PASSWORD);
+        when(this.ldapSettingsService.load()).thenReturn(enabledLdapSettings);
+        LdapSystemPasswordValidationRequest request = this.buildRequest(VALID_PASSWORD);
+
+        LdapSystemPasswordValidationResponse response = this.resource.validateSystemPassword(request);
+
+        assertThat(response.systemPasswordMatches()).isTrue();
+    }
+
+    @Test
+    public void testValidateSystemPasswordWithInvalidPassword() throws BadRequestException {
+        LdapSettings enabledLdapSettings = this.getLdapSettings(true, VALID_PASSWORD);
+        when(this.ldapSettingsService.load()).thenReturn(enabledLdapSettings);
+        LdapSystemPasswordValidationRequest request = this.buildRequest(INVALID_PASSWORD);
+
+        LdapSystemPasswordValidationResponse response = this.resource.validateSystemPassword(request);
+
+        assertThat(response.systemPasswordMatches()).isFalse();
+    }
+
+    private LdapSystemPasswordValidationRequest buildRequest(String password) {
+        return new LdapSystemPasswordValidationRequest() {
+            @Override
+            public String systemPassword() {
+                return password;
+            }
+        };
+    }
+
+    private LdapSettings getLdapSettings(boolean enabled, String password) {
+        LdapSettings ldapSettings = mock(LdapSettings.class);
+        when(ldapSettings.isEnabled()).thenReturn(enabled);
+        when(ldapSettings.getSystemPassword()).thenReturn(password);
+        return ldapSettings;
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/rest/resources/system/ldap/LdapResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/rest/resources/system/ldap/LdapResourceTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.rest.resources.system.ldap;
 
 import org.graylog2.rest.models.system.ldap.requests.LdapSystemPasswordValidationRequest;


### PR DESCRIPTION
Add a new API endpoint to check if the provided LDAP password in the request matches the one stored in graylog configuration. Useful to "sanity-check" the LDAP configuration when your password policy forces to update the password quite often.

## Description
New API endpoint under /api/system/ldap/validate
Method: POST
Payload format: `{"system_password":"xxxxx"}`
Response format: `{"system_password_matches":true|false}`
In case of LDAP not configured or disabled a BadRequest response will be returned (400).

## Motivation and Context
Implements #5941 

## How Has This Been Tested?
Just make some POST requests to the new /api/system/ldap/validate endpoint with different ldap scenarios and verify it does what is should.

To add tests to the new endpoint I had to move the dependency injection to a constructor.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
