### PR TITLE
Prevent cutting off field names in auto completion.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/ace-queryinput.css
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/ace-queryinput.css
@@ -104,3 +104,7 @@
 .ace-queryinput .ace_indent-guide {
     background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAE0lEQVQImWP4////f4bdu3f/BwAlfgctduB85QAAAABJRU5ErkJggg==) right repeat-y
 }
+
+.ace_editor.ace_autocomplete {
+    width: 600px !important;
+}


### PR DESCRIPTION
Before this change, the autocompletion dropdown was 300px wide and
therefore too narrow for longer field names. This change is increasing
its width (lacking a good way to make it relate to the width to the
actual content) to decrease the risk of cutting off field names.

Before:

![Screen Shot 2019-09-19 at 12 53 25](https://user-images.githubusercontent.com/41929/65238205-85905600-dadc-11e9-9023-95d5fd024b76.png)

After:

![Screen Shot 2019-09-19 at 12 51 36](https://user-images.githubusercontent.com/41929/65238213-888b4680-dadc-11e9-90a1-6a55da77fa5b.png)
