### PR TITLE
Adding Github Action for automatic rebase

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,0 +1,12 @@
+on: issue_comment
+name: Automatic Rebase
+jobs:
+  rebase:
+    name: Rebase
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Automatic Rebase
+      uses: cirrus-actions/rebase@1.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -7,6 +7,6 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Automatic Rebase
-      uses: cirrus-actions/rebase@1.1
+      uses: cirrus-actions/rebase@1.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -7,6 +7,6 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Automatic Rebase
-      uses: cirrus-actions/rebase@1.2
+      uses: Graylog2/rebase@1.2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This allows us to automatically rebase by commenting with

```
/rebase
```

on a PR, speeding up the process of maintaining PRs and ensuring they are up to date with the target branch.
