### PR TITLE
Add IfSearch component

### DIFF
--- a/graylog2-web-interface/src/views/components/dashboard/IfDashboard.test.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/IfDashboard.test.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import 'helpers/mocking/react-dom_mock';
+
+import View from 'views/logic/views/View';
+import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
+
+import IfDashboard from './IfDashboard';
+
+describe('IfDashboard', () => {
+  it('should render children with Dashboard context', () => {
+    const wrapper = renderer.create(
+      <ViewTypeContext.Provider value={View.Type.Dashboard}>
+        <span>I must not fear.</span>
+        <IfDashboard>
+          <span>Fear is the mind-killer.</span>
+        </IfDashboard>
+      </ViewTypeContext.Provider>,
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should not render children without search context', () => {
+    const wrapper = renderer.create(
+      <ViewTypeContext.Provider value={View.Type.Search}>
+        <span>I must not fear.</span>
+        <IfDashboard>
+          <span>Fear is the mind-killer.</span>
+        </IfDashboard>
+      </ViewTypeContext.Provider>,
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+
+  it('should not render children without context', () => {
+    const wrapper = renderer.create(
+      <div>
+        <span>I must not fear.</span>
+        <IfDashboard>
+          <span>Fear is the mind-killer.</span>
+        </IfDashboard>
+      </div>,
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/graylog2-web-interface/src/views/components/dashboard/IfDashboard.test.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/IfDashboard.test.jsx
@@ -34,7 +34,7 @@ describe('IfDashboard', () => {
   });
 
 
-  it('should not render children without context', () => {
+  it('should render children without context since Dashboard is the default', () => {
     const wrapper = renderer.create(
       <div>
         <span>I must not fear.</span>

--- a/graylog2-web-interface/src/views/components/dashboard/IfDashboard.test.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/IfDashboard.test.jsx
@@ -8,7 +8,7 @@ import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
 import IfDashboard from './IfDashboard';
 
 describe('IfDashboard', () => {
-  it('should render children with Dashboard context', () => {
+  it('should render children with dashboard context', () => {
     const wrapper = renderer.create(
       <ViewTypeContext.Provider value={View.Type.Dashboard}>
         <span>I must not fear.</span>
@@ -20,7 +20,7 @@ describe('IfDashboard', () => {
     expect(wrapper).toMatchSnapshot();
   });
 
-  it('should not render children without search context', () => {
+  it('should not render children without dashboard context', () => {
     const wrapper = renderer.create(
       <ViewTypeContext.Provider value={View.Type.Search}>
         <span>I must not fear.</span>

--- a/graylog2-web-interface/src/views/components/dashboard/__snapshots__/IfDashboard.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/dashboard/__snapshots__/IfDashboard.test.jsx.snap
@@ -1,16 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IfDashboard should not render children without context 1`] = `
-<div>
-  <span>
-    I must not fear.
-  </span>
-  <span>
-    Fear is the mind-killer.
-  </span>
-</div>
-`;
-
 exports[`IfDashboard should not render children without dashboard context 1`] = `
 <span>
   I must not fear.

--- a/graylog2-web-interface/src/views/components/dashboard/__snapshots__/IfDashboard.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/dashboard/__snapshots__/IfDashboard.test.jsx.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`IfDashboard should not render children without context 1`] = `
+<div>
+  <span>
+    I must not fear.
+  </span>
+  <span>
+    Fear is the mind-killer.
+  </span>
+</div>
+`;
+
+exports[`IfDashboard should not render children without dashboard context 1`] = `
+<span>
+  I must not fear.
+</span>
+`;
+
+exports[`IfDashboard should render children with dashboard context 1`] = `
+Array [
+  <span>
+    I must not fear.
+  </span>,
+  <span>
+    Fear is the mind-killer.
+  </span>,
+]
+`;

--- a/graylog2-web-interface/src/views/components/dashboard/__snapshots__/IfDashboard.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/dashboard/__snapshots__/IfDashboard.test.jsx.snap
@@ -27,3 +27,14 @@ Array [
   </span>,
 ]
 `;
+
+exports[`IfDashboard should render children without context since Dashboard is the default 1`] = `
+<div>
+  <span>
+    I must not fear.
+  </span>
+  <span>
+    Fear is the mind-killer.
+  </span>
+</div>
+`;

--- a/graylog2-web-interface/src/views/components/search/IfSearch.jsx
+++ b/graylog2-web-interface/src/views/components/search/IfSearch.jsx
@@ -1,0 +1,15 @@
+// @flow strict
+import * as React from 'react';
+import View from 'views/logic/views/View';
+import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
+
+type Props = {
+  children: React.Node,
+};
+const IfSearch = ({ children }: Props) => (
+  <ViewTypeContext.Consumer>
+    {viewType => ((viewType === View.Type.Search) ? children : null)}
+  </ViewTypeContext.Consumer>
+);
+
+export default IfSearch;

--- a/graylog2-web-interface/src/views/components/search/IfSearch.test.jsx
+++ b/graylog2-web-interface/src/views/components/search/IfSearch.test.jsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import 'helpers/mocking/react-dom_mock';
+
+import View from 'views/logic/views/View';
+import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
+
+import IfSearch from './IfSearch';
+
+describe('IfSearch', () => {
+  it('should render children with search context', () => {
+    const wrapper = renderer.create(
+      <ViewTypeContext.Provider value={View.Type.Search}>
+        <span>I must not fear.</span>
+        <IfSearch>
+          <span>Fear is the mind-killer.</span>
+        </IfSearch>
+      </ViewTypeContext.Provider>,
+    );
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should not render children without context', () => {
+    const wrapper = renderer.create(
+      <div>
+        <span>I must not fear.</span>
+        <IfSearch>
+          <span>Fear is the mind-killer.</span>
+        </IfSearch>
+      </div>,
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should not render children without search context', () => {
+    const wrapper = renderer.create(
+      <ViewTypeContext.Provider value={View.Type.Dashboard}>
+        <span>I must not fear.</span>
+        <IfSearch>
+          <span>Fear is the mind-killer.</span>
+        </IfSearch>
+      </ViewTypeContext.Provider>,
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/graylog2-web-interface/src/views/components/search/__snapshots__/IfSearch.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/search/__snapshots__/IfSearch.test.jsx.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`IfSearch should not render children without context 1`] = `
+<div>
+  <span>
+    I must not fear.
+  </span>
+</div>
+`;
+
+exports[`IfSearch should not render children without search context 1`] = `
+<span>
+  I must not fear.
+</span>
+`;
+
+exports[`IfSearch should render children with search context 1`] = `
+Array [
+  <span>
+    I must not fear.
+  </span>,
+  <span>
+    Fear is the mind-killer.
+  </span>,
+]
+`;


### PR DESCRIPTION
## Description
Add a component which only renders its children when the
context provides a ViewType of search

Also add unit test for IfDashboard

## Motivation and Context
We need a way to only render components based on which page we are.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
