### PR TITLE
Hide replacing search/dashboard functionality behind feature flag.

### DIFF
--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -23,6 +23,7 @@ import {
   CreateEventNotificationPage,
   CreateExtractorsPage,
   CreateUsersPage,
+  DashboardsPage,
   DelegatedSearchPage,
   EditAlertConditionPage,
   EditEventDefinitionPage,
@@ -62,6 +63,7 @@ import {
   RulesPage,
   ShowAlertPage,
   ShowContentPackPage,
+  ShowDashboardPage,
   ShowMessagePage,
   ShowMetricsPage,
   ShowNodePage,
@@ -85,6 +87,7 @@ import {
   ThreadDumpPage,
   UsersPage,
 } from 'pages';
+import AppConfig from 'util/AppConfig';
 
 const AppRouter = () => {
   const pluginRoutes = PluginStore.exports('routes').map((pluginRoute) => {
@@ -94,6 +97,7 @@ const AppRouter = () => {
              component={pluginRoute.component} />
     );
   });
+  const enableNewSearch = AppConfig.isFeatureEnabled('search_3_2');
   return (
     <Router history={history}>
       <Route path={Routes.STARTPAGE} component={App}>
@@ -102,9 +106,10 @@ const AppRouter = () => {
           <Route component={AppWithSearchBar}>
             <Route path={Routes.message_show(':index', ':messageId')} component={ShowMessagePage} />
             <Route path={Routes.SOURCES} component={SourcesPage} />
+            {enableNewSearch || <Route path={Routes.SEARCH} component={DelegatedSearchPage} />}
           </Route>
           <Route component={AppWithoutSearchBar}>
-            <Route path={Routes.SEARCH} component={DelegatedSearchPage} />
+            {enableNewSearch && <Route path={Routes.SEARCH} component={DelegatedSearchPage} />}
             <Redirect from={Routes.legacy_stream_search(':streamId')} to={Routes.stream_search(':streamId')} />
             <Route path={Routes.GETTING_STARTED} component={GettingStartedPage} />
             <Route path={Routes.STREAMS} component={StreamsPage} />
@@ -125,6 +130,8 @@ const AppRouter = () => {
             <Route path={Routes.ALERTS.NOTIFICATIONS.edit(':notificationId')} component={EditEventNotificationPage} />
             <Route path={Routes.show_alert_condition(':streamId', ':conditionId')} component={EditAlertConditionPage} />
             <Route path={Routes.show_alert(':alertId')} component={ShowAlertPage} />
+            {enableNewSearch || <Route path={Routes.DASHBOARDS} component={DashboardsPage} />}
+            {enableNewSearch || <Route path={Routes.dashboard_show(':dashboardId')} component={ShowDashboardPage} />}
             <Route path={Routes.SYSTEM.INPUTS} component={InputsPage} />
             <Route path={Routes.node_inputs(':nodeId')} component={NodeInputsPage} />
             <Route path={Routes.global_input_extractors(':inputId')} component={ExtractorsPage} />

--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -61,7 +61,8 @@ import type { ValueActionHandlerConditionProps } from 'views/logic/valueactions/
 import type { FieldActionHandlerConditionProps } from 'views/logic/fieldactions/FieldActionHandler';
 import { dashboardsPath, extendedSearchPath, newDashboardsPath, showViewsPath, viewsPath } from 'views/Constants';
 import NewDashboardPage from 'views/pages/NewDashboardPage';
-import StreamSearchPage from './pages/StreamSearchPage';
+import StreamSearchPage from 'views/pages/StreamSearchPage';
+import AppConfig from 'util/AppConfig';
 
 Widget.registerSubtype(AggregationWidget.type, AggregationWidget);
 Widget.registerSubtype(MessagesWidget.type, MessagesWidget);
@@ -74,17 +75,31 @@ ViewSharing.registerSubtype(AllUsersOfInstance.Type, AllUsersOfInstance);
 ViewSharing.registerSubtype(SpecificRoles.Type, SpecificRoles);
 ViewSharing.registerSubtype(SpecificUsers.Type, SpecificUsers);
 
+const enableNewSearch = AppConfig.isFeatureEnabled('search_3_2');
+
+const searchRoutes = enableNewSearch
+  ? [
+    { path: newDashboardsPath, component: NewDashboardPage },
+    { path: Routes.stream_search(':streamId'), component: StreamSearchPage },
+    { path: dashboardsPath, component: DashboardsPage },
+  ]
+  : [];
+
+const searchPages = enableNewSearch
+  ? {
+    search: { component: NewSearchPage },
+  }
+  : {};
+
 export default {
   pages: {
-    search: { component: NewSearchPage },
+    ...searchPages,
   },
   routes: [
     { path: extendedSearchPath, component: NewSearchPage, permissions: Permissions.ExtendedSearch.Use },
     { path: viewsPath, component: ViewManagementPage, permissions: Permissions.View.Use },
-    { path: newDashboardsPath, component: NewDashboardPage },
     { path: showViewsPath, component: ShowViewPage },
-    { path: Routes.stream_search(':streamId'), component: StreamSearchPage },
-    { path: dashboardsPath, component: DashboardsPage },
+    ...searchRoutes,
   ],
   enterpriseWidgets: [
     {


### PR DESCRIPTION
This change disables replacing the existing search/dashboard functionality with the new views-based ones per default, so other developers/users of the `master` branch are not impacted, until existing dashboards are migrated properly. To enable the new functionality, run the development server like this:

```
FEATURES=search_3_2 yarn run start
```