### PR TITLE
Allowing to enable (experimental) frontend features for development.

### DIFF
--- a/graylog2-web-interface/src/util/AppConfig.js
+++ b/graylog2-web-interface/src/util/AppConfig.js
@@ -18,6 +18,14 @@ const AppConfig = {
     return typeof (DEVELOPMENT) !== 'undefined' && DEVELOPMENT;
   },
 
+  isFeatureEnabled(feature) {
+    // eslint-disable-next-line no-undef
+    return typeof (FEATURES) !== 'undefined' && FEATURES.split(',')
+      .filter(s => typeof s === 'string')
+      .map(s => s.trim().toLowerCase())
+      .includes(feature.toLowerCase());
+  },
+
   rootTimeZone() {
     return this.appConfig().rootTimeZone;
   },

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -143,6 +143,7 @@ if (TARGET === 'start') {
       new webpack.DefinePlugin({
         DEVELOPMENT: true,
         GRAYLOG_HTTP_PUBLISH_URI: JSON.stringify(process.env.GRAYLOG_HTTP_PUBLISH_URI),
+        FEATURES: JSON.stringify(process.env.FEATURES),
       }),
       new CopyWebpackPlugin([{ from: 'config.js' }]),
       new webpack.HotModuleReplacementPlugin(),


### PR DESCRIPTION
## Description

This change is adding a simple way to enable frontend features for
development which are disabled per default. The change is two-fold:

  * Evaluating a `FEATURES` environment variable which contains a
comma-delimited string of feature names to enable
  * Adding a `AppConfig.isFeatureEnabled` function, which returns a
boolean indicating if the given feature is enabled or not. This can be
used in the code to conditionally render parts of the UI.

Notes:

The content of the `FEATURES` can contain multiple features separated by
commas. Additionally, individual feature flags are compared
case-insensitively, so `FEATURES=Time_Travel` will enable the
`time_travel` feature as well.

Example:

If a feature `time_travel` is developed but should not be enabled by
default, developers can do a `FEATURES=time_travel yarn run start` to
enable it for their development environment. In the code, something like
this can be done:

```
<div>
  {AppConfig.isFeatureEnabled('time_travel') && <TimeTravel />}
  ...
  {AppConfig.isFeatureEnabled('time_travel') || <OldBoringStuff />}
</div>
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.