### PR TITLE
Link to the latest documentation and use HTTPS

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,7 @@
 
 Welcome! _Graylog_ is an open source log management platform.
 
-You can read more about the project on our [website](https://www.graylog.org/) and check out the [documentation](http://docs.graylog.org/) on the documentation site.
+You can read more about the project on our [website](https://www.graylog.org/) and check out the [documentation](https://docs.graylog.org/) on the documentation site.
 
 
 ## Issue Tracking

--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -5,7 +5,7 @@ Upgrading to Graylog 3.0.x
 .. _upgrade-from-24-to-30:
 
 This file only contains the upgrade note for the upcoming release.
-Please see `our documentation <http://docs.graylog.org/en/latest/pages/upgrade.html>`_
+Please see `our documentation <https://docs.graylog.org/en/latest/pages/upgrade.html>`_
 for the complete upgrade notes.
 
 Elasticsearch Version Requirements
@@ -109,7 +109,7 @@ Starting with Graylog 3.0.0, the following official plugins were merged into the
 - `NetFlow Input <https://github.com/Graylog2/graylog-plugin-netflow>`_
 - `Pipeline Processor <https://github.com/Graylog2/graylog-plugin-pipeline-processor>`_
 
-That means these plugins are not available as separate plugins anymore. If you manually update your Graylog installation (without using operating system packages), make sure to remove all old plugin files from the `plugin_dir <http://docs.graylog.org/en/3.0/pages/configuration/server.conf.html>`_ folder.
+That means these plugins are not available as separate plugins anymore. If you manually update your Graylog installation (without using operating system packages), make sure to remove all old plugin files from the `plugin_dir <https://docs.graylog.org/en/3.0/pages/configuration/server.conf.html>`_ folder.
 
 The old issues in these repositories are still available for reference but new issues should only be created in the `Graylog server issue tracker <https://github.com/Graylog2/graylog2-server/issues>`_.
 
@@ -159,7 +159,7 @@ For a long time, Graylog allowed to use `Drools <https://www.drools.org/>`_ to f
 
 Starting with Graylog 3.0.0, the support for Drools-based message filters has been removed from Graylog. The ``rules_file`` configuration setting has been removed accordingly.
 
-We recommend migrating the Drools-based logic to `Processing Pipelines <http://docs.graylog.org/en/3.0/pages/pipelines.html>`_.
+We recommend migrating the Drools-based logic to `Processing Pipelines <https://docs.graylog.org/en/3.0/pages/pipelines.html>`_.
 
 
 Drools-based blacklist
@@ -167,7 +167,7 @@ Drools-based blacklist
 
 Graylog provided undocumented blacklist-functionality based on Drools. This blacklist could only be modified via the Graylog REST API on the ``/filters/blacklist`` resource.
 
-If you've been using this functionality, you'll have to migrate these blacklist rules to the `Processing Pipelines <http://docs.graylog.org/en/3.0/pages/pipelines.html>`_.
+If you've been using this functionality, you'll have to migrate these blacklist rules to the `Processing Pipelines <https://docs.graylog.org/en/3.0/pages/pipelines.html>`_.
 
 To check if you're using the Drools-based blacklist in Graylog prior to version 3.0.0, you can run the following command::
 
@@ -202,9 +202,9 @@ New pipeline rule::
 
 See also:
 
-* `has_field() <http://docs.graylog.org/en/3.0/pages/pipelines/functions.html#has-field>`_
-* `lowercase() <http://docs.graylog.org/en/3.0/pages/pipelines/functions.html#lowercase>`_
-* `drop_message() <http://docs.graylog.org/en/3.0/pages/pipelines/functions.html#drop-message>`_
+* `has_field() <https://docs.graylog.org/en/3.0/pages/pipelines/functions.html#has-field>`_
+* `lowercase() <https://docs.graylog.org/en/3.0/pages/pipelines/functions.html#lowercase>`_
+* `drop_message() <https://docs.graylog.org/en/3.0/pages/pipelines/functions.html#drop-message>`_
 
 Regex-based blacklist rule
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -234,9 +234,9 @@ New pipeline rule::
 
 See also:
 
-* `has_field() <http://docs.graylog.org/en/3.0/pages/pipelines/functions.html#has-field>`_
-* `regex() <http://docs.graylog.org/en/3.0/pages/pipelines/functions.html#regex>`_
-* `drop_message() <http://docs.graylog.org/en/3.0/pages/pipelines/functions.html#drop-message>`_
+* `has_field() <https://docs.graylog.org/en/3.0/pages/pipelines/functions.html#has-field>`_
+* `regex() <https://docs.graylog.org/en/3.0/pages/pipelines/functions.html#regex>`_
+* `drop_message() <https://docs.graylog.org/en/3.0/pages/pipelines/functions.html#drop-message>`_
 
 IP Range-based blacklist rule
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -266,10 +266,10 @@ New pipeline rule::
 
 See also:
 
-* `has_field() <http://docs.graylog.org/en/3.0/pages/pipelines/functions.html#has-field>`_
-* `to_ip() <http://docs.graylog.org/en/3.0/pages/pipelines/functions.html#to-ip>`_
-* `cidr_match() <http://docs.graylog.org/en/3.0/pages/pipelines/functions.html#cidr-match>`_
-* `drop_message() <http://docs.graylog.org/en/3.0/pages/pipelines/functions.html#drop-message>`_
+* `has_field() <https://docs.graylog.org/en/3.0/pages/pipelines/functions.html#has-field>`_
+* `to_ip() <https://docs.graylog.org/en/3.0/pages/pipelines/functions.html#to-ip>`_
+* `cidr_match() <https://docs.graylog.org/en/3.0/pages/pipelines/functions.html#cidr-match>`_
+* `drop_message() <https://docs.graylog.org/en/3.0/pages/pipelines/functions.html#drop-message>`_
 
 
 Changed metrics name for stream rules

--- a/docs/cef/README.md
+++ b/docs/cef/README.md
@@ -28,7 +28,7 @@ Some systems will send CEF as part of a RFC compliant syslog message. In this ca
 
 ### Parsing raw CEF or CEF embedded in any other envelopes
 
-If the envelope is not syslog or the CEF message is not in an envelope at all, you can use the [Graylog Processing Pipelines](http://docs.graylog.org/en/latest/pages/pipelines.html) and the `parse_cef` function this plugin provides:
+If the envelope is not syslog or the CEF message is not in an envelope at all, you can use the [Graylog Processing Pipelines](https://docs.graylog.org/en/latest/pages/pipelines.html) and the `parse_cef` function this plugin provides:
 
 1. Use a pipeline rule to parse out the CEF part of the message (for example, using regex) and then apply the `parse_cef()` function on that extracted string.
 1. If desired, use a second pipeline step to rename the `cef_` prefixed message fields to something easier to use and easier to remember.

--- a/graylog-plugin-archetype/README.md
+++ b/graylog-plugin-archetype/README.md
@@ -1,7 +1,7 @@
 Graylog Plugin Maven Archetype
 ==============================
 
-See our latest documentation on [writing plugins](http://docs.graylog.org/en/latest/pages/plugins.html).
+See our latest documentation on [writing plugins](https://docs.graylog.org/en/latest/pages/plugins.html).
 
 ## Creating a new plugin project
 

--- a/graylog-plugin-archetype/src/main/resources/archetype-resources/GETTING-STARTED.md
+++ b/graylog-plugin-archetype/src/main/resources/archetype-resources/GETTING-STARTED.md
@@ -3,7 +3,7 @@ Getting started with your new Graylog plugin
 
 Welcome to your new Graylog plugin!
 
-Please refer to http://docs.graylog.org/en/latest/pages/plugins.html for documentation on how to write
+Please refer to https://docs.graylog.org/en/latest/pages/plugins.html for documentation on how to write
 plugins for Graylog.
 
 Travis CI

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorMessageDecorator.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/PipelineProcessorMessageDecorator.java
@@ -86,7 +86,7 @@ public class PipelineProcessorMessageDecorator implements SearchResponseDecorato
 
     public static class Descriptor extends SearchResponseDecorator.Descriptor {
         public Descriptor() {
-            super("Pipeline Processor Decorator", "http://docs.graylog.org/en/2.0/pages/pipelines.html", "Pipeline Processor Decorator");
+            super("Pipeline Processor Decorator", "https://docs.graylog.org/en/latest/pages/pipelines.html", "Pipeline Processor Decorator");
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/decorators/FormatStringDecorator.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/FormatStringDecorator.java
@@ -88,7 +88,7 @@ public class FormatStringDecorator implements SearchResponseDecorator {
 
     public static class Descriptor extends SearchResponseDecorator.Descriptor {
         public Descriptor() {
-            super("Format String", "http://docs.graylog.org/", "Format string");
+            super("Format String", "https://docs.graylog.org/", "Format string");
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/decorators/LinkFieldDecorator.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/LinkFieldDecorator.java
@@ -73,7 +73,7 @@ public class LinkFieldDecorator implements SearchResponseDecorator {
 
     public static class Descriptor extends SearchResponseDecorator.Descriptor {
         public Descriptor() {
-            super("Hyperlink String", "http://docs.graylog.org/", "Hyperlink string");
+            super("Hyperlink String", "https://docs.graylog.org/", "Hyperlink string");
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/decorators/LookupTableDecorator.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/LookupTableDecorator.java
@@ -102,7 +102,7 @@ public class LookupTableDecorator implements SearchResponseDecorator {
 
     public static class Descriptor extends SearchResponseDecorator.Descriptor {
         public Descriptor() {
-            super("Lookup Table", "http://docs.graylog.org/", "Lookup Table Decorator");
+            super("Lookup Table", "https://docs.graylog.org/", "Lookup Table Decorator");
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/decorators/SyslogSeverityMapperDecorator.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/SyslogSeverityMapperDecorator.java
@@ -87,7 +87,7 @@ public class SyslogSeverityMapperDecorator implements SearchResponseDecorator {
 
     public static class Descriptor extends SearchResponseDecorator.Descriptor {
         public Descriptor() {
-            super("Syslog Severity Mapper", "http://docs.graylog.org/", "Syslog Severity Mapper");
+            super("Syslog Severity Mapper", "https://docs.graylog.org/", "Syslog Severity Mapper");
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/DocsHelper.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/DocsHelper.java
@@ -21,7 +21,7 @@ public enum DocsHelper {
     PAGE_ES_CONFIGURATION("configuration/elasticsearch.html"),
     PAGE_LDAP_TROUBLESHOOTING("users_and_roles/external_auth.html#troubleshooting");
 
-    private static final String DOCS_URL = "http://docs.graylog.org/en/";
+    private static final String DOCS_URL = "https://docs.graylog.org/en/";
 
     private final String path;
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/UI.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/UI.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
 
 public class UI {
 
-    private static final String HELP_DOCS = "http://docs.graylog.org/";
+    private static final String HELP_DOCS = "https://docs.graylog.org/";
     private static final String HELP_COMMUNITY = "https://www.graylog.org/community-support/";
     private static final String HELP_COMMERCIAL = "https://www.graylog.com/support/";
 

--- a/graylog2-web-interface/packages/graylog-web-plugin/src/loadBuildConfig.js
+++ b/graylog2-web-interface/packages/graylog-web-plugin/src/loadBuildConfig.js
@@ -9,7 +9,7 @@ module.exports = function loadBuildConfig(filename) {
       console.error('Path to graylog web interface sources is not defined, does not exist or is not a directory: (', buildConfig.web_src_path, ').');
       console.error('Please configure it in a file named `build.config.js` before trying to build the plugin.');
       // TODO: add link to documentation
-      console.error('For further information please check http://docs.graylog.org/PLACEHOLDER');
+      console.error('For further information please check https://docs.graylog.org/PLACEHOLDER');
       process.exit(-1);
       /* eslint-enable no-console */
     }

--- a/graylog2-web-interface/src/components/common/ExternalLink.md
+++ b/graylog2-web-interface/src/components/common/ExternalLink.md
@@ -1,11 +1,11 @@
 `ExternalLink` in a text:
 ```js
-<p>Please read the <ExternalLink href="http://docs.graylog.org/">Graylog documentation</ExternalLink> to learn about the product.</p>
+<p>Please read the <ExternalLink href="https://docs.graylog.org/">Graylog documentation</ExternalLink> to learn about the product.</p>
 ```
 
 `ExternalLink` with a different icon:
 ```js
-<ExternalLink href="http://docs.graylog.org/"
+<ExternalLink href="https://docs.graylog.org/"
               iconClass="fa-external-link-square">
   Graylog documentation
 </ExternalLink>

--- a/graylog2-web-interface/src/components/common/ExternalLinkButton.md
+++ b/graylog2-web-interface/src/components/common/ExternalLinkButton.md
@@ -1,11 +1,11 @@
 `ExternalLinkButton`:
 ```js
-<ExternalLinkButton href="http://docs.graylog.org/">Graylog documentation</ExternalLinkButton>
+<ExternalLinkButton href="https://docs.graylog.org/">Graylog documentation</ExternalLinkButton>
 ```
 
 `ExternalLinkButton` with different size, style and icon:
 ```js
-<ExternalLinkButton href="http://docs.graylog.org/"
+<ExternalLinkButton href="https://docs.graylog.org/"
                     bsStyle="success"
                     bsSize="lg"
                     iconClass="fa-external-link-square">
@@ -15,5 +15,5 @@
 
 `ExternalLinkButton` that is disabled:
 ```js
-<ExternalLinkButton href="http://docs.graylog.org/" disabled>Graylog documentation</ExternalLinkButton>
+<ExternalLinkButton href="https://docs.graylog.org/" disabled>Graylog documentation</ExternalLinkButton>
 ```

--- a/graylog2-web-interface/src/util/DocsHelper.js
+++ b/graylog2-web-interface/src/util/DocsHelper.js
@@ -30,7 +30,7 @@ class DocsHelper {
     WELCOME: '', // Welcome page to the documentation
   };
 
-  DOCS_URL = 'http://docs.graylog.org/en/';
+  DOCS_URL = 'https://docs.graylog.org/en/';
 
   toString(path) {
     const baseUrl = this.DOCS_URL + Version.getMajorAndMinorVersion();

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -6,7 +6,7 @@
 # Characters that cannot be directly represented in this encoding can be written using Unicode escapes
 # as defined in https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.3, using the \u prefix.
 # For example, \u002c.
-# 
+#
 # * Entries are generally expected to be a single line of the form, one of the following:
 #
 # propertyName=propertyValue
@@ -14,7 +14,7 @@
 #
 # * White space that appears between the property name and property value is ignored,
 #   so the following are equivalent:
-# 
+#
 # name=Stephen
 # name = Stephen
 #
@@ -34,11 +34,11 @@
 #         Los Angeles
 #
 #   This is equivalent to targetCities=Detroit,Chicago,Los Angeles (white space at the beginning of lines is ignored).
-# 
+#
 # * The characters newline, carriage return, and tab can be inserted with characters \n, \r, and \t, respectively.
-# 
+#
 # * The backslash character must be escaped as a double backslash. For example:
-# 
+#
 # path=c:\\docs\\doc1
 #
 
@@ -252,7 +252,7 @@ plugin_dir = plugin
 #            to your previous 1.x settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/en/latest/pages/configuration/index_model.html#index-set-configuration.
 rotation_strategy = count
 
 # (Approximate) maximum number of documents in an Elasticsearch index before a new index
@@ -263,7 +263,7 @@ rotation_strategy = count
 #            to your previous 1.x settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/en/latest/pages/configuration/index_model.html#index-set-configuration.
 elasticsearch_max_docs_per_index = 20000000
 
 # (Approximate) maximum size in bytes per Elasticsearch index on disk before a new index is being created, also see
@@ -274,7 +274,7 @@ elasticsearch_max_docs_per_index = 20000000
 #            to your previous 1.x settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/en/latest/pages/configuration/index_model.html#index-set-configuration.
 #elasticsearch_max_size_per_index = 1073741824
 
 # (Approximate) maximum time before a new Elasticsearch index is being created, also see
@@ -292,7 +292,7 @@ elasticsearch_max_docs_per_index = 20000000
 #            to your previous 1.x settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/en/latest/pages/configuration/index_model.html#index-set-configuration.
 #elasticsearch_max_time_per_index = 1d
 
 # Disable checking the version of Elasticsearch for being compatible with this Graylog release.
@@ -308,7 +308,7 @@ elasticsearch_max_docs_per_index = 20000000
 #            to your previous 1.x settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/en/latest/pages/configuration/index_model.html#index-set-configuration.
 elasticsearch_max_number_of_indices = 20
 
 # Decide what happens with the oldest indices when the maximum number of indices is reached.
@@ -320,7 +320,7 @@ elasticsearch_max_number_of_indices = 20
 #            to your previous 1.x settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/en/latest/pages/configuration/index_model.html#index-set-configuration.
 retention_strategy = delete
 
 # How many Elasticsearch shards and replicas should be used per index? Note that this only applies to newly created indices.
@@ -328,7 +328,7 @@ retention_strategy = delete
 #            to your previous settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/en/latest/pages/configuration/index_model.html#index-set-configuration.
 elasticsearch_shards = 4
 elasticsearch_replicas = 0
 
@@ -338,7 +338,7 @@ elasticsearch_replicas = 0
 #            to your previous settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/en/latest/pages/configuration/index_model.html#index-set-configuration.
 elasticsearch_index_prefix = graylog
 
 # Name of the Elasticsearch index template used by Graylog to apply the mandatory index mapping.
@@ -348,11 +348,11 @@ elasticsearch_index_prefix = graylog
 #            to your previous settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/en/latest/pages/configuration/index_model.html#index-set-configuration.
 #elasticsearch_template_name = graylog-internal
 
 # Do you want to allow searches with leading wildcards? This can be extremely resource hungry and should only
-# be enabled with care. See also: http://docs.graylog.org/en/2.1/pages/queries.html
+# be enabled with care. See also: https://docs.graylog.org/en/latest/pages/queries.html
 allow_leading_wildcard_searches = false
 
 # Do you want to allow searches to be highlighted? Depending on the size of your messages this can be memory hungry and
@@ -368,7 +368,7 @@ allow_highlighting = false
 #            to your previous settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/en/latest/pages/configuration/index_model.html#index-set-configuration.
 elasticsearch_analyzer = standard
 
 # Global request timeout for Elasticsearch requests (e. g. during search, index creation, or index time-range
@@ -606,7 +606,7 @@ mongodb_threads_allowed_to_block_multiplier = 5
 #            to your previous settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/en/latest/pages/configuration/index_model.html#index-set-configuration.
 #disable_index_optimization = true
 
 # Optimize the index down to <= index_optimization_max_num_segments. A higher number may take some load from Elasticsearch
@@ -616,7 +616,7 @@ mongodb_threads_allowed_to_block_multiplier = 5
 #            to your previous settings so they will be migrated to the database!
 #            This configuration setting is only used on the first start of Graylog. After that,
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
-#            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
+#            Also see https://docs.graylog.org/en/latest/pages/configuration/index_model.html#index-set-configuration.
 #index_optimization_max_num_segments = 1
 
 # The threshold of the garbage collection runs. If GC runs take longer than this threshold, a system notification


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR switches links to [docs.graylog.org](https://docs.graylog.org/) from HTTP to HTTPS (now that it is available) and switches some links from specific versions to `latest`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The usual reasons to prefer HTTPS: integrity, privacy, etc.

Switching to `latest` ensures users see the most up-to-date documentation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Accessed all updated links to ensure they still work and are relevant.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
