### PR TITLE
Remove old ProcessingStatus index (backport of #6389 to `3.1`)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
@@ -40,5 +40,6 @@ public class MigrationsModule extends PluginModule {
         addMigration(V20190705071400_AddEventIndexSetsMigration.class);
         addMigration(V20190730100900_AddAlertsManagerRole.class);
         addMigration(V20190730000000_CreateDefaultEventsConfiguration.class);
+        addMigration(V20190905114400_RemoveOldProcessingStatusIndex.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20190905114400_RemoveOldProcessingStatusIndex.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20190905114400_RemoveOldProcessingStatusIndex.java
@@ -1,0 +1,50 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.migrations;
+
+import com.mongodb.DBCollection;
+import com.mongodb.MongoException;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.system.processing.DBProcessingStatusService;
+
+import javax.inject.Inject;
+import java.time.ZonedDateTime;
+
+public class V20190905114400_RemoveOldProcessingStatusIndex extends Migration {
+    private final MongoConnection mongoConnection;
+
+    @Inject
+    public V20190905114400_RemoveOldProcessingStatusIndex(MongoConnection mongoConnection) {
+        this.mongoConnection = mongoConnection;
+    }
+    @Override
+    public ZonedDateTime createdAt() {
+        return ZonedDateTime.parse("2019-09-05T11:40:00Z");
+    }
+
+    @Override
+    public void upgrade() {
+        final String OLD_INDEX_NAME = "updated_at_1_input_journal.uncommitted_entries_1_input_journal.written_messages_1m_rate_1";
+
+        DBCollection processing_status = mongoConnection.getDatabase().getCollection(DBProcessingStatusService.COLLECTION_NAME);
+        try {
+            processing_status.dropIndex(OLD_INDEX_NAME);
+        } catch (MongoException ignored) {
+            // index was either never created or already deleted
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/DBProcessingStatusService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/DBProcessingStatusService.java
@@ -43,7 +43,7 @@ import static org.graylog2.system.processing.ProcessingStatusDto.FIELD_UPDATED_A
  * Manages the database collection for processing status.
  */
 public class DBProcessingStatusService {
-    static final String COLLECTION_NAME = "processing_status";
+    public static final String COLLECTION_NAME = "processing_status";
     private static final String FIELD_WRITTEN_MESSAGES_1M = ProcessingStatusDto.FIELD_INPUT_JOURNAL + "." + ProcessingStatusDto.JournalInfo.FIELD_WRITTEN_MESSAGES_1M_RATE;
     private static final String FIELD_UNCOMMITTED_ENTRIES = ProcessingStatusDto.FIELD_INPUT_JOURNAL + "." + ProcessingStatusDto.JournalInfo.FIELD_UNCOMMITTED_ENTRIES;
 


### PR DESCRIPTION
This is needed, because mongodb >= 4.2 won't allow
the creation of identical indixes with a different name.

Fixes #6383

(cherry picked from commit 5c1020933cf108c68ab94b07d81f1e78efebeb87)