### PR TITLE
Providing type of actual view instead of hardcoding one in context provider.

### DIFF
--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -96,10 +96,10 @@ export default {
     ...searchPages,
   },
   routes: [
+    ...searchRoutes,
     { path: extendedSearchPath, component: NewSearchPage, permissions: Permissions.ExtendedSearch.Use },
     { path: viewsPath, component: ViewManagementPage, permissions: Permissions.View.Use },
     { path: showViewsPath, component: ShowViewPage },
-    ...searchRoutes,
   ],
   enterpriseWidgets: [
     {

--- a/graylog2-web-interface/src/views/components/QueryTabs.jsx
+++ b/graylog2-web-interface/src/views/components/QueryTabs.jsx
@@ -46,7 +46,7 @@ const QueryTabs = ({ children, onSelect, onRemove, onTitleChange, queries, selec
 };
 
 QueryTabs.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.element, PropTypes.arrayOf(PropTypes.element)]).isRequired,
+  children: PropTypes.node,
   onSaveView: PropTypes.func.isRequired,
   onSelect: PropTypes.func.isRequired,
   onRemove: PropTypes.func.isRequired,
@@ -54,6 +54,10 @@ QueryTabs.propTypes = {
   queries: PropTypes.object.isRequired,
   selectedQuery: PropTypes.string.isRequired,
   titles: PropTypes.object.isRequired,
+};
+
+QueryTabs.defaultProps = {
+  children: null,
 };
 
 export default QueryTabs;

--- a/graylog2-web-interface/src/views/components/QueryTabs.jsx
+++ b/graylog2-web-interface/src/views/components/QueryTabs.jsx
@@ -48,6 +48,7 @@ const QueryTabs = ({ children, onSelect, onRemove, onTitleChange, queries, selec
 QueryTabs.propTypes = {
   children: PropTypes.node,
   onSaveView: PropTypes.func.isRequired,
+  onSaveAsView: PropTypes.func.isRequired,
   onSelect: PropTypes.func.isRequired,
   onRemove: PropTypes.func.isRequired,
   onTitleChange: PropTypes.func.isRequired,

--- a/graylog2-web-interface/src/views/components/contexts/ViewTypeContext.jsx
+++ b/graylog2-web-interface/src/views/components/contexts/ViewTypeContext.jsx
@@ -1,8 +1,7 @@
 // @flow strict
 import * as React from 'react';
 import type { ViewType } from 'views/logic/views/View';
-import View from 'views/logic/views/View';
 
-const ViewTypeContext = React.createContext<ViewType>(View.Type.Dashboard);
+const ViewTypeContext = React.createContext<?ViewType>();
 
 export default ViewTypeContext;

--- a/graylog2-web-interface/src/views/components/dashboard/IfDashboard.test.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/IfDashboard.test.jsx
@@ -34,7 +34,7 @@ describe('IfDashboard', () => {
   });
 
 
-  it('should render children without context since Dashboard is the default', () => {
+  it('should not render children without context', () => {
     const wrapper = renderer.create(
       <div>
         <span>I must not fear.</span>

--- a/graylog2-web-interface/src/views/components/dashboard/__snapshots__/IfDashboard.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/dashboard/__snapshots__/IfDashboard.test.jsx.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`IfDashboard should not render children without context 1`] = `
+<div>
+  <span>
+    I must not fear.
+  </span>
+</div>
+`;
+
 exports[`IfDashboard should not render children without dashboard context 1`] = `
 <span>
   I must not fear.
@@ -15,12 +23,4 @@ Array [
     Fear is the mind-killer.
   </span>,
 ]
-`;
-
-exports[`IfDashboard should render children without context since Dashboard is the default 1`] = `
-<div>
-  <span>
-    I must not fear.
-  </span>
-</div>
 `;

--- a/graylog2-web-interface/src/views/components/dashboard/__snapshots__/IfDashboard.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/dashboard/__snapshots__/IfDashboard.test.jsx.snap
@@ -22,8 +22,5 @@ exports[`IfDashboard should render children without context since Dashboard is t
   <span>
     I must not fear.
   </span>
-  <span>
-    Fear is the mind-killer.
-  </span>
 </div>
 `;

--- a/graylog2-web-interface/src/views/components/widgets/__snapshots__/Widget.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/widgets/__snapshots__/Widget.test.jsx.snap
@@ -33,11 +33,6 @@ exports[`<Widget /> should render with empty props 1`] = `
           />
         </span>
          
-        <i
-          className="fa fa-filter widgetActionDropdownCaret filterNotSet"
-          onClick={[Function]}
-        />
-         
         <span
           onClick={[Function]}
           onMouseDown={[Function]}

--- a/graylog2-web-interface/src/views/logic/views/View.js
+++ b/graylog2-web-interface/src/views/logic/views/View.js
@@ -134,7 +134,7 @@ export default class View {
 
   // eslint-disable-next-line no-use-before-define
   toBuilder(): Builder {
-    const { id, title, summary, description, search, properties, state, createdAt, owner, requires } = this._value;
+    const { id, title, summary, description, search, properties, state, createdAt, owner, requires, type } = this._value;
     // eslint-disable-next-line no-use-before-define
     return new Builder(Immutable.Map({
       id,
@@ -147,6 +147,7 @@ export default class View {
       createdAt,
       owner,
       requires,
+      type,
     }));
   }
 

--- a/graylog2-web-interface/src/views/logic/views/ViewGenerator.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewGenerator.js
@@ -3,12 +3,13 @@ import Search from '../search/Search';
 import QueryGenerator from '../queries/QueryGenerator';
 import ViewStateGenerator from './ViewStateGenerator';
 
-export default () => {
+export default (type) => {
   const query = QueryGenerator();
   const search = Search.create().toBuilder().queries([query]).build();
   const viewState = ViewStateGenerator();
   return View.create()
     .toBuilder()
+    .type(type)
     .state({ [query.id]: viewState })
     .search(search)
     .build();

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -13,6 +13,7 @@ import type {
 } from 'views/logic/hooks/SearchRefreshCondition';
 import { FieldTypesActions } from 'views/stores/FieldTypesStore';
 import { SearchConfigActions } from 'views/stores/SearchConfigStore';
+import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
 
 import { SearchExecutionStateStore } from 'views/stores/SearchExecutionStateStore';
 import { SearchMetadataActions } from 'views/stores/SearchMetadataStore';
@@ -53,6 +54,12 @@ const _refreshIfNotUndeclared = (searchRefreshHooks, executionState, view) => {
   });
 };
 
+const CurrentViewTypeProvider = connect(
+  ({ type, children }) => <ViewTypeContext.Provider value={type}>{children}</ViewTypeContext.Provider>,
+  { view: ViewStore },
+  ({ view }) => ({ type: view && view.view ? view.view.type : undefined }),
+);
+
 const ExtendedSearchPage = ({ executionState, route, searchRefreshHooks }) => {
   const refreshIfNotUndeclared = view => _refreshIfNotUndeclared(searchRefreshHooks, executionState, view);
   useEffect(() => {
@@ -83,7 +90,7 @@ const ExtendedSearchPage = ({ executionState, route, searchRefreshHooks }) => {
   }, []);
 
   return (
-    <React.Fragment>
+    <CurrentViewTypeProvider>
       <WindowLeaveMessage route={route} />
       <HeaderElements />
       <Row id="main-row">
@@ -96,7 +103,7 @@ const ExtendedSearchPage = ({ executionState, route, searchRefreshHooks }) => {
 
         <SearchResult />
       </Row>
-    </React.Fragment>
+    </CurrentViewTypeProvider>
   );
 };
 

--- a/graylog2-web-interface/src/views/pages/NewDashboardPage.jsx
+++ b/graylog2-web-interface/src/views/pages/NewDashboardPage.jsx
@@ -5,7 +5,6 @@ import Spinner from 'components/common/Spinner';
 
 import { ViewActions } from 'views/stores/ViewStore';
 import View from 'views/logic/views/View';
-import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
 import ExtendedSearchPage from './ExtendedSearchPage';
 
 type Props = {
@@ -14,15 +13,11 @@ type Props = {
 const NewDashboardPage = ({ route }: Props) => {
   const [loaded, setLoaded] = useState(false);
   useEffect(() => {
-    ViewActions.create().then(() => setLoaded(true));
+    ViewActions.create(View.Type.Dashboard).then(() => setLoaded(true));
   }, []);
 
   return loaded
-    ? (
-      <ViewTypeContext.Provider value={View.Type.Dashboard}>
-        <ExtendedSearchPage route={route} />
-      </ViewTypeContext.Provider>
-    )
+    ? <ExtendedSearchPage route={route} />
     : <Spinner />;
 };
 

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
@@ -12,7 +12,6 @@ import { SearchExecutionStateStore } from 'views/stores/SearchExecutionStateStor
 import ViewLoaderContext from 'views/logic/ViewLoaderContext';
 import View from 'views/logic/views/View';
 import ViewLoader from 'views/logic/views/ViewLoader';
-import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
 import { SearchActions } from 'views/stores/SearchStore';
 
 import ExtendedSearchPage from './ExtendedSearchPage';
@@ -102,9 +101,7 @@ class NewSearchPage extends React.Component<Props, State> {
       const { route } = this.props;
       return (
         <ViewLoaderContext.Provider value={{ loaderFunc: this.loadView, dirty, loadedView }}>
-          <ViewTypeContext.Provider value={View.Type.Search}>
-            <ExtendedSearchPage route={route} />
-          </ViewTypeContext.Provider>
+          <ExtendedSearchPage route={route} />
         </ViewLoaderContext.Provider>
       );
     }

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
@@ -50,7 +50,7 @@ class NewSearchPage extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    ViewActions.create().then(() => this.setState({ loaded: true }));
+    ViewActions.create(View.Type.Search).then(() => this.setState({ loaded: true }));
   }
 
   componentWillReceiveProps(nextProps: Props): any {

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 
 import { ViewActions } from 'views/stores/ViewStore';
 import { QueryFiltersActions } from 'views/stores/QueryFiltersStore';
+import View from 'views/logic/views/View';
 import Spinner from 'components/common/Spinner';
 import ExtendedSearchPage from './ExtendedSearchPage';
 
@@ -16,7 +17,7 @@ type Props = {
 export default ({ params: { streamId }, route }: Props) => {
   const [loaded, setLoaded] = useState(false);
   useEffect(() => {
-    ViewActions.create()
+    ViewActions.create(View.Type.Search)
       .then(({ activeQuery }) => QueryFiltersActions.streams(activeQuery, [streamId]))
       .then(() => setLoaded(true));
   }, []);

--- a/graylog2-web-interface/src/views/stores/ViewStore.js
+++ b/graylog2-web-interface/src/views/stores/ViewStore.js
@@ -6,11 +6,11 @@ import { get, isEqualWith } from 'lodash';
 import ViewGenerator from 'views/logic/views/ViewGenerator';
 import SearchTypesGenerator from 'views/logic/searchtypes/SearchTypesGenerator';
 import { QueriesActions } from 'views/actions/QueriesActions';
+import type { Properties, ViewType } from 'views/logic/views/View';
 import View from 'views/logic/views/View';
+import type { QuerySet } from 'views/logic/search/Search';
 import Search from 'views/logic/search/Search';
 import ViewState from 'views/logic/views/ViewState';
-import type { Properties } from 'views/logic/views/View';
-import type { QuerySet } from 'views/logic/search/Search';
 import Query from 'views/logic/queries/Query';
 import SearchActions from 'views/actions/SearchActions';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
@@ -24,7 +24,7 @@ export type ViewStoreState = {
 };
 
 type ViewActionsType = RefluxActions<{
-  create: () => Promise<ViewStoreState>,
+  create: (ViewType) => Promise<ViewStoreState>,
   description: (string) => Promise<ViewStoreState>,
   load: (View) => Promise<ViewStoreState>,
   properties: (Properties) => Promise<void>,
@@ -78,12 +78,11 @@ export const ViewStore: ViewStoreType = singletonStore(
       return this._state();
     },
 
-    create() {
-      const [view] = this._updateSearch(ViewGenerator());
+    create(type: ViewType) {
+      const [view] = this._updateSearch(ViewGenerator(type));
       this.view = view;
       const queries: QuerySet = get(view, 'search.queries', Immutable.Set());
-      const firstQueryId = queries.first().id;
-      this.activeQuery = firstQueryId;
+      this.activeQuery = queries.first().id;
 
       const promise = ViewActions.search(view.search)
         .then(() => {


### PR DESCRIPTION
Before this change, creating a new search/dashboard or loading one was
explicitly providing the view type by calling the
`ViewTypeContext.Provider` with a static value. This was prone to errors
caused by forgetting to do this in other places, leading to the default
being used.

Instead of this, this PR is now consolidating the context providers to a
single place that takes the view type from the currently loaded view.