### PR TITLE
Fix saving searches

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewStateDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewStateDTO.java
@@ -25,6 +25,7 @@ import org.graylog.autovalue.WithBeanGetter;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 @AutoValue
@@ -40,12 +41,13 @@ public abstract class ViewStateDTO {
     static final String FIELD_FORMATTING = "formatting";
     static final String FIELD_DISPLAY_MODE_SETTINGS = "display_mode_settings";
 
+    @Nullable
     @JsonProperty(FIELD_SELECTED_FIELDS)
-    public abstract Set<String> fields();
+    public abstract Optional<Set<String>> fields();
 
     @Nullable
     @JsonProperty(FIELD_STATIC_MESSAGE_LIST_ID)
-    public abstract String staticMessageListId();
+    public abstract Optional<String> staticMessageListId();
 
     @JsonProperty(FIELD_TITLES)
     public abstract Map<String, Map<String, String>> titles();
@@ -68,6 +70,7 @@ public abstract class ViewStateDTO {
 
     @AutoValue.Builder
     public static abstract class Builder {
+        @Nullable
         @JsonProperty(FIELD_SELECTED_FIELDS)
         public abstract Builder fields(Set<String> fields);
 

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.jsx
@@ -9,6 +9,7 @@ import { ViewStore, ViewActions } from 'views/stores/ViewStore';
 import View from 'views/logic/views/View';
 import type { ViewStoreState } from 'views/stores/ViewStore';
 import connect from 'stores/connect';
+import ViewLoaderContext from 'views/logic/ViewLoaderContext';
 
 import BookmarkForm from './BookmarkForm';
 import BookmarkList from './BookmarkList';
@@ -28,6 +29,8 @@ class BookmarkControls extends React.Component<Props, State> {
   static propTypes = {
     viewStoreState: PropTypes.object.isRequired,
   };
+
+  static contextType = ViewLoaderContext;
 
   formTarget: any;
 
@@ -103,7 +106,7 @@ class BookmarkControls extends React.Component<Props, State> {
 
     ViewManagementActions.create(newView)
       .then(() => {
-        const { loaderFunc } = this.context;
+        const loaderFunc = this.context;
         loaderFunc(newView.id);
       })
       .then(this.toggleFormModal)

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.test.jsx
@@ -4,10 +4,11 @@ import { mount } from 'enzyme';
 
 import View from 'views/logic/views/View';
 import Search from 'views/logic/search/Search';
-import BookmarkControls from './BookmarkControls';
 import ViewLoaderContext from 'views/logic/ViewLoaderContext';
 import mockAction from 'helpers/mocking/MockAction';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
+
+import BookmarkControls from './BookmarkControls';
 
 describe('BookmarkControls', () => {
   describe('Button handling', () => {

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.test.jsx
@@ -5,8 +5,41 @@ import { mount } from 'enzyme';
 import View from 'views/logic/views/View';
 import Search from 'views/logic/search/Search';
 import BookmarkControls from './BookmarkControls';
+import ViewLoaderContext from 'views/logic/ViewLoaderContext';
+import mockAction from 'helpers/mocking/MockAction';
+import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 
 describe('BookmarkControls', () => {
+  describe('Button handling', () => {
+    it('should loadView after create', (done) => {
+      ViewManagementActions.create = mockAction(jest.fn(() => Promise.resolve()));
+      const onLoadView = jest.fn(() => {
+        return Promise.resolve();
+      });
+      const viewStoreState = {
+        activeQuery: '',
+        view: View.builder()
+          .title('title')
+          .description('description')
+          .search(Search.create().toBuilder().id('id-beef').build())
+          .build(),
+        dirty: false,
+      };
+      const wrapper = mount(
+        <ViewLoaderContext.Provider value={onLoadView}>
+          <BookmarkControls viewStoreState={viewStoreState} />
+        </ViewLoaderContext.Provider>,
+      );
+      wrapper.find('button[title="Save search"]').simulate('click');
+      wrapper.find('input[value="title"]').simulate('change', { target: { value: 'Test' } });
+      wrapper.find('button[children="Create new"]').simulate('click');
+      setImmediate(() => {
+        expect(onLoadView).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+  });
+
   describe('render the BookmarkControls', () => {
     it('should render not dirty with unsaved view', () => {
       const viewStoreState = {


### PR DESCRIPTION
## Description
Prior to this change, selected_fields attribute was no longer send
from the frontend but the backend was still expecting it.
Saving a view was therefore broken.
Also prior to this change, the context type was not declared for
BookmarkControls, which was leading to a empty context.

## Motivation and Context
When clicking on create or save on a search the request to save failed.

## How Has This Been Tested?
Created a new Search and saved it afterwards again.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
