### PR TITLE
Do not try to add nonexisting subcharts to stacked chart. (#6432 3.1 backport)

### DIFF
--- a/graylog2-web-interface/src/stores/field-analyzers/FieldGraphsStore.ts
+++ b/graylog2-web-interface/src/stores/field-analyzers/FieldGraphsStore.ts
@@ -280,7 +280,9 @@ class FieldGraphsStore {
 
         stackedGraphs.forEach((stackedGraphId) => {
             var stackedGraph = this.fieldGraphs.get(stackedGraphId);
-            series.push(this.getSeriesInformation(stackedGraph));
+            if (stackedGraph) {
+              series.push(this.getSeriesInformation(stackedGraph));
+            }
         }, this);
 
         requestParams['series'] = series;


### PR DESCRIPTION
Before this change, stacked charts on the current search page could
reference a nonexisting subchart (see #6355 for an example), leading to
a nonfunctioning search page where the user is not able to remove the
faulty chart to restore it.

This change is adding subcharts conditionally, skipping them if the
given reference cannot be resolved. Therefore, even stacked chart
definitions which reference nonexisting subcharts can be displayed
(partially) correct.

Fixes #6355.

(cherry picked from commit dbd1e4402f94dd7fd9b824bd51c1b2ac90aae493)
