### PR TITLE
Set the loglevel for org.graylog2 AND org.graylog

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/loggers/responses/SingleSubsystemSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/loggers/responses/SingleSubsystemSummary.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 
+import java.util.List;
+
 @AutoValue
 @WithBeanGetter
 @JsonAutoDetect
@@ -29,7 +31,7 @@ public abstract class SingleSubsystemSummary {
     @JsonProperty
     public abstract String title();
     @JsonProperty
-    public abstract String category();
+    public abstract List<String> categories();
     @JsonProperty
     public abstract String description();
     @JsonProperty
@@ -39,10 +41,10 @@ public abstract class SingleSubsystemSummary {
 
     @JsonCreator
     public static SingleSubsystemSummary create(@JsonProperty("title") String title,
-                                                @JsonProperty("category") String category,
+                                                @JsonProperty("categories") List<String> categories,
                                                 @JsonProperty("description") String description,
                                                 @JsonProperty("level") String level,
                                                 @JsonProperty("level_syslog") int levelSyslog) {
-        return new AutoValue_SingleSubsystemSummary(title, category, description, level, levelSyslog);
+        return new AutoValue_SingleSubsystemSummary(title, categories, description, level, levelSyslog);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/logs/LoggersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/logs/LoggersResource.java
@@ -185,6 +185,9 @@ public class LoggersResource extends RestResource {
         final Subsystem subsystem = SUBSYSTEMS.get(subsystemTitle);
         final Level newLevel = Level.toLevel(level.toUpperCase(Locale.ENGLISH));
         setLoggerLevel(subsystem.getCategory(), newLevel);
+        if (subsystem.getCategory().equals("org.graylog2")) {
+            setLoggerLevel("org.graylog", newLevel);
+        }
 
         LOG.debug("Successfully set log level for subsystem \"{}\" to \"{}\"", subsystem.getTitle(), newLevel);
     }


### PR DESCRIPTION
We have added lots of code to the `org.graylog` package,
which we are missing a lot of useful debugging info from.
