### PR TITLE
Implement Notification Test button

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/legacy/LegacyAlarmCallbackSender.java
+++ b/graylog2-server/src/main/java/org/graylog/events/legacy/LegacyAlarmCallbackSender.java
@@ -135,6 +135,7 @@ public class LegacyAlarmCallbackSender {
     private static class MissingStream extends StreamImpl {
         static Stream create() {
             final ImmutableMap<String, Object> fields = ImmutableMap.<String, Object>builder()
+                    .put("_id", new ObjectId("5400deadbeefdeadbeefaffe"))
                     .put(StreamImpl.FIELD_TITLE, "Missing stream")
                     .put(StreamImpl.FIELD_DESCRIPTION, "We could find a stream")
                     .put(StreamImpl.FIELD_RULES, ImmutableList.<StreamRule>of())

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/EventNotificationContext.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/EventNotificationContext.java
@@ -35,7 +35,7 @@ public abstract class EventNotificationContext {
 
     public abstract Optional<EventDefinitionDto> eventDefinition();
 
-    public abstract JobTriggerDto jobTrigger();
+    public abstract Optional<JobTriggerDto> jobTrigger();
 
     public static Builder builder() {
         return Builder.create();

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationResourceHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationResourceHandler.java
@@ -174,13 +174,11 @@ public class NotificationResourceHandler {
     /**
      * Tests an notification definition by executing it with a dummy event.
      *
-     * @param notificationId the notification definition to test
+     * @param notificationDto the notification definition to test
      * @param userName the name of the user that triggered the test
      * @throws NotFoundException if the notification definition or the notification factory cannot be found
      */
-    public void test(String notificationId, String userName) throws NotFoundException {
-        final NotificationDto notificationDto =
-                notificationService.get(notificationId).orElseThrow(() -> new NotFoundException("Notification " + notificationId + " doesn't exist"));
+    public void test(NotificationDto notificationDto, String userName) throws NotFoundException {
         final EventNotification.Factory eventNotificationFactory = eventNotificationFactories.get(notificationDto.config().type());
         if (eventNotificationFactory == null) {
             throw new NotFoundException("Couldn't find factory for notification type <" + notificationDto.config().type() + ">");

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationResourceHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationResourceHandler.java
@@ -17,20 +17,10 @@
 package org.graylog.events.notifications;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import org.graylog.events.contentpack.entities.EventProcessorConfigEntity;
-import org.graylog.events.event.EventDto;
-import org.graylog.events.event.EventOriginContext;
 import org.graylog.events.processor.DBEventDefinitionService;
 import org.graylog.events.processor.EventDefinitionDto;
-import org.graylog.events.processor.EventProcessorConfig;
 import org.graylog.scheduler.DBJobDefinitionService;
 import org.graylog.scheduler.JobDefinitionDto;
-import org.graylog2.contentpacks.EntityDescriptorIds;
-import org.graylog2.plugin.Tools;
-import org.graylog2.plugin.rest.ValidationResult;
-import org.graylog2.plugin.streams.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +41,8 @@ public class NotificationResourceHandler {
     @Inject
     public NotificationResourceHandler(DBNotificationService notificationService,
                                        DBJobDefinitionService jobDefinitionService,
-                                       DBEventDefinitionService eventDefinitionService, Map<String, EventNotification.Factory> eventNotificationFactories) {
+                                       DBEventDefinitionService eventDefinitionService,
+                                       Map<String, EventNotification.Factory> eventNotificationFactories) {
         this.notificationService = notificationService;
         this.jobDefinitionService = jobDefinitionService;
         this.eventDefinitionService = eventDefinitionService;
@@ -177,85 +168,20 @@ public class NotificationResourceHandler {
      * @param notificationDto the notification definition to test
      * @param userName the name of the user that triggered the test
      * @throws NotFoundException if the notification definition or the notification factory cannot be found
+     * @throws InternalServerErrorException if the notification definition failed to be executed
      */
-    public void test(NotificationDto notificationDto, String userName) throws NotFoundException {
+    public void test(NotificationDto notificationDto, String userName) throws NotFoundException, InternalServerErrorException {
         final EventNotification.Factory eventNotificationFactory = eventNotificationFactories.get(notificationDto.config().type());
         if (eventNotificationFactory == null) {
             throw new NotFoundException("Couldn't find factory for notification type <" + notificationDto.config().type() + ">");
         }
-        final EventNotificationContext notificationContext = getDummyContext(notificationDto, userName);
+        final EventNotificationContext notificationContext = NotificationTestData.getDummyContext(notificationDto, userName);
         final EventNotification eventNotification = eventNotificationFactory.create();
         try {
             eventNotification.execute(notificationContext);
         } catch (EventNotificationException e) {
             throw new InternalServerErrorException(e.getMessage(), e);
         }
-    }
-
-    private EventNotificationContext getDummyContext(NotificationDto notificationDto, String userName) {
-        final EventDto eventDto = EventDto.builder()
-                .alert(true)
-                .eventDefinitionId("EventDefinitionTestId")
-                .eventDefinitionType("notification-test-v1")
-                .eventTimestamp(Tools.nowUTC())
-                .processingTimestamp(Tools.nowUTC())
-                .id("NotificationTestId")
-                .streams(ImmutableSet.of(Stream.DEFAULT_EVENTS_STREAM_ID))
-                .message("Notification test message triggered from user <" + userName + ">")
-                .source(Stream.DEFAULT_STREAM_ID)
-                .keyTuple(ImmutableList.of("testkey"))
-                .key("testkey")
-                .originContext(EventOriginContext.elasticsearchMessage("testIndex_42", "b5e53442-12bb-4374-90ed-0deadbeefbaz"))
-                .priority(2)
-                .fields(ImmutableMap.of("field1", "value1", "field2", "value2"))
-                .build();
-
-        final EventDefinitionDto eventDefinitionDto = EventDefinitionDto.builder()
-                .alert(true)
-                .id("1234")
-                .title("Event Definition Test Title")
-                .description("Event Definition Test Description")
-                .config(new EventProcessorConfig() {
-                    @Override
-                    public String type() {
-                        return "test-dummy-v1";
-                    }
-                    @Override
-                    public ValidationResult validate() {
-                        return null;
-                    }
-                    @Override
-                    public EventProcessorConfigEntity toContentPackEntity(EntityDescriptorIds entityDescriptorIds) {
-                        return null;
-                    }
-                })
-                .fieldSpec(ImmutableMap.of())
-                .priority(2)
-                .keySpec(ImmutableList.of())
-                .notificationSettings(new EventNotificationSettings() {
-                                          @Override
-                                          public long gracePeriodMs() {
-                                              return 0;
-                                          }
-                                          @Override
-                                          // disable to avoid errors in getBacklogForEvent()
-                                          public long backlogSize() {
-                                              return 0;
-                                          }
-                                          @Override
-                                          public Builder toBuilder() {
-                                              return null;
-                                          }
-                                      }
-
-                ).build();
-
-        return EventNotificationContext.builder()
-                .notificationId("1234")
-                .notificationConfig(notificationDto.config())
-                .event(eventDto)
-                .eventDefinition(eventDefinitionDto)
-                .build();
     }
 
     private EventNotificationExecutionJob.Config getSchedulerConfig(String notificationId) {

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationResourceHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationResourceHandler.java
@@ -17,14 +17,27 @@
 package org.graylog.events.notifications;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.graylog.events.contentpack.entities.EventProcessorConfigEntity;
+import org.graylog.events.event.EventDto;
+import org.graylog.events.event.EventOriginContext;
 import org.graylog.events.processor.DBEventDefinitionService;
 import org.graylog.events.processor.EventDefinitionDto;
+import org.graylog.events.processor.EventProcessorConfig;
 import org.graylog.scheduler.DBJobDefinitionService;
 import org.graylog.scheduler.JobDefinitionDto;
+import org.graylog2.contentpacks.EntityDescriptorIds;
+import org.graylog2.plugin.Tools;
+import org.graylog2.plugin.rest.ValidationResult;
+import org.graylog2.plugin.streams.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.NotFoundException;
+import java.util.Map;
 import java.util.Optional;
 
 public class NotificationResourceHandler {
@@ -33,14 +46,16 @@ public class NotificationResourceHandler {
     private final DBNotificationService notificationService;
     private final DBJobDefinitionService jobDefinitionService;
     private final DBEventDefinitionService eventDefinitionService;
+    private final Map<String, EventNotification.Factory> eventNotificationFactories;
 
     @Inject
     public NotificationResourceHandler(DBNotificationService notificationService,
                                        DBJobDefinitionService jobDefinitionService,
-                                       DBEventDefinitionService eventDefinitionService) {
+                                       DBEventDefinitionService eventDefinitionService, Map<String, EventNotification.Factory> eventNotificationFactories) {
         this.notificationService = notificationService;
         this.jobDefinitionService = jobDefinitionService;
         this.eventDefinitionService = eventDefinitionService;
+        this.eventNotificationFactories = eventNotificationFactories;
     }
 
     /**
@@ -154,6 +169,95 @@ public class NotificationResourceHandler {
             });
         LOG.debug("Deleting notification definition <{}/{}>", dto.get().id(), dto.get().title());
         return notificationService.delete(dtoId) > 0;
+    }
+
+    /**
+     * Tests an notification definition by executing it with a dummy event.
+     *
+     * @param notificationId the notification definition to test
+     * @param userName the name of the user that triggered the test
+     * @throws NotFoundException if the notification definition or the notification factory cannot be found
+     */
+    public void test(String notificationId, String userName) throws NotFoundException {
+        final NotificationDto notificationDto =
+                notificationService.get(notificationId).orElseThrow(() -> new NotFoundException("Notification " + notificationId + " doesn't exist"));
+        final EventNotification.Factory eventNotificationFactory = eventNotificationFactories.get(notificationDto.config().type());
+        if (eventNotificationFactory == null) {
+            throw new NotFoundException("Couldn't find factory for notification type <" + notificationDto.config().type() + ">");
+        }
+        final EventNotificationContext notificationContext = getDummyContext(notificationDto, userName);
+        final EventNotification eventNotification = eventNotificationFactory.create();
+        try {
+            eventNotification.execute(notificationContext);
+        } catch (EventNotificationException e) {
+            throw new InternalServerErrorException(e.getMessage(), e);
+        }
+    }
+
+    private EventNotificationContext getDummyContext(NotificationDto notificationDto, String userName) {
+        final EventDto eventDto = EventDto.builder()
+                .alert(true)
+                .eventDefinitionId("EventDefinitionTestId")
+                .eventDefinitionType("notification-test-v1")
+                .eventTimestamp(Tools.nowUTC())
+                .processingTimestamp(Tools.nowUTC())
+                .id("NotificationTestId")
+                .streams(ImmutableSet.of(Stream.DEFAULT_EVENTS_STREAM_ID))
+                .message("Notification test message triggered from user <" + userName + ">")
+                .source(Stream.DEFAULT_STREAM_ID)
+                .keyTuple(ImmutableList.of("testkey"))
+                .key("testkey")
+                .originContext(EventOriginContext.elasticsearchMessage("testIndex_42", "b5e53442-12bb-4374-90ed-0deadbeefbaz"))
+                .priority(2)
+                .fields(ImmutableMap.of("field1", "value1", "field2", "value2"))
+                .build();
+
+        final EventDefinitionDto eventDefinitionDto = EventDefinitionDto.builder()
+                .alert(true)
+                .id("1234")
+                .title("Event Definition Test Title")
+                .description("Event Definition Test Description")
+                .config(new EventProcessorConfig() {
+                    @Override
+                    public String type() {
+                        return "test-dummy-v1";
+                    }
+                    @Override
+                    public ValidationResult validate() {
+                        return null;
+                    }
+                    @Override
+                    public EventProcessorConfigEntity toContentPackEntity(EntityDescriptorIds entityDescriptorIds) {
+                        return null;
+                    }
+                })
+                .fieldSpec(ImmutableMap.of())
+                .priority(2)
+                .keySpec(ImmutableList.of())
+                .notificationSettings(new EventNotificationSettings() {
+                                          @Override
+                                          public long gracePeriodMs() {
+                                              return 0;
+                                          }
+                                          @Override
+                                          // disable to avoid errors in getBacklogForEvent()
+                                          public long backlogSize() {
+                                              return 0;
+                                          }
+                                          @Override
+                                          public Builder toBuilder() {
+                                              return null;
+                                          }
+                                      }
+
+                ).build();
+
+        return EventNotificationContext.builder()
+                .notificationId(notificationDto.id())
+                .notificationConfig(notificationDto.config())
+                .event(eventDto)
+                .eventDefinition(eventDefinitionDto)
+                .build();
     }
 
     private EventNotificationExecutionJob.Config getSchedulerConfig(String notificationId) {

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationResourceHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationResourceHandler.java
@@ -251,7 +251,7 @@ public class NotificationResourceHandler {
                 ).build();
 
         return EventNotificationContext.builder()
-                .notificationId(notificationDto.id())
+                .notificationId("1234")
                 .notificationConfig(notificationDto.config())
                 .event(eventDto)
                 .eventDefinition(eventDefinitionDto)

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationResourceHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationResourceHandler.java
@@ -180,7 +180,11 @@ public class NotificationResourceHandler {
         try {
             eventNotification.execute(notificationContext);
         } catch (EventNotificationException e) {
-            throw new InternalServerErrorException(e.getMessage(), e);
+            if (e.getCause() != null) {
+                throw new InternalServerErrorException(e.getCause().getMessage(), e);
+            } else {
+                throw new InternalServerErrorException(e.getMessage(), e);
+            }
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationResourceHandler.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationResourceHandler.java
@@ -172,7 +172,7 @@ public class NotificationResourceHandler {
     }
 
     /**
-     * Tests an notification definition by executing it with a dummy event.
+     * Tests a notification definition by executing it with a dummy event.
      *
      * @param notificationDto the notification definition to test
      * @param userName the name of the user that triggered the test

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationTestData.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationTestData.java
@@ -1,0 +1,99 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog.events.notifications;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.graylog.events.contentpack.entities.EventProcessorConfigEntity;
+import org.graylog.events.event.EventDto;
+import org.graylog.events.event.EventOriginContext;
+import org.graylog.events.processor.EventDefinitionDto;
+import org.graylog.events.processor.EventProcessorConfig;
+import org.graylog2.contentpacks.EntityDescriptorIds;
+import org.graylog2.plugin.Tools;
+import org.graylog2.plugin.rest.ValidationResult;
+import org.graylog2.plugin.streams.Stream;
+
+class NotificationTestData {
+    static EventNotificationContext getDummyContext(NotificationDto notificationDto, String userName) {
+        final EventDto eventDto = EventDto.builder()
+                .alert(true)
+                .eventDefinitionId("EventDefinitionTestId")
+                .eventDefinitionType("notification-test-v1")
+                .eventTimestamp(Tools.nowUTC())
+                .processingTimestamp(Tools.nowUTC())
+                .id("NotificationTestId")
+                .streams(ImmutableSet.of(Stream.DEFAULT_EVENTS_STREAM_ID))
+                .message("Notification test message triggered from user <" + userName + ">")
+                .source(Stream.DEFAULT_STREAM_ID)
+                .keyTuple(ImmutableList.of("testkey"))
+                .key("testkey")
+                .originContext(EventOriginContext.elasticsearchMessage("testIndex_42", "b5e53442-12bb-4374-90ed-0deadbeefbaz"))
+                .priority(2)
+                .fields(ImmutableMap.of("field1", "value1", "field2", "value2"))
+                .build();
+
+        final EventDefinitionDto eventDefinitionDto = EventDefinitionDto.builder()
+                .alert(true)
+                .id("1234")
+                .title("Event Definition Test Title")
+                .description("Event Definition Test Description")
+                .config(new EventProcessorConfig() {
+                    @Override
+                    public String type() {
+                        return "test-dummy-v1";
+                    }
+                    @Override
+                    public ValidationResult validate() {
+                        return null;
+                    }
+                    @Override
+                    public EventProcessorConfigEntity toContentPackEntity(EntityDescriptorIds entityDescriptorIds) {
+                        return null;
+                    }
+                })
+                .fieldSpec(ImmutableMap.of())
+                .priority(2)
+                .keySpec(ImmutableList.of())
+                .notificationSettings(new EventNotificationSettings() {
+                                          @Override
+                                          public long gracePeriodMs() {
+                                              return 0;
+                                          }
+                                          @Override
+                                          // disable to avoid errors in getBacklogForEvent()
+                                          public long backlogSize() {
+                                              return 0;
+                                          }
+                                          @Override
+                                          public Builder toBuilder() {
+                                              return null;
+                                          }
+                                      }
+
+                ).build();
+
+        return EventNotificationContext.builder()
+                .notificationId("1234")
+                .notificationConfig(notificationDto.config())
+                .event(eventDto)
+                .eventDefinition(eventDefinitionDto)
+                .build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailSender.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailSender.java
@@ -31,6 +31,7 @@ import org.graylog.events.notifications.EventNotificationContext;
 import org.graylog.events.notifications.EventNotificationModelData;
 import org.graylog.events.processor.DBEventDefinitionService;
 import org.graylog.events.processor.EventDefinitionDto;
+import org.graylog.scheduler.JobTriggerDto;
 import org.graylog2.alerts.EmailRecipients;
 import org.graylog2.configuration.EmailConfiguration;
 import org.graylog2.jackson.TypeReferences;
@@ -109,6 +110,7 @@ public class EmailSender {
 
     private Map<String, Object> getModel(EventNotificationContext ctx, ImmutableList<MessageSummary> backlog) {
         final Optional<EventDefinitionDto> definitionDto = ctx.eventDefinition();
+        final Optional<JobTriggerDto> jobTriggerDto = ctx.jobTrigger();
 
         // TODO: This needs at search URL, event definition URL, anything else?
         final EventNotificationModelData modelData = EventNotificationModelData.builder()
@@ -116,8 +118,8 @@ public class EmailSender {
                 .eventDefinitionType(definitionDto.map(d -> d.config().type()).orElse(UNKNOWN))
                 .eventDefinitionTitle(definitionDto.map(EventDefinitionDto::title).orElse(UNKNOWN))
                 .eventDefinitionDescription(definitionDto.map(EventDefinitionDto::description).orElse(UNKNOWN))
-                .jobDefinitionId(ctx.jobTrigger().jobDefinitionId())
-                .jobTriggerId(ctx.jobTrigger().id())
+                .jobDefinitionId(jobTriggerDto.map(JobTriggerDto::jobDefinitionId).orElse(UNKNOWN))
+                .jobTriggerId(jobTriggerDto.map(JobTriggerDto::id).orElse(UNKNOWN))
                 .event(ctx.event())
                 .backlog(backlog)
                 .build();

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotification.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotification.java
@@ -32,6 +32,7 @@ import org.graylog.events.notifications.EventNotificationService;
 import org.graylog.events.notifications.PermanentEventNotificationException;
 import org.graylog.events.notifications.TemporaryEventNotificationException;
 import org.graylog.events.processor.EventDefinitionDto;
+import org.graylog.scheduler.JobTriggerDto;
 import org.graylog2.plugin.MessageSummary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -105,14 +106,15 @@ public class HTTPEventNotification implements EventNotification {
 
     private EventNotificationModelData getModel(EventNotificationContext ctx, ImmutableList<MessageSummary> backlog) {
         final Optional<EventDefinitionDto> definitionDto = ctx.eventDefinition();
+        final Optional<JobTriggerDto> jobTriggerDto = ctx.jobTrigger();
 
         return EventNotificationModelData.builder()
                 .eventDefinitionId(definitionDto.map(EventDefinitionDto::id).orElse(UNKNOWN))
                 .eventDefinitionType(definitionDto.map(d -> d.config().type()).orElse(UNKNOWN))
                 .eventDefinitionTitle(definitionDto.map(EventDefinitionDto::title).orElse(UNKNOWN))
                 .eventDefinitionDescription(definitionDto.map(EventDefinitionDto::description).orElse(UNKNOWN))
-                .jobDefinitionId(ctx.jobTrigger().jobDefinitionId())
-                .jobTriggerId(ctx.jobTrigger().id())
+                .jobDefinitionId(jobTriggerDto.map(JobTriggerDto::jobDefinitionId).orElse(UNKNOWN))
+                .jobTriggerId(jobTriggerDto.map(JobTriggerDto::id).orElse(UNKNOWN))
                 .event(ctx.event())
                 .backlog(backlog)
                 .build();

--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventNotificationsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventNotificationsResource.java
@@ -27,7 +27,6 @@ import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog.events.audit.EventsAuditEventTypes;
 import org.graylog.events.notifications.DBNotificationService;
-import org.graylog.events.notifications.EventNotification;
 import org.graylog.events.notifications.NotificationDto;
 import org.graylog.events.notifications.NotificationResourceHandler;
 import org.graylog2.alarmcallbacks.EmailAlarmCallback;
@@ -86,7 +85,7 @@ public class EventNotificationsResource extends RestResource implements PluginRe
     @Inject
     public EventNotificationsResource(DBNotificationService dbNotificationService,
                                       Set<AlarmCallback> availableLegacyAlarmCallbacks,
-                                      NotificationResourceHandler resourceHandler, Map<String, EventNotification.Factory> eventNotificationFactories) {
+                                      NotificationResourceHandler resourceHandler) {
         this.dbNotificationService = dbNotificationService;
         this.availableLegacyAlarmCallbacks = availableLegacyAlarmCallbacks;
         this.resourceHandler = resourceHandler;

--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventNotificationsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventNotificationsResource.java
@@ -16,18 +16,23 @@
  */
 package org.graylog.events.rest;
 
+import com.codahale.metrics.annotation.Timed;
 import com.google.common.collect.ImmutableMap;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog.events.audit.EventsAuditEventTypes;
 import org.graylog.events.notifications.DBNotificationService;
+import org.graylog.events.notifications.EventNotification;
 import org.graylog.events.notifications.NotificationDto;
 import org.graylog.events.notifications.NotificationResourceHandler;
 import org.graylog2.alarmcallbacks.EmailAlarmCallback;
 import org.graylog2.audit.jersey.AuditEvent;
+import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.database.PaginatedList;
 import org.graylog2.plugin.alarms.callbacks.AlarmCallback;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
@@ -81,7 +86,7 @@ public class EventNotificationsResource extends RestResource implements PluginRe
     @Inject
     public EventNotificationsResource(DBNotificationService dbNotificationService,
                                       Set<AlarmCallback> availableLegacyAlarmCallbacks,
-                                      NotificationResourceHandler resourceHandler) {
+                                      NotificationResourceHandler resourceHandler, Map<String, EventNotification.Factory> eventNotificationFactories) {
         this.dbNotificationService = dbNotificationService;
         this.availableLegacyAlarmCallbacks = availableLegacyAlarmCallbacks;
         this.resourceHandler = resourceHandler;
@@ -150,6 +155,24 @@ public class EventNotificationsResource extends RestResource implements PluginRe
     public void delete(@ApiParam(name = "notificationId") @PathParam("notificationId") @NotBlank String notificationId) {
         checkPermission(RestPermissions.EVENT_NOTIFICATIONS_DELETE, notificationId);
         resourceHandler.delete(notificationId);
+    }
+
+    @POST
+    @Timed
+    @Path("/{notificationId}/test")
+    @ApiOperation(value = "Send a test alert for a given event notification")
+    @ApiResponses(value = {
+            @ApiResponse(code = 404, message = "Event notification not found."),
+            @ApiResponse(code = 500, message = "Error while testing event notification")
+    })
+    @NoAuditEvent("only used to test event notifications")
+    public Response test(@ApiParam(name = "notificationId", value = "The event notificaiton id to send a test alert for.", required = true)
+                         @NotBlank String notificationId) {
+        checkPermission(RestPermissions.EVENT_NOTIFICATIONS_CREATE, notificationId);
+
+        resourceHandler.test(notificationId, getSubject().getPrincipal().toString());
+
+        return Response.ok().build();
     }
 
     @GET

--- a/graylog2-server/src/test/java/org/graylog/events/legacy/LegacyAlertConditionMigratorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/legacy/LegacyAlertConditionMigratorTest.java
@@ -24,6 +24,7 @@ import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
 import org.graylog.events.JobSchedulerTestClock;
 import org.graylog.events.conditions.Expr;
 import org.graylog.events.notifications.DBNotificationService;
+import org.graylog.events.notifications.EventNotification;
 import org.graylog.events.notifications.EventNotificationExecutionJob;
 import org.graylog.events.notifications.EventNotificationHandler;
 import org.graylog.events.notifications.NotificationDto;
@@ -51,10 +52,12 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -82,6 +85,9 @@ public class LegacyAlertConditionMigratorTest {
     private DBNotificationService notificationService;
     private NotificationResourceHandler notificationResourceHandler;
 
+    @Mock
+    private Map<String, EventNotification.Factory> eventNotificationFactories;
+
     @Before
     public void setUp() throws Exception {
         final ObjectMapper objectMapper = new ObjectMapperProvider().get();
@@ -105,7 +111,7 @@ public class LegacyAlertConditionMigratorTest {
 
         this.eventDefinitionService = new DBEventDefinitionService(mongoConnection, mongoJackObjectMapperProvider, mock(DBEventProcessorStateService.class));
         this.eventDefinitionHandler = spy(new EventDefinitionHandler(eventDefinitionService, jobDefinitionService, jobTriggerService, clock));
-        this.notificationResourceHandler = spy(new NotificationResourceHandler(notificationService, jobDefinitionService, eventDefinitionService));
+        this.notificationResourceHandler = spy(new NotificationResourceHandler(notificationService, jobDefinitionService, eventDefinitionService, eventNotificationFactories));
         this.migrator = new LegacyAlertConditionMigrator(mongoConnection, eventDefinitionHandler, notificationResourceHandler, notificationService, CHECK_INTERVAL);
     }
 

--- a/graylog2-server/src/test/java/org/graylog/events/notifications/NotificationResourceHandlerTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/notifications/NotificationResourceHandlerTest.java
@@ -77,7 +77,7 @@ public class NotificationResourceHandlerTest {
 
     @Test
     public void testExecution() throws EventNotificationException {
-        notificationResourceHandler.test("1234", "testUser");
+        notificationResourceHandler.test(getHttpNotification(), "testUser");
 
         ArgumentCaptor<EventNotificationContext> captor = ArgumentCaptor.forClass(EventNotificationContext.class);
         verify(eventNotification, times(1)).execute(captor.capture());

--- a/graylog2-server/src/test/java/org/graylog/events/notifications/NotificationResourceHandlerTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/notifications/NotificationResourceHandlerTest.java
@@ -1,0 +1,92 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog.events.notifications;
+
+import org.graylog.events.notifications.types.HTTPEventNotificationConfig;
+import org.graylog.events.processor.DBEventDefinitionService;
+import org.graylog.scheduler.DBJobDefinitionService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NotificationResourceHandlerTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private NotificationResourceHandler notificationResourceHandler;
+
+    @Mock
+    private DBNotificationService dbNotificationService;
+    @Mock
+    private DBJobDefinitionService jobDefinitionService;
+    @Mock
+    private DBEventDefinitionService eventDefinitionService;
+    @Mock
+    private Map<String, EventNotification.Factory> eventNotificationFactories;
+    @Mock
+    private EventNotification.Factory eventNotificationFactory;
+    @Mock
+    private EventNotification eventNotification;
+
+    private NotificationDto getHttpNotification() {
+        return NotificationDto.builder()
+                .title("Foobar")
+                .id("1234")
+                .description("")
+                .config(HTTPEventNotificationConfig.Builder.create()
+                        .url("http://localhost")
+                        .build())
+                .build();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        when(dbNotificationService.get(anyString())).thenReturn(Optional.of(getHttpNotification()));
+        when(eventNotificationFactory.create()).thenReturn(eventNotification);
+        when(eventNotificationFactories.get(anyString())).thenReturn(eventNotificationFactory);
+        notificationResourceHandler = new NotificationResourceHandler(dbNotificationService, jobDefinitionService, eventDefinitionService, eventNotificationFactories);
+    }
+
+    @Test
+    public void testExecution() throws EventNotificationException {
+        notificationResourceHandler.test("1234", "testUser");
+
+        ArgumentCaptor<EventNotificationContext> captor = ArgumentCaptor.forClass(EventNotificationContext.class);
+        verify(eventNotification, times(1)).execute(captor.capture());
+
+        assertThat(captor.getValue()).satisfies(ctx -> {
+            assertThat(ctx.event().message()).isEqualTo("Notification test message triggered from user <testUser>");
+            assertThat(ctx.notificationId()).isEqualTo("1234");
+            assertThat(ctx.notificationConfig().type()).isEqualTo(HTTPEventNotificationConfig.TYPE_NAME);
+            assertThat(ctx.eventDefinition().get().title()).isEqualTo("Event Definition Test Title");
+        });
+    }
+}

--- a/graylog2-web-interface/src/actions/event-notifications/EventNotificationsActions.js
+++ b/graylog2-web-interface/src/actions/event-notifications/EventNotificationsActions.js
@@ -8,6 +8,7 @@ const EventNotificationsActions = Reflux.createActions({
   create: { asyncResult: true },
   update: { asyncResult: true },
   delete: { asyncResult: true },
+  test: { asyncResult: true },
 });
 
 export default EventNotificationsActions;

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
@@ -127,15 +127,14 @@ class EventNotificationForm extends React.Component {
 
             {!embedded && (
               <div>
+                <Button bsStyle="info" disabled={testButtonDisabled} onClick={() => onTest(notification)}> {testButtonText} </Button>
+                <HelpBlock>
+                  Trigger this notification with a test Alert
+                </HelpBlock>
                 <ButtonToolbar>
                   <Button bsStyle="primary" type="submit">{action === 'create' ? 'Create' : 'Update'}</Button>
                   <Button onClick={onCancel}>Cancel</Button>
                 </ButtonToolbar>
-                <hr />
-                <HelpBlock>
-                  Trigger this notification with a test Alert
-                </HelpBlock>
-                <Button bsStyle="info" disabled={testButtonDisabled} onClick={() => onTest(notification)}> {testButtonText} </Button>
               </div>
             )}
           </form>

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
@@ -126,11 +126,17 @@ class EventNotificationForm extends React.Component {
             {notificationFormComponent}
 
             {!embedded && (
-              <ButtonToolbar>
-                <Button bsStyle="primary" type="submit">{action === 'create' ? 'Create' : 'Update'}</Button>
-                <Button onClick={onCancel}>Cancel</Button>
+              <div>
+                <ButtonToolbar>
+                  <Button bsStyle="primary" type="submit">{action === 'create' ? 'Create' : 'Update'}</Button>
+                  <Button onClick={onCancel}>Cancel</Button>
+                </ButtonToolbar>
+                <hr />
+                <HelpBlock>
+                  Trigger this notification with a test Alert
+                </HelpBlock>
                 <Button bsStyle="info" disabled={testButtonDisabled} onClick={() => onTest(notification)}> {testButtonText} </Button>
-              </ButtonToolbar>
+              </div>
             )}
           </form>
         </Col>

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationFormContainer.jsx
@@ -108,6 +108,21 @@ class EventNotificationFormContainer extends React.Component {
     onSubmit(promise);
   };
 
+  handleTest = () => {
+    const { notification } = this.state;
+    const promise = EventNotificationsActions.test(notification);
+    promise.then(
+      () => {
+      },
+      (errorResponse) => {
+        const { body } = errorResponse.additional;
+        if (errorResponse.status === 400 && body && body.failed) {
+          this.setState({ validation: body });
+        }
+      },
+    );
+  };
+
   render() {
     const { action, embedded, formId, route } = this.props;
     const { notification, validation, isDirty } = this.state;
@@ -125,7 +140,8 @@ class EventNotificationFormContainer extends React.Component {
                                embedded={embedded}
                                onChange={this.handleChange}
                                onCancel={this.handleCancel}
-                               onSubmit={this.handleSubmit} />
+                               onSubmit={this.handleSubmit}
+                               onTest={this.handleTest} />
       </React.Fragment>
     );
   }

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationFormContainer.jsx
@@ -111,7 +111,7 @@ class EventNotificationFormContainer extends React.Component {
   handleTest = () => {
     const { notification } = this.state;
     const promise = EventNotificationsActions.test(notification);
-    promise.then(
+    return promise.then(
       () => {
       },
       (errorResponse) => {

--- a/graylog2-web-interface/src/stores/event-notifications/EventNotificationsStore.js
+++ b/graylog2-web-interface/src/stores/event-notifications/EventNotificationsStore.js
@@ -16,7 +16,6 @@ const EventNotificationsStore = Reflux.createStore({
   allLegacyTypes: undefined,
   notifications: undefined,
   query: undefined,
-  testState: undefined,
   pagination: {
     count: undefined,
     page: undefined,
@@ -39,7 +38,6 @@ const EventNotificationsStore = Reflux.createStore({
       allLegacyTypes: this.allLegacyTypes,
       notifications: this.notifications,
       query: this.query,
-      testState: this.testState,
       pagination: this.pagination,
     };
   },
@@ -170,20 +168,14 @@ const EventNotificationsStore = Reflux.createStore({
 
   test(notification) {
     const promise = fetch('POST', this.eventNotificationsUrl({ segments: ['test'] }), notification);
-    this.testState = { running: true };
-    this.propagateChanges();
 
     promise.then(
       (response) => {
-        this.testState = { running: false };
-        this.propagateChanges();
         UserNotification.success(`Notification "${notification.title}" was executed successfully.`,
           'Notification Test Result');
         return response;
       },
       (error) => {
-        this.testState = { running: false };
-        this.propagateChanges();
         if (error.status !== 400 || !error.additional.body || !error.additional.body.failed) {
           const errorMessage = error.responseMessage ? `error: ${error.responseMessage}` : 'unknown error';
           UserNotification.error(`Notification "${notification.title} execution" failed with ${errorMessage}`,


### PR DESCRIPTION
This change implements the ability to test notifications with a dummy event.

Tests can also be triggered while editing or creating a notification.
Testing from the embedded mode within event creation page is currently not supported.

Fixes #6138 