### PR TITLE
Set isNew flag to false when a new view is loaded

### DIFF
--- a/graylog2-web-interface/src/views/components/SearchBar.test.jsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.test.jsx
@@ -34,6 +34,11 @@ jest.mock('views/stores/ViewManagementStore', () => ({
         listen: jest.fn(),
       },
     },
+    get: {
+      completed: {
+        listen: jest.fn(),
+      },
+    },
   },
 }));
 jest.mock('views/components/searchbar/QueryInput', () => 'query-input');

--- a/graylog2-web-interface/src/views/stores/ViewStore.js
+++ b/graylog2-web-interface/src/views/stores/ViewStore.js
@@ -50,7 +50,6 @@ export const ViewActions: ViewActionsType = singletonActions(
     state: { asyncResult: true },
     summary: { asyncResult: true },
     title: { asyncResult: true },
-    setNew: { asyncResult: true },
   }),
 );
 
@@ -77,6 +76,10 @@ export const ViewStore: ViewStoreType = singletonStore(
         this._trigger();
       });
       ViewManagementActions.create.completed.listen(() => {
+        this.isNew = false;
+        this._trigger();
+      });
+      ViewManagementActions.get.completed.listen(() => {
         this.isNew = false;
         this._trigger();
       });
@@ -187,10 +190,6 @@ export const ViewStore: ViewStoreType = singletonStore(
     title(newTitle) {
       this.dirty = true;
       this.view = this.view.toBuilder().title(newTitle).build();
-      this._trigger();
-    },
-    setNew() {
-      this.isNew = true;
       this._trigger();
     },
     _updateSearch(view: View): [View, boolean] {


### PR DESCRIPTION
## Motivation and Context
Prior to this change, when a new view was loaded the ViewStore
could still have the isNew flag set to true.

## Description
This change will add a listener to the ViewManagementStore.
If the get action was completed then we have a not so new View
loaded.

Also remove unused setNew action.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
