### PR TITLE
Update plugin archetype yarn version syntax from yarn.version to yarnVersion

### DIFF
--- a/graylog-plugin-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/graylog-plugin-archetype/src/main/resources/archetype-resources/pom.xml
@@ -244,7 +244,7 @@
                                 </goals>
                                 <configuration>
                                     <nodeVersion>${nodejs.version}</nodeVersion>
-                                    <yarn.version>${yarn.version}</yarn.version>
+                                    <yarnVersion>${yarn.version}</yarnVersion>
                                 </configuration>
                             </execution>
 


### PR DESCRIPTION
Little syntax fix for our plugin archetype. The syntax for the yarn version tag got unified with the node version tag.

## Motivation and Context
Found while creating an example plugin and using the archetype

## How Has This Been Tested?
I've executed `mvn install` inside the graylog-plugin-archtype dir, created a new plugin skeleton with  `mvn archetype:generate -DarchetypeGroupId=org.graylog -DarchetypeArtifactId=graylog-plugin-archetype` plus the required `-DarchetypeCatalog=local` attribute and run `mvn package` to be sure the build still works.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
