### PR TITLE
Remove Event indices from global search default (#6413)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
@@ -84,6 +84,7 @@ import java.util.stream.Stream;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.util.stream.Collectors.toSet;
+import static org.graylog2.plugin.streams.Stream.DEFAULT_EVENT_STREAM_IDS;
 
 // TODO permission system
 @Api(value = "Enterprise/Search", description = "Searching")
@@ -203,6 +204,11 @@ public class SearchResource extends RestResource implements PluginRestResource {
                 throwStreamAccessForbiddenException();
             }
 
+            // Unless explicitly queried, exclude event indices by default
+            // Having the event indices in every search, makes sorting almost impossible
+            // because it triggers https://github.com/Graylog2/graylog2-server/issues/6378
+            // TODO this can be removed, once we implement https://github.com/Graylog2/graylog2-server/issues/6490
+            allAvailableStreamIds.removeAll(DEFAULT_EVENT_STREAM_IDS);
 
             final ImmutableSet<Query> newQueries = search.queries().stream().map(query -> {
                 if (query.usedStreamIds().isEmpty()) {


### PR DESCRIPTION
* Remove event indices from global search

Filter IndexRanges by the Event index prefix name.

Fixes #6384

* Remove event streams from new search default

Fixes #6384

* Add comment and TODO

* Filter event indices by using IndexSets

This will also work, if the event index prefix settings were changed.

* Fix SearchesIT by turning the index event filter upside down

Instead of having to mock all the IndexSets for the test,
invert the filter and skip event indices only if matching IndexSets have been
found.

Pull in some code from MongoIndexSet into TestIndexSet to make the test
work.

(cherry picked from commit 7bbb761711533ab7ffe7740d07287806826ef600)
