### PR TITLE
Notification test button improvements

### DIFF
--- a/graylog2-web-interface/src/actions/event-notifications/EventNotificationsActions.js
+++ b/graylog2-web-interface/src/actions/event-notifications/EventNotificationsActions.js
@@ -9,6 +9,7 @@ const EventNotificationsActions = Reflux.createActions({
   update: { asyncResult: true },
   delete: { asyncResult: true },
   test: { asyncResult: true },
+  testPersisted: { asyncResult: true },
 });
 
 export default EventNotificationsActions;

--- a/graylog2-web-interface/src/stores/event-notifications/EventNotificationsStore.js
+++ b/graylog2-web-interface/src/stores/event-notifications/EventNotificationsStore.js
@@ -168,21 +168,6 @@ const EventNotificationsStore = Reflux.createStore({
 
   test(notification) {
     const promise = fetch('POST', this.eventNotificationsUrl({ segments: ['test'] }), notification);
-
-    promise.then(
-      (response) => {
-        UserNotification.success(`Notification "${notification.title}" was executed successfully.`,
-          'Notification Test Result');
-        return response;
-      },
-      (error) => {
-        if (error.status !== 400 || !error.additional.body || !error.additional.body.failed) {
-          const errorMessage = error.responseMessage ? `error: ${error.responseMessage}` : 'unknown error';
-          UserNotification.error(`Notification "${notification.title} execution" failed with ${errorMessage}`,
-            'Notification Test Result');
-        }
-      },
-    );
     EventNotificationsActions.test.promise(promise);
   },
 

--- a/graylog2-web-interface/src/stores/event-notifications/EventNotificationsStore.js
+++ b/graylog2-web-interface/src/stores/event-notifications/EventNotificationsStore.js
@@ -171,6 +171,11 @@ const EventNotificationsStore = Reflux.createStore({
     EventNotificationsActions.test.promise(promise);
   },
 
+  testPersisted(notification) {
+    const promise = fetch('POST', this.eventNotificationsUrl({ segments: [notification.id, 'test'] }));
+    EventNotificationsActions.testPersisted.promise(promise);
+  },
+
   listAllLegacyTypes() {
     const promise = fetch('GET', this.eventNotificationsUrl({ segments: ['legacy', 'types'] }));
 


### PR DESCRIPTION
This PR makes some improvements on the test Notification functionality:
- Makes results of test more visible, by rendering them inline instead of using a toaster notification for that
- Display test button on embedded Notifications (that is, while creating a Notification from the Event Definition form)
- Adds a test button in the Notification list, so people can quickly test a Notification without open the edit page

Refs #6366