### PR TITLE
Relax the journal metrics constraint for the processing status (#6469)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/system/processing/DBProcessingStatusService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/DBProcessingStatusService.java
@@ -34,6 +34,7 @@ import org.mongojack.JacksonDBCollection;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -107,17 +108,24 @@ public class DBProcessingStatusService {
      */
     public Optional<DateTime> earliestPostIndexingTimestamp() {
         final String sortField = ProcessingStatusDto.FIELD_RECEIVE_TIMES + "." + ProcessingStatusDto.ReceiveTimes.FIELD_POST_INDEXING;
-        final DBQuery.Query query = getDataSelectionQuery(clock, updateThreshold, journalWriteRateThreshold);
+        final DateTime updateThresholdTimestamp = clock.nowUTC().minus(updateThreshold.toMilliseconds());
+        final DBQuery.Query queryWithoutMetrics = DBQuery.greaterThan(FIELD_UPDATED_AT, updateThresholdTimestamp);
+        final DBQuery.Query queryWithMetrics = getDataSelectionQuery(clock, updateThreshold, journalWriteRateThreshold);
 
-        // Get the earliest timestamp of the post-indexing receive timestamp by sorting and returning the first one.
-        // We use the earliest timestamp because some nodes can be faster than others and we need to make sure
-        // to return the timestamp of the slowest one.
-        try (DBCursor<ProcessingStatusDto> cursor = db.find(query).sort(DBSort.asc(sortField)).limit(1)) {
-            if (cursor.hasNext()) {
-                return Optional.of(cursor.next().receiveTimes().postIndexing());
+        // First try to query processing status from nodes that are active (include journal metrics restrictions).
+        // If no result is found, query the processing status again, but without weeding out nodes with a low input volume.
+        // This prevents to completely stall the event processing if the ingestion volume is too low.
+        for (DBQuery.Query query: Arrays.asList(queryWithMetrics, queryWithoutMetrics)) {
+            // Get the earliest timestamp of the post-indexing receive timestamp by sorting and returning the first one.
+            // We use the earliest timestamp because some nodes can be faster than others and we need to make sure
+            // to return the timestamp of the slowest one.
+            try (DBCursor<ProcessingStatusDto> cursor = db.find(query).sort(DBSort.asc(sortField)).limit(1)) {
+                if (cursor.hasNext()) {
+                    return Optional.of(cursor.next().receiveTimes().postIndexing());
+                }
             }
-            return Optional.empty();
         }
+        return Optional.empty();
     }
 
     // This has been put into a static method to simplify testing the processing status selection

--- a/graylog2-server/src/test/java/org/graylog2/system/processing/DBProcessingStatusServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/system/processing/DBProcessingStatusServiceTest.java
@@ -265,4 +265,11 @@ public class DBProcessingStatusServiceTest {
         assertThat(db.find(query2).toArray().stream().map(ProcessingStatusDto::nodeId).collect(Collectors.toSet()))
                 .containsOnly("abc-123", "abc-456");
     }
+
+    @Test
+    @UsingDataSet(locations = "processing-status-single-active-node.json", loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
+    public void singleNodeStatus() {
+        when(clock.nowUTC()).thenReturn(DateTime.parse("2019-01-01T00:01:00.000Z"));
+        assertThat(dbService.earliestPostIndexingTimestamp()).isPresent();
+    }
 }

--- a/graylog2-server/src/test/resources/org/graylog2/system/processing/processing-status-single-active-node.json
+++ b/graylog2-server/src/test/resources/org/graylog2/system/processing/processing-status-single-active-node.json
@@ -1,0 +1,56 @@
+{
+  "processing_status": [
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0000"
+      },
+      "node_id": "abc-123",
+      "node_lifecycle_status": "RUNNING",
+      "updated_at": {
+        "$date": "2019-01-01T00:01:00.000Z"
+      },
+      "receive_times": {
+        "ingest": {
+          "$date": "2019-01-01T00:03:00.000Z"
+        },
+        "post_processing": {
+          "$date": "2019-01-01T00:02:00.000Z"
+        },
+        "post_indexing": {
+          "$date": "2019-01-01T00:01:00.000Z"
+        }
+      },
+      "input_journal": {
+        "uncommitted_entries": 0,
+        "read_messages_1m_rate": 0,
+        "written_messages_1m_rate": 0
+      }
+    },
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0001"
+      },
+      "node_id": "abc-456",
+      "node_lifecycle_status": "RUNNING",
+      "updated_at": {
+        "$date": "2018-01-01T00:03:00.000Z"
+      },
+      "receive_times": {
+        "ingest": {
+          "$date": "2018-01-01T00:02:00.000Z"
+        },
+        "post_processing": {
+          "$date": "2018-01-01T00:02:00.000Z"
+        },
+        "post_indexing": {
+          "$date": "2018-01-01T00:02:00.000Z"
+        }
+      },
+      "input_journal": {
+        "uncommitted_entries": 23,
+        "read_messages_1m_rate": 0.0,
+        "written_messages_1m_rate": 0.0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
We introduced checks to exclude cluster nodes that don't do any input
processing from the processing status.
In cases where there is a very low message rate, these were too strict
and did not report any processing status.

Relax the condition for situations where there is only nodes
with a low ingestion rate in the processing status collection.

Fixes #6453

(cherry picked from commit fe24e0e3035ccc313e7f78af8aa46df301bd22cb)
