### PR TITLE
Preventing mouse events from leaking `Widget` component. (#6431 3.1 backport)

### DIFF
--- a/graylog2-web-interface/src/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/components/widgets/Widget.jsx
@@ -281,9 +281,7 @@ const Widget = createReactClass({
       <div role="presentation"
            ref={(node) => { this.node = node; }}
            className="widget"
-           data-widget-id={widget.id}
-           onClick={this._stopPropagation}
-           onMouseDown={this._stopPropagation}>
+           data-widget-id={widget.id}>
         <WidgetHeader title={widget.description} />
 
         {this._getVisualization()}
@@ -297,7 +295,11 @@ const Widget = createReactClass({
                       calculatedAt={calculatedAt}
                       error={error}
                       errorMessage={errorMessage} />
-        {locked ? showConfigModal : editConfigModal}
+        <div role="presentation"
+             onClick={this._stopPropagation}
+             onMouseDown={this._stopPropagation}>
+          {locked ? showConfigModal : editConfigModal}
+        </div>
       </div>
     );
   },


### PR DESCRIPTION
* Preventing mouse events from leaking `Widget` component. (#6431)

  (cherry picked from commit f1c6b2bfbf96332ccfb6cb051ec8aa944d571bcd)

* Fixing event leak prevention in `Widget` component.
    
In #6431 a event propagation barrier was implemented that was supposed
to prevent mouse events from leaking the `Widget` component. This was
done in a too radical way, also preventing valid mouse events (when
dragging a widget in dashboard edit mode) from reaching the grid
container.
   
  This change is now preventing mouse events from leaking the edit/show config modals only.
    
  (cherry picked from commit 7555bed2114887663757663ec8753ca2cdab7152)
