### PR TITLE
Fix mvn test / sync versions between server and enterprise (#6320)

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -962,7 +962,7 @@
                     <plugin>
                         <groupId>com.googlecode.maven-download-plugin</groupId>
                         <artifactId>download-maven-plugin</artifactId>
-                        <version>1.4.1</version>
+                        <version>${download-maven-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>install-headless-shell</id>

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,8 @@
 
         <!-- Plugin versions -->
         <license-maven.version>2.11</license-maven.version>
+        <!-- Downgraded to 1.3.0 because of this issue: https://github.com/maven-download-plugin/maven-download-plugin/issues/80 -->
+        <download-maven-plugin.version>1.3.0</download-maven-plugin.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
This PR is backporting #6320 to `3.1`.

Downgrade download-maven-plugin to version 1.3.0 until this is fixed:
https://github.com/maven-download-plugin/maven-download-plugin/issues/80

```
[ERROR] Failed to execute goal com.googlecode.maven-download-plugin:download-maven-plugin:1.4.1:wget (install-headless-shell) on project graylog2-server: Execution install-headless-shell of goal com.googlecode.maven-download-plugin:download-maven-plugin:1.4.1:wget failed: java.lang.ClassNotFoundException: com.googlecode.download.maven.plugin.internal.CachedFileEntry -> [Help 1]
```
(cherry picked from commit fafe8b5653c25f05841565ea0ef607b2b8e4e8dd)