### PR TITLE
Support MaxMind ASN geo ip database

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/map/config/DatabaseType.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/map/config/DatabaseType.java
@@ -17,5 +17,5 @@
 package org.graylog.plugins.map.config;
 
 public enum DatabaseType {
-    MAXMIND_CITY, MAXMIND_COUNTRY
+    MAXMIND_ASN, MAXMIND_CITY, MAXMIND_COUNTRY
 }

--- a/graylog2-web-interface/src/components/maps/adapter/MaxmindAdapterDocumentation.jsx
+++ b/graylog2-web-interface/src/components/maps/adapter/MaxmindAdapterDocumentation.jsx
@@ -34,17 +34,26 @@ class MaxmindAdapterDocumentation extends React.Component {
     }
 }`;
 
+    const asnFields = `{
+    "as_number": 15169,
+    "as_organization": "Google LLC"
+}`;
+
     return (
       <div>
         <p>The GeoIP data adapter supports reading MaxMind's GeoIP2 databases.</p>
 
         <Alert style={{ marginBottom: 10 }} bsStyle="info">
           <h4 style={{ marginBottom: 10 }}>Limitations</h4>
-          <p>Currently the city and country databases are supported.</p>
+          <p>Currently the ASN, city and country databases are supported.</p>
           <p>For support of additional database types, please visit our support channels.</p>
         </Alert>
 
         <hr />
+
+        <h3 style={{ marginBottom: 10 }}>ASN database fields</h3>
+
+        <pre>{asnFields}</pre>
 
         <h3 style={{ marginBottom: 10 }}>Country database fields</h3>
 

--- a/graylog2-web-interface/src/components/maps/adapter/MaxmindAdapterFieldSet.jsx
+++ b/graylog2-web-interface/src/components/maps/adapter/MaxmindAdapterFieldSet.jsx
@@ -34,6 +34,7 @@ class MaxmindAdapterFieldSet extends React.Component {
   render() {
     const { config } = this.props;
     const databaseTypes = [
+      { label: 'ASN database', value: 'MAXMIND_ASN' },
       { label: 'City database', value: 'MAXMIND_CITY' },
       { label: 'Country database', value: 'MAXMIND_COUNTRY' },
     ];

--- a/graylog2-web-interface/src/components/maps/adapter/MaxmindAdapterSummary.jsx
+++ b/graylog2-web-interface/src/components/maps/adapter/MaxmindAdapterSummary.jsx
@@ -10,6 +10,7 @@ class MaxmindAdapterSummary extends React.Component {
   render() {
     const { config } = this.props.dataAdapter;
     const databaseTypes = {
+      MAXMIND_ASN: 'ASN database',
       MAXMIND_CITY: 'City database',
       MAXMIND_COUNTRY: 'Country database',
     };


### PR DESCRIPTION
## Description
Add support for GeoIP2 ASN databases.

## Motivation and Context
Currently Graylog only supports the GeoIP2 city and country databases, but adding ASN support is a simple matter of calling the right method and mapping the fields.
Some users have requested supporting ASN data as well.

## How Has This Been Tested?
There is a basic unit test, which requires placing a suitable GeoIP2 database into the test resources directory (not included in source tree, because of size and license issues).
Grab the databases here: https://dev.maxmind.com/geoip/geoip2/geolite2/ and put the `.mmdb` file directly into `graylog2-server/src/test/resources` for running the tests.

Additionally sanity checks in the UI have been done:
 * creating an ASN data adapter
 * looking up various well-known addresses and cross checking their ASN and organization name
 * looking up private IP addresses, which always result in "empty" lookups

## Screenshots (if appropriate):

n/a

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
