### PR TITLE
Fixing existing stream search when feature flag is disabled.

### DIFF
--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -81,6 +81,7 @@ import {
   StreamAlertsOverviewPage,
   StreamEditPage,
   StreamOutputsPage,
+  StreamSearchPage,
   StreamsPage,
   SystemOutputsPage,
   SystemOverviewPage,
@@ -107,6 +108,7 @@ const AppRouter = () => {
             <Route path={Routes.message_show(':index', ':messageId')} component={ShowMessagePage} />
             <Route path={Routes.SOURCES} component={SourcesPage} />
             {enableNewSearch || <Route path={Routes.SEARCH} component={DelegatedSearchPage} />}
+            {enableNewSearch || <Route path={Routes.stream_search(':streamId')} component={StreamSearchPage} />}
           </Route>
           <Route component={AppWithoutSearchBar}>
             {enableNewSearch && <Route path={Routes.SEARCH} component={DelegatedSearchPage} />}


### PR DESCRIPTION
## Description
## Motivation and Context

In #6368, a feature flag was introduced, that enables the new
views-based search. Unfortunately, it was forgotten to add the route
for the existing stream search when the feature flag is disabled, so
without the feature flag it is inaccessible. This PR is fixing this.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.