### PR TITLE
Migrate EmailConfiguration to ClusterConfig

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/audit/AuditEventTypes.java
+++ b/graylog2-server/src/main/java/org/graylog2/audit/AuditEventTypes.java
@@ -49,6 +49,7 @@ public class AuditEventTypes implements PluginAuditEventTypes {
     public static final String DASHBOARD_WIDGET_DELETE = PREFIX + "dashboard_widget:delete";
     public static final String DASHBOARD_WIDGET_POSITIONS_UPDATE = PREFIX + "dashboard_widget_positions:update";
     public static final String DASHBOARD_WIDGET_UPDATE = PREFIX + "dashboard_widget:update";
+    public static final String EMAIL_CONFIGURATION_UPDATE = PREFIX + "email_configuration:update";
     public static final String ES_INDEX_CLOSE = PREFIX + "es_index:close";
     public static final String ES_INDEX_CREATE = PREFIX + "es_index:create";
     public static final String ES_INDEX_DELETE = PREFIX + "es_index:delete";
@@ -175,6 +176,7 @@ public class AuditEventTypes implements PluginAuditEventTypes {
             .add(DASHBOARD_WIDGET_DELETE)
             .add(DASHBOARD_WIDGET_POSITIONS_UPDATE)
             .add(DASHBOARD_WIDGET_UPDATE)
+            .add(EMAIL_CONFIGURATION_UPDATE)
             .add(ES_INDEX_CLOSE)
             .add(ES_INDEX_CREATE)
             .add(ES_INDEX_DELETE)

--- a/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
@@ -23,6 +23,8 @@ import org.graylog2.cluster.NodeService;
 import org.graylog2.cluster.NodeServiceImpl;
 import org.graylog2.dashboards.DashboardService;
 import org.graylog2.dashboards.DashboardServiceImpl;
+import org.graylog2.email.configuration.EmailConfigurationService;
+import org.graylog2.email.configuration.EmailConfigurationServiceImpl;
 import org.graylog2.indexer.IndexFailureService;
 import org.graylog2.indexer.IndexFailureServiceImpl;
 import org.graylog2.indexer.ranges.IndexRangeService;
@@ -68,5 +70,6 @@ public class PersistenceServicesBindings extends AbstractModule {
         bind(SavedSearchService.class).to(SavedSearchServiceImpl.class);
         bind(LdapSettingsService.class).to(LdapSettingsServiceImpl.class);
         bind(MongoDBSessionService.class).to(MongoDBSessionServiceImpl.class);
+        bind(EmailConfigurationService.class).to(EmailConfigurationServiceImpl.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/email/configuration/EmailConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/email/configuration/EmailConfiguration.java
@@ -1,0 +1,98 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.email.configuration;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+
+import javax.annotation.Nullable;
+import java.net.URI;
+
+@JsonAutoDetect
+@AutoValue
+@WithBeanGetter
+public abstract class EmailConfiguration {
+
+    @JsonProperty
+    public abstract boolean enabled();
+
+    @JsonProperty
+    @Nullable
+    public abstract String hostname();
+
+    @JsonProperty
+    public abstract int port();
+
+    @JsonProperty
+    public abstract boolean useAuth();
+
+    @JsonProperty
+    public abstract boolean useTls();
+
+    @JsonProperty
+    public abstract boolean useSsl();
+
+    @JsonProperty
+    @Nullable
+    public abstract String username();
+
+    @JsonProperty
+    @Nullable
+    public abstract String password();
+
+    @JsonProperty
+    @Nullable
+    public abstract String fromEmail();
+
+    @JsonProperty
+    @Nullable
+    public abstract URI webInterfaceUri();
+
+    @JsonCreator
+    public static EmailConfiguration create(@JsonProperty("enabled") boolean enabled,
+                                            @JsonProperty("hostname") String hostname,
+                                            @JsonProperty("port") int port,
+                                            @JsonProperty("use_auth") boolean useAuth,
+                                            @JsonProperty("use_tls") boolean useTls,
+                                            @JsonProperty("use_ssl") boolean useSsl,
+                                            @JsonProperty("username") String username,
+                                            @JsonProperty("password") String password,
+                                            @JsonProperty("from_email") String fromEmail,
+                                            @JsonProperty("web_interface_uri") URI webInterfaceUri) {
+        return new AutoValue_EmailConfiguration(
+                enabled, hostname, port, useAuth, useTls, useSsl, username, password, fromEmail, webInterfaceUri
+        );
+    }
+
+    public static EmailConfiguration create() {
+        return create(false,
+                null,
+                25,
+                false,
+                true,
+                false,
+                null,
+                null,
+                null,
+                null);
+    }
+
+}
+

--- a/graylog2-server/src/main/java/org/graylog2/email/configuration/EmailConfigurationService.java
+++ b/graylog2-server/src/main/java/org/graylog2/email/configuration/EmailConfigurationService.java
@@ -1,0 +1,24 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.email.configuration;
+
+public interface EmailConfigurationService {
+
+    void save(EmailConfiguration emailConfiguration);
+
+    EmailConfiguration load();
+}

--- a/graylog2-server/src/main/java/org/graylog2/email/configuration/EmailConfigurationServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/email/configuration/EmailConfigurationServiceImpl.java
@@ -1,0 +1,40 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.email.configuration;
+
+import org.graylog2.plugin.cluster.ClusterConfigService;
+
+import javax.inject.Inject;
+
+public class EmailConfigurationServiceImpl implements EmailConfigurationService {
+
+    private ClusterConfigService clusterConfigService;
+
+    @Inject
+    public EmailConfigurationServiceImpl(ClusterConfigService clusterConfigService) {
+        this.clusterConfigService = clusterConfigService;
+    }
+    @Override
+    public void save(EmailConfiguration emailConfiguration) {
+        clusterConfigService.write(emailConfiguration);
+    }
+
+    @Override
+    public EmailConfiguration load() {
+        return clusterConfigService.get(EmailConfiguration.class);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
@@ -44,5 +44,6 @@ public class MigrationsModule extends PluginModule {
         addMigration(V20191129134600_CreateInitialUrlWhitelist.class);
         addMigration(V20191219090834_AddSourcesPage.class);
         addMigration(V20200102140000_UnifyEventSeriesId.class);
+        addMigration(V20190823000000_EmailConfigMigration.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
@@ -44,6 +44,6 @@ public class MigrationsModule extends PluginModule {
         addMigration(V20191129134600_CreateInitialUrlWhitelist.class);
         addMigration(V20191219090834_AddSourcesPage.class);
         addMigration(V20200102140000_UnifyEventSeriesId.class);
-        addMigration(V20190823000000_EmailConfigMigration.class);
+        addMigration(V20200214000000_EmailConfigMigration.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20190823000000_EmailConfigMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20190823000000_EmailConfigMigration.java
@@ -1,0 +1,65 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.migrations;
+
+import org.graylog2.email.configuration.EmailConfiguration;
+import org.graylog2.email.configuration.EmailConfigurationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.time.ZonedDateTime;
+
+public class V20190823000000_EmailConfigMigration extends Migration {
+    private static final Logger LOG = LoggerFactory.getLogger(V20190823000000_EmailConfigMigration.class);
+
+    private org.graylog2.configuration.EmailConfiguration oldEmailConfiguration;
+    private EmailConfigurationService emailConfigurationService;
+
+    @Inject
+    public V20190823000000_EmailConfigMigration(org.graylog2.configuration.EmailConfiguration oldEmailConfiguration,
+                                                EmailConfigurationService emailConfigurationService) {
+        this.oldEmailConfiguration = oldEmailConfiguration;
+        this.emailConfigurationService = emailConfigurationService;
+    }
+
+    @Override
+    public ZonedDateTime createdAt() {
+        return ZonedDateTime.parse("2019-08-23T00:00:00Z");
+    }
+
+    @Override
+    public void upgrade() {
+        final EmailConfiguration emailConfiguration = emailConfigurationService.load();
+        if (emailConfiguration == null) {
+            final EmailConfiguration toMigrateEmailConfiguration = EmailConfiguration.create(
+                    oldEmailConfiguration.isEnabled(),
+                    oldEmailConfiguration.getHostname(),
+                    oldEmailConfiguration.getPort(),
+                    oldEmailConfiguration.isUseAuth(),
+                    oldEmailConfiguration.isUseTls(),
+                    oldEmailConfiguration.isUseSsl(),
+                    oldEmailConfiguration.getUsername(),
+                    oldEmailConfiguration.getPassword(),
+                    oldEmailConfiguration.getFromEmail(),
+                    oldEmailConfiguration.getWebInterfaceUri()
+            );
+            emailConfigurationService.save(toMigrateEmailConfiguration);
+            LOG.info("Migrated EmailConfiguration: {}", toMigrateEmailConfiguration);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20200214000000_EmailConfigMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20200214000000_EmailConfigMigration.java
@@ -24,14 +24,14 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import java.time.ZonedDateTime;
 
-public class V20190823000000_EmailConfigMigration extends Migration {
-    private static final Logger LOG = LoggerFactory.getLogger(V20190823000000_EmailConfigMigration.class);
+public class V20200214000000_EmailConfigMigration extends Migration {
+    private static final Logger LOG = LoggerFactory.getLogger(V20200214000000_EmailConfigMigration.class);
 
     private org.graylog2.configuration.EmailConfiguration oldEmailConfiguration;
     private EmailConfigurationService emailConfigurationService;
 
     @Inject
-    public V20190823000000_EmailConfigMigration(org.graylog2.configuration.EmailConfiguration oldEmailConfiguration,
+    public V20200214000000_EmailConfigMigration(org.graylog2.configuration.EmailConfiguration oldEmailConfiguration,
                                                 EmailConfigurationService emailConfigurationService) {
         this.oldEmailConfiguration = oldEmailConfiguration;
         this.emailConfigurationService = emailConfigurationService;
@@ -39,7 +39,7 @@ public class V20190823000000_EmailConfigMigration extends Migration {
 
     @Override
     public ZonedDateTime createdAt() {
-        return ZonedDateTime.parse("2019-08-23T00:00:00Z");
+        return ZonedDateTime.parse("2020-02-14T00:00:00Z");
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/email/EmailConfigResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/email/EmailConfigResource.java
@@ -22,6 +22,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
+import org.graylog2.audit.AuditEventTypes;
+import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.email.configuration.EmailConfiguration;
 import org.graylog2.email.configuration.EmailConfigurationService;
 import org.graylog2.shared.rest.resources.RestResource;
@@ -63,6 +65,7 @@ public class EmailConfigResource extends RestResource {
     @RequiresPermissions(RestPermissions.EMAIL_EDIT)
     @ApiOperation("Update the Email configuration")
     @Consumes(MediaType.APPLICATION_JSON)
+    @AuditEvent(type = AuditEventTypes.EMAIL_CONFIGURATION_UPDATE)
     public void updateEmailConfig(@ApiParam(name = "JSON body", required = true)
                                   @Valid @NotNull EmailConfiguration request) {
         emailConfigurationService.save(request);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/email/EmailConfigResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/email/EmailConfigResource.java
@@ -1,0 +1,71 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.resources.system.email;
+
+import com.codahale.metrics.annotation.Timed;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.apache.shiro.authz.annotation.RequiresPermissions;
+import org.graylog2.email.configuration.EmailConfiguration;
+import org.graylog2.email.configuration.EmailConfigurationService;
+import org.graylog2.shared.rest.resources.RestResource;
+import org.graylog2.shared.security.RestPermissions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+
+@RequiresAuthentication
+
+@Api(value = "System/Email", description = "Email configuration")
+@Path("/system/email")
+public class EmailConfigResource extends RestResource {
+    private static final Logger LOG = LoggerFactory.getLogger(EmailConfigResource.class);
+
+    private EmailConfigurationService emailConfigurationService;
+
+    @Inject
+    public EmailConfigResource(EmailConfigurationService emailConfigurationService) {
+        this.emailConfigurationService = emailConfigurationService;
+    }
+
+    @GET
+    @Timed
+    @RequiresPermissions(RestPermissions.EMAIL_READ)
+    @ApiOperation("Get the Email configuration")
+    @Produces(MediaType.APPLICATION_JSON)
+    public EmailConfiguration getEmailConfig() {
+        return emailConfigurationService.load();
+    }
+
+    @PUT
+    @Timed
+    @RequiresPermissions(RestPermissions.EMAIL_EDIT)
+    @ApiOperation("Update the Email configuration")
+    @Consumes(MediaType.APPLICATION_JSON)
+    public void updateEmailConfig(@ApiParam(name = "JSON body", required = true)
+                                  @Valid @NotNull EmailConfiguration request) {
+        emailConfigurationService.save(request);
+    }
+
+}

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
@@ -52,6 +52,8 @@ public class RestPermissions implements PluginPermissions {
     public static final String DECORATORS_READ = "decorators:read";
     public static final String DEFLECTOR_CYCLE = "deflector:cycle";
     public static final String DEFLECTOR_READ = "deflector:read";
+    public static final String EMAIL_EDIT = "email:edit";
+    public static final String EMAIL_READ = "email:read";
     public static final String EVENT_DEFINITIONS_CREATE = "eventdefinitions:create";
     public static final String EVENT_DEFINITIONS_DELETE = "eventdefinitions:delete";
     public static final String EVENT_DEFINITIONS_EDIT = "eventdefinitions:edit";
@@ -168,6 +170,8 @@ public class RestPermissions implements PluginPermissions {
         .add(create(DECORATORS_READ, ""))
         .add(create(DEFLECTOR_CYCLE, ""))
         .add(create(DEFLECTOR_READ, ""))
+        .add(create(EMAIL_EDIT, ""))
+        .add(create(EMAIL_READ, ""))
         .add(create(EVENT_DEFINITIONS_CREATE, ""))
         .add(create(EVENT_DEFINITIONS_DELETE, ""))
         .add(create(EVENT_DEFINITIONS_EDIT, ""))

--- a/graylog2-server/src/test/java/org/graylog2/alarmcallbacks/EmailAlarmCallbackTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alarmcallbacks/EmailAlarmCallbackTest.java
@@ -19,7 +19,8 @@ package org.graylog2.alarmcallbacks;
 import com.google.common.collect.ImmutableMap;
 import org.graylog2.alerts.AlertSender;
 import org.graylog2.alerts.EmailRecipients;
-import org.graylog2.configuration.EmailConfiguration;
+import org.graylog2.email.configuration.EmailConfiguration;
+import org.graylog2.email.configuration.EmailConfigurationService;
 import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.configuration.ConfigurationException;
@@ -47,6 +48,7 @@ public class EmailAlarmCallbackTest {
     private NodeId nodeId = mock(NodeId.class);
     private EmailRecipients.Factory emailRecipientsFactory = mock(EmailRecipients.Factory.class);
     private UserService userService = mock(UserService.class);
+    private EmailConfigurationService emailConfigurationService = mock(EmailConfigurationService.class);
     private EmailConfiguration emailConfiguration = mock(EmailConfiguration.class);
     private org.graylog2.Configuration graylogConfig = mock(org.graylog2.Configuration.class);
 
@@ -54,8 +56,9 @@ public class EmailAlarmCallbackTest {
 
     @Before
     public void setUp() throws Exception {
+        when(emailConfigurationService.load()).thenReturn(emailConfiguration);
         alarmCallback = new EmailAlarmCallback(alertSender, notificationService, nodeId, emailRecipientsFactory,
-                userService, emailConfiguration, graylogConfig);
+                userService, emailConfigurationService, graylogConfig);
     }
 
     @Test
@@ -81,7 +84,7 @@ public class EmailAlarmCallbackTest {
                 "email_receivers", Collections.emptyList()
         );
         final Configuration configuration = new Configuration(configMap);
-        when(emailConfiguration.getFromEmail()).thenReturn("default@sender.org");
+        when(emailConfiguration.fromEmail()).thenReturn("default@sender.org");
 
         alarmCallback.initialize(configuration);
         alarmCallback.checkConfiguration();
@@ -98,7 +101,7 @@ public class EmailAlarmCallbackTest {
         final Configuration configuration = new Configuration(configMap);
         alarmCallback.initialize(configuration);
 
-        when(emailConfiguration.getFromEmail()).thenReturn("");
+        when(emailConfiguration.fromEmail()).thenReturn("");
 
         expectedException.expect(ConfigurationException.class);
         expectedException.expectMessage("Sender or subject are missing or invalid.");

--- a/graylog2-server/src/test/java/org/graylog2/alerts/FormattedEmailAlertSenderTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/FormattedEmailAlertSenderTest.java
@@ -17,7 +17,8 @@
 package org.graylog2.alerts;
 
 import com.floreysoft.jmte.Engine;
-import org.graylog2.configuration.EmailConfiguration;
+import org.graylog2.email.configuration.EmailConfiguration;
+import org.graylog2.email.configuration.EmailConfigurationService;
 import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.alarms.AlertCondition;
@@ -45,6 +46,10 @@ public class FormattedEmailAlertSenderTest {
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
     @Mock
+    private EmailConfigurationService emailConfigurationService;
+    @Mock
+    private EmailConfiguration emailConfiguration;
+    @Mock
     private NotificationService mockNotificationService;
     @Mock
     private NodeId mockNodeId;
@@ -54,7 +59,8 @@ public class FormattedEmailAlertSenderTest {
 
     @Before
     public void setUp() throws Exception {
-        this.emailAlertSender = new FormattedEmailAlertSender(new EmailConfiguration(), mockNotificationService, mockNodeId, templateEngine);
+        when(emailConfigurationService.load()).thenReturn(emailConfiguration);
+        this.emailAlertSender = new FormattedEmailAlertSender(emailConfigurationService, mockNotificationService, mockNodeId, templateEngine);
     }
 
     @Test
@@ -120,13 +126,7 @@ public class FormattedEmailAlertSenderTest {
 
     @Test
     public void buildBodyContainsURLIfWebInterfaceURLIsSet() throws Exception {
-        final EmailConfiguration configuration = new EmailConfiguration() {
-            @Override
-            public URI getWebInterfaceUri() {
-                return URI.create("https://localhost");
-            }
-        };
-        this.emailAlertSender = new FormattedEmailAlertSender(configuration, mockNotificationService, mockNodeId, templateEngine);
+        when(emailConfiguration.webInterfaceUri()).thenReturn(URI.create("https://localhost"));
 
         Stream stream = mock(Stream.class);
         when(stream.getId()).thenReturn("123456");
@@ -145,13 +145,7 @@ public class FormattedEmailAlertSenderTest {
 
     @Test
     public void buildBodyContainsInfoMessageIfWebInterfaceURLIsNotSet() throws Exception {
-        final EmailConfiguration configuration = new EmailConfiguration() {
-            @Override
-            public URI getWebInterfaceUri() {
-                return null;
-            }
-        };
-        this.emailAlertSender = new FormattedEmailAlertSender(configuration, mockNotificationService, mockNodeId, templateEngine);
+        when(emailConfiguration.webInterfaceUri()).thenReturn(null);
 
         Stream stream = mock(Stream.class);
         when(stream.getId()).thenReturn("123456");
@@ -170,13 +164,7 @@ public class FormattedEmailAlertSenderTest {
 
     @Test
     public void buildBodyContainsInfoMessageIfWebInterfaceURLIsIncomplete() throws Exception {
-        final EmailConfiguration configuration = new EmailConfiguration() {
-            @Override
-            public URI getWebInterfaceUri() {
-                return URI.create("");
-            }
-        };
-        this.emailAlertSender = new FormattedEmailAlertSender(configuration, mockNotificationService, mockNodeId, templateEngine);
+        when(emailConfiguration.webInterfaceUri()).thenReturn(URI.create(""));
 
         Stream stream = mock(Stream.class);
         when(stream.getId()).thenReturn("123456");
@@ -195,7 +183,6 @@ public class FormattedEmailAlertSenderTest {
 
     @Test
     public void defaultBodyTemplateDoesNotShowBacklogIfBacklogIsEmpty() throws Exception {
-        FormattedEmailAlertSender emailAlertSender = new FormattedEmailAlertSender(new EmailConfiguration(), mockNotificationService, mockNodeId, templateEngine);
 
         Stream stream = mock(Stream.class);
         when(stream.getId()).thenReturn("123456");
@@ -216,7 +203,6 @@ public class FormattedEmailAlertSenderTest {
 
     @Test
     public void defaultBodyTemplateShowsBacklogIfBacklogIsNotEmpty() throws Exception {
-        FormattedEmailAlertSender emailAlertSender = new FormattedEmailAlertSender(new EmailConfiguration(), mockNotificationService, mockNodeId, templateEngine);
 
         Stream stream = mock(Stream.class);
         when(stream.getId()).thenReturn("123456");

--- a/graylog2-server/src/test/java/org/graylog2/email/configuration/EmailConfigurationServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/email/configuration/EmailConfigurationServiceImplTest.java
@@ -1,0 +1,57 @@
+package org.graylog2.email.configuration;
+
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class EmailConfigurationServiceImplTest {
+
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private EmailConfigurationServiceImpl emailConfigurationService;
+
+    @Mock
+    private ClusterConfigService clusterConfigService;
+
+    @Before
+    public void setUp() {
+        emailConfigurationService = new EmailConfigurationServiceImpl(clusterConfigService);
+    }
+
+    @Test
+    public void loadAndReturnWithoutModifying() {
+        EmailConfiguration emailConfiguration = mock(EmailConfiguration.class);
+        when(clusterConfigService.get(EmailConfiguration.class)).thenReturn(emailConfiguration);
+
+        EmailConfiguration result = emailConfigurationService.load();
+
+        verify(clusterConfigService, times(1)).get(EmailConfiguration.class);
+        assertThat(result).isEqualTo(emailConfiguration);
+    }
+
+    @Test
+    public void loadAndReturnNullIfNotFound() {
+        when(clusterConfigService.get(EmailConfiguration.class)).thenReturn(null);
+
+        EmailConfiguration result = emailConfigurationService.load();
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    public void save() {
+        EmailConfiguration emailConfiguration = mock(EmailConfiguration.class);
+
+        emailConfigurationService.save(emailConfiguration);
+
+        verify(clusterConfigService, times(1)).write(emailConfiguration);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/email/configuration/EmailConfigurationServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/email/configuration/EmailConfigurationServiceImplTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.email.configuration;
 
 import org.graylog2.plugin.cluster.ClusterConfigService;

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20200214000000_EmailConfigMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20200214000000_EmailConfigMigrationTest.java
@@ -1,0 +1,103 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.migrations;
+
+import org.graylog2.email.configuration.EmailConfiguration;
+import org.graylog2.email.configuration.EmailConfigurationService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class V20200214000000_EmailConfigMigrationTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private V20200214000000_EmailConfigMigration emailConfigMigration;
+
+    @Mock
+    private org.graylog2.configuration.EmailConfiguration oldEmailConfiguration;
+
+    @Mock
+    private EmailConfigurationService emailConfigurationService;
+
+    @Before
+    public void setUp() {
+        emailConfigMigration = new V20200214000000_EmailConfigMigration(oldEmailConfiguration, emailConfigurationService);
+    }
+
+    @Test
+    public void alreadyMigrated() {
+        EmailConfiguration emailConfiguration = mock(EmailConfiguration.class);
+        when(emailConfigurationService.load()).thenReturn(emailConfiguration);
+
+        emailConfigMigration.upgrade();
+
+        verify(emailConfigurationService, never()).save(any());
+    }
+
+    @Test
+    public void migrateSuccessful() throws URISyntaxException {
+        boolean isEnabled = true;
+        String hostname = "random.hostname";
+        int port = 25;
+        boolean isUseAuth = false;
+        boolean isUseTls = false;
+        boolean isUseSsl = true;
+        String username = "imausername";
+        String password = "SupersecurePassword";
+        String fromEmail = "random@emaildotgraylog.org";
+        URI webInterfaceUri = new URI("https://fake.webmail");
+
+        when(emailConfigurationService.load()).thenReturn(null);
+        when(oldEmailConfiguration.isEnabled()).thenReturn(isEnabled);
+        when(oldEmailConfiguration.getHostname()).thenReturn(hostname);
+        when(oldEmailConfiguration.getPort()).thenReturn(port);
+        when(oldEmailConfiguration.isUseAuth()).thenReturn(isUseAuth);
+        when(oldEmailConfiguration.isUseTls()).thenReturn(isUseTls);
+        when(oldEmailConfiguration.isUseSsl()).thenReturn(isUseSsl);
+        when(oldEmailConfiguration.getUsername()).thenReturn(username);
+        when(oldEmailConfiguration.getPassword()).thenReturn(password);
+        when(oldEmailConfiguration.getFromEmail()).thenReturn(fromEmail);
+        when(oldEmailConfiguration.getWebInterfaceUri()).thenReturn(webInterfaceUri);
+        ArgumentCaptor<EmailConfiguration> emailConfigurationArgumentCaptor = ArgumentCaptor.forClass(EmailConfiguration.class);
+
+        emailConfigMigration.upgrade();
+
+        verify(emailConfigurationService, times(1)).save(emailConfigurationArgumentCaptor.capture());
+        EmailConfiguration migratedEmailConfig = emailConfigurationArgumentCaptor.getValue();
+        assertThat(migratedEmailConfig.enabled()).isEqualTo(isEnabled);
+        assertThat(migratedEmailConfig.hostname()).isEqualTo(hostname);
+        assertThat(migratedEmailConfig.port()).isEqualTo(port);
+        assertThat(migratedEmailConfig.useAuth()).isEqualTo(isUseAuth);
+        assertThat(migratedEmailConfig.useTls()).isEqualTo(isUseTls);
+        assertThat(migratedEmailConfig.useSsl()).isEqualTo(isUseSsl);
+        assertThat(migratedEmailConfig.username()).isEqualTo(username);
+        assertThat(migratedEmailConfig.password()).isEqualTo(password);
+        assertThat(migratedEmailConfig.fromEmail()).isEqualTo(fromEmail);
+        assertThat(migratedEmailConfig.webInterfaceUri()).isEqualTo(webInterfaceUri);
+    }
+}

--- a/graylog2-web-interface/src/components/configurations/EmailConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/EmailConfig.jsx
@@ -1,0 +1,255 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import createReactClass from 'create-react-class';
+import { Button, FormGroup, HelpBlock } from 'react-bootstrap';
+import { BootstrapModalForm } from 'components/bootstrap';
+import { IfPermitted } from 'components/common';
+import FormUtils from 'util/FormsUtils';
+import Input from 'components/bootstrap/Input';
+import StringUtils from 'util/StringUtils';
+import lodash from 'lodash';
+
+const EmailConfig = createReactClass({
+  displayName: 'EmailConfig',
+
+  propTypes: {
+    config: PropTypes.shape({
+      enabled: PropTypes.bool,
+      hostname: PropTypes.string,
+      port: PropTypes.number,
+      use_auth: PropTypes.bool,
+      use_tls: PropTypes.bool,
+      use_ssl: PropTypes.bool,
+      username: PropTypes.string,
+      password: PropTypes.string,
+      from_email: PropTypes.string,
+      web_interface_uri: PropTypes.string,
+    }),
+    updateConfig: PropTypes.func.isRequired,
+  },
+
+  getDefaultProps() {
+    return {
+      config: {
+        enabled: false,
+        hostname: null,
+        port: 25,
+        use_auth: false,
+        use_tls: true,
+        use_ssl: false,
+        username: null,
+        password: null,
+        from_email: null,
+        web_interface_uri: null,
+      },
+    };
+  },
+
+  getInitialState() {
+    const { config } = this.props;
+    return {
+      config: config,
+    };
+  },
+
+  componentWillReceiveProps(newProps) {
+    this.setState({ config: newProps.config });
+  },
+
+  _openModal() {
+    this.modal.open();
+  },
+
+  _closeModal() {
+    this.modal.close();
+  },
+
+  _resetConfig() {
+    this.setState(this.getInitialState());
+  },
+
+  _saveConfig() {
+    const { updateConfig } = this.props;
+    const { config } = this.state;
+    updateConfig(config).then(() => {
+      this._closeModal();
+    });
+  },
+
+  _propagateChanges(key, value) {
+    const { config } = this.state;
+    const nextConfig = lodash.cloneDeep(config);
+    nextConfig[key] = value;
+    this.setState({ config: nextConfig });
+  },
+
+  _onEnabledUpdate(event) {
+    const value = FormUtils.getValueFromInput(event.target);
+    this._propagateChanges('enabled', value);
+  },
+
+  _onHostnameUpdate(event) {
+    const value = FormUtils.getValueFromInput(event.target);
+    this._propagateChanges('hostname', value);
+  },
+
+  _onPortUpdate(event) {
+    const value = FormUtils.getValueFromInput(event.target);
+    this._propagateChanges('port', value);
+  },
+
+  _onUseAuthUpdate(event) {
+    const value = FormUtils.getValueFromInput(event.target);
+    this._propagateChanges('use_auth', value);
+  },
+
+  _onUseTlsUpdate(event) {
+    const value = FormUtils.getValueFromInput(event.target);
+    this._propagateChanges('use_tls', value);
+  },
+
+  _onUseSslUpdate(event) {
+    const value = FormUtils.getValueFromInput(event.target);
+    this._propagateChanges('use_ssl', value);
+  },
+
+  _onUsernameUpdate(event) {
+    const value = FormUtils.getValueFromInput(event.target);
+    this._propagateChanges('username', value);
+  },
+
+  _onPasswordUpdate(event) {
+    const value = FormUtils.getValueFromInput(event.target);
+    this._propagateChanges('password', value);
+  },
+
+  _onFromEmailUpdate(event) {
+    const value = FormUtils.getValueFromInput(event.target);
+    this._propagateChanges('from_email', value);
+  },
+
+  _onWebInterfaceUriUpdate(event) {
+    const value = FormUtils.getValueFromInput(event.target);
+    this._propagateChanges('web_interface_uri', value);
+  },
+
+  render() {
+    const { config } = this.state;
+    const enabled = config.enabled;
+    const hostname = config.hostname;
+    const port = config.port;
+    const useAuth = config.use_auth;
+    const useTls = config.use_tls;
+    const useSsl = config.use_ssl;
+    const username = config.username;
+    const password = config.password;
+    const fromEmail = config.from_email;
+    const webInterfaceUri = config.web_interface_uri;
+    return (
+      <div>
+        <h2>Email configuration</h2>
+
+        <dl className="deflist">
+          <dt>Enabled:</dt>
+          <dd>{StringUtils.capitalizeFirstLetter(enabled.toString())}</dd>
+          <dt>Hostname:</dt>
+          <dd>{hostname ? hostname : '[not set]'}</dd>
+          <dt>Port:</dt>
+          <dd>{port}</dd>
+          <dt>Use Auth:</dt>
+          <dd>{StringUtils.capitalizeFirstLetter(useAuth.toString())}</dd>
+          <dt>Use TLS:</dt>
+          <dd>{StringUtils.capitalizeFirstLetter(useTls.toString())}</dd>
+          <dt>Use SSL:</dt>
+          <dd>{StringUtils.capitalizeFirstLetter(useSsl.toString())}</dd>
+          <dt>Username:</dt>
+          <dd>{username ? username : '[not set]'}</dd>
+          <dt>Password:</dt>
+          <dd>{password ? '***********' : '[not set]'}</dd>
+          <dt>From email:</dt>
+          <dd>{fromEmail ? fromEmail : '[not set]'}</dd>
+          <dt>Web Interface URI:</dt>
+          <dd>{webInterfaceUri ? webInterfaceUri : '[not set]'}</dd>
+        </dl>
+
+        <IfPermitted permissions="email:edit">
+          <Button bsStyle="info" bsSize="xs" onClick={this._openModal}>Update</Button>
+        </IfPermitted>
+
+        <BootstrapModalForm ref={(modal) => { this.modal = modal; }}
+                            title="Update Email Configuration"
+                            onSubmitForm={this._saveConfig}
+                            onModalClose={this._resetConfig}
+                            submitButtonText="Save">
+          <fieldset>
+            <Input id="enabled-field"
+                   type="checkbox"
+                   onChange={this._onEnabledUpdate}
+                   label="Enable"
+                   help="Enable Email configuration"
+                   checked={enabled} />
+            <Input id="hostname-field"
+                   type="text"
+                   onChange={this._onHostnameUpdate}
+                   label="Hostname"
+                   help="SMTP Server hostname or IP address"
+                   value={hostname} />
+            <Input id="port-field"
+                   type="number"
+                   onChange={this._onPortUpdate}
+                   label="SMTP Port"
+                   help="Port to connect to the SMTP server"
+                   value={port}
+                   min="0"
+                   max="65535"
+                   required />
+            <Input id="use-auth-field"
+                   type="checkbox"
+                   onChange={this._onUseAuthUpdate}
+                   label="Use Auth"
+                   help="Use SMTP authentication"
+                   checked={useAuth} />
+            <Input id="use-tls-field"
+                   type="checkbox"
+                   onChange={this._onUseTlsUpdate}
+                   label="Use TLS"
+                   help="Use TLS"
+                   checked={useTls} />
+            <Input id="use-ssl-field"
+                   type="checkbox"
+                   onChange={this._onSslUpdate}
+                   label="Use SSL"
+                   help="Use SSL"
+                   checked={useSsl} />
+            <Input id="username-field"
+                   type="text"
+                   onChange={this._onUsernameUpdate}
+                   label="Username"
+                   help="SMTP Username (requires Use Auth to be enabled)"
+                   value={username} />
+            <Input id="password-field"
+                   type="password"
+                   onChange={this._onPasswordUpdate}
+                   label="Password"
+                   help="SMTP Password (requires Use Auth to be enabled)"
+                   value={password} />
+            <Input id="from-email-field"
+                   type="text"
+                   onChange={this._onFromEmailUpdate}
+                   label="From email:"
+                   help="Email address to use as default from address"
+                   value={fromEmail} />
+            <Input id="web-interface-uri-field"
+                   type="text"
+                   onChange={this._onWebInterfaceUriUpdate}
+                   label="Web Interface URI:"
+                   help="Web Interface URI"
+                   value={webInterfaceUri} />
+          </fieldset>
+        </BootstrapModalForm>
+      </div>
+    )
+  },
+});
+
+export default EmailConfig;

--- a/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
+++ b/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
@@ -13,6 +13,8 @@ import SidecarConfig from 'components/configurations/SidecarConfig';
 import EventsConfig from 'components/configurations/EventsConfig';
 import UrlWhiteListConfig from 'components/configurations/UrlWhiteListConfig';
 import DecoratorsConfig from '../components/configurations/DecoratorsConfig';
+import EmailConfig from 'components/configurations/EmailConfig';
+
 import {} from 'components/maps/configurations';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
@@ -26,6 +28,7 @@ const MESSAGE_PROCESSORS_CONFIG = 'org.graylog2.messageprocessors.MessageProcess
 const SIDECAR_CONFIG = 'org.graylog.plugins.sidecar.system.SidecarConfiguration';
 const EVENTS_CONFIG = 'org.graylog.events.configuration.EventsConfiguration';
 const URL_WHITELIST_CONFIG = 'org.graylog2.system.urlwhitelist.UrlWhitelist';
+const EMAIL_CONFIG = 'org.graylog2.email.configuration.EmailConfiguration';
 
 class ConfigurationsPage extends React.Component {
   componentDidMount() {
@@ -35,6 +38,7 @@ class ConfigurationsPage extends React.Component {
     ConfigurationsActions.listMessageProcessorsConfig(MESSAGE_PROCESSORS_CONFIG);
     ConfigurationsActions.list(SIDECAR_CONFIG);
     ConfigurationsActions.list(EVENTS_CONFIG);
+    ConfigurationActions.list(EMAIL_CONFIG);
     if (PermissionsMixin.isPermitted(permissions, ['urlwhitelist:read'])) {
       ConfigurationsActions.listWhiteListConfig(URL_WHITELIST_CONFIG);
     }
@@ -109,11 +113,13 @@ class ConfigurationsPage extends React.Component {
     const sidecarConfig = this._getConfig(SIDECAR_CONFIG);
     const eventsConfig = this._getConfig(EVENTS_CONFIG);
     const urlWhiteListConfig = this._getConfig(URL_WHITELIST_CONFIG);
+    const emailConfig = this._getConfig(EMAIL_CONFIG);
     let searchesConfigComponent;
     let messageProcessorsConfigComponent;
     let sidecarConfigComponent;
     let eventsConfigComponent;
     let urlWhiteListConfigComponent;
+    let emailConfigComponent;
     if (searchesConfig) {
       searchesConfigComponent = (
         <SearchesConfig config={searchesConfig}
@@ -154,6 +160,15 @@ class ConfigurationsPage extends React.Component {
     } else {
       urlWhiteListConfigComponent = PermissionsMixin.isPermitted(permissions, ['urlwhitelist:read']) ? <Spinner /> : null;
     }
+    if (emailConfig) {
+      emailConfigComponent = (
+        <EmailConfig config={emailConfig}
+                     updateConfig={this._onUpdate(EMAIL_CONFIG)} />
+      );
+    } else {
+      emailConfigComponent = (<Spinner />);
+    }
+
     const pluginConfigRows = this._pluginConfigRows();
 
     return (
@@ -180,6 +195,9 @@ class ConfigurationsPage extends React.Component {
             </Col>
             <Col md={6}>
               {urlWhiteListConfigComponent}
+            </Col>
+            <Col md={6}>
+              {emailConfigComponent}
             </Col>
             <Col md={6}>
               <DecoratorsConfig />


### PR DESCRIPTION
## Description
Migrates the current email configuration from conf files to cluster config (mongodb)

## Motivation and Context
Implements #6049 

## How Has This Been Tested?
Configure email transport in conf file (or not). Run graylog server and check the migration is executed and the email configuration (or default one if not configured in file) is saved in mongodb.
From the UI go to "System / Configurations" and check there is a section with email configuration showing the current config and the update button allows to edit the config in a modal form.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
