### PR TITLE
Make searchbar reponsive and add refresh controls to dashboard searchbar

### DIFF
--- a/graylog2-web-interface/src/components/common/Select.jsx
+++ b/graylog2-web-interface/src/components/common/Select.jsx
@@ -102,7 +102,7 @@ const placeholder = base => ({
   whiteSpace: 'nowrap',
   textOverflow: 'ellipsis',
   overflow: 'hidden',
-  width: '100%',
+  maxWidth: '100%',
   paddingRight: '20px',
 });
 

--- a/graylog2-web-interface/src/components/common/Select.jsx
+++ b/graylog2-web-interface/src/components/common/Select.jsx
@@ -99,6 +99,11 @@ const placeholder = base => ({
   fontSize: '14px',
   fontWeight: 400,
   color: '#999',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+  overflow: 'hidden',
+  width: '100%',
+  paddingRight: '20px',
 });
 
 const controlFocus = props => (base, { isFocused }) => {

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
@@ -57,7 +57,7 @@ const DashboardSearchBar = ({ config, currentQuery, disableSearch = false, onExe
         <Col md={12}>
           <form method="GET" onSubmit={submitForm}>
             <Row className="no-bm">
-              <Col md={9} xs={7}>
+              <Col lg={8} md={7} xs={6}>
                 <div className="pull-right search-help">
                   <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
                                      title="Search query syntax documentation"
@@ -70,7 +70,7 @@ const DashboardSearchBar = ({ config, currentQuery, disableSearch = false, onExe
                             onChange={value => GlobalOverrideActions.query(value).then(performSearch).then(() => value)}
                             onExecute={performSearch} />
               </Col>
-              <Col md={3} xs={5}>
+              <Col lg={4} md={5} xs={6}>
                 <TimeRangeOverrideTypeSelector onSelect={newRangeType => GlobalOverrideActions.rangeType(newRangeType).then(performSearch)}
                                                value={rangeType} />
                 <TimeRangeOverrideInput onChange={(key, value) => GlobalOverrideActions.rangeParams(key, value).then(performSearch)}

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
@@ -81,7 +81,7 @@ const DashboardSearchBar = ({ config, currentQuery, disableSearch = false, onExe
             </Row>
             <Row className="no-bm">
               <Col>
-                <HorizontalSpacer className="mdHidden" />
+                <HorizontalSpacer />
               </Col>
             </Row>
             <Row className="no-bm">

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
@@ -7,6 +7,8 @@ import { Col, Row } from 'components/graylog';
 import connect from 'stores/connect';
 import DocumentationLink from 'components/support/DocumentationLink';
 import DocsHelper from 'util/DocsHelper';
+import RefreshControls from 'views/components/searchbar/RefreshControls';
+import HorizontalSpacer from 'views/components/horizontalspacer/HorizontalSpacer';
 import Spinner from 'components/common/Spinner';
 import ScrollToHint from 'views/components/common/ScrollToHint';
 import TimeRangeOverrideTypeSelector from 'views/components/searchbar/TimeRangeOverrideTypeSelector';
@@ -53,9 +55,9 @@ const DashboardSearchBar = ({ config, currentQuery, disableSearch = false, onExe
     <ScrollToHint value={query.query_string || ''}>
       <Row className="content" style={{ marginRight: 0, marginLeft: 0 }}>
         <Col md={12}>
-          <Row className="no-bm">
-            <form method="GET" onSubmit={submitForm}>
-              <Col md={9}>
+          <form method="GET" onSubmit={submitForm}>
+            <Row className="no-bm">
+              <Col md={9} xs={7}>
                 <div className="pull-right search-help">
                   <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
                                      title="Search query syntax documentation"
@@ -68,7 +70,7 @@ const DashboardSearchBar = ({ config, currentQuery, disableSearch = false, onExe
                             onChange={value => GlobalOverrideActions.query(value).then(performSearch).then(() => value)}
                             onExecute={performSearch} />
               </Col>
-              <Col md={3}>
+              <Col md={3} xs={5}>
                 <TimeRangeOverrideTypeSelector onSelect={newRangeType => GlobalOverrideActions.rangeType(newRangeType).then(performSearch)}
                                                value={rangeType} />
                 <TimeRangeOverrideInput onChange={(key, value) => GlobalOverrideActions.rangeParams(key, value).then(performSearch)}
@@ -76,8 +78,18 @@ const DashboardSearchBar = ({ config, currentQuery, disableSearch = false, onExe
                                         rangeParams={rangeParams}
                                         config={config} />
               </Col>
-            </form>
-          </Row>
+            </Row>
+            <Row className="no-bm">
+              <Col>
+                <HorizontalSpacer className="mdHidden" />
+              </Col>
+            </Row>
+            <Row className="no-bm">
+              <Col md={12}>
+                <RefreshControls />
+              </Col>
+            </Row>
+          </form>
         </Col>
       </Row>
     </ScrollToHint>

--- a/graylog2-web-interface/src/views/components/SearchBar.jsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.jsx
@@ -72,7 +72,7 @@ const SearchBar = ({ availableStreams, config, currentQuery, disableSearch = fal
               <form method="GET" onSubmit={submitForm}>
 
                 <Row className="no-bm extended-search-query-metadata">
-                  <Col md={3}>
+                  <Col md={4}>
                     <TimeRangeTypeSelector onSelect={newRangeType => QueriesActions.rangeType(id, newRangeType).then(performSearch)}
                                            value={rangeType} />
                     <TimeRangeInput onChange={(key, value) => QueriesActions.rangeParams(id, key, value).then(performSearch)}
@@ -85,7 +85,7 @@ const SearchBar = ({ availableStreams, config, currentQuery, disableSearch = fal
                     <HorizontalSpacer className="mdHidden" />
                   </Col>
 
-                  <Col md={6} xs={8}>
+                  <Col md={5} xs={8}>
                     <StreamsFilter value={streams}
                                    streams={availableStreams}
                                    onChange={value => QueryFiltersActions.streams(id, value)} />

--- a/graylog2-web-interface/src/views/components/SearchBar.jsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.jsx
@@ -17,6 +17,7 @@ import QueryInput from 'views/components/searchbar/AsyncQueryInput';
 import StreamsFilter from 'views/components/searchbar/StreamsFilter';
 import RefreshControls from 'views/components/searchbar/RefreshControls';
 import ScrollToHint from 'views/components/common/ScrollToHint';
+import HorizontalSpacer from 'views/components/horizontalspacer/HorizontalSpacer';
 import { QueriesActions } from 'views/stores/QueriesStore';
 import { CurrentQueryStore } from 'views/stores/CurrentQueryStore';
 import { StreamsStore } from 'views/stores/StreamsStore';
@@ -71,7 +72,7 @@ const SearchBar = ({ availableStreams, config, currentQuery, disableSearch = fal
               <form method="GET" onSubmit={submitForm}>
 
                 <Row className="no-bm extended-search-query-metadata">
-                  <Col md={4}>
+                  <Col md={3}>
                     <TimeRangeTypeSelector onSelect={newRangeType => QueriesActions.rangeType(id, newRangeType).then(performSearch)}
                                            value={rangeType} />
                     <TimeRangeInput onChange={(key, value) => QueriesActions.rangeParams(id, key, value).then(performSearch)}
@@ -80,18 +81,23 @@ const SearchBar = ({ availableStreams, config, currentQuery, disableSearch = fal
                                     config={config} />
                   </Col>
 
-                  <Col md={6}>
+                  <Col mdHidden lgHidden>
+                    <HorizontalSpacer className="mdHidden" />
+                  </Col>
+
+                  <Col md={6} xs={8}>
                     <StreamsFilter value={streams}
                                    streams={availableStreams}
                                    onChange={value => QueryFiltersActions.streams(id, value)} />
                   </Col>
-                  <Col md={2}>
+
+                  <Col md={3} xs={4}>
                     <RefreshControls />
                   </Col>
                 </Row>
 
                 <Row className="no-bm">
-                  <Col md={10}>
+                  <Col md={10} xs={9}>
                     <div className="pull-right search-help">
                       <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
                                          title="Search query syntax documentation"
@@ -104,7 +110,7 @@ const SearchBar = ({ availableStreams, config, currentQuery, disableSearch = fal
                                 onChange={value => QueriesActions.query(id, value).then(performSearch).then(() => value)}
                                 onExecute={performSearch} />
                   </Col>
-                  <Col md={2}>
+                  <Col md={2} xs={3}>
                     <BookmarkControls />
                   </Col>
                 </Row>

--- a/graylog2-web-interface/src/views/components/SearchBar.jsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.jsx
@@ -82,7 +82,7 @@ const SearchBar = ({ availableStreams, config, currentQuery, disableSearch = fal
                   </Col>
 
                   <Col mdHidden lgHidden>
-                    <HorizontalSpacer className="mdHidden" />
+                    <HorizontalSpacer />
                   </Col>
 
                   <Col md={5} xs={8}>

--- a/graylog2-web-interface/src/views/components/__snapshots__/WidgetQueryControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/__snapshots__/WidgetQueryControls.test.jsx.snap
@@ -114,6 +114,7 @@ exports[`WidgetQueryControls should do something 1`] = `
       <div
         data-testid="streams-filter"
         style="position: relative; z-index: 10;"
+        title="Select streams the search should include. Searches in all streams if empty."
       >
         <div
           class="css-1pcexqc-container"
@@ -125,7 +126,7 @@ exports[`WidgetQueryControls should do something 1`] = `
               class="css-1hio1c"
             >
               <div
-                class="css-15vyb8i-placeholder"
+                class="css-22r4e1-placeholder"
               >
                 Select streams the search should include. Searches in all streams if empty.
               </div>

--- a/graylog2-web-interface/src/views/components/horizontalspacer/HorizontalSpacer.jsx
+++ b/graylog2-web-interface/src/views/components/horizontalspacer/HorizontalSpacer.jsx
@@ -13,7 +13,7 @@ type Props = {
   /** Needed height in px */
   height: number,
   /** Allow custom classNames */
-  className: string,
+  className?: string,
 };
 
 const Spacer = styled.div`

--- a/graylog2-web-interface/src/views/components/horizontalspacer/HorizontalSpacer.jsx
+++ b/graylog2-web-interface/src/views/components/horizontalspacer/HorizontalSpacer.jsx
@@ -1,5 +1,6 @@
 // @flow strict
 import * as React from 'react';
+import type { ComponentType } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -16,7 +17,7 @@ type Props = {
   className?: string,
 };
 
-const Spacer = styled.div`
+const Spacer: ComponentType<Props> = styled.div`
   width: 100%;
   height: ${props => props.height}px;
 `;

--- a/graylog2-web-interface/src/views/components/horizontalspacer/HorizontalSpacer.jsx
+++ b/graylog2-web-interface/src/views/components/horizontalspacer/HorizontalSpacer.jsx
@@ -1,0 +1,38 @@
+// @flow strict
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+/**
+ * Component to display horisontal space.
+ * Mainly needed for responsive bootstrap grids.
+ * Can be used in combination with bootstrap Cols to show horizontal space only for specific viewports.
+ */
+
+type Props = {
+  /** Needed height in px */
+  height: number,
+  /** Allow custom classNames */
+  className: string,
+};
+
+const Spacer = styled.div`
+  width: 100%;
+  height: ${props => props.height}px;
+`;
+
+const HorizontalSpacer = ({ height, className }: Props) => {
+  return <Spacer height={height} className={className} />;
+};
+
+HorizontalSpacer.propTypes = {
+  height: PropTypes.number,
+  className: PropTypes.string,
+};
+
+HorizontalSpacer.defaultProps = {
+  height: 10,
+  className: undefined,
+};
+
+export default HorizontalSpacer;

--- a/graylog2-web-interface/src/views/components/horizontalspacer/HorizontalSpacer.jsx
+++ b/graylog2-web-interface/src/views/components/horizontalspacer/HorizontalSpacer.jsx
@@ -1,6 +1,5 @@
 // @flow strict
 import * as React from 'react';
-import type { ComponentType } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -17,14 +16,12 @@ type Props = {
   className?: string,
 };
 
-const Spacer: ComponentType<Props> = styled.div`
+const Spacer: React.ComponentType<Props> = styled.div`
   width: 100%;
   height: ${props => props.height}px;
 `;
 
-const HorizontalSpacer = ({ height, className }: Props) => {
-  return <Spacer height={height} className={className} />;
-};
+const HorizontalSpacer = ({ height, className }: Props) => <Spacer height={height} className={className} />;
 
 HorizontalSpacer.propTypes = {
   height: PropTypes.number,

--- a/graylog2-web-interface/src/views/components/searchbar/KeywordTimeRangeSelector.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/KeywordTimeRangeSelector.jsx
@@ -2,11 +2,26 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Alert, Col, FormControl, FormGroup, InputGroup, Row } from 'components/graylog';
 import Immutable from 'immutable';
+import styled from 'styled-components';
 
 import DateTime from 'logic/datetimes/DateTime';
 import StoreProvider from 'injection/StoreProvider';
 
 const ToolsStore = StoreProvider.getStore('Tools');
+
+const KeywordPreview = styled(Alert)`
+  display: flex;
+  align-items: center;
+  min-height: 34px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  margin-top: 0 !important;  /* Would be overwritten by graylog.less */
+`;
+
+const TimeRangeInput = styled(FormControl)`
+  min-height: 34px;
+  font-size: 14px;
+`;
 
 export default class KeywordTimeRangeSelector extends React.Component {
   static propTypes = {
@@ -71,29 +86,29 @@ export default class KeywordTimeRangeSelector extends React.Component {
     const { disabled } = this.props;
     const { from, to } = keywordPreview.toObject();
     const keywordPreviewElement = keywordPreview.size > 0 && (
-      <Alert bsStyle="info" style={{ height: 30, paddingTop: 5, paddingBottom: 5, marginTop: 0 }}>
+      <KeywordPreview bsStyle="info">
         <strong style={{ marginRight: 8 }}>Preview:</strong>
         {from} to {to}
-      </Alert>
+      </KeywordPreview>
     );
     return (
-      <div className="timerange-selector keyword" style={{ width: 650 }}>
+      <div className="timerange-selector keyword">
         <Row className="no-bm" style={{ marginLeft: 50 }}>
-          <Col md={3} style={{ padding: 0 }}>
+          <Col xs={3} style={{ padding: 0 }}>
             <FormGroup controlId="form-inline-keyword" style={{ marginRight: 5, width: '100%' }} validationState={validationState}>
               <InputGroup>
-                <FormControl type="text"
-                             className="input-sm"
-                             name="keyword"
-                             disabled={disabled}
-                             placeholder="Last week"
-                             onChange={this._keywordSearchChanged}
-                             required
-                             value={value} />
+                <TimeRangeInput type="text"
+                                className="input-sm"
+                                name="keyword"
+                                disabled={disabled}
+                                placeholder="Last week"
+                                onChange={this._keywordSearchChanged}
+                                required
+                                value={value} />
               </InputGroup>
             </FormGroup>
           </Col>
-          <Col md={8} style={{ paddingRight: 0 }}>
+          <Col xs={8} style={{ paddingRight: 0 }}>
             {keywordPreviewElement}
           </Col>
         </Row>

--- a/graylog2-web-interface/src/views/components/searchbar/RefreshControls.css
+++ b/graylog2-web-interface/src/views/components/searchbar/RefreshControls.css
@@ -1,3 +1,0 @@
-:local(.position) {
-    margin-right: 15px;
-}

--- a/graylog2-web-interface/src/views/components/searchbar/RefreshControls.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/RefreshControls.jsx
@@ -45,12 +45,7 @@ type Props = {
   refreshConfig: RefreshConfig,
 };
 
-type State = {
-  /* eslint-disable-next-line no-undef */
-  intervalId: ?IntervalID,
-};
-
-class RefreshControls extends React.Component<Props, State> {
+class RefreshControls extends React.Component<Props> {
   static propTypes = {
     refreshConfig: PropTypes.object.isRequired,
   };
@@ -65,20 +60,13 @@ class RefreshControls extends React.Component<Props, State> {
     ['5 Minutes', 300000],
   ];
 
-  constructor(props: Props) {
-    super(props);
-
-    this.state = {
-      intervalId: undefined,
-    };
-  }
-
   componentWillUnmount(): void {
     RefreshActions.disable();
   }
 
   _toggleEnable = (): void => {
-    if (this.props.refreshConfig.enabled) {
+    const { refreshConfig } = this.props;
+    if (refreshConfig.enabled) {
       RefreshActions.disable();
     } else {
       RefreshActions.enable();

--- a/graylog2-web-interface/src/views/components/searchbar/RefreshControls.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/RefreshControls.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
+import styled from 'styled-components';
 
 // $FlowFixMe: imports from core need to be fixed in flow
 import connect from 'stores/connect';
@@ -12,7 +13,28 @@ import { MenuItem, ButtonGroup, DropdownButton, Button } from 'components/graylo
 import Pluralize from 'components/common/Pluralize';
 import { RefreshActions, RefreshStore } from 'views/stores/RefreshStore';
 
-import styles from './RefreshControls.css';
+const ControlsContainer = styled.div`
+  max-width: 100%;
+`;
+
+const FlexibleButtonGroup = styled(ButtonGroup)`
+  display: flex;
+  > .btn-group {
+    max-width: calc(100% - 34px);
+    .btn:first-child {
+      max-width: 100%;
+    }
+  }
+`;
+
+const ButtonLabel = styled.div`
+  display: inline-block;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: calc(100% - 9px);
+  vertical-align: inherit;
+`;
+
 
 type RefreshConfig = {
   interval: number,
@@ -67,27 +89,36 @@ class RefreshControls extends React.Component<Props, State> {
     RefreshActions.setInterval(interval);
   };
 
+  _buttonLabel = (refreshConfigEnabled, naturalInterval) => {
+    let buttonText = 'Not updating';
+    if (refreshConfigEnabled) {
+      buttonText = <React.Fragment>Update every {naturalInterval}</React.Fragment>;
+    }
+    return <ButtonLabel>{buttonText}</ButtonLabel>;
+  }
+
   render() {
+    const { refreshConfig } = this.props;
     const intervalOptions = RefreshControls.INTERVAL_OPTIONS.map(([label, interval]: [string, number]) => {
       return <MenuItem key={`RefreshControls-${label}`} onClick={() => this._onChange(interval)}>{label}</MenuItem>;
     });
-    const intervalDuration = moment.duration(this.props.refreshConfig.interval);
+    const intervalDuration = moment.duration(refreshConfig.interval);
     const naturalInterval = intervalDuration.asSeconds() < 60
       ? <span>{intervalDuration.asSeconds()} <Pluralize singular="second" plural="seconds" value={intervalDuration.asSeconds()} /></span>
       : <span>{intervalDuration.asMinutes()} <Pluralize singular="minute" plural="minutes" value={intervalDuration.asMinutes()} /></span>;
-    const buttonLabel = <span>Update every {naturalInterval}</span>;
+    const buttonLabel = this._buttonLabel(refreshConfig.enabled, naturalInterval);
     return (
-      <div className={`${styles.position} pull-right`}>
-        <ButtonGroup>
+      <ControlsContainer className="pull-right">
+        <FlexibleButtonGroup>
           <Button onClick={this._toggleEnable}>
-            {this.props.refreshConfig.enabled ? <i className="fa fa-pause" /> : <i className="fa fa-play" />}
+            {refreshConfig.enabled ? <i className="fa fa-pause" /> : <i className="fa fa-play" />}
           </Button>
 
-          <DropdownButton title={this.props.refreshConfig.enabled ? buttonLabel : 'Not updating'} id="refresh-options-dropdown">
+          <DropdownButton title={buttonLabel} id="refresh-options-dropdown">
             {intervalOptions}
           </DropdownButton>
-        </ButtonGroup>
-      </div>
+        </FlexibleButtonGroup>
+      </ControlsContainer>
     );
   }
 }

--- a/graylog2-web-interface/src/views/components/searchbar/StreamsFilter.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/StreamsFilter.jsx
@@ -5,9 +5,10 @@ import Select from 'components/common/Select';
 
 const StreamsFilter = ({ disabled, value, streams, onChange }) => {
   const selectedStreams = value.join(',');
+  const placeholder = 'Select streams the search should include. Searches in all streams if empty.';
   return (
-    <div style={{ position: 'relative', zIndex: 10 }} data-testid="streams-filter">
-      <Select placeholder="Select streams the search should include. Searches in all streams if empty."
+    <div style={{ position: 'relative', zIndex: 10 }} data-testid="streams-filter" title={placeholder}>
+      <Select placeholder={placeholder}
               disabled={disabled}
               displayKey="key"
               inputId="streams-filter"

--- a/graylog2-web-interface/src/views/components/searchbar/__snapshots__/RefreshControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/__snapshots__/RefreshControls.test.jsx.snap
@@ -2,10 +2,10 @@
 
 exports[`RefreshControls rendering it renders refresh controlls with enabled: false and interval: 1000 1`] = `
 <div
-  className="position pull-right"
+  className="pull-right RefreshControls__ControlsContainer-sc-1pygk8n-0 kShVuS"
 >
   <div
-    className="btn-group"
+    className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 etyOYS btn-group"
   >
     <button
       className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
@@ -31,7 +31,11 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: fa
         role="button"
         type="button"
       >
-        Not updating
+        <div
+          className="RefreshControls__ButtonLabel-sc-1pygk8n-2 jztvlP"
+        >
+          Not updating
+        </div>
          
         <span
           className="caret"
@@ -148,10 +152,10 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: fa
 
 exports[`RefreshControls rendering it renders refresh controlls with enabled: false and interval: 300000 1`] = `
 <div
-  className="position pull-right"
+  className="pull-right RefreshControls__ControlsContainer-sc-1pygk8n-0 kShVuS"
 >
   <div
-    className="btn-group"
+    className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 etyOYS btn-group"
   >
     <button
       className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
@@ -177,7 +181,11 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: fa
         role="button"
         type="button"
       >
-        Not updating
+        <div
+          className="RefreshControls__ButtonLabel-sc-1pygk8n-2 jztvlP"
+        >
+          Not updating
+        </div>
          
         <span
           className="caret"
@@ -294,10 +302,10 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: fa
 
 exports[`RefreshControls rendering it renders refresh controlls with enabled: true and interval: 1000 1`] = `
 <div
-  className="position pull-right"
+  className="pull-right RefreshControls__ControlsContainer-sc-1pygk8n-0 kShVuS"
 >
   <div
-    className="btn-group"
+    className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 etyOYS btn-group"
   >
     <button
       className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
@@ -323,7 +331,9 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
         role="button"
         type="button"
       >
-        <span>
+        <div
+          className="RefreshControls__ButtonLabel-sc-1pygk8n-2 jztvlP"
+        >
           Update every 
           <span>
             1
@@ -332,7 +342,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
               second
             </span>
           </span>
-        </span>
+        </div>
          
         <span
           className="caret"
@@ -449,10 +459,10 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
 
 exports[`RefreshControls rendering it renders refresh controlls with enabled: true and interval: 2000 1`] = `
 <div
-  className="position pull-right"
+  className="pull-right RefreshControls__ControlsContainer-sc-1pygk8n-0 kShVuS"
 >
   <div
-    className="btn-group"
+    className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 etyOYS btn-group"
   >
     <button
       className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
@@ -478,7 +488,9 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
         role="button"
         type="button"
       >
-        <span>
+        <div
+          className="RefreshControls__ButtonLabel-sc-1pygk8n-2 jztvlP"
+        >
           Update every 
           <span>
             2
@@ -487,7 +499,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
               seconds
             </span>
           </span>
-        </span>
+        </div>
          
         <span
           className="caret"
@@ -604,10 +616,10 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
 
 exports[`RefreshControls rendering it renders refresh controlls with enabled: true and interval: 5000 1`] = `
 <div
-  className="position pull-right"
+  className="pull-right RefreshControls__ControlsContainer-sc-1pygk8n-0 kShVuS"
 >
   <div
-    className="btn-group"
+    className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 etyOYS btn-group"
   >
     <button
       className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
@@ -633,7 +645,9 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
         role="button"
         type="button"
       >
-        <span>
+        <div
+          className="RefreshControls__ButtonLabel-sc-1pygk8n-2 jztvlP"
+        >
           Update every 
           <span>
             5
@@ -642,7 +656,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
               seconds
             </span>
           </span>
-        </span>
+        </div>
          
         <span
           className="caret"
@@ -759,10 +773,10 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
 
 exports[`RefreshControls rendering it renders refresh controlls with enabled: true and interval: 10000 1`] = `
 <div
-  className="position pull-right"
+  className="pull-right RefreshControls__ControlsContainer-sc-1pygk8n-0 kShVuS"
 >
   <div
-    className="btn-group"
+    className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 etyOYS btn-group"
   >
     <button
       className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
@@ -788,7 +802,9 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
         role="button"
         type="button"
       >
-        <span>
+        <div
+          className="RefreshControls__ButtonLabel-sc-1pygk8n-2 jztvlP"
+        >
           Update every 
           <span>
             10
@@ -797,7 +813,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
               seconds
             </span>
           </span>
-        </span>
+        </div>
          
         <span
           className="caret"
@@ -914,10 +930,10 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
 
 exports[`RefreshControls rendering it renders refresh controlls with enabled: true and interval: 30000 1`] = `
 <div
-  className="position pull-right"
+  className="pull-right RefreshControls__ControlsContainer-sc-1pygk8n-0 kShVuS"
 >
   <div
-    className="btn-group"
+    className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 etyOYS btn-group"
   >
     <button
       className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
@@ -943,7 +959,9 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
         role="button"
         type="button"
       >
-        <span>
+        <div
+          className="RefreshControls__ButtonLabel-sc-1pygk8n-2 jztvlP"
+        >
           Update every 
           <span>
             30
@@ -952,7 +970,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
               seconds
             </span>
           </span>
-        </span>
+        </div>
          
         <span
           className="caret"
@@ -1069,10 +1087,10 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
 
 exports[`RefreshControls rendering it renders refresh controlls with enabled: true and interval: 60000 1`] = `
 <div
-  className="position pull-right"
+  className="pull-right RefreshControls__ControlsContainer-sc-1pygk8n-0 kShVuS"
 >
   <div
-    className="btn-group"
+    className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 etyOYS btn-group"
   >
     <button
       className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
@@ -1098,7 +1116,9 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
         role="button"
         type="button"
       >
-        <span>
+        <div
+          className="RefreshControls__ButtonLabel-sc-1pygk8n-2 jztvlP"
+        >
           Update every 
           <span>
             1
@@ -1107,7 +1127,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
               minute
             </span>
           </span>
-        </span>
+        </div>
          
         <span
           className="caret"
@@ -1224,10 +1244,10 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
 
 exports[`RefreshControls rendering it renders refresh controlls with enabled: true and interval: 300000 1`] = `
 <div
-  className="position pull-right"
+  className="pull-right RefreshControls__ControlsContainer-sc-1pygk8n-0 kShVuS"
 >
   <div
-    className="btn-group"
+    className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 etyOYS btn-group"
   >
     <button
       className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
@@ -1253,7 +1273,9 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
         role="button"
         type="button"
       >
-        <span>
+        <div
+          className="RefreshControls__ButtonLabel-sc-1pygk8n-2 jztvlP"
+        >
           Update every 
           <span>
             5
@@ -1262,7 +1284,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
               minutes
             </span>
           </span>
-        </span>
+        </div>
          
         <span
           className="caret"

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.css
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.css
@@ -1,3 +1,0 @@
-:local(.position) {
-    margin-right: 15px;
-}

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.jsx
@@ -13,7 +13,6 @@ import ViewLoaderContext from 'views/logic/ViewLoaderContext';
 
 import BookmarkForm from './BookmarkForm';
 import BookmarkList from './BookmarkList';
-import styles from './BookmarkControls.css';
 
 type Props = {
   viewStoreState: ViewStoreState,
@@ -164,7 +163,7 @@ class BookmarkControls extends React.Component<Props, State> {
     );
 
     return (
-      <div className={`${styles.position} pull-right`}>
+      <div className="pull-right">
         <ButtonGroup>
           <React.Fragment>
             <Button disabled={disableReset} title="Empty search" onClick={() => ViewActions.create(View.Type.Search)}>

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkControls.test.jsx.snap
@@ -42,7 +42,7 @@ exports[`BookmarkControls render the BookmarkControls should render dirty 1`] = 
     }
   >
     <div
-      className="position pull-right"
+      className="pull-right"
     >
       <ButtonGroup
         block={false}
@@ -344,7 +344,7 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty 1`
     }
   >
     <div
-      className="position pull-right"
+      className="pull-right"
     >
       <ButtonGroup
         block={false}
@@ -646,7 +646,7 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty wi
     }
   >
     <div
-      className="position pull-right"
+      className="pull-right"
     >
       <ButtonGroup
         block={false}

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.css
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.css
@@ -8,7 +8,6 @@
 }
 
 .timerange-selector .relative {
-    font-size: 12px;
     color: #666;
 }
 
@@ -17,7 +16,7 @@
 }
 
 .extended-search-query-metadata {
-    margin-bottom: 7px !important;
+    margin-bottom: 10px !important;
 }
 
 .search-button-execute {


### PR DESCRIPTION
Initially I just wanted to add the RefreshControls to the dashboard searchbar. During the layout adjustment I couldn't resist and made the search and dashboard searchbar more responsive. 

To make the layout perfect I would have to rewrite a lot more things, but for now I fixed the general responsiveness and unified some component styles. I know the responsiveness is not that important in general, but I think it was worth the effort. I suspect it is a common scenario to have the search on one half of the screen and something else on the other.

## How Has This Been Tested?
Tested in Chrome, Safari and Firefox.

## Screenshots (if appropriate):
Before (on a very small screen to show most problems): 
![image](https://user-images.githubusercontent.com/46300478/67030370-92ba5800-f10f-11e9-833c-856057db31b8.png)

After:
![image](https://user-images.githubusercontent.com/46300478/67030392-9cdc5680-f10f-11e9-8836-34bcdabcb71b.png) 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
