### PR TITLE
Add bash script to execute linting in the same way the CI does

### DIFF
--- a/graylog2-web-interface/dev/lintChanges.sh
+++ b/graylog2-web-interface/dev/lintChanges.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# This script will run the lint command in the same way like the ci.
+# Right now the ci is running the lint command only for changes files.
+# You can run this script with `yarn lint:changes`.
+# It will give you an idea of the ci result, before pushing your changes.
+# You may need to set the correct permissions for this file by running `chmod +x ./dev/lintChanges.sh`
+
+git diff --name-only origin/master...|grep -E '^graylog2-web-interface/(.*).js(x)?$'|sed s,graylog2-web-interface/,,g|xargs yarn lint:path

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -19,6 +19,7 @@
     "build:analyze": "yarn build:stats && webpack-bundle-analyzer ./webpack/stats-$(git rev-parse --abbrev-ref HEAD).json ./target/web/build --mode=\"static\" --report=\"./webpack/analysis-$(git rev-parse --abbrev-ref HEAD).html\"",
     "lint": "eslint --ext js,jsx src",
     "lint:path": "eslint --ext js,jsx",
+    "lint:changes": "./dev/lintChanges.sh",
     "test": "jest",
     "check-production-build": "node checkProductionBuild.js"
   },


### PR DESCRIPTION
I just had the problem, that the linting for my PR fails because the CI is linting the all the changed files. I thought it is a good idea to have a yarn script for that. I think the CI script will not change in the near future

Possible cons:
- When the CI script changes, we need to adjust this script as well
- As far as I know you have to make the bash script executable by hand (I added a comment inside the script)
- There is maybe a better place than the dev dir. What do you think?


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Make development easier

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
