### PR TITLE
Adjust query tab title editing

### DIFF
--- a/graylog2-web-interface/src/views/components/QueryBar.jsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.jsx
@@ -44,7 +44,7 @@ const QueryBar = ({ children, queries, queryTitles, router, viewMetadata }) => {
   const selectQueryAndExecute = queryId => onSelectQuery(queryId);
   return (
     <QueryTabs queries={queries}
-               selectedQuery={activeQuery}
+               selectedQueryId={activeQuery}
                titles={queryTitles}
                onSelect={selectQueryAndExecute}
                onTitleChange={onTitleChange}

--- a/graylog2-web-interface/src/views/components/QueryBar.jsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.jsx
@@ -1,7 +1,6 @@
 // @flow strict
 import React from 'react';
 import PropTypes from 'prop-types';
-// $FlowFixMe: imports from core need to be fixed in flow
 import { withRouter } from 'react-router';
 
 import connect from 'stores/connect';

--- a/graylog2-web-interface/src/views/components/QueryTabs.jsx
+++ b/graylog2-web-interface/src/views/components/QueryTabs.jsx
@@ -23,39 +23,24 @@ class QueryTabs extends React.Component {
     children: null,
   }
 
-  state = {
-    showTitleEditModal: false,
-    titleDraft: '',
+  openTitleEditModal = (activeQueryTitle) => {
+    if (this.queryTitleEditModal) {
+      this.queryTitleEditModal.open(activeQueryTitle);
+    }
   }
 
-  _toggleTitleEditModal = (currentTitle) => {
-    const { showTitleEditModal } = this.state;
-    // Toggle edit modal depending on current state
-    // We need to set the selected query title as the draft on open
-    // and reset the draft input on close
-    this.setState({
-      showTitleEditModal: !showTitleEditModal,
-      titleDraft: showTitleEditModal ? '' : currentTitle,
-    });
-  };
-
-  _onTitleDraftSave = () => {
-    const { titleDraft } = this.state;
-    const { onTitleChange, selectedQueryId } = this.props;
-    onTitleChange(selectedQueryId, titleDraft);
-    this._toggleTitleEditModal();
-  };
-
-  // eslint-disable-next-line no-undef
-  _onTitleDraftChange = (evt: SyntheticInputEvent<HTMLInputElement>) => {
-    evt.preventDefault();
-    evt.stopPropagation();
-    this.setState({ titleDraft: evt.target.value });
-  };
-
   render() {
-    const { children, onSelect, onRemove, queries, selectedQueryId, titles, onSaveView, onSaveAsView } = this.props;
-    const { showTitleEditModal, titleDraft } = this.state;
+    const {
+      children,
+      onRemove,
+      onSaveAsView,
+      onSaveView,
+      onSelect,
+      onTitleChange,
+      queries,
+      selectedQueryId,
+      titles,
+    } = this.props;
     const queryTitles = titles;
     const queryTabs = queries.map((id, index) => {
       const title = queryTitles.get(id, `Query#${index + 1}`);
@@ -63,8 +48,8 @@ class QueryTabs extends React.Component {
         <QueryTitle active={id === selectedQueryId}
                     id={id}
                     onClose={() => onRemove(id)}
-                    title={title}
-                    toggleEditModal={this._toggleTitleEditModal} />
+                    openEditModal={this.openTitleEditModal}
+                    title={title} />
       );
       return (
         <Tab eventKey={id}
@@ -95,11 +80,7 @@ class QueryTabs extends React.Component {
           due to the react bootstrap tabs keybindings.
           The input would always lose the focus when using the arrow keys.
         */}
-        <QueryTitleEditModal onDraftChange={this._onTitleDraftChange}
-                             onSave={this._onTitleDraftSave}
-                             show={showTitleEditModal}
-                             titleDraft={titleDraft}
-                             toggleModal={this._toggleTitleEditModal} />
+        <QueryTitleEditModal onTitleChange={onTitleChange} ref={(queryTitleEditModal) => { this.queryTitleEditModal = queryTitleEditModal; }} selectedQueryId={selectedQueryId} />
       </span>
     );
   }

--- a/graylog2-web-interface/src/views/components/QueryTabs.jsx
+++ b/graylog2-web-interface/src/views/components/QueryTabs.jsx
@@ -1,4 +1,6 @@
-import React from 'react';
+// @flow strict
+import * as React from 'react';
+import * as Immutable from 'immutable';
 import PropTypes from 'prop-types';
 
 import { Tab, Tabs } from 'components/graylog';
@@ -6,7 +8,25 @@ import ViewActionsMenu from 'views/components/ViewActionsMenu';
 import QueryTitle from 'views/components/queries/QueryTitle';
 import QueryTitleEditModal from 'views/components/queries/QueryTitleEditModal';
 
-class QueryTabs extends React.Component {
+import { QueryIdsStore } from 'views/stores/QueryIdsStore';
+import Query from 'views/logic/queries/Query';
+import type { TitlesMap } from 'views/stores/TitleTypes';
+import View from 'views/logic/views/View';
+import ViewState from 'views/logic/views/ViewState';
+
+type Props = {
+  children: React.Node,
+  onRemove: (queryId: string) => Promise<void> | Promise<ViewState>,
+  onSaveAsView: (view: View) => Promise<mixed>,
+  onSaveView: (View) => void,
+  onSelect: (queryId: string) => Promise<Query> | Promise<string>,
+  onTitleChange: (queryId: string, newTitle: string) => Promise<TitlesMap>,
+  queries: Array<QueryIdsStore>,
+  selectedQueryId: string,
+  titles: Immutable.Map<{[queryId: string]: string}>,
+}
+
+class QueryTabs extends React.Component<Props> {
   static propTypes = {
     children: PropTypes.node,
     onRemove: PropTypes.func.isRequired,
@@ -23,7 +43,9 @@ class QueryTabs extends React.Component {
     children: null,
   }
 
-  openTitleEditModal = (activeQueryTitle) => {
+  queryTitleEditModal: ?QueryTitleEditModal
+
+  openTitleEditModal = (activeQueryTitle: string) => {
     if (this.queryTitleEditModal) {
       this.queryTitleEditModal.open(activeQueryTitle);
     }

--- a/graylog2-web-interface/src/views/components/QueryTabs.jsx
+++ b/graylog2-web-interface/src/views/components/QueryTabs.jsx
@@ -17,7 +17,7 @@ import ViewState from 'views/logic/views/ViewState';
 type Props = {
   children: React.Node,
   onRemove: (queryId: string) => Promise<void> | Promise<ViewState>,
-  onSaveAsView: (view: View) => Promise<mixed>,
+  onSaveAsView: (view: View) => Promise<View>,
   onSaveView: (View) => void,
   onSelect: (queryId: string) => Promise<Query> | Promise<string>,
   onTitleChange: (queryId: string, newTitle: string) => Promise<TitlesMap>,

--- a/graylog2-web-interface/src/views/components/QueryTabs.jsx
+++ b/graylog2-web-interface/src/views/components/QueryTabs.jsx
@@ -4,61 +4,105 @@ import PropTypes from 'prop-types';
 import { Tab, Tabs } from 'components/graylog';
 import ViewActionsMenu from 'views/components/ViewActionsMenu';
 import QueryTitle from 'views/components/queries/QueryTitle';
+import QueryTitleEditModal from 'views/components/queries/QueryTitleEditModal';
 
-const QueryTabs = ({ children, onSelect, onRemove, onTitleChange, queries, selectedQuery, titles, onSaveView, onSaveAsView }) => {
-  const queryTitles = titles;
-  const queryTabs = queries.map((id, index) => {
-    const title = queryTitles.get(id, `Query#${index + 1}`);
-    const tabTitle = (
-      <QueryTitle value={title}
-                  id={id}
-                  active={id === selectedQuery}
-                  onChange={newTitle => onTitleChange(id, newTitle)}
-                  onClose={() => onRemove(id)} />
-    );
+class QueryTabs extends React.Component {
+  static propTypes = {
+    children: PropTypes.node,
+    onRemove: PropTypes.func.isRequired,
+    onSaveAsView: PropTypes.func.isRequired,
+    onSaveView: PropTypes.func.isRequired,
+    onSelect: PropTypes.func.isRequired,
+    onTitleChange: PropTypes.func.isRequired,
+    queries: PropTypes.object.isRequired,
+    selectedQueryId: PropTypes.string.isRequired,
+    titles: PropTypes.object.isRequired,
+  }
+
+  static defaultProps = {
+    children: null,
+  }
+
+  state = {
+    showTitleEditModal: false,
+    titleDraft: '',
+  }
+
+  _toggleTitleEditModal = (currentTitle) => {
+    const { showTitleEditModal } = this.state;
+    // Toggle edit modal depending on current state
+    // We need to set the selected query title as the draft on open
+    // and reset the draft input on close
+    this.setState({
+      showTitleEditModal: !showTitleEditModal,
+      titleDraft: showTitleEditModal ? '' : currentTitle,
+    });
+  };
+
+  _onTitleDraftSave = () => {
+    const { titleDraft } = this.state;
+    const { onTitleChange, selectedQueryId } = this.props;
+    onTitleChange(selectedQueryId, titleDraft);
+    this._toggleTitleEditModal();
+  };
+
+  // eslint-disable-next-line no-undef
+  _onTitleDraftChange = (evt: SyntheticInputEvent<HTMLInputElement>) => {
+    evt.preventDefault();
+    evt.stopPropagation();
+    this.setState({ titleDraft: evt.target.value });
+  };
+
+  render() {
+    const { children, onSelect, onRemove, queries, selectedQueryId, titles, onSaveView, onSaveAsView } = this.props;
+    const { showTitleEditModal, titleDraft } = this.state;
+    const queryTitles = titles;
+    const queryTabs = queries.map((id, index) => {
+      const title = queryTitles.get(id, `Query#${index + 1}`);
+      const tabTitle = (
+        <QueryTitle active={id === selectedQueryId}
+                    id={id}
+                    onClose={() => onRemove(id)}
+                    title={title}
+                    toggleEditModal={this._toggleTitleEditModal} />
+      );
+      return (
+        <Tab eventKey={id}
+             key={id}
+             mountOnEnter
+             title={tabTitle}
+             unmountOnExit>
+          {children}
+        </Tab>
+      );
+    });
+    const newTab = <Tab key="new" eventKey="new" title="+" />;
+    const tabs = [queryTabs, newTab];
+
     return (
-      <Tab key={id}
-           eventKey={id}
-           title={tabTitle}
-           mountOnEnter
-           unmountOnExit>
-        {children}
-      </Tab>
-    );
-  });
-  const newTab = <Tab key="new" eventKey="new" title="+" />;
-
-  const tabs = [queryTabs, newTab];
-
-  return (
-    <span>
-      <span className="pull-right">
-        <ViewActionsMenu onSaveView={onSaveView} onSaveAsView={onSaveAsView} />
+      <span>
+        <span className="pull-right">
+          <ViewActionsMenu onSaveView={onSaveView} onSaveAsView={onSaveAsView} />
+        </span>
+        <Tabs activeKey={selectedQueryId}
+              animation={false}
+              id="QueryTabs"
+              onSelect={onSelect}>
+          {tabs}
+        </Tabs>
+        {/*
+          The title edit modal can't be part of the QueryTitle component,
+          due to the react bootstrap tabs keybindings.
+          The input would always lose the focus when using the arrow keys.
+        */}
+        <QueryTitleEditModal onDraftChange={this._onTitleDraftChange}
+                             onSave={this._onTitleDraftSave}
+                             show={showTitleEditModal}
+                             titleDraft={titleDraft}
+                             toggleModal={this._toggleTitleEditModal} />
       </span>
-      <Tabs id="QueryTabs"
-            activeKey={selectedQuery}
-            animation={false}
-            onSelect={onSelect}>
-        {tabs}
-      </Tabs>
-    </span>
-  );
-};
-
-QueryTabs.propTypes = {
-  children: PropTypes.node,
-  onSaveView: PropTypes.func.isRequired,
-  onSaveAsView: PropTypes.func.isRequired,
-  onSelect: PropTypes.func.isRequired,
-  onRemove: PropTypes.func.isRequired,
-  onTitleChange: PropTypes.func.isRequired,
-  queries: PropTypes.object.isRequired,
-  selectedQuery: PropTypes.string.isRequired,
-  titles: PropTypes.object.isRequired,
-};
-
-QueryTabs.defaultProps = {
-  children: null,
-};
+    );
+  }
+}
 
 export default QueryTabs;

--- a/graylog2-web-interface/src/views/components/QueryTabs.jsx
+++ b/graylog2-web-interface/src/views/components/QueryTabs.jsx
@@ -102,7 +102,8 @@ class QueryTabs extends React.Component<Props> {
           due to the react bootstrap tabs keybindings.
           The input would always lose the focus when using the arrow keys.
         */}
-        <QueryTitleEditModal onTitleChange={onTitleChange} ref={(queryTitleEditModal) => { this.queryTitleEditModal = queryTitleEditModal; }} selectedQueryId={selectedQueryId} />
+        <QueryTitleEditModal onTitleChange={(newTitle: string) => onTitleChange(selectedQueryId, newTitle)}
+                             ref={(queryTitleEditModal) => { this.queryTitleEditModal = queryTitleEditModal; }} />
       </span>
     );
   }

--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.jsx
@@ -12,59 +12,36 @@ import QueryActionDropdown from './QueryActionDropdown';
 type Props = {
   active: boolean,
   id: QueryId,
-  onChange: (string) => void,
   onClose: () => void,
-  value: string,
+  title: string,
+  toggleEditModal: (string) => void
 };
 
 type State = {
   editing: boolean,
-  value: string,
+  title: string,
 };
 
 class QueryTitle extends React.Component<Props, State> {
   static propTypes = {
-    onChange: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
-    value: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    toggleEditModal: PropTypes.func.isRequired,
   };
 
   state = {
     editing: false,
     // eslint-disable-next-line react/destructuring-assignment
-    value: this.props.value,
+    title: this.props.title,
   };
 
   componentWillReceiveProps(nextProps: Props) {
-    this.setState({ value: nextProps.value });
+    this.setState({ title: nextProps.title });
   }
-
-  _toggleEditing = () => {
-    this.setState(state => ({ editing: !state.editing }));
-  };
-
-  // eslint-disable-next-line no-undef
-  _onChange = (evt: SyntheticInputEvent<HTMLInputElement>) => {
-    evt.preventDefault();
-    evt.stopPropagation();
-    this.setState({ value: evt.target.value });
-  };
 
   _onClose = () => {
     const { onClose } = this.props;
     onClose();
-  };
-
-  _onSubmit = () => {
-    const { value } = this.state;
-    if (value !== '') {
-      const { onChange } = this.props;
-      onChange(value);
-    } else {
-      // eslint-disable-next-line react/destructuring-assignment
-      this.setState({ value: this.props.value });
-    }
-    this.setState({ editing: false });
   };
 
   _onDuplicate = (id: QueryId) => {
@@ -73,27 +50,15 @@ class QueryTitle extends React.Component<Props, State> {
   };
 
   render() {
-    const { editing, value } = this.state;
-    const { active, id } = this.props;
-    const valueField = editing ? (
-      <form onSubmit={this._onSubmit}>
-        <input type="text"
-               value={value}
-               onFocus={e => e.target.select()}
-               onBlur={this._toggleEditing}
-               onChange={this._onChange} />
-      </form>
-    ) : (
-      <span onDoubleClick={this._toggleEditing}>
-        {value}
-      </span>
-    );
+    const { editing, title } = this.state;
+    const { active, id, toggleEditModal } = this.props;
     return (
       <span>
-        {valueField}{' '}
+        {title}
         {!editing && active && (
           <QueryActionDropdown>
             <MenuItem onSelect={() => this._onDuplicate(id)}>Duplicate</MenuItem>
+            <MenuItem onSelect={() => toggleEditModal(title)}>Edit Title</MenuItem>
             <MenuItem divider />
             <MenuItem onSelect={this._onClose}>Close</MenuItem>
           </QueryActionDropdown>

--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.jsx
@@ -6,13 +6,14 @@ import { MenuItem } from 'components/graylog';
 import { QueriesActions } from 'views/stores/QueriesStore';
 import { ViewActions } from 'views/stores/ViewStore';
 import type { QueryId } from 'views/logic/queries/Query';
+import ViewState from 'views/logic/views/ViewState';
 
 import QueryActionDropdown from './QueryActionDropdown';
 
 type Props = {
   active: boolean,
   id: QueryId,
-  onClose: () => void,
+  onClose: () => Promise<void> | Promise<ViewState>,
   openEditModal: (string) => void,
   title: string,
 };

--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.jsx
@@ -13,8 +13,8 @@ type Props = {
   active: boolean,
   id: QueryId,
   onClose: () => void,
+  openEditModal: (string) => void,
   title: string,
-  toggleEditModal: (string) => void
 };
 
 type State = {
@@ -26,7 +26,7 @@ class QueryTitle extends React.Component<Props, State> {
   static propTypes = {
     onClose: PropTypes.func.isRequired,
     title: PropTypes.string.isRequired,
-    toggleEditModal: PropTypes.func.isRequired,
+    openEditModal: PropTypes.func.isRequired,
   };
 
   state = {
@@ -51,14 +51,14 @@ class QueryTitle extends React.Component<Props, State> {
 
   render() {
     const { editing, title } = this.state;
-    const { active, id, toggleEditModal } = this.props;
+    const { active, id, openEditModal } = this.props;
     return (
       <span>
         {title}
         {!editing && active && (
           <QueryActionDropdown>
             <MenuItem onSelect={() => this._onDuplicate(id)}>Duplicate</MenuItem>
-            <MenuItem onSelect={() => toggleEditModal(title)}>Edit Title</MenuItem>
+            <MenuItem onSelect={() => openEditModal(title)}>Edit Title</MenuItem>
             <MenuItem divider />
             <MenuItem onSelect={this._onClose}>Close</MenuItem>
           </QueryActionDropdown>

--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.jsx
@@ -54,7 +54,7 @@ class QueryTitle extends React.Component<Props, State> {
     const { editing, title } = this.state;
     const { active, id, openEditModal } = this.props;
     return (
-      <span>
+      <span title={title}>
         {title}
         {!editing && active && (
           <QueryActionDropdown>

--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.test.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.test.jsx
@@ -17,21 +17,22 @@ describe('QueryTitle', () => {
     QueriesActions.duplicate = mockAction(jest.fn(() => Promise.resolve(Query.builder().newId().build())));
     ViewActions.selectQuery = mockAction(jest.fn(queryId => Promise.resolve(queryId)));
   });
-  describe('duplicate action', () => {
-    const findAction = (wrapper, name) => {
-      const openMenuTrigger = wrapper.find('i[data-testid="query-action-dropdown"]');
-      openMenuTrigger.simulate('click');
 
-      wrapper.update();
-      const { onSelect } = wrapper.find(`MenuItem[children="${name}"]`).props();
-      return () => new Promise((resolve) => {
-        onSelect(undefined, { preventDefault: jest.fn(), stopPropagation: jest.fn() });
-        setImmediate(() => {
-          resolve();
-        });
+  const findAction = (wrapper, name) => {
+    const openMenuTrigger = wrapper.find('i[data-testid="query-action-dropdown"]');
+    openMenuTrigger.simulate('click');
+
+    wrapper.update();
+    const { onSelect } = wrapper.find(`MenuItem[children="${name}"]`).props();
+    return () => new Promise((resolve) => {
+      onSelect(undefined, { preventDefault: jest.fn(), stopPropagation: jest.fn() });
+      setImmediate(() => {
+        resolve();
       });
-    };
+    });
+  };
 
+  describe('duplicate action', () => {
     it('triggers duplication of query', () => {
       const wrapper = mount(
         <QueryTitle active
@@ -47,6 +48,7 @@ describe('QueryTitle', () => {
         expect(QueriesActions.duplicate).toHaveBeenCalled();
       });
     });
+
     it('selects new query after duplicating it', () => {
       const wrapper = mount(
         <QueryTitle active
@@ -61,6 +63,25 @@ describe('QueryTitle', () => {
       return duplicate().then(() => {
         expect(ViewActions.selectQuery).toHaveBeenCalled();
         expect(asMock(ViewActions.selectQuery).mock.calls[0][0]).not.toBeNull();
+      });
+    });
+  });
+
+  describe('edit title action', () => {
+    it('opens edit modal', () => {
+      const openEditModalFn = jest.fn();
+      const wrapper = mount(
+        <QueryTitle active
+                    id="deadbeef"
+                    openEditModal={openEditModalFn}
+                    onChange={() => {}}
+                    onClose={() => Promise.resolve()}
+                    title="Foo" />,
+      );
+      const clickOnEditOption = findAction(wrapper, 'Edit Title');
+
+      return clickOnEditOption().then(() => {
+        expect(openEditModalFn).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.test.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.test.jsx
@@ -33,7 +33,14 @@ describe('QueryTitle', () => {
     };
 
     it('triggers duplication of query', () => {
-      const wrapper = mount(<QueryTitle active id="deadbeef" onChange={() => {}} onClose={() => {}} value="Foo" />);
+      const wrapper = mount(
+        <QueryTitle active
+                    id="deadbeef"
+                    openEditModal={() => {}}
+                    onChange={() => {}}
+                    onClose={() => Promise.resolve()}
+                    title="Foo" />,
+      );
       const duplicate = findAction(wrapper, 'Duplicate');
 
       return duplicate().then(() => {
@@ -41,7 +48,14 @@ describe('QueryTitle', () => {
       });
     });
     it('selects new query after duplicating it', () => {
-      const wrapper = mount(<QueryTitle active id="deadbeef" onChange={() => {}} onClose={() => {}} value="Foo" />);
+      const wrapper = mount(
+        <QueryTitle active
+                    id="deadbeef"
+                    openEditModal={() => {}}
+                    onChange={() => {}}
+                    onClose={() => Promise.resolve()}
+                    title="Foo" />,
+      );
       const duplicate = findAction(wrapper, 'Duplicate');
 
       return duplicate().then(() => {
@@ -49,32 +63,5 @@ describe('QueryTitle', () => {
         expect(asMock(ViewActions.selectQuery).mock.calls[0][0]).not.toBeNull();
       });
     });
-  });
-  it('double clicking the query title opens input', () => {
-    const wrapper = mount(<QueryTitle active id="deadbeef" onChange={() => {}} onClose={() => {}} value="Foo" />);
-    expect(wrapper.find('input[value="Foo"]')).not.toExist();
-    const title = wrapper.find('span[children="Foo"]');
-
-    title.simulate('doubleClick');
-    wrapper.update();
-
-    expect(wrapper.find('input[value="Foo"]')).toExist();
-  });
-  it('double clicking the query title and changing the name triggers change event', () => {
-    const onChange = jest.fn();
-    const wrapper = mount(<QueryTitle active id="deadbeef" onChange={onChange} onClose={() => {}} value="Foo" />);
-    const title = wrapper.find('span[children="Foo"]');
-
-    title.simulate('doubleClick');
-    wrapper.update();
-
-    const input = wrapper.find('input[value="Foo"]');
-
-    input.simulate('change', { target: { value: 'Bar' } });
-
-    const form = wrapper.find('form');
-    form.simulate('submit');
-
-    expect(onChange).toHaveBeenCalledWith('Bar');
   });
 });

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
@@ -66,7 +66,7 @@ class QueryTitleEditModal extends React.Component<Props, State> {
     return (
       <Modal show={show} bsSize="large" onHide={this._close}>
         <Modal.Header closeButton>
-          <Modal.Title>Edit query title</Modal.Title>
+          <Modal.Title>Editing query title</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <Input autoFocus

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
@@ -7,7 +7,16 @@ import Input from 'components/bootstrap/Input';
 
 import type { TitlesMap } from 'views/stores/TitleTypes';
 
+/**
+ * Component that allows the user to update a QueryTab title.
+ * It takes the active query title as an argument on open and will use it as the draft.
+ * The open action is getting called outside by referencing this component.
+ * The state of this modal can't be handled inside the QueryTitle, due to the react bootstrap tabs keybindings.
+ * E.g. using the arrow keys inside the title input would result in losing the focus.
+ */
+
 type Props = {
+  /** Function to update the query tab tite on save */
   onTitleChange: (newTitle: string) => Promise<TitlesMap>,
 }
 

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
@@ -11,7 +11,7 @@ import type { TitlesMap } from 'views/stores/TitleTypes';
  * Component that allows the user to update a QueryTab title.
  * It takes the active query title as an argument on open and will use it as the draft.
  * The open action is getting called outside by referencing this component.
- * The state of this modal can't be handled inside the QueryTitle, due to the react bootstrap tabs keybindings.
+ * The state of this modal can't be handled inside the QueryTitle, due to the react bootstrap tabs key bindings.
  * E.g. using the arrow keys inside the title input would result in losing the focus.
  */
 

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
@@ -11,12 +11,9 @@ import type { TitlesMap } from 'views/stores/TitleTypes';
  * Component that allows the user to update a QueryTab title.
  * It takes the active query title as an argument on open and will use it as the draft.
  * The open action is getting called outside by referencing this component.
- * The state of this modal can't be handled inside the QueryTitle, due to the react bootstrap tabs key bindings.
- * E.g. using the arrow keys inside the title input would result in losing the focus.
  */
 
 type Props = {
-  /** Function to update the query tab tite on save */
   onTitleChange: (newTitle: string) => Promise<TitlesMap>,
 }
 

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
@@ -20,7 +20,7 @@ type State = {
 class QueryTitleEditModal extends React.Component<Props, State> {
   static propTypes = {
     onTitleChange: PropTypes.func.isRequired,
-    selectedQueryId: PropTypes.number.isRequired,
+    selectedQueryId: PropTypes.string.isRequired,
   };
 
   state = {
@@ -35,7 +35,7 @@ class QueryTitleEditModal extends React.Component<Props, State> {
     });
   }
 
-  close = () => {
+  _close = () => {
     this.setState({
       show: false,
       titleDraft: '',
@@ -46,7 +46,7 @@ class QueryTitleEditModal extends React.Component<Props, State> {
     const { titleDraft } = this.state;
     const { onTitleChange, selectedQueryId } = this.props;
     onTitleChange(selectedQueryId, titleDraft);
-    this.close();
+    this._close();
   };
 
   // eslint-disable-next-line no-undef
@@ -57,7 +57,7 @@ class QueryTitleEditModal extends React.Component<Props, State> {
   render() {
     const { show, titleDraft } = this.state;
     return (
-      <Modal show={show} bsSize="large" onHide={this.close}>
+      <Modal show={show} bsSize="large" onHide={this._close}>
         <Modal.Header closeButton>
           <Modal.Title>Edit query title</Modal.Title>
         </Modal.Header>
@@ -74,7 +74,7 @@ class QueryTitleEditModal extends React.Component<Props, State> {
         </Modal.Body>
         <Modal.Footer>
           <Button onClick={this._onDraftSave} bsStyle="success">Save</Button>
-          <Button onClick={this.close}>Cancel</Button>
+          <Button onClick={this._close}>Cancel</Button>
         </Modal.Footer>
       </Modal>
     );

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
@@ -62,6 +62,7 @@ class QueryTitleEditModal extends React.Component<Props, State> {
         <Modal.Body>
           <Input autoFocus
                  help="The title of the query tab."
+                 id="title"
                  label="Title"
                  name="title"
                  onChange={this._onDraftChange}

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
@@ -4,35 +4,68 @@ import PropTypes from 'prop-types';
 import { Modal, Button } from 'components/graylog';
 import Input from 'components/bootstrap/Input';
 
-const QueryTitleEditModal = ({ show, toggleModal, onDraftChange, titleDraft, onSave }) => (
-  <Modal show={show} bsSize="large" onHide={toggleModal}>
-    <Modal.Header closeButton>
-      <Modal.Title>Edit query title</Modal.Title>
-    </Modal.Header>
-    <Modal.Body>
-      <Input autoFocus
-             help="The title of the query tab."
-             id="title"
-             label="Title"
-             name="title"
-             onChange={onDraftChange}
-             required
-             type="text"
-             value={titleDraft} />
-    </Modal.Body>
-    <Modal.Footer>
-      <Button onClick={onSave} bsStyle="success">Save</Button>
-      <Button onClick={toggleModal}>Cancel</Button>
-    </Modal.Footer>
-  </Modal>
-);
+class QueryTitleEditModal extends React.Component {
+  state = {
+    show: false,
+    titleDraft: '',
+  };
+
+  open = (activeQueryTitle) => {
+    this.setState({
+      show: true,
+      titleDraft: activeQueryTitle,
+    });
+  }
+
+  close = () => {
+    this.setState({
+      show: false,
+      titleDraft: '',
+    });
+  }
+
+  _onDraftSave = () => {
+    const { titleDraft } = this.state;
+    const { onTitleChange, selectedQueryId } = this.props;
+    onTitleChange(selectedQueryId, titleDraft);
+    this.close();
+  };
+
+  // eslint-disable-next-line no-undef
+  _onDraftChange = (evt: SyntheticInputEvent<HTMLInputElement>) => {
+    this.setState({ titleDraft: evt.target.value });
+  };
+
+  render() {
+    const { show, titleDraft } = this.state;
+    return (
+      <Modal show={show} bsSize="large" onHide={this.toggleModal}>
+        <Modal.Header closeButton>
+          <Modal.Title>Edit query title</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Input autoFocus
+                 help="The title of the query tab."
+                 id="title"
+                 label="Title"
+                 name="title"
+                 onChange={this._onDraftChange}
+                 required
+                 type="text"
+                 value={titleDraft} />
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={this._onDraftSave} bsStyle="success">Save</Button>
+          <Button onClick={this.toggleModal}>Cancel</Button>
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+}
 
 QueryTitleEditModal.propTypes = {
-  show: PropTypes.bool.isRequired,
-  toggleModal: PropTypes.func.isRequired,
-  onDraftChange: PropTypes.func.isRequired,
-  onSave: PropTypes.func.isRequired,
-  titleDraft: PropTypes.func.isRequired,
+  onTitleChange: PropTypes.func.isRequired,
+  selectedQueryId: PropTypes.number.isRequired,
 };
 
 export default QueryTitleEditModal;

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
@@ -69,7 +69,7 @@ class QueryTitleEditModal extends React.Component<Props, State> {
         </Modal.Header>
         <Modal.Body>
           <Input autoFocus
-                 help="The title of the query tab."
+                 help="The title of the query tab. It has a maximum length of 40 characters."
                  id="title"
                  label="Title"
                  name="title"

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
@@ -73,6 +73,7 @@ class QueryTitleEditModal extends React.Component<Props, State> {
                  name="title"
                  onChange={this._onDraftChange}
                  required
+                 maxLength={40}
                  type="text"
                  value={titleDraft} />
         </Modal.Body>

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
@@ -1,16 +1,34 @@
+// @flow strict
 import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Modal, Button } from 'components/graylog';
 import Input from 'components/bootstrap/Input';
 
-class QueryTitleEditModal extends React.Component {
+import type { TitlesMap } from 'views/stores/TitleTypes';
+
+type Props = {
+  onTitleChange: (queryId: string, newTitle: string) => Promise<TitlesMap>,
+  selectedQueryId: string,
+}
+
+type State = {
+  show: boolean,
+  titleDraft: string,
+}
+
+class QueryTitleEditModal extends React.Component<Props, State> {
+  static propTypes = {
+    onTitleChange: PropTypes.func.isRequired,
+    selectedQueryId: PropTypes.number.isRequired,
+  };
+
   state = {
     show: false,
     titleDraft: '',
   };
 
-  open = (activeQueryTitle) => {
+  open = (activeQueryTitle: string) => {
     this.setState({
       show: true,
       titleDraft: activeQueryTitle,
@@ -39,7 +57,7 @@ class QueryTitleEditModal extends React.Component {
   render() {
     const { show, titleDraft } = this.state;
     return (
-      <Modal show={show} bsSize="large" onHide={this.toggleModal}>
+      <Modal show={show} bsSize="large" onHide={this.close}>
         <Modal.Header closeButton>
           <Modal.Title>Edit query title</Modal.Title>
         </Modal.Header>
@@ -56,16 +74,11 @@ class QueryTitleEditModal extends React.Component {
         </Modal.Body>
         <Modal.Footer>
           <Button onClick={this._onDraftSave} bsStyle="success">Save</Button>
-          <Button onClick={this.toggleModal}>Cancel</Button>
+          <Button onClick={this.close}>Cancel</Button>
         </Modal.Footer>
       </Modal>
     );
   }
 }
-
-QueryTitleEditModal.propTypes = {
-  onTitleChange: PropTypes.func.isRequired,
-  selectedQueryId: PropTypes.number.isRequired,
-};
 
 export default QueryTitleEditModal;

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
@@ -8,8 +8,7 @@ import Input from 'components/bootstrap/Input';
 import type { TitlesMap } from 'views/stores/TitleTypes';
 
 type Props = {
-  onTitleChange: (queryId: string, newTitle: string) => Promise<TitlesMap>,
-  selectedQueryId: string,
+  onTitleChange: (newTitle: string) => Promise<TitlesMap>,
 }
 
 type State = {
@@ -20,7 +19,6 @@ type State = {
 class QueryTitleEditModal extends React.Component<Props, State> {
   static propTypes = {
     onTitleChange: PropTypes.func.isRequired,
-    selectedQueryId: PropTypes.string.isRequired,
   };
 
   state = {
@@ -44,8 +42,8 @@ class QueryTitleEditModal extends React.Component<Props, State> {
 
   _onDraftSave = () => {
     const { titleDraft } = this.state;
-    const { onTitleChange, selectedQueryId } = this.props;
-    onTitleChange(selectedQueryId, titleDraft);
+    const { onTitleChange } = this.props;
+    onTitleChange(titleDraft);
     this._close();
   };
 
@@ -64,7 +62,6 @@ class QueryTitleEditModal extends React.Component<Props, State> {
         <Modal.Body>
           <Input autoFocus
                  help="The title of the query tab."
-                 id="title"
                  label="Title"
                  name="title"
                  onChange={this._onDraftChange}

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
@@ -49,8 +49,10 @@ class QueryTitleEditModal extends React.Component<Props, State> {
   _onDraftSave = () => {
     const { titleDraft } = this.state;
     const { onTitleChange } = this.props;
-    onTitleChange(titleDraft);
-    this._close();
+    if (titleDraft !== '') {
+      onTitleChange(titleDraft);
+      this._close();
+    }
   };
 
   // eslint-disable-next-line no-undef
@@ -72,7 +74,6 @@ class QueryTitleEditModal extends React.Component<Props, State> {
                  label="Title"
                  name="title"
                  onChange={this._onDraftChange}
-                 required
                  maxLength={40}
                  type="text"
                  value={titleDraft} />

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Modal, Button } from 'components/graylog';
+import Input from 'components/bootstrap/Input';
+
+const QueryTitleEditModal = ({ show, toggleModal, onDraftChange, titleDraft, onSave }) => (
+  <Modal show={show} bsSize="large" onHide={toggleModal}>
+    <Modal.Header closeButton>
+      <Modal.Title>Edit query title</Modal.Title>
+    </Modal.Header>
+    <Modal.Body>
+      <Input autoFocus
+             help="The title of the query tab."
+             id="title"
+             label="Title"
+             name="title"
+             onChange={onDraftChange}
+             required
+             type="text"
+             value={titleDraft} />
+    </Modal.Body>
+    <Modal.Footer>
+      <Button onClick={onSave} bsStyle="success">Save</Button>
+      <Button onClick={toggleModal}>Cancel</Button>
+    </Modal.Footer>
+  </Modal>
+);
+
+QueryTitleEditModal.propTypes = {
+  show: PropTypes.bool.isRequired,
+  toggleModal: PropTypes.func.isRequired,
+  onDraftChange: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
+  titleDraft: PropTypes.func.isRequired,
+};
+
+export default QueryTitleEditModal;

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.jsx
@@ -19,8 +19,7 @@ describe('QueryTitleEditModal', () => {
     let modalRef;
     const { queryByText } = render(
       <QueryTitleEditModal ref={(ref) => { modalRef = ref; }}
-                           onTitleChange={() => Promise.resolve()}
-                           selectedQueryId="selected-query-id" />,
+                           onTitleChange={() => Promise.resolve()} />,
     );
     // Modal should not be visible initially
     expect(queryByText('Edit query title')).toBeNull();
@@ -33,8 +32,7 @@ describe('QueryTitleEditModal', () => {
     let modalRef;
     const { getByDisplayValue } = render(
       <QueryTitleEditModal ref={(ref) => { modalRef = ref; }}
-                           onTitleChange={() => Promise.resolve()}
-                           selectedQueryId="selected-query-id" />,
+                           onTitleChange={() => Promise.resolve()} />,
     );
     openModal(modalRef);
     expect(getByDisplayValue('CurrentTitle')).not.toBeNull();
@@ -45,8 +43,7 @@ describe('QueryTitleEditModal', () => {
     const onTitleChangeFn = jest.fn();
     const { getByDisplayValue, getByText } = render(
       <QueryTitleEditModal ref={(ref) => { modalRef = ref; }}
-                           onTitleChange={onTitleChangeFn}
-                           selectedQueryId="selected-query-id" />,
+                           onTitleChange={onTitleChangeFn} />,
     );
     openModal(modalRef);
     const titleInput = getByDisplayValue('CurrentTitle');
@@ -54,7 +51,7 @@ describe('QueryTitleEditModal', () => {
     fireEvent.change(titleInput, { target: { value: 'NewTitle' } });
     fireEvent.click(saveButton);
     expect(onTitleChangeFn).toHaveBeenCalledTimes(1);
-    expect(onTitleChangeFn).toHaveBeenCalledWith('selected-query-id', 'NewTitle');
+    expect(onTitleChangeFn).toHaveBeenCalledWith('NewTitle');
     // TODO: Fix this test case, right now the modal is still visible
     // // Modal should not be visible anymore
     // expect(queryByText('Edit query title')).toBeNull();
@@ -66,8 +63,7 @@ describe('QueryTitleEditModal', () => {
   //     const onTitleChangeFn = jest.fn();
   //     const { getByText, queryByText } = render(
   //       <QueryTitleEditModal ref={(ref) => { modalRef = ref; }}
-  //                            onTitleChange={onTitleChangeFn}
-  //                            selectedQueryId="selected-query-id" />,
+  //                            onTitleChange={onTitleChangeFn} />,
   //     );
   //     openModal(modalRef);
   //     // Modal should be visible

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.jsx
@@ -9,7 +9,7 @@ jest.mock('views/stores/ViewStore', () => ({ ViewActions: {} }));
 
 describe('QueryTitleEditModal', () => {
   afterEach(cleanup);
-  const modalHeadline = 'Edit query title';
+  const modalHeadline = 'Editing query title';
   const openModal = (modalRef, currentTitle = 'CurrentTitle') => {
     if (modalRef) {
       modalRef.open(currentTitle);

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.jsx
@@ -1,6 +1,6 @@
 // @flow strict
 import * as React from 'react';
-import { render, cleanup, fireEvent } from '@testing-library/react';
+import { render, cleanup, fireEvent, wait } from '@testing-library/react';
 
 import QueryTitleEditModal from './QueryTitleEditModal';
 
@@ -9,6 +9,7 @@ jest.mock('views/stores/ViewStore', () => ({ ViewActions: {} }));
 
 describe('QueryTitleEditModal', () => {
   afterEach(cleanup);
+  const modalHeadline = 'Edit query title';
   const openModal = (modalRef, currentTitle = 'CurrentTitle') => {
     if (modalRef) {
       modalRef.open(currentTitle);
@@ -22,10 +23,10 @@ describe('QueryTitleEditModal', () => {
                            onTitleChange={() => Promise.resolve()} />,
     );
     // Modal should not be visible initially
-    expect(queryByText('Edit query title')).toBeNull();
+    expect(queryByText(modalHeadline)).toBeNull();
     openModal(modalRef);
     // Modal should be visible
-    expect(queryByText('Edit query title')).not.toBeNull();
+    expect(queryByText(modalHeadline)).not.toBeNull();
   });
 
   it('has correct initial input value', () => {
@@ -38,10 +39,10 @@ describe('QueryTitleEditModal', () => {
     expect(getByDisplayValue('CurrentTitle')).not.toBeNull();
   });
 
-  it('updates query title and closes', () => {
+  it('updates query title and closes', async () => {
     let modalRef;
     const onTitleChangeFn = jest.fn();
-    const { getByDisplayValue, getByText } = render(
+    const { getByDisplayValue, getByText, queryByText } = render(
       <QueryTitleEditModal ref={(ref) => { modalRef = ref; }}
                            onTitleChange={onTitleChangeFn} />,
     );
@@ -52,26 +53,27 @@ describe('QueryTitleEditModal', () => {
     fireEvent.click(saveButton);
     expect(onTitleChangeFn).toHaveBeenCalledTimes(1);
     expect(onTitleChangeFn).toHaveBeenCalledWith('NewTitle');
-    // TODO: Fix this test case, right now the modal is still visible
-    // // Modal should not be visible anymore
-    // expect(queryByText('Edit query title')).toBeNull();
+    // Modal should not be visible anymore
+    await wait(() => {
+      expect(queryByText(modalHeadline)).toBeNull();
+    });
   });
 
-  // TODO: Fix this test case
-  //   it('closes on click on cancel', async () => {
-  //     let modalRef;
-  //     const onTitleChangeFn = jest.fn();
-  //     const { getByText, queryByText } = render(
-  //       <QueryTitleEditModal ref={(ref) => { modalRef = ref; }}
-  //                            onTitleChange={onTitleChangeFn} />,
-  //     );
-  //     openModal(modalRef);
-  //     // Modal should be visible
-  //     expect(queryByText('Edit query title')).not.toBeNull();
-  //     // Modal should not be visible after click on cancel
-  //     const canselButton = getByText('Cancel');
-  //     fireEvent.click(canselButton);
-  //     await wait();
-  //     expect(queryByText('Edit query title')).toBeNull();
-  //   });
+  it('closes on click on cancel', async () => {
+    let modalRef;
+    const onTitleChangeFn = jest.fn();
+    const { getByText, queryByText } = render(
+      <QueryTitleEditModal ref={(ref) => { modalRef = ref; }}
+                           onTitleChange={onTitleChangeFn} />,
+    );
+    openModal(modalRef);
+    // Modal should be visible
+    expect(queryByText(modalHeadline)).not.toBeNull();
+    // Modal should not be visible after click on cancel
+    const canselButton = getByText('Cancel');
+    fireEvent.click(canselButton);
+    await wait(() => {
+      expect(queryByText(modalHeadline)).toBeNull();
+    });
+  });
 });

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.jsx
@@ -70,8 +70,8 @@ describe('QueryTitleEditModal', () => {
     // Modal should be visible
     expect(queryByText(modalHeadline)).not.toBeNull();
     // Modal should not be visible after click on cancel
-    const canselButton = getByText('Cancel');
-    fireEvent.click(canselButton);
+    const cancelButton = getByText('Cancel');
+    fireEvent.click(cancelButton);
     await wait(() => {
       expect(queryByText(modalHeadline)).toBeNull();
     });

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.jsx
@@ -1,0 +1,81 @@
+// @flow strict
+import * as React from 'react';
+import { render, cleanup, fireEvent } from '@testing-library/react';
+
+import QueryTitleEditModal from './QueryTitleEditModal';
+
+jest.mock('views/stores/QueriesStore', () => ({ QueriesActions: {} }));
+jest.mock('views/stores/ViewStore', () => ({ ViewActions: {} }));
+
+describe('QueryTitleEditModal', () => {
+  afterEach(cleanup);
+  const openModal = (modalRef, currentTitle = 'CurrentTitle') => {
+    if (modalRef) {
+      modalRef.open(currentTitle);
+    }
+  };
+
+  it('shows after triggering open action', () => {
+    let modalRef;
+    const { queryByText } = render(
+      <QueryTitleEditModal ref={(ref) => { modalRef = ref; }}
+                           onTitleChange={() => Promise.resolve()}
+                           selectedQueryId="selected-query-id" />,
+    );
+    // Modal should not be visible initially
+    expect(queryByText('Edit query title')).toBeNull();
+    openModal(modalRef);
+    // Modal should be visible
+    expect(queryByText('Edit query title')).not.toBeNull();
+  });
+
+  it('has correct initial input value', () => {
+    let modalRef;
+    const { getByDisplayValue } = render(
+      <QueryTitleEditModal ref={(ref) => { modalRef = ref; }}
+                           onTitleChange={() => Promise.resolve()}
+                           selectedQueryId="selected-query-id" />,
+    );
+    openModal(modalRef);
+    expect(getByDisplayValue('CurrentTitle')).not.toBeNull();
+  });
+
+  it('updates query title and closes', () => {
+    let modalRef;
+    const onTitleChangeFn = jest.fn();
+    const { getByDisplayValue, getByText } = render(
+      <QueryTitleEditModal ref={(ref) => { modalRef = ref; }}
+                           onTitleChange={onTitleChangeFn}
+                           selectedQueryId="selected-query-id" />,
+    );
+    openModal(modalRef);
+    const titleInput = getByDisplayValue('CurrentTitle');
+    const saveButton = getByText('Save');
+    fireEvent.change(titleInput, { target: { value: 'NewTitle' } });
+    fireEvent.click(saveButton);
+    expect(onTitleChangeFn).toHaveBeenCalledTimes(1);
+    expect(onTitleChangeFn).toHaveBeenCalledWith('selected-query-id', 'NewTitle');
+    // TODO: Fix this test case, right now the modal is still visible
+    // // Modal should not be visible anymore
+    // expect(queryByText('Edit query title')).toBeNull();
+  });
+
+  // TODO: Fix this test case
+  //   it('closes on click on cancel', async () => {
+  //     let modalRef;
+  //     const onTitleChangeFn = jest.fn();
+  //     const { getByText, queryByText } = render(
+  //       <QueryTitleEditModal ref={(ref) => { modalRef = ref; }}
+  //                            onTitleChange={onTitleChangeFn}
+  //                            selectedQueryId="selected-query-id" />,
+  //     );
+  //     openModal(modalRef);
+  //     // Modal should be visible
+  //     expect(queryByText('Edit query title')).not.toBeNull();
+  //     // Modal should not be visible after click on cancel
+  //     const canselButton = getByText('Cancel');
+  //     fireEvent.click(canselButton);
+  //     await wait();
+  //     expect(queryByText('Edit query title')).toBeNull();
+  //   });
+});

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.css
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.css
@@ -33,6 +33,16 @@
     color: #333;
 }
 
+#QueryTabs .nav-tabs li.active a .fa {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    margin-left: 6px;
+    cursor: pointer;
+}
+
 #QueryTabs .nav-tabs li a:hover {
     border: 1px solid transparent;
     color: #000;


### PR DESCRIPTION
This PR changes the way we edit a query tab title. Right now we have to double click on the current query tab title to edit it inline. There are two problems: 
- The user will may not see this option
- The react bootstrap key bindings are causing a strange behaviour when using e.g the arrow keys. The input loses the focus, a new tab will be created, the focus is still on another, not active, tab.

The new way is just another entry in the query tab context menu "Edit Title". Clicking on this entry will open a model containing the title input.

I did some refactoring of the QueryTitle and QueryTabs component in this PR (like adding flow strict). I hope you can still get an overview of the changes.


## How Has This Been Tested?
Added tests for all changes / new functionality

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
