### PR TITLE
Set the loglevel for org.graylog2 AND org.graylog (#6423)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/loggers/responses/SingleSubsystemSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/loggers/responses/SingleSubsystemSummary.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 
+import java.util.List;
+
 @AutoValue
 @WithBeanGetter
 @JsonAutoDetect
@@ -29,7 +31,7 @@ public abstract class SingleSubsystemSummary {
     @JsonProperty
     public abstract String title();
     @JsonProperty
-    public abstract String category();
+    public abstract List<String> categories();
     @JsonProperty
     public abstract String description();
     @JsonProperty
@@ -39,10 +41,10 @@ public abstract class SingleSubsystemSummary {
 
     @JsonCreator
     public static SingleSubsystemSummary create(@JsonProperty("title") String title,
-                                                @JsonProperty("category") String category,
+                                                @JsonProperty("categories") List<String> categories,
                                                 @JsonProperty("description") String description,
                                                 @JsonProperty("level") String level,
                                                 @JsonProperty("level_syslog") int levelSyslog) {
-        return new AutoValue_SingleSubsystemSummary(title, category, description, level, levelSyslog);
+        return new AutoValue_SingleSubsystemSummary(title, categories, description, level, levelSyslog);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/logs/LoggersResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/logs/LoggersResource.java
@@ -18,6 +18,7 @@ package org.graylog2.rest.resources.system.logs;
 
 import com.codahale.metrics.annotation.Timed;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import io.swagger.annotations.Api;
@@ -77,7 +78,7 @@ public class LoggersResource extends RestResource {
     private static final String MEMORY_APPENDER_NAME = "graylog-internal-logs";
 
     private static final Map<String, Subsystem> SUBSYSTEMS = ImmutableMap.<String, Subsystem>of(
-            "graylog", new Subsystem("Graylog", "org.graylog2", "All messages from Graylog-owned systems."),
+            "graylog", new Subsystem("Graylog", ImmutableList.of("org.graylog2", "org.graylog"), "All messages from Graylog-owned systems."),
             "indexer", new Subsystem("Indexer", "org.elasticsearch", "All messages related to indexing and searching."),
             "authentication", new Subsystem("Authentication", "org.apache.shiro", "All user authentication messages."),
             "sockets", new Subsystem("Sockets", "netty", "All messages related to socket communication."));
@@ -121,13 +122,13 @@ public class LoggersResource extends RestResource {
             }
 
             try {
-                final String category = subsystem.getValue().getCategory();
+                final String category = subsystem.getValue().getCategories().get(0);
                 final Level level = getLoggerLevel(category);
 
                 subsystems.put(subsystem.getKey(),
                         SingleSubsystemSummary.create(
                                 subsystem.getValue().getTitle(),
-                                subsystem.getValue().getCategory(),
+                                subsystem.getValue().getCategories(),
                                 subsystem.getValue().getDescription(),
                                 level.toString().toLowerCase(Locale.ENGLISH),
                                 level.intLevel()));
@@ -184,7 +185,9 @@ public class LoggersResource extends RestResource {
 
         final Subsystem subsystem = SUBSYSTEMS.get(subsystemTitle);
         final Level newLevel = Level.toLevel(level.toUpperCase(Locale.ENGLISH));
-        setLoggerLevel(subsystem.getCategory(), newLevel);
+        for (String category: subsystem.getCategories()) {
+            setLoggerLevel(category, newLevel);
+        }
 
         LOG.debug("Successfully set log level for subsystem \"{}\" to \"{}\"", subsystem.getTitle(), newLevel);
     }
@@ -269,12 +272,18 @@ public class LoggersResource extends RestResource {
 
     private static class Subsystem {
         private final String title;
-        private final String category;
+        private final List<String> categories;
         private final String description;
 
         public Subsystem(String title, String category, String description) {
             this.title = title;
-            this.category = category;
+            this.categories = ImmutableList.of(category);
+            this.description = description;
+        }
+
+        public Subsystem(String title, List<String> categories, String description) {
+            this.title = title;
+            this.categories = ImmutableList.copyOf(categories);
             this.description = description;
         }
 
@@ -282,8 +291,8 @@ public class LoggersResource extends RestResource {
             return title;
         }
 
-        private String getCategory() {
-            return category;
+        private List<String> getCategories() {
+            return categories;
         }
 
         private String getDescription() {


### PR DESCRIPTION
* Set the loglevel for org.graylog2 AND org.graylog

We have added lots of code to the `org.graylog` package,
which we are missing a lot of useful debugging info from.

* Add multiple categories support to logging subsystems

This introduces an API change, but no frontend code uses
the category info yet.

(cherry picked from commit d22244d1ec9302d41c0c0fe5bb2227528c790019)
