### PR TITLE
Render `null` for message field if its value is `undefined` (3.1).

### DIFF
--- a/graylog2-web-interface/src/views/components/messagelist/PossiblyHighlight.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/PossiblyHighlight.jsx
@@ -19,11 +19,14 @@ const highlight = (value: any, idx: number, style = {}) => <span key={`highlight
 type Props = {
   color: string,
   field: string,
-  value: any,
+  value?: any,
   highlightRanges: Ranges,
 };
 
 const PossiblyHighlight = ({ color = DEFAULT_HIGHLIGHT_COLOR, field, value, highlightRanges = {} }: Props) => {
+  if (value === undefined || value == null) {
+    return '';
+  }
   if (!highlightRanges || !highlightRanges[field]) {
     return value;
   }
@@ -31,9 +34,6 @@ const PossiblyHighlight = ({ color = DEFAULT_HIGHLIGHT_COLOR, field, value, high
     backgroundColor: color,
   };
 
-  if (value === undefined) {
-    return '';
-  }
   // Ensure the field is a string for later processing
   const origValue = StringUtils.stringify(value);
 
@@ -61,13 +61,14 @@ const PossiblyHighlight = ({ color = DEFAULT_HIGHLIGHT_COLOR, field, value, high
 PossiblyHighlight.propTypes = {
   color: PropTypes.string,
   field: PropTypes.string.isRequired,
-  value: PropTypes.any.isRequired,
+  value: PropTypes.any,
   highlightRanges: PropTypes.object,
 };
 
 PossiblyHighlight.defaultProps = {
   color: DEFAULT_HIGHLIGHT_COLOR,
   highlightRanges: {},
+  value: undefined,
 };
 
 export default PossiblyHighlight;

--- a/graylog2-web-interface/src/views/components/messagelist/PossiblyHighlight.test.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/PossiblyHighlight.test.jsx
@@ -1,0 +1,20 @@
+// @flow strict
+import React from 'react';
+import { mount } from 'enzyme';
+
+import PossiblyHighlight from './PossiblyHighlight';
+
+describe('PossiblyHighlight', () => {
+  it('renders something for an `undefined` field value', () => {
+    const wrapper = mount(<PossiblyHighlight field="foo" value={undefined} />);
+    expect(wrapper).not.toBeNull();
+  });
+  it('renders something for a `null` field value', () => {
+    const wrapper = mount(<PossiblyHighlight field="foo" value={null} />);
+    expect(wrapper).not.toBeNull();
+  });
+  it('renders for invalid highlighting ranges', () => {
+    const wrapper = mount(<PossiblyHighlight field="foo" value="bar" highlightRanges={undefined} />);
+    expect(wrapper).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Description
## Motivation and Context

This is a backport of #6512 to `3.1`.

Before this change, the `PossiblyHighlight` component which is used to determine if given highlighting rules apply to a message field and its value and generates highlighting areas for the given field value in this case returns `undefined`. This violates a React invariant limiting the result of a component to `React.Node` or `null`.

This change is slightly changing the logic of the affected component and
returns `null` in this case.

Fixes #6511.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.