### PR TITLE
Introduce a cluster global API browser button

### DIFF
--- a/graylog2-server/src/main/resources/swagger/css/screen.css
+++ b/graylog2-server/src/main/resources/swagger/css/screen.css
@@ -413,6 +413,21 @@ body #header {
     font-size: 14px;
 }
 
+.warning-box {
+    color: #9F6000;
+    background-color: #FEEFB3;
+    vertical-align:middle;
+    position: fixed;
+    top: 75px;
+    left: 20px;
+    width: 250px;
+    margin: 5px;
+    padding: 20px;
+    font-size: 14px;
+    border-radius:.5em;
+    box-shadow: 6px 6px 11px -4px rgba(0,0,0,0.43);
+}
+
 body #header a#logo {
     font-size: 1.5em;
     font-weight: bold;

--- a/graylog2-server/src/main/resources/swagger/index.html.template
+++ b/graylog2-server/src/main/resources/swagger/index.html.template
@@ -1,8 +1,9 @@
+
 <!DOCTYPE html>
 <html>
 <head>
   <title>Graylog REST API browser</title>
-  <base href="${baseUri}api-browser/">
+  <base href="${baseUri}api-browser/${globalModePath}">
   <link href='css/fonts.css' rel='stylesheet' type='text/css'/>
   <link href='css/highlight.default.css' media='screen' rel='stylesheet' type='text/css'/>
   <link href='css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
@@ -22,7 +23,7 @@
     var apiTarget = "${baseUri}";
     $(function () {
       window.swaggerUi = new SwaggerUi({
-      url: apiTarget + "api-docs",
+      url: apiTarget + "api-docs" + "${globalUriMarker}",
       dom_id: "swagger-ui-container",
       supportedSubmitMethods: ['get', 'post', 'put', 'delete'],
       onComplete: function(swaggerApi, swaggerUi){
@@ -37,6 +38,10 @@
           console.log("Loaded SwaggerUI")
         }
         $('pre code').each(function(i, e) {hljs.highlightBlock(e)});
+
+        if ("${showWarning}") {
+          $('.warning-box').css('visibility', '');
+        }
       },
       onFailure: function(data) {
         if(console) {
@@ -67,6 +72,13 @@
 </head>
 
 <body>
+<div class="warning-box" style="visibility:hidden;">
+  <h3>Attention</h3>
+  <p>
+  The API browser is running in global mode. API requests made against this URI will not be bound to a specific node,
+  but might end up on any random node in your Graylog cluster. Keep that in mind when using node specific API requests.
+  </p>
+</div>
 <div id='header'>
   <div class="swagger-ui-wrap">
     <img src="images/toplogo.png">

--- a/graylog2-server/src/main/resources/swagger/swagger-ui.js
+++ b/graylog2-server/src/main/resources/swagger/swagger-ui.js
@@ -1435,7 +1435,7 @@ helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
 
     ResourceView.prototype.render = function() {
       var operation, _i, _len, _ref4;
-      console.log(this.model.description);
+      //console.log(this.model.description);
       $(this.el).html(Handlebars.templates.resource(this.model));
       this.number = 0;
       _ref4 = this.model.operationsArray;

--- a/graylog2-server/src/main/resources/swagger/swagger-ui.js
+++ b/graylog2-server/src/main/resources/swagger/swagger-ui.js
@@ -1435,7 +1435,6 @@ helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
 
     ResourceView.prototype.render = function() {
       var operation, _i, _len, _ref4;
-      //console.log(this.model.description);
       $(this.el).html(Handlebars.templates.resource(this.model));
       this.number = 0;
       _ref4 = this.model.operationsArray;

--- a/graylog2-web-interface/src/components/nodes/NodesList.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodesList.jsx
@@ -9,7 +9,6 @@ import { Spinner, EntityList, Pluralize } from 'components/common';
 import StoreProvider from 'injection/StoreProvider';
 import NodeListItem from './NodeListItem';
 
-const NodesStore = StoreProvider.getStore('Nodes');
 const ClusterOverviewStore = StoreProvider.getStore('ClusterOverview');
 
 const NodesList = createReactClass({
@@ -17,12 +16,13 @@ const NodesList = createReactClass({
 
   propTypes: {
     permissions: PropTypes.array.isRequired,
+    nodes: PropTypes.array.isRequired,
   },
 
-  mixins: [Reflux.connect(NodesStore), Reflux.connect(ClusterOverviewStore)],
+  mixins: [Reflux.connect(ClusterOverviewStore)],
 
   _isLoading() {
-    return !(this.state.nodes && this.state.clusterOverview);
+    return !(this.props.nodes && this.state.clusterOverview);
   },
 
   _formatNodes(nodes, clusterOverview) {
@@ -38,7 +38,7 @@ const NodesList = createReactClass({
       return <Spinner />;
     }
 
-    const nodesNo = Object.keys(this.state.nodes).length;
+    const nodesNo = Object.keys(this.props.nodes).length;
 
     return (
       <Row className="content">
@@ -48,7 +48,7 @@ const NodesList = createReactClass({
           </h2>
           <EntityList bsNoItemsStyle="info"
                       noItemsText="There are no active nodes."
-                      items={this._formatNodes(this.state.nodes, this.state.clusterOverview)} />
+                      items={this._formatNodes(this.props.nodes, this.state.clusterOverview)} />
         </Col>
       </Row>
     );

--- a/graylog2-web-interface/src/components/nodes/NodesList.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodesList.jsx
@@ -16,13 +16,15 @@ const NodesList = createReactClass({
 
   propTypes: {
     permissions: PropTypes.array.isRequired,
-    nodes: PropTypes.array.isRequired,
+    nodes: PropTypes.arrayOf(PropTypes.object).isRequired,
   },
 
   mixins: [Reflux.connect(ClusterOverviewStore)],
 
   _isLoading() {
-    return !(this.props.nodes && this.state.clusterOverview);
+    const { nodes } = this.props;
+    const { clusterOverview } = this.state;
+    return !(nodes && clusterOverview);
   },
 
   _formatNodes(nodes, clusterOverview) {

--- a/graylog2-web-interface/src/pages/NodesPage.jsx
+++ b/graylog2-web-interface/src/pages/NodesPage.jsx
@@ -1,19 +1,51 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
+import Routes from 'routing/Routes';
+import URLUtils from 'util/URLUtils';
 
 import StoreProvider from 'injection/StoreProvider';
 
-import { DocumentTitle, PageHeader } from 'components/common';
+import { DocumentTitle, ExternalLinkButton, PageHeader, Spinner } from 'components/common';
 import { NodesList } from 'components/nodes';
+import { Alert } from 'components/graylog';
+import URI from 'urijs';
 
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
+const NodesStore = StoreProvider.getStore('Nodes');
 
 const NodesPage = createReactClass({
   displayName: 'NodesPage',
-  mixins: [Reflux.connect(CurrentUserStore)],
+  mixins: [Reflux.connect(CurrentUserStore), Reflux.connect(NodesStore)],
+
+  _isLoading() {
+    const { nodes } = this.state;
+    return !(nodes);
+  },
+
+  _renderGlobalAPIButton() {
+    if (this._isLoading()) {
+      return <Spinner />;
+    }
+    if (this._hasExternalURI()) {
+      return (
+        <ExternalLinkButton bsStyle="info" href={URLUtils.qualifyUrl(Routes.GLOBAL_API_BROWSER)}>
+          Cluster Global API browser
+        </ExternalLinkButton>
+      );
+    }
+    return null;
+  },
+
+  _hasExternalURI() {
+    const { nodes } = this.state;
+    const nodeVals = Object.values(nodes);
+    const publishURI = URLUtils.qualifyUrl('/');
+    return (nodeVals.findIndex(node => new URI(node.transport_address).normalizePathname().toString() !== publishURI) >= 0);
+  },
 
   render() {
+    const { nodes } = this.state;
     return (
       <DocumentTitle title="Nodes">
         <div>
@@ -25,8 +57,11 @@ const NodesPage = createReactClass({
               you resume it. If the message journal is enabled for a node, which it is by default, incoming messages
               will be persisted to disk, even when processing is disabled.
             </span>
+            <span>
+              {this._renderGlobalAPIButton()}
+            </span>
           </PageHeader>
-          <NodesList permissions={this.state.currentUser.permissions} />
+          <NodesList permissions={this.state.currentUser.permissions} nodes={nodes} />
         </div>
       </DocumentTitle>
     );

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -31,6 +31,7 @@ const Routes = {
   SOURCES: '/sources',
   DASHBOARDS: '/dashboards',
   GETTING_STARTED: '/gettingstarted',
+  GLOBAL_API_BROWSER: '/api-browser/global/index.html',
   SYSTEM: {
     CONFIGURATIONS: '/system/configurations',
     CONTENTPACKS: {


### PR DESCRIPTION
Usually, the link to the API browser is meant to talk to one specific node only.

In cases where Graylog is served behind a load balancer, the node
specific URL is not reachable.
We autodetect that ( `http_external_uri` != `http_publish_uri` )
and display a "cluster global API browser button".

Since the API browser behind this address might end up talking
to random nodes of the cluster, display a warning box, to make
users aware of this.

Fixes #5920

Refs #2360
Refs https://github.com/Graylog2/graylog2-server/pull/2587
