### PR TITLE
Fixing root route in `AppRouter`.

### DIFF
--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -119,7 +119,7 @@ const AppRouter = () => {
 
   return (
     <Router history={history}>
-      <Route path={Routes.STARTPAGE} component={AppErrorBoundary}>
+      <Route component={AppErrorBoundary}>
         {pluginRoutesWithNullParent}
         <Route path={Routes.STARTPAGE} component={App}>
           <Route component={AppWithGlobalNotifications}>

--- a/graylog2-web-interface/src/routing/AppRouter.test.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.test.jsx
@@ -25,7 +25,7 @@ jest.mock('injection/CombinedProvider', () => {
 });
 
 // To prevent exceptions from getting swallwoed
-jest.mock('./AppErrorBoundary',() => mockComponent('AppErrorBoundary'));
+jest.mock('./AppErrorBoundary', () => mockComponent('AppErrorBoundary'));
 
 jest.mock('components/search/SearchBar', () => mockComponent('SearchBar'));
 

--- a/graylog2-web-interface/src/routing/AppRouter.test.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.test.jsx
@@ -1,0 +1,37 @@
+// @flow strict
+import * as React from 'react';
+import { mount } from 'enzyme';
+
+import mockComponent from 'helpers/mocking/MockComponent';
+import { CombinedProviderMock as MockCombinedProvider, StoreMock as MockStore } from 'helpers/mocking';
+import AppRouter from './AppRouter';
+
+jest.mock('pages', () => ({
+  StartPage: mockComponent('StartPage'),
+}));
+
+jest.mock('injection/CombinedProvider', () => {
+  const mockCurrentUserStoretore = MockStore('get', 'listen', ['getInitialState', () => ({
+    currentUser: {
+      full_name: 'Ares Vallis',
+      username: 'ares',
+      permissions: ['*'],
+    },
+  })]);
+  return new MockCombinedProvider({
+    CurrentUser: { CurrentUserStore: mockCurrentUserStoretore },
+    Notifications: { NotificationsActions: { list: jest.fn() } },
+  });
+});
+
+// To prevent exceptions from getting swallwoed
+jest.mock('./AppErrorBoundary',() => mockComponent('AppErrorBoundary'));
+
+jest.mock('components/search/SearchBar', () => mockComponent('SearchBar'));
+
+describe('AppRouter', () => {
+  it('routes to Getting Started Page for `/` or empty location', () => {
+    const wrapper = mount(<AppRouter />);
+    expect(wrapper.find('StartPage')).toExist();
+  });
+});


### PR DESCRIPTION
## Description
## Motivation and Context
In #6602 the `AppRouter`'s route structure was changed to allow supplying routes from plugins with an explicitly defined `null` value for the `parentComponent`. This enforces hoisting of these routes to the top level of the router so they are not contained within the `App` or other parent components.

Unfortunately the path of the global `AppErrorBoundary` was left in place, erroneously meant to fix a unrelated route matching issue, leading to a ` ` or `/` route to go nowhere.

This change is removing the path specification so ` ` and `/` routes are correctly routed to the `StartPage` component again.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.