### PR TITLE
Add stringListValue() support to LookupTables

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTable.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTable.java
@@ -71,7 +71,7 @@ public abstract class LookupTable {
     public LookupResult lookup(@Nonnull Object key) {
         final LookupResult result = cache().get(LookupCacheKey.create(dataAdapter(), key), () -> dataAdapter().get(key));
 
-        // The default value will only be used if both single and multi value are empty
+        // The default value will only be used if single, multi and list values are empty
         if (result.isEmpty()) {
             return LookupResult.addDefaults(defaultSingleValue(), defaultMultiValue()).hasError(result.hasError()).build();
         }

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/DnsLookupDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/DnsLookupDataAdapter.java
@@ -237,7 +237,8 @@ public class DnsLookupDataAdapter extends LookupDataAdapter {
         final String singleValue = aDnsAnswers.get(0).ipAddress();
         LookupResult.Builder builder = LookupResult.builder()
                                                    .single(singleValue)
-                                                   .multiValue(Collections.singletonMap(RESULTS_FIELD, aDnsAnswers));
+                                                   .multiValue(Collections.singletonMap(RESULTS_FIELD, aDnsAnswers))
+                                                   .stringListValue(ADnsAnswer.convertToStringListValue(aDnsAnswers));
 
         assignMinimumTTL(aDnsAnswers, builder);
 
@@ -289,7 +290,7 @@ public class DnsLookupDataAdapter extends LookupDataAdapter {
             allAnswers.addAll(ip6Answers);
 
             if (CollectionUtils.isNotEmpty(allAnswers)) {
-                builder.multiValue(Collections.singletonMap(RESULTS_FIELD, allAnswers));
+                builder.multiValue(Collections.singletonMap(RESULTS_FIELD, allAnswers)).stringListValue(ADnsAnswer.convertToStringListValue(allAnswers));
             }
 
             assignMinimumTTL(allAnswers, builder);
@@ -355,7 +356,8 @@ public class DnsLookupDataAdapter extends LookupDataAdapter {
 
         if (CollectionUtils.isNotEmpty(txtDnsAnswers)) {
             final LookupResult.Builder builder = LookupResult.builder();
-            builder.multiValue(Collections.singletonMap(RAW_RESULTS_FIELD, txtDnsAnswers));
+            builder.multiValue(Collections.singletonMap(RAW_RESULTS_FIELD, txtDnsAnswers))
+                    .stringListValue(TxtDnsAnswer.convertToStringListValue(txtDnsAnswers));
             assignMinimumTTL(txtDnsAnswers, builder);
 
             return builder.build();

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/HTTPJSONPathDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/HTTPJSONPathDataAdapter.java
@@ -61,8 +61,10 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
@@ -201,6 +203,13 @@ public class HTTPJSONPathDataAdapter extends LookupDataAdapter {
                     if (multiValue instanceof Map) {
                         //noinspection unchecked
                         builder = builder.multiValue((Map<Object, Object>) multiValue);
+                    } else if (multiValue instanceof List) {
+                        //noinspection unchecked
+                        final List<String> stringList = ((List<Object>) multiValue).stream().map(Object::toString).collect(Collectors.toList());
+                        builder = builder.stringListValue(stringList);
+
+                        // for backwards compatibility
+                        builder = builder.multiSingleton(multiValue);
                     } else {
                         builder = builder.multiSingleton(multiValue);
                     }

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dnslookup/ADnsAnswer.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dnslookup/ADnsAnswer.java
@@ -26,6 +26,8 @@ import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 
 import javax.annotation.Nullable;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Address (A/AAAA) DNS lookup response from {@link DnsClient}.
@@ -85,5 +87,9 @@ public abstract class ADnsAnswer implements DnsAnswer {
 
             return autoBuild();
         }
+    }
+
+    public static List<String> convertToStringListValue(List<ADnsAnswer> aDnsAnswers) {
+        return aDnsAnswers.stream().map(ADnsAnswer::ipAddress).collect(Collectors.toList());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dnslookup/TxtDnsAnswer.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/dnslookup/TxtDnsAnswer.java
@@ -24,6 +24,9 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
  * Text (TXT) DNS lookup response from {@link DnsClient}.
  */
@@ -68,5 +71,9 @@ public abstract class TxtDnsAnswer implements DnsAnswer {
 
             return autoBuild();
         }
+    }
+
+    public static List<String> convertToStringListValue(List<TxtDnsAnswer> txtDnsAnswer) {
+        return txtDnsAnswer.stream().map(TxtDnsAnswer::value).collect(Collectors.toList());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupResult.java
@@ -68,7 +68,7 @@ public abstract class LookupResult {
     @Nullable
     public abstract Map<Object, Object> multiValue();
 
-    @JsonProperty("list_string_value")
+    @JsonProperty("string_list_value")
     @Nullable
     public abstract List<String> stringListValue();
 
@@ -164,7 +164,7 @@ public abstract class LookupResult {
     @JsonCreator
     public static LookupResult createFromJSON(@JsonProperty("single_value") final Object singleValue,
                                               @JsonProperty("multi_value") final Map<Object, Object> multiValue,
-                                              @JsonProperty("list_string_value") final List<String> stringListValue,
+                                              @JsonProperty("string_list_value") final List<String> stringListValue,
                                               @JsonProperty("has_error") final boolean hasError,
                                               @JsonProperty("ttl") final long cacheTTL) {
         return builder()

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupResult.java
@@ -26,6 +26,7 @@ import org.graylog2.lookup.LookupDefaultSingleValue;
 import javax.annotation.Nullable;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -67,6 +68,10 @@ public abstract class LookupResult {
     @Nullable
     public abstract Map<Object, Object> multiValue();
 
+    @JsonProperty("list_string_value")
+    @Nullable
+    public abstract List<String> stringListValue();
+
 
     @JsonProperty("has_error")
     public abstract boolean hasError();
@@ -80,7 +85,7 @@ public abstract class LookupResult {
 
     @JsonIgnore
     public boolean isEmpty() {
-        return singleValue() == null && multiValue() == null;
+        return singleValue() == null && multiValue() == null && stringListValue() == null;
     }
 
     @JsonIgnore
@@ -159,11 +164,13 @@ public abstract class LookupResult {
     @JsonCreator
     public static LookupResult createFromJSON(@JsonProperty("single_value") final Object singleValue,
                                               @JsonProperty("multi_value") final Map<Object, Object> multiValue,
+                                              @JsonProperty("list_string_value") final List<String> stringListValue,
                                               @JsonProperty("has_error") final boolean hasError,
                                               @JsonProperty("ttl") final long cacheTTL) {
         return builder()
                 .singleValue(singleValue)
                 .multiValue(multiValue)
+                .stringListValue(stringListValue)
                 .hasError(hasError)
                 .cacheTTL(cacheTTL)
                 .build();
@@ -183,6 +190,7 @@ public abstract class LookupResult {
         // We don't want users of this class to set a generic Object single value
         abstract Builder singleValue(Object singleValue);
         public abstract Builder multiValue(Map<Object, Object> multiValue);
+        public abstract Builder stringListValue(List<String> stringListValue);
         public abstract Builder cacheTTL(long cacheTTL);
         public abstract Builder hasError(boolean hasError);
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
@@ -72,7 +72,6 @@ public class ObjectMapperProvider implements Provider<ObjectMapper> {
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
                 .disable(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)
-                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .setPropertyNamingStrategy(new PropertyNamingStrategy.SnakeCaseStrategy())
                 .setSubtypeResolver(subtypeResolver)
                 .setTypeFactory(typeFactory)

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
@@ -72,6 +72,7 @@ public class ObjectMapperProvider implements Provider<ObjectMapper> {
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
                 .disable(DeserializationFeature.FAIL_ON_MISSING_EXTERNAL_TYPE_ID_PROPERTY)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .setPropertyNamingStrategy(new PropertyNamingStrategy.SnakeCaseStrategy())
                 .setSubtypeResolver(subtypeResolver)
                 .setTypeFactory(typeFactory)

--- a/graylog2-server/src/test/java/org/graylog2/lookup/adapters/HTTPJSONPathDataAdapterTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/lookup/adapters/HTTPJSONPathDataAdapterTest.java
@@ -84,6 +84,8 @@ public class HTTPJSONPathDataAdapterTest {
         assertThat(result.multiValue().get("value")).isInstanceOf(Collection.class);
         //noinspection unchecked,ConstantConditions
         assertThat((Collection) result.multiValue().get("value")).containsOnly("a", "b", "c");
+
+        assertThat(result.stringListValue()).containsOnly("a", "b", "c");
     }
 
     @Test


### PR DESCRIPTION
Since our current use cases for listValues only need String objects,
and we don't want to complicate the API unneccessarily, don't
implement this as a List of Objects.

The idea is that each DataAdapter should decide which values
make most sense to be in the List, and convert them accordingly.
