### PR TITLE
Increase height of navigation to show collapsable content

### DIFF
--- a/graylog2-web-interface/public/stylesheets/bootstrap-config.json
+++ b/graylog2-web-interface/public/stylesheets/bootstrap-config.json
@@ -142,7 +142,7 @@
     "@navbar-border-radius": "@border-radius-base",
     "@navbar-padding-horizontal": "floor((@grid-gutter-width / 2))",
     "@navbar-padding-vertical": "((@navbar-height - @line-height-computed) / 2)",
-    "@navbar-collapse-max-height": "340px",
+    "@navbar-collapse-max-height": "90vh",
     "@navbar-default-color": "#777",
     "@navbar-default-bg": "#f8f8f8",
     "@navbar-default-border": "darken(@navbar-default-bg, 6.5%)",

--- a/graylog2-web-interface/src/components/throughput/GlobalThroughput.css
+++ b/graylog2-web-interface/src/components/throughput/GlobalThroughput.css
@@ -53,6 +53,7 @@
   :local(.total-throughput__content),
   :local(.total-throughput) > a {
     height: auto;
+    display: block;
   }
 
   :local(.total-throughput__content)::before {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed max-height of 340px to 90vh to allow for the dropdown navigation to show as much as possible.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #6328

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/122591/63328006-9c058f00-c32f-11e9-8cf9-cea7388c64a3.png)
![NavCollapse](https://user-images.githubusercontent.com/122591/63328206-06b6ca80-c330-11e9-9b41-b4a417f3ae8b.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
