### PR TITLE
Simplify implementation of isNew

### DIFF
--- a/graylog2-web-interface/src/views/stores/ViewStore.js
+++ b/graylog2-web-interface/src/views/stores/ViewStore.js
@@ -76,10 +76,6 @@ export const ViewStore: ViewStoreType = singletonStore(
         this.dirty = false;
         this._trigger();
       });
-      ViewManagementActions.create.completed.listen(() => {
-        this.isNew = false;
-        this._trigger();
-      });
     },
 
     getInitialState(): ViewStoreState {
@@ -144,6 +140,7 @@ export const ViewStore: ViewStoreType = singletonStore(
       const firstQueryId = get(queries.first(), 'id');
       const selectedQuery = this.activeQuery && queries.find(q => (q.id === this.activeQuery)) ? this.activeQuery : firstQueryId;
       this.selectQuery(selectedQuery);
+      this.isNew = false;
 
       const promise = Promise.resolve(this._state());
       ViewActions.load.promise(promise);
@@ -187,10 +184,6 @@ export const ViewStore: ViewStoreType = singletonStore(
     title(newTitle) {
       this.dirty = true;
       this.view = this.view.toBuilder().title(newTitle).build();
-      this._trigger();
-    },
-    setNew() {
-      this.isNew = true;
       this._trigger();
     },
     _updateSearch(view: View): [View, boolean] {

--- a/graylog2-web-interface/src/views/stores/ViewStore.test.js
+++ b/graylog2-web-interface/src/views/stores/ViewStore.test.js
@@ -32,6 +32,8 @@ describe('ViewStore', () => {
   const dummyView = View.builder().search(dummySearch).build();
   it('.load should select first query if activeQuery is not set', () => ViewActions.load(dummyView)
     .then(state => expect(state.activeQuery).toBe('firstQueryId')));
+  it('.load should set isNew to false', () => ViewActions.load(dummyView)
+    .then(state => expect(state.isNew).toBeFalsy()));
   it('.load should select activeQuery if it is set and present in view', () => ViewActions.selectQuery('secondQueryId')
     .then(() => ViewActions.load(dummyView))
     .then(state => expect(state.activeQuery).toBe('secondQueryId')));
@@ -60,6 +62,10 @@ describe('ViewStore', () => {
     it('sets dirty flag to false when creating a view', () => {
       return ViewActions.create(View.Type.Dashboard)
         .then(({ dirty }) => expect(dirty).toBeFalsy());
+    });
+    it('sets isNew flag to true when creating a view', () => {
+      return ViewActions.create(View.Type.Dashboard)
+        .then(({ isNew }) => expect(isNew).toBeTruthy());
     });
   });
 


### PR DESCRIPTION
## Motivation and Context
Prior to this change, the ViewStore needed a listener to the create
completed action and did not update the isNew flag when changing from
a new view to a loaded.

## Description
This change will remove the listener and implement the setting of isNew
in `load` and `create` actions.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
