### PR TITLE
Fix widget width alignment for search and dashboard page

### DIFF
--- a/graylog2-web-interface/src/components/common/ReactGridContainer.css
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.css
@@ -1,7 +1,3 @@
-:local(.reactGridLayout) {
-    margin: -10px -10px 0 -10px;
-}
-
 :local(.reactGridLayout).unlocked .react-draggable {
     cursor: move;
 }

--- a/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
+++ b/graylog2-web-interface/src/components/common/ReactGridContainer.jsx
@@ -215,6 +215,7 @@ class ReactGridContainer extends React.Component {
                                breakpoints={BREAKPOINTS}
                                cols={columns}
                                rowHeight={rowHeight}
+                               containerPadding={[0, 0]}
                                margin={[10, 10]}
                                measureBeforeMount={measureBeforeMount}
         // Do not allow dragging from elements inside a `.actions` css class. This is

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.css
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.css
@@ -68,7 +68,7 @@
 
 .search-grid {
     z-index: 1;
-    padding-left: 15px;
+    padding: 15px;
     grid-area: search;
     grid-column-start: 2;
     grid-column-end: 4;


### PR DESCRIPTION
I had a look at the widget alignment, because they mostly never really had the full width.

## How Has This Been Tested?
Testes the changes with and without the search feature flag

## Screenshots (if appropriate):
The problem:
![image](https://user-images.githubusercontent.com/46300478/66843871-a7f78100-ef6d-11e9-8db1-1004568b92ad.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
