### PR TITLE
Create Graylog Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-Graylog is addressing vulnerabilities in the product for the current and the last releases (a release is anything that increases either the major or the minor version part, in a [semver](https://semver.org) understanding) of the last twelve months.
+Graylog is addressing vulnerabilities in the product for the current and the previous releases (a release is anything that increases either the major or the minor version part, in a [semver](https://semver.org) understanding) of the last twelve months.
 
 For the current release (3.1) this means:
 
@@ -19,7 +19,7 @@ We are grateful for anyone reporting a vulnerability, helping us to make Graylog
 That means:
 
   - If you want to report a *critical bug* that could: allow someone to steal credentials, execute code or escalate privileges, please send a bug report to security@graylog.com before publishing it. This allows us to fix it, create a new version and allows other Graylog users to update before the information is out in the wild. After receiving the bug report, we will immediately get back to you to coordinate the required action.
-  - If you want to report a *non-critical bug*, write to security@graylog.org _or_ [open an issue on github](https://github.com/Graylog2/graylog2-server/issues/new).
+  - If you want to report a *non-critical bug*, write to security@graylog.com _or_ [open an issue on github](https://github.com/Graylog2/graylog2-server/issues/new).
   - This is an open source project. If you discover a bug and fix it, you are very welcome to submit a PR. You will be rewarded with the everlasting gratitude of the Graylog team and the community!
   
   Thanks and happy logging!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Graylog Security Policy
+
+## Supported Versions
+
+Graylog is addressing vulnerabilities in the product for the current and the last releases (a release is anything that increases either the major or the minor version part, in a [semver](https://semver.org) understanding) of the last twelve months.
+
+For the current release (3.1) this means:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.1.x   | :white_check_mark: |
+| 3.0.x   | :white_check_mark: |
+| 2.5.x   | :white_check_mark: |
+| < 2.5.0 | :x:                |
+
+## Reporting a Vulnerability
+
+We are grateful for anyone reporting a vulnerability, helping us to make Graylog better and more secure. Additionally, we encourage everyone to disclose bugs in a responsible way, allowing us and other Graylog users to react accordingly in a timely manner.
+That means:
+
+  - If you want to report a *critical bug* that could: allow someone to steal credentials, execute code or escalate privileges, please send a bug report to security@graylog.com before publishing it. This allows us to fix it, create a new version and allows other Graylog users to update before the information is out in the wild. After receiving the bug report, we will immediately get back to you to coordinate the required action.
+  - If you want to report a *non-critical bug*, write to security@graylog.org _or_ [open an issue on github](https://github.com/Graylog2/graylog2-server/issues/new).
+  - This is an open source project. If you discover a bug and fix it, you are very welcome to submit a PR. You will be rewarded with the everlasting gratitude of the Graylog team and the community!
+  
+  Thanks and happy logging!


### PR DESCRIPTION
This PR is adding the `SECURITY.md` file which contains the Graylog Security Policy which includes information how to report security issues back to the project.