### PR TITLE
Showing dashboards in non-interactive big display/tv mode.

### DIFF
--- a/graylog2-web-interface/src/routing/AppErrorBoundary.jsx
+++ b/graylog2-web-interface/src/routing/AppErrorBoundary.jsx
@@ -34,10 +34,11 @@ class AppErrorBoundary extends React.Component {
 
   render() {
     const { error, info } = this.state;
+    const { children } = this.props;
     if (error) {
       return <ErrorPage error={error} info={info} />;
     }
-    return this.props.children;
+    return children;
   }
 }
 

--- a/graylog2-web-interface/src/routing/AppErrorBoundary.jsx
+++ b/graylog2-web-interface/src/routing/AppErrorBoundary.jsx
@@ -5,11 +5,12 @@ import ErrorPage from '../pages/ErrorPage';
 
 class AppErrorBoundary extends React.Component {
   static propTypes = {
-    children: PropTypes.oneOfType([
-      PropTypes.element,
-      PropTypes.arrayOf(PropTypes.element),
-    ]).isRequired,
+    children: PropTypes.node,
     router: PropTypes.object.isRequired,
+  };
+
+  static defaultProps = {
+    children: null,
   };
 
   constructor(props) {

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -90,19 +90,25 @@ import {
   UsersPage,
 } from 'pages';
 import AppConfig from 'util/AppConfig';
+import AppErrorBoundary from './AppErrorBoundary';
 
 const AppRouter = () => {
   const pluginRoutes = PluginStore.exports('routes');
-  const pluginRoutesWithParent = pluginRoutes.filter(route => route.parentComponent).map((pluginRoute) => {
+  const pluginRoutesWithNullParent = pluginRoutes.filter(route => (route.parentComponent === null)).map((pluginRoute) => {
     return (
       <Route key={`${pluginRoute.path}-${pluginRoute.component.displayName}`}
-             component={pluginRoute.parentComponent}>
-        <Route path={URLUtils.appPrefixed(pluginRoute.path)}
-               component={pluginRoute.component} />
-      </Route>
+             path={URLUtils.appPrefixed(pluginRoute.path)}
+             component={pluginRoute.component} />
     );
   });
-  const standardPluginRoutes = pluginRoutes.filter(route => !route.parentComponent).map((pluginRoute) => {
+  const pluginRoutesWithParent = pluginRoutes.filter(route => route.parentComponent).map((pluginRoute) => (
+    <Route key={`${pluginRoute.path}-${pluginRoute.component.displayName}`}
+           component={pluginRoute.parentComponent}>
+      <Route path={URLUtils.appPrefixed(pluginRoute.path)}
+             component={pluginRoute.component} />
+    </Route>
+  ));
+  const standardPluginRoutes = pluginRoutes.filter(route => (route.parentComponent === undefined)).map((pluginRoute) => {
     return (
       <Route key={`${pluginRoute.path}-${pluginRoute.component.displayName}`}
              path={URLUtils.appPrefixed(pluginRoute.path)}
@@ -113,116 +119,130 @@ const AppRouter = () => {
 
   return (
     <Router history={history}>
-      <Route path={Routes.STARTPAGE} component={App}>
-        <Route component={AppWithGlobalNotifications}>
-          <IndexRoute component={StartPage} />
-          {pluginRoutesWithParent}
-          <Route component={AppWithSearchBar}>
-            <Route path={Routes.message_show(':index', ':messageId')} component={ShowMessagePage} />
-            <Route path={Routes.SOURCES} component={SourcesPage} />
-            {enableNewSearch || <Route path={Routes.SEARCH} component={DelegatedSearchPage} />}
-            {enableNewSearch || <Route path={Routes.stream_search(':streamId')} component={StreamSearchPage} />}
-          </Route>
-          <Route component={AppWithExtendedSearchBar}>
-            {enableNewSearch && <Route path={Routes.SEARCH} component={DelegatedSearchPage} />}
+      <Route path={Routes.STARTPAGE} component={AppErrorBoundary}>
+        {pluginRoutesWithNullParent}
+        <Route path={Routes.STARTPAGE} component={App}>
+          <Route component={AppWithGlobalNotifications}>
+            <IndexRoute component={StartPage} />
+            {pluginRoutesWithParent}
+            <Route component={AppWithSearchBar}>
+              <Route path={Routes.message_show(':index', ':messageId')} component={ShowMessagePage} />
+              <Route path={Routes.SOURCES} component={SourcesPage} />
+              {enableNewSearch || <Route path={Routes.SEARCH} component={DelegatedSearchPage} />}
+              {enableNewSearch || <Route path={Routes.stream_search(':streamId')} component={StreamSearchPage} />}
+            </Route>
+            <Route component={AppWithExtendedSearchBar}>
+              {enableNewSearch && <Route path={Routes.SEARCH} component={DelegatedSearchPage} />}
+            </Route>
+            <Route component={AppWithoutSearchBar}>
+              <Redirect from={Routes.legacy_stream_search(':streamId')} to={Routes.stream_search(':streamId')} />
+              <Route path={Routes.GETTING_STARTED} component={GettingStartedPage} />
+              <Route path={Routes.STREAMS} component={StreamsPage} />
+              <Route path={Routes.stream_edit(':streamId')} component={StreamEditPage} />
+              <Route path={Routes.stream_outputs(':streamId')} component={StreamOutputsPage} />
+              <Route path={Routes.stream_alerts(':streamId')} component={StreamAlertsOverviewPage} />
+              <Route path={Routes.LEGACY_ALERTS.LIST} component={AlertsPage} />
+              <Route path={Routes.LEGACY_ALERTS.CONDITIONS} component={AlertConditionsPage} />
+              <Route path={Routes.LEGACY_ALERTS.NEW_CONDITION} component={NewAlertConditionPage} />
+              <Route path={Routes.LEGACY_ALERTS.NOTIFICATIONS} component={AlertNotificationsPage} />
+              <Route path={Routes.LEGACY_ALERTS.NEW_NOTIFICATION} component={NewAlertNotificationPage} />
+              <Route path={Routes.ALERTS.LIST} component={EventsPage} />
+              <Route path={Routes.ALERTS.DEFINITIONS.LIST} component={EventDefinitionsPage} />
+              <Route path={Routes.ALERTS.DEFINITIONS.CREATE} component={CreateEventDefinitionPage} />
+              <Route path={Routes.ALERTS.DEFINITIONS.edit(':definitionId')} component={EditEventDefinitionPage} />
+              <Route path={Routes.ALERTS.NOTIFICATIONS.LIST} component={EventNotificationsPage} />
+              <Route path={Routes.ALERTS.NOTIFICATIONS.CREATE} component={CreateEventNotificationPage} />
+              <Route path={Routes.ALERTS.NOTIFICATIONS.edit(':notificationId')} component={EditEventNotificationPage} />
+              <Route path={Routes.show_alert_condition(':streamId', ':conditionId')}
+                     component={EditAlertConditionPage} />
+              <Route path={Routes.show_alert(':alertId')} component={ShowAlertPage} />
+              {enableNewSearch || <Route path={Routes.DASHBOARDS} component={DashboardsPage} />}
+              {enableNewSearch || <Route path={Routes.dashboard_show(':dashboardId')} component={ShowDashboardPage} />}
+              <Route path={Routes.SYSTEM.INPUTS} component={InputsPage} />
+              <Route path={Routes.node_inputs(':nodeId')} component={NodeInputsPage} />
+              <Route path={Routes.global_input_extractors(':inputId')} component={ExtractorsPage} />
+              <Route path={Routes.local_input_extractors(':nodeId', ':inputId')} component={ExtractorsPage} />
+              <Route path={Routes.new_extractor(':nodeId', ':inputId')} component={CreateExtractorsPage} />
+              <Route path={Routes.edit_extractor(':nodeId', ':inputId', ':extractorId')}
+                     component={EditExtractorsPage} />
+              <Route path={Routes.import_extractors(':nodeId', ':inputId')} component={ImportExtractorsPage} />
+              <Route path={Routes.export_extractors(':nodeId', ':inputId')} component={ExportExtractorsPage} />
+              <Route path={Routes.SYSTEM.CONFIGURATIONS} component={ConfigurationsPage} />
+              <Route path={Routes.SYSTEM.CONTENTPACKS.LIST} component={ContentPacksPage} />
+              <Route path={Routes.SYSTEM.CONTENTPACKS.CREATE} component={CreateContentPackPage} />
+              <Route path={Routes.SYSTEM.CONTENTPACKS.edit(':contentPackId', ':contentPackRev')}
+                     component={EditContentPackPage} />
+              <Route path={Routes.SYSTEM.CONTENTPACKS.show(':contentPackId')} component={ShowContentPackPage} />
+              <Route path={Routes.SYSTEM.GROKPATTERNS} component={GrokPatternsPage} />
+              <Route path={Routes.SYSTEM.INDICES.LIST} component={IndicesPage} />
+              <Route path={Routes.SYSTEM.INDEX_SETS.CREATE} component={IndexSetCreationPage} />
+              <Route path={Routes.SYSTEM.INDEX_SETS.SHOW(':indexSetId')} component={IndexSetPage} />
+              <Route path={Routes.SYSTEM.INDEX_SETS.CONFIGURATION(':indexSetId')}
+                     component={IndexSetConfigurationPage} />
+              <Route path={Routes.SYSTEM.INDICES.FAILURES} component={IndexerFailuresPage} />
+
+              <Route path={Routes.SYSTEM.LOOKUPTABLES.OVERVIEW} component={LUTTablesPage} />
+              <Route path={Routes.SYSTEM.LOOKUPTABLES.CREATE} component={LUTTablesPage} action="create" />
+              <Route path={Routes.SYSTEM.LOOKUPTABLES.show(':tableName')} component={LUTTablesPage} action="show" />
+              <Route path={Routes.SYSTEM.LOOKUPTABLES.edit(':tableName')} component={LUTTablesPage} action="edit" />
+
+              <Route path={Routes.SYSTEM.LOOKUPTABLES.CACHES.OVERVIEW} component={LUTCachesPage} />
+              <Route path={Routes.SYSTEM.LOOKUPTABLES.CACHES.CREATE} component={LUTCachesPage} action="create" />
+              <Route path={Routes.SYSTEM.LOOKUPTABLES.CACHES.show(':cacheName')} component={LUTCachesPage}
+                     action="show" />
+              <Route path={Routes.SYSTEM.LOOKUPTABLES.CACHES.edit(':cacheName')} component={LUTCachesPage}
+                     action="edit" />
+
+              <Route path={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.OVERVIEW} component={LUTDataAdaptersPage} />
+              <Route path={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.CREATE} component={LUTDataAdaptersPage}
+                     action="create" />
+              <Route path={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.show(':adapterName')}
+                     component={LUTDataAdaptersPage} action="show" />
+              <Route path={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.edit(':adapterName')}
+                     component={LUTDataAdaptersPage} action="edit" />
+
+              <Route path={Routes.SYSTEM.PIPELINES.OVERVIEW} component={PipelinesOverviewPage} />
+              <Route path={Routes.SYSTEM.PIPELINES.RULES} component={RulesPage} />
+              <Route path={Routes.SYSTEM.PIPELINES.RULE(':ruleId')} component={RuleDetailsPage} />
+              <Route path={Routes.SYSTEM.PIPELINES.SIMULATOR} component={SimulatorPage} />
+              <Route path={Routes.SYSTEM.PIPELINES.PIPELINE(':pipelineId')} component={PipelineDetailsPage} />
+
+              <Route path={Routes.SYSTEM.LOGGING} component={LoggersPage} />
+              <Route path={Routes.SYSTEM.METRICS(':nodeId')} component={ShowMetricsPage} />
+              <Route path={Routes.SYSTEM.NODES.LIST} component={NodesPage} />
+              <Route path={Routes.SYSTEM.NODES.SHOW(':nodeId')} component={ShowNodePage} />
+              <Route path={Routes.SYSTEM.OUTPUTS} component={SystemOutputsPage} />
+              <Route path={Routes.SYSTEM.AUTHENTICATION.OVERVIEW} component={AuthenticationPage}>
+                <IndexRoute component={UsersPage} />
+                <Route path={Routes.SYSTEM.AUTHENTICATION.USERS.LIST} component={UsersPage} />
+                <Route path={Routes.SYSTEM.AUTHENTICATION.USERS.CREATE} component={CreateUsersPage} />
+                <Route path={Routes.SYSTEM.AUTHENTICATION.USERS.edit(':username')} component={EditUsersPage} />
+                <Route path={Routes.SYSTEM.AUTHENTICATION.USERS.TOKENS.edit(':username')} component={EditTokensPage} />
+                <Route path={Routes.SYSTEM.AUTHENTICATION.ROLES} component={RolesPage} />
+                <Route path={Routes.SYSTEM.AUTHENTICATION.PROVIDERS.CONFIG} />
+                <Route path={Routes.SYSTEM.AUTHENTICATION.PROVIDERS.provider(':name')} />
+              </Route>
+              <Route path={Routes.SYSTEM.OVERVIEW} component={SystemOverviewPage} />
+              <Route path={Routes.SYSTEM.THREADDUMP(':nodeId')} component={ThreadDumpPage} />
+              <Route path={Routes.SYSTEM.ENTERPRISE} component={EnterprisePage} />
+
+              <Route path={Routes.SYSTEM.SIDECARS.OVERVIEW} component={SidecarsPage} />
+              <Route path={Routes.SYSTEM.SIDECARS.STATUS(':sidecarId')} component={SidecarStatusPage} />
+              <Route path={Routes.SYSTEM.SIDECARS.ADMINISTRATION} component={SidecarAdministrationPage} />
+              <Route path={Routes.SYSTEM.SIDECARS.CONFIGURATION} component={SidecarConfigurationPage} />
+              <Route path={Routes.SYSTEM.SIDECARS.NEW_CONFIGURATION} component={SidecarNewConfigurationPage} />
+              <Route path={Routes.SYSTEM.SIDECARS.EDIT_CONFIGURATION(':configurationId')}
+                     component={SidecarEditConfigurationPage} />
+              <Route path={Routes.SYSTEM.SIDECARS.NEW_COLLECTOR} component={SidecarNewCollectorPage} />
+              <Route path={Routes.SYSTEM.SIDECARS.EDIT_COLLECTOR(':collectorId')}
+                     component={SidecarEditCollectorPage} />
+              {standardPluginRoutes}
+            </Route>
           </Route>
           <Route component={AppWithoutSearchBar}>
-            <Redirect from={Routes.legacy_stream_search(':streamId')} to={Routes.stream_search(':streamId')} />
-            <Route path={Routes.GETTING_STARTED} component={GettingStartedPage} />
-            <Route path={Routes.STREAMS} component={StreamsPage} />
-            <Route path={Routes.stream_edit(':streamId')} component={StreamEditPage} />
-            <Route path={Routes.stream_outputs(':streamId')} component={StreamOutputsPage} />
-            <Route path={Routes.stream_alerts(':streamId')} component={StreamAlertsOverviewPage} />
-            <Route path={Routes.LEGACY_ALERTS.LIST} component={AlertsPage} />
-            <Route path={Routes.LEGACY_ALERTS.CONDITIONS} component={AlertConditionsPage} />
-            <Route path={Routes.LEGACY_ALERTS.NEW_CONDITION} component={NewAlertConditionPage} />
-            <Route path={Routes.LEGACY_ALERTS.NOTIFICATIONS} component={AlertNotificationsPage} />
-            <Route path={Routes.LEGACY_ALERTS.NEW_NOTIFICATION} component={NewAlertNotificationPage} />
-            <Route path={Routes.ALERTS.LIST} component={EventsPage} />
-            <Route path={Routes.ALERTS.DEFINITIONS.LIST} component={EventDefinitionsPage} />
-            <Route path={Routes.ALERTS.DEFINITIONS.CREATE} component={CreateEventDefinitionPage} />
-            <Route path={Routes.ALERTS.DEFINITIONS.edit(':definitionId')} component={EditEventDefinitionPage} />
-            <Route path={Routes.ALERTS.NOTIFICATIONS.LIST} component={EventNotificationsPage} />
-            <Route path={Routes.ALERTS.NOTIFICATIONS.CREATE} component={CreateEventNotificationPage} />
-            <Route path={Routes.ALERTS.NOTIFICATIONS.edit(':notificationId')} component={EditEventNotificationPage} />
-            <Route path={Routes.show_alert_condition(':streamId', ':conditionId')} component={EditAlertConditionPage} />
-            <Route path={Routes.show_alert(':alertId')} component={ShowAlertPage} />
-            {enableNewSearch || <Route path={Routes.DASHBOARDS} component={DashboardsPage} />}
-            {enableNewSearch || <Route path={Routes.dashboard_show(':dashboardId')} component={ShowDashboardPage} />}
-            <Route path={Routes.SYSTEM.INPUTS} component={InputsPage} />
-            <Route path={Routes.node_inputs(':nodeId')} component={NodeInputsPage} />
-            <Route path={Routes.global_input_extractors(':inputId')} component={ExtractorsPage} />
-            <Route path={Routes.local_input_extractors(':nodeId', ':inputId')} component={ExtractorsPage} />
-            <Route path={Routes.new_extractor(':nodeId', ':inputId')} component={CreateExtractorsPage} />
-            <Route path={Routes.edit_extractor(':nodeId', ':inputId', ':extractorId')} component={EditExtractorsPage} />
-            <Route path={Routes.import_extractors(':nodeId', ':inputId')} component={ImportExtractorsPage} />
-            <Route path={Routes.export_extractors(':nodeId', ':inputId')} component={ExportExtractorsPage} />
-            <Route path={Routes.SYSTEM.CONFIGURATIONS} component={ConfigurationsPage} />
-            <Route path={Routes.SYSTEM.CONTENTPACKS.LIST} component={ContentPacksPage} />
-            <Route path={Routes.SYSTEM.CONTENTPACKS.CREATE} component={CreateContentPackPage} />
-            <Route path={Routes.SYSTEM.CONTENTPACKS.edit(':contentPackId', ':contentPackRev')} component={EditContentPackPage} />
-            <Route path={Routes.SYSTEM.CONTENTPACKS.show(':contentPackId')} component={ShowContentPackPage} />
-            <Route path={Routes.SYSTEM.GROKPATTERNS} component={GrokPatternsPage} />
-            <Route path={Routes.SYSTEM.INDICES.LIST} component={IndicesPage} />
-            <Route path={Routes.SYSTEM.INDEX_SETS.CREATE} component={IndexSetCreationPage} />
-            <Route path={Routes.SYSTEM.INDEX_SETS.SHOW(':indexSetId')} component={IndexSetPage} />
-            <Route path={Routes.SYSTEM.INDEX_SETS.CONFIGURATION(':indexSetId')} component={IndexSetConfigurationPage} />
-            <Route path={Routes.SYSTEM.INDICES.FAILURES} component={IndexerFailuresPage} />
-
-            <Route path={Routes.SYSTEM.LOOKUPTABLES.OVERVIEW} component={LUTTablesPage} />
-            <Route path={Routes.SYSTEM.LOOKUPTABLES.CREATE} component={LUTTablesPage} action="create" />
-            <Route path={Routes.SYSTEM.LOOKUPTABLES.show(':tableName')} component={LUTTablesPage} action="show" />
-            <Route path={Routes.SYSTEM.LOOKUPTABLES.edit(':tableName')} component={LUTTablesPage} action="edit" />
-
-            <Route path={Routes.SYSTEM.LOOKUPTABLES.CACHES.OVERVIEW} component={LUTCachesPage} />
-            <Route path={Routes.SYSTEM.LOOKUPTABLES.CACHES.CREATE} component={LUTCachesPage} action="create" />
-            <Route path={Routes.SYSTEM.LOOKUPTABLES.CACHES.show(':cacheName')} component={LUTCachesPage} action="show" />
-            <Route path={Routes.SYSTEM.LOOKUPTABLES.CACHES.edit(':cacheName')} component={LUTCachesPage} action="edit" />
-
-            <Route path={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.OVERVIEW} component={LUTDataAdaptersPage} />
-            <Route path={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.CREATE} component={LUTDataAdaptersPage} action="create" />
-            <Route path={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.show(':adapterName')} component={LUTDataAdaptersPage} action="show" />
-            <Route path={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.edit(':adapterName')} component={LUTDataAdaptersPage} action="edit" />
-
-            <Route path={Routes.SYSTEM.PIPELINES.OVERVIEW} component={PipelinesOverviewPage} />
-            <Route path={Routes.SYSTEM.PIPELINES.RULES} component={RulesPage} />
-            <Route path={Routes.SYSTEM.PIPELINES.RULE(':ruleId')} component={RuleDetailsPage} />
-            <Route path={Routes.SYSTEM.PIPELINES.SIMULATOR} component={SimulatorPage} />
-            <Route path={Routes.SYSTEM.PIPELINES.PIPELINE(':pipelineId')} component={PipelineDetailsPage} />
-
-            <Route path={Routes.SYSTEM.LOGGING} component={LoggersPage} />
-            <Route path={Routes.SYSTEM.METRICS(':nodeId')} component={ShowMetricsPage} />
-            <Route path={Routes.SYSTEM.NODES.LIST} component={NodesPage} />
-            <Route path={Routes.SYSTEM.NODES.SHOW(':nodeId')} component={ShowNodePage} />
-            <Route path={Routes.SYSTEM.OUTPUTS} component={SystemOutputsPage} />
-            <Route path={Routes.SYSTEM.AUTHENTICATION.OVERVIEW} component={AuthenticationPage}>
-              <IndexRoute component={UsersPage} />
-              <Route path={Routes.SYSTEM.AUTHENTICATION.USERS.LIST} component={UsersPage} />
-              <Route path={Routes.SYSTEM.AUTHENTICATION.USERS.CREATE} component={CreateUsersPage} />
-              <Route path={Routes.SYSTEM.AUTHENTICATION.USERS.edit(':username')} component={EditUsersPage} />
-              <Route path={Routes.SYSTEM.AUTHENTICATION.USERS.TOKENS.edit(':username')} component={EditTokensPage} />
-              <Route path={Routes.SYSTEM.AUTHENTICATION.ROLES} component={RolesPage} />
-              <Route path={Routes.SYSTEM.AUTHENTICATION.PROVIDERS.CONFIG} />
-              <Route path={Routes.SYSTEM.AUTHENTICATION.PROVIDERS.provider(':name')} />
-            </Route>
-            <Route path={Routes.SYSTEM.OVERVIEW} component={SystemOverviewPage} />
-            <Route path={Routes.SYSTEM.THREADDUMP(':nodeId')} component={ThreadDumpPage} />
-            <Route path={Routes.SYSTEM.ENTERPRISE} component={EnterprisePage} />
-
-            <Route path={Routes.SYSTEM.SIDECARS.OVERVIEW} component={SidecarsPage} />
-            <Route path={Routes.SYSTEM.SIDECARS.STATUS(':sidecarId')} component={SidecarStatusPage} />
-            <Route path={Routes.SYSTEM.SIDECARS.ADMINISTRATION} component={SidecarAdministrationPage} />
-            <Route path={Routes.SYSTEM.SIDECARS.CONFIGURATION} component={SidecarConfigurationPage} />
-            <Route path={Routes.SYSTEM.SIDECARS.NEW_CONFIGURATION} component={SidecarNewConfigurationPage} />
-            <Route path={Routes.SYSTEM.SIDECARS.EDIT_CONFIGURATION(':configurationId')} component={SidecarEditConfigurationPage} />
-            <Route path={Routes.SYSTEM.SIDECARS.NEW_COLLECTOR} component={SidecarNewCollectorPage} />
-            <Route path={Routes.SYSTEM.SIDECARS.EDIT_COLLECTOR(':collectorId')} component={SidecarEditCollectorPage} />
-            {standardPluginRoutes}
+            <Route path={Routes.NOTFOUND} component={NotFoundPage} />
+            <Route path="*" component={NotFoundPage} />
           </Route>
-        </Route>
-        <Route component={AppWithoutSearchBar}>
-          <Route path={Routes.NOTFOUND} component={NotFoundPage} />
-          <Route path="*" component={NotFoundPage} />
         </Route>
       </Route>
     </Router>

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -101,7 +101,7 @@ const AppRouter = () => {
              component={pluginRoute.component} />
     );
   });
-  const pluginRoutesWithParent = pluginRoutes.filter(route => route.parentComponent).map((pluginRoute) => (
+  const pluginRoutesWithParent = pluginRoutes.filter(route => route.parentComponent).map(pluginRoute => (
     <Route key={`${pluginRoute.path}-${pluginRoute.component.displayName}`}
            component={pluginRoute.parentComponent}>
       <Route path={URLUtils.appPrefixed(pluginRoute.path)}
@@ -188,18 +188,23 @@ const AppRouter = () => {
 
               <Route path={Routes.SYSTEM.LOOKUPTABLES.CACHES.OVERVIEW} component={LUTCachesPage} />
               <Route path={Routes.SYSTEM.LOOKUPTABLES.CACHES.CREATE} component={LUTCachesPage} action="create" />
-              <Route path={Routes.SYSTEM.LOOKUPTABLES.CACHES.show(':cacheName')} component={LUTCachesPage}
+              <Route path={Routes.SYSTEM.LOOKUPTABLES.CACHES.show(':cacheName')}
+                     component={LUTCachesPage}
                      action="show" />
-              <Route path={Routes.SYSTEM.LOOKUPTABLES.CACHES.edit(':cacheName')} component={LUTCachesPage}
+              <Route path={Routes.SYSTEM.LOOKUPTABLES.CACHES.edit(':cacheName')}
+                     component={LUTCachesPage}
                      action="edit" />
 
               <Route path={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.OVERVIEW} component={LUTDataAdaptersPage} />
-              <Route path={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.CREATE} component={LUTDataAdaptersPage}
+              <Route path={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.CREATE}
+                     component={LUTDataAdaptersPage}
                      action="create" />
               <Route path={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.show(':adapterName')}
-                     component={LUTDataAdaptersPage} action="show" />
+                     component={LUTDataAdaptersPage}
+                     action="show" />
               <Route path={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.edit(':adapterName')}
-                     component={LUTDataAdaptersPage} action="edit" />
+                     component={LUTDataAdaptersPage}
+                     action="edit" />
 
               <Route path={Routes.SYSTEM.PIPELINES.OVERVIEW} component={PipelinesOverviewPage} />
               <Route path={Routes.SYSTEM.PIPELINES.RULES} component={RulesPage} />

--- a/graylog2-web-interface/src/views/components/Field.jsx
+++ b/graylog2-web-interface/src/views/components/Field.jsx
@@ -6,6 +6,7 @@ import FieldType from 'views/logic/fieldtypes/FieldType';
 
 import CustomPropTypes from './CustomPropTypes';
 import FieldActions from './actions/FieldActions';
+import InteractiveContext from './contexts/InteractiveContext';
 
 type Props = {|
   children?: React.Node,
@@ -17,14 +18,20 @@ type Props = {|
 |}
 
 const Field = ({ children, disabled = false, menuContainer, name, queryId, type }: Props) => (
-  <FieldActions element={children || name}
-                disabled={disabled}
-                menuContainer={menuContainer}
-                name={name}
-                type={type}
-                queryId={queryId}>
-    {name} = {type.type}
-  </FieldActions>
+  <InteractiveContext.Consumer>
+    {interactive => (interactive
+      ? (
+        <FieldActions element={children || name}
+                      disabled={!interactive || disabled}
+                      menuContainer={menuContainer}
+                      name={name}
+                      type={type}
+                      queryId={queryId}>
+          {name} = {type.type}
+        </FieldActions>
+      )
+      : <span>{name}</span>)}
+  </InteractiveContext.Consumer>
 );
 
 Field.propTypes = {

--- a/graylog2-web-interface/src/views/components/Field.test.jsx
+++ b/graylog2-web-interface/src/views/components/Field.test.jsx
@@ -1,0 +1,35 @@
+// @flow strict
+import * as React from 'react';
+import { mount } from 'enzyme';
+
+import FieldType from 'views/logic/fieldtypes/FieldType';
+import Field from './Field';
+import InteractiveContext from './contexts/InteractiveContext';
+
+describe('Field', () => {
+  describe('handles value action menu depending on interactive context', () => {
+    const component = interactive => props => (
+      <InteractiveContext.Provider value={interactive}>
+        <Field {...props} />
+      </InteractiveContext.Provider>
+    );
+    it('does not show value actions if interactive context is `false`', () => {
+      const NoninteractiveComponent = component(false);
+      const wrapper = mount(<NoninteractiveComponent name="foo"
+                                                     queryId="someQueryId"
+                                                     type={FieldType.Unknown} />);
+      const fieldActions = wrapper.find('FieldActions');
+      expect(fieldActions).not.toExist();
+      expect(wrapper).toHaveText('foo');
+    });
+    it('shows value actions if interactive context is `true`', () => {
+      const InteractiveComponent = component(true);
+      const wrapper = mount(<InteractiveComponent name="foo"
+                                                  queryId="someQueryId"
+                                                  type={FieldType.Unknown} />);
+      const fieldActions = wrapper.find('FieldActions');
+      expect(fieldActions).toExist();
+      expect(wrapper).toHaveText('foo');
+    });
+  });
+});

--- a/graylog2-web-interface/src/views/components/Query.jsx
+++ b/graylog2-web-interface/src/views/components/Query.jsx
@@ -13,6 +13,7 @@ import IfSearch from 'views/components/search/IfSearch';
 import WidgetGrid from 'views/components/WidgetGrid';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import { PositionsMap, ImmutableWidgetsMap } from './widgets/WidgetPropTypes';
+import InteractiveContext from './contexts/InteractiveContext';
 
 const MAXIMUM_GRID_SIZE = 12;
 
@@ -49,14 +50,18 @@ const _renderWidgetGrid = (widgetDefs, widgetMapping, results, positions, queryI
     }
   });
   return (
-    <WidgetGrid allFields={allFields}
-                data={data}
-                errors={errors}
-                fields={fields}
-                locked={false}
-                onPositionsChange={p => _onPositionsChange(p)}
-                positions={positions}
-                widgets={widgets} />
+    <InteractiveContext.Consumer>
+      {interactive => (
+        <WidgetGrid allFields={allFields}
+                    data={data}
+                    errors={errors}
+                    fields={fields}
+                    locked={!interactive}
+                    onPositionsChange={p => _onPositionsChange(p)}
+                    positions={positions}
+                    widgets={widgets} />
+      )}
+    </InteractiveContext.Consumer>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/Query.test.jsx
+++ b/graylog2-web-interface/src/views/components/Query.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import Immutable from 'immutable';
 import mockComponent from 'helpers/mocking/MockComponent';
 
@@ -10,10 +10,10 @@ import AggregationWidget from '../logic/aggregationbuilder/AggregationWidget';
 import AggregationWidgetConfig from '../logic/aggregationbuilder/AggregationWidgetConfig';
 import WidgetGrid from './WidgetGrid';
 
-
 jest.mock('components/common', () => ({ Spinner: mockComponent('Spinner') }));
 jest.mock('views/logic/Widgets', () => ({ widgetDefinition: () => ({}) }));
 jest.mock('views/components/widgets/Widget', () => mockComponent('Widget'));
+jest.mock('views/components/WidgetGrid', () => mockComponent('WidgetGrid'));
 
 const widgetMapping = Immutable.Map([
   ['widget1', ['searchType1']],
@@ -38,7 +38,7 @@ describe('Query', () => {
         searchType2: { bar: 42 },
       },
     };
-    const wrapper = shallow((
+    const wrapper = mount((
       <Query results={results}
              widgetMapping={widgetMapping}
              widgets={widgets}
@@ -63,7 +63,7 @@ describe('Query', () => {
         searchType2: { bar: 42 },
       },
     };
-    const wrapper = shallow((
+    const wrapper = mount((
       <Query results={results}
              widgetMapping={widgetMapping}
              widgets={widgets}
@@ -89,7 +89,7 @@ describe('Query', () => {
         searchType1: { foo: 17 },
       },
     };
-    const wrapper = shallow((
+    const wrapper = mount((
       <Query results={results}
              widgetMapping={widgetMapping}
              widgets={widgets}
@@ -113,7 +113,7 @@ describe('Query', () => {
       errors: [error1, error2],
       searchTypes: {},
     };
-    const wrapper = shallow((
+    const wrapper = mount((
       <Query results={results}
              widgetMapping={widgetMapping}
              widgets={widgets}
@@ -178,7 +178,7 @@ describe('Query', () => {
       errors: [],
       searchTypes: {},
     };
-    const wrapper = shallow((
+    const wrapper = mount((
       <Query results={results}
              widgetMapping={widgetMapping}
              widgets={widgets}

--- a/graylog2-web-interface/src/views/components/Value.jsx
+++ b/graylog2-web-interface/src/views/components/Value.jsx
@@ -6,6 +6,7 @@ import type { ValueRenderer, ValueRendererProps } from 'views/components/message
 
 import ValueActions from './actions/ValueActions';
 import TypeSpecificValue from './TypeSpecificValue';
+import InteractiveContext from './contexts/InteractiveContext';
 
 type Props = {|
   children?: React.Node,
@@ -24,9 +25,15 @@ const Value = ({ children, field, value, queryId, render = defaultRenderer, type
   const element = <TypeSpecificValue field={field} value={value} type={type} render={Component} />;
 
   return (
-    <ValueActions element={children || element} field={field} queryId={queryId} type={type} value={value}>
-      {field} = <TypeSpecificValue field={field} value={value} type={type} truncate />
-    </ValueActions>
+    <InteractiveContext.Consumer>
+      {interactive => (interactive
+        ? (
+          <ValueActions element={children || element} field={field} queryId={queryId} type={type} value={value}>
+            {field} = <TypeSpecificValue field={field} value={value} type={type} truncate />
+          </ValueActions>
+        )
+        : <span>{value}</span>)}
+    </InteractiveContext.Consumer>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/Value.jsx
+++ b/graylog2-web-interface/src/views/components/Value.jsx
@@ -32,7 +32,7 @@ const Value = ({ children, field, value, queryId, render = defaultRenderer, type
             {field} = <TypeSpecificValue field={field} value={value} type={type} truncate />
           </ValueActions>
         )
-        : <TypeSpecificValue field={field} value={value} type={type} truncate />)}
+        : <span><TypeSpecificValue field={field} value={value} type={type} truncate /></span>)}
     </InteractiveContext.Consumer>
   );
 };

--- a/graylog2-web-interface/src/views/components/Value.jsx
+++ b/graylog2-web-interface/src/views/components/Value.jsx
@@ -32,7 +32,7 @@ const Value = ({ children, field, value, queryId, render = defaultRenderer, type
             {field} = <TypeSpecificValue field={field} value={value} type={type} truncate />
           </ValueActions>
         )
-        : <span>{value}</span>)}
+        : <TypeSpecificValue field={field} value={value} type={type} truncate />)}
     </InteractiveContext.Consumer>
   );
 };

--- a/graylog2-web-interface/src/views/components/Value.test.jsx
+++ b/graylog2-web-interface/src/views/components/Value.test.jsx
@@ -121,7 +121,7 @@ describe('Value', () => {
   });
 
   describe('handles value action menu depending on interactive context', () => {
-    const component = (interactive) => props => (
+    const component = interactive => props => (
       <InteractiveContext.Provider value={interactive}>
         <Value {...props} />
       </InteractiveContext.Provider>

--- a/graylog2-web-interface/src/views/components/Value.test.jsx
+++ b/graylog2-web-interface/src/views/components/Value.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
+import each from 'jest-each';
 
 import mockComponent from 'helpers/mocking/MockComponent';
 import FieldType from 'views/logic/fieldtypes/FieldType';
@@ -7,49 +8,148 @@ import UserTimezoneTimestamp from 'views/components/common/UserTimezoneTimestamp
 
 import Value from './Value';
 import EmptyValue from './EmptyValue';
+import InteractiveContext from './contexts/InteractiveContext';
 
 jest.mock('./actions/ValueActions', () => mockComponent('ValueActions'));
 jest.mock('views/components/common/UserTimezoneTimestamp', () => mockComponent('UserTimezoneTimestamp'));
 
 describe('Value', () => {
-  it('render without type information but no children', () => {
-    const wrapper = mount(<Value field="foo" queryId="someQueryId" value={42} />);
-    const valueActions = wrapper.find('ValueActions');
-    expect(valueActions).toIncludeText('foo = 42');
+  describe('shows value actions menu', () => {
+    const Component = props => <Value {...props} />;
+    it('render without type information but no children', () => {
+      const wrapper = mount(<Component field="foo" queryId="someQueryId" value={42} />);
+      const valueActions = wrapper.find('ValueActions');
+      expect(valueActions).toIncludeText('foo = 42');
+    });
+    it('renders timestamps with a custom component', () => {
+      const wrapper = mount(<Component field="foo"
+                                       queryId="someQueryId"
+                                       value="2018-10-02T14:45:40Z"
+                                       type={new FieldType('date', [], [])} />);
+      const valueActions = wrapper.find('ValueActions');
+      expect(valueActions).toContainReact(<UserTimezoneTimestamp dateTime="2018-10-02T14:45:40Z" />);
+    });
+    it('renders numeric timestamps with a custom component', () => {
+      const wrapper = mount(<Component field="foo"
+                                       queryId="someQueryId"
+                                       value={1571302317}
+                                       type={new FieldType('date', [], [])} />);
+      const valueActions = wrapper.find('ValueActions');
+      expect(valueActions).toContainReact(<UserTimezoneTimestamp dateTime={1571302317} />);
+    });
+    it('renders booleans as strings', () => {
+      const wrapper = mount(<Component field="foo"
+                                       queryId="someQueryId"
+                                       value={false}
+                                       type={new FieldType('boolean', [], [])} />);
+      const valueActions = wrapper.find('ValueActions');
+      expect(valueActions).toIncludeText('foo = false');
+    });
+    it('renders booleans as strings even if field type is unknown', () => {
+      const wrapper = mount(<Component field="foo" queryId="someQueryId" value={false} type={FieldType.Unknown} />);
+      const valueActions = wrapper.find('ValueActions');
+      expect(valueActions).toIncludeText('foo = false');
+    });
+    it('renders arrays as strings', () => {
+      const wrapper = mount(<Component field="foo"
+                                       queryId="someQueryId"
+                                       value={[23, 'foo']}
+                                       type={FieldType.Unknown} />);
+      const valueActions = wrapper.find('ValueActions');
+      expect(valueActions).toIncludeText('foo = [23,"foo"]');
+    });
+    it('renders objects as strings', () => {
+      const wrapper = mount(<Component field="foo"
+                                       queryId="someQueryId"
+                                       value={{ foo: 23 }}
+                                       type={FieldType.Unknown} />);
+      const valueActions = wrapper.find('ValueActions');
+      expect(valueActions).toIncludeText('foo = {"foo":23}');
+    });
+    it('truncates values longer than 30 characters', () => {
+      const wrapper = mount(<Component field="message"
+                                       queryId="someQueryId"
+                                       value="sophon unbound: [84785:0] error: outgoing tcp: connect: Address already in use for 1.0.0.1"
+                                       type={new FieldType('string', [], [])} />);
+      const valueActions = wrapper.find('ValueActions');
+      expect(valueActions).toIncludeText('message = sophon unbound: [84785:0] e...');
+    });
   });
-  it('renders timestamps with a custom component', () => {
-    const wrapper = mount(<Value field="foo" queryId="someQueryId" value="2018-10-02T14:45:40Z" type={new FieldType('date', [], [])} />);
-    const valueActions = wrapper.find('ValueActions');
-    expect(valueActions).toContainReact(<UserTimezoneTimestamp dateTime="2018-10-02T14:45:40Z" />);
+  each([true, false]).describe('setting interactive context to `%p`', (interactive) => {
+    const Component = props => (
+      <InteractiveContext.Provider value={interactive}>
+        <Value {...props} />
+      </InteractiveContext.Provider>
+    );
+    it('renders without type information but no children', () => {
+      const wrapper = mount(<Component field="foo" queryId="someQueryId" value={42} />);
+      const typeSpecificValue = wrapper.find('TypeSpecificValue');
+      expect(typeSpecificValue).toHaveValue(42);
+    });
+    it('renders timestamps with a custom component', () => {
+      const wrapper = mount(<Component field="foo"
+                                       queryId="someQueryId"
+                                       value="2018-10-02T14:45:40Z"
+                                       type={new FieldType('date', [], [])} />);
+      const typeSpecificValue = wrapper.find('TypeSpecificValue');
+      expect(typeSpecificValue).toHaveValue('2018-10-02T14:45:40Z');
+    });
+    it('renders booleans', () => {
+      const wrapper = mount(<Component field="foo"
+                                       queryId="someQueryId"
+                                       value={false}
+                                       type={new FieldType('boolean', [], [])} />);
+      const typeSpecificValue = wrapper.find('TypeSpecificValue');
+      expect(typeSpecificValue).toHaveValue(false);
+    });
+    it('renders arrays', () => {
+      const wrapper = mount(<Component field="foo"
+                                       queryId="someQueryId"
+                                       value={[23, 'foo']}
+                                       type={FieldType.Unknown} />);
+      const typeSpecificValue = wrapper.find('TypeSpecificValue');
+      expect(typeSpecificValue).toHaveProp('value', [23, 'foo']);
+    });
+    it('renders objects', () => {
+      const wrapper = mount(<Component field="foo"
+                                       queryId="someQueryId"
+                                       value={{ foo: 23 }}
+                                       type={FieldType.Unknown} />);
+      const typeSpecificValue = wrapper.find('TypeSpecificValue');
+      expect(typeSpecificValue).toHaveProp('value', { foo: 23 });
+    });
   });
-  it('renders booleans as strings', () => {
-    const wrapper = mount(<Value field="foo" queryId="someQueryId" value={false} type={new FieldType('boolean', [], [])} />);
-    const valueActions = wrapper.find('ValueActions');
-    expect(valueActions).toIncludeText('foo = false');
+
+  describe('handles value action menu depending on interactive context', () => {
+    const component = (interactive) => props => (
+      <InteractiveContext.Provider value={interactive}>
+        <Value {...props} />
+      </InteractiveContext.Provider>
+    );
+    it('does not show value actions if interactive context is `false`', () => {
+      const NoninteractiveComponent = component(false);
+      const wrapper = mount(<NoninteractiveComponent field="foo"
+                                                     queryId="someQueryId"
+                                                     value={{ foo: 23 }}
+                                                     type={FieldType.Unknown} />);
+      const valueActions = wrapper.find('ValueActions');
+      expect(valueActions).not.toExist();
+      const typeSpecificValue = wrapper.find('TypeSpecificValue');
+      expect(typeSpecificValue).toHaveProp('value', { foo: 23 });
+    });
+    it('shows value actions if interactive context is `true`', () => {
+      const InteractiveComponent = component(true);
+      const wrapper = mount(<InteractiveComponent field="foo"
+                                                  queryId="someQueryId"
+                                                  value={{ foo: 23 }}
+                                                  type={FieldType.Unknown} />);
+      const valueActions = wrapper.find('ValueActions');
+      expect(valueActions).toExist();
+      const typeSpecificValue = wrapper.find('TypeSpecificValue');
+      expect(typeSpecificValue).toHaveProp('value', { foo: 23 });
+    });
   });
-  it('renders booleans as strings even if field type is unknown', () => {
-    const wrapper = mount(<Value field="foo" queryId="someQueryId" value={false} type={FieldType.Unknown} />);
-    const valueActions = wrapper.find('ValueActions');
-    expect(valueActions).toIncludeText('foo = false');
-  });
-  it('renders arrays as strings', () => {
-    const wrapper = mount(<Value field="foo" queryId="someQueryId" value={[23, 'foo']} type={FieldType.Unknown} />);
-    const valueActions = wrapper.find('ValueActions');
-    expect(valueActions).toIncludeText('foo = [23,"foo"]');
-  });
-  it('renders objects as strings', () => {
-    const wrapper = mount(<Value field="foo" queryId="someQueryId" value={{ foo: 23 }} type={FieldType.Unknown} />);
-    const valueActions = wrapper.find('ValueActions');
-    expect(valueActions).toIncludeText('foo = {"foo":23}');
-  });
-  it('truncates values longer than 30 characters', () => {
-    const wrapper = mount(<Value field="message"
-                                 queryId="someQueryId"
-                                 value="sophon unbound: [84785:0] error: outgoing tcp: connect: Address already in use for 1.0.0.1"
-                                 type={new FieldType('string', [], [])} />);
-    const valueActions = wrapper.find('ValueActions');
-    expect(valueActions).toIncludeText('message = sophon unbound: [84785:0] e...');
-  });
+
   const verifyReplacementOfEmptyValues = ({ value }) => {
     const wrapper = mount(<Value field="foo" queryId="someQueryId" value={value} />);
     const valueActions = wrapper.find('ValueActions');

--- a/graylog2-web-interface/src/views/components/contexts/InteractiveContext.js
+++ b/graylog2-web-interface/src/views/components/contexts/InteractiveContext.js
@@ -1,0 +1,6 @@
+// @flow strict
+import * as React from 'react';
+
+const InteractiveContext = React.createContext<boolean>(true);
+
+export default InteractiveContext;

--- a/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.jsx
@@ -95,11 +95,19 @@ const redirectToBigDisplayMode = (view: View, config: UntypedBigDisplayModeQuery
     .toString(),
 );
 
-const createQueryFromConfiguration = ({ queryCycleInterval, queryTabs, refreshInterval }: Configuration): UntypedBigDisplayModeQuery => ({
-  interval: Number(queryCycleInterval).toString(),
-  tabs: queryTabs !== undefined ? queryTabs.join(',') : undefined,
-  refresh: Number(refreshInterval).toString(),
-});
+const createQueryFromConfiguration = (
+  { queryCycleInterval, queryTabs, refreshInterval }: Configuration,
+  view: View,
+): UntypedBigDisplayModeQuery => {
+  const basicConfiguration = {
+    interval: Number(queryCycleInterval).toString(),
+    refresh: Number(refreshInterval).toString(),
+  };
+  const allQueryIndices = view.search.queries.toIndexedSeq().map((_, v) => v).toJS();
+  return !queryTabs || allQueryIndices.join(',') === queryTabs.join(',')
+    ? basicConfiguration
+    : { ...basicConfiguration, tabs: queryTabs.join(',') };
+};
 
 type Props = {
   disabled?: boolean,
@@ -111,7 +119,7 @@ const BigDisplayModeConfiguration = ({ disabled, view, show }: Props) => {
   const [showConfigurationModal, setShowConfigurationModal] = useState(show);
   const onCancel = useCallback(() => setShowConfigurationModal(false), [setShowConfigurationModal]);
 
-  const onSave = (config: Configuration) => redirectToBigDisplayMode(view, createQueryFromConfiguration(config));
+  const onSave = (config: Configuration) => redirectToBigDisplayMode(view, createQueryFromConfiguration(config, view));
 
   return (
     <React.Fragment>

--- a/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.jsx
@@ -8,7 +8,12 @@ import Input from 'components/bootstrap/Input';
 import Routes from 'routing/Routes';
 import View from 'views/logic/views/View';
 import queryTitle from 'views/logic/queries/QueryTitle';
-import type { UntypedBigDisplayModeQuery } from 'views/pages/ShowDashboardInBigDisplayMode';
+
+export type UntypedBigDisplayModeQuery = {|
+  tabs?: string,
+  interval?: string,
+  refresh?: string,
+|};
 
 type Configuration = {
   refreshInterval: number,

--- a/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.jsx
@@ -25,7 +25,7 @@ type ConfigurationModalProps = {
 const ConfigurationModal = ({ onSave, onCancel, view }: ConfigurationModalProps) => {
   const availableTabs = view.search.queries.keySeq().map((query, idx) => [
     idx,
-    queryTitle(view, query),
+    queryTitle(view, query.id),
   ]).toJS();
 
   const [refreshInterval, setRefreshInterval] = useState(10);

--- a/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.test.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.test.jsx
@@ -98,7 +98,7 @@ describe('BigDisplayModeConfiguration', () => {
       fireEvent.click(saveButton);
 
       expect(Routes.pluginRoute).toHaveBeenCalledWith('DASHBOARDS_TV_VIEWID');
-      expect(history.push).toHaveBeenCalledWith('/dashboards/tv/deadbeef?interval=30&tabs=&refresh=10');
+      expect(history.push).toHaveBeenCalledWith('/dashboards/tv/deadbeef?interval=30&refresh=10');
     });
 
     it('including changed refresh interval', () => {
@@ -112,7 +112,7 @@ describe('BigDisplayModeConfiguration', () => {
       fireEvent.click(saveButton);
 
       expect(Routes.pluginRoute).toHaveBeenCalledWith('DASHBOARDS_TV_VIEWID');
-      expect(history.push).toHaveBeenCalledWith('/dashboards/tv/deadbeef?interval=30&tabs=&refresh=42');
+      expect(history.push).toHaveBeenCalledWith('/dashboards/tv/deadbeef?interval=30&refresh=42');
     });
 
     it('including tab cycle interval setting', () => {
@@ -125,7 +125,7 @@ describe('BigDisplayModeConfiguration', () => {
       fireEvent.click(saveButton);
 
       expect(Routes.pluginRoute).toHaveBeenCalledWith('DASHBOARDS_TV_VIEWID');
-      expect(history.push).toHaveBeenCalledWith('/dashboards/tv/deadbeef?interval=4242&tabs=&refresh=10');
+      expect(history.push).toHaveBeenCalledWith('/dashboards/tv/deadbeef?interval=4242&refresh=10');
     });
 
     it('including selected tabs', () => {
@@ -139,7 +139,7 @@ describe('BigDisplayModeConfiguration', () => {
       fireEvent.click(saveButton);
 
       expect(Routes.pluginRoute).toHaveBeenCalledWith('DASHBOARDS_TV_VIEWID');
-      expect(history.push).toHaveBeenCalledWith('/dashboards/tv/deadbeef?interval=30&tabs=1%2C2&refresh=10');
+      expect(history.push).toHaveBeenCalledWith('/dashboards/tv/deadbeef?interval=30&refresh=10&tabs=1%2C2');
     });
   });
 });

--- a/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeHeader.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeHeader.jsx
@@ -1,0 +1,31 @@
+// @flow strict
+import * as React from 'react';
+import connect from 'stores/connect';
+
+import Spinner from 'components/common/Spinner';
+import { ViewStore } from 'views/stores/ViewStore';
+import queryTitle from 'views/logic/queries/QueryTitle';
+import type { QueryId } from 'views/logic/queries/Query';
+import View from 'views/logic/views/View';
+
+type Props = {
+  view: {
+    activeQuery: ?QueryId,
+    view: ?View,
+  }
+};
+
+const BigDisplayModeHeader = ({ view: { activeQuery, view } = {} }: Props) => {
+  if (!view || !activeQuery) {
+    return <Spinner />;
+  }
+  const currentQueryTitle = queryTitle(view, activeQuery);
+  return (
+    <React.Fragment>
+      <h1>{view.title}</h1>
+      <h2>{currentQueryTitle}</h2>
+    </React.Fragment>
+  );
+};
+
+export default connect(BigDisplayModeHeader, { view: ViewStore });

--- a/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeHeader.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeHeader.jsx
@@ -1,6 +1,7 @@
 // @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import connect from 'stores/connect';
 
 import Spinner from 'components/common/Spinner';
@@ -16,16 +17,20 @@ type Props = {
   }
 };
 
+const PositioningWrapper = styled.div`
+  padding-left: 20px;
+`;
+
 const BigDisplayModeHeader = ({ view: { activeQuery, view } = {} }: Props) => {
   if (!view || !activeQuery) {
     return <Spinner />;
   }
   const currentQueryTitle = queryTitle(view, activeQuery);
   return (
-    <React.Fragment>
+    <PositioningWrapper>
       <h1>{view.title}</h1>
       <h2>{currentQueryTitle}</h2>
-    </React.Fragment>
+    </PositioningWrapper>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeHeader.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeHeader.jsx
@@ -1,5 +1,6 @@
 // @flow strict
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import connect from 'stores/connect';
 
 import Spinner from 'components/common/Spinner';
@@ -26,6 +27,12 @@ const BigDisplayModeHeader = ({ view: { activeQuery, view } = {} }: Props) => {
       <h2>{currentQueryTitle}</h2>
     </React.Fragment>
   );
+};
+
+BigDisplayModeHeader.propTypes = {
+  view: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 export default connect(BigDisplayModeHeader, { view: ViewStore });

--- a/graylog2-web-interface/src/views/components/dashboard/IfInteractive.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/IfInteractive.jsx
@@ -1,0 +1,10 @@
+// @flow strict
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+const IfInteractive = () => {
+};
+
+IfInteractive.propTypes = {};
+
+export default IfInteractive;

--- a/graylog2-web-interface/src/views/components/dashboard/IfInteractive.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/IfInteractive.jsx
@@ -1,10 +1,14 @@
 // @flow strict
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import InteractiveContext from '../contexts/InteractiveContext';
 
-const IfInteractive = () => {
+type Props = {
+  children: React.Node,
 };
-
-IfInteractive.propTypes = {};
+const IfInteractive = ({ children }: Props) => (
+  <InteractiveContext.Consumer>
+    {interactive => (interactive ? children : null)}
+  </InteractiveContext.Consumer>
+);
 
 export default IfInteractive;

--- a/graylog2-web-interface/src/views/components/dashboard/bigdisplay/CycleQueryTab.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/bigdisplay/CycleQueryTab.jsx
@@ -1,0 +1,36 @@
+// @flow strict
+import { useEffect } from 'react';
+import View from 'views/logic/views/View';
+import type { QueryId } from 'views/logic/queries/Query';
+import { ViewActions } from 'views/stores/ViewStore';
+
+type Props = {
+  interval: number,
+  view: ?View,
+  activeQuery: ?QueryId,
+  tabs: ?Array<number>,
+};
+
+const CycleQueryTab = ({ interval, view, activeQuery, tabs }: Props) => {
+  useEffect(() => {
+    const cycleInterval = setInterval(() => {
+      if (!view || !activeQuery) {
+        return;
+      }
+      const queryTabs = tabs || view.search.queries.toIndexedSeq().map((k, v) => v).toJS();
+      const currentQueryIndex = view.search.queries.toIndexedSeq().findIndex(q => q.id === activeQuery);
+      const currentTabIndex = queryTabs.indexOf(currentQueryIndex);
+      const nextQueryIndex = queryTabs[(currentTabIndex + 1) % queryTabs.length];
+      const nextQueryId = view.search.queries.toIndexedSeq().get(nextQueryIndex).id;
+      ViewActions.selectQuery(nextQueryId);
+    }, interval * 1000);
+
+    return () => clearInterval(cycleInterval);
+  }, [interval, view, activeQuery]);
+
+  return null;
+};
+
+CycleQueryTab.propTypes = {};
+
+export default CycleQueryTab;

--- a/graylog2-web-interface/src/views/components/dashboard/bigdisplay/CycleQueryTab.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/bigdisplay/CycleQueryTab.jsx
@@ -8,7 +8,7 @@ type Props = {
   interval: number,
   view: ?View,
   activeQuery: ?QueryId,
-  tabs: ?Array<number>,
+  tabs?: ?Array<number>,
 };
 
 const CycleQueryTab = ({ interval, view, activeQuery, tabs }: Props) => {
@@ -22,15 +22,15 @@ const CycleQueryTab = ({ interval, view, activeQuery, tabs }: Props) => {
       const currentTabIndex = queryTabs.indexOf(currentQueryIndex);
       const nextQueryIndex = queryTabs[(currentTabIndex + 1) % queryTabs.length];
       const nextQueryId = view.search.queries.toIndexedSeq().get(nextQueryIndex).id;
-      ViewActions.selectQuery(nextQueryId);
+      if (nextQueryId !== activeQuery) {
+        ViewActions.selectQuery(nextQueryId);
+      }
     }, interval * 1000);
 
     return () => clearInterval(cycleInterval);
-  }, [interval, view, activeQuery]);
+  }, [interval, view, activeQuery, tabs]);
 
   return null;
 };
-
-CycleQueryTab.propTypes = {};
 
 export default CycleQueryTab;

--- a/graylog2-web-interface/src/views/components/dashboard/bigdisplay/CycleQueryTab.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/bigdisplay/CycleQueryTab.jsx
@@ -17,7 +17,7 @@ const CycleQueryTab = ({ interval, view, activeQuery, tabs }: Props) => {
       if (!view || !activeQuery) {
         return;
       }
-      const queryTabs = tabs || view.search.queries.toIndexedSeq().map((k, v) => v).toJS();
+      const queryTabs = tabs || view.search.queries.toIndexedSeq().map((_, v) => v).toJS();
       const currentQueryIndex = view.search.queries.toIndexedSeq().findIndex(q => q.id === activeQuery);
       const currentTabIndex = queryTabs.indexOf(currentQueryIndex);
       const nextQueryIndex = queryTabs[(currentTabIndex + 1) % queryTabs.length];

--- a/graylog2-web-interface/src/views/components/dashboard/bigdisplay/CycleQueryTab.test.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/bigdisplay/CycleQueryTab.test.jsx
@@ -1,0 +1,103 @@
+// @flow strict
+import * as React from 'react';
+import { mount } from 'enzyme';
+
+import asMock from 'helpers/mocking/AsMock';
+import View from 'views/logic/views/View';
+import Search from 'views/logic/search/Search';
+import Query from 'views/logic/queries/Query';
+import { ViewActions } from 'views/stores/ViewStore';
+
+import CycleQueryTab from './CycleQueryTab';
+
+jest.mock('views/stores/ViewStore', () => ({
+  ViewActions: {
+    selectQuery: jest.fn(),
+  },
+}));
+
+const search = Search.create().toBuilder().queries([
+  Query.builder().id('foo').build(),
+  Query.builder().id('bar').build(),
+  Query.builder().id('baz').build(),
+]).build();
+const view = View.create().toBuilder().search(search).build();
+
+describe('CycleQueryTab', () => {
+  describe('cycles tabs:', () => {
+    let wrapper;
+    afterEach(() => {
+      wrapper.unmount();
+    });
+    it('does not return markup', () => {
+      wrapper = mount(<CycleQueryTab view={view} activeQuery="bar" interval={1} tabs={[1, 2]} />);
+      expect(wrapper).toBeEmptyRender();
+    });
+    it('should switch to next tab after interval', () => {
+      return new Promise((resolve) => {
+        asMock(ViewActions.selectQuery).mockImplementationOnce((queryId) => {
+          expect(queryId).toEqual('baz');
+          resolve();
+        });
+
+        wrapper = mount(<CycleQueryTab view={view} activeQuery="bar" interval={1} tabs={[1, 2]} />);
+      });
+    });
+    it('should switch to first tab if current one is the last', () => {
+      return new Promise((resolve) => {
+        asMock(ViewActions.selectQuery).mockImplementationOnce((queryId) => {
+          expect(queryId).toEqual('foo');
+          resolve();
+        });
+
+        wrapper = mount(<CycleQueryTab view={view} activeQuery="baz" interval={1} tabs={[0, 1, 2]} />);
+      });
+    });
+    it('should switch to next tab skipping gaps after interval', () => {
+      return new Promise((resolve) => {
+        asMock(ViewActions.selectQuery).mockImplementationOnce((queryId) => {
+          expect(queryId).toEqual('baz');
+          resolve();
+        });
+
+        wrapper = mount(<CycleQueryTab view={view} activeQuery="foo" interval={1} tabs={[0, 2]} />);
+      });
+    });
+    it('should switch to next tab defaulting to all tabs if `tabs` prop` is left out', () => {
+      return new Promise((resolve) => {
+        asMock(ViewActions.selectQuery).mockImplementationOnce((queryId) => {
+          expect(queryId).toEqual('bar');
+          resolve();
+        });
+
+        wrapper = mount(<CycleQueryTab view={view} activeQuery="foo" tabs={[1]} interval={1} />);
+      });
+    });
+  });
+
+  describe('uses setInterval/clearInterval properly', () => {
+    const origSetInterval = window.setInterval;
+    const origClearInterval = window.clearInterval;
+    beforeEach(() => {
+      jest.resetAllMocks();
+      window.setInterval = jest.fn(() => 'deadbeef');
+      window.clearInterval = jest.fn();
+    });
+    afterAll(() => {
+      window.setInterval = origSetInterval;
+      window.clearInterval = origClearInterval;
+    });
+    it('passes the correct interval to setInterval', () => {
+      const wrapper = mount(<CycleQueryTab view={view} activeQuery="foo" interval={42} />);
+      expect(window.setInterval).toHaveBeenCalledTimes(1);
+      expect(window.setInterval).toHaveBeenCalledWith(expect.anything(), 42000);
+      wrapper.unmount();
+      expect(ViewActions.selectQuery).not.toHaveBeenCalled();
+    });
+    it('when unmounting', () => {
+      const wrapper = mount(<CycleQueryTab view={view} activeQuery="foo" interval={1} />);
+      wrapper.unmount();
+      expect(window.clearInterval).toHaveBeenCalledWith('deadbeef');
+    });
+  });
+});

--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.jsx
@@ -51,16 +51,14 @@ class NumberVisualization extends React.Component<Props, State> {
 
     const { fontSize } = this.state;
     const { width, height } = this.props;
-    const { childNodes } = container;
+    const { children } = container;
 
-    if (childNodes.length <= 0) {
+    if (children.length <= 0) {
       return;
     }
 
-    const content = childNodes[0];
-    // $FlowFixMe offsetWidth is part of Node!
+    const content = children[0];
     const contentWidth = content.offsetWidth;
-    // $FlowFixMe offsetHeight is part of Node!
     const contentHeight = content.offsetHeight;
 
     const widthMultiplier = (width * 0.8) / contentWidth;

--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.jsx
@@ -72,7 +72,7 @@ class NumberVisualization extends React.Component<Props, State> {
 
     const newFontsize = Math.floor(fontSize * multiplier);
 
-    if (fontSize !== newFontsize) {
+    if (fontSize !== newFontsize && Number.isFinite(newFontsize)) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ fontSize: newFontsize });
     }

--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.test.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.test.jsx
@@ -56,8 +56,8 @@ describe('NumberVisualization', () => {
 
     wrapper.instance().getContainer = jest
       .fn()
-      .mockImplementationOnce(() => ({ childNodes: [{ offsetHeight: 90, offsetWidth: 90 }] }))
-      .mockImplementationOnce(() => ({ childNodes: [{ offsetHeight: 100, offsetWidth: 100 }] }));
+      .mockImplementationOnce(() => ({ children: [{ offsetHeight: 90, offsetWidth: 90 }] }))
+      .mockImplementationOnce(() => ({ children: [{ offsetHeight: 100, offsetWidth: 100 }] }));
 
     wrapper.setProps({ height: 125, width: 125 });
 

--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.test.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.test.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+// @flow strict
+import * as React from 'react';
 import { mount } from 'enzyme';
 import { List } from 'immutable';
 import renderer from 'react-test-renderer';
@@ -35,7 +36,7 @@ describe('NumberVisualization', () => {
     ],
   }];
   const currentView = { activeQuery: 'dead-beef' };
-  const fields = List([FieldTypeMapping.create('lines_add', FieldTypes.INT)]);
+  const fields = List([FieldTypeMapping.create('lines_add', FieldTypes.INT())]);
 
   it('should render a number visualization', () => {
     const wrapper = renderer.create(<NumberVisualization data={data}

--- a/graylog2-web-interface/src/views/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.jsx
@@ -206,24 +206,26 @@ class Widget extends React.Component<Props, State> {
         <WidgetFrame widgetId={id} onSizeChange={onSizeChange}>
           <span>
             <InteractiveContext.Consumer>
-              {interactive => (<WidgetHeader title={title}
-                                             hideDragHandle={!interactive}
-                                             onRename={newTitle => TitlesActions.set('widget', id, newTitle)}
-                                             editing={editing}>
-                <IfInteractive>
-                  <WidgetHorizontalStretch widgetId={widget.id}
-                                           widgetType={widget.type}
-                                           onStretch={onPositionsChange}
-                                           position={position} />
-                  {' '}
-                  <WidgetActionDropdown>
-                    <MenuItem onSelect={this._onToggleEdit}>Edit</MenuItem>
-                    <MenuItem onSelect={() => this._onDuplicate(id)}>Duplicate</MenuItem>
-                    <MenuItem divider />
-                    <MenuItem onSelect={() => this._onDelete(widget)}>Delete</MenuItem>
-                  </WidgetActionDropdown>
-                </IfInteractive>
-              </WidgetHeader>)}
+              {interactive => (
+                <WidgetHeader title={title}
+                              hideDragHandle={!interactive}
+                              onRename={newTitle => TitlesActions.set('widget', id, newTitle)}
+                              editing={editing}>
+                  <IfInteractive>
+                    <WidgetHorizontalStretch widgetId={widget.id}
+                                             widgetType={widget.type}
+                                             onStretch={onPositionsChange}
+                                             position={position} />
+                    {' '}
+                    <WidgetActionDropdown>
+                      <MenuItem onSelect={this._onToggleEdit}>Edit</MenuItem>
+                      <MenuItem onSelect={() => this._onDuplicate(id)}>Duplicate</MenuItem>
+                      <MenuItem divider />
+                      <MenuItem onSelect={() => this._onDelete(widget)}>Delete</MenuItem>
+                    </WidgetActionDropdown>
+                  </IfInteractive>
+                </WidgetHeader>
+              )}
             </InteractiveContext.Consumer>
             {visualization}
           </span>

--- a/graylog2-web-interface/src/views/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.jsx
@@ -28,6 +28,8 @@ import ErrorWidget from './ErrorWidget';
 import { WidgetErrorsList } from './WidgetPropTypes';
 import SaveOrCancelButtons from './SaveOrCancelButtons';
 import WidgetColorContext from './WidgetColorContext';
+import IfInteractive from '../dashboard/IfInteractive';
+import InteractiveContext from '../contexts/InteractiveContext';
 
 type Props = {
   id: string,
@@ -203,21 +205,26 @@ class Widget extends React.Component<Props, State> {
       <WidgetColorContext id={id}>
         <WidgetFrame widgetId={id} onSizeChange={onSizeChange}>
           <span>
-            <WidgetHeader title={title}
-                          onRename={newTitle => TitlesActions.set('widget', id, newTitle)}
-                          editing={editing}>
-              <WidgetHorizontalStretch widgetId={widget.id}
-                                       widgetType={widget.type}
-                                       onStretch={onPositionsChange}
-                                       position={position} />
-              {' '}
-              <WidgetActionDropdown>
-                <MenuItem onSelect={this._onToggleEdit}>Edit</MenuItem>
-                <MenuItem onSelect={() => this._onDuplicate(id)}>Duplicate</MenuItem>
-                <MenuItem divider />
-                <MenuItem onSelect={() => this._onDelete(widget)}>Delete</MenuItem>
-              </WidgetActionDropdown>
-            </WidgetHeader>
+            <InteractiveContext.Consumer>
+              {interactive => (<WidgetHeader title={title}
+                                             hideDragHandle={!interactive}
+                                             onRename={newTitle => TitlesActions.set('widget', id, newTitle)}
+                                             editing={editing}>
+                <IfInteractive>
+                  <WidgetHorizontalStretch widgetId={widget.id}
+                                           widgetType={widget.type}
+                                           onStretch={onPositionsChange}
+                                           position={position} />
+                  {' '}
+                  <WidgetActionDropdown>
+                    <MenuItem onSelect={this._onToggleEdit}>Edit</MenuItem>
+                    <MenuItem onSelect={() => this._onDuplicate(id)}>Duplicate</MenuItem>
+                    <MenuItem divider />
+                    <MenuItem onSelect={() => this._onDelete(widget)}>Delete</MenuItem>
+                  </WidgetActionDropdown>
+                </IfInteractive>
+              </WidgetHeader>)}
+            </InteractiveContext.Consumer>
             {visualization}
           </span>
         </WidgetFrame>

--- a/graylog2-web-interface/src/views/components/widgets/__snapshots__/Widget.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/widgets/__snapshots__/Widget.test.jsx.snap
@@ -21,6 +21,7 @@ exports[`<Widget /> should render with empty props 1`] = `
     <span>
       <widget-header
         editing={false}
+        hideDragHandle={false}
         onRename={[Function]}
         title="Widget Title"
       >

--- a/graylog2-web-interface/src/views/logic/queries/QueryTitle.js
+++ b/graylog2-web-interface/src/views/logic/queries/QueryTitle.js
@@ -3,15 +3,17 @@ import View from '../views/View';
 import ViewState from '../views/ViewState';
 import type { QueryId } from './Query';
 
-const queryTitle = (view: View, queryId: QueryId): string => view.search.queries.keySeq()
-  .map((q, idx) => {
-    if (queryId !== undefined && q.id !== undefined && queryId === q.id) {
-      return view.state
-        ? view.state.getIn([q.id], ViewState.create()).titles.getIn(['tab', 'title'], `Query#${idx + 1}`)
-        : `Query#${idx + 1}`;
-    }
-    return undefined;
-  }).filter(title => title !== undefined)
-  .first();
+const queryTitle = (view: View, queryId: QueryId): ?string => (view && view.search && view.search.queries
+  ? view.search.queries.keySeq()
+    .map((q, idx) => {
+      if (queryId !== undefined && q.id !== undefined && queryId === q.id) {
+        return view.state
+          ? view.state.getIn([q.id], ViewState.create()).titles.getIn(['tab', 'title'], `Query#${idx + 1}`)
+          : `Query#${idx + 1}`;
+      }
+      return undefined;
+    }).filter(title => title !== undefined)
+    .first()
+  : undefined);
 
 export default queryTitle;

--- a/graylog2-web-interface/src/views/logic/queries/QueryTitle.js
+++ b/graylog2-web-interface/src/views/logic/queries/QueryTitle.js
@@ -3,10 +3,11 @@
 import View from '../views/View';
 import ViewState from '../views/ViewState';
 import Query from './Query';
+import type { QueryId } from './Query';
 
-const queryTitle = (view: View, query: Query): string => view.search.queries.keySeq()
+const queryTitle = (view: View, queryId: QueryId): string => view.search.queries.keySeq()
   .map((q, idx) => {
-    if (query.id !== undefined && q.id !== undefined && query.id === q.id) {
+    if (queryId !== undefined && q.id !== undefined && queryId === q.id) {
       return view.state
         ? view.state.getIn([q.id], ViewState.create()).titles.getIn(['tab', 'title'], `Query#${idx + 1}`)
         : `Query#${idx + 1}`;

--- a/graylog2-web-interface/src/views/logic/queries/QueryTitle.js
+++ b/graylog2-web-interface/src/views/logic/queries/QueryTitle.js
@@ -1,8 +1,6 @@
 // @flow strict
-
 import View from '../views/View';
 import ViewState from '../views/ViewState';
-import Query from './Query';
 import type { QueryId } from './Query';
 
 const queryTitle = (view: View, queryId: QueryId): string => view.search.queries.keySeq()

--- a/graylog2-web-interface/src/views/logic/queries/QueryTitle.test.jsx
+++ b/graylog2-web-interface/src/views/logic/queries/QueryTitle.test.jsx
@@ -1,0 +1,61 @@
+// @flow strict
+import * as Immutable from 'immutable';
+
+import queryTitle from './QueryTitle';
+import Search from '../search/Search';
+import Query from './Query';
+import View from '../views/View';
+import ViewState from '../views/ViewState';
+
+describe('QueryTitle', () => {
+  const search = Search.create().toBuilder().queries([
+    Query.builder().id('foo').build(),
+    Query.builder().id('bar').build(),
+    Query.builder().id('baz').build(),
+  ]).build();
+  const view = View.create().toBuilder().search(search)
+    .state(Immutable.fromJS({
+      foo: ViewState.builder().titles(Immutable.fromJS({
+        tab: { title: 'The Fabulous Foo Tab' },
+      })).build(),
+      baz: ViewState.builder().titles(Immutable.fromJS({
+        tab: { title: 'The Incredible Other Tab' },
+      })).build(),
+    }))
+    .build();
+  it('returns actual name of first tab', () => {
+    expect(queryTitle(view, 'foo')).toEqual('The Fabulous Foo Tab');
+  });
+  it('returns generated name of nameless second tab', () => {
+    expect(queryTitle(view, 'bar')).toEqual('Query#2');
+  });
+  it('returns actual name of third tab', () => {
+    expect(queryTitle(view, 'baz')).toEqual('The Incredible Other Tab');
+  });
+  it('returns `undefined` for missing tab', () => {
+    expect(queryTitle(view, 'qux')).toEqual(undefined);
+  });
+  it('returns `undefined` if query id is `undefined`', () => {
+    // $FlowFixMe: passing invalid values on purpose
+    expect(queryTitle(view, undefined)).toEqual(undefined);
+  });
+  it('returns `undefined` if view is `undefined`', () => {
+    // $FlowFixMe: passing invalid values on purpose
+    expect(queryTitle(undefined, undefined)).toEqual(undefined);
+  });
+  it('returns `undefined` if search is `undefined`', () => {
+    // $FlowFixMe: passing invalid values on purpose
+    expect(queryTitle(View.create(), undefined)).toEqual(undefined);
+  });
+  it('returns `undefined` if queries are `undefined`', () => {
+    expect(queryTitle(View.create()
+      .toBuilder()
+      .search(Search.create()
+        .toBuilder()
+        // $FlowFixMe: passing invalid values on purpose
+        .queries(undefined)
+        .build())
+      // $FlowFixMe: passing invalid values on purpose
+      .build(), undefined)).toEqual(undefined);
+  });
+});

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -38,6 +38,7 @@ import { AdditionalContext } from 'views/logic/ActionContext';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import style from '!style/useable!css!./ExtendedSearchPage.css';
 import IfInteractive from '../components/dashboard/IfInteractive';
+import InteractiveContext from '../components/contexts/InteractiveContext';
 
 const ConnectedSideBar = connect(SideBar, { viewMetadata: ViewMetadataStore, searches: SearchStore },
   props => Object.assign(
@@ -121,32 +122,36 @@ const ExtendedSearchPage = ({ route, searchRefreshHooks }: Props) => {
           <WindowLeaveMessage route={route} />
         </IfDashboard>
       </IfInteractive>
-      <div id="main-row" className="grid-container">
-        <IfInteractive>
-          <ConnectedSideBar>
-            <ConnectedFieldList />
-          </ConnectedSideBar>
-        </IfInteractive>
-        <div className="search-grid">
-          <IfInteractive>
-            <HeaderElements />
-            <IfDashboard>
-              <DashboardSearchBarWithStatus onExecute={refreshIfNotUndeclared} />
-              <QueryBar />
-            </IfDashboard>
-            <IfSearch>
-              <SearchBarWithStatus onExecute={refreshIfNotUndeclared} />
-            </IfSearch>
+      <InteractiveContext.Consumer>
+        {interactive => (
+          <div id="main-row" className={interactive ? 'grid-container' : null}>
+            <IfInteractive>
+              <ConnectedSideBar>
+                <ConnectedFieldList />
+              </ConnectedSideBar>
+            </IfInteractive>
+            <div className="search-grid">
+              <IfInteractive>
+                <HeaderElements />
+                <IfDashboard>
+                  <DashboardSearchBarWithStatus onExecute={refreshIfNotUndeclared} />
+                  <QueryBar />
+                </IfDashboard>
+                <IfSearch>
+                  <SearchBarWithStatus onExecute={refreshIfNotUndeclared} />
+                </IfSearch>
 
-            <QueryBarElements />
-          </IfInteractive>
+                <QueryBarElements />
+              </IfInteractive>
 
-          <ViewAdditionalContextProvider>
-            <SearchResult />
-          </ViewAdditionalContextProvider>
-          <Footer />
-        </div>
-      </div>
+              <ViewAdditionalContextProvider>
+                <SearchResult />
+              </ViewAdditionalContextProvider>
+              <Footer />
+            </div>
+          </div>
+        )}
+      </InteractiveContext.Consumer>
     </CurrentViewTypeProvider>
   );
 };

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -37,6 +37,7 @@ import { AdditionalContext } from 'views/logic/ActionContext';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import style from '!style/useable!css!./ExtendedSearchPage.css';
+import IfInteractive from '../components/dashboard/IfInteractive';
 
 const ConnectedSideBar = connect(SideBar, { viewMetadata: ViewMetadataStore, searches: SearchStore },
   props => Object.assign(
@@ -115,24 +116,30 @@ const ExtendedSearchPage = ({ route, searchRefreshHooks }: Props) => {
 
   return (
     <CurrentViewTypeProvider>
-      <IfDashboard>
-        <WindowLeaveMessage route={route} />
-      </IfDashboard>
+      <IfInteractive>
+        <IfDashboard>
+          <WindowLeaveMessage route={route} />
+        </IfDashboard>
+      </IfInteractive>
       <div id="main-row" className="grid-container">
-        <ConnectedSideBar>
-          <ConnectedFieldList />
-        </ConnectedSideBar>
+        <IfInteractive>
+          <ConnectedSideBar>
+            <ConnectedFieldList />
+          </ConnectedSideBar>
+        </IfInteractive>
         <div className="search-grid">
-          <HeaderElements />
-          <IfDashboard>
-            <DashboardSearchBarWithStatus onExecute={refreshIfNotUndeclared} />
-            <QueryBar />
-          </IfDashboard>
-          <IfSearch>
-            <SearchBarWithStatus onExecute={refreshIfNotUndeclared} />
-          </IfSearch>
+          <IfInteractive>
+            <HeaderElements />
+            <IfDashboard>
+              <DashboardSearchBarWithStatus onExecute={refreshIfNotUndeclared} />
+              <QueryBar />
+            </IfDashboard>
+            <IfSearch>
+              <SearchBarWithStatus onExecute={refreshIfNotUndeclared} />
+            </IfSearch>
 
-          <QueryBarElements />
+            <QueryBarElements />
+          </IfInteractive>
 
           <ViewAdditionalContextProvider>
             <SearchResult />

--- a/graylog2-web-interface/src/views/pages/ShowDashboardInBigDisplayMode.jsx
+++ b/graylog2-web-interface/src/views/pages/ShowDashboardInBigDisplayMode.jsx
@@ -42,8 +42,8 @@ type Props = {
 
 const castQueryWithDefaults = ({ tabs, interval, refresh }: UntypedBigDisplayModeQuery): BigDisplayModeQuery => ({
   tabs: tabs !== undefined ? tabs.split(',').map(tab => Number.parseInt(tab, 10)) : undefined,
-  interval: interval !== undefined ? Number.parseInt(interval, 10) : 30,
-  refresh: refresh !== undefined ? Number.parseInt(refresh, 10) : 10,
+  interval: interval !== undefined ? Math.max(Number.parseInt(interval, 10), 1) : 30,
+  refresh: refresh !== undefined ? Math.max(Number.parseInt(refresh, 10), 1) : 10,
 });
 
 const BodyPositioningWrapper = styled.div`

--- a/graylog2-web-interface/src/views/pages/ShowDashboardInBigDisplayMode.jsx
+++ b/graylog2-web-interface/src/views/pages/ShowDashboardInBigDisplayMode.jsx
@@ -1,6 +1,18 @@
 // @flow strict
 import * as React from 'react';
 import { withRouter } from 'react-router';
+import styled from 'styled-components';
+
+import connect from 'stores/connect';
+import InteractiveContext from 'views/components/contexts/InteractiveContext';
+import { ViewStore } from 'views/stores/ViewStore';
+import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
+import { CurrentQueryStore } from 'views/stores/CurrentQueryStore';
+import BigDisplayModeHeader from 'views/components/dashboard/BigDisplayModeHeader';
+import CycleQueryTab from 'views/components/dashboard/bigdisplay/CycleQueryTab';
+import type { QueryId } from 'views/logic/queries/Query';
+import View from 'views/logic/views/View';
+import ShowViewPage from './ShowViewPage';
 
 export type BigDisplayModeQuery = {|
   tabs?: Array<number>,
@@ -18,6 +30,12 @@ type Props = {
   location: {
     query: UntypedBigDisplayModeQuery,
   },
+  params: any,
+  route: any,
+  view: {
+    view: ?View,
+    activeQuery: ?QueryId,
+  },
 };
 
 const castQueryWithDefaults = ({ tabs, interval, refresh }: UntypedBigDisplayModeQuery): BigDisplayModeQuery => ({
@@ -26,8 +44,23 @@ const castQueryWithDefaults = ({ tabs, interval, refresh }: UntypedBigDisplayMod
   refresh: refresh !== undefined ? Number.parseInt(refresh, 10) : undefined,
 });
 
-const ShowDashboardInBigDisplayMode = ({ location: { query } }: Props) => (
-  <div>{JSON.stringify(castQueryWithDefaults(query))}</div>
-);
+const BodyPositioningWrapper = styled.div`
+  margin-top: -45px;
+  padding: 10px;
+`;
 
-export default withRouter(ShowDashboardInBigDisplayMode);
+const ShowDashboardInBigDisplayMode = ({ location, params, route, view: { view, activeQuery } }: Props) => {
+  const { query } = location;
+  const configuration = castQueryWithDefaults(query);
+  return (
+    <InteractiveContext.Provider value={false}>
+      <BodyPositioningWrapper>
+        {view && activeQuery ? <CycleQueryTab interval={configuration.interval || 30} view={view} activeQuery={activeQuery} tabs={configuration.tabs} /> : null}
+        <BigDisplayModeHeader />
+        <ShowViewPage location={location} params={params} route={route} />
+      </BodyPositioningWrapper>
+    </InteractiveContext.Provider>
+  );
+};
+
+export default withRouter(connect(ShowDashboardInBigDisplayMode, { view: ViewStore, viewMetadata: ViewMetadataStore, query: CurrentQueryStore }));

--- a/graylog2-web-interface/src/views/pages/ShowDashboardInBigDisplayMode.jsx
+++ b/graylog2-web-interface/src/views/pages/ShowDashboardInBigDisplayMode.jsx
@@ -13,19 +13,13 @@ import CycleQueryTab from 'views/components/dashboard/bigdisplay/CycleQueryTab';
 import type { QueryId } from 'views/logic/queries/Query';
 import View from 'views/logic/views/View';
 import { RefreshActions } from 'views/stores/RefreshStore';
-// eslint-disable-next-line import/no-cycle
+import type { UntypedBigDisplayModeQuery } from 'views/components/dashboard/BigDisplayModeConfiguration';
 import ShowViewPage from './ShowViewPage';
 
 type BigDisplayModeQuery = {|
   tabs: ?Array<number>,
   interval: number,
   refresh: number,
-|};
-
-export type UntypedBigDisplayModeQuery = {|
-  tabs?: string,
-  interval?: string,
-  refresh?: string,
 |};
 
 type Props = {

--- a/graylog2-web-interface/src/views/stores/ViewStore.js
+++ b/graylog2-web-interface/src/views/stores/ViewStore.js
@@ -16,9 +16,10 @@ import SearchActions from 'views/actions/SearchActions';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
 import { ViewManagementActions } from './ViewManagementStore';
 import type { RefluxActions } from './StoreTypes';
+import type { QueryId } from 'views/logic/queries/Query';
 
 export type ViewStoreState = {
-  activeQuery: string,
+  activeQuery: QueryId,
   view: View,
   dirty: boolean,
 };

--- a/graylog2-web-interface/src/views/stores/ViewStore.js
+++ b/graylog2-web-interface/src/views/stores/ViewStore.js
@@ -14,9 +14,9 @@ import ViewState from 'views/logic/views/ViewState';
 import Query from 'views/logic/queries/Query';
 import SearchActions from 'views/actions/SearchActions';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
+import type { QueryId } from 'views/logic/queries/Query';
 import { ViewManagementActions } from './ViewManagementStore';
 import type { RefluxActions } from './StoreTypes';
-import type { QueryId } from 'views/logic/queries/Query';
 
 export type ViewStoreState = {
   activeQuery: QueryId,


### PR DESCRIPTION
## Description
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is adding functionality to show dashboards in a non-interactive,
read-only mode suitable for big displays and unattended setups. It tries
to:

  * Maximize usage of screen estate by removing navigation and side bar
  * Removes interactive elements of widgets
  * Cycles through (configured) tabs of dashboard automatically
  * Refreshes the search in configured intervals

Fixes #6401.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.