### PR TITLE
Fix webpack-resolver for jest --watch

### DIFF
--- a/graylog2-web-interface/src/components/common/webpack-resolver.js
+++ b/graylog2-web-interface/src/components/common/webpack-resolver.js
@@ -9,7 +9,7 @@ const modes = [
 
 modes.forEach((mode) => {
   ace.config.setModuleUrl(
-    `ace/mode/${mode}`, require(`file-loader!ace-builds/src-min-noconflict/mode-${mode}.js`)
+    'ace/mode/' + mode, require('file-loader!ace-builds/src-min-noconflict/mode-' + mode + '.js')
   );
 });
 
@@ -24,6 +24,6 @@ const themes = [
 
 themes.forEach((theme) => {
   ace.config.setModuleUrl(
-    `ace/theme/${theme}`, require(`file-loader!ace-builds/src-min-noconflict/theme-${theme}.js`)
+    'ace/theme/' + theme, require('file-loader!ace-builds/src-min-noconflict/theme-' + theme + '.js')
   );
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes `jest` to allow the `--watch` flag to work again

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`yarn test --watch` was failing with an error from dynamically imported Ace dependencies.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local environment is now testing on the fly

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
