### PR TITLE
Ignore case when sorting Inputs

### DIFF
--- a/graylog2-web-interface/src/components/inputs/InputsList.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputsList.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Row, Col } from 'react-bootstrap';
-import naturalSort from 'javascript-natural-sort';
+import { naturalSortIgnoreCase } from 'util/SortUtils';
 
 import EntityList from 'components/common/EntityList';
 import { IfPermitted, Spinner, SearchForm } from 'components/common';
@@ -56,10 +56,10 @@ const InputsList = createReactClass({
     const { inputs } = state;
     const globalInputs = inputs
       .filter(input => input.global === true)
-      .sort((inputA, inputB) => naturalSort(inputA.title, inputB.title));
+      .sort((inputA, inputB) => naturalSortIgnoreCase(inputA.title, inputB.title));
     let localInputs = inputs
       .filter(input => input.global === false)
-      .sort((inputA, inputB) => naturalSort(inputA.title, inputB.title));
+      .sort((inputA, inputB) => naturalSortIgnoreCase(inputA.title, inputB.title));
 
     if (this.props.node) {
       localInputs = localInputs.filter(input => input.node === this.props.node.node_id);


### PR DESCRIPTION
## Motivation and Context
Fixes #5921

## How Has This Been Tested?
Create some inputs starting with uppercase and lowercase, they were sorted as described in the issue. With this changes the case wont matter in sorting.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
