### PR TITLE
Pass dataAdapterId to DocumentationComponent of DataAdapter

### DIFF
--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
@@ -197,7 +197,9 @@ class DataAdapterForm extends React.Component {
         validationState: this._validationState,
       });
       if (p.documentationComponent) {
-        documentationComponent = React.createElement(p.documentationComponent);
+        documentationComponent = React.createElement(p.documentationComponent, {
+          dataAdapterId: dataAdapter.id,
+        });
       }
     }
 


### PR DESCRIPTION
## Description
For implementing a ediatable LocalStore table in the documentation
column of the LocalStoreDataAdapter, the dataAdapterId
needs to be passed there.

Refs https://github.com/Graylog2/graylog-plugin-enterprise/issues/1235

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
