### PR TITLE
Updating Button reference issue

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/__snapshots__/Input.test.jsx.snap
+++ b/graylog2-web-interface/src/components/bootstrap/__snapshots__/Input.test.jsx.snap
@@ -68,7 +68,7 @@ exports[`Input renders a button after the input if buttonAfter is passed 1`] = `
   addonAfter={null}
   bsStyle={null}
   buttonAfter={
-    <Button
+    <ForwardRef
       active={false}
       bsStyle="default"
     />
@@ -119,7 +119,7 @@ exports[`Input renders a button after the input if buttonAfter is passed 1`] = `
                 <span
                   className="input-group-btn"
                 >
-                  <Button
+                  <ForwardRef
                     active={false}
                     bsStyle="default"
                   >
@@ -149,10 +149,9 @@ exports[`Input renders a button after the input if buttonAfter is passed 1`] = `
                             "componentStyle": ComponentStyle {
                               "componentId": "Button__StyledButton-c9cbmb-0",
                               "isStatic": false,
-                              "lastClassName": "cBCVOY",
+                              "lastClassName": "kRDLih",
                               "rules": Array [
                                 [Function],
-                                ";",
                               ],
                             },
                             "displayName": "Button__StyledButton",
@@ -172,18 +171,18 @@ exports[`Input renders a button after the input if buttonAfter is passed 1`] = `
                           block={false}
                           bsClass="btn"
                           bsStyle="default"
-                          className="Button__StyledButton-c9cbmb-0 cBCVOY"
+                          className="Button__StyledButton-c9cbmb-0 kRDLih"
                           disabled={false}
                         >
                           <button
-                            className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                             disabled={false}
                             type="button"
                           />
                         </Button>
                       </StyledComponent>
                     </Button__StyledButton>
-                  </Button>
+                  </ForwardRef>
                 </span>
               </InputGroupButton>
             </span>

--- a/graylog2-web-interface/src/components/common/__snapshots__/Wizard.test.jsx.snap
+++ b/graylog2-web-interface/src/components/common/__snapshots__/Wizard.test.jsx.snap
@@ -15,7 +15,7 @@ exports[`<Wizard /> should render in horizontal mode with 3 steps 1`] = `
         role="toolbar"
       >
         <button
-          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-xs btn-info"
+          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-info"
           disabled={true}
           onClick={[Function]}
           type="button"
@@ -25,7 +25,7 @@ exports[`<Wizard /> should render in horizontal mode with 3 steps 1`] = `
           />
         </button>
         <button
-          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-xs btn-info"
+          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-info"
           disabled={false}
           onClick={[Function]}
           type="button"
@@ -106,7 +106,7 @@ exports[`<Wizard /> should render in horizontal mode with 3 steps and children 1
         role="toolbar"
       >
         <button
-          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-xs btn-info"
+          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-info"
           disabled={true}
           onClick={[Function]}
           type="button"
@@ -116,7 +116,7 @@ exports[`<Wizard /> should render in horizontal mode with 3 steps and children 1
           />
         </button>
         <button
-          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-xs btn-info"
+          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-info"
           disabled={false}
           onClick={[Function]}
           type="button"
@@ -248,7 +248,7 @@ exports[`<Wizard /> should render with 3 steps 1`] = `
         className="col-xs-6"
       >
         <button
-          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
           disabled={true}
           onClick={[Function]}
           type="button"
@@ -260,7 +260,7 @@ exports[`<Wizard /> should render with 3 steps 1`] = `
         className="text-right col-xs-6"
       >
         <button
-          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
           disabled={false}
           onClick={[Function]}
           type="button"
@@ -339,7 +339,7 @@ exports[`<Wizard /> should render with 3 steps and children 1`] = `
         className="col-xs-6"
       >
         <button
-          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
           disabled={true}
           onClick={[Function]}
           type="button"
@@ -351,7 +351,7 @@ exports[`<Wizard /> should render with 3 steps and children 1`] = `
         className="text-right col-xs-6"
       >
         <button
-          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
           disabled={false}
           onClick={[Function]}
           type="button"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackApplyParameter.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackApplyParameter.test.jsx.snap
@@ -112,7 +112,7 @@ exports[`<ContentPackApplyParameter /> should render with full props 1`] = `
         className="col-sm-2 col-sm-offset-10"
       >
         <button
-          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-primary"
+          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
           disabled={true}
           type="submit"
         >
@@ -164,7 +164,7 @@ exports[`<ContentPackApplyParameter /> should render with full props 1`] = `
                     </td>
                     <td>
                       <button
-                        className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+                        className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
                         disabled={false}
                         onClick={[Function]}
                         type="button"
@@ -293,7 +293,7 @@ exports[`<ContentPackApplyParameter /> should render with minimal props 1`] = `
         className="col-sm-2 col-sm-offset-10"
       >
         <button
-          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-primary"
+          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
           disabled={true}
           type="submit"
         >
@@ -443,7 +443,7 @@ exports[`<ContentPackApplyParameter /> should render with readOnly 1`] = `
         className="col-sm-2 col-sm-offset-10"
       >
         <button
-          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-primary"
+          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
           disabled={true}
           type="submit"
         >

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
@@ -72,7 +72,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
           className="col-xs-6"
         >
           <button
-            className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
             disabled={true}
             onClick={[Function]}
             type="button"
@@ -84,7 +84,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
           className="text-right col-xs-6"
         >
           <button
-            className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
             disabled={true}
             onClick={[Function]}
             type="button"
@@ -318,7 +318,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                   }
                 >
                   <button
-                    className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                    className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                     disabled={false}
                     type="submit"
                   >
@@ -334,7 +334,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                   }
                 >
                   <button
-                    className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                    className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                     disabled={false}
                     onClick={[Function]}
                     type="reset"
@@ -546,7 +546,7 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
           className="col-xs-6"
         >
           <button
-            className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
             disabled={true}
             onClick={[Function]}
             type="button"
@@ -558,7 +558,7 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
           className="text-right col-xs-6"
         >
           <button
-            className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
             disabled={false}
             onClick={[Function]}
             type="button"
@@ -792,7 +792,7 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
                   }
                 >
                   <button
-                    className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                    className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                     disabled={false}
                     type="submit"
                   >
@@ -808,7 +808,7 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
                   }
                 >
                   <button
-                    className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                    className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                     disabled={false}
                     onClick={[Function]}
                     type="reset"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntitiesList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntitiesList.test.jsx.snap
@@ -46,7 +46,7 @@ exports[`<ContentPackEntitiesList /> should render with empty entities 1`] = `
         }
       >
         <button
-          className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+          className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
           disabled={false}
           type="submit"
         >
@@ -62,7 +62,7 @@ exports[`<ContentPackEntitiesList /> should render with empty entities 1`] = `
         }
       >
         <button
-          className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+          className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
           disabled={false}
           onClick={[Function]}
           type="reset"
@@ -139,7 +139,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
         }
       >
         <button
-          className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+          className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
           disabled={false}
           type="submit"
         >
@@ -155,7 +155,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
         }
       >
         <button
-          className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+          className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
           disabled={false}
           onClick={[Function]}
           type="reset"
@@ -233,7 +233,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
                     role="toolbar"
                   >
                     <button
-                      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-xs btn-primary"
+                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-primary"
                       disabled={false}
                       onClick={[Function]}
                       type="button"
@@ -241,7 +241,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
                       Edit
                     </button>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-xs btn-info"
+                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-info"
                       disabled={false}
                       onClick={[Function]}
                       type="button"
@@ -282,7 +282,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
                     role="toolbar"
                   >
                     <button
-                      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-xs btn-primary"
+                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-primary"
                       disabled={false}
                       onClick={[Function]}
                       type="button"
@@ -290,7 +290,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
                       Edit
                     </button>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-xs btn-info"
+                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-info"
                       disabled={false}
                       onClick={[Function]}
                       type="button"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstall.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstall.test.jsx.snap
@@ -132,7 +132,7 @@ exports[`<ContentPackInstall /> should render a install 1`] = `
               }
             >
               <button
-                className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                 disabled={false}
                 type="submit"
               >
@@ -148,7 +148,7 @@ exports[`<ContentPackInstall /> should render a install 1`] = `
               }
             >
               <button
-                className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                 disabled={false}
                 onClick={[Function]}
                 type="reset"
@@ -209,7 +209,7 @@ exports[`<ContentPackInstall /> should render a install 1`] = `
                           role="toolbar"
                         >
                           <button
-                            className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-xs btn-info"
+                            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-info"
                             disabled={false}
                             onClick={[Function]}
                             type="button"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstallations.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstallations.test.jsx.snap
@@ -47,7 +47,7 @@ exports[`<ContentPackInstallations /> should render with a installation 1`] = `
                     role="toolbar"
                   >
                     <button
-                      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-primary"
+                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-primary"
                       disabled={false}
                       onClick={[Function]}
                       type="button"
@@ -55,7 +55,7 @@ exports[`<ContentPackInstallations /> should render with a installation 1`] = `
                       Uninstall
                     </button>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
                       disabled={false}
                       onClick={[Function]}
                       type="button"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameterList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameterList.test.jsx.snap
@@ -46,7 +46,7 @@ exports[`<ContentPackParameterList /> should render with empty parameters with r
         }
       >
         <button
-          className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+          className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
           disabled={false}
           type="submit"
         >
@@ -62,7 +62,7 @@ exports[`<ContentPackParameterList /> should render with empty parameters with r
         }
       >
         <button
-          className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+          className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
           disabled={false}
           onClick={[Function]}
           type="reset"
@@ -100,7 +100,7 @@ exports[`<ContentPackParameterList /> should render with empty parameters withou
   </h2>
   <br />
   <button
-    className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
     disabled={false}
     onClick={[Function]}
     title="Edit Modal"
@@ -152,7 +152,7 @@ exports[`<ContentPackParameterList /> should render with empty parameters withou
         }
       >
         <button
-          className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+          className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
           disabled={false}
           type="submit"
         >
@@ -168,7 +168,7 @@ exports[`<ContentPackParameterList /> should render with empty parameters withou
         }
       >
         <button
-          className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+          className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
           disabled={false}
           onClick={[Function]}
           type="reset"
@@ -245,7 +245,7 @@ exports[`<ContentPackParameterList /> should render with parameters with readOnl
         }
       >
         <button
-          className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+          className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
           disabled={false}
           type="submit"
         >
@@ -261,7 +261,7 @@ exports[`<ContentPackParameterList /> should render with parameters with readOnl
         }
       >
         <button
-          className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+          className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
           disabled={false}
           onClick={[Function]}
           type="reset"
@@ -354,7 +354,7 @@ exports[`<ContentPackParameterList /> should render with parameters without read
   </h2>
   <br />
   <button
-    className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
     disabled={false}
     onClick={[Function]}
     title="Edit Modal"
@@ -406,7 +406,7 @@ exports[`<ContentPackParameterList /> should render with parameters without read
         }
       >
         <button
-          className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+          className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
           disabled={false}
           type="submit"
         >
@@ -422,7 +422,7 @@ exports[`<ContentPackParameterList /> should render with parameters without read
         }
       >
         <button
-          className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+          className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
           disabled={false}
           onClick={[Function]}
           type="reset"
@@ -507,7 +507,7 @@ exports[`<ContentPackParameterList /> should render with parameters without read
                     role="toolbar"
                   >
                     <button
-                      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-xs btn-primary"
+                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-primary"
                       disabled={false}
                       onClick={[Function]}
                       title="Delete Parameter"
@@ -516,7 +516,7 @@ exports[`<ContentPackParameterList /> should render with parameters without read
                       Delete
                     </button>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-xs btn-info"
+                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-info"
                       disabled={false}
                       onClick={[Function]}
                       title="Edit Modal"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameters.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameters.test.jsx.snap
@@ -14,7 +14,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
         </h2>
         <br />
         <button
-          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
           disabled={false}
           onClick={[Function]}
           title="Edit Modal"
@@ -66,7 +66,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
               }
             >
               <button
-                className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                 disabled={false}
                 type="submit"
               >
@@ -82,7 +82,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
               }
             >
               <button
-                className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                 disabled={false}
                 onClick={[Function]}
                 type="reset"
@@ -167,7 +167,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                           role="toolbar"
                         >
                           <button
-                            className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-xs btn-primary"
+                            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-primary"
                             disabled={false}
                             onClick={[Function]}
                             title="Delete Parameter"
@@ -176,7 +176,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                             Delete
                           </button>
                           <button
-                            className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-xs btn-info"
+                            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-info"
                             disabled={false}
                             onClick={[Function]}
                             title="Edit Modal"
@@ -247,7 +247,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
               }
             >
               <button
-                className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                 disabled={false}
                 type="submit"
               >
@@ -263,7 +263,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
               }
             >
               <button
-                className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                 disabled={false}
                 onClick={[Function]}
                 type="reset"
@@ -341,7 +341,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                           role="toolbar"
                         >
                           <button
-                            className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-xs btn-primary"
+                            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-primary"
                             disabled={false}
                             onClick={[Function]}
                             type="button"
@@ -349,7 +349,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                             Edit
                           </button>
                           <button
-                            className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-xs btn-info"
+                            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-info"
                             disabled={false}
                             onClick={[Function]}
                             type="button"
@@ -385,7 +385,7 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
         </h2>
         <br />
         <button
-          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
           disabled={false}
           onClick={[Function]}
           title="Edit Modal"
@@ -437,7 +437,7 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
               }
             >
               <button
-                className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                 disabled={false}
                 type="submit"
               >
@@ -453,7 +453,7 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
               }
             >
               <button
-                className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                 disabled={false}
                 onClick={[Function]}
                 type="reset"
@@ -535,7 +535,7 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
               }
             >
               <button
-                className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                 disabled={false}
                 type="submit"
               >
@@ -551,7 +551,7 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
               }
             >
               <button
-                className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                 disabled={false}
                 onClick={[Function]}
                 type="reset"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackPreview.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackPreview.test.jsx.snap
@@ -180,7 +180,7 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
               }
             >
               <button
-                className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                 disabled={false}
                 type="submit"
               >
@@ -196,7 +196,7 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
               }
             >
               <button
-                className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                 disabled={false}
                 onClick={[Function]}
                 type="reset"
@@ -270,7 +270,7 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
               }
             >
               <button
-                className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                 disabled={false}
                 type="submit"
               >
@@ -286,7 +286,7 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
               }
             >
               <button
-                className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                 disabled={false}
                 onClick={[Function]}
                 type="reset"
@@ -324,7 +324,7 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
       className="col-sm-6"
     >
       <button
-        className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-primary"
+        className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
         disabled={false}
         id="create"
         onClick={[Function]}
@@ -338,7 +338,7 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
         href="data:text/plain;charset=utf-8,%7B%0A%20%20%22v%22%3A%201%2C%0A%20%20%22id%22%3A%20%22dead-beef%22%2C%0A%20%20%22rev%22%3A%201%2C%0A%20%20%22name%22%3A%20%22%22%2C%0A%20%20%22summary%22%3A%20%22%22%2C%0A%20%20%22description%22%3A%20%22%22%2C%0A%20%20%22vendor%22%3A%20%22%22%2C%0A%20%20%22url%22%3A%20%22%22%2C%0A%20%20%22parameters%22%3A%20%5B%5D%2C%0A%20%20%22entities%22%3A%20%5B%5D%0A%7D"
       >
         <button
-          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-info"
+          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-info"
           disabled={false}
           id="download"
           onClick={[Function]}
@@ -548,7 +548,7 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
               }
             >
               <button
-                className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                 disabled={false}
                 type="submit"
               >
@@ -564,7 +564,7 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
               }
             >
               <button
-                className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                 disabled={false}
                 onClick={[Function]}
                 type="reset"
@@ -638,7 +638,7 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
               }
             >
               <button
-                className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                 disabled={false}
                 type="submit"
               >
@@ -654,7 +654,7 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
               }
             >
               <button
-                className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                 disabled={false}
                 onClick={[Function]}
                 type="reset"
@@ -692,7 +692,7 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
       className="col-sm-6"
     >
       <button
-        className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-primary"
+        className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
         disabled={false}
         id="create"
         onClick={[Function]}
@@ -706,7 +706,7 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
         href="data:text/plain;charset=utf-8,%7B%0A%20%20%22v%22%3A%201%2C%0A%20%20%22id%22%3A%20%22dead-beef%22%2C%0A%20%20%22rev%22%3A%201%2C%0A%20%20%22name%22%3A%20%22name%22%2C%0A%20%20%22summary%22%3A%20%22summary%22%2C%0A%20%20%22description%22%3A%20%22descr%22%2C%0A%20%20%22vendor%22%3A%20%22vendor%22%2C%0A%20%20%22url%22%3A%20%22http%3A%2F%2Fexample.com%22%2C%0A%20%20%22parameters%22%3A%20%5B%5D%2C%0A%20%20%22entities%22%3A%20%5B%5D%0A%7D"
       >
         <button
-          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-info"
+          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-info"
           disabled={false}
           id="download"
           onClick={[Function]}

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
@@ -222,7 +222,7 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
             }
           >
             <button
-              className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+              className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
               disabled={false}
               type="submit"
             >
@@ -238,7 +238,7 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
             }
           >
             <button
-              className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+              className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
               disabled={false}
               onClick={[Function]}
               type="reset"
@@ -499,7 +499,7 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
             }
           >
             <button
-              className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+              className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
               disabled={false}
               type="submit"
             >
@@ -515,7 +515,7 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
             }
           >
             <button
-              className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+              className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
               disabled={false}
               onClick={[Function]}
               type="reset"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackUploadControls.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackUploadControls.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`<ContentPackUploadControls /> should render 1`] = `
 <span>
   <button
-    className="button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-success"
+    className="button Button__StyledButton-c9cbmb-0 kRDLih btn btn-success"
     disabled={false}
     id="upload-content-pack-button"
     onClick={[Function]}

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackVersions.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackVersions.test.jsx.snap
@@ -51,7 +51,7 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                   role="toolbar"
                 >
                   <button
-                    className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-success"
+                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-success"
                     disabled={false}
                     onClick={[Function]}
                     type="button"
@@ -156,7 +156,7 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                   role="toolbar"
                 >
                   <button
-                    className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-success"
+                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-success"
                     disabled={false}
                     onClick={[Function]}
                     type="button"
@@ -261,7 +261,7 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                   role="toolbar"
                 >
                   <button
-                    className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-success"
+                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-success"
                     disabled={false}
                     onClick={[Function]}
                     type="button"
@@ -366,7 +366,7 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                   role="toolbar"
                 >
                   <button
-                    className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-success"
+                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-success"
                     disabled={false}
                     onClick={[Function]}
                     type="button"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPacksList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPacksList.test.jsx.snap
@@ -44,7 +44,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             </div>
           </div>
           <button
-            className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
             disabled={false}
             style={
               Object {
@@ -56,7 +56,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             Filter
           </button>
           <button
-            className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
             disabled={true}
             onClick={[Function]}
             style={
@@ -261,7 +261,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             
              
             <button
-              className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -413,7 +413,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             
              
             <button
-              className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -554,7 +554,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             
              
             <button
-              className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -695,7 +695,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             
              
             <button
-              className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -836,7 +836,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             
              
             <button
-              className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -977,7 +977,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             
              
             <button
-              className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -1118,7 +1118,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             
              
             <button
-              className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -1259,7 +1259,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             
              
             <button
-              className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -1400,7 +1400,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             
              
             <button
-              className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -1541,7 +1541,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             
              
             <button
-              className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-sm btn-info"
+              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -1840,7 +1840,7 @@ exports[`<ContentPacksList /> should render with empty content packs 1`] = `
             </div>
           </div>
           <button
-            className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
             disabled={false}
             style={
               Object {
@@ -1852,7 +1852,7 @@ exports[`<ContentPacksList /> should render with empty content packs 1`] = `
             Filter
           </button>
           <button
-            className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
             disabled={true}
             onClick={[Function]}
             style={

--- a/graylog2-web-interface/src/components/graylog/Button.jsx
+++ b/graylog2-web-interface/src/components/graylog/Button.jsx
@@ -1,19 +1,19 @@
-import React from 'react';
+import React, { forwardRef, useCallback } from 'react';
 import { Button as BootstrapButton } from 'react-bootstrap';
 import styled from 'styled-components';
 
 import buttonStyles from './styles/button';
 import { propTypes, defaultProps } from './props/button';
 
-const Button = ({ active, bsStyle, ...props }) => {
-  const StyledButton = styled(BootstrapButton)`
-    ${buttonStyles({ active })};
-  `;
+const Button = forwardRef(({ active, bsStyle, ...props }, ref) => {
+  const StyledButton = useCallback(styled(BootstrapButton)`
+    ${buttonStyles({ active })}
+  `, [active]);
 
   return (
-    <StyledButton bsStyle={bsStyle} {...props} />
+    <StyledButton bsStyle={bsStyle} ref={ref} {...props} />
   );
-};
+});
 
 Button.propTypes = propTypes;
 

--- a/graylog2-web-interface/src/components/graylog/DropdownButton.jsx
+++ b/graylog2-web-interface/src/components/graylog/DropdownButton.jsx
@@ -1,19 +1,19 @@
-import React from 'react';
+import React, { forwardRef, useCallback } from 'react';
 import { DropdownButton as BootstrapDropdownButton } from 'react-bootstrap';
 import styled from 'styled-components';
 
 import buttonStyles from './styles/button';
 import { propTypes, defaultProps } from './props/button';
 
-const DropdownButton = ({ active, bsStyle, ...props }) => {
-  const StyledDropdownButton = styled(BootstrapDropdownButton)`
+const DropdownButton = forwardRef(({ active, bsStyle, ...props }, ref) => {
+  const StyledDropdownButton = useCallback(styled(BootstrapDropdownButton)`
     ${buttonStyles({ active })};
-  `;
+  `, [active]);
 
   return (
-    <StyledDropdownButton bsStyle={bsStyle} {...props} />
+    <StyledDropdownButton bsStyle={bsStyle} ref={ref} {...props} />
   );
-};
+});
 
 DropdownButton.propTypes = propTypes;
 

--- a/graylog2-web-interface/src/components/graylog/SplitButton.jsx
+++ b/graylog2-web-interface/src/components/graylog/SplitButton.jsx
@@ -1,23 +1,23 @@
-import React from 'react';
+import React, { forwardRef, useCallback } from 'react';
 import { SplitButton as BootstrapSplitButton } from 'react-bootstrap';
 import styled from 'styled-components';
 
 import buttonStyles from './styles/button';
 import { propTypes, defaultProps } from './props/button';
 
-const SplitButton = ({ active, bsStyle, ...props }) => {
-  const StyledSplitButton = styled(BootstrapSplitButton)`
+const SplitButton = forwardRef(({ active, bsStyle, ...props }, ref) => {
+  const StyledSplitButton = useCallback(styled(BootstrapSplitButton)`
     ${buttonStyles({ active })};
 
     ~ .btn.dropdown-toggle {
       ${buttonStyles({ active, specific: false })};
     }
-  `;
+  `, [active]);
 
   return (
-    <StyledSplitButton bsStyle={bsStyle} {...props} />
+    <StyledSplitButton bsStyle={bsStyle} ref={ref} {...props} />
   );
-};
+});
 
 SplitButton.propTypes = propTypes;
 

--- a/graylog2-web-interface/src/components/grok-patterns/__snapshots__/GrokPatternInput.test.jsx.snap
+++ b/graylog2-web-interface/src/components/grok-patterns/__snapshots__/GrokPatternInput.test.jsx.snap
@@ -90,7 +90,7 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
             className="addButton"
           >
             <button
-              className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-xs btn-primary"
+              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-primary"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -122,7 +122,7 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
             className="addButton"
           >
             <button
-              className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-xs btn-primary"
+              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-primary"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -154,7 +154,7 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
             className="addButton"
           >
             <button
-              className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-xs btn-primary"
+              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-primary"
               disabled={false}
               onClick={[Function]}
               type="button"

--- a/graylog2-web-interface/src/components/search/__snapshots__/MessageTableEntry.test.jsx.snap
+++ b/graylog2-web-interface/src/components/search/__snapshots__/MessageTableEntry.test.jsx.snap
@@ -41,7 +41,7 @@ exports[`<MessageTableEntry /> rendering should render a MessageTableEntry 1`] =
               className="pull-right btn-group btn-group-sm"
             >
               <a
-                className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                 href="/messages/01/01"
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -49,7 +49,7 @@ exports[`<MessageTableEntry /> rendering should render a MessageTableEntry 1`] =
                 Permalink
               </a>
               <button
-                className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                 data-clipboard-action="copy"
                 data-clipboard-button={true}
                 data-clipboard-text="01"

--- a/graylog2-web-interface/src/components/users/__snapshots__/PermissionSelector.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/PermissionSelector.test.jsx.snap
@@ -103,7 +103,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                       </div>
                     </div>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                       disabled={false}
                       style={
                         Object {
@@ -115,7 +115,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                       Filter
                     </button>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                       disabled={true}
                       onClick={[Function]}
                       style={
@@ -182,7 +182,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                         className="btn-group btn-group-sm"
                       >
                         <button
-                          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -190,7 +190,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                           Allow reading
                         </button>
                         <button
-                          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -246,7 +246,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                         className="btn-group btn-group-sm"
                       >
                         <button
-                          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -254,7 +254,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                           Allow reading
                         </button>
                         <button
-                          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -359,7 +359,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                       </div>
                     </div>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                       disabled={false}
                       style={
                         Object {
@@ -371,7 +371,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                       Filter
                     </button>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                       disabled={true}
                       onClick={[Function]}
                       style={
@@ -438,7 +438,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                         className="btn-group btn-group-sm"
                       >
                         <button
-                          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -446,7 +446,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                           Allow reading
                         </button>
                         <button
-                          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -502,7 +502,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                         className="btn-group btn-group-sm"
                       >
                         <button
-                          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -510,7 +510,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                           Allow reading
                         </button>
                         <button
-                          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -666,7 +666,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                       </div>
                     </div>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                       disabled={false}
                       style={
                         Object {
@@ -678,7 +678,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                       Filter
                     </button>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                       disabled={true}
                       onClick={[Function]}
                       style={
@@ -745,7 +745,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                         className="btn-group btn-group-sm"
                       >
                         <button
-                          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-info"
+                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-info"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -753,7 +753,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                           Allow reading
                         </button>
                         <button
-                          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -809,7 +809,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                         className="btn-group btn-group-sm"
                       >
                         <button
-                          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -817,7 +817,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                           Allow reading
                         </button>
                         <button
-                          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-info"
+                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-info"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -922,7 +922,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                       </div>
                     </div>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                       disabled={false}
                       style={
                         Object {
@@ -934,7 +934,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                       Filter
                     </button>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                       disabled={true}
                       onClick={[Function]}
                       style={
@@ -1001,7 +1001,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                         className="btn-group btn-group-sm"
                       >
                         <button
-                          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -1009,7 +1009,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                           Allow reading
                         </button>
                         <button
-                          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -1065,7 +1065,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                         className="btn-group btn-group-sm"
                       >
                         <button
-                          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-info"
+                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-info"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -1073,7 +1073,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                           Allow reading
                         </button>
                         <button
-                          className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"

--- a/graylog2-web-interface/src/components/users/__snapshots__/TokenList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/TokenList.test.jsx.snap
@@ -36,7 +36,7 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
           className="col-sm-2"
         >
           <button
-            className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-primary"
+            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
             disabled={true}
             id="create-token"
             type="submit"
@@ -91,7 +91,7 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
               </div>
             </div>
             <button
-              className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
               disabled={false}
               style={
                 Object {
@@ -103,7 +103,7 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
               Filter
             </button>
             <button
-              className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
               disabled={true}
               onClick={[Function]}
               style={
@@ -198,7 +198,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
           className="col-sm-2"
         >
           <button
-            className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-primary"
+            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
             disabled={true}
             id="create-token"
             type="submit"
@@ -253,7 +253,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
               </div>
             </div>
             <button
-              className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
               disabled={false}
               style={
                 Object {
@@ -265,7 +265,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
               Filter
             </button>
             <button
-              className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
               disabled={true}
               onClick={[Function]}
               style={
@@ -315,7 +315,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
                   title="Copy to clipboard"
                 />
                 <button
-                  className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-xs btn-primary"
+                  className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-primary"
                   disabled={false}
                   onClick={[Function]}
                   type="button"
@@ -350,7 +350,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
                   title="Copy to clipboard"
                 />
                 <button
-                  className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-xs btn-primary"
+                  className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-primary"
                   disabled={false}
                   onClick={[Function]}
                   type="button"

--- a/graylog2-web-interface/src/components/users/__snapshots__/UserPreferencesButton.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/UserPreferencesButton.test.jsx.snap
@@ -7,7 +7,7 @@ Object {
     <div>
       <span>
         <button
-          class="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-success"
+          class="Button__StyledButton-c9cbmb-0 kRDLih btn btn-success"
           data-testid="user-preferences-button"
           type="button"
         >
@@ -19,7 +19,7 @@ Object {
   "container": <div>
     <span>
       <button
-        class="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-success"
+        class="Button__StyledButton-c9cbmb-0 kRDLih btn btn-success"
         data-testid="user-preferences-button"
         type="button"
       >

--- a/graylog2-web-interface/src/components/widgets/__snapshots__/WidgetFooter.test.jsx.snap
+++ b/graylog2-web-interface/src/components/widgets/__snapshots__/WidgetFooter.test.jsx.snap
@@ -32,7 +32,7 @@ exports[`<WidgetFooter /> should render a widget footer locked and disabled repl
         className="widget-info"
       >
         <button
-          className="btn-text Button__StyledButton-c9cbmb-0 cBCVOY btn btn-link"
+          className="btn-text Button__StyledButton-c9cbmb-0 kRDLih btn btn-link"
           disabled={false}
           onClick={[Function]}
           title="Show widget configuration"
@@ -80,7 +80,7 @@ exports[`<WidgetFooter /> should render a widget footer locked and enabled repla
         className="widget-replay"
       >
         <a
-          className="btn-text Button__StyledButton-c9cbmb-0 cBCVOY btn btn-link"
+          className="btn-text Button__StyledButton-c9cbmb-0 kRDLih btn btn-link"
           href="http://example.org"
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -95,7 +95,7 @@ exports[`<WidgetFooter /> should render a widget footer locked and enabled repla
         className="widget-info"
       >
         <button
-          className="btn-text Button__StyledButton-c9cbmb-0 cBCVOY btn btn-link"
+          className="btn-text Button__StyledButton-c9cbmb-0 kRDLih btn btn-link"
           disabled={false}
           onClick={[Function]}
           title="Show widget configuration"
@@ -143,7 +143,7 @@ exports[`<WidgetFooter /> should render a widget footer with unlocked 1`] = `
         className="widget-delete"
       >
         <button
-          className="btn-text Button__StyledButton-c9cbmb-0 cBCVOY btn btn-link"
+          className="btn-text Button__StyledButton-c9cbmb-0 kRDLih btn btn-link"
           disabled={false}
           onClick={[Function]}
           title="Delete widget"
@@ -158,7 +158,7 @@ exports[`<WidgetFooter /> should render a widget footer with unlocked 1`] = `
         className="widget-edit"
       >
         <button
-          className="btn-text Button__StyledButton-c9cbmb-0 cBCVOY btn btn-link"
+          className="btn-text Button__StyledButton-c9cbmb-0 kRDLih btn btn-link"
           disabled={false}
           onClick={[Function]}
           title="Edit widget"

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/ColumnPivotConfiguration.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/ColumnPivotConfiguration.test.jsx.snap
@@ -41,7 +41,7 @@ exports[`<ColumnPivotConfiguraiton /> should render as expected 1`] = `
     }
   >
     <button
-      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-success"
+      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-success"
       disabled={false}
       onClick={[Function]}
       type="button"

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/SeriesConfiguration.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/SeriesConfiguration.test.jsx.snap
@@ -31,7 +31,7 @@ exports[`SeriesConfiguration renders the configuration dialog 1`] = `
     }
   >
     <button
-      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-success"
+      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-success"
       disabled={false}
       onClick={[Function]}
       type="button"

--- a/graylog2-web-interface/src/views/components/searchbar/__snapshots__/RefreshControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/__snapshots__/RefreshControls.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: fa
     className="btn-group"
   >
     <button
-      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
       disabled={false}
       onClick={[Function]}
       type="button"
@@ -154,7 +154,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: fa
     className="btn-group"
   >
     <button
-      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
       disabled={false}
       onClick={[Function]}
       type="button"
@@ -300,7 +300,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
     className="btn-group"
   >
     <button
-      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
       disabled={false}
       onClick={[Function]}
       type="button"
@@ -455,7 +455,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
     className="btn-group"
   >
     <button
-      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
       disabled={false}
       onClick={[Function]}
       type="button"
@@ -610,7 +610,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
     className="btn-group"
   >
     <button
-      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
       disabled={false}
       onClick={[Function]}
       type="button"
@@ -765,7 +765,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
     className="btn-group"
   >
     <button
-      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
       disabled={false}
       onClick={[Function]}
       type="button"
@@ -920,7 +920,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
     className="btn-group"
   >
     <button
-      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
       disabled={false}
       onClick={[Function]}
       type="button"
@@ -1075,7 +1075,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
     className="btn-group"
   >
     <button
-      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
       disabled={false}
       onClick={[Function]}
       type="button"
@@ -1230,7 +1230,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
     className="btn-group"
   >
     <button
-      className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
       disabled={false}
       onClick={[Function]}
       type="button"

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Button, ButtonGroup } from 'react-bootstrap';
+import { Button, ButtonGroup } from 'components/graylog';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import UserNotification from 'util/UserNotification';
 import { ViewStore, ViewActions } from 'views/stores/ViewStore';

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkForm.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkForm.jsx
@@ -1,6 +1,6 @@
 // @flow strict
 import React from 'react';
-import { Button, ControlLabel, FormControl, FormGroup, Popover } from 'react-bootstrap';
+import { Button, ControlLabel, FormControl, FormGroup, Popover } from 'components/graylog';
 import { Portal } from 'react-portal';
 import { Position } from 'react-overlays';
 

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkControls.test.jsx.snap
@@ -53,74 +53,248 @@ exports[`BookmarkControls render the BookmarkControls should render dirty 1`] = 
         <div
           className="btn-group"
         >
-          <Button
+          <ForwardRef
             active={false}
-            block={false}
-            bsClass="btn"
             bsStyle="default"
             disabled={false}
             onClick={[Function]}
             title="Empty search"
           >
-            <button
-              className="btn btn-default"
+            <Button__StyledButton
+              bsStyle="default"
               disabled={false}
               onClick={[Function]}
               title="Empty search"
-              type="button"
             >
-              <i
-                className="fa fa-eraser"
-              />
-            </button>
-          </Button>
-          <Button
+              <StyledComponent
+                bsStyle="default"
+                disabled={false}
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "SIZES": Array [
+                      "large",
+                      "small",
+                      "xsmall",
+                    ],
+                    "STYLES": Array [
+                      "success",
+                      "warning",
+                      "danger",
+                      "info",
+                      "default",
+                      "primary",
+                      "link",
+                    ],
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Button__StyledButton-c9cbmb-0",
+                      "isStatic": false,
+                      "lastClassName": "kRDLih",
+                      "rules": Array [
+                        [Function],
+                      ],
+                    },
+                    "displayName": "Button__StyledButton",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                    "target": [Function],
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                onClick={[Function]}
+                title="Empty search"
+              >
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="Button__StyledButton-c9cbmb-0 kRDLih"
+                  disabled={false}
+                  onClick={[Function]}
+                  title="Empty search"
+                >
+                  <button
+                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    disabled={false}
+                    onClick={[Function]}
+                    title="Empty search"
+                    type="button"
+                  >
+                    <i
+                      className="fa fa-eraser"
+                    />
+                  </button>
+                </Button>
+              </StyledComponent>
+            </Button__StyledButton>
+          </ForwardRef>
+          <ForwardRef
             active={false}
-            block={false}
-            bsClass="btn"
             bsStyle="default"
-            disabled={false}
             onClick={[Function]}
             title="Unsaved changes"
           >
-            <button
-              className="btn btn-default"
-              disabled={false}
+            <Button__StyledButton
+              bsStyle="default"
               onClick={[Function]}
               title="Unsaved changes"
-              type="button"
             >
-              <i
-                className="fa fa-bookmark"
-                style={
+              <StyledComponent
+                bsStyle="default"
+                forwardedComponent={
                   Object {
-                    "color": "#ffc107",
+                    "$$typeof": Symbol(react.forward_ref),
+                    "SIZES": Array [
+                      "large",
+                      "small",
+                      "xsmall",
+                    ],
+                    "STYLES": Array [
+                      "success",
+                      "warning",
+                      "danger",
+                      "info",
+                      "default",
+                      "primary",
+                      "link",
+                    ],
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Button__StyledButton-c9cbmb-0",
+                      "isStatic": false,
+                      "lastClassName": "kRDLih",
+                      "rules": Array [
+                        [Function],
+                      ],
+                    },
+                    "displayName": "Button__StyledButton",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                    "target": [Function],
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
                   }
                 }
-              />
-            </button>
-          </Button>
-          <Button
+                forwardedRef={[Function]}
+                onClick={[Function]}
+                title="Unsaved changes"
+              >
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="Button__StyledButton-c9cbmb-0 kRDLih"
+                  disabled={false}
+                  onClick={[Function]}
+                  title="Unsaved changes"
+                >
+                  <button
+                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    disabled={false}
+                    onClick={[Function]}
+                    title="Unsaved changes"
+                    type="button"
+                  >
+                    <i
+                      className="fa fa-bookmark"
+                      style={
+                        Object {
+                          "color": "#ffc107",
+                        }
+                      }
+                    />
+                  </button>
+                </Button>
+              </StyledComponent>
+            </Button__StyledButton>
+          </ForwardRef>
+          <ForwardRef
             active={false}
-            block={false}
-            bsClass="btn"
             bsStyle="default"
-            disabled={false}
             onClick={[Function]}
             title="List of saved searches"
           >
-            <button
-              className="btn btn-default"
-              disabled={false}
+            <Button__StyledButton
+              bsStyle="default"
               onClick={[Function]}
               title="List of saved searches"
-              type="button"
             >
-              <i
-                className="fa fa-folder-o"
-              />
-            </button>
-          </Button>
+              <StyledComponent
+                bsStyle="default"
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "SIZES": Array [
+                      "large",
+                      "small",
+                      "xsmall",
+                    ],
+                    "STYLES": Array [
+                      "success",
+                      "warning",
+                      "danger",
+                      "info",
+                      "default",
+                      "primary",
+                      "link",
+                    ],
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Button__StyledButton-c9cbmb-0",
+                      "isStatic": false,
+                      "lastClassName": "kRDLih",
+                      "rules": Array [
+                        [Function],
+                      ],
+                    },
+                    "displayName": "Button__StyledButton",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                    "target": [Function],
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                onClick={[Function]}
+                title="List of saved searches"
+              >
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="Button__StyledButton-c9cbmb-0 kRDLih"
+                  disabled={false}
+                  onClick={[Function]}
+                  title="List of saved searches"
+                >
+                  <button
+                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    disabled={false}
+                    onClick={[Function]}
+                    title="List of saved searches"
+                    type="button"
+                  >
+                    <i
+                      className="fa fa-folder-o"
+                    />
+                  </button>
+                </Button>
+              </StyledComponent>
+            </Button__StyledButton>
+          </ForwardRef>
         </div>
       </ButtonGroup>
     </div>
@@ -181,74 +355,248 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty 1`
         <div
           className="btn-group"
         >
-          <Button
+          <ForwardRef
             active={false}
-            block={false}
-            bsClass="btn"
             bsStyle="default"
             disabled={false}
             onClick={[Function]}
             title="Empty search"
           >
-            <button
-              className="btn btn-default"
+            <Button__StyledButton
+              bsStyle="default"
               disabled={false}
               onClick={[Function]}
               title="Empty search"
-              type="button"
             >
-              <i
-                className="fa fa-eraser"
-              />
-            </button>
-          </Button>
-          <Button
+              <StyledComponent
+                bsStyle="default"
+                disabled={false}
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "SIZES": Array [
+                      "large",
+                      "small",
+                      "xsmall",
+                    ],
+                    "STYLES": Array [
+                      "success",
+                      "warning",
+                      "danger",
+                      "info",
+                      "default",
+                      "primary",
+                      "link",
+                    ],
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Button__StyledButton-c9cbmb-0",
+                      "isStatic": false,
+                      "lastClassName": "kRDLih",
+                      "rules": Array [
+                        [Function],
+                      ],
+                    },
+                    "displayName": "Button__StyledButton",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                    "target": [Function],
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                onClick={[Function]}
+                title="Empty search"
+              >
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="Button__StyledButton-c9cbmb-0 kRDLih"
+                  disabled={false}
+                  onClick={[Function]}
+                  title="Empty search"
+                >
+                  <button
+                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    disabled={false}
+                    onClick={[Function]}
+                    title="Empty search"
+                    type="button"
+                  >
+                    <i
+                      className="fa fa-eraser"
+                    />
+                  </button>
+                </Button>
+              </StyledComponent>
+            </Button__StyledButton>
+          </ForwardRef>
+          <ForwardRef
             active={false}
-            block={false}
-            bsClass="btn"
             bsStyle="default"
-            disabled={false}
             onClick={[Function]}
             title="Saved search"
           >
-            <button
-              className="btn btn-default"
-              disabled={false}
+            <Button__StyledButton
+              bsStyle="default"
               onClick={[Function]}
               title="Saved search"
-              type="button"
             >
-              <i
-                className="fa fa-bookmark"
-                style={
+              <StyledComponent
+                bsStyle="default"
+                forwardedComponent={
                   Object {
-                    "color": "#007bff",
+                    "$$typeof": Symbol(react.forward_ref),
+                    "SIZES": Array [
+                      "large",
+                      "small",
+                      "xsmall",
+                    ],
+                    "STYLES": Array [
+                      "success",
+                      "warning",
+                      "danger",
+                      "info",
+                      "default",
+                      "primary",
+                      "link",
+                    ],
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Button__StyledButton-c9cbmb-0",
+                      "isStatic": false,
+                      "lastClassName": "kRDLih",
+                      "rules": Array [
+                        [Function],
+                      ],
+                    },
+                    "displayName": "Button__StyledButton",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                    "target": [Function],
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
                   }
                 }
-              />
-            </button>
-          </Button>
-          <Button
+                forwardedRef={[Function]}
+                onClick={[Function]}
+                title="Saved search"
+              >
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="Button__StyledButton-c9cbmb-0 kRDLih"
+                  disabled={false}
+                  onClick={[Function]}
+                  title="Saved search"
+                >
+                  <button
+                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    disabled={false}
+                    onClick={[Function]}
+                    title="Saved search"
+                    type="button"
+                  >
+                    <i
+                      className="fa fa-bookmark"
+                      style={
+                        Object {
+                          "color": "#007bff",
+                        }
+                      }
+                    />
+                  </button>
+                </Button>
+              </StyledComponent>
+            </Button__StyledButton>
+          </ForwardRef>
+          <ForwardRef
             active={false}
-            block={false}
-            bsClass="btn"
             bsStyle="default"
-            disabled={false}
             onClick={[Function]}
             title="List of saved searches"
           >
-            <button
-              className="btn btn-default"
-              disabled={false}
+            <Button__StyledButton
+              bsStyle="default"
               onClick={[Function]}
               title="List of saved searches"
-              type="button"
             >
-              <i
-                className="fa fa-folder-o"
-              />
-            </button>
-          </Button>
+              <StyledComponent
+                bsStyle="default"
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "SIZES": Array [
+                      "large",
+                      "small",
+                      "xsmall",
+                    ],
+                    "STYLES": Array [
+                      "success",
+                      "warning",
+                      "danger",
+                      "info",
+                      "default",
+                      "primary",
+                      "link",
+                    ],
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Button__StyledButton-c9cbmb-0",
+                      "isStatic": false,
+                      "lastClassName": "kRDLih",
+                      "rules": Array [
+                        [Function],
+                      ],
+                    },
+                    "displayName": "Button__StyledButton",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                    "target": [Function],
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                onClick={[Function]}
+                title="List of saved searches"
+              >
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="Button__StyledButton-c9cbmb-0 kRDLih"
+                  disabled={false}
+                  onClick={[Function]}
+                  title="List of saved searches"
+                >
+                  <button
+                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    disabled={false}
+                    onClick={[Function]}
+                    title="List of saved searches"
+                    type="button"
+                  >
+                    <i
+                      className="fa fa-folder-o"
+                    />
+                  </button>
+                </Button>
+              </StyledComponent>
+            </Button__StyledButton>
+          </ForwardRef>
         </div>
       </ButtonGroup>
     </div>
@@ -309,74 +657,248 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty wi
         <div
           className="btn-group"
         >
-          <Button
+          <ForwardRef
             active={false}
-            block={false}
-            bsClass="btn"
             bsStyle="default"
             disabled={true}
             onClick={[Function]}
             title="Empty search"
           >
-            <button
-              className="btn btn-default"
+            <Button__StyledButton
+              bsStyle="default"
               disabled={true}
               onClick={[Function]}
               title="Empty search"
-              type="button"
             >
-              <i
-                className="fa fa-eraser"
-              />
-            </button>
-          </Button>
-          <Button
+              <StyledComponent
+                bsStyle="default"
+                disabled={true}
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "SIZES": Array [
+                      "large",
+                      "small",
+                      "xsmall",
+                    ],
+                    "STYLES": Array [
+                      "success",
+                      "warning",
+                      "danger",
+                      "info",
+                      "default",
+                      "primary",
+                      "link",
+                    ],
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Button__StyledButton-c9cbmb-0",
+                      "isStatic": false,
+                      "lastClassName": "kRDLih",
+                      "rules": Array [
+                        [Function],
+                      ],
+                    },
+                    "displayName": "Button__StyledButton",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                    "target": [Function],
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                onClick={[Function]}
+                title="Empty search"
+              >
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="Button__StyledButton-c9cbmb-0 kRDLih"
+                  disabled={true}
+                  onClick={[Function]}
+                  title="Empty search"
+                >
+                  <button
+                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    disabled={true}
+                    onClick={[Function]}
+                    title="Empty search"
+                    type="button"
+                  >
+                    <i
+                      className="fa fa-eraser"
+                    />
+                  </button>
+                </Button>
+              </StyledComponent>
+            </Button__StyledButton>
+          </ForwardRef>
+          <ForwardRef
             active={false}
-            block={false}
-            bsClass="btn"
             bsStyle="default"
-            disabled={false}
             onClick={[Function]}
             title="Save search"
           >
-            <button
-              className="btn btn-default"
-              disabled={false}
+            <Button__StyledButton
+              bsStyle="default"
               onClick={[Function]}
               title="Save search"
-              type="button"
             >
-              <i
-                className="fa fa-bookmark-o"
-                style={
+              <StyledComponent
+                bsStyle="default"
+                forwardedComponent={
                   Object {
-                    "color": "",
+                    "$$typeof": Symbol(react.forward_ref),
+                    "SIZES": Array [
+                      "large",
+                      "small",
+                      "xsmall",
+                    ],
+                    "STYLES": Array [
+                      "success",
+                      "warning",
+                      "danger",
+                      "info",
+                      "default",
+                      "primary",
+                      "link",
+                    ],
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Button__StyledButton-c9cbmb-0",
+                      "isStatic": false,
+                      "lastClassName": "kRDLih",
+                      "rules": Array [
+                        [Function],
+                      ],
+                    },
+                    "displayName": "Button__StyledButton",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                    "target": [Function],
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
                   }
                 }
-              />
-            </button>
-          </Button>
-          <Button
+                forwardedRef={[Function]}
+                onClick={[Function]}
+                title="Save search"
+              >
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="Button__StyledButton-c9cbmb-0 kRDLih"
+                  disabled={false}
+                  onClick={[Function]}
+                  title="Save search"
+                >
+                  <button
+                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    disabled={false}
+                    onClick={[Function]}
+                    title="Save search"
+                    type="button"
+                  >
+                    <i
+                      className="fa fa-bookmark-o"
+                      style={
+                        Object {
+                          "color": "",
+                        }
+                      }
+                    />
+                  </button>
+                </Button>
+              </StyledComponent>
+            </Button__StyledButton>
+          </ForwardRef>
+          <ForwardRef
             active={false}
-            block={false}
-            bsClass="btn"
             bsStyle="default"
-            disabled={false}
             onClick={[Function]}
             title="List of saved searches"
           >
-            <button
-              className="btn btn-default"
-              disabled={false}
+            <Button__StyledButton
+              bsStyle="default"
               onClick={[Function]}
               title="List of saved searches"
-              type="button"
             >
-              <i
-                className="fa fa-folder-o"
-              />
-            </button>
-          </Button>
+              <StyledComponent
+                bsStyle="default"
+                forwardedComponent={
+                  Object {
+                    "$$typeof": Symbol(react.forward_ref),
+                    "SIZES": Array [
+                      "large",
+                      "small",
+                      "xsmall",
+                    ],
+                    "STYLES": Array [
+                      "success",
+                      "warning",
+                      "danger",
+                      "info",
+                      "default",
+                      "primary",
+                      "link",
+                    ],
+                    "attrs": Array [],
+                    "componentStyle": ComponentStyle {
+                      "componentId": "Button__StyledButton-c9cbmb-0",
+                      "isStatic": false,
+                      "lastClassName": "kRDLih",
+                      "rules": Array [
+                        [Function],
+                      ],
+                    },
+                    "displayName": "Button__StyledButton",
+                    "foldedComponentIds": Array [],
+                    "render": [Function],
+                    "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                    "target": [Function],
+                    "toString": [Function],
+                    "warnTooManyClasses": [Function],
+                    "withComponent": [Function],
+                  }
+                }
+                forwardedRef={null}
+                onClick={[Function]}
+                title="List of saved searches"
+              >
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="Button__StyledButton-c9cbmb-0 kRDLih"
+                  disabled={false}
+                  onClick={[Function]}
+                  title="List of saved searches"
+                >
+                  <button
+                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    disabled={false}
+                    onClick={[Function]}
+                    title="List of saved searches"
+                    type="button"
+                  >
+                    <i
+                      className="fa fa-folder-o"
+                    />
+                  </button>
+                </Button>
+              </StyledComponent>
+            </Button__StyledButton>
+          </ForwardRef>
         </div>
       </ButtonGroup>
     </div>

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkForm.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkForm.test.jsx.snap
@@ -54,7 +54,7 @@ exports[`BookmarkForm render the BookmarkForm should render create new 1`] = `
             />
           </div>
           <button
-            className="button btn btn-info"
+            className="button Button__StyledButton-c9cbmb-0 kRDLih btn btn-info"
             disabled={false}
             onClick={[Function]}
             type="submit"
@@ -62,7 +62,7 @@ exports[`BookmarkForm render the BookmarkForm should render create new 1`] = `
             Create new
           </button>
           <button
-            className="button btn btn-default"
+            className="button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
             disabled={false}
             onClick={[Function]}
             type="button"
@@ -130,7 +130,7 @@ exports[`BookmarkForm render the BookmarkForm should render disabled create new 
             />
           </div>
           <button
-            className="button btn btn-primary"
+            className="button Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
             disabled={false}
             onClick={[Function]}
             type="submit"
@@ -138,7 +138,7 @@ exports[`BookmarkForm render the BookmarkForm should render disabled create new 
             Save
           </button>
           <button
-            className="button btn btn-info"
+            className="button Button__StyledButton-c9cbmb-0 kRDLih btn btn-info"
             disabled={true}
             onClick={[Function]}
             type="submit"
@@ -146,7 +146,7 @@ exports[`BookmarkForm render the BookmarkForm should render disabled create new 
             Save as
           </button>
           <button
-            className="button btn btn-default"
+            className="button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
             disabled={false}
             onClick={[Function]}
             type="button"
@@ -214,7 +214,7 @@ exports[`BookmarkForm render the BookmarkForm should render save 1`] = `
             />
           </div>
           <button
-            className="button btn btn-primary"
+            className="button Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
             disabled={false}
             onClick={[Function]}
             type="submit"
@@ -222,7 +222,7 @@ exports[`BookmarkForm render the BookmarkForm should render save 1`] = `
             Save
           </button>
           <button
-            className="button btn btn-info"
+            className="button Button__StyledButton-c9cbmb-0 kRDLih btn btn-info"
             disabled={false}
             onClick={[Function]}
             type="submit"
@@ -230,7 +230,7 @@ exports[`BookmarkForm render the BookmarkForm should render save 1`] = `
             Save as
           </button>
           <button
-            className="button btn btn-default"
+            className="button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
             disabled={false}
             onClick={[Function]}
             type="button"

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkList.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkList.test.jsx.snap
@@ -98,7 +98,7 @@ exports[`BookmarkList render the BookmarkList should handle toggleModal 1`] = `
                       }
                     }
                   >
-                    <Button
+                    <ForwardRef
                       active={false}
                       bsStyle="default"
                       className="submit-button"
@@ -136,10 +136,9 @@ exports[`BookmarkList render the BookmarkList should handle toggleModal 1`] = `
                               "componentStyle": ComponentStyle {
                                 "componentId": "Button__StyledButton-c9cbmb-0",
                                 "isStatic": false,
-                                "lastClassName": "cBCVOY",
+                                "lastClassName": "kRDLih",
                                 "rules": Array [
                                   [Function],
-                                  ";",
                                 ],
                               },
                               "displayName": "Button__StyledButton",
@@ -160,12 +159,12 @@ exports[`BookmarkList render the BookmarkList should handle toggleModal 1`] = `
                             block={false}
                             bsClass="btn"
                             bsStyle="default"
-                            className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY"
+                            className="submit-button Button__StyledButton-c9cbmb-0 kRDLih"
                             disabled={false}
                             type="submit"
                           >
                             <button
-                              className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                              className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                               disabled={false}
                               type="submit"
                             >
@@ -174,7 +173,7 @@ exports[`BookmarkList render the BookmarkList should handle toggleModal 1`] = `
                           </Button>
                         </StyledComponent>
                       </Button__StyledButton>
-                    </Button>
+                    </ForwardRef>
                   </div>
                   <div
                     className="form-group"
@@ -184,7 +183,7 @@ exports[`BookmarkList render the BookmarkList should handle toggleModal 1`] = `
                       }
                     }
                   >
-                    <Button
+                    <ForwardRef
                       active={false}
                       bsStyle="default"
                       className="reset-button"
@@ -221,10 +220,9 @@ exports[`BookmarkList render the BookmarkList should handle toggleModal 1`] = `
                               "componentStyle": ComponentStyle {
                                 "componentId": "Button__StyledButton-c9cbmb-0",
                                 "isStatic": false,
-                                "lastClassName": "cBCVOY",
+                                "lastClassName": "kRDLih",
                                 "rules": Array [
                                   [Function],
-                                  ";",
                                 ],
                               },
                               "displayName": "Button__StyledButton",
@@ -246,13 +244,13 @@ exports[`BookmarkList render the BookmarkList should handle toggleModal 1`] = `
                             block={false}
                             bsClass="btn"
                             bsStyle="default"
-                            className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY"
+                            className="reset-button Button__StyledButton-c9cbmb-0 kRDLih"
                             disabled={false}
                             onClick={[Function]}
                             type="reset"
                           >
                             <button
-                              className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                              className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                               disabled={false}
                               onClick={[Function]}
                               type="reset"
@@ -262,7 +260,7 @@ exports[`BookmarkList render the BookmarkList should handle toggleModal 1`] = `
                           </Button>
                         </StyledComponent>
                       </Button__StyledButton>
-                    </Button>
+                    </ForwardRef>
                   </div>
                 </form>
               </div>
@@ -765,7 +763,7 @@ exports[`BookmarkList render the BookmarkList should render empty 1`] = `
                       }
                     }
                   >
-                    <Button
+                    <ForwardRef
                       active={false}
                       bsStyle="default"
                       className="submit-button"
@@ -803,10 +801,9 @@ exports[`BookmarkList render the BookmarkList should render empty 1`] = `
                               "componentStyle": ComponentStyle {
                                 "componentId": "Button__StyledButton-c9cbmb-0",
                                 "isStatic": false,
-                                "lastClassName": "cBCVOY",
+                                "lastClassName": "kRDLih",
                                 "rules": Array [
                                   [Function],
-                                  ";",
                                 ],
                               },
                               "displayName": "Button__StyledButton",
@@ -827,12 +824,12 @@ exports[`BookmarkList render the BookmarkList should render empty 1`] = `
                             block={false}
                             bsClass="btn"
                             bsStyle="default"
-                            className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY"
+                            className="submit-button Button__StyledButton-c9cbmb-0 kRDLih"
                             disabled={false}
                             type="submit"
                           >
                             <button
-                              className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                              className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                               disabled={false}
                               type="submit"
                             >
@@ -841,7 +838,7 @@ exports[`BookmarkList render the BookmarkList should render empty 1`] = `
                           </Button>
                         </StyledComponent>
                       </Button__StyledButton>
-                    </Button>
+                    </ForwardRef>
                   </div>
                   <div
                     className="form-group"
@@ -851,7 +848,7 @@ exports[`BookmarkList render the BookmarkList should render empty 1`] = `
                       }
                     }
                   >
-                    <Button
+                    <ForwardRef
                       active={false}
                       bsStyle="default"
                       className="reset-button"
@@ -888,10 +885,9 @@ exports[`BookmarkList render the BookmarkList should render empty 1`] = `
                               "componentStyle": ComponentStyle {
                                 "componentId": "Button__StyledButton-c9cbmb-0",
                                 "isStatic": false,
-                                "lastClassName": "cBCVOY",
+                                "lastClassName": "kRDLih",
                                 "rules": Array [
                                   [Function],
-                                  ";",
                                 ],
                               },
                               "displayName": "Button__StyledButton",
@@ -913,13 +909,13 @@ exports[`BookmarkList render the BookmarkList should render empty 1`] = `
                             block={false}
                             bsClass="btn"
                             bsStyle="default"
-                            className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY"
+                            className="reset-button Button__StyledButton-c9cbmb-0 kRDLih"
                             disabled={false}
                             onClick={[Function]}
                             type="reset"
                           >
                             <button
-                              className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                              className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                               disabled={false}
                               onClick={[Function]}
                               type="reset"
@@ -929,7 +925,7 @@ exports[`BookmarkList render the BookmarkList should render empty 1`] = `
                           </Button>
                         </StyledComponent>
                       </Button__StyledButton>
-                    </Button>
+                    </ForwardRef>
                   </div>
                 </form>
               </div>
@@ -1377,7 +1373,7 @@ exports[`BookmarkList render the BookmarkList should render with views 1`] = `
                       }
                     }
                   >
-                    <Button
+                    <ForwardRef
                       active={false}
                       bsStyle="default"
                       className="submit-button"
@@ -1415,10 +1411,9 @@ exports[`BookmarkList render the BookmarkList should render with views 1`] = `
                               "componentStyle": ComponentStyle {
                                 "componentId": "Button__StyledButton-c9cbmb-0",
                                 "isStatic": false,
-                                "lastClassName": "cBCVOY",
+                                "lastClassName": "kRDLih",
                                 "rules": Array [
                                   [Function],
-                                  ";",
                                 ],
                               },
                               "displayName": "Button__StyledButton",
@@ -1439,12 +1434,12 @@ exports[`BookmarkList render the BookmarkList should render with views 1`] = `
                             block={false}
                             bsClass="btn"
                             bsStyle="default"
-                            className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY"
+                            className="submit-button Button__StyledButton-c9cbmb-0 kRDLih"
                             disabled={false}
                             type="submit"
                           >
                             <button
-                              className="submit-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                              className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                               disabled={false}
                               type="submit"
                             >
@@ -1453,7 +1448,7 @@ exports[`BookmarkList render the BookmarkList should render with views 1`] = `
                           </Button>
                         </StyledComponent>
                       </Button__StyledButton>
-                    </Button>
+                    </ForwardRef>
                   </div>
                   <div
                     className="form-group"
@@ -1463,7 +1458,7 @@ exports[`BookmarkList render the BookmarkList should render with views 1`] = `
                       }
                     }
                   >
-                    <Button
+                    <ForwardRef
                       active={false}
                       bsStyle="default"
                       className="reset-button"
@@ -1500,10 +1495,9 @@ exports[`BookmarkList render the BookmarkList should render with views 1`] = `
                               "componentStyle": ComponentStyle {
                                 "componentId": "Button__StyledButton-c9cbmb-0",
                                 "isStatic": false,
-                                "lastClassName": "cBCVOY",
+                                "lastClassName": "kRDLih",
                                 "rules": Array [
                                   [Function],
-                                  ";",
                                 ],
                               },
                               "displayName": "Button__StyledButton",
@@ -1525,13 +1519,13 @@ exports[`BookmarkList render the BookmarkList should render with views 1`] = `
                             block={false}
                             bsClass="btn"
                             bsStyle="default"
-                            className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY"
+                            className="reset-button Button__StyledButton-c9cbmb-0 kRDLih"
                             disabled={false}
                             onClick={[Function]}
                             type="reset"
                           >
                             <button
-                              className="reset-button Button__StyledButton-c9cbmb-0 cBCVOY btn btn-default"
+                              className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
                               disabled={false}
                               onClick={[Function]}
                               type="reset"
@@ -1541,7 +1535,7 @@ exports[`BookmarkList render the BookmarkList should render with views 1`] = `
                           </Button>
                         </StyledComponent>
                       </Button__StyledButton>
-                    </Button>
+                    </ForwardRef>
                   </div>
                 </form>
               </div>

--- a/graylog2-web-interface/src/views/hooks/__snapshots__/RequirementsProvided.test.jsx.snap
+++ b/graylog2-web-interface/src/views/hooks/__snapshots__/RequirementsProvided.test.jsx.snap
@@ -103,7 +103,7 @@ exports[`RequirementsProvided throws Component if not all requirements are provi
               onlyActiveOnIndex={false}
               to="/path/to/views"
             >
-              <Button
+              <ForwardRef
                 action="push"
                 active={false}
                 bsStyle="success"
@@ -140,10 +140,9 @@ exports[`RequirementsProvided throws Component if not all requirements are provi
                         "componentStyle": ComponentStyle {
                           "componentId": "Button__StyledButton-c9cbmb-0",
                           "isStatic": false,
-                          "lastClassName": "cBCVOY",
+                          "lastClassName": "kRDLih",
                           "rules": Array [
                             [Function],
-                            ";",
                           ],
                         },
                         "displayName": "Button__StyledButton",
@@ -166,14 +165,14 @@ exports[`RequirementsProvided throws Component if not all requirements are provi
                       block={false}
                       bsClass="btn"
                       bsStyle="success"
-                      className="Button__StyledButton-c9cbmb-0 cBCVOY"
+                      className="Button__StyledButton-c9cbmb-0 kRDLih"
                       disabled={false}
                       onClick={[Function]}
                       type="submit"
                     >
                       <button
                         action="push"
-                        className="Button__StyledButton-c9cbmb-0 cBCVOY btn btn-success"
+                        className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-success"
                         disabled={false}
                         onClick={[Function]}
                         type="submit"
@@ -183,7 +182,7 @@ exports[`RequirementsProvided throws Component if not all requirements are provi
                     </Button>
                   </StyledComponent>
                 </Button__StyledButton>
-              </Button>
+              </ForwardRef>
             </LinkContainer>
           </div>
         </Col>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added `useCallback` for styled-component function memoization (Thank you @kmerz for this solution!) 
- Added `forwardRef` to allow refs to be forwarded to styled button

This PR is a revision of #6560 as it had a unnecessary changes and unnecessary commits

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If you tried to use `ref` in a new themeable button, it would not properly pass the ref through and the button would rebuild in the DOM losing the context of the selector.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
