### PR TITLE
Wait for `ViewActions.load` in promise chain and still return view.

### DIFF
--- a/graylog2-web-interface/src/views/logic/views/ViewDeserializer.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewDeserializer.js
@@ -11,8 +11,5 @@ export default function ViewDeserializer(viewResponse: ViewJson): Promise<View> 
   return SearchActions.get(viewResponse.search_id)
     .then((search: SearchJson): Search => Search.fromJSON(search))
     .then((search: Search): View => view.toBuilder().search(search).build())
-    .then((v: View): View => {
-      ViewActions.load(v);
-      return v;
-    });
+    .then((v: View): Promise<View> => ViewActions.load(v).then(() => v));
 }


### PR DESCRIPTION
## Description
## Motivation and Context

Before this change, calling the `ViewActions.load` action from
`ViewDeserializer` was not returning the promise of it, so it was not
waited upon to resolve. This lead to an issue, where loading the view
took longer than toggling the `loaded` status flag in `ShowViewPage`,
leading to rendering components which relied on the view being loaded
already.

This change is now returning the promise received from
`ViewActions.load`, so it is waited on.

Fixes #6346.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.