### PR TITLE
Use separate routes for show views/show dashboards.

### DIFF
--- a/graylog2-web-interface/src/views/Constants.js
+++ b/graylog2-web-interface/src/views/Constants.js
@@ -16,4 +16,5 @@ export const dashboardsPath = '/dashboards';
 export const newDashboardsPath = '/dashboards/new';
 export const extendedSearchPath = '/extendedsearch';
 export const viewsPath = '/views';
-export const showViewsPath = `${dashboardsPath}/:viewId`;
+export const showViewsPath = `${viewsPath}/:viewId`;
+export const showDashboardsPath = `${dashboardsPath}/:viewId`;

--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -59,7 +59,14 @@ import OperatorCompletion from 'views/components/searchbar/completions/OperatorC
 import requirementsProvided from 'views/hooks/RequirementsProvided';
 import type { ValueActionHandlerConditionProps } from 'views/logic/valueactions/ValueActionHandler';
 import type { FieldActionHandlerConditionProps } from 'views/logic/fieldactions/FieldActionHandler';
-import { dashboardsPath, extendedSearchPath, newDashboardsPath, showViewsPath, viewsPath } from 'views/Constants';
+import {
+  dashboardsPath,
+  extendedSearchPath,
+  newDashboardsPath,
+  showDashboardsPath,
+  showViewsPath,
+  viewsPath,
+} from 'views/Constants';
 import NewDashboardPage from 'views/pages/NewDashboardPage';
 import StreamSearchPage from 'views/pages/StreamSearchPage';
 import AppConfig from 'util/AppConfig';
@@ -82,6 +89,7 @@ const searchRoutes = enableNewSearch
     { path: newDashboardsPath, component: NewDashboardPage },
     { path: Routes.stream_search(':streamId'), component: StreamSearchPage },
     { path: dashboardsPath, component: DashboardsPage },
+    { path: showDashboardsPath, component: ShowViewPage },
   ]
   : [];
 

--- a/graylog2-web-interface/src/views/components/views/View.jsx
+++ b/graylog2-web-interface/src/views/components/views/View.jsx
@@ -15,7 +15,7 @@ const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
 const formatTitle = (title, id, disabled = false) => (disabled
   ? <h2>{title}</h2>
-  : <Link to={Routes.pluginRoute('DASHBOARDS_VIEWID')(id)}>{title}</Link>);
+  : <Link to={Routes.pluginRoute('VIEWS_VIEWID')(id)}>{title}</Link>);
 
 const _OwnerTag = ({ owner, currentUser }) => {
   if (!owner || owner === currentUser.username) {


### PR DESCRIPTION
## Description
## Motivation and Context

When using the feature flag for the new search, this PR avoids reusing
the show dashboard route for the show views code. This prevents a double
registration of the same component for `/dashboards/:id`, where only the
order of registration decides which component will be actually used.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.