### PR TITLE
Applying filters to all dashboard tabs using dashboard search bar.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
@@ -92,8 +92,9 @@ public abstract class Query {
             return this;
         }
         final boolean hasTimerange = state.hasNonNull("timerange");
+        final boolean hasQuery = state.hasNonNull("query");
         final boolean hasSearchTypes = state.hasNonNull("search_types");
-        if (hasTimerange || hasSearchTypes) {
+        if (hasTimerange || hasQuery || hasSearchTypes) {
             final Builder builder = toBuilder();
             if (hasTimerange) {
                 try {
@@ -103,6 +104,11 @@ public abstract class Query {
                 } catch (Exception e) {
                     LOG.error("Unable to deserialize execution state for time range", e);
                 }
+            }
+            if (hasQuery) {
+                final Object rawQuery = state.path("query");
+                final BackendQuery newQuery = objectMapper.convertValue(rawQuery, BackendQuery.class);
+                builder.query(newQuery);
             }
             if (hasSearchTypes) {
                 // copy all existing search types, we'll update them by id if necessary below

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
@@ -87,9 +87,15 @@ public abstract class Search {
                     .collect(ImmutableSet.toImmutableSet());
             builder.parameters(parameters);
         }
-        if (state.hasNonNull("queries")) {
+        if (state.hasNonNull("queries") || state.hasNonNull("global_override")) {
+
             final ImmutableSet<Query> queries = queries().stream()
-                    .map(query -> query.applyExecutionState(objectMapper, state.path("queries").path(query.id())))
+                    .map(query -> {
+                        final JsonNode queryOverride = state.hasNonNull("global_override")
+                                ? state.path("global_override")
+                                : state.path("queries").path(query.id());
+                        return query.applyExecutionState(objectMapper, queryOverride);
+                    })
                     .collect(ImmutableSet.toImmutableSet());
             builder.queries(queries);
         }

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
@@ -17,6 +17,7 @@ import View from 'views/logic/views/View';
 import { QueriesActions } from 'views/actions/QueriesActions';
 import { ViewStore } from 'views/stores/ViewStore';
 import { CurrentQueryStore } from 'views/stores/CurrentQueryStore';
+import { GlobalOverrideActions, GlobalOverrideStore } from '../stores/GlobalOverrideStore';
 
 type Props = {
   availableStreams: Array<*>,
@@ -39,7 +40,7 @@ const _performSearch = (onExecute) => {
 };
 
 const DashboardSearchBar = ({ config, currentQuery, disableSearch = false, onExecute }: Props) => {
-  if (!currentQuery || !config) {
+  if (!config) {
     return <Spinner />;
   }
   const performSearch = () => _performSearch(onExecute);
@@ -47,7 +48,7 @@ const DashboardSearchBar = ({ config, currentQuery, disableSearch = false, onExe
     event.preventDefault();
     performSearch();
   };
-  const { timerange, query, id } = currentQuery;
+  const { timerange = { type: 'relative' }, query = {} } = currentQuery || {};
   const { type, ...rest } = timerange;
   const rangeParams = Immutable.Map(rest);
   const rangeType = type;
@@ -68,13 +69,13 @@ const DashboardSearchBar = ({ config, currentQuery, disableSearch = false, onExe
 
                 <QueryInput value={query.query_string}
                             placeholder="Apply filter to all widgets"
-                            onChange={value => QueriesActions.query(id, value).then(performSearch).then(() => value)}
+                            onChange={value => GlobalOverrideActions.query(value).then(performSearch).then(() => value)}
                             onExecute={performSearch} />
               </Col>
               <Col md={3}>
-                <TimeRangeTypeSelector onSelect={newRangeType => QueriesActions.rangeType(id, newRangeType).then(performSearch)}
+                <TimeRangeTypeSelector onSelect={newRangeType => GlobalOverrideActions.rangeType(newRangeType).then(performSearch)}
                                        value={rangeType} />
-                <TimeRangeInput onChange={(key, value) => QueriesActions.rangeParams(id, key, value).then(performSearch)}
+                <TimeRangeInput onChange={(key, value) => GlobalOverrideActions.rangeParams(key, value).then(performSearch)}
                                 rangeType={rangeType}
                                 rangeParams={rangeParams}
                                 config={config} />
@@ -100,6 +101,6 @@ DashboardSearchBar.defaultProps = {
 export default connect(
   DashboardSearchBar,
   {
-    currentQuery: CurrentQueryStore,
+    currentQuery: GlobalOverrideStore,
   },
 );

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
@@ -14,13 +14,10 @@ import TimeRangeInput from 'views/components/searchbar/TimeRangeInput';
 import SearchButton from 'views/components/searchbar/SearchButton';
 import QueryInput from 'views/components/searchbar/AsyncQueryInput';
 import View from 'views/logic/views/View';
-import { QueriesActions } from 'views/actions/QueriesActions';
 import { ViewStore } from 'views/stores/ViewStore';
-import { CurrentQueryStore } from 'views/stores/CurrentQueryStore';
 import { GlobalOverrideActions, GlobalOverrideStore } from '../stores/GlobalOverrideStore';
 
 type Props = {
-  availableStreams: Array<*>,
   config: any,
   currentQuery: {
     id: string,
@@ -31,7 +28,6 @@ type Props = {
   },
   disableSearch: boolean,
   onExecute: (View) => void,
-  queryFilters: Immutable.Map,
 };
 
 const _performSearch = (onExecute) => {

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
@@ -9,8 +9,8 @@ import DocumentationLink from 'components/support/DocumentationLink';
 import DocsHelper from 'util/DocsHelper';
 import Spinner from 'components/common/Spinner';
 import ScrollToHint from 'views/components/common/ScrollToHint';
-import TimeRangeTypeSelector from 'views/components/searchbar/TimeRangeTypeSelector';
-import TimeRangeInput from 'views/components/searchbar/TimeRangeInput';
+import TimeRangeOverrideTypeSelector from 'views/components/searchbar/TimeRangeOverrideTypeSelector';
+import TimeRangeOverrideInput from 'views/components/searchbar/TimeRangeOverrideInput';
 import SearchButton from 'views/components/searchbar/SearchButton';
 import QueryInput from 'views/components/searchbar/AsyncQueryInput';
 import View from 'views/logic/views/View';
@@ -44,7 +44,7 @@ const DashboardSearchBar = ({ config, currentQuery, disableSearch = false, onExe
     event.preventDefault();
     performSearch();
   };
-  const { timerange = { type: 'relative' }, query = {} } = currentQuery || {};
+  const { timerange = {}, query = {} } = currentQuery || {};
   const { type, ...rest } = timerange;
   const rangeParams = Immutable.Map(rest);
   const rangeType = type;
@@ -69,12 +69,12 @@ const DashboardSearchBar = ({ config, currentQuery, disableSearch = false, onExe
                             onExecute={performSearch} />
               </Col>
               <Col md={3}>
-                <TimeRangeTypeSelector onSelect={newRangeType => GlobalOverrideActions.rangeType(newRangeType).then(performSearch)}
-                                       value={rangeType} />
-                <TimeRangeInput onChange={(key, value) => GlobalOverrideActions.rangeParams(key, value).then(performSearch)}
-                                rangeType={rangeType}
-                                rangeParams={rangeParams}
-                                config={config} />
+                <TimeRangeOverrideTypeSelector onSelect={newRangeType => GlobalOverrideActions.rangeType(newRangeType).then(performSearch)}
+                                               value={rangeType} />
+                <TimeRangeOverrideInput onChange={(key, value) => GlobalOverrideActions.rangeParams(key, value).then(performSearch)}
+                                        rangeType={rangeType}
+                                        rangeParams={rangeParams}
+                                        config={config} />
               </Col>
             </form>
           </Row>

--- a/graylog2-web-interface/src/views/components/searchbar/DisabledTimeRangeSelector.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/DisabledTimeRangeSelector.jsx
@@ -1,9 +1,20 @@
 // @flow strict
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import Input from 'components/bootstrap/Input';
 
-const DisabledTimeRangeSelector = () => {
-};
+const DisabledTimeRangeSelector = () => (
+  <div className="timerange-selector relative"
+       style={{ marginLeft: 50 }}>
+    <Input id="relative-timerange-selector"
+           type="select"
+           disabled
+           className="relative"
+           value="disabled"
+           name="relative">
+      <option value="disabled">No Override</option>
+    </Input>
+  </div>
+);
 
 DisabledTimeRangeSelector.propTypes = {};
 

--- a/graylog2-web-interface/src/views/components/searchbar/DisabledTimeRangeSelector.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/DisabledTimeRangeSelector.jsx
@@ -1,0 +1,10 @@
+// @flow strict
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+const DisabledTimeRangeSelector = () => {
+};
+
+DisabledTimeRangeSelector.propTypes = {};
+
+export default DisabledTimeRangeSelector;

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeOverrideInput.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeOverrideInput.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import RelativeTimeRangeSelector from 'views/components/searchbar/RelativeTimeRangeSelector';
+import AbsoluteTimeRangeSelector from 'views/components/searchbar/AbsoluteTimeRangeSelector';
+import KeywordTimeRangeSelector from 'views/components/searchbar/KeywordTimeRangeSelector';
+import DisabledTimeRangeSelector from './DisabledTimeRangeSelector';
+
+export default function TimeRangeOverrideInput({ rangeType, rangeParams, config, onChange }) {
+  switch (rangeType) {
+    case undefined:
+      return <DisabledTimeRangeSelector />;
+    case 'relative':
+      return <RelativeTimeRangeSelector value={rangeParams} config={config} onChange={onChange} />;
+    case 'absolute':
+      return <AbsoluteTimeRangeSelector value={rangeParams} onChange={onChange} />;
+    case 'keyword':
+      return <KeywordTimeRangeSelector value={rangeParams} onChange={onChange} />;
+    default:
+      throw new Error(`Unsupported range type ${rangeType}`);
+  }
+}
+
+TimeRangeOverrideInput.propTypes = {
+  config: PropTypes.shape({
+    relative_timerange_options: PropTypes.objectOf(PropTypes.string).isRequired,
+  }).isRequired,
+  onChange: PropTypes.func.isRequired,
+  rangeParams: PropTypes.object.isRequired,
+  rangeType: PropTypes.string.isRequired,
+};

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeOverrideTypeSelector.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeOverrideTypeSelector.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { ButtonToolbar, DropdownButton, MenuItem } from 'react-bootstrap';
+
+import PropTypes from 'views/components/CustomPropTypes';
+
+const TimeRangeOverrideTypeSelector = ({ onSelect, value }) => (
+  <ButtonToolbar className="extended-search-timerange-chooser pull-left">
+    <DropdownButton bsStyle="info"
+                    title={<i className="fa fa-clock-o" />}
+                    onSelect={onSelect}
+                    id="dropdown-timerange-selector">
+      <MenuItem eventKey="disabled"
+                className={value === undefined ? 'selected' : null}>
+        No Override
+      </MenuItem>
+      <MenuItem eventKey="relative"
+                className={value === 'relative' ? 'selected' : null}>
+        Relative
+      </MenuItem>
+      <MenuItem eventKey="absolute"
+                className={value === 'absolute' ? 'selected' : null}>
+        Absolute
+      </MenuItem>
+      <MenuItem eventKey="keyword"
+                className={value === 'keyword' ? 'selected' : null}>
+        Keyword
+      </MenuItem>
+    </DropdownButton>
+  </ButtonToolbar>
+);
+
+TimeRangeOverrideTypeSelector.propTypes = {
+  onSelect: PropTypes.func.isRequired,
+  value: PropTypes.TimeRangeType.isRequired,
+};
+
+export default TimeRangeOverrideTypeSelector;

--- a/graylog2-web-interface/src/views/logic/search/SearchExecutionState.js
+++ b/graylog2-web-interface/src/views/logic/search/SearchExecutionState.js
@@ -4,8 +4,8 @@ import ParameterBinding from '../parameters/ParameterBinding';
 import type { QueryString, TimeRange } from '../queries/Query';
 
 export type GlobalOverride = {
-  timerange: ?TimeRange,
-  query: ?QueryString,
+  timerange?: TimeRange,
+  query?: QueryString,
 };
 
 export type ParameterBindings = Immutable.Map<string, ParameterBinding>;

--- a/graylog2-web-interface/src/views/logic/search/SearchExecutionState.js
+++ b/graylog2-web-interface/src/views/logic/search/SearchExecutionState.js
@@ -1,37 +1,49 @@
 // @flow strict
 import * as Immutable from 'immutable';
 import ParameterBinding from '../parameters/ParameterBinding';
+import type { QueryString, TimeRange } from '../queries/Query';
+
+export type GlobalOverride = {
+  timerange: ?TimeRange,
+  query: ?QueryString,
+};
 
 export type ParameterBindings = Immutable.Map<string, ParameterBinding>;
 
 type InternalState = {
   parameterBindings: ParameterBindings,
+  globalOverride: ?GlobalOverride,
 };
 
 type JsonRepresentation = {
-  parameter_bindings: ParameterBindings;
+  global_override: ?GlobalOverride,
+  parameter_bindings: ParameterBindings,
 };
 
 export default class SearchExecutionState {
   _value: InternalState;
 
-  constructor(parameterBindings: ParameterBindings = Immutable.Map()) {
-    this._value = { parameterBindings };
+  constructor(parameterBindings: ParameterBindings = Immutable.Map(), globalOverride: ?GlobalOverride) {
+    this._value = { parameterBindings, globalOverride };
   }
 
   get parameterBindings(): ParameterBindings {
     return this._value.parameterBindings;
   }
 
-  // eslint-disable-next-line no-use-before-define
-  toBuilder(): Builder {
-    const { parameterBindings } = this._value;
-    // eslint-disable-next-line no-use-before-define
-    return new Builder(Immutable.Map({ parameterBindings }));
+  get globalOverride(): ?GlobalOverride {
+    return this._value.globalOverride;
   }
 
-  static create(parameterBindings: ParameterBindings): SearchExecutionState {
-    return new SearchExecutionState(parameterBindings);
+  // eslint-disable-next-line no-use-before-define
+  toBuilder(): Builder {
+    const { globalOverride, parameterBindings } = this._value;
+    // eslint-disable-next-line no-use-before-define
+    return new Builder(Immutable.Map({ globalOverride, parameterBindings }));
+  }
+
+  static create(parameterBindings: ParameterBindings, globalOverride: ?GlobalOverride): SearchExecutionState {
+    return new SearchExecutionState(parameterBindings, globalOverride);
   }
 
   static empty(): SearchExecutionState {
@@ -39,17 +51,18 @@ export default class SearchExecutionState {
   }
 
   toJSON(): JsonRepresentation {
-    const { parameterBindings } = this._value;
+    const { globalOverride, parameterBindings } = this._value;
 
     return {
+      global_override: globalOverride,
       parameter_bindings: parameterBindings,
     };
   }
 
   static fromJSON(value: JsonRepresentation): SearchExecutionState {
     // eslint-disable-next-line camelcase
-    const { parameter_bindings } = value;
-    return SearchExecutionState.create(parameter_bindings);
+    const { global_override, parameter_bindings } = value;
+    return SearchExecutionState.create(parameter_bindings, global_override);
   }
 }
 
@@ -66,9 +79,13 @@ class Builder {
     return new Builder(this.value.set('parameterBindings', newBindings));
   }
 
+  globalOverride(globalOverride: GlobalOverride): Builder {
+    return new Builder(this.value.set('globalOverride', globalOverride));
+  }
+
   build(): SearchExecutionState {
-    const { parameterBindings } = this.value.toObject();
-    return new SearchExecutionState(parameterBindings);
+    const { globalOverride, parameterBindings } = this.value.toObject();
+    return new SearchExecutionState(parameterBindings, globalOverride);
   }
 }
 

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -19,10 +19,8 @@ import { SearchMetadataActions } from 'views/stores/SearchMetadataStore';
 import { SearchActions } from 'views/stores/SearchStore';
 import { StreamsActions } from 'views/stores/StreamsStore';
 import { ViewActions, ViewStore } from 'views/stores/ViewStore';
-import CustomPropTypes from 'views/components/CustomPropTypes';
 import HeaderElements from 'views/components/HeaderElements';
 import QueryBarElements from 'views/components/QueryBarElements';
-import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import WindowLeaveMessage from 'views/components/common/WindowLeaveMessage';
 import withPluginEntities from 'views/logic/withPluginEntities';
 import IfDashboard from 'views/components/dashboard/IfDashboard';
@@ -119,7 +117,6 @@ const ExtendedSearchPage = ({ route, searchRefreshHooks }) => {
 };
 
 ExtendedSearchPage.propTypes = {
-  executionState: CustomPropTypes.instanceOf(SearchExecutionState).isRequired,
   route: PropTypes.object.isRequired,
   searchRefreshHooks: PropTypes.arrayOf(PropTypes.func).isRequired,
 };

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -30,11 +30,11 @@ import QueryBar from 'views/components/QueryBar';
 import DashboardSearchBar from 'views/components/DashboardSearchBar';
 import SearchBar from 'views/components/SearchBar';
 import CurrentViewTypeProvider from 'views/components/views/CurrentViewTypeProvider';
+import IfSearch from 'views/components/search/IfSearch';
+import { AdditionalContext } from 'views/logic/ActionContext';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import style from '!style/useable!css!./ExtendedSearchPage.css';
-import IfSearch from '../components/search/IfSearch';
-import { AdditionalContext } from '../logic/ActionContext';
 
 type Props = {
   route: any,
@@ -63,8 +63,8 @@ const DashboardSearchBarWithStatus = WithSearchStatus(DashboardSearchBar);
 
 const ViewAdditionalContextProvider = connect(AdditionalContext.Provider, { view: ViewStore }, ({ view }) => ({ value: { view: view.view } }));
 
-const ExtendedSearchPage = ({ executionState, route, searchRefreshHooks }) => {
-  const refreshIfNotUndeclared = view => _refreshIfNotUndeclared(searchRefreshHooks, executionState, view);
+const ExtendedSearchPage = ({ route, searchRefreshHooks }) => {
+  const refreshIfNotUndeclared = view => _refreshIfNotUndeclared(searchRefreshHooks, SearchExecutionStateStore.getInitialState(), view);
   useEffect(() => {
     style.use();
 
@@ -124,10 +124,8 @@ ExtendedSearchPage.propTypes = {
   searchRefreshHooks: PropTypes.arrayOf(PropTypes.func).isRequired,
 };
 
-const ExtendedSearchPageWithExecutionState = connect(ExtendedSearchPage, { executionState: SearchExecutionStateStore });
-
 const mapping = {
   searchRefreshHooks: 'views.hooks.searchRefresh',
 };
 
-export default withPluginEntities<Props, typeof mapping>(ExtendedSearchPageWithExecutionState, mapping);
+export default withPluginEntities<Props, typeof mapping>(ExtendedSearchPage, mapping);

--- a/graylog2-web-interface/src/views/stores/GlobalOverrideStore.js
+++ b/graylog2-web-interface/src/views/stores/GlobalOverrideStore.js
@@ -1,0 +1,104 @@
+// @flow strict
+import Reflux from 'reflux';
+import moment from 'moment';
+
+import SearchExecutionState from 'views/logic/search/SearchExecutionState';
+import { singletonActions, singletonStore } from 'views/logic/singleton';
+import type { GlobalOverride } from 'views/logic/search/SearchExecutionState';
+import type { RefluxActions } from './StoreTypes';
+import { SearchExecutionStateStore, SearchExecutionStateActions } from './SearchExecutionStateStore';
+
+export type GlobalOverrideActionsType = RefluxActions<{
+  rangeType: (string) => Promise<?GlobalOverride>,
+  rangeParams: (string, string | number) => Promise<?GlobalOverride>,
+  query: (string) => Promise<?GlobalOverride>,
+}>;
+
+export const GlobalOverrideActions: GlobalOverrideActionsType = singletonActions(
+  'views.GlobalOverride',
+  () => Reflux.createActions({
+    rangeType: { asyncResult: true },
+    rangeParams: { asyncResult: true },
+    query: { asyncResult: true },
+  }),
+);
+
+export const GlobalOverrideStore = singletonStore(
+  'views.GlobalOverride',
+  () => Reflux.createStore({
+    listenables: [GlobalOverrideActions],
+    globalOverride: undefined,
+    init() {
+      this.listenTo(SearchExecutionStateStore, this.handleSearchExecutionStateStoreChange, this.handleSearchExecutionStateStoreChange);
+    },
+    handleSearchExecutionStateStoreChange(newSearchExecutionState: SearchExecutionState) {
+      if (newSearchExecutionState.globalOverride !== this.globalOverride) {
+        this.globalOverride = newSearchExecutionState.globalOverride;
+        this.trigger(this.globalOverride);
+      }
+    },
+    getInitialState() {
+      return this.globalOverride;
+    },
+    rangeType(newType: string) {
+      console.log('rangeType: ', newType, this.globalOverride);
+      const oldTimerange = this.globalOverride && this.globalOverride.timerange ? this.globalOverride.timerange : {};
+      const { type: oldType } = oldTimerange;
+      if (oldType !== newType) {
+        let newTimerange;
+        // eslint-disable-next-line default-case
+        switch (newType) {
+          case 'absolute':
+            newTimerange = {
+              type: newType,
+              from: moment().subtract(oldTimerange.range || 300, 'seconds').toISOString(),
+              to: moment().toISOString(),
+            };
+            break;
+          case 'relative':
+            newTimerange = {
+              type: newType,
+              range: 300,
+            };
+            break;
+          case 'keyword':
+            newTimerange = {
+              type: newType,
+              keyword: 'Last five Minutes',
+            };
+            break;
+        }
+        const newGlobalOverride = this.globalOverride ? { ...this.globalOverride, timerange: newTimerange } : { timerange: newTimerange };
+        const promise = newGlobalOverride !== this.globalOverride
+          ? SearchExecutionStateActions.globalOverride(newGlobalOverride).then(() => newGlobalOverride)
+          : Promise.resolve(this.globalOverride);
+        GlobalOverrideActions.timerange.promise(promise);
+        return promise;
+      }
+      const promise = Promise.resolve(this.globalOverride);
+      GlobalOverrideActions.rangeType.promise(promise);
+      return promise;
+    },
+    rangeParams(key: string, value: string | number) {
+      const newTimerange = this.globalOverride && this.globalOverride.timerange ? { ...this.globalOverride.timerange, [key]: value } : { [key]: value };
+      const newGlobalOverride = this.globalOverride ? { ...this.globalOverride, timerange: newTimerange } : { timerange: newTimerange };
+      const promise = newGlobalOverride !== this.globalOverride
+        ? SearchExecutionStateActions.globalOverride(newGlobalOverride).then(() => newGlobalOverride)
+        : Promise.resolve(this.globalOverride);
+      GlobalOverrideActions.rangeParams.promise(promise);
+      return promise;
+    },
+    query(newQueryString: string) {
+      const newQuery = {
+        type: 'elasticsearch',
+        query_string: newQueryString,
+      };
+      const newGlobalOverride = this.globalOverride ? { ...this.globalOverride, query: newQuery } : { query: newQuery };
+      const promise = newGlobalOverride !== this.globalOverride
+        ? SearchExecutionStateActions.globalOverride(newGlobalOverride).then(() => newGlobalOverride)
+        : Promise.resolve(this.globalOverride);
+      GlobalOverrideActions.query.promise(promise);
+      return promise;
+    },
+  }),
+);

--- a/graylog2-web-interface/src/views/stores/GlobalOverrideStore.js
+++ b/graylog2-web-interface/src/views/stores/GlobalOverrideStore.js
@@ -5,6 +5,7 @@ import moment from 'moment';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
 import type { GlobalOverride } from 'views/logic/search/SearchExecutionState';
+import type { TimeRange } from 'views/logic/queries/Query';
 import type { RefluxActions } from './StoreTypes';
 import { SearchExecutionStateStore, SearchExecutionStateActions } from './SearchExecutionStateStore';
 
@@ -68,11 +69,11 @@ export const GlobalOverrideStore = singletonStore(
             };
             break;
         }
-        const newGlobalOverride = this.globalOverride ? { ...this.globalOverride, timerange: newTimerange } : { timerange: newTimerange };
+        const newGlobalOverride: GlobalOverride = this.globalOverride ? { ...this.globalOverride, timerange: newTimerange } : { timerange: newTimerange };
         const promise = newGlobalOverride !== this.globalOverride
           ? SearchExecutionStateActions.globalOverride(newGlobalOverride).then(() => newGlobalOverride)
           : Promise.resolve(this.globalOverride);
-        GlobalOverrideActions.timerange.promise(promise);
+        GlobalOverrideActions.rangeType.promise(promise);
         return promise;
       }
       const promise = Promise.resolve(this.globalOverride);
@@ -80,8 +81,8 @@ export const GlobalOverrideStore = singletonStore(
       return promise;
     },
     rangeParams(key: string, value: string | number) {
-      const newTimerange = this.globalOverride && this.globalOverride.timerange ? { ...this.globalOverride.timerange, [key]: value } : { [key]: value };
-      const newGlobalOverride = this.globalOverride ? { ...this.globalOverride, timerange: newTimerange } : { timerange: newTimerange };
+      const newTimerange: TimeRange = this.globalOverride && this.globalOverride.timerange ? { ...this.globalOverride.timerange, [key]: value } : { [key]: value };
+      const newGlobalOverride: GlobalOverride = this.globalOverride ? { ...this.globalOverride, timerange: newTimerange } : { timerange: newTimerange };
       const promise = newGlobalOverride !== this.globalOverride
         ? SearchExecutionStateActions.globalOverride(newGlobalOverride).then(() => newGlobalOverride)
         : Promise.resolve(this.globalOverride);
@@ -93,7 +94,7 @@ export const GlobalOverrideStore = singletonStore(
         type: 'elasticsearch',
         query_string: newQueryString,
       };
-      const newGlobalOverride = this.globalOverride ? { ...this.globalOverride, query: newQuery } : { query: newQuery };
+      const newGlobalOverride: GlobalOverride = this.globalOverride ? { ...this.globalOverride, query: newQuery } : { query: newQuery };
       const promise = newGlobalOverride !== this.globalOverride
         ? SearchExecutionStateActions.globalOverride(newGlobalOverride).then(() => newGlobalOverride)
         : Promise.resolve(this.globalOverride);

--- a/graylog2-web-interface/src/views/stores/SearchExecutionStateStore.js
+++ b/graylog2-web-interface/src/views/stores/SearchExecutionStateStore.js
@@ -6,6 +6,7 @@ import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import ParameterBinding from 'views/logic/parameters/ParameterBinding';
 import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
+import type { GlobalOverride } from 'views/logic/search/SearchExecutionState';
 import type { RefluxActions } from './StoreTypes';
 
 const defaultExecutionState = SearchExecutionState.empty();
@@ -17,6 +18,7 @@ export type SearchExecutionStateActionsType = RefluxActions<{
   setParameterValues: (ParameterMap) => Promise<SearchExecutionState>,
   replace: (SearchExecutionState, ?boolean) => Promise<SearchExecutionState>,
   clear: () => Promise<SearchExecutionState>,
+  globalOverride: (?GlobalOverride) => Promise<SearchExecutionState>,
 }>;
 
 export const SearchExecutionStateActions: SearchExecutionStateActionsType = singletonActions(
@@ -26,6 +28,7 @@ export const SearchExecutionStateActions: SearchExecutionStateActionsType = sing
     setParameterValues: { asyncResult: true },
     replace: { asyncResult: true },
     clear: { asyncResult: true },
+    globalOverride: { asyncResult: true },
   }),
 );
 
@@ -85,6 +88,15 @@ export const SearchExecutionStateStore = singletonStore(
         .build();
       this.trigger(this.executionState);
       SearchExecutionStateActions.bindParameterValue.promise(Promise.resolve(this.executionState));
+      return this.executionState;
+    },
+
+    globalOverride(newGlobalOverride: ?GlobalOverride): SearchExecutionState {
+      this.executionState = this.executionState.toBuilder()
+        .globalOverride(newGlobalOverride)
+        .build();
+      this.trigger(this.executionState);
+      SearchExecutionStateActions.globalOverride.promise(Promise.resolve(this.executionState));
       return this.executionState;
     },
   }),

--- a/graylog2-web-interface/src/views/stores/SearchExecutionStateStore.js
+++ b/graylog2-web-interface/src/views/stores/SearchExecutionStateStore.js
@@ -4,10 +4,10 @@ import * as Immutable from 'immutable';
 
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import ParameterBinding from 'views/logic/parameters/ParameterBinding';
-import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
 import type { GlobalOverride } from 'views/logic/search/SearchExecutionState';
 import type { RefluxActions } from './StoreTypes';
+import { ViewActions } from './ViewStore';
 
 const defaultExecutionState = SearchExecutionState.empty();
 
@@ -40,18 +40,12 @@ export const SearchExecutionStateStore = singletonStore(
     executionState: defaultExecutionState,
 
     init() {
-      this.listenTo(ViewMetadataStore, this.handleViewMetadataChange, this.handleViewMetadataChange);
+      ViewActions.create.completed.listen(this.clear);
+      ViewActions.load.completed.listen(this.clear);
     },
 
     getInitialState(): SearchExecutionState {
       return this.executionState;
-    },
-
-    handleViewMetadataChange({ id }) {
-      if (this.viewId !== id) {
-        this.clear();
-        this.viewId = id;
-      }
     },
 
     clear(): SearchExecutionState {


### PR DESCRIPTION
This change allows add a filter that is pushed down (by doing a logical
AND)and to specify a time range that is overriding the time ranges of
all widgets on all tabs. When either a query or an overriding time range
is specified, it is added to the "global override" section of the search
execution state which is kept temporarily (not persisted when saving a
dashboard) and included in the context of each search execution. The
search backend uses it to override all root queries (which are combined
with the widget queries).

That means the final query of a widget is determined like this:

  `(override query || root query) + widget query -> final query`

where `+` is a concatenation using an `AND` operator.