### PR TITLE
Add elasticsearch_discovery_default_scheme to config

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/JestClientProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/JestClientProvider.java
@@ -61,6 +61,7 @@ public class JestClientProvider implements Provider<JestClient> {
                               @Named("elasticsearch_discovery_enabled") boolean discoveryEnabled,
                               @Named("elasticsearch_discovery_filter") @Nullable String discoveryFilter,
                               @Named("elasticsearch_discovery_frequency") Duration discoveryFrequency,
+                              @Named("elasticsearch_discovery_default_scheme") String defaultSchemeForDiscoveredNodes,
                               @Named("elasticsearch_compression_enabled") boolean compressionEnabled,
                               ObjectMapper objectMapper) {
         this.factory = new JestClientFactory() {
@@ -108,6 +109,7 @@ public class JestClientProvider implements Provider<JestClient> {
                 .discoveryEnabled(discoveryEnabled)
                 .discoveryFilter(discoveryFilter)
                 .discoveryFrequency(discoveryFrequency.toSeconds(), TimeUnit.SECONDS)
+                .defaultSchemeForDiscoveredNodes(defaultSchemeForDiscoveredNodes)
                 .preemptiveAuthTargetHosts(preemptiveAuthHosts)
                 .requestCompressionEnabled(compressionEnabled)
                 .retryHandler(new GraylogJestRetryHandler(elasticsearchMaxRetries))

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
@@ -57,7 +57,7 @@ public class ElasticsearchClientConfiguration {
     @Parameter(value = "elasticsearch_discovery_filter")
     String discoveryFilter = null;
 
-    @Parameter(value = "elasticsearch_discovery_frequency", validator = PositiveDurationValidator.class)
+    @Parameter(value = "elasticsearch_discovery_frequency", validators = {PositiveDurationValidator.class})
     Duration discoveryFrequency = Duration.seconds(30L);
 
     @Parameter(value = "elasticsearch_discovery_default_scheme", validators = {HttpOrHttpsSchemeValidator.class})

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
@@ -59,6 +59,9 @@ public class ElasticsearchClientConfiguration {
     @Parameter(value = "elasticsearch_discovery_frequency", validator = PositiveDurationValidator.class)
     Duration discoveryFrequency = Duration.seconds(30L);
 
+    @Parameter(value = "elasticsearch_discovery_default_scheme")
+    String defaultSchemeForDiscoveredNodes = "http";
+
     @Parameter(value = "elasticsearch_compression_enabled")
     boolean compressionEnabled = false;
 

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
@@ -21,6 +21,7 @@ import com.github.joschi.jadconfig.util.Duration;
 import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
 import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 import org.graylog2.configuration.converters.URIListConverter;
+import org.graylog2.configuration.validators.HttpOrHttpsSchemeValidator;
 import org.graylog2.configuration.validators.ListOfURIsWithHostAndSchemeValidator;
 import org.graylog2.configuration.validators.NonEmptyListValidator;
 
@@ -59,7 +60,7 @@ public class ElasticsearchClientConfiguration {
     @Parameter(value = "elasticsearch_discovery_frequency", validator = PositiveDurationValidator.class)
     Duration discoveryFrequency = Duration.seconds(30L);
 
-    @Parameter(value = "elasticsearch_discovery_default_scheme")
+    @Parameter(value = "elasticsearch_discovery_default_scheme", validators = {HttpOrHttpsSchemeValidator.class})
     String defaultSchemeForDiscoveredNodes = "http";
 
     @Parameter(value = "elasticsearch_compression_enabled")

--- a/graylog2-server/src/main/java/org/graylog2/configuration/validators/HttpOrHttpsSchemeValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/validators/HttpOrHttpsSchemeValidator.java
@@ -1,0 +1,19 @@
+package org.graylog2.configuration.validators;
+
+import com.github.joschi.jadconfig.ValidationException;
+import com.github.joschi.jadconfig.Validator;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class HttpOrHttpsSchemeValidator implements Validator<String> {
+
+    private static final List<String> validScheme = Arrays.asList("http", "https");
+
+    @Override
+    public void validate(String name, String value) throws ValidationException {
+        if (!validScheme.contains(value.toLowerCase())) {
+            throw new ValidationException(String.format("Parameter " + name + " must be one of [%s]", String.join(",")));
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/configuration/validators/HttpOrHttpsSchemeValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/validators/HttpOrHttpsSchemeValidator.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.configuration.validators;
 
 import com.github.joschi.jadconfig.ValidationException;

--- a/graylog2-server/src/main/java/org/graylog2/configuration/validators/HttpOrHttpsSchemeValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/validators/HttpOrHttpsSchemeValidator.java
@@ -21,6 +21,7 @@ import com.github.joschi.jadconfig.Validator;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 public class HttpOrHttpsSchemeValidator implements Validator<String> {
 
@@ -28,8 +29,8 @@ public class HttpOrHttpsSchemeValidator implements Validator<String> {
 
     @Override
     public void validate(String name, String value) throws ValidationException {
-        if (!validScheme.contains(value.toLowerCase())) {
-            throw new ValidationException(String.format("Parameter " + name + " must be one of [%s]", String.join(",")));
+        if (!validScheme.contains(value.toLowerCase(Locale.ENGLISH))) {
+            throw new ValidationException(String.format(Locale.ENGLISH, "Parameter " + name + " must be one of [%s]", String.join(",")));
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/configuration/validators/HttpOrHttpsSchemeValidator.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/validators/HttpOrHttpsSchemeValidator.java
@@ -30,7 +30,7 @@ public class HttpOrHttpsSchemeValidator implements Validator<String> {
     @Override
     public void validate(String name, String value) throws ValidationException {
         if (!validScheme.contains(value.toLowerCase(Locale.ENGLISH))) {
-            throw new ValidationException(String.format(Locale.ENGLISH, "Parameter " + name + " must be one of [%s]", String.join(",")));
+            throw new ValidationException(String.format(Locale.ENGLISH, "Parameter " + name + " must be one of [%s]", String.join(",", validScheme)));
         }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchInstance.java
@@ -125,6 +125,7 @@ public class ElasticsearchInstance extends ExternalResource {
                 false,
                 null,
                 Duration.seconds(60),
+                "http",
                 false,
                 new ObjectMapperProvider().get()
         ).get();

--- a/graylog2-server/src/test/java/org/graylog2/bindings/providers/JestClientProviderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/bindings/providers/JestClientProviderTest.java
@@ -41,6 +41,7 @@ public class JestClientProviderTest {
                 false,
                 null,
                 Duration.seconds(5L),
+                "http",
                 false,
                 new ObjectMapper()
         );
@@ -62,6 +63,7 @@ public class JestClientProviderTest {
                 false,
                 null,
                 Duration.seconds(5L),
+                "http",
                 false,
                 new ObjectMapper()
         );
@@ -83,6 +85,7 @@ public class JestClientProviderTest {
                 false,
                 null,
                 Duration.seconds(5L),
+                "http",
                 false,
                 new ObjectMapper()
         );

--- a/graylog2-server/src/test/java/org/graylog2/configuration/ElasticsearchClientConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/ElasticsearchClientConfigurationTest.java
@@ -45,6 +45,7 @@ public class ElasticsearchClientConfigurationTest {
                 .put("elasticsearch_discovery_enabled", "true")
                 .put("elasticsearch_discovery_filter", "foo:bar")
                 .put("elasticsearch_discovery_frequency", "1m")
+                .put("elasticsearch_discovery_default_scheme", "http")
                 .put("elasticsearch_compression_enabled", "true")
                 .build();
         final InMemoryRepository repository = new InMemoryRepository(configMap);
@@ -62,6 +63,7 @@ public class ElasticsearchClientConfigurationTest {
         assertThat(configuration.discoveryEnabled).isTrue();
         assertThat(configuration.discoveryFilter).isEqualTo("foo:bar");
         assertThat(configuration.discoveryFrequency).isEqualTo(Duration.minutes(1L));
+        assertThat(configuration.defaultSchemeForDiscoveredNodes).isEqualTo("http");
         assertThat(configuration.compressionEnabled).isTrue();
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/configuration/ElasticsearchClientConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/ElasticsearchClientConfigurationTest.java
@@ -138,4 +138,13 @@ public class ElasticsearchClientConfigurationTest {
         assertThatExceptionOfType(ParameterException.class).isThrownBy(jadConfig::process)
                 .withMessage("Couldn't convert value for parameter \"elasticsearch_discovery_frequency\"");
     }
+
+    @Test
+    public void jadConfigFailsWithInvalidDiscoveryDefaultScheme() throws Exception {
+        final InMemoryRepository repository = new InMemoryRepository(Collections.singletonMap("elasticsearch_discovery_default_scheme", "foobar"));
+        final ElasticsearchClientConfiguration configuration = new ElasticsearchClientConfiguration();
+        JadConfig jadConfig = new JadConfig(repository, configuration);
+        assertThatExceptionOfType(ValidationException.class).isThrownBy(jadConfig::process)
+                .withMessage("Parameter elasticsearch_discovery_default_scheme must be one of [http,https]");
+    }
 }

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -238,7 +238,7 @@ plugin_dir = plugin
 
 # Set the default scheme when connecting to Elasticsearch discovered nodes
 #
-# Default: http
+# Default: http (available options: http, https)
 #elasticsearch_discovery_default_scheme = http
 
 # Enable payload compression for Elasticsearch requests.

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -236,6 +236,11 @@ plugin_dir = plugin
 # Default: 30s
 # elasticsearch_discovery_frequency = 30s
 
+# Set the default scheme when connecting to Elasticsearch discovered nodes
+#
+# Default: http
+#elasticsearch_discovery_default_scheme = http
+
 # Enable payload compression for Elasticsearch requests.
 #
 # Default: false


### PR DESCRIPTION
## Description
Adds a new elasticsearch_discovery_default_scheme option in graylog config file.

## Motivation and Context
Implements #6280 

## How Has This Been Tested?
During graylog bootstrap ensure http (default scheme) is passed to JestClientProvider when no config provided and the one in the config file is used when specified.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
