### PR TITLE
Add test/bin to .gitignore in graylog2-web-interface

### DIFF
--- a/graylog2-web-interface/.gitignore
+++ b/graylog2-web-interface/.gitignore
@@ -16,5 +16,7 @@ cache
 webpack/stats-*
 webpack/analysis-*
 
+test/bin
+
 # Generated frontend style guide
 docs/styleguide


### PR DESCRIPTION
Add `test/bin` to `graylog2-web-interface/.gitignore`

## Description
Added one line to .gitignore in order to ignore the autogenerated file `headless_shell`in there.

It works on my machine.&trade;  
