### PR TITLE
Fix KafkaJournal metrics on inactive nodes

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
@@ -399,7 +399,13 @@ public class KafkaJournal extends AbstractIdleService implements Journal {
     private void registerUncommittedGauge(MetricRegistry metricRegistry, String name) {
         try {
             metricRegistry.register(name,
-                    (Gauge<Long>) () -> Math.max(0, getLogEndOffset() - 1 - committedOffset.get()));
+                    (Gauge<Long>) () -> {
+                        if (getCommittedOffset() == DEFAULT_COMMITTED_OFFSET && size() == 0) {
+                            // nothing committed at all
+                            return 0L;
+                        }
+                        return Math.max(0, getLogEndOffset() - 1 - committedOffset.get());
+                    });
         } catch (IllegalArgumentException ignored) {
             // already registered, we'll ignore that.
         }


### PR DESCRIPTION
If nothing was ever commited to a journal,
the uncommitedMessages gauge always reported `9223372036854775807` (Long.MAX_VALUE)

This happens because committedOffset is initialized as DEFAULT_COMMITTED_OFFSET (Long.MIN_VALUE)
(substracted by 1 underflows the long to Long.MAX_VALUE)

This breaks the idle node detection feature for the processing status,
which would exclude entries that have no messages in the journal.

Steal the code from the `ThrottleStateUpdaterThread`, which already deals with this edge case.

Fixes #6415

refs https://github.com/Graylog2/graylog2-server/pull/6252