### PR TITLE
Fix ui style guide PageHeader example by removing unsupported component import

### DIFF
--- a/graylog2-web-interface/src/components/common/PageHeader.md
+++ b/graylog2-web-interface/src/components/common/PageHeader.md
@@ -8,12 +8,10 @@ Simple page header with only a title and description:
 Experimental page header with description, support message, and action. Notice
 that there is no border around the header, as the `subpage` prop is set:
 ```js
-import { Button } from 'components/graylog';
-
 <PageHeader title="Here goes the page title" lifecycle="experimental" subpage>
   <span>This is a page description</span>
   <span>This is a support message</span>
-  <span><Button bsStyle="info">Action</Button></span>
+  <span>Here goes the action (usually the button component)</span>
 </PageHeader>
 ```
 


### PR DESCRIPTION
Little fix for a problem with the second [page header example](https://graylog2.github.io/frontend-documentation/#pageheader) due to the unsupported component import

## Motivation and Context
Found while working with the ui docs

## How Has This Been Tested?
The docs are still working

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
