### PR TITLE
Hide Event Streams from Pipelines (#6513)

### DIFF
--- a/graylog2-web-interface/src/pages/PipelineDetailsPage.jsx
+++ b/graylog2-web-interface/src/pages/PipelineDetailsPage.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { Row, Col, Button } from 'react-bootstrap';
+import { Button, Col, Row } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
@@ -18,6 +18,12 @@ const { PipelinesStore, PipelinesActions } = CombinedProvider.get('Pipelines');
 const { RulesStore } = CombinedProvider.get('Rules');
 const { PipelineConnectionsStore, PipelineConnectionsActions } = CombinedProvider.get('PipelineConnections');
 const { StreamsStore } = CombinedProvider.get('Streams');
+
+// Events do not work on Pipelines yet, hide Events and System Events Streams.
+const HIDDEN_STREAMS = [
+  '000000000000000000000002',
+  '000000000000000000000003',
+];
 
 function filterPipeline(state) {
   return state.pipelines ? state.pipelines.filter(p => p.id === this.props.params.pipelineId)[0] : undefined;
@@ -40,14 +46,16 @@ const PipelineDetailsPage = createReactClass({
   mixins: [Reflux.connectFilter(PipelinesStore, 'pipeline', filterPipeline), Reflux.connectFilter(PipelineConnectionsStore, 'connections', filterConnections)],
 
   componentDidMount() {
-    if (!this._isNewPipeline(this.props.params.pipelineId)) {
-      PipelinesActions.get(this.props.params.pipelineId);
+    const { params } = this.props;
+    if (!this._isNewPipeline(params.pipelineId)) {
+      PipelinesActions.get(params.pipelineId);
     }
     RulesStore.list();
     PipelineConnectionsActions.list();
 
     StreamsStore.listStreams().then((streams) => {
-      this.setState({ streams });
+      const filteredStreams = streams.filter(s => !HIDDEN_STREAMS.includes(s.id));
+      this.setState({ streams: filteredStreams });
     });
   },
 
@@ -63,7 +71,8 @@ const PipelineDetailsPage = createReactClass({
   },
 
   _onStagesChange(newStages, callback) {
-    const newPipeline = ObjectUtils.clone(this.state.pipeline);
+    const { pipeline } = this.state;
+    const newPipeline = ObjectUtils.clone(pipeline);
     newPipeline.stages = newStages;
     const pipelineSource = SourceGenerator.generatePipeline(newPipeline);
     newPipeline.source = pipelineSource;
@@ -91,37 +100,41 @@ const PipelineDetailsPage = createReactClass({
   },
 
   _isLoading() {
-    return !this._isNewPipeline(this.props.params.pipelineId) && (!this.state.pipeline || !this.state.connections || !this.state.streams);
+    const { params } = this.props;
+    const { connections, streams, pipeline } = this.state;
+    return !this._isNewPipeline(params.pipelineId) && (!pipeline || !connections || !streams);
   },
 
   render() {
     if (this._isLoading()) {
       return <Spinner />;
     }
+    const { params } = this.props;
+    const { connections, streams, pipeline, rules } = this.state;
 
     let title;
-    if (this._isNewPipeline(this.props.params.pipelineId)) {
+    if (this._isNewPipeline(params.pipelineId)) {
       title = 'New pipeline';
     } else {
-      title = <span>Pipeline <em>{this.state.pipeline.title}</em></span>;
+      title = <span>Pipeline <em>{pipeline.title}</em></span>;
     }
 
     let content;
-    if (this._isNewPipeline(this.props.params.pipelineId)) {
+    if (this._isNewPipeline(params.pipelineId)) {
       content = <NewPipeline onChange={this._savePipeline} />;
     } else {
       content = (
-        <Pipeline pipeline={this.state.pipeline}
-                  connections={this.state.connections}
-                  streams={this.state.streams}
-                  rules={this.state.rules}
+        <Pipeline pipeline={pipeline}
+                  connections={connections}
+                  streams={streams}
+                  rules={rules}
                   onConnectionsChange={this._onConnectionsChange}
                   onStagesChange={this._onStagesChange}
                   onPipelineChange={this._savePipeline} />
       );
     }
 
-    const pageTitle = (this._isNewPipeline(this.props.params.pipelineId) ? 'New pipeline' : `Pipeline ${this.state.pipeline.title}`);
+    const pageTitle = (this._isNewPipeline(params.pipelineId) ? 'New pipeline' : `Pipeline ${pipeline.title}`);
 
     return (
       <DocumentTitle title={pageTitle}>

--- a/graylog2-web-interface/src/pages/SimulatorPage.jsx
+++ b/graylog2-web-interface/src/pages/SimulatorPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Button, Row, Col } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 
+import { Button, Col, Row } from 'react-bootstrap';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import DocumentationLink from 'components/support/DocumentationLink';
 import ProcessorSimulator from 'components/simulator/ProcessorSimulator';
@@ -13,6 +13,12 @@ import Routes from 'routing/Routes';
 
 const StreamsStore = StoreProvider.getStore('Streams');
 
+// Events do not work on Pipelines yet, hide Events and System Events Streams.
+const HIDDEN_STREAMS = [
+  '000000000000000000000002',
+  '000000000000000000000003',
+];
+
 class SimulatorPage extends React.Component {
   state = {
     streams: undefined,
@@ -20,21 +26,20 @@ class SimulatorPage extends React.Component {
 
   componentDidMount() {
     StreamsStore.listStreams().then((streams) => {
-      this.setState({ streams: streams });
+      const filteredStreams = streams.filter(s => !HIDDEN_STREAMS.includes(s.id));
+      this.setState({ streams: filteredStreams });
     });
   }
 
   _isLoading = () => {
-    return !this.state.streams;
+    const { streams } = this.state;
+    return !streams;
   };
 
   render() {
-    let content;
-    if (this._isLoading()) {
-      content = <Spinner />;
-    } else {
-      content = <ProcessorSimulator streams={this.state.streams} />;
-    }
+    const { streams } = this.state;
+
+    const content = this._isLoading() ? <Spinner /> : <ProcessorSimulator streams={streams} />;
 
     return (
       <DocumentTitle title="Simulate processing">


### PR DESCRIPTION
* Filter event streams in pipelines

Events are not regular messages ingested from an input and at the moment
are not supported in pipelines.

Fixes #6454

* Fix linter errors

(cherry picked from commit e8ee0fb1b08d3c26f637c021e27cc0206246e20c)