### PR TITLE
Fix mvn test / sync versions between server and enterprise (3.1)

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -962,7 +962,7 @@
                     <plugin>
                         <groupId>com.googlecode.maven-download-plugin</groupId>
                         <artifactId>download-maven-plugin</artifactId>
-                        <version>1.4.1</version>
+                        <version>${download-maven-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>install-headless-shell</id>

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/DBProcessingStatusService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/DBProcessingStatusService.java
@@ -70,9 +70,12 @@ public class DBProcessingStatusService {
                 mapper.get());
 
         db.createIndex(new BasicDBObject(ProcessingStatusDto.FIELD_NODE_ID, 1), new BasicDBObject("unique", true));
+        // Use a custom index name to avoid the automatically generated index name which will be pretty long and
+        // might cause errors due to the 127 character index name limit. (e.g. when using a long database name)
+        // See: https://github.com/Graylog2/graylog2-server/issues/6322
         db.createIndex(new BasicDBObject(FIELD_UPDATED_AT, 1)
                 .append(FIELD_UNCOMMITTED_ENTRIES, 1)
-                .append(FIELD_WRITTEN_MESSAGES_1M, 1));
+                .append(FIELD_WRITTEN_MESSAGES_1M, 1), new BasicDBObject("name", "compound_0"));
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,8 @@
 
         <!-- Plugin versions -->
         <license-maven.version>2.11</license-maven.version>
+        <!-- Downgraded to 1.3.0 because of this issue: https://github.com/maven-download-plugin/maven-download-plugin/issues/80 -->
+        <download-maven-plugin.version>1.3.0</download-maven-plugin.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
This PR is backporting #6320 to `3.1`.

Downgrade download-maven-plugin to version 1.3.0 until this is fixed: 

https://github.com/maven-download-plugin/maven-download-plugin/issues/80

```
[ERROR] Failed to execute goal com.googlecode.maven-download-plugin:download-maven-plugin:1.4.1:wget (install-headless-shell) on project graylog2-server: Execution install-headless-shell of goal com.googlecode.maven-download-plugin:download-maven-plugin:1.4.1:wget failed: java.lang.ClassNotFoundException: com.googlecode.download.maven.plugin.internal.CachedFileEntry -> [Help 1]
```
(cherry picked from commit fafe8b5653c25f05841565ea0ef607b2b8e4e8dd)