### PR TITLE
Fixing event leak prevention in `Widget` component.

### DIFF
--- a/graylog2-web-interface/src/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/components/widgets/Widget.jsx
@@ -281,9 +281,7 @@ const Widget = createReactClass({
       <div role="presentation"
            ref={(node) => { this.node = node; }}
            className="widget"
-           data-widget-id={widget.id}
-           onClick={this._stopPropagation}
-           onMouseDown={this._stopPropagation}>
+           data-widget-id={widget.id}>
         <WidgetHeader title={widget.description} />
 
         {this._getVisualization()}
@@ -297,7 +295,11 @@ const Widget = createReactClass({
                       calculatedAt={calculatedAt}
                       error={error}
                       errorMessage={errorMessage} />
-        {locked ? showConfigModal : editConfigModal}
+        <div role="presentation"
+             onClick={this._stopPropagation}
+             onMouseDown={this._stopPropagation}>
+          {locked ? showConfigModal : editConfigModal}
+        </div>
       </div>
     );
   },


### PR DESCRIPTION
## Description
## Motivation and Context

In #6431 a event propagation barrier was implemented that was supposed
to prevent mouse events from leaking the `Widget` component. This was
done in a too radical way, also preventing valid mouse events (when
dragging a widget in dashboard edit mode) from reaching the grid
container.

This change is now preventing mouse events from leaking the edit/show
config modals only.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.