### PR TITLE
Preventing mouse events from leaking `Widget` component.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/periodical/ThrottleStateUpdaterThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ThrottleStateUpdaterThread.java
@@ -1,4 +1,5 @@
 /**
+/**
  * This file is part of Graylog.
  *
  * Graylog is free software: you can redistribute it and/or modify
@@ -231,7 +232,7 @@ public class ThrottleStateUpdaterThread extends Periodical {
 
         // the journal needs this to provide information to rest clients
         journal.setThrottleState(throttleState);
-        
+
         // publish to interested parties
         eventBus.post(throttleState);
 

--- a/graylog2-web-interface/src/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/components/widgets/Widget.jsx
@@ -224,6 +224,10 @@ const Widget = createReactClass({
     }
   },
 
+  _stopPropagation(e) {
+    e.stopPropagation();
+  },
+
   render() {
     if (this.state.deleted) {
       return <span />;
@@ -252,7 +256,11 @@ const Widget = createReactClass({
     const disabledReplay = !canReadConfiguredStream && !canSearchGlobally;
 
     return (
-      <div ref={(node) => { this.node = node; }} className="widget" data-widget-id={this.props.widget.id}>
+      <div ref={(node) => { this.node = node; }}
+           className="widget"
+           data-widget-id={this.props.widget.id}
+           onClick={this._stopPropagation}
+           onMouseDown={this._stopPropagation}>
         <WidgetHeader title={this.props.widget.description} />
 
         {this._getVisualization()}


### PR DESCRIPTION
## Description
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In `3.1.0` the component related to drawing the dashboard grid was
updated as part of the views integration into the OSS core. This lead to
an unwanted regression where uncaught events from dashboard widgets were
processed by the grid engine, leading to various effects (unable to
focus input fields in the edit widget modal, being able to move
dashboard widgets while the edit widget modal is open).

This change is catching the related events for widgets, preventing them
from reaching the grid engine.

Fixes #6356.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.