### PR TITLE
Do not try to add nonexisting subcharts to stacked chart.

### DIFF
--- a/graylog2-web-interface/src/stores/field-analyzers/FieldGraphsStore.ts
+++ b/graylog2-web-interface/src/stores/field-analyzers/FieldGraphsStore.ts
@@ -280,7 +280,9 @@ class FieldGraphsStore {
 
         stackedGraphs.forEach((stackedGraphId) => {
             var stackedGraph = this.fieldGraphs.get(stackedGraphId);
-            series.push(this.getSeriesInformation(stackedGraph));
+            if (stackedGraph) {
+              series.push(this.getSeriesInformation(stackedGraph));
+            }
         }, this);
 
         requestParams['series'] = series;


### PR DESCRIPTION
## Description
## Motivation and Context

Before this change, stacked charts on the current search page could
reference a nonexisting subchart (see #6355 for an example), leading to
a nonfunctioning search page where the user is not able to remove the
faulty chart to restore it.

This change is adding subcharts conditionally, skipping them if the
given reference cannot be resolved. Therefore, even stacked chart
definitions which reference nonexisting subcharts can be displayed
(partially) correct.

Fixes #6355.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.