### PR TITLE
 Implement Notification Test button (#6366) (#6522) (3.1 backport)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/legacy/LegacyAlarmCallbackSender.java
+++ b/graylog2-server/src/main/java/org/graylog/events/legacy/LegacyAlarmCallbackSender.java
@@ -135,6 +135,7 @@ public class LegacyAlarmCallbackSender {
     private static class MissingStream extends StreamImpl {
         static Stream create() {
             final ImmutableMap<String, Object> fields = ImmutableMap.<String, Object>builder()
+                    .put("_id", new ObjectId("5400deadbeefdeadbeefaffe"))
                     .put(StreamImpl.FIELD_TITLE, "Missing stream")
                     .put(StreamImpl.FIELD_DESCRIPTION, "We could find a stream")
                     .put(StreamImpl.FIELD_RULES, ImmutableList.<StreamRule>of())

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/EventNotificationContext.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/EventNotificationContext.java
@@ -35,7 +35,7 @@ public abstract class EventNotificationContext {
 
     public abstract Optional<EventDefinitionDto> eventDefinition();
 
-    public abstract JobTriggerDto jobTrigger();
+    public abstract Optional<JobTriggerDto> jobTrigger();
 
     public static Builder builder() {
         return Builder.create();

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationTestData.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationTestData.java
@@ -1,0 +1,99 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog.events.notifications;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.graylog.events.contentpack.entities.EventProcessorConfigEntity;
+import org.graylog.events.event.EventDto;
+import org.graylog.events.event.EventOriginContext;
+import org.graylog.events.processor.EventDefinitionDto;
+import org.graylog.events.processor.EventProcessorConfig;
+import org.graylog2.contentpacks.EntityDescriptorIds;
+import org.graylog2.plugin.Tools;
+import org.graylog2.plugin.rest.ValidationResult;
+import org.graylog2.plugin.streams.Stream;
+
+class NotificationTestData {
+    static EventNotificationContext getDummyContext(NotificationDto notificationDto, String userName) {
+        final EventDto eventDto = EventDto.builder()
+                .alert(true)
+                .eventDefinitionId("EventDefinitionTestId")
+                .eventDefinitionType("notification-test-v1")
+                .eventTimestamp(Tools.nowUTC())
+                .processingTimestamp(Tools.nowUTC())
+                .id("NotificationTestId")
+                .streams(ImmutableSet.of(Stream.DEFAULT_EVENTS_STREAM_ID))
+                .message("Notification test message triggered from user <" + userName + ">")
+                .source(Stream.DEFAULT_STREAM_ID)
+                .keyTuple(ImmutableList.of("testkey"))
+                .key("testkey")
+                .originContext(EventOriginContext.elasticsearchMessage("testIndex_42", "b5e53442-12bb-4374-90ed-0deadbeefbaz"))
+                .priority(2)
+                .fields(ImmutableMap.of("field1", "value1", "field2", "value2"))
+                .build();
+
+        final EventDefinitionDto eventDefinitionDto = EventDefinitionDto.builder()
+                .alert(true)
+                .id("1234")
+                .title("Event Definition Test Title")
+                .description("Event Definition Test Description")
+                .config(new EventProcessorConfig() {
+                    @Override
+                    public String type() {
+                        return "test-dummy-v1";
+                    }
+                    @Override
+                    public ValidationResult validate() {
+                        return null;
+                    }
+                    @Override
+                    public EventProcessorConfigEntity toContentPackEntity(EntityDescriptorIds entityDescriptorIds) {
+                        return null;
+                    }
+                })
+                .fieldSpec(ImmutableMap.of())
+                .priority(2)
+                .keySpec(ImmutableList.of())
+                .notificationSettings(new EventNotificationSettings() {
+                                          @Override
+                                          public long gracePeriodMs() {
+                                              return 0;
+                                          }
+                                          @Override
+                                          // disable to avoid errors in getBacklogForEvent()
+                                          public long backlogSize() {
+                                              return 0;
+                                          }
+                                          @Override
+                                          public Builder toBuilder() {
+                                              return null;
+                                          }
+                                      }
+
+                ).build();
+
+        return EventNotificationContext.builder()
+                .notificationId("1234")
+                .notificationConfig(notificationDto.config())
+                .event(eventDto)
+                .eventDefinition(eventDefinitionDto)
+                .build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailSender.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailSender.java
@@ -31,6 +31,7 @@ import org.graylog.events.notifications.EventNotificationContext;
 import org.graylog.events.notifications.EventNotificationModelData;
 import org.graylog.events.processor.DBEventDefinitionService;
 import org.graylog.events.processor.EventDefinitionDto;
+import org.graylog.scheduler.JobTriggerDto;
 import org.graylog2.alerts.EmailRecipients;
 import org.graylog2.configuration.EmailConfiguration;
 import org.graylog2.jackson.TypeReferences;
@@ -109,6 +110,7 @@ public class EmailSender {
 
     private Map<String, Object> getModel(EventNotificationContext ctx, ImmutableList<MessageSummary> backlog) {
         final Optional<EventDefinitionDto> definitionDto = ctx.eventDefinition();
+        final Optional<JobTriggerDto> jobTriggerDto = ctx.jobTrigger();
 
         // TODO: This needs at search URL, event definition URL, anything else?
         final EventNotificationModelData modelData = EventNotificationModelData.builder()
@@ -116,8 +118,8 @@ public class EmailSender {
                 .eventDefinitionType(definitionDto.map(d -> d.config().type()).orElse(UNKNOWN))
                 .eventDefinitionTitle(definitionDto.map(EventDefinitionDto::title).orElse(UNKNOWN))
                 .eventDefinitionDescription(definitionDto.map(EventDefinitionDto::description).orElse(UNKNOWN))
-                .jobDefinitionId(ctx.jobTrigger().jobDefinitionId())
-                .jobTriggerId(ctx.jobTrigger().id())
+                .jobDefinitionId(jobTriggerDto.map(JobTriggerDto::jobDefinitionId).orElse(UNKNOWN))
+                .jobTriggerId(jobTriggerDto.map(JobTriggerDto::id).orElse(UNKNOWN))
                 .event(ctx.event())
                 .backlog(backlog)
                 .build();

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotification.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotification.java
@@ -32,6 +32,7 @@ import org.graylog.events.notifications.EventNotificationService;
 import org.graylog.events.notifications.PermanentEventNotificationException;
 import org.graylog.events.notifications.TemporaryEventNotificationException;
 import org.graylog.events.processor.EventDefinitionDto;
+import org.graylog.scheduler.JobTriggerDto;
 import org.graylog2.plugin.MessageSummary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -105,14 +106,15 @@ public class HTTPEventNotification implements EventNotification {
 
     private EventNotificationModelData getModel(EventNotificationContext ctx, ImmutableList<MessageSummary> backlog) {
         final Optional<EventDefinitionDto> definitionDto = ctx.eventDefinition();
+        final Optional<JobTriggerDto> jobTriggerDto = ctx.jobTrigger();
 
         return EventNotificationModelData.builder()
                 .eventDefinitionId(definitionDto.map(EventDefinitionDto::id).orElse(UNKNOWN))
                 .eventDefinitionType(definitionDto.map(d -> d.config().type()).orElse(UNKNOWN))
                 .eventDefinitionTitle(definitionDto.map(EventDefinitionDto::title).orElse(UNKNOWN))
                 .eventDefinitionDescription(definitionDto.map(EventDefinitionDto::description).orElse(UNKNOWN))
-                .jobDefinitionId(ctx.jobTrigger().jobDefinitionId())
-                .jobTriggerId(ctx.jobTrigger().id())
+                .jobDefinitionId(jobTriggerDto.map(JobTriggerDto::jobDefinitionId).orElse(UNKNOWN))
+                .jobTriggerId(jobTriggerDto.map(JobTriggerDto::id).orElse(UNKNOWN))
                 .event(ctx.event())
                 .backlog(backlog)
                 .build();

--- a/graylog2-server/src/test/java/org/graylog/events/legacy/LegacyAlertConditionMigratorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/legacy/LegacyAlertConditionMigratorTest.java
@@ -24,6 +24,7 @@ import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
 import org.graylog.events.JobSchedulerTestClock;
 import org.graylog.events.conditions.Expr;
 import org.graylog.events.notifications.DBNotificationService;
+import org.graylog.events.notifications.EventNotification;
 import org.graylog.events.notifications.EventNotificationExecutionJob;
 import org.graylog.events.notifications.EventNotificationHandler;
 import org.graylog.events.notifications.NotificationDto;
@@ -51,10 +52,12 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -82,6 +85,9 @@ public class LegacyAlertConditionMigratorTest {
     private DBNotificationService notificationService;
     private NotificationResourceHandler notificationResourceHandler;
 
+    @Mock
+    private Map<String, EventNotification.Factory> eventNotificationFactories;
+
     @Before
     public void setUp() throws Exception {
         final ObjectMapper objectMapper = new ObjectMapperProvider().get();
@@ -105,7 +111,7 @@ public class LegacyAlertConditionMigratorTest {
 
         this.eventDefinitionService = new DBEventDefinitionService(mongoConnection, mongoJackObjectMapperProvider, mock(DBEventProcessorStateService.class));
         this.eventDefinitionHandler = spy(new EventDefinitionHandler(eventDefinitionService, jobDefinitionService, jobTriggerService, clock));
-        this.notificationResourceHandler = spy(new NotificationResourceHandler(notificationService, jobDefinitionService, eventDefinitionService));
+        this.notificationResourceHandler = spy(new NotificationResourceHandler(notificationService, jobDefinitionService, eventDefinitionService, eventNotificationFactories));
         this.migrator = new LegacyAlertConditionMigrator(mongoConnection, eventDefinitionHandler, notificationResourceHandler, notificationService, CHECK_INTERVAL);
     }
 

--- a/graylog2-server/src/test/java/org/graylog/events/notifications/NotificationResourceHandlerTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/notifications/NotificationResourceHandlerTest.java
@@ -1,0 +1,92 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog.events.notifications;
+
+import org.graylog.events.notifications.types.HTTPEventNotificationConfig;
+import org.graylog.events.processor.DBEventDefinitionService;
+import org.graylog.scheduler.DBJobDefinitionService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NotificationResourceHandlerTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private NotificationResourceHandler notificationResourceHandler;
+
+    @Mock
+    private DBNotificationService dbNotificationService;
+    @Mock
+    private DBJobDefinitionService jobDefinitionService;
+    @Mock
+    private DBEventDefinitionService eventDefinitionService;
+    @Mock
+    private Map<String, EventNotification.Factory> eventNotificationFactories;
+    @Mock
+    private EventNotification.Factory eventNotificationFactory;
+    @Mock
+    private EventNotification eventNotification;
+
+    private NotificationDto getHttpNotification() {
+        return NotificationDto.builder()
+                .title("Foobar")
+                .id("1234")
+                .description("")
+                .config(HTTPEventNotificationConfig.Builder.create()
+                        .url("http://localhost")
+                        .build())
+                .build();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        when(dbNotificationService.get(anyString())).thenReturn(Optional.of(getHttpNotification()));
+        when(eventNotificationFactory.create()).thenReturn(eventNotification);
+        when(eventNotificationFactories.get(anyString())).thenReturn(eventNotificationFactory);
+        notificationResourceHandler = new NotificationResourceHandler(dbNotificationService, jobDefinitionService, eventDefinitionService, eventNotificationFactories);
+    }
+
+    @Test
+    public void testExecution() throws EventNotificationException {
+        notificationResourceHandler.test(getHttpNotification(), "testUser");
+
+        ArgumentCaptor<EventNotificationContext> captor = ArgumentCaptor.forClass(EventNotificationContext.class);
+        verify(eventNotification, times(1)).execute(captor.capture());
+
+        assertThat(captor.getValue()).satisfies(ctx -> {
+            assertThat(ctx.event().message()).isEqualTo("Notification test message triggered from user <testUser>");
+            assertThat(ctx.notificationId()).isEqualTo("1234");
+            assertThat(ctx.notificationConfig().type()).isEqualTo(HTTPEventNotificationConfig.TYPE_NAME);
+            assertThat(ctx.eventDefinition().get().title()).isEqualTo("Event Definition Test Title");
+        });
+    }
+}

--- a/graylog2-web-interface/src/actions/event-notifications/EventNotificationsActions.js
+++ b/graylog2-web-interface/src/actions/event-notifications/EventNotificationsActions.js
@@ -9,6 +9,7 @@ const EventNotificationsActions = Reflux.createActions({
   update: { asyncResult: true },
   delete: { asyncResult: true },
   test: { asyncResult: true },
+  testPersisted: { asyncResult: true },
 });
 
 export default EventNotificationsActions;

--- a/graylog2-web-interface/src/actions/event-notifications/EventNotificationsActions.js
+++ b/graylog2-web-interface/src/actions/event-notifications/EventNotificationsActions.js
@@ -8,6 +8,7 @@ const EventNotificationsActions = Reflux.createActions({
   create: { asyncResult: true },
   update: { asyncResult: true },
   delete: { asyncResult: true },
+  test: { asyncResult: true },
 });
 
 export default EventNotificationsActions;

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
@@ -1,20 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, ButtonToolbar, Col, ControlLabel, FormGroup, HelpBlock, Row } from 'react-bootstrap';
-import { PluginStore } from 'graylog-web-plugin/plugin';
 import lodash from 'lodash';
 
+import { PluginStore } from 'graylog-web-plugin/plugin';
+import { Alert, Button, ButtonToolbar, Col, ControlLabel, FormControl, FormGroup, HelpBlock, Row } from 'react-bootstrap';
 import { Select, Spinner } from 'components/common';
 import { Input } from 'components/bootstrap';
 
 import FormsUtils from 'util/FormsUtils';
-
 
 class EventNotificationForm extends React.Component {
   static propTypes = {
     action: PropTypes.oneOf(['create', 'edit']),
     notification: PropTypes.object.isRequired,
     validation: PropTypes.object.isRequired,
+    testResult: PropTypes.shape({
+      isLoading: PropTypes.bool,
+      error: PropTypes.bool,
+      message: PropTypes.string,
+    }).isRequired,
     formId: PropTypes.string,
     embedded: PropTypes.bool.isRequired,
     onChange: PropTypes.func.isRequired,
@@ -27,11 +31,6 @@ class EventNotificationForm extends React.Component {
     action: 'edit',
     formId: undefined,
   };
-
-  constructor(props, context) {
-    super(props, context);
-    this.state = { testRunning: false };
-  }
 
   handleSubmit = (event) => {
     const { notification, onSubmit } = this.props;
@@ -64,10 +63,9 @@ class EventNotificationForm extends React.Component {
     this.handleConfigChange({ ...defaultConfig, type: nextType });
   };
 
-  handleTestTrigger = (notification) => {
-    this.setState({ testRunning: true });
-    const { onTest } = this.props;
-    onTest(notification).finally(() => this.setState({ testRunning: false }));
+  handleTestTrigger = () => {
+    const { notification, onTest } = this.props;
+    onTest(notification);
   };
 
   formattedEventNotificationTypes = () => {
@@ -76,7 +74,7 @@ class EventNotificationForm extends React.Component {
   };
 
   render() {
-    const { action, embedded, formId, notification, onCancel, validation } = this.props;
+    const { action, embedded, formId, notification, onCancel, validation, testResult } = this.props;
 
     const notificationPlugin = this.getNotificationPlugin(notification.config.type);
     const notificationFormComponent = notificationPlugin.formComponent
@@ -87,8 +85,7 @@ class EventNotificationForm extends React.Component {
       })
       : null;
 
-    const { testRunning } = this.state;
-    const testButtonText = testRunning ? <Spinner text="Testing..." /> : 'Test';
+    const testButtonText = testResult.isLoading ? <Spinner text="Testing..." /> : 'Execute Test Notification';
 
     return (
       <Row>
@@ -128,17 +125,29 @@ class EventNotificationForm extends React.Component {
 
             {notificationFormComponent}
 
+            <FormGroup>
+              <ControlLabel>Test Notification <small className="text-muted">(Optional)</small></ControlLabel>
+              <FormControl.Static>
+                <Button bsStyle="info" bsSize="small" disabled={testResult.isLoading} onClick={this.handleTestTrigger}>
+                  {testButtonText}
+                </Button>
+              </FormControl.Static>
+              {testResult.message && (
+                <Alert bsStyle={testResult.error ? 'danger' : 'success'}>
+                  <b>{testResult.error ? 'Error: ' : 'Success: '}</b>
+                  {testResult.message}
+                </Alert>
+              )}
+              <HelpBlock>
+                Execute this Notification with a test Alert.
+              </HelpBlock>
+            </FormGroup>
+
             {!embedded && (
-              <div>
-                <Button bsStyle="info" disabled={testRunning} onClick={() => this.handleTestTrigger(notification)}> {testButtonText} </Button>
-                <HelpBlock>
-                  Trigger this notification with a test Alert
-                </HelpBlock>
-                <ButtonToolbar>
-                  <Button bsStyle="primary" type="submit">{action === 'create' ? 'Create' : 'Update'}</Button>
-                  <Button onClick={onCancel}>Cancel</Button>
-                </ButtonToolbar>
-              </div>
+              <ButtonToolbar>
+                <Button bsStyle="primary" type="submit">{action === 'create' ? 'Create' : 'Update'}</Button>
+                <Button onClick={onCancel}>Cancel</Button>
+              </ButtonToolbar>
             )}
           </form>
         </Col>

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationFormContainer.jsx
@@ -108,6 +108,21 @@ class EventNotificationFormContainer extends React.Component {
     onSubmit(promise);
   };
 
+  handleTest = () => {
+    const { notification } = this.state;
+    const promise = EventNotificationsActions.test(notification);
+    return promise.then(
+      () => {
+      },
+      (errorResponse) => {
+        const { body } = errorResponse.additional;
+        if (errorResponse.status === 400 && body && body.failed) {
+          this.setState({ validation: body });
+        }
+      },
+    );
+  };
+
   render() {
     const { action, embedded, formId, route } = this.props;
     const { notification, validation, isDirty } = this.state;
@@ -125,7 +140,8 @@ class EventNotificationFormContainer extends React.Component {
                                embedded={embedded}
                                onChange={this.handleChange}
                                onCancel={this.handleCancel}
-                               onSubmit={this.handleSubmit} />
+                               onSubmit={this.handleSubmit}
+                               onTest={this.handleTest} />
       </React.Fragment>
     );
   }

--- a/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.jsx
@@ -4,8 +4,15 @@ import { Button, Col, DropdownButton, MenuItem, Row } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
-import { EmptyEntity, EntityList, EntityListItem, IfPermitted, PaginatedList, SearchForm } from 'components/common';
-
+import {
+  EmptyEntity,
+  EntityList,
+  EntityListItem,
+  IfPermitted,
+  PaginatedList,
+  SearchForm,
+  Spinner,
+} from 'components/common';
 import Routes from 'routing/Routes';
 
 import styles from './EventNotifications.css';
@@ -15,9 +22,16 @@ class EventNotifications extends React.Component {
     notifications: PropTypes.array.isRequired,
     pagination: PropTypes.object.isRequired,
     query: PropTypes.string.isRequired,
+    testResult: PropTypes.shape({
+      isLoading: PropTypes.bool,
+      id: PropTypes.string,
+      error: PropTypes.bool,
+      message: PropTypes.string,
+    }).isRequired,
     onPageChange: PropTypes.func.isRequired,
     onQueryChange: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
+    onTest: PropTypes.func.isRequired,
   };
 
   renderEmptyContent = () => {
@@ -48,35 +62,61 @@ class EventNotifications extends React.Component {
   };
 
   formatNotification = (notifications) => {
-    const { onDelete } = this.props;
+    const { testResult } = this.props;
 
     return notifications.map((notification) => {
-      const actions = (
-        <React.Fragment>
-          <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.edit(notification.id)}>
-            <IfPermitted permissions={`eventnotifications:edit:${notification.id}`}>
-              <Button bsStyle="info">Edit</Button>
-            </IfPermitted>
-          </LinkContainer>
-          <IfPermitted permissions={`eventnotifications:delete:${notification.id}`}>
-            <DropdownButton id={`more-dropdown-${notification.id}`} title="More" pullRight>
-              <MenuItem onClick={onDelete(notification)}>Delete</MenuItem>
-            </DropdownButton>
-          </IfPermitted>
-        </React.Fragment>
-      );
+      const isTestLoading = testResult.id === notification.id && testResult.isLoading;
+      const actions = this.formatActions(notification, isTestLoading);
 
       const plugin = this.getNotificationPlugin(notification.config.type);
+      const content = testResult.id === notification.id ? (
+        <Col md={12}>
+          {testResult.isLoading ? (
+            <Spinner text="Testing Notification..." />
+          ) : (
+            <p className={testResult.error ? 'text-danger' : 'text-success'}>
+              <b>{testResult.error ? 'Error' : 'Success'}:</b> {testResult.message}
+            </p>
+          )}
+        </Col>
+      ) : null;
 
       return (
         <EntityListItem key={`event-definition-${notification.id}`}
                         title={notification.title}
                         titleSuffix={plugin.displayName || notification.config.type}
                         description={notification.description || <em>No description given</em>}
-                        actions={actions} />
+                        actions={actions}
+                        contentRow={content} />
       );
     });
   };
+
+  formatActions(notification, isTestLoading) {
+    const { onDelete, onTest } = this.props;
+    return (
+      <React.Fragment>
+        <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.edit(notification.id)}>
+          <IfPermitted permissions={`eventnotifications:edit:${notification.id}`}>
+            <Button bsStyle="info">Edit</Button>
+          </IfPermitted>
+        </LinkContainer>
+        <IfPermitted permissions={[`eventnotifications:edit:${notification.id}`, `eventnotifications:delete:${notification.id}`]}>
+          <DropdownButton id={`more-dropdown-${notification.id}`} title="More" pullRight>
+            <IfPermitted permissions={`eventnotifications:edit:${notification.id}`}>
+              <MenuItem disabled={isTestLoading} onClick={onTest(notification)}>
+                {isTestLoading ? 'Testing...' : 'Test Notification'}
+              </MenuItem>
+            </IfPermitted>
+            <MenuItem divider />
+            <IfPermitted permissions={`eventnotifications:delete:${notification.id}`}>
+              <MenuItem onClick={onDelete(notification)}>Delete</MenuItem>
+            </IfPermitted>
+          </DropdownButton>
+        </IfPermitted>
+      </React.Fragment>
+    );
+  }
 
   render() {
     const { notifications, pagination, query, onPageChange, onQueryChange } = this.props;

--- a/graylog2-web-interface/src/stores/event-notifications/EventNotificationsStore.js
+++ b/graylog2-web-interface/src/stores/event-notifications/EventNotificationsStore.js
@@ -168,22 +168,12 @@ const EventNotificationsStore = Reflux.createStore({
 
   test(notification) {
     const promise = fetch('POST', this.eventNotificationsUrl({ segments: ['test'] }), notification);
-
-    promise.then(
-      (response) => {
-        UserNotification.success(`Notification "${notification.title}" was executed successfully.`,
-          'Notification Test Result');
-        return response;
-      },
-      (error) => {
-        if (error.status !== 400 || !error.additional.body || !error.additional.body.failed) {
-          const errorMessage = error.responseMessage ? `error: ${error.responseMessage}` : 'unknown error';
-          UserNotification.error(`Notification "${notification.title} execution" failed with ${errorMessage}`,
-            'Notification Test Result');
-        }
-      },
-    );
     EventNotificationsActions.test.promise(promise);
+  },
+
+  testPersisted(notification) {
+    const promise = fetch('POST', this.eventNotificationsUrl({ segments: [notification.id, 'test'] }));
+    EventNotificationsActions.testPersisted.promise(promise);
   },
 
   listAllLegacyTypes() {

--- a/graylog2-web-interface/src/stores/event-notifications/EventNotificationsStore.js
+++ b/graylog2-web-interface/src/stores/event-notifications/EventNotificationsStore.js
@@ -166,6 +166,26 @@ const EventNotificationsStore = Reflux.createStore({
     EventNotificationsActions.delete.promise(promise);
   },
 
+  test(notification) {
+    const promise = fetch('POST', this.eventNotificationsUrl({ segments: ['test'] }), notification);
+
+    promise.then(
+      (response) => {
+        UserNotification.success(`Notification "${notification.title}" was executed successfully.`,
+          'Notification Test Result');
+        return response;
+      },
+      (error) => {
+        if (error.status !== 400 || !error.additional.body || !error.additional.body.failed) {
+          const errorMessage = error.responseMessage ? `error: ${error.responseMessage}` : 'unknown error';
+          UserNotification.error(`Notification "${notification.title} execution" failed with ${errorMessage}`,
+            'Notification Test Result');
+        }
+      },
+    );
+    EventNotificationsActions.test.promise(promise);
+  },
+
   listAllLegacyTypes() {
     const promise = fetch('GET', this.eventNotificationsUrl({ segments: ['legacy', 'types'] }));
 


### PR DESCRIPTION
* Add Notification test Resource

Make jobTrigger Optional for the EventNotificationContext,
to avoid having to create a huge dummy instance to execute
the test.

* Add another notification test resource

This one accepts NotificationDtos directly,
which allows us to live test notifications, while we are editing them.

* Add frontend for notification tests

- The testState is held in the EventNotificationsStore
- The handleTest wrapper is needed to render validation errors

* Keep test notification message on screen

Before this change, the result of testing a notification was displayed
in a toaster message and gone in a few seconds. This change makes the
message to be displayed below the test button until one of the input
changes.

* Add button to test notification from list

This change allows users to test notifications from within the notification list.

Fixes #6138