### PR TITLE
Do not render empty string for `0` value in number visualization.

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.jsx
@@ -105,8 +105,8 @@ class NumberVisualization extends React.Component<Props, State> {
     const { currentView, fields, data } = this.props;
     const { activeQuery } = currentView;
     const { value, field } = this._extractValueAndField(data);
-    if (!value || !field) {
-      return '';
+    if (value !== 0 && (!value || !field)) {
+      return 'N/A';
     }
 
     return (

--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.jsx
@@ -105,7 +105,7 @@ class NumberVisualization extends React.Component<Props, State> {
     const { currentView, fields, data } = this.props;
     const { activeQuery } = currentView;
     const { value, field } = this._extractValueAndField(data);
-    if (value !== 0 && (!value || !field)) {
+    if (!field || (value !== 0 && !value)) {
       return 'N/A';
     }
 

--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.test.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.test.jsx
@@ -30,7 +30,7 @@ describe('NumberVisualization', () => {
         key: ['sum(lines_add)'],
         rollup: true,
         source: 'row-leaf',
-        value: '2134342',
+        value: 2134342,
       },
     ],
   }];
@@ -46,7 +46,7 @@ describe('NumberVisualization', () => {
     expect(wrapper.toJSON()).toMatchSnapshot();
   });
 
-  it('should mount a number visualization', () => {
+  it('changes font size upon resize', () => {
     const wrapper = mount(<NumberVisualization data={data}
                                                width={300}
                                                height={300}
@@ -62,5 +62,45 @@ describe('NumberVisualization', () => {
     wrapper.setProps({ height: 125, width: 125 });
 
     expect(wrapper.state().fontSize).toBe(22);
+  });
+  it('renders 0 if value is 0', () => {
+    const dataWithZeroValue = [{
+      key: [],
+      source: 'leaf',
+      values: [
+        {
+          key: ['count()'],
+          rollup: true,
+          source: 'row-leaf',
+          value: 0,
+        },
+      ],
+    }];
+    const wrapper = mount(<NumberVisualization data={dataWithZeroValue}
+                                               width={300}
+                                               height={300}
+                                               fields={fields}
+                                               currentView={currentView} />);
+    expect(wrapper).toHaveText('0');
+  });
+  it('renders N/A if value is null', () => {
+    const dataWithZeroValue = [{
+      key: [],
+      source: 'leaf',
+      values: [
+        {
+          key: ['count()'],
+          rollup: true,
+          source: 'row-leaf',
+          value: null,
+        },
+      ],
+    }];
+    const wrapper = mount(<NumberVisualization data={dataWithZeroValue}
+                                               width={300}
+                                               height={300}
+                                               fields={fields}
+                                               currentView={currentView} />);
+    expect(wrapper).toHaveText('N/A');
   });
 });


### PR DESCRIPTION
## Description
## Motivation and Context
<!--- Describe your changes in detail -->

Before this change, the number visualization of the aggregation builder rendered an empty string if the actual value was `0`, related to a type coercion in a conditional meant to catch `null`/`undefined` values.

This change is making that conditional stricted. In addition, it also returns `N/A` instead of `''` for `null`/`undefined` values.

Before:

![Screen Shot 2019-10-09 at 10 56 44](https://user-images.githubusercontent.com/41929/66466827-a4528e80-ea83-11e9-8643-5d4e82556786.png)

After:

![Screen Shot 2019-10-09 at 10 53 56](https://user-images.githubusercontent.com/41929/66466841-a7e61580-ea83-11e9-98a0-b56800a6ba20.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.