### PR TITLE
Add journaling_enabled field to processing status (#6472)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/system/processing/DBProcessingStatusService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/DBProcessingStatusService.java
@@ -24,6 +24,7 @@ import org.bson.types.ObjectId;
 import org.graylog.scheduler.clock.JobSchedulerClock;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
+import org.graylog2.plugin.BaseConfiguration;
 import org.graylog2.plugin.system.NodeId;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -46,12 +47,14 @@ public class DBProcessingStatusService {
     public static final String COLLECTION_NAME = "processing_status";
     private static final String FIELD_WRITTEN_MESSAGES_1M = ProcessingStatusDto.FIELD_INPUT_JOURNAL + "." + ProcessingStatusDto.JournalInfo.FIELD_WRITTEN_MESSAGES_1M_RATE;
     private static final String FIELD_UNCOMMITTED_ENTRIES = ProcessingStatusDto.FIELD_INPUT_JOURNAL + "." + ProcessingStatusDto.JournalInfo.FIELD_UNCOMMITTED_ENTRIES;
+    private static final String FIELD_JOURNAL_ENABLED = ProcessingStatusDto.FIELD_INPUT_JOURNAL + "." + ProcessingStatusDto.JournalInfo.FIELD_JOURNAL_ENABLED;
 
     private final String nodeId;
     private final JobSchedulerClock clock;
     private final Duration updateThreshold;
     private final double journalWriteRateThreshold;
     private final JacksonDBCollection<ProcessingStatusDto, ObjectId> db;
+    private final BaseConfiguration baseConfiguration;
 
     @Inject
     public DBProcessingStatusService(MongoConnection mongoConnection,
@@ -59,11 +62,13 @@ public class DBProcessingStatusService {
                                      JobSchedulerClock clock,
                                      @Named(ProcessingStatusConfig.UPDATE_THRESHOLD) Duration updateThreshold,
                                      @Named(ProcessingStatusConfig.JOURNAL_WRITE_RATE_THRESHOLD) int journalWriteRateThreshold,
-                                     MongoJackObjectMapperProvider mapper) {
+                                     MongoJackObjectMapperProvider mapper,
+                                     BaseConfiguration baseConfiguration) {
         this.nodeId = nodeId.toString();
         this.clock = clock;
         this.updateThreshold = updateThreshold;
         this.journalWriteRateThreshold = ((Number) journalWriteRateThreshold).doubleValue();
+        this.baseConfiguration = baseConfiguration;
         this.db = JacksonDBCollection.wrap(mongoConnection.getDatabase().getCollection(COLLECTION_NAME),
                 ProcessingStatusDto.class,
                 ObjectId.class,
@@ -134,7 +139,9 @@ public class DBProcessingStatusService {
                         // ... received a certain amount of messages in the last minute
                         DBQuery.greaterThanEquals(FIELD_WRITTEN_MESSAGES_1M, journalWriteRateThreshold),
                         // ... or has messages left in the journal
-                        DBQuery.greaterThanEquals(FIELD_UNCOMMITTED_ENTRIES, 1L)
+                        DBQuery.greaterThanEquals(FIELD_UNCOMMITTED_ENTRIES, 1L),
+                        // ... or has journaling disabled
+                        DBQuery.is(FIELD_JOURNAL_ENABLED, false)
                 )
         );
     }
@@ -160,7 +167,7 @@ public class DBProcessingStatusService {
                 null,
                 null,
                 false,
-                ProcessingStatusDto.of(nodeId, processingStatusRecorder, updatedAt),
+                ProcessingStatusDto.of(nodeId, processingStatusRecorder, updatedAt, baseConfiguration.isMessageJournalEnabled()),
                 true, // We want to return the updated document to the caller
                 true);
     }

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusDto.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/ProcessingStatusDto.java
@@ -58,7 +58,7 @@ public abstract class ProcessingStatusDto {
     @JsonProperty(FIELD_INPUT_JOURNAL)
     public abstract JournalInfo inputJournal();
 
-    public static ProcessingStatusDto of(String nodeId, ProcessingStatusRecorder processingStatusRecorder, DateTime updatedAt) {
+    public static ProcessingStatusDto of(String nodeId, ProcessingStatusRecorder processingStatusRecorder, DateTime updatedAt, boolean messageJournalEnabled) {
         return builder()
                 .nodeId(nodeId)
                 .updatedAt(updatedAt)
@@ -72,6 +72,7 @@ public abstract class ProcessingStatusDto {
                         .uncommittedEntries(processingStatusRecorder.getJournalInfoUncommittedEntries())
                         .readMessages1mRate(processingStatusRecorder.getJournalInfoReadMessages1mRate())
                         .writtenMessages1mRate(processingStatusRecorder.getJournalInfoWrittenMessages1mRate())
+                        .journalEnabled(messageJournalEnabled)
                         .build())
                 .build();
     }
@@ -162,6 +163,7 @@ public abstract class ProcessingStatusDto {
         static final String FIELD_UNCOMMITTED_ENTRIES = "uncommitted_entries";
         private static final String FIELD_READ_MESSAGES_1M_RATE = "read_messages_1m_rate";
         static final String FIELD_WRITTEN_MESSAGES_1M_RATE = "written_messages_1m_rate";
+        static final String FIELD_JOURNAL_ENABLED = "journal_enabled";
 
         @JsonProperty(FIELD_UNCOMMITTED_ENTRIES)
         public abstract long uncommittedEntries();
@@ -171,6 +173,9 @@ public abstract class ProcessingStatusDto {
 
         @JsonProperty(FIELD_WRITTEN_MESSAGES_1M_RATE)
         public abstract double writtenMessages1mRate();
+
+        @JsonProperty(FIELD_JOURNAL_ENABLED)
+        public abstract boolean journalEnabled();
 
         public static Builder builder() {
             return Builder.create();
@@ -183,7 +188,8 @@ public abstract class ProcessingStatusDto {
                 return new AutoValue_ProcessingStatusDto_JournalInfo.Builder()
                         .uncommittedEntries(0)
                         .readMessages1mRate(0d)
-                        .writtenMessages1mRate(0d);
+                        .writtenMessages1mRate(0d)
+                        .journalEnabled(true);
             }
 
             @JsonProperty(FIELD_UNCOMMITTED_ENTRIES)
@@ -194,6 +200,9 @@ public abstract class ProcessingStatusDto {
 
             @JsonProperty(FIELD_WRITTEN_MESSAGES_1M_RATE)
             public abstract Builder writtenMessages1mRate(double writtenMessages1mRate);
+
+            @JsonProperty(FIELD_JOURNAL_ENABLED)
+            public abstract Builder journalEnabled(boolean journalEnabled);
 
             public abstract JournalInfo build();
         }

--- a/graylog2-server/src/test/java/org/graylog2/system/processing/DBProcessingStatusServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/system/processing/DBProcessingStatusServiceTest.java
@@ -25,6 +25,7 @@ import org.bson.types.ObjectId;
 import org.graylog.events.JobSchedulerTestClock;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnectionRule;
+import org.graylog2.plugin.BaseConfiguration;
 import org.graylog2.plugin.lifecycles.Lifecycle;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
@@ -61,6 +62,9 @@ public class DBProcessingStatusServiceTest {
     @Mock
     private NodeId nodeId;
 
+    @Mock
+    private BaseConfiguration baseConfiguration;
+
     private DBProcessingStatusService dbService;
     private JobSchedulerTestClock clock;
     private Duration updateThreshold;
@@ -75,7 +79,7 @@ public class DBProcessingStatusServiceTest {
 
         clock = spy(new JobSchedulerTestClock(DateTime.parse("2019-01-01T00:00:00.000Z")));
         updateThreshold = spy(Duration.minutes(1));
-        dbService = new DBProcessingStatusService(mongoRule.getMongoConnection(), nodeId, clock, updateThreshold, 1, mapperProvider);
+        dbService = new DBProcessingStatusService(mongoRule.getMongoConnection(), nodeId, clock, updateThreshold, 1, mapperProvider, baseConfiguration);
         db = JacksonDBCollection.wrap(mongoRule.getMongoConnection().getDatabase().getCollection(DBProcessingStatusService.COLLECTION_NAME),
                 ProcessingStatusDto.class,
                 ObjectId.class,
@@ -264,5 +268,25 @@ public class DBProcessingStatusServiceTest {
 
         assertThat(db.find(query2).toArray().stream().map(ProcessingStatusDto::nodeId).collect(Collectors.toSet()))
                 .containsOnly("abc-123", "abc-456");
+    }
+
+    @Test
+    @UsingDataSet(loadStrategy = LoadStrategyEnum.DELETE_ALL)
+    public void updateProcessingStatusWithJournalDisabled() {
+        when(baseConfiguration.isMessageJournalEnabled()).thenReturn(false);
+        dbService.save(new InMemoryProcessingStatusRecorder());
+        assertThat(dbService.get()).isPresent();
+        assertThat(dbService.get()).satisfies(dto -> {
+           assertThat(dto.get().inputJournal().journalEnabled()).isFalse();
+        });
+    }
+
+    @Test
+    @UsingDataSet(locations = "processing-status-disabled-journal.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void retrieveWithDisabledJournal() {
+        when(clock.nowUTC()).thenReturn(DateTime.parse("2019-01-01T02:01:00.000Z"));
+        when(updateThreshold.toMilliseconds()).thenReturn(Duration.hours(4).toMilliseconds());
+        // Entries with disabled journal should be retrieved, regardless of their metrics being all 0
+        assertThat(dbService.earliestPostIndexingTimestamp()).isPresent().get().isEqualTo(DateTime.parse("2019-01-01T00:01:00.000Z"));
     }
 }

--- a/graylog2-server/src/test/resources/org/graylog2/system/processing/processing-status-disabled-journal.json
+++ b/graylog2-server/src/test/resources/org/graylog2/system/processing/processing-status-disabled-journal.json
@@ -1,0 +1,31 @@
+{
+  "processing_status": [
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0000"
+      },
+      "node_id": "abc-123",
+      "node_lifecycle_status": "RUNNING",
+      "updated_at": {
+        "$date": "2019-01-01T00:01:00.000Z"
+      },
+      "receive_times": {
+        "ingest": {
+          "$date": "2019-01-01T00:03:00.000Z"
+        },
+        "post_processing": {
+          "$date": "2019-01-01T00:02:00.000Z"
+        },
+        "post_indexing": {
+          "$date": "2019-01-01T00:01:00.000Z"
+        }
+      },
+      "input_journal": {
+        "uncommitted_entries": 0,
+        "read_messages_1m_rate": 0,
+        "written_messages_1m_rate": 0,
+        "journal_enabled": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
If nodes have their journal disabled, return the processing status
results, regardless of their metrics being all 0.

Fixes #6449

(cherry picked from commit f4cda3fff6397b033895d2f0c2c4015d9f21883a)
