### PR TITLE
Remove unnecessary ViewLoaderContext keys and usage

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Button, ButtonGroup } from 'react-bootstrap';
-import type { ViewLoaderContextType } from 'views/logic/ViewLoaderContext';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import UserNotification from 'util/UserNotification';
 import { ViewStore, ViewActions } from 'views/stores/ViewStore';
@@ -32,8 +31,8 @@ class BookmarkControls extends React.Component<Props, State> {
 
   formTarget: any;
 
-  constructor(props: Props, context: ViewLoaderContextType) {
-    super(props, context);
+  constructor(props: Props) {
+    super(props);
 
     const { viewStoreState } = props;
     const { view } = viewStoreState;

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Button, ButtonGroup } from 'react-bootstrap';
-import ViewLoaderContext from 'views/logic/ViewLoaderContext';
 import type { ViewLoaderContextType } from 'views/logic/ViewLoaderContext';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import UserNotification from 'util/UserNotification';
@@ -27,8 +26,6 @@ type State = {
 };
 
 class BookmarkControls extends React.Component<Props, State> {
-  static contextType = ViewLoaderContext;
-
   static propTypes = {
     viewStoreState: PropTypes.object.isRequired,
   };
@@ -129,7 +126,7 @@ class BookmarkControls extends React.Component<Props, State> {
   render() {
     const { showForm, showList, newTitle } = this.state;
     const { viewStoreState } = this.props;
-    const { view } = viewStoreState;
+    const { view, dirty } = viewStoreState;
 
 
     const bookmarkList = showList && (
@@ -138,49 +135,44 @@ class BookmarkControls extends React.Component<Props, State> {
                     toggleModal={this.toggleListModal} />
     );
 
+    const loaded = (view && view.id);
+    const bookmarkStyle = loaded ? 'fa-bookmark' : 'fa-bookmark-o';
+    let bookmarkColor: string = '';
+    if (loaded) {
+      bookmarkColor = dirty ? '#ffc107' : '#007bff';
+    }
+
+    const disableReset = !(dirty || loaded);
+    let title: string;
+    if (dirty) {
+      title = 'Unsaved changes';
+    } else {
+      title = loaded ? 'Saved search' : 'Save search';
+    }
+
+    const bookmarkForm = showForm && (
+      <BookmarkForm onChangeTitle={this.onChangeTitle}
+                    target={this.formTarget}
+                    saveSearch={this.saveSearch}
+                    saveAsSearch={this.saveAsSearch}
+                    disableCreateNew={newTitle === view.title}
+                    isCreateNew={!view.id}
+                    toggleModal={this.toggleFormModal}
+                    value={newTitle} />
+    );
+
     return (
       <div className={`${styles.position} pull-right`}>
         <ButtonGroup>
-          <ViewLoaderContext.Consumer>
-            {({ loadedView, dirty }) => {
-              const loaded = (loadedView && loadedView.id);
-              const bookmarkStyle = loaded ? 'fa-bookmark' : 'fa-bookmark-o';
-              let bookmarkColor: string = '';
-              if (loaded) {
-                bookmarkColor = dirty ? '#ffc107' : '#007bff';
-              }
-
-              const disableReset = !(dirty || loaded);
-              let title: string;
-              if (dirty) {
-                title = 'Unsaved changes';
-              } else {
-                title = loaded ? 'Saved search' : 'Save search';
-              }
-
-              const bookmarkForm = showForm && (
-                <BookmarkForm onChangeTitle={this.onChangeTitle}
-                              target={this.formTarget}
-                              saveSearch={this.saveSearch}
-                              saveAsSearch={this.saveAsSearch}
-                              disableCreateNew={newTitle === view.title}
-                              isCreateNew={!view.id}
-                              toggleModal={this.toggleFormModal}
-                              value={newTitle} />
-              );
-              return (
-                <React.Fragment>
-                  <Button disabled={disableReset} title="Empty search" onClick={ViewActions.create}>
-                    <i className="fa fa-eraser" />
-                  </Button>
-                  <Button title={title} ref={(elem) => { this.formTarget = elem; }} onClick={this.toggleFormModal}>
-                    <i style={{ color: bookmarkColor }} className={`fa ${bookmarkStyle}`} />
-                  </Button>
-                  {bookmarkForm}
-                </React.Fragment>
-              );
-            }}
-          </ViewLoaderContext.Consumer>
+          <React.Fragment>
+            <Button disabled={disableReset} title="Empty search" onClick={ViewActions.create}>
+              <i className="fa fa-eraser" />
+            </Button>
+            <Button title={title} ref={(elem) => { this.formTarget = elem; }} onClick={this.toggleFormModal}>
+              <i style={{ color: bookmarkColor }} className={`fa ${bookmarkStyle}`} />
+            </Button>
+            {bookmarkForm}
+          </React.Fragment>
           <Button title="List of saved searches"
                   onClick={this.toggleListModal}>
             <i className="fa fa-folder-o" />

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.test.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import View from 'views/logic/views/View';
-import ViewLoaderContext from 'views/logic/ViewLoaderContext';
 import Search from 'views/logic/search/Search';
 import BookmarkControls from './BookmarkControls';
 

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.test.jsx
@@ -25,7 +25,6 @@ describe('BookmarkControls', () => {
     });
 
     it('should render with context', () => {
-      const onLoad = jest.fn();
       const view = View.builder()
         .title('title')
         .description('description')
@@ -37,11 +36,7 @@ describe('BookmarkControls', () => {
         view: view,
         dirty: true,
       };
-      const wrapper = mount(
-        <ViewLoaderContext.Provider value={{ loaderFunc: onLoad, dirty: true, loadedView: view }}>
-          <BookmarkControls viewStoreState={viewStoreState} />
-        </ViewLoaderContext.Provider>,
-      );
+      const wrapper = mount(<BookmarkControls viewStoreState={viewStoreState} />);
       expect(wrapper).toMatchSnapshot();
     });
   });

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.test.jsx
@@ -9,6 +9,20 @@ import BookmarkControls from './BookmarkControls';
 
 describe('BookmarkControls', () => {
   describe('render the BookmarkControls', () => {
+    it('should render not dirty with unsaved view', () => {
+      const viewStoreState = {
+        activeQuery: '',
+        view: View.builder()
+          .title('title')
+          .description('description')
+          .search(Search.create().toBuilder().id('id-beef').build())
+          .build(),
+        dirty: false,
+      };
+      const wrapper = mount(<BookmarkControls viewStoreState={viewStoreState} />);
+      expect(wrapper).toMatchSnapshot();
+    });
+
     it('should render not dirty', () => {
       const viewStoreState = {
         activeQuery: '',
@@ -24,7 +38,7 @@ describe('BookmarkControls', () => {
       expect(wrapper).toMatchSnapshot();
     });
 
-    it('should render with context', () => {
+    it('should render dirty', () => {
       const view = View.builder()
         .title('title')
         .description('description')

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkList.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkList.jsx
@@ -128,7 +128,7 @@ class BookmarkList extends React.Component<Props, State> {
         </Modal.Body>
         <Modal.Footer>
           <ViewLoaderContext.Consumer>
-            {({ loaderFunc }) => (
+            {loaderFunc => (
               <Button disabled={!selectedBookmark}
                       bsStyle="primary"
                       onClick={() => { this.onLoad(selectedBookmark, loaderFunc); }}>

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkList.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkList.jsx
@@ -70,7 +70,7 @@ class BookmarkList extends React.Component<Props, State> {
 
   onLoad = (selectedBookmark, loadFunc) => {
     const { toggleModal } = this.props;
-    if (!selectedBookmark) {
+    if (!selectedBookmark || !loadFunc) {
       return;
     }
     loadFunc(selectedBookmark).then(toggleModal);

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkList.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkList.test.jsx
@@ -93,7 +93,7 @@ describe('BookmarkList', () => {
       const views = createViewsResponse(1);
 
       const wrapper = mount(
-        <ViewLoaderContext.Provider value={{ loaderFunc: onLoad, dirty: false, loadedView: undefined }}>
+        <ViewLoaderContext.Provider value={onLoad}>
           <BookmarkList toggleModal={() => {}}
                         showModal
                         deleteBookmark={() => {}}

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkControls.test.jsx.snap
@@ -58,13 +58,13 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty 1`
             block={false}
             bsClass="btn"
             bsStyle="default"
-            disabled={true}
+            disabled={false}
             onClick={[Function]}
             title="Empty search"
           >
             <button
               className="btn btn-default"
-              disabled={true}
+              disabled={false}
               onClick={[Function]}
               title="Empty search"
               type="button"
@@ -81,20 +81,20 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty 1`
             bsStyle="default"
             disabled={false}
             onClick={[Function]}
-            title="Save search"
+            title="Saved search"
           >
             <button
               className="btn btn-default"
               disabled={false}
               onClick={[Function]}
-              title="Save search"
+              title="Saved search"
               type="button"
             >
               <i
-                className="fa fa-bookmark-o"
+                className="fa fa-bookmark"
                 style={
                   Object {
-                    "color": "",
+                    "color": "#007bff",
                   }
                 }
               />

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkControls.test.jsx.snap
@@ -1,5 +1,133 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`BookmarkControls render the BookmarkControls should render dirty 1`] = `
+<ConnectStoresWrapper[BookmarkControls] stores=viewStoreState
+  viewStoreState={
+    Object {
+      "activeQuery": "",
+      "dirty": true,
+      "view": Object {
+        "created_at": undefined,
+        "description": "description",
+        "id": "id-beef",
+        "owner": undefined,
+        "properties": undefined,
+        "search_id": "id-beef",
+        "state": undefined,
+        "summary": undefined,
+        "title": "title",
+        "type": undefined,
+      },
+    }
+  }
+>
+  <BookmarkControls
+    viewStoreState={
+      Object {
+        "activeQuery": "",
+        "dirty": true,
+        "view": Object {
+          "created_at": undefined,
+          "description": "description",
+          "id": "id-beef",
+          "owner": undefined,
+          "properties": undefined,
+          "search_id": "id-beef",
+          "state": undefined,
+          "summary": undefined,
+          "title": "title",
+          "type": undefined,
+        },
+      }
+    }
+  >
+    <div
+      className="position pull-right"
+    >
+      <ButtonGroup
+        block={false}
+        bsClass="btn-group"
+        justified={false}
+        vertical={false}
+      >
+        <div
+          className="btn-group"
+        >
+          <Button
+            active={false}
+            block={false}
+            bsClass="btn"
+            bsStyle="default"
+            disabled={false}
+            onClick={[Function]}
+            title="Empty search"
+          >
+            <button
+              className="btn btn-default"
+              disabled={false}
+              onClick={[Function]}
+              title="Empty search"
+              type="button"
+            >
+              <i
+                className="fa fa-eraser"
+              />
+            </button>
+          </Button>
+          <Button
+            active={false}
+            block={false}
+            bsClass="btn"
+            bsStyle="default"
+            disabled={false}
+            onClick={[Function]}
+            title="Unsaved changes"
+          >
+            <button
+              className="btn btn-default"
+              disabled={false}
+              onClick={[Function]}
+              title="Unsaved changes"
+              type="button"
+            >
+              <i
+                className="fa fa-bookmark"
+                style={
+                  Object {
+                    "color": "#ffc107",
+                  }
+                }
+              />
+            </button>
+          </Button>
+          <Button
+            active={false}
+            block={false}
+            bsClass="btn"
+            bsStyle="default"
+            disabled={false}
+            onClick={[Function]}
+            title="List of saved searches"
+          >
+            <button
+              className="btn btn-default"
+              disabled={false}
+              onClick={[Function]}
+              title="List of saved searches"
+              type="button"
+            >
+              <i
+                className="fa fa-folder-o"
+              />
+            </button>
+          </Button>
+        </div>
+      </ButtonGroup>
+    </div>
+  </BookmarkControls>
+</ConnectStoresWrapper[BookmarkControls] stores=viewStoreState>
+`;
+
 exports[`BookmarkControls render the BookmarkControls should render not dirty 1`] = `
 <ConnectStoresWrapper[BookmarkControls] stores=viewStoreState
   viewStoreState={
@@ -128,16 +256,16 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty 1`
 </ConnectStoresWrapper[BookmarkControls] stores=viewStoreState>
 `;
 
-exports[`BookmarkControls render the BookmarkControls should render with context 1`] = `
+exports[`BookmarkControls render the BookmarkControls should render not dirty with unsaved view 1`] = `
 <ConnectStoresWrapper[BookmarkControls] stores=viewStoreState
   viewStoreState={
     Object {
       "activeQuery": "",
-      "dirty": true,
+      "dirty": false,
       "view": Object {
         "created_at": undefined,
         "description": "description",
-        "id": "id-beef",
+        "id": undefined,
         "owner": undefined,
         "properties": undefined,
         "search_id": "id-beef",
@@ -153,11 +281,11 @@ exports[`BookmarkControls render the BookmarkControls should render with context
     viewStoreState={
       Object {
         "activeQuery": "",
-        "dirty": true,
+        "dirty": false,
         "view": Object {
           "created_at": undefined,
           "description": "description",
-          "id": "id-beef",
+          "id": undefined,
           "owner": undefined,
           "properties": undefined,
           "search_id": "id-beef",
@@ -186,13 +314,13 @@ exports[`BookmarkControls render the BookmarkControls should render with context
             block={false}
             bsClass="btn"
             bsStyle="default"
-            disabled={false}
+            disabled={true}
             onClick={[Function]}
             title="Empty search"
           >
             <button
               className="btn btn-default"
-              disabled={false}
+              disabled={true}
               onClick={[Function]}
               title="Empty search"
               type="button"
@@ -209,20 +337,20 @@ exports[`BookmarkControls render the BookmarkControls should render with context
             bsStyle="default"
             disabled={false}
             onClick={[Function]}
-            title="Unsaved changes"
+            title="Save search"
           >
             <button
               className="btn btn-default"
               disabled={false}
               onClick={[Function]}
-              title="Unsaved changes"
+              title="Save search"
               type="button"
             >
               <i
-                className="fa fa-bookmark"
+                className="fa fa-bookmark-o"
                 style={
                   Object {
-                    "color": "#ffc107",
+                    "color": "",
                   }
                 }
               />

--- a/graylog2-web-interface/src/views/logic/ViewLoaderContext.jsx
+++ b/graylog2-web-interface/src/views/logic/ViewLoaderContext.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import View from 'views/logic/views/View';
 
-export type ViewLoaderContextType = { loaderFunc: string => Promise<?View>, loadedView: ?View, dirty: boolean };
+export type ViewLoaderContextType = { loaderFunc: string => Promise<?View> };
 
 const ViewLoaderContext = React.createContext<ViewLoaderContextType>({});
 

--- a/graylog2-web-interface/src/views/logic/ViewLoaderContext.jsx
+++ b/graylog2-web-interface/src/views/logic/ViewLoaderContext.jsx
@@ -3,8 +3,8 @@ import * as React from 'react';
 
 import View from 'views/logic/views/View';
 
-export type ViewLoaderContextType = { loaderFunc: string => Promise<?View> };
+export type ViewLoaderContextType = string => Promise<?View>;
 
-const ViewLoaderContext = React.createContext<ViewLoaderContextType>({});
+const ViewLoaderContext = React.createContext<?ViewLoaderContextType>();
 
 export default ViewLoaderContext;

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
@@ -23,13 +23,11 @@ type Props = {
   },
   executingViewHooks: Array<ViewHook>,
   loadingViewHooks: Array<ViewHook>,
-  viewStoreState: ViewStoreState,
 };
 
 type State = {
   loaded: boolean,
   hookComponent: ?any,
-  loadedView: ?View,
 };
 
 class NewSearchPage extends React.Component<Props, State> {
@@ -45,20 +43,11 @@ class NewSearchPage extends React.Component<Props, State> {
     this.state = {
       hookComponent: undefined,
       loaded: false,
-      loadedView: undefined,
     };
   }
 
   componentDidMount() {
     ViewActions.create(View.Type.Search).then(() => this.setState({ loaded: true }));
-  }
-
-  componentWillReceiveProps(nextProps: Props): any {
-    const { viewStoreState } = nextProps;
-    const { view } = viewStoreState;
-    if (!view.id || view.id === '') {
-      this.setState({ loadedView: view });
-    }
   }
 
   loadView = (viewId: string): Promise<?View> => {
@@ -80,7 +69,7 @@ class NewSearchPage extends React.Component<Props, State> {
         this.setState({ hookComponent: e });
       },
     ).then((view) => {
-      this.setState({ loaded: true, loadedView: view });
+      this.setState({ loaded: true });
       return view;
     }).then(() => {
       SearchActions.executeWithCurrentState();
@@ -88,9 +77,7 @@ class NewSearchPage extends React.Component<Props, State> {
   };
 
   render() {
-    const { hookComponent, loaded, loadedView } = this.state;
-    const { viewStoreState } = this.props;
-    const { dirty } = viewStoreState;
+    const { hookComponent, loaded } = this.state;
 
     if (hookComponent) {
       const HookComponent = hookComponent;
@@ -100,7 +87,7 @@ class NewSearchPage extends React.Component<Props, State> {
     if (loaded) {
       const { route } = this.props;
       return (
-        <ViewLoaderContext.Provider value={{ loaderFunc: this.loadView, dirty, loadedView }}>
+        <ViewLoaderContext.Provider value={{ loaderFunc: this.loadView }}>
           <ExtendedSearchPage route={route} />
         </ViewLoaderContext.Provider>
       );

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
@@ -86,7 +86,7 @@ class NewSearchPage extends React.Component<Props, State> {
     if (loaded) {
       const { route } = this.props;
       return (
-        <ViewLoaderContext.Provider value={{ loaderFunc: this.loadView }}>
+        <ViewLoaderContext.Provider value={this.loadView}>
           <ExtendedSearchPage route={route} />
         </ViewLoaderContext.Provider>
       );

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
@@ -6,7 +6,6 @@ import connect from 'stores/connect';
 import withPluginEntities from 'views/logic/withPluginEntities';
 import { Spinner } from 'components/common';
 import { ViewActions, ViewStore } from 'views/stores/ViewStore';
-import type { ViewStoreState } from 'views/stores/ViewStore';
 import type { ViewHook } from 'views/logic/hooks/ViewHook';
 import { SearchExecutionStateStore } from 'views/stores/SearchExecutionStateStore';
 import ViewLoaderContext from 'views/logic/ViewLoaderContext';


### PR DESCRIPTION
## Description
Before there was a unnecessary use of ViewLoaderContext in BookmarkControls.

## Motivation and Context
This PR will remove the ViewLoaderContext from BookmarkControls and uses the
already imported ViewStoreState instead.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
