### PR TITLE
Passing `FEATURES` flag to production build too.

### DIFF
--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -125,6 +125,9 @@ const webpackConfig = {
       },
     }),
     new HtmlWebpackPlugin({ filename: 'module.json', inject: false, template: path.resolve(ROOT_PATH, 'templates/module.json.template'), excludeChunks: ['config'] }),
+    new webpack.DefinePlugin({
+      FEATURES: JSON.stringify(process.env.FEATURES),
+    }),
   ],
 };
 
@@ -143,7 +146,6 @@ if (TARGET === 'start') {
       new webpack.DefinePlugin({
         DEVELOPMENT: true,
         GRAYLOG_HTTP_PUBLISH_URI: JSON.stringify(process.env.GRAYLOG_HTTP_PUBLISH_URI),
-        FEATURES: JSON.stringify(process.env.FEATURES),
       }),
       new CopyWebpackPlugin([{ from: 'config.js' }]),
       new webpack.HotModuleReplacementPlugin(),


### PR DESCRIPTION
This change is passing the `FEATURES` variable, which was confined to
the dev env before, to all environments including the production build.
This allows building a production build containing a given feature by
doing something like:

```
FEATURES=time_travel mvn package
```