### PR TITLE
Improving `UserPreferencesButton` tests usage of mocks and snapshots.

### DIFF
--- a/graylog2-web-interface/src/components/users/UserPreferencesButton.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserPreferencesButton.test.jsx
@@ -1,33 +1,18 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 
-import { CombinedProviderMock as MockCombinedProvider, StoreMock as MockStore } from 'helpers/mocking';
-
+import { StoreMock as MockStore } from 'helpers/mocking';
 import UserPreferencesButton from 'components/users/UserPreferencesButton';
+import PreferencesStore from 'stores/users/PreferencesStore';
 
-import StoreProvider from 'injection/StoreProvider';
-
-jest.mock('injection/CombinedProvider', () => {
-  const mockPreferencesStore = MockStore('get', 'listen', 'loadUserPreferences');
-  const combinedProviderMock = new MockCombinedProvider({
-    Preferences: { PreferencesStore: mockPreferencesStore },
-  });
-
-  return combinedProviderMock;
-});
-
-const PreferencesStore = StoreProvider.getStore('Preferences');
+jest.mock('stores/users/PreferencesStore', () => MockStore('get', 'listen', 'loadUserPreferences'));
 
 describe('UserPreferencesButton', () => {
-  beforeEach(() => {
-    jest.resetModules();
-  });
-
   it('should load user data when user clicks edit button', () => {
     const instance = render(<UserPreferencesButton userName="Full" />);
     const button = instance.getByTestId('user-preferences-button');
 
-    expect(instance).toMatchSnapshot();
+    expect(instance.container).toMatchSnapshot();
     expect(button).toBeDefined();
 
     fireEvent.click(button);

--- a/graylog2-web-interface/src/components/users/__snapshots__/UserPreferencesButton.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/UserPreferencesButton.test.jsx.snap
@@ -1,82 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`UserPreferencesButton should load user data when user clicks edit button 1`] = `
-Object {
-  "asFragment": [Function],
-  "baseElement": <body>
-    <div>
-      <span>
-        <button
-          class="Button__StyledButton-c9cbmb-0 kRDLih btn btn-success"
-          data-testid="user-preferences-button"
-          type="button"
-        >
-          User preferences
-        </button>
-      </span>
-    </div>
-  </body>,
-  "container": <div>
-    <span>
-      <button
-        class="Button__StyledButton-c9cbmb-0 kRDLih btn btn-success"
-        data-testid="user-preferences-button"
-        type="button"
-      >
-        User preferences
-      </button>
-    </span>
-  </div>,
-  "debug": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "rerender": [Function],
-  "unmount": [Function],
-}
+<div>
+  <span>
+    <button
+      class="Button__StyledButton-c9cbmb-0 kRDLih btn btn-success"
+      data-testid="user-preferences-button"
+      type="button"
+    >
+      User preferences
+    </button>
+  </span>
+</div>
 `;


### PR DESCRIPTION
## Description
## Motivation and Context
<Before this change, the `UserPreferencesButton` test was snapshotting
the instance returned from testing-library directly, including a lot of
internal structure in the code which is likely to change and therefore
break the test in future versions of the library. This change is fixing
this. Additionally, it removes a lot of unnecessary boiler plate.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.