### PR TITLE
Deduplicating query/search type errors before returning them.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/JestUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/JestUtils.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 
 public class JestUtils {
@@ -95,7 +96,11 @@ public class JestUtils {
             return new ElasticsearchException(errorMessage.get(), Collections.singletonList(errorNode.toString()));
         }
 
-        return new ElasticsearchException(errorMessage.get(), reasons);
+        return new ElasticsearchException(errorMessage.get(), deduplicateErrors(reasons));
+    }
+
+    public static List<String> deduplicateErrors(List<String> errors) {
+        return errors.stream().distinct().collect(Collectors.toList());
     }
 
     private static FieldTypeException buildFieldTypeException(Supplier<String> errorMessage, String reason) {

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendErrorHandlingTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendErrorHandlingTest.java
@@ -1,0 +1,162 @@
+package org.graylog.plugins.views.search.elasticsearch;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.searchbox.client.JestClient;
+import io.searchbox.core.MultiSearchResult;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.QueryResult;
+import org.graylog.plugins.views.search.Search;
+import org.graylog.plugins.views.search.SearchJob;
+import org.graylog.plugins.views.search.SearchType;
+import org.graylog.plugins.views.search.elasticsearch.searchtypes.ESSearchTypeHandler;
+import org.graylog.plugins.views.search.errors.SearchError;
+import org.graylog2.indexer.ElasticsearchException;
+import org.graylog2.indexer.ranges.IndexRangeService;
+import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.graylog2.streams.StreamService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ElasticsearchBackendErrorHandlingTest extends ElasticsearchBackendTestBase {
+    @Rule
+    public MockitoRule rule = MockitoJUnit.rule();
+
+    @Mock
+    private JestClient jestClient;
+
+    @Mock
+    private IndexRangeService indexRangeService;
+
+    @Mock
+    private StreamService streamService;
+
+    @Mock
+    private MultiSearchResult result;
+
+    private ElasticsearchBackend backend;
+    private SearchJob searchJob;
+    private Query query;
+    private ESGeneratedQueryContext queryContext;
+
+    static abstract class DummyHandler implements ESSearchTypeHandler<SearchType> {}
+
+    @Before
+    public void setUp() throws Exception {
+        this.backend = new ElasticsearchBackend(
+                ImmutableMap.of(
+                        "dummy", () -> mock(DummyHandler.class)
+                ),
+                new QueryStringParser(),
+                jestClient,
+                indexRangeService,
+                streamService,
+                new ESQueryDecorators(Collections.emptySet())
+        );
+        when(streamService.loadByIds(any())).thenReturn(Collections.emptySet());
+
+        final SearchType searchType1 = mock(SearchType.class);
+        when(searchType1.id()).thenReturn("deadbeef");
+        when(searchType1.type()).thenReturn("dummy");
+        final SearchType searchType2 = mock(SearchType.class);
+        when(searchType2.id()).thenReturn("cafeaffe");
+        when(searchType2.type()).thenReturn("dummy");
+
+        final Set<SearchType> searchTypes = ImmutableSet.of(searchType1, searchType2);
+        this.query = Query.builder()
+                .id("query1")
+                .timerange(RelativeRange.create(300))
+                .query(ElasticsearchQueryString.builder().queryString("*").build())
+                .searchTypes(searchTypes)
+                .build();
+        final Search search = Search.builder()
+                .id("search1")
+                .queries(ImmutableSet.of(query))
+                .build();
+
+        this.searchJob = new SearchJob("job1", search, "admin");
+
+        this.queryContext = new ESGeneratedQueryContext(
+                this.backend,
+                new SearchSourceBuilder(),
+                searchJob,
+                query,
+                Collections.emptySet()
+        );
+
+        searchTypes.forEach(queryContext::searchSourceBuilder);
+
+        when(jestClient.execute(any())).thenReturn(result);
+    }
+
+    @Test
+    public void deduplicatesShardErrorsOnQueryLevel() throws IOException {
+        when(result.isSucceeded()).thenReturn(false);
+        final JsonNode resultObject = objectMapper
+                .readTree(resourceFile("errorhandling/failureOnQueryLevel.json"));
+        when(result.getJsonObject()).thenReturn(resultObject);
+
+        try {
+            this.backend.doRun(searchJob, query, queryContext, Collections.emptySet());
+        } catch (ElasticsearchException e) {
+            assertThat(e.getErrorDetails()).hasSize(1);
+            assertThat(e.getErrorDetails()).containsExactly("Something went wrong");
+        }
+    }
+
+    @Test
+    public void deduplicateShardErrorsOnSearchTypeLevel() throws IOException {
+        final MultiSearchResult multiSearchResult = searchResultFromFixture("errorhandling/failureOnSearchTypeLevel.json");
+        when(jestClient.execute(any())).thenReturn(multiSearchResult);
+
+        final QueryResult queryResult = this.backend.doRun(searchJob, query, queryContext, Collections.emptySet());
+
+        final Set<SearchError> errors = queryResult.errors();
+
+        assertThat(errors).isNotNull();
+        assertThat(errors).hasSize(1);
+        assertThat(errors.stream().map(SearchError::description).collect(Collectors.toList()))
+                .containsExactly("Unable to perform search query: \n\nFailed to parse query [[].");
+    }
+
+    @Test
+    public void deduplicateNumericShardErrorsOnSearchTypeLevel() throws IOException {
+        final MultiSearchResult multiSearchResult = searchResultFromFixture("errorhandling/numericFailureOnSearchTypeLevel.json");
+        when(jestClient.execute(any())).thenReturn(multiSearchResult);
+
+        final QueryResult queryResult = this.backend.doRun(searchJob, query, queryContext, Collections.emptySet());
+
+        final Set<SearchError> errors = queryResult.errors();
+
+        assertThat(errors).isNotNull();
+        assertThat(errors).hasSize(1);
+        assertThat(errors.stream().map(SearchError::description).collect(Collectors.toList()))
+                .containsExactly("Unable to perform search query: \n\nExpected numeric type on field [facility], but got [keyword].");
+    }
+
+    private MultiSearchResult searchResultFromFixture(String filename) throws IOException {
+        final JsonNode resultObject = objectMapper
+                .readTree(resourceFile(filename));
+        final MultiSearchResult multiSearchResult = new MultiSearchResult(objectMapper);
+        multiSearchResult.setJsonObject(resultObject);
+        multiSearchResult.setSucceeded(true);
+
+        return multiSearchResult;
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendErrorHandlingTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendErrorHandlingTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.views.search.elasticsearch;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendErrorHandlingTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendErrorHandlingTest.java
@@ -46,6 +46,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -128,12 +129,12 @@ public class ElasticsearchBackendErrorHandlingTest extends ElasticsearchBackendT
                 .readTree(resourceFile("errorhandling/failureOnQueryLevel.json"));
         when(result.getJsonObject()).thenReturn(resultObject);
 
-        try {
-            this.backend.doRun(searchJob, query, queryContext, Collections.emptySet());
-        } catch (ElasticsearchException e) {
-            assertThat(e.getErrorDetails()).hasSize(1);
-            assertThat(e.getErrorDetails()).containsExactly("Something went wrong");
-        }
+        assertThatExceptionOfType(ElasticsearchException.class)
+                .isThrownBy(() -> this.backend.doRun(searchJob, query, queryContext, Collections.emptySet()))
+                .satisfies(ex -> {
+                    assertThat(ex.getErrorDetails()).hasSize(1);
+                    assertThat(ex.getErrorDetails()).containsExactly("Something went wrong");
+                });
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendMultiSearchTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendMultiSearchTest.java
@@ -131,7 +131,7 @@ public class ElasticsearchBackendMultiSearchTest extends ElasticsearchBackendGen
         assertThat(queryResult.errors()).hasSize(1);
         final SearchTypeError searchTypeError = (SearchTypeError) new ArrayList<>(queryResult.errors()).get(0);
         assertThat(searchTypeError.description()).isEqualTo(
-                "Unable to perform search query\n" +
+                "Unable to perform search query: \n" +
                         "\n" +
                         "Expected numeric type on field [field1], but got [keyword]."
         );

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendTestBase.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendTestBase.java
@@ -40,6 +40,7 @@ import java.util.stream.IntStream;
 
 abstract class ElasticsearchBackendTestBase {
     static final ObjectMapperProvider objectMapperProvider = new ObjectMapperProvider();
+    static final ObjectMapper objectMapper = objectMapperProvider.get();
 
     MultiSearchResult resultFor(String result) {
         final ObjectMapper objectMapper = objectMapperProvider.get();
@@ -65,7 +66,6 @@ abstract class ElasticsearchBackendTestBase {
     }
 
     List<String> indicesOf(MultiSearch clientRequest) throws IOException {
-        final ObjectMapper objectMapper = objectMapperProvider.get();
         final String request = clientRequest.getData(objectMapper);
         final String[] lines = request.split("\\r?\\n");
         final int noOfHeaders = lines.length / 2;

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/search/elasticsearch/errorhandling/failureOnQueryLevel.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/search/elasticsearch/errorhandling/failureOnQueryLevel.json
@@ -1,0 +1,18 @@
+{
+  "error": {
+    "root_cause": [
+      {
+        "type": "generic",
+        "reason": "Something went wrong"
+      },
+      {
+        "type": "generic",
+        "reason": "Something went wrong"
+      },
+      {
+        "type": "generic",
+        "reason": "Something went wrong"
+      }
+    ]
+  }
+}

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/search/elasticsearch/errorhandling/failureOnSearchTypeLevel.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/search/elasticsearch/errorhandling/failureOnSearchTypeLevel.json
@@ -1,0 +1,94 @@
+{
+  "responses": [
+    {
+      "took": 8,
+      "timed_out": false,
+      "_shards": {
+        "total": 20,
+        "successful": 20,
+        "skipped": 0,
+        "failed": 0
+      },
+      "hits": {
+        "total": 33,
+        "max_score": 0,
+        "hits": []
+      },
+      "aggregations": {
+        "timestamp-min": {
+          "value": 1571733480000,
+          "value_as_string": "2019-10-22 08:38:00.000"
+        },
+        "timestamp-max": {
+          "value": 1571733775000,
+          "value_as_string": "2019-10-22 08:42:55.000"
+        }
+      },
+      "status": 200
+    },
+    {
+      "took": 3,
+      "timed_out": false,
+      "_shards": {
+        "total": 20,
+        "successful": 14,
+        "skipped": 0,
+        "failed": 6,
+        "failures": [
+          {
+            "shard": 0,
+            "index": "graylog_1",
+            "node": "Mc1oQWuEQom5uQyCljDEGA",
+            "reason": {
+              "type": "query_shard_exception",
+              "reason": "Failed to parse query [[]",
+              "index_uuid": "pN_PP-0aTx2XE_wtCNnUgg",
+              "index": "graylog_1",
+              "caused_by": {
+                "type": "parse_exception",
+                "reason": "Cannot parse '[': Encountered \"<EOF>\" at line 1, column 1.\nWas expecting one of:\n    \"TO\" ...\n    <RANGE_QUOTED> ...\n    <RANGE_GOOP> ...\n    ",
+                "caused_by": {
+                  "type": "parse_exception",
+                  "reason": "Encountered \"<EOF>\" at line 1, column 1.\nWas expecting one of:\n    \"TO\" ...\n    <RANGE_QUOTED> ...\n    <RANGE_GOOP> ...\n    "
+                }
+              }
+            }
+          },
+          {
+            "shard": 0,
+            "index": "graylog_8",
+            "node": "Mc1oQWuEQom5uQyCljDEGA",
+            "reason": {
+              "type": "query_shard_exception",
+              "reason": "Failed to parse query [[]",
+              "index_uuid": "4shnjqLeS5imL69NrEtCEg",
+              "index": "graylog_8",
+              "caused_by": {
+                "type": "parse_exception",
+                "reason": "Cannot parse '[': Encountered \"<EOF>\" at line 1, column 1.\nWas expecting one of:\n    \"TO\" ...\n    <RANGE_QUOTED> ...\n    <RANGE_GOOP> ...\n    ",
+                "caused_by": {
+                  "type": "parse_exception",
+                  "reason": "Encountered \"<EOF>\" at line 1, column 1.\nWas expecting one of:\n    \"TO\" ...\n    <RANGE_QUOTED> ...\n    <RANGE_GOOP> ...\n    "
+                }
+              }
+            }
+          }
+        ]
+      },
+      "hits": {
+        "total": 0,
+        "max_score": 0,
+        "hits": []
+      },
+      "aggregations": {
+        "timestamp-min": {
+          "value": null
+        },
+        "timestamp-max": {
+          "value": null
+        }
+      },
+      "status": 200
+    }
+  ]
+}

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/search/elasticsearch/errorhandling/numericFailureOnSearchTypeLevel.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/search/elasticsearch/errorhandling/numericFailureOnSearchTypeLevel.json
@@ -1,0 +1,88 @@
+{
+  "responses": [
+    {
+      "took": 7,
+      "timed_out": false,
+      "_shards": {
+        "total": 20,
+        "successful": 8,
+        "skipped": 0,
+        "failed": 12,
+        "failures": [
+          {
+            "shard": 0,
+            "index": "dns_0",
+            "node": "Mc1oQWuEQom5uQyCljDEGA",
+            "reason": {
+              "type": "illegal_argument_exception",
+              "reason": "Expected numeric type on field [facility], but got [keyword]"
+            }
+          },
+          {
+            "shard": 0,
+            "index": "graylog_1",
+            "node": "Mc1oQWuEQom5uQyCljDEGA",
+            "reason": {
+              "type": "illegal_argument_exception",
+              "reason": "Expected numeric type on field [facility], but got [keyword]"
+            }
+          },
+          {
+            "shard": 0,
+            "index": "graylog_8",
+            "node": "Mc1oQWuEQom5uQyCljDEGA",
+            "reason": {
+              "type": "illegal_argument_exception",
+              "reason": "Expected numeric type on field [facility], but got [keyword]"
+            }
+          }
+        ]
+      },
+      "hits": {
+        "total": 0,
+        "max_score": 0,
+        "hits": []
+      },
+      "aggregations": {
+        "timestamp-min": {
+          "value": null
+        },
+        "timestamp-max": {
+          "value": null
+        },
+        "dea2c9df-029a-430e-a9c4-4746b635bb11-series-percentile(facility)": {
+          "values": {
+            "90.0": "NaN"
+          }
+        }
+      },
+      "status": 200
+    },
+    {
+      "took": 7,
+      "timed_out": false,
+      "_shards": {
+        "total": 20,
+        "successful": 20,
+        "skipped": 0,
+        "failed": 0
+      },
+      "hits": {
+        "total": 105,
+        "max_score": 0,
+        "hits": []
+      },
+      "aggregations": {
+        "timestamp-min": {
+          "value": 1571735854000,
+          "value_as_string": "2019-10-22 09:17:34.000"
+        },
+        "timestamp-max": {
+          "value": 1571736121000,
+          "value_as_string": "2019-10-22 09:22:01.000"
+        }
+      },
+      "status": 200
+    }
+  ]
+}


### PR DESCRIPTION
## Description
## Motivation and Context
Before this change, errors returned from the execution of a `Search` on
a query or search type level were returned as is from ES to the API
consumer, leading to repeating each error for every index it occurs on.

This change is deduplicating errors by only returning distinct
descriptions to the caller.

## Screenshots (if appropriate):

In the frontend this leads to better readable errors, changing from:

![Screen Shot 2019-10-22 at 09 39 09](https://user-images.githubusercontent.com/41929/67274261-5c3e5d80-f4c0-11e9-8ec3-21d90eaf3ce2.png)

to:

![Screen Shot 2019-10-22 at 11 39 17](https://user-images.githubusercontent.com/41929/67274391-a0316280-f4c0-11e9-8c6c-5299990b5367.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.