### PR TITLE
Change url after loading a bookmarked search

### DIFF
--- a/graylog2-web-interface/src/views/Constants.js
+++ b/graylog2-web-interface/src/views/Constants.js
@@ -13,9 +13,11 @@ export const DEFAULT_HIGHLIGHT_COLOR = '#ffec3d';
 export const DEFAULT_CUSTOM_HIGHLIGHT_RANGE = chroma.scale(['lightyellow', 'lightgreen', 'lightblue', 'red']).mode('lch').colors(40);
 
 export const dashboardsPath = '/dashboards';
-export const newDashboardsPath = '/dashboards/new';
-export const dashboardsTvPath = '/dashboards/tv/:viewId';
-export const extendedSearchPath = '/extendedsearch';
 export const viewsPath = '/views';
+export const searchPath = '/search';
+export const newDashboardsPath = `${dashboardsPath}/new`;
+export const dashboardsTvPath = `${dashboardsPath}/tv/:viewId`;
+export const extendedSearchPath = '/extendedsearch';
+export const showSearchPath = `${searchPath}/:viewId`
 export const showViewsPath = `${viewsPath}/:viewId`;
 export const showDashboardsPath = `${dashboardsPath}/:viewId`;

--- a/graylog2-web-interface/src/views/Constants.js
+++ b/graylog2-web-interface/src/views/Constants.js
@@ -18,6 +18,6 @@ export const searchPath = '/search';
 export const newDashboardsPath = `${dashboardsPath}/new`;
 export const dashboardsTvPath = `${dashboardsPath}/tv/:viewId`;
 export const extendedSearchPath = '/extendedsearch';
-export const showSearchPath = `${searchPath}/:viewId`
+export const showSearchPath = `${searchPath}/:viewId`;
 export const showViewsPath = `${viewsPath}/:viewId`;
 export const showDashboardsPath = `${dashboardsPath}/:viewId`;

--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -65,6 +65,7 @@ import {
   newDashboardsPath,
   showDashboardsPath,
   showViewsPath,
+  showSearchPath,
   viewsPath,
 } from 'views/Constants';
 import NewDashboardPage from 'views/pages/NewDashboardPage';
@@ -89,6 +90,7 @@ const enableNewSearch = AppConfig.isFeatureEnabled('search_3_2');
 const searchRoutes = enableNewSearch
   ? [
     { path: newDashboardsPath, component: NewDashboardPage, parentComponent: AppWithExtendedSearchBar },
+    { path: showSearchPath, component: ShowViewPage, parentComponent: AppWithExtendedSearchBar },
     { path: dashboardsTvPath, component: ShowDashboardInBigDisplayMode, parentComponent: null },
     { path: Routes.stream_search(':streamId'), component: StreamSearchPage, parentComponent: AppWithExtendedSearchBar },
     { path: dashboardsPath, component: DashboardsPage },

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.jsx
@@ -123,10 +123,17 @@ class BookmarkControls extends React.Component<Props, State> {
     this.toggleListModal();
   };
 
-  deleteBookmark = (view) => {
-    return ViewManagementActions.delete(view)
-      .then(() => UserNotification.success(`Deleting view "${view.title}" was successful!`, 'Success!'))
+  deleteBookmark = (deletedView) => {
+    const { viewStoreState } = this.props;
+    const { view } = viewStoreState;
+    return ViewManagementActions.delete(deletedView)
+      .then(() => UserNotification.success(`Deleting view "${deletedView.title}" was successful!`, 'Success!'))
       .then(() => ViewActions.create(View.Type.Search))
+      .then(() => {
+        if (deletedView.id === view.id) {
+          browserHistory.push(Routes.SEARCH);
+        }
+      })
       .catch(error => UserNotification.error(`Deleting view failed: ${this._extractErrorMessage(error)}`, 'Error!'));
   };
 

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { browserHistory } from 'react-router';
 
+import Routes from 'routing/Routes';
 import { newDashboardsPath } from 'views/Constants';
 import { Button, ButtonGroup } from 'components/graylog';
 import { Icon } from 'components/common';
@@ -109,7 +110,9 @@ class BookmarkControls extends React.Component<Props, State> {
     ViewManagementActions.create(newView)
       .then((createdView) => {
         const loaderFunc = this.context;
-        loaderFunc(createdView.id);
+        loaderFunc(createdView.id).then(() => {
+          browserHistory.push(Routes.pluginRoute('SEARCH_VIEWID')(createdView.id));
+        });
       })
       .then(this.toggleFormModal)
       .then(() => UserNotification.success(`Saving view "${newView.title}" was successful!`, 'Success!'))
@@ -185,7 +188,11 @@ class BookmarkControls extends React.Component<Props, State> {
                     onClick={this.loadAsDashboard}>
               <Icon name="dashboard" />
             </Button>
-            <Button disabled={disableReset} title="Empty search" onClick={() => ViewActions.create(View.Type.Search)}>
+            <Button disabled={disableReset}
+                    title="Empty search"
+                    onClick={() => {
+                      browserHistory.push(Routes.SEARCH);
+                    }}>
               <Icon name="eraser" />
             </Button>
             <Button title={title} ref={(elem) => { this.formTarget = elem; }} onClick={this.toggleFormModal}>

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.test.jsx
@@ -1,20 +1,21 @@
 // @flow strict
 import React from 'react';
 import { mount } from 'enzyme';
+import { browserHistory } from 'react-router';
 
 import View from 'views/logic/views/View';
 import Search from 'views/logic/search/Search';
 import ViewLoaderContext from 'views/logic/ViewLoaderContext';
 import mockAction from 'helpers/mocking/MockAction';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
-import { ViewActions } from 'views/stores/ViewStore';
+import Routes from 'routing/Routes';
 
 import BookmarkControls from './BookmarkControls';
 
 describe('BookmarkControls', () => {
   describe('Button handling', () => {
     it('should clear a view', (done) => {
-      ViewActions.create = mockAction(jest.fn(() => Promise.resolve()));
+      browserHistory.push = jest.fn();
       const viewStoreState = {
         activeQuery: '',
         view: View.builder()
@@ -27,7 +28,7 @@ describe('BookmarkControls', () => {
       const wrapper = mount(<BookmarkControls viewStoreState={viewStoreState} />);
       wrapper.find('button[title="Empty search"]').simulate('click');
       setImmediate(() => {
-        expect(ViewActions.create).toHaveBeenCalledWith(View.Type.Search);
+        expect(browserHistory.push).toHaveBeenCalledWith(Routes.SEARCH);
         done();
       });
     });

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkList.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkList.jsx
@@ -71,12 +71,14 @@ class BookmarkList extends React.Component<Props, State> {
   };
 
   onLoad = (selectedBookmark, loadFunc) => {
+    const { toggleModal } = this.props;
     if (!selectedBookmark || !loadFunc) {
       return;
     }
     loadFunc(selectedBookmark).then(() => {
       browserHistory.push(Routes.pluginRoute('SEARCH_VIEWID')(selectedBookmark));
     });
+    toggleModal();
   };
 
   onDelete = (selectedBookmark) => {

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkList.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkList.jsx
@@ -1,7 +1,9 @@
 // @flow strict
 import React from 'react';
 import PropTypes from 'prop-types';
+import { browserHistory } from 'react-router';
 
+import Routes from 'routing/Routes';
 import { SavedSearchesStore, SavedSearchesActions } from 'views/stores/SavedSearchesStore';
 import type { SavedSearchesState } from 'views/stores/SavedSearchesStore';
 import connect from 'stores/connect';
@@ -69,11 +71,12 @@ class BookmarkList extends React.Component<Props, State> {
   };
 
   onLoad = (selectedBookmark, loadFunc) => {
-    const { toggleModal } = this.props;
     if (!selectedBookmark || !loadFunc) {
       return;
     }
-    loadFunc(selectedBookmark).then(toggleModal);
+    loadFunc(selectedBookmark).then(() => {
+      browserHistory.push(Routes.pluginRoute('SEARCH_VIEWID')(selectedBookmark));
+    });
   };
 
   onDelete = (selectedBookmark) => {

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkList.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkList.test.jsx
@@ -1,7 +1,6 @@
 // @flow strict
 import React from 'react';
-import { render, fireEvent, wait } from '@testing-library/react';
-import { mount } from 'enzyme';
+import { render, cleanup, fireEvent, wait } from '@testing-library/react';
 import { browserHistory } from 'react-router';
 import Routes from 'routing/Routes';
 
@@ -36,42 +35,38 @@ const createViewsResponse = (count = 1) => {
 
 describe('BookmarkList', () => {
   describe('render the BookmarkList', () => {
+    afterEach(() => {
+      cleanup();
+    });
     it('should render empty', () => {
       const views = createViewsResponse(0);
-      const wrapper = mount(<BookmarkList toggleModal={() => {}}
-                                          showModal
-                                          deleteBookmark={() => {}}
-                                          views={views} />);
-      expect(wrapper.find('ModalDialog')).toMatchSnapshot();
+      const { baseElement } = render(<BookmarkList toggleModal={() => {}}
+                                                   showModal
+                                                   deleteBookmark={() => {}}
+                                                   views={views} />);
+      expect(baseElement).toMatchSnapshot();
     });
 
     it('should render with views', () => {
       const views = createViewsResponse(1);
-      const wrapper = mount(<BookmarkList toggleModal={() => {}}
-                                          showModal
-                                          deleteBookmark={() => {}}
-                                          views={views} />);
-      expect(wrapper.find('ModalDialog')).toMatchSnapshot();
+      const { baseElement } = render(<BookmarkList toggleModal={() => {}}
+                                                   showModal
+                                                   deleteBookmark={() => {}}
+                                                   views={views} />);
+      expect(baseElement).toMatchSnapshot();
     });
 
-    it('should handle toggleModal', () => {
-      const views = createViewsResponse(1);
-      const wrapper = mount(<BookmarkList toggleModal={() => {}}
-                                          showModal
-                                          deleteBookmark={() => {}}
-                                          views={views} />);
-      expect(wrapper.find('ModalDialog')).toMatchSnapshot();
-    });
-
-    it('should handle with toggle modal', () => {
+    it('should handle toggle modal', () => {
       const onToggleModal = jest.fn();
       const views = createViewsResponse(1);
 
-      const wrapper = mount(<BookmarkList toggleModal={onToggleModal}
-                                          showModal
-                                          deleteBookmark={() => {}}
-                                          views={views} />);
-      wrapper.find('button[children="Cancel"]').simulate('click');
+      const { getByText } = render(<BookmarkList toggleModal={onToggleModal}
+                                                 showModal
+                                                 deleteBookmark={() => {}}
+                                                 views={views} />);
+
+      const cancel = getByText('Cancel');
+      fireEvent.click(cancel);
       expect(onToggleModal).toBeCalledTimes(1);
     });
 
@@ -81,12 +76,14 @@ describe('BookmarkList', () => {
         return new Promise(() => {});
       });
       const views = createViewsResponse(1);
-      const wrapper = mount(<BookmarkList toggleModal={() => {}}
-                                          showModal
-                                          deleteBookmark={onDelete}
-                                          views={views} />);
-      wrapper.find('button.list-group-item').simulate('click');
-      wrapper.find('button[children="Delete"]').simulate('click');
+      const { getByText } = render(<BookmarkList toggleModal={() => {}}
+                                                 showModal
+                                                 deleteBookmark={onDelete}
+                                                 views={views} />);
+      const listItem = getByText('test-0');
+      fireEvent.click(listItem);
+      const deleteBtn = getByText('Delete');
+      fireEvent.click(deleteBtn);
       expect(window.confirm).toBeCalledTimes(1);
       expect(onDelete).toBeCalledTimes(1);
     });
@@ -95,7 +92,7 @@ describe('BookmarkList', () => {
       const onLoad = jest.fn(() => { return new Promise(() => {}); });
       const views = createViewsResponse(1);
 
-      const wrapper = mount(
+      const { getByText } = render(
         <ViewLoaderContext.Provider value={onLoad}>
           <BookmarkList toggleModal={() => {}}
                         showModal
@@ -103,11 +100,17 @@ describe('BookmarkList', () => {
                         views={views} />
         </ViewLoaderContext.Provider>,
       );
-      wrapper.find('button.list-group-item').simulate('click');
-      wrapper.find('button[children="Load"]').simulate('click');
+      const listItem = getByText('test-0');
+      fireEvent.click(listItem);
+      const loadBtn = getByText('Load');
+      fireEvent.click(loadBtn);
       expect(onLoad).toBeCalledTimes(1);
     });
-
+  });
+  describe('load new bookmark', () => {
+    afterEach(() => {
+      cleanup();
+    });
     it('should change url after load', async () => {
       const onLoad = jest.fn(() => Promise.resolve());
       Routes.pluginRoute = jest.fn(route => id => `${route}:${id}`);

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkList.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkList.test.jsx.snap
@@ -1,2529 +1,477 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BookmarkList render the BookmarkList should handle toggleModal 1`] = `
-<ModalDialog
-  bsClass="modal"
-  className="fade in"
-  onClick={[Function]}
-  role="document"
-  style={
-    Object {
-      "paddingLeft": undefined,
-      "paddingRight": 0,
-    }
-  }
-  tabIndex="-1"
->
-  <div
-    className="fade in modal"
-    onClick={[Function]}
-    role="dialog"
-    style={
-      Object {
-        "display": "block",
-        "paddingLeft": undefined,
-        "paddingRight": 0,
-      }
-    }
-    tabIndex="-1"
-  >
-    <div
-      className="modal-dialog"
-    >
-      <div
-        className="modal-content"
-        role="document"
-      >
-        <ModalBody
-          bsClass="modal-body"
-          componentClass="div"
-        >
-          <div
-            className="modal-body"
-          >
-            <SearchForm
-              buttonLeftMargin={5}
-              label={null}
-              loadingLabel="Loading..."
-              onQueryChange={[Function]}
-              onReset={[Function]}
-              onSearch={[Function]}
-              placeholder="Enter search query..."
-              query=""
-              queryHelpComponent={null}
-              queryWidth="auto"
-              resetButtonLabel="Reset"
-              searchBsStyle="default"
-              searchButtonLabel="Search"
-              topMargin={15}
-              useLoadingState={false}
-              wrapperClass="search"
-            >
-              <div
-                className="search"
-                style={
-                  Object {
-                    "marginTop": 15,
-                  }
-                }
-              >
-                <form
-                  className="form-inline"
-                  onSubmit={[Function]}
-                >
-                  <div
-                    className="form-group has-feedback"
-                  >
-                    <input
-                      autoComplete="off"
-                      className="query form-control"
-                      id="common-search-form-query-input"
-                      onChange={[Function]}
-                      placeholder="Enter search query..."
-                      spellCheck="false"
-                      style={
-                        Object {
-                          "width": "auto",
-                        }
-                      }
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                  <div
-                    className="form-group"
-                    style={
-                      Object {
-                        "marginLeft": 5,
-                      }
-                    }
-                  >
-                    <ForwardRef
-                      bsStyle="default"
-                      className="submit-button"
-                      disabled={false}
-                      type="submit"
-                    >
-                      <Button__StyledButton
-                        bsStyle="default"
-                        className="submit-button"
-                        disabled={false}
-                        type="submit"
-                      >
-                        <StyledComponent
-                          bsStyle="default"
-                          className="submit-button"
-                          disabled={false}
-                          forwardedComponent={
-                            Object {
-                              "$$typeof": Symbol(react.forward_ref),
-                              "SIZES": Array [
-                                "large",
-                                "small",
-                                "xsmall",
-                              ],
-                              "STYLES": Array [
-                                "success",
-                                "warning",
-                                "danger",
-                                "info",
-                                "default",
-                                "primary",
-                                "link",
-                              ],
-                              "attrs": Array [],
-                              "componentStyle": ComponentStyle {
-                                "componentId": "Button__StyledButton-c9cbmb-0",
-                                "isStatic": false,
-                                "lastClassName": "kRDLih",
-                                "rules": Array [
-                                  [Function],
-                                ],
-                              },
-                              "displayName": "Button__StyledButton",
-                              "foldedComponentIds": Array [],
-                              "render": [Function],
-                              "styledComponentId": "Button__StyledButton-c9cbmb-0",
-                              "target": [Function],
-                              "toString": [Function],
-                              "warnTooManyClasses": [Function],
-                              "withComponent": [Function],
-                            }
-                          }
-                          forwardedRef={null}
-                          type="submit"
-                        >
-                          <Button
-                            active={false}
-                            block={false}
-                            bsClass="btn"
-                            bsStyle="default"
-                            className="submit-button Button__StyledButton-c9cbmb-0 kRDLih"
-                            disabled={false}
-                            type="submit"
-                          >
-                            <button
-                              className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
-                              disabled={false}
-                              type="submit"
-                            >
-                              Search
-                            </button>
-                          </Button>
-                        </StyledComponent>
-                      </Button__StyledButton>
-                    </ForwardRef>
-                  </div>
-                  <div
-                    className="form-group"
-                    style={
-                      Object {
-                        "marginLeft": 5,
-                      }
-                    }
-                  >
-                    <ForwardRef
-                      bsStyle="default"
-                      className="reset-button"
-                      onClick={[Function]}
-                      type="reset"
-                    >
-                      <Button__StyledButton
-                        bsStyle="default"
-                        className="reset-button"
-                        onClick={[Function]}
-                        type="reset"
-                      >
-                        <StyledComponent
-                          bsStyle="default"
-                          className="reset-button"
-                          forwardedComponent={
-                            Object {
-                              "$$typeof": Symbol(react.forward_ref),
-                              "SIZES": Array [
-                                "large",
-                                "small",
-                                "xsmall",
-                              ],
-                              "STYLES": Array [
-                                "success",
-                                "warning",
-                                "danger",
-                                "info",
-                                "default",
-                                "primary",
-                                "link",
-                              ],
-                              "attrs": Array [],
-                              "componentStyle": ComponentStyle {
-                                "componentId": "Button__StyledButton-c9cbmb-0",
-                                "isStatic": false,
-                                "lastClassName": "kRDLih",
-                                "rules": Array [
-                                  [Function],
-                                ],
-                              },
-                              "displayName": "Button__StyledButton",
-                              "foldedComponentIds": Array [],
-                              "render": [Function],
-                              "styledComponentId": "Button__StyledButton-c9cbmb-0",
-                              "target": [Function],
-                              "toString": [Function],
-                              "warnTooManyClasses": [Function],
-                              "withComponent": [Function],
-                            }
-                          }
-                          forwardedRef={null}
-                          onClick={[Function]}
-                          type="reset"
-                        >
-                          <Button
-                            active={false}
-                            block={false}
-                            bsClass="btn"
-                            bsStyle="default"
-                            className="reset-button Button__StyledButton-c9cbmb-0 kRDLih"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="reset"
-                          >
-                            <button
-                              className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
-                              disabled={false}
-                              onClick={[Function]}
-                              type="reset"
-                            >
-                              Reset
-                            </button>
-                          </Button>
-                        </StyledComponent>
-                      </Button__StyledButton>
-                    </ForwardRef>
-                  </div>
-                </form>
-              </div>
-            </SearchForm>
-            <PaginatedList
-              activePage={1}
-              onChange={[Function]}
-              pageSize={5}
-              pageSizes={
-                Array [
-                  5,
-                  10,
-                  15,
-                ]
-              }
-              showPageSizeSelect={true}
-              totalItems={1}
-            >
-              <span>
-                <div
-                  className="form-inline page-size"
-                  style={
-                    Object {
-                      "float": "right",
-                    }
-                  }
-                >
-                  <Input
-                    addonAfter={null}
-                    bsSize="small"
-                    bsStyle={null}
-                    buttonAfter={null}
-                    help=""
-                    id="page-size"
-                    label="Show:"
-                    onChange={[Function]}
-                    placeholder=""
-                    type="select"
-                    value={5}
-                  >
-                    <FormGroup
-                      bsClass="form-group"
-                      controlId="page-size"
-                      validationState={null}
-                    >
-                      <div
-                        className="form-group"
-                      >
-                        <ForwardRef>
-                          <ControlLabel>
-                            <StyledComponent
-                              forwardedComponent={
-                                Object {
-                                  "$$typeof": Symbol(react.forward_ref),
-                                  "attrs": Array [],
-                                  "componentStyle": ComponentStyle {
-                                    "componentId": "ControlLabel-sc-1edmum5-0",
-                                    "isStatic": true,
-                                    "lastClassName": "iZJNbd",
-                                    "rules": Array [
-                                      "color:",
-                                      "#1F1F1F",
-                                      ";font-weight:bold;margin-bottom:5px;display:inline-block;",
-                                    ],
-                                  },
-                                  "displayName": "ControlLabel",
-                                  "foldedComponentIds": Array [],
-                                  "render": [Function],
-                                  "styledComponentId": "ControlLabel-sc-1edmum5-0",
-                                  "target": [Function],
-                                  "toString": [Function],
-                                  "warnTooManyClasses": [Function],
-                                  "withComponent": [Function],
-                                }
-                              }
-                              forwardedRef={null}
-                            >
-                              <ControlLabel
-                                bsClass="control-label"
-                                className="ControlLabel-sc-1edmum5-0 iZJNbd"
-                                srOnly={false}
-                              >
-                                <label
-                                  className="ControlLabel-sc-1edmum5-0 iZJNbd control-label"
-                                  htmlFor="page-size"
-                                >
-                                  Show:
-                                </label>
-                              </ControlLabel>
-                            </StyledComponent>
-                          </ControlLabel>
-                        </ForwardRef>
-                        <InputWrapper>
-                          <span>
-                            <FormControl
-                              bsClass="form-control"
-                              bsSize="small"
-                              componentClass="select"
-                              inputRef={[Function]}
-                              label="Show:"
-                              name="page-size"
-                              onChange={[Function]}
-                              placeholder=""
-                              type="select"
-                              value={5}
-                            >
-                              <select
-                                className="form-control input-sm"
-                                id="page-size"
-                                label="Show:"
-                                name="page-size"
-                                onChange={[Function]}
-                                placeholder=""
-                                type="select"
-                                value={5}
-                              >
-                                <option
-                                  key="option-5"
-                                  value={5}
-                                >
-                                  5
-                                </option>
-                                <option
-                                  key="option-10"
-                                  value={10}
-                                >
-                                  10
-                                </option>
-                                <option
-                                  key="option-15"
-                                  value={15}
-                                >
-                                  15
-                                </option>
-                              </select>
-                            </FormControl>
-                          </span>
-                        </InputWrapper>
-                      </div>
-                    </FormGroup>
-                  </Input>
-                </div>
-                <ListGroup
-                  bsClass="list-group"
-                >
-                  <div
-                    className="list-group"
-                  >
-                    <ListGroupItem
-                      active={false}
-                      bsClass="list-group-item"
-                      header="test-0"
-                      key="foo-bar-0"
-                      listItem={false}
-                      onClick={[Function]}
-                    >
-                      <button
-                        className="list-group-item"
-                        onClick={[Function]}
-                        type="button"
-                      >
-                        <h4
-                          className="list-group-item-heading"
-                        >
-                          test-0
-                        </h4>
-                        <p
-                          className="list-group-item-text"
-                        />
-                      </button>
-                    </ListGroupItem>
-                  </div>
-                </ListGroup>
-                <div
-                  className="text-center"
-                >
-                  <Pagination
-                    activePage={1}
-                    boundaryLinks={false}
-                    bsClass="pagination"
-                    bsSize="small"
-                    ellipsis={true}
-                    first={true}
-                    items={1}
-                    last={true}
-                    maxButtons={10}
-                    next={true}
-                    onSelect={[Function]}
-                    prev={true}
-                  >
-                    <ul
-                      className="pagination pagination-sm"
-                    >
-                      <PaginationButton
-                        active={false}
-                        componentClass={[Function]}
-                        disabled={true}
-                        eventKey={1}
-                        onSelect={[Function]}
-                      >
-                        <li
-                          className="disabled"
-                        >
-                          <SafeAnchor
-                            componentClass="a"
-                            disabled={true}
-                            onClick={[Function]}
-                          >
-                            <a
-                              href="#"
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              role="button"
-                              style={
-                                Object {
-                                  "pointerEvents": "none",
-                                }
-                              }
-                              tabIndex={-1}
-                            >
-                              <span
-                                aria-label="First"
-                              >
-                                «
-                              </span>
-                            </a>
-                          </SafeAnchor>
-                        </li>
-                      </PaginationButton>
-                      <PaginationButton
-                        active={false}
-                        componentClass={[Function]}
-                        disabled={true}
-                        eventKey={0}
-                        onSelect={[Function]}
-                      >
-                        <li
-                          className="disabled"
-                        >
-                          <SafeAnchor
-                            componentClass="a"
-                            disabled={true}
-                            onClick={[Function]}
-                          >
-                            <a
-                              href="#"
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              role="button"
-                              style={
-                                Object {
-                                  "pointerEvents": "none",
-                                }
-                              }
-                              tabIndex={-1}
-                            >
-                              <span
-                                aria-label="Previous"
-                              >
-                                ‹
-                              </span>
-                            </a>
-                          </SafeAnchor>
-                        </li>
-                      </PaginationButton>
-                      <PaginationButton
-                        active={true}
-                        componentClass={[Function]}
-                        disabled={false}
-                        eventKey={1}
-                        key="1"
-                        onSelect={[Function]}
-                      >
-                        <li
-                          className="active"
-                        >
-                          <SafeAnchor
-                            componentClass="a"
-                            disabled={false}
-                            onClick={[Function]}
-                          >
-                            <a
-                              href="#"
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              role="button"
-                            >
-                              1
-                            </a>
-                          </SafeAnchor>
-                        </li>
-                      </PaginationButton>
-                      <PaginationButton
-                        active={false}
-                        componentClass={[Function]}
-                        disabled={true}
-                        eventKey={2}
-                        onSelect={[Function]}
-                      >
-                        <li
-                          className="disabled"
-                        >
-                          <SafeAnchor
-                            componentClass="a"
-                            disabled={true}
-                            onClick={[Function]}
-                          >
-                            <a
-                              href="#"
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              role="button"
-                              style={
-                                Object {
-                                  "pointerEvents": "none",
-                                }
-                              }
-                              tabIndex={-1}
-                            >
-                              <span
-                                aria-label="Next"
-                              >
-                                ›
-                              </span>
-                            </a>
-                          </SafeAnchor>
-                        </li>
-                      </PaginationButton>
-                      <PaginationButton
-                        active={false}
-                        componentClass={[Function]}
-                        disabled={true}
-                        eventKey={1}
-                        onSelect={[Function]}
-                      >
-                        <li
-                          className="disabled"
-                        >
-                          <SafeAnchor
-                            componentClass="a"
-                            disabled={true}
-                            onClick={[Function]}
-                          >
-                            <a
-                              href="#"
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              role="button"
-                              style={
-                                Object {
-                                  "pointerEvents": "none",
-                                }
-                              }
-                              tabIndex={-1}
-                            >
-                              <span
-                                aria-label="Last"
-                              >
-                                »
-                              </span>
-                            </a>
-                          </SafeAnchor>
-                        </li>
-                      </PaginationButton>
-                    </ul>
-                  </Pagination>
-                </div>
-              </span>
-            </PaginatedList>
-          </div>
-        </ModalBody>
-        <ModalFooter
-          bsClass="modal-footer"
-          componentClass="div"
-        >
-          <div
-            className="modal-footer"
-          >
-            <ForwardRef
-              bsStyle="primary"
-              disabled={true}
-              onClick={[Function]}
-            >
-              <Button__StyledButton
-                bsStyle="primary"
-                disabled={true}
-                onClick={[Function]}
-              >
-                <StyledComponent
-                  bsStyle="primary"
-                  disabled={true}
-                  forwardedComponent={
-                    Object {
-                      "$$typeof": Symbol(react.forward_ref),
-                      "SIZES": Array [
-                        "large",
-                        "small",
-                        "xsmall",
-                      ],
-                      "STYLES": Array [
-                        "success",
-                        "warning",
-                        "danger",
-                        "info",
-                        "default",
-                        "primary",
-                        "link",
-                      ],
-                      "attrs": Array [],
-                      "componentStyle": ComponentStyle {
-                        "componentId": "Button__StyledButton-c9cbmb-0",
-                        "isStatic": false,
-                        "lastClassName": "kRDLih",
-                        "rules": Array [
-                          [Function],
-                        ],
-                      },
-                      "displayName": "Button__StyledButton",
-                      "foldedComponentIds": Array [],
-                      "render": [Function],
-                      "styledComponentId": "Button__StyledButton-c9cbmb-0",
-                      "target": [Function],
-                      "toString": [Function],
-                      "warnTooManyClasses": [Function],
-                      "withComponent": [Function],
-                    }
-                  }
-                  forwardedRef={null}
-                  onClick={[Function]}
-                >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="primary"
-                    className="Button__StyledButton-c9cbmb-0 kRDLih"
-                    disabled={true}
-                    onClick={[Function]}
-                  >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
-                      disabled={true}
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      Load
-                    </button>
-                  </Button>
-                </StyledComponent>
-              </Button__StyledButton>
-            </ForwardRef>
-            <ForwardRef
-              bsStyle="default"
-              disabled={true}
-              onClick={[Function]}
-            >
-              <Button__StyledButton
-                bsStyle="default"
-                disabled={true}
-                onClick={[Function]}
-              >
-                <StyledComponent
-                  bsStyle="default"
-                  disabled={true}
-                  forwardedComponent={
-                    Object {
-                      "$$typeof": Symbol(react.forward_ref),
-                      "SIZES": Array [
-                        "large",
-                        "small",
-                        "xsmall",
-                      ],
-                      "STYLES": Array [
-                        "success",
-                        "warning",
-                        "danger",
-                        "info",
-                        "default",
-                        "primary",
-                        "link",
-                      ],
-                      "attrs": Array [],
-                      "componentStyle": ComponentStyle {
-                        "componentId": "Button__StyledButton-c9cbmb-0",
-                        "isStatic": false,
-                        "lastClassName": "kRDLih",
-                        "rules": Array [
-                          [Function],
-                        ],
-                      },
-                      "displayName": "Button__StyledButton",
-                      "foldedComponentIds": Array [],
-                      "render": [Function],
-                      "styledComponentId": "Button__StyledButton-c9cbmb-0",
-                      "target": [Function],
-                      "toString": [Function],
-                      "warnTooManyClasses": [Function],
-                      "withComponent": [Function],
-                    }
-                  }
-                  forwardedRef={null}
-                  onClick={[Function]}
-                >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="default"
-                    className="Button__StyledButton-c9cbmb-0 kRDLih"
-                    disabled={true}
-                    onClick={[Function]}
-                  >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
-                      disabled={true}
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      Delete
-                    </button>
-                  </Button>
-                </StyledComponent>
-              </Button__StyledButton>
-            </ForwardRef>
-            <ForwardRef
-              bsStyle="default"
-              onClick={[Function]}
-            >
-              <Button__StyledButton
-                bsStyle="default"
-                onClick={[Function]}
-              >
-                <StyledComponent
-                  bsStyle="default"
-                  forwardedComponent={
-                    Object {
-                      "$$typeof": Symbol(react.forward_ref),
-                      "SIZES": Array [
-                        "large",
-                        "small",
-                        "xsmall",
-                      ],
-                      "STYLES": Array [
-                        "success",
-                        "warning",
-                        "danger",
-                        "info",
-                        "default",
-                        "primary",
-                        "link",
-                      ],
-                      "attrs": Array [],
-                      "componentStyle": ComponentStyle {
-                        "componentId": "Button__StyledButton-c9cbmb-0",
-                        "isStatic": false,
-                        "lastClassName": "kRDLih",
-                        "rules": Array [
-                          [Function],
-                        ],
-                      },
-                      "displayName": "Button__StyledButton",
-                      "foldedComponentIds": Array [],
-                      "render": [Function],
-                      "styledComponentId": "Button__StyledButton-c9cbmb-0",
-                      "target": [Function],
-                      "toString": [Function],
-                      "warnTooManyClasses": [Function],
-                      "withComponent": [Function],
-                    }
-                  }
-                  forwardedRef={null}
-                  onClick={[Function]}
-                >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="default"
-                    className="Button__StyledButton-c9cbmb-0 kRDLih"
-                    disabled={false}
-                    onClick={[Function]}
-                  >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
-                      disabled={false}
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      Cancel
-                    </button>
-                  </Button>
-                </StyledComponent>
-              </Button__StyledButton>
-            </ForwardRef>
-          </div>
-        </ModalFooter>
-      </div>
-    </div>
-  </div>
-</ModalDialog>
-`;
-
 exports[`BookmarkList render the BookmarkList should render empty 1`] = `
-<ModalDialog
-  bsClass="modal"
-  className="fade in"
-  onClick={[Function]}
-  role="document"
-  style={
-    Object {
-      "paddingLeft": undefined,
-      "paddingRight": 0,
-    }
-  }
-  tabIndex="-1"
+<body
+  class="modal-open"
+  style="padding-right: 0px;"
 >
   <div
-    className="fade in modal"
-    onClick={[Function]}
+    aria-hidden="true"
+  />
+  <div
     role="dialog"
-    style={
-      Object {
-        "display": "block",
-        "paddingLeft": undefined,
-        "paddingRight": 0,
-      }
-    }
-    tabIndex="-1"
   >
     <div
-      className="modal-dialog"
+      class="modal-backdrop fade in"
+    />
+    <div
+      class="fade in modal"
+      role="dialog"
+      style="display: block; padding-right: 0px;"
+      tabindex="-1"
     >
       <div
-        className="modal-content"
-        role="document"
+        class="modal-dialog"
       >
-        <ModalBody
-          bsClass="modal-body"
-          componentClass="div"
+        <div
+          class="modal-content"
+          role="document"
         >
           <div
-            className="modal-body"
+            class="modal-body"
           >
-            <SearchForm
-              buttonLeftMargin={5}
-              label={null}
-              loadingLabel="Loading..."
-              onQueryChange={[Function]}
-              onReset={[Function]}
-              onSearch={[Function]}
-              placeholder="Enter search query..."
-              query=""
-              queryHelpComponent={null}
-              queryWidth="auto"
-              resetButtonLabel="Reset"
-              searchBsStyle="default"
-              searchButtonLabel="Search"
-              topMargin={15}
-              useLoadingState={false}
-              wrapperClass="search"
+            <div
+              class="search"
+              style="margin-top: 15px;"
             >
+              <form
+                class="form-inline"
+              >
+                <div
+                  class="form-group has-feedback"
+                >
+                  <input
+                    autocomplete="off"
+                    class="query form-control"
+                    id="common-search-form-query-input"
+                    placeholder="Enter search query..."
+                    spellcheck="false"
+                    style="width: auto;"
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <div
+                  class="form-group"
+                  style="margin-left: 5px;"
+                >
+                  <button
+                    class="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    type="submit"
+                  >
+                    Search
+                  </button>
+                </div>
+                <div
+                  class="form-group"
+                  style="margin-left: 5px;"
+                >
+                  <button
+                    class="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    type="reset"
+                  >
+                    Reset
+                  </button>
+                </div>
+              </form>
+            </div>
+            <span>
               <div
-                className="search"
-                style={
-                  Object {
-                    "marginTop": 15,
-                  }
-                }
+                class="form-inline page-size"
+                style="float: right;"
               >
-                <form
-                  className="form-inline"
-                  onSubmit={[Function]}
+                <div
+                  class="form-group"
                 >
-                  <div
-                    className="form-group has-feedback"
+                  <label
+                    class="ControlLabel-sc-1edmum5-0 iZJNbd control-label"
+                    for="page-size"
                   >
-                    <input
-                      autoComplete="off"
-                      className="query form-control"
-                      id="common-search-form-query-input"
-                      onChange={[Function]}
-                      placeholder="Enter search query..."
-                      spellCheck="false"
-                      style={
-                        Object {
-                          "width": "auto",
-                        }
-                      }
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                  <div
-                    className="form-group"
-                    style={
-                      Object {
-                        "marginLeft": 5,
-                      }
-                    }
-                  >
-                    <ForwardRef
-                      bsStyle="default"
-                      className="submit-button"
-                      disabled={false}
-                      type="submit"
+                    Show:
+                  </label>
+                  <span>
+                    <select
+                      class="form-control input-sm"
+                      id="page-size"
+                      label="Show:"
+                      name="page-size"
+                      placeholder=""
+                      type="select"
                     >
-                      <Button__StyledButton
-                        bsStyle="default"
-                        className="submit-button"
-                        disabled={false}
-                        type="submit"
+                      <option
+                        value="5"
                       >
-                        <StyledComponent
-                          bsStyle="default"
-                          className="submit-button"
-                          disabled={false}
-                          forwardedComponent={
-                            Object {
-                              "$$typeof": Symbol(react.forward_ref),
-                              "SIZES": Array [
-                                "large",
-                                "small",
-                                "xsmall",
-                              ],
-                              "STYLES": Array [
-                                "success",
-                                "warning",
-                                "danger",
-                                "info",
-                                "default",
-                                "primary",
-                                "link",
-                              ],
-                              "attrs": Array [],
-                              "componentStyle": ComponentStyle {
-                                "componentId": "Button__StyledButton-c9cbmb-0",
-                                "isStatic": false,
-                                "lastClassName": "kRDLih",
-                                "rules": Array [
-                                  [Function],
-                                ],
-                              },
-                              "displayName": "Button__StyledButton",
-                              "foldedComponentIds": Array [],
-                              "render": [Function],
-                              "styledComponentId": "Button__StyledButton-c9cbmb-0",
-                              "target": [Function],
-                              "toString": [Function],
-                              "warnTooManyClasses": [Function],
-                              "withComponent": [Function],
-                            }
-                          }
-                          forwardedRef={null}
-                          type="submit"
-                        >
-                          <Button
-                            active={false}
-                            block={false}
-                            bsClass="btn"
-                            bsStyle="default"
-                            className="submit-button Button__StyledButton-c9cbmb-0 kRDLih"
-                            disabled={false}
-                            type="submit"
-                          >
-                            <button
-                              className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
-                              disabled={false}
-                              type="submit"
-                            >
-                              Search
-                            </button>
-                          </Button>
-                        </StyledComponent>
-                      </Button__StyledButton>
-                    </ForwardRef>
-                  </div>
-                  <div
-                    className="form-group"
-                    style={
-                      Object {
-                        "marginLeft": 5,
-                      }
-                    }
-                  >
-                    <ForwardRef
-                      bsStyle="default"
-                      className="reset-button"
-                      onClick={[Function]}
-                      type="reset"
-                    >
-                      <Button__StyledButton
-                        bsStyle="default"
-                        className="reset-button"
-                        onClick={[Function]}
-                        type="reset"
+                        5
+                      </option>
+                      <option
+                        value="10"
                       >
-                        <StyledComponent
-                          bsStyle="default"
-                          className="reset-button"
-                          forwardedComponent={
-                            Object {
-                              "$$typeof": Symbol(react.forward_ref),
-                              "SIZES": Array [
-                                "large",
-                                "small",
-                                "xsmall",
-                              ],
-                              "STYLES": Array [
-                                "success",
-                                "warning",
-                                "danger",
-                                "info",
-                                "default",
-                                "primary",
-                                "link",
-                              ],
-                              "attrs": Array [],
-                              "componentStyle": ComponentStyle {
-                                "componentId": "Button__StyledButton-c9cbmb-0",
-                                "isStatic": false,
-                                "lastClassName": "kRDLih",
-                                "rules": Array [
-                                  [Function],
-                                ],
-                              },
-                              "displayName": "Button__StyledButton",
-                              "foldedComponentIds": Array [],
-                              "render": [Function],
-                              "styledComponentId": "Button__StyledButton-c9cbmb-0",
-                              "target": [Function],
-                              "toString": [Function],
-                              "warnTooManyClasses": [Function],
-                              "withComponent": [Function],
-                            }
-                          }
-                          forwardedRef={null}
-                          onClick={[Function]}
-                          type="reset"
-                        >
-                          <Button
-                            active={false}
-                            block={false}
-                            bsClass="btn"
-                            bsStyle="default"
-                            className="reset-button Button__StyledButton-c9cbmb-0 kRDLih"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="reset"
-                          >
-                            <button
-                              className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
-                              disabled={false}
-                              onClick={[Function]}
-                              type="reset"
-                            >
-                              Reset
-                            </button>
-                          </Button>
-                        </StyledComponent>
-                      </Button__StyledButton>
-                    </ForwardRef>
-                  </div>
-                </form>
+                        10
+                      </option>
+                      <option
+                        value="15"
+                      >
+                        15
+                      </option>
+                    </select>
+                    
+                  </span>
+                </div>
               </div>
-            </SearchForm>
-            <PaginatedList
-              activePage={0}
-              onChange={[Function]}
-              pageSize={5}
-              pageSizes={
-                Array [
-                  5,
-                  10,
-                  15,
-                ]
-              }
-              showPageSizeSelect={true}
-              totalItems={0}
-            >
               <span>
-                <div
-                  className="form-inline page-size"
-                  style={
-                    Object {
-                      "float": "right",
-                    }
-                  }
-                >
-                  <Input
-                    addonAfter={null}
-                    bsSize="small"
-                    bsStyle={null}
-                    buttonAfter={null}
-                    help=""
-                    id="page-size"
-                    label="Show:"
-                    onChange={[Function]}
-                    placeholder=""
-                    type="select"
-                    value={5}
-                  >
-                    <FormGroup
-                      bsClass="form-group"
-                      controlId="page-size"
-                      validationState={null}
-                    >
-                      <div
-                        className="form-group"
-                      >
-                        <ForwardRef>
-                          <ControlLabel>
-                            <StyledComponent
-                              forwardedComponent={
-                                Object {
-                                  "$$typeof": Symbol(react.forward_ref),
-                                  "attrs": Array [],
-                                  "componentStyle": ComponentStyle {
-                                    "componentId": "ControlLabel-sc-1edmum5-0",
-                                    "isStatic": true,
-                                    "lastClassName": "iZJNbd",
-                                    "rules": Array [
-                                      "color:",
-                                      "#1F1F1F",
-                                      ";font-weight:bold;margin-bottom:5px;display:inline-block;",
-                                    ],
-                                  },
-                                  "displayName": "ControlLabel",
-                                  "foldedComponentIds": Array [],
-                                  "render": [Function],
-                                  "styledComponentId": "ControlLabel-sc-1edmum5-0",
-                                  "target": [Function],
-                                  "toString": [Function],
-                                  "warnTooManyClasses": [Function],
-                                  "withComponent": [Function],
-                                }
-                              }
-                              forwardedRef={null}
-                            >
-                              <ControlLabel
-                                bsClass="control-label"
-                                className="ControlLabel-sc-1edmum5-0 iZJNbd"
-                                srOnly={false}
-                              >
-                                <label
-                                  className="ControlLabel-sc-1edmum5-0 iZJNbd control-label"
-                                  htmlFor="page-size"
-                                >
-                                  Show:
-                                </label>
-                              </ControlLabel>
-                            </StyledComponent>
-                          </ControlLabel>
-                        </ForwardRef>
-                        <InputWrapper>
-                          <span>
-                            <FormControl
-                              bsClass="form-control"
-                              bsSize="small"
-                              componentClass="select"
-                              inputRef={[Function]}
-                              label="Show:"
-                              name="page-size"
-                              onChange={[Function]}
-                              placeholder=""
-                              type="select"
-                              value={5}
-                            >
-                              <select
-                                className="form-control input-sm"
-                                id="page-size"
-                                label="Show:"
-                                name="page-size"
-                                onChange={[Function]}
-                                placeholder=""
-                                type="select"
-                                value={5}
-                              >
-                                <option
-                                  key="option-5"
-                                  value={5}
-                                >
-                                  5
-                                </option>
-                                <option
-                                  key="option-10"
-                                  value={10}
-                                >
-                                  10
-                                </option>
-                                <option
-                                  key="option-15"
-                                  value={15}
-                                >
-                                  15
-                                </option>
-                              </select>
-                            </FormControl>
-                          </span>
-                        </InputWrapper>
-                      </div>
-                    </FormGroup>
-                  </Input>
-                </div>
-                <span>
-                  No bookmarks found
-                </span>
-                <div
-                  className="text-center"
-                >
-                  <Pagination
-                    activePage={1}
-                    boundaryLinks={false}
-                    bsClass="pagination"
-                    bsSize="small"
-                    ellipsis={true}
-                    first={true}
-                    items={0}
-                    last={true}
-                    maxButtons={10}
-                    next={true}
-                    onSelect={[Function]}
-                    prev={true}
-                  >
-                    <ul
-                      className="pagination pagination-sm"
-                    >
-                      <PaginationButton
-                        active={false}
-                        componentClass={[Function]}
-                        disabled={true}
-                        eventKey={1}
-                        onSelect={[Function]}
-                      >
-                        <li
-                          className="disabled"
-                        >
-                          <SafeAnchor
-                            componentClass="a"
-                            disabled={true}
-                            onClick={[Function]}
-                          >
-                            <a
-                              href="#"
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              role="button"
-                              style={
-                                Object {
-                                  "pointerEvents": "none",
-                                }
-                              }
-                              tabIndex={-1}
-                            >
-                              <span
-                                aria-label="First"
-                              >
-                                «
-                              </span>
-                            </a>
-                          </SafeAnchor>
-                        </li>
-                      </PaginationButton>
-                      <PaginationButton
-                        active={false}
-                        componentClass={[Function]}
-                        disabled={true}
-                        eventKey={0}
-                        onSelect={[Function]}
-                      >
-                        <li
-                          className="disabled"
-                        >
-                          <SafeAnchor
-                            componentClass="a"
-                            disabled={true}
-                            onClick={[Function]}
-                          >
-                            <a
-                              href="#"
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              role="button"
-                              style={
-                                Object {
-                                  "pointerEvents": "none",
-                                }
-                              }
-                              tabIndex={-1}
-                            >
-                              <span
-                                aria-label="Previous"
-                              >
-                                ‹
-                              </span>
-                            </a>
-                          </SafeAnchor>
-                        </li>
-                      </PaginationButton>
-                      <PaginationButton
-                        active={false}
-                        componentClass={[Function]}
-                        disabled={true}
-                        eventKey={2}
-                        onSelect={[Function]}
-                      >
-                        <li
-                          className="disabled"
-                        >
-                          <SafeAnchor
-                            componentClass="a"
-                            disabled={true}
-                            onClick={[Function]}
-                          >
-                            <a
-                              href="#"
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              role="button"
-                              style={
-                                Object {
-                                  "pointerEvents": "none",
-                                }
-                              }
-                              tabIndex={-1}
-                            >
-                              <span
-                                aria-label="Next"
-                              >
-                                ›
-                              </span>
-                            </a>
-                          </SafeAnchor>
-                        </li>
-                      </PaginationButton>
-                      <PaginationButton
-                        active={false}
-                        componentClass={[Function]}
-                        disabled={true}
-                        eventKey={0}
-                        onSelect={[Function]}
-                      >
-                        <li
-                          className="disabled"
-                        >
-                          <SafeAnchor
-                            componentClass="a"
-                            disabled={true}
-                            onClick={[Function]}
-                          >
-                            <a
-                              href="#"
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              role="button"
-                              style={
-                                Object {
-                                  "pointerEvents": "none",
-                                }
-                              }
-                              tabIndex={-1}
-                            >
-                              <span
-                                aria-label="Last"
-                              >
-                                »
-                              </span>
-                            </a>
-                          </SafeAnchor>
-                        </li>
-                      </PaginationButton>
-                    </ul>
-                  </Pagination>
-                </div>
+                No bookmarks found
               </span>
-            </PaginatedList>
+              <div
+                class="text-center"
+              >
+                <ul
+                  class="pagination pagination-sm"
+                >
+                  <li
+                    class="disabled"
+                  >
+                    <a
+                      href="#"
+                      role="button"
+                      style="pointer-events: none;"
+                      tabindex="-1"
+                    >
+                      <span
+                        aria-label="First"
+                      >
+                        «
+                      </span>
+                    </a>
+                  </li>
+                  <li
+                    class="disabled"
+                  >
+                    <a
+                      href="#"
+                      role="button"
+                      style="pointer-events: none;"
+                      tabindex="-1"
+                    >
+                      <span
+                        aria-label="Previous"
+                      >
+                        ‹
+                      </span>
+                    </a>
+                  </li>
+                  <li
+                    class="disabled"
+                  >
+                    <a
+                      href="#"
+                      role="button"
+                      style="pointer-events: none;"
+                      tabindex="-1"
+                    >
+                      <span
+                        aria-label="Next"
+                      >
+                        ›
+                      </span>
+                    </a>
+                  </li>
+                  <li
+                    class="disabled"
+                  >
+                    <a
+                      href="#"
+                      role="button"
+                      style="pointer-events: none;"
+                      tabindex="-1"
+                    >
+                      <span
+                        aria-label="Last"
+                      >
+                        »
+                      </span>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </span>
           </div>
-        </ModalBody>
-        <ModalFooter
-          bsClass="modal-footer"
-          componentClass="div"
-        >
           <div
-            className="modal-footer"
+            class="modal-footer"
           >
-            <ForwardRef
-              bsStyle="primary"
-              disabled={true}
-              onClick={[Function]}
+            <button
+              class="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
+              disabled=""
+              type="button"
             >
-              <Button__StyledButton
-                bsStyle="primary"
-                disabled={true}
-                onClick={[Function]}
-              >
-                <StyledComponent
-                  bsStyle="primary"
-                  disabled={true}
-                  forwardedComponent={
-                    Object {
-                      "$$typeof": Symbol(react.forward_ref),
-                      "SIZES": Array [
-                        "large",
-                        "small",
-                        "xsmall",
-                      ],
-                      "STYLES": Array [
-                        "success",
-                        "warning",
-                        "danger",
-                        "info",
-                        "default",
-                        "primary",
-                        "link",
-                      ],
-                      "attrs": Array [],
-                      "componentStyle": ComponentStyle {
-                        "componentId": "Button__StyledButton-c9cbmb-0",
-                        "isStatic": false,
-                        "lastClassName": "kRDLih",
-                        "rules": Array [
-                          [Function],
-                        ],
-                      },
-                      "displayName": "Button__StyledButton",
-                      "foldedComponentIds": Array [],
-                      "render": [Function],
-                      "styledComponentId": "Button__StyledButton-c9cbmb-0",
-                      "target": [Function],
-                      "toString": [Function],
-                      "warnTooManyClasses": [Function],
-                      "withComponent": [Function],
-                    }
-                  }
-                  forwardedRef={null}
-                  onClick={[Function]}
-                >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="primary"
-                    className="Button__StyledButton-c9cbmb-0 kRDLih"
-                    disabled={true}
-                    onClick={[Function]}
-                  >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
-                      disabled={true}
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      Load
-                    </button>
-                  </Button>
-                </StyledComponent>
-              </Button__StyledButton>
-            </ForwardRef>
-            <ForwardRef
-              bsStyle="default"
-              disabled={true}
-              onClick={[Function]}
+              Load
+            </button>
+            <button
+              class="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+              disabled=""
+              type="button"
             >
-              <Button__StyledButton
-                bsStyle="default"
-                disabled={true}
-                onClick={[Function]}
-              >
-                <StyledComponent
-                  bsStyle="default"
-                  disabled={true}
-                  forwardedComponent={
-                    Object {
-                      "$$typeof": Symbol(react.forward_ref),
-                      "SIZES": Array [
-                        "large",
-                        "small",
-                        "xsmall",
-                      ],
-                      "STYLES": Array [
-                        "success",
-                        "warning",
-                        "danger",
-                        "info",
-                        "default",
-                        "primary",
-                        "link",
-                      ],
-                      "attrs": Array [],
-                      "componentStyle": ComponentStyle {
-                        "componentId": "Button__StyledButton-c9cbmb-0",
-                        "isStatic": false,
-                        "lastClassName": "kRDLih",
-                        "rules": Array [
-                          [Function],
-                        ],
-                      },
-                      "displayName": "Button__StyledButton",
-                      "foldedComponentIds": Array [],
-                      "render": [Function],
-                      "styledComponentId": "Button__StyledButton-c9cbmb-0",
-                      "target": [Function],
-                      "toString": [Function],
-                      "warnTooManyClasses": [Function],
-                      "withComponent": [Function],
-                    }
-                  }
-                  forwardedRef={null}
-                  onClick={[Function]}
-                >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="default"
-                    className="Button__StyledButton-c9cbmb-0 kRDLih"
-                    disabled={true}
-                    onClick={[Function]}
-                  >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
-                      disabled={true}
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      Delete
-                    </button>
-                  </Button>
-                </StyledComponent>
-              </Button__StyledButton>
-            </ForwardRef>
-            <ForwardRef
-              bsStyle="default"
-              onClick={[Function]}
+              Delete
+            </button>
+            <button
+              class="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+              type="button"
             >
-              <Button__StyledButton
-                bsStyle="default"
-                onClick={[Function]}
-              >
-                <StyledComponent
-                  bsStyle="default"
-                  forwardedComponent={
-                    Object {
-                      "$$typeof": Symbol(react.forward_ref),
-                      "SIZES": Array [
-                        "large",
-                        "small",
-                        "xsmall",
-                      ],
-                      "STYLES": Array [
-                        "success",
-                        "warning",
-                        "danger",
-                        "info",
-                        "default",
-                        "primary",
-                        "link",
-                      ],
-                      "attrs": Array [],
-                      "componentStyle": ComponentStyle {
-                        "componentId": "Button__StyledButton-c9cbmb-0",
-                        "isStatic": false,
-                        "lastClassName": "kRDLih",
-                        "rules": Array [
-                          [Function],
-                        ],
-                      },
-                      "displayName": "Button__StyledButton",
-                      "foldedComponentIds": Array [],
-                      "render": [Function],
-                      "styledComponentId": "Button__StyledButton-c9cbmb-0",
-                      "target": [Function],
-                      "toString": [Function],
-                      "warnTooManyClasses": [Function],
-                      "withComponent": [Function],
-                    }
-                  }
-                  forwardedRef={null}
-                  onClick={[Function]}
-                >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="default"
-                    className="Button__StyledButton-c9cbmb-0 kRDLih"
-                    disabled={false}
-                    onClick={[Function]}
-                  >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
-                      disabled={false}
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      Cancel
-                    </button>
-                  </Button>
-                </StyledComponent>
-              </Button__StyledButton>
-            </ForwardRef>
+              Cancel
+            </button>
           </div>
-        </ModalFooter>
+        </div>
       </div>
     </div>
   </div>
-</ModalDialog>
+</body>
 `;
 
 exports[`BookmarkList render the BookmarkList should render with views 1`] = `
-<ModalDialog
-  bsClass="modal"
-  className="fade in"
-  onClick={[Function]}
-  role="document"
-  style={
-    Object {
-      "paddingLeft": undefined,
-      "paddingRight": 0,
-    }
-  }
-  tabIndex="-1"
+<body
+  class="modal-open"
+  style="padding-right: 0px;"
 >
   <div
-    className="fade in modal"
-    onClick={[Function]}
+    aria-hidden="true"
+  />
+  <div
     role="dialog"
-    style={
-      Object {
-        "display": "block",
-        "paddingLeft": undefined,
-        "paddingRight": 0,
-      }
-    }
-    tabIndex="-1"
   >
     <div
-      className="modal-dialog"
+      class="modal-backdrop fade in"
+    />
+    <div
+      class="fade in modal"
+      role="dialog"
+      style="display: block; padding-right: 0px;"
+      tabindex="-1"
     >
       <div
-        className="modal-content"
-        role="document"
+        class="modal-dialog"
       >
-        <ModalBody
-          bsClass="modal-body"
-          componentClass="div"
+        <div
+          class="modal-content"
+          role="document"
         >
           <div
-            className="modal-body"
+            class="modal-body"
           >
-            <SearchForm
-              buttonLeftMargin={5}
-              label={null}
-              loadingLabel="Loading..."
-              onQueryChange={[Function]}
-              onReset={[Function]}
-              onSearch={[Function]}
-              placeholder="Enter search query..."
-              query=""
-              queryHelpComponent={null}
-              queryWidth="auto"
-              resetButtonLabel="Reset"
-              searchBsStyle="default"
-              searchButtonLabel="Search"
-              topMargin={15}
-              useLoadingState={false}
-              wrapperClass="search"
+            <div
+              class="search"
+              style="margin-top: 15px;"
             >
+              <form
+                class="form-inline"
+              >
+                <div
+                  class="form-group has-feedback"
+                >
+                  <input
+                    autocomplete="off"
+                    class="query form-control"
+                    id="common-search-form-query-input"
+                    placeholder="Enter search query..."
+                    spellcheck="false"
+                    style="width: auto;"
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <div
+                  class="form-group"
+                  style="margin-left: 5px;"
+                >
+                  <button
+                    class="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    type="submit"
+                  >
+                    Search
+                  </button>
+                </div>
+                <div
+                  class="form-group"
+                  style="margin-left: 5px;"
+                >
+                  <button
+                    class="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    type="reset"
+                  >
+                    Reset
+                  </button>
+                </div>
+              </form>
+            </div>
+            <span>
               <div
-                className="search"
-                style={
-                  Object {
-                    "marginTop": 15,
-                  }
-                }
+                class="form-inline page-size"
+                style="float: right;"
               >
-                <form
-                  className="form-inline"
-                  onSubmit={[Function]}
+                <div
+                  class="form-group"
                 >
-                  <div
-                    className="form-group has-feedback"
+                  <label
+                    class="ControlLabel-sc-1edmum5-0 iZJNbd control-label"
+                    for="page-size"
                   >
-                    <input
-                      autoComplete="off"
-                      className="query form-control"
-                      id="common-search-form-query-input"
-                      onChange={[Function]}
-                      placeholder="Enter search query..."
-                      spellCheck="false"
-                      style={
-                        Object {
-                          "width": "auto",
-                        }
-                      }
-                      type="text"
-                      value=""
-                    />
-                  </div>
-                  <div
-                    className="form-group"
-                    style={
-                      Object {
-                        "marginLeft": 5,
-                      }
-                    }
-                  >
-                    <ForwardRef
-                      bsStyle="default"
-                      className="submit-button"
-                      disabled={false}
-                      type="submit"
+                    Show:
+                  </label>
+                  <span>
+                    <select
+                      class="form-control input-sm"
+                      id="page-size"
+                      label="Show:"
+                      name="page-size"
+                      placeholder=""
+                      type="select"
                     >
-                      <Button__StyledButton
-                        bsStyle="default"
-                        className="submit-button"
-                        disabled={false}
-                        type="submit"
+                      <option
+                        value="5"
                       >
-                        <StyledComponent
-                          bsStyle="default"
-                          className="submit-button"
-                          disabled={false}
-                          forwardedComponent={
-                            Object {
-                              "$$typeof": Symbol(react.forward_ref),
-                              "SIZES": Array [
-                                "large",
-                                "small",
-                                "xsmall",
-                              ],
-                              "STYLES": Array [
-                                "success",
-                                "warning",
-                                "danger",
-                                "info",
-                                "default",
-                                "primary",
-                                "link",
-                              ],
-                              "attrs": Array [],
-                              "componentStyle": ComponentStyle {
-                                "componentId": "Button__StyledButton-c9cbmb-0",
-                                "isStatic": false,
-                                "lastClassName": "kRDLih",
-                                "rules": Array [
-                                  [Function],
-                                ],
-                              },
-                              "displayName": "Button__StyledButton",
-                              "foldedComponentIds": Array [],
-                              "render": [Function],
-                              "styledComponentId": "Button__StyledButton-c9cbmb-0",
-                              "target": [Function],
-                              "toString": [Function],
-                              "warnTooManyClasses": [Function],
-                              "withComponent": [Function],
-                            }
-                          }
-                          forwardedRef={null}
-                          type="submit"
-                        >
-                          <Button
-                            active={false}
-                            block={false}
-                            bsClass="btn"
-                            bsStyle="default"
-                            className="submit-button Button__StyledButton-c9cbmb-0 kRDLih"
-                            disabled={false}
-                            type="submit"
-                          >
-                            <button
-                              className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
-                              disabled={false}
-                              type="submit"
-                            >
-                              Search
-                            </button>
-                          </Button>
-                        </StyledComponent>
-                      </Button__StyledButton>
-                    </ForwardRef>
-                  </div>
-                  <div
-                    className="form-group"
-                    style={
-                      Object {
-                        "marginLeft": 5,
-                      }
-                    }
-                  >
-                    <ForwardRef
-                      bsStyle="default"
-                      className="reset-button"
-                      onClick={[Function]}
-                      type="reset"
-                    >
-                      <Button__StyledButton
-                        bsStyle="default"
-                        className="reset-button"
-                        onClick={[Function]}
-                        type="reset"
+                        5
+                      </option>
+                      <option
+                        value="10"
                       >
-                        <StyledComponent
-                          bsStyle="default"
-                          className="reset-button"
-                          forwardedComponent={
-                            Object {
-                              "$$typeof": Symbol(react.forward_ref),
-                              "SIZES": Array [
-                                "large",
-                                "small",
-                                "xsmall",
-                              ],
-                              "STYLES": Array [
-                                "success",
-                                "warning",
-                                "danger",
-                                "info",
-                                "default",
-                                "primary",
-                                "link",
-                              ],
-                              "attrs": Array [],
-                              "componentStyle": ComponentStyle {
-                                "componentId": "Button__StyledButton-c9cbmb-0",
-                                "isStatic": false,
-                                "lastClassName": "kRDLih",
-                                "rules": Array [
-                                  [Function],
-                                ],
-                              },
-                              "displayName": "Button__StyledButton",
-                              "foldedComponentIds": Array [],
-                              "render": [Function],
-                              "styledComponentId": "Button__StyledButton-c9cbmb-0",
-                              "target": [Function],
-                              "toString": [Function],
-                              "warnTooManyClasses": [Function],
-                              "withComponent": [Function],
-                            }
-                          }
-                          forwardedRef={null}
-                          onClick={[Function]}
-                          type="reset"
-                        >
-                          <Button
-                            active={false}
-                            block={false}
-                            bsClass="btn"
-                            bsStyle="default"
-                            className="reset-button Button__StyledButton-c9cbmb-0 kRDLih"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="reset"
-                          >
-                            <button
-                              className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
-                              disabled={false}
-                              onClick={[Function]}
-                              type="reset"
-                            >
-                              Reset
-                            </button>
-                          </Button>
-                        </StyledComponent>
-                      </Button__StyledButton>
-                    </ForwardRef>
-                  </div>
-                </form>
+                        10
+                      </option>
+                      <option
+                        value="15"
+                      >
+                        15
+                      </option>
+                    </select>
+                    
+                  </span>
+                </div>
               </div>
-            </SearchForm>
-            <PaginatedList
-              activePage={1}
-              onChange={[Function]}
-              pageSize={5}
-              pageSizes={
-                Array [
-                  5,
-                  10,
-                  15,
-                ]
-              }
-              showPageSizeSelect={true}
-              totalItems={1}
-            >
-              <span>
-                <div
-                  className="form-inline page-size"
-                  style={
-                    Object {
-                      "float": "right",
-                    }
-                  }
+              <div
+                class="list-group"
+              >
+                <button
+                  class="list-group-item"
+                  type="button"
                 >
-                  <Input
-                    addonAfter={null}
-                    bsSize="small"
-                    bsStyle={null}
-                    buttonAfter={null}
-                    help=""
-                    id="page-size"
-                    label="Show:"
-                    onChange={[Function]}
-                    placeholder=""
-                    type="select"
-                    value={5}
+                  <h4
+                    class="list-group-item-heading"
                   >
-                    <FormGroup
-                      bsClass="form-group"
-                      controlId="page-size"
-                      validationState={null}
-                    >
-                      <div
-                        className="form-group"
-                      >
-                        <ForwardRef>
-                          <ControlLabel>
-                            <StyledComponent
-                              forwardedComponent={
-                                Object {
-                                  "$$typeof": Symbol(react.forward_ref),
-                                  "attrs": Array [],
-                                  "componentStyle": ComponentStyle {
-                                    "componentId": "ControlLabel-sc-1edmum5-0",
-                                    "isStatic": true,
-                                    "lastClassName": "iZJNbd",
-                                    "rules": Array [
-                                      "color:",
-                                      "#1F1F1F",
-                                      ";font-weight:bold;margin-bottom:5px;display:inline-block;",
-                                    ],
-                                  },
-                                  "displayName": "ControlLabel",
-                                  "foldedComponentIds": Array [],
-                                  "render": [Function],
-                                  "styledComponentId": "ControlLabel-sc-1edmum5-0",
-                                  "target": [Function],
-                                  "toString": [Function],
-                                  "warnTooManyClasses": [Function],
-                                  "withComponent": [Function],
-                                }
-                              }
-                              forwardedRef={null}
-                            >
-                              <ControlLabel
-                                bsClass="control-label"
-                                className="ControlLabel-sc-1edmum5-0 iZJNbd"
-                                srOnly={false}
-                              >
-                                <label
-                                  className="ControlLabel-sc-1edmum5-0 iZJNbd control-label"
-                                  htmlFor="page-size"
-                                >
-                                  Show:
-                                </label>
-                              </ControlLabel>
-                            </StyledComponent>
-                          </ControlLabel>
-                        </ForwardRef>
-                        <InputWrapper>
-                          <span>
-                            <FormControl
-                              bsClass="form-control"
-                              bsSize="small"
-                              componentClass="select"
-                              inputRef={[Function]}
-                              label="Show:"
-                              name="page-size"
-                              onChange={[Function]}
-                              placeholder=""
-                              type="select"
-                              value={5}
-                            >
-                              <select
-                                className="form-control input-sm"
-                                id="page-size"
-                                label="Show:"
-                                name="page-size"
-                                onChange={[Function]}
-                                placeholder=""
-                                type="select"
-                                value={5}
-                              >
-                                <option
-                                  key="option-5"
-                                  value={5}
-                                >
-                                  5
-                                </option>
-                                <option
-                                  key="option-10"
-                                  value={10}
-                                >
-                                  10
-                                </option>
-                                <option
-                                  key="option-15"
-                                  value={15}
-                                >
-                                  15
-                                </option>
-                              </select>
-                            </FormControl>
-                          </span>
-                        </InputWrapper>
-                      </div>
-                    </FormGroup>
-                  </Input>
-                </div>
-                <ListGroup
-                  bsClass="list-group"
+                    test-0
+                  </h4>
+                  <p
+                    class="list-group-item-text"
+                  />
+                </button>
+              </div>
+              <div
+                class="text-center"
+              >
+                <ul
+                  class="pagination pagination-sm"
                 >
-                  <div
-                    className="list-group"
+                  <li
+                    class="disabled"
                   >
-                    <ListGroupItem
-                      active={false}
-                      bsClass="list-group-item"
-                      header="test-0"
-                      key="foo-bar-0"
-                      listItem={false}
-                      onClick={[Function]}
+                    <a
+                      href="#"
+                      role="button"
+                      style="pointer-events: none;"
+                      tabindex="-1"
                     >
-                      <button
-                        className="list-group-item"
-                        onClick={[Function]}
-                        type="button"
+                      <span
+                        aria-label="First"
                       >
-                        <h4
-                          className="list-group-item-heading"
-                        >
-                          test-0
-                        </h4>
-                        <p
-                          className="list-group-item-text"
-                        />
-                      </button>
-                    </ListGroupItem>
-                  </div>
-                </ListGroup>
-                <div
-                  className="text-center"
-                >
-                  <Pagination
-                    activePage={1}
-                    boundaryLinks={false}
-                    bsClass="pagination"
-                    bsSize="small"
-                    ellipsis={true}
-                    first={true}
-                    items={1}
-                    last={true}
-                    maxButtons={10}
-                    next={true}
-                    onSelect={[Function]}
-                    prev={true}
+                        «
+                      </span>
+                    </a>
+                  </li>
+                  <li
+                    class="disabled"
                   >
-                    <ul
-                      className="pagination pagination-sm"
+                    <a
+                      href="#"
+                      role="button"
+                      style="pointer-events: none;"
+                      tabindex="-1"
                     >
-                      <PaginationButton
-                        active={false}
-                        componentClass={[Function]}
-                        disabled={true}
-                        eventKey={1}
-                        onSelect={[Function]}
+                      <span
+                        aria-label="Previous"
                       >
-                        <li
-                          className="disabled"
-                        >
-                          <SafeAnchor
-                            componentClass="a"
-                            disabled={true}
-                            onClick={[Function]}
-                          >
-                            <a
-                              href="#"
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              role="button"
-                              style={
-                                Object {
-                                  "pointerEvents": "none",
-                                }
-                              }
-                              tabIndex={-1}
-                            >
-                              <span
-                                aria-label="First"
-                              >
-                                «
-                              </span>
-                            </a>
-                          </SafeAnchor>
-                        </li>
-                      </PaginationButton>
-                      <PaginationButton
-                        active={false}
-                        componentClass={[Function]}
-                        disabled={true}
-                        eventKey={0}
-                        onSelect={[Function]}
+                        ‹
+                      </span>
+                    </a>
+                  </li>
+                  <li
+                    class="active"
+                  >
+                    <a
+                      href="#"
+                      role="button"
+                    >
+                      1
+                    </a>
+                  </li>
+                  <li
+                    class="disabled"
+                  >
+                    <a
+                      href="#"
+                      role="button"
+                      style="pointer-events: none;"
+                      tabindex="-1"
+                    >
+                      <span
+                        aria-label="Next"
                       >
-                        <li
-                          className="disabled"
-                        >
-                          <SafeAnchor
-                            componentClass="a"
-                            disabled={true}
-                            onClick={[Function]}
-                          >
-                            <a
-                              href="#"
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              role="button"
-                              style={
-                                Object {
-                                  "pointerEvents": "none",
-                                }
-                              }
-                              tabIndex={-1}
-                            >
-                              <span
-                                aria-label="Previous"
-                              >
-                                ‹
-                              </span>
-                            </a>
-                          </SafeAnchor>
-                        </li>
-                      </PaginationButton>
-                      <PaginationButton
-                        active={true}
-                        componentClass={[Function]}
-                        disabled={false}
-                        eventKey={1}
-                        key="1"
-                        onSelect={[Function]}
+                        ›
+                      </span>
+                    </a>
+                  </li>
+                  <li
+                    class="disabled"
+                  >
+                    <a
+                      href="#"
+                      role="button"
+                      style="pointer-events: none;"
+                      tabindex="-1"
+                    >
+                      <span
+                        aria-label="Last"
                       >
-                        <li
-                          className="active"
-                        >
-                          <SafeAnchor
-                            componentClass="a"
-                            disabled={false}
-                            onClick={[Function]}
-                          >
-                            <a
-                              href="#"
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              role="button"
-                            >
-                              1
-                            </a>
-                          </SafeAnchor>
-                        </li>
-                      </PaginationButton>
-                      <PaginationButton
-                        active={false}
-                        componentClass={[Function]}
-                        disabled={true}
-                        eventKey={2}
-                        onSelect={[Function]}
-                      >
-                        <li
-                          className="disabled"
-                        >
-                          <SafeAnchor
-                            componentClass="a"
-                            disabled={true}
-                            onClick={[Function]}
-                          >
-                            <a
-                              href="#"
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              role="button"
-                              style={
-                                Object {
-                                  "pointerEvents": "none",
-                                }
-                              }
-                              tabIndex={-1}
-                            >
-                              <span
-                                aria-label="Next"
-                              >
-                                ›
-                              </span>
-                            </a>
-                          </SafeAnchor>
-                        </li>
-                      </PaginationButton>
-                      <PaginationButton
-                        active={false}
-                        componentClass={[Function]}
-                        disabled={true}
-                        eventKey={1}
-                        onSelect={[Function]}
-                      >
-                        <li
-                          className="disabled"
-                        >
-                          <SafeAnchor
-                            componentClass="a"
-                            disabled={true}
-                            onClick={[Function]}
-                          >
-                            <a
-                              href="#"
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              role="button"
-                              style={
-                                Object {
-                                  "pointerEvents": "none",
-                                }
-                              }
-                              tabIndex={-1}
-                            >
-                              <span
-                                aria-label="Last"
-                              >
-                                »
-                              </span>
-                            </a>
-                          </SafeAnchor>
-                        </li>
-                      </PaginationButton>
-                    </ul>
-                  </Pagination>
-                </div>
-              </span>
-            </PaginatedList>
+                        »
+                      </span>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </span>
           </div>
-        </ModalBody>
-        <ModalFooter
-          bsClass="modal-footer"
-          componentClass="div"
-        >
           <div
-            className="modal-footer"
+            class="modal-footer"
           >
-            <ForwardRef
-              bsStyle="primary"
-              disabled={true}
-              onClick={[Function]}
+            <button
+              class="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
+              disabled=""
+              type="button"
             >
-              <Button__StyledButton
-                bsStyle="primary"
-                disabled={true}
-                onClick={[Function]}
-              >
-                <StyledComponent
-                  bsStyle="primary"
-                  disabled={true}
-                  forwardedComponent={
-                    Object {
-                      "$$typeof": Symbol(react.forward_ref),
-                      "SIZES": Array [
-                        "large",
-                        "small",
-                        "xsmall",
-                      ],
-                      "STYLES": Array [
-                        "success",
-                        "warning",
-                        "danger",
-                        "info",
-                        "default",
-                        "primary",
-                        "link",
-                      ],
-                      "attrs": Array [],
-                      "componentStyle": ComponentStyle {
-                        "componentId": "Button__StyledButton-c9cbmb-0",
-                        "isStatic": false,
-                        "lastClassName": "kRDLih",
-                        "rules": Array [
-                          [Function],
-                        ],
-                      },
-                      "displayName": "Button__StyledButton",
-                      "foldedComponentIds": Array [],
-                      "render": [Function],
-                      "styledComponentId": "Button__StyledButton-c9cbmb-0",
-                      "target": [Function],
-                      "toString": [Function],
-                      "warnTooManyClasses": [Function],
-                      "withComponent": [Function],
-                    }
-                  }
-                  forwardedRef={null}
-                  onClick={[Function]}
-                >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="primary"
-                    className="Button__StyledButton-c9cbmb-0 kRDLih"
-                    disabled={true}
-                    onClick={[Function]}
-                  >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
-                      disabled={true}
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      Load
-                    </button>
-                  </Button>
-                </StyledComponent>
-              </Button__StyledButton>
-            </ForwardRef>
-            <ForwardRef
-              bsStyle="default"
-              disabled={true}
-              onClick={[Function]}
+              Load
+            </button>
+            <button
+              class="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+              disabled=""
+              type="button"
             >
-              <Button__StyledButton
-                bsStyle="default"
-                disabled={true}
-                onClick={[Function]}
-              >
-                <StyledComponent
-                  bsStyle="default"
-                  disabled={true}
-                  forwardedComponent={
-                    Object {
-                      "$$typeof": Symbol(react.forward_ref),
-                      "SIZES": Array [
-                        "large",
-                        "small",
-                        "xsmall",
-                      ],
-                      "STYLES": Array [
-                        "success",
-                        "warning",
-                        "danger",
-                        "info",
-                        "default",
-                        "primary",
-                        "link",
-                      ],
-                      "attrs": Array [],
-                      "componentStyle": ComponentStyle {
-                        "componentId": "Button__StyledButton-c9cbmb-0",
-                        "isStatic": false,
-                        "lastClassName": "kRDLih",
-                        "rules": Array [
-                          [Function],
-                        ],
-                      },
-                      "displayName": "Button__StyledButton",
-                      "foldedComponentIds": Array [],
-                      "render": [Function],
-                      "styledComponentId": "Button__StyledButton-c9cbmb-0",
-                      "target": [Function],
-                      "toString": [Function],
-                      "warnTooManyClasses": [Function],
-                      "withComponent": [Function],
-                    }
-                  }
-                  forwardedRef={null}
-                  onClick={[Function]}
-                >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="default"
-                    className="Button__StyledButton-c9cbmb-0 kRDLih"
-                    disabled={true}
-                    onClick={[Function]}
-                  >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
-                      disabled={true}
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      Delete
-                    </button>
-                  </Button>
-                </StyledComponent>
-              </Button__StyledButton>
-            </ForwardRef>
-            <ForwardRef
-              bsStyle="default"
-              onClick={[Function]}
+              Delete
+            </button>
+            <button
+              class="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+              type="button"
             >
-              <Button__StyledButton
-                bsStyle="default"
-                onClick={[Function]}
-              >
-                <StyledComponent
-                  bsStyle="default"
-                  forwardedComponent={
-                    Object {
-                      "$$typeof": Symbol(react.forward_ref),
-                      "SIZES": Array [
-                        "large",
-                        "small",
-                        "xsmall",
-                      ],
-                      "STYLES": Array [
-                        "success",
-                        "warning",
-                        "danger",
-                        "info",
-                        "default",
-                        "primary",
-                        "link",
-                      ],
-                      "attrs": Array [],
-                      "componentStyle": ComponentStyle {
-                        "componentId": "Button__StyledButton-c9cbmb-0",
-                        "isStatic": false,
-                        "lastClassName": "kRDLih",
-                        "rules": Array [
-                          [Function],
-                        ],
-                      },
-                      "displayName": "Button__StyledButton",
-                      "foldedComponentIds": Array [],
-                      "render": [Function],
-                      "styledComponentId": "Button__StyledButton-c9cbmb-0",
-                      "target": [Function],
-                      "toString": [Function],
-                      "warnTooManyClasses": [Function],
-                      "withComponent": [Function],
-                    }
-                  }
-                  forwardedRef={null}
-                  onClick={[Function]}
-                >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="default"
-                    className="Button__StyledButton-c9cbmb-0 kRDLih"
-                    disabled={false}
-                    onClick={[Function]}
-                  >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
-                      disabled={false}
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      Cancel
-                    </button>
-                  </Button>
-                </StyledComponent>
-              </Button__StyledButton>
-            </ForwardRef>
+              Cancel
+            </button>
           </div>
-        </ModalFooter>
+        </div>
       </div>
     </div>
   </div>
-</ModalDialog>
+</body>
 `;

--- a/graylog2-web-interface/src/views/pages/ShowViewPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ShowViewPage.jsx
@@ -6,11 +6,13 @@ import connect from 'stores/connect';
 import Spinner from 'components/common/Spinner';
 
 import View from 'views/logic/views/View';
+import ViewLoaderContext from 'views/logic/ViewLoaderContext';
 import { SearchExecutionStateStore } from 'views/stores/SearchExecutionStateStore';
 import withPluginEntities from 'views/logic/withPluginEntities';
 import type { ViewHook } from 'views/logic/hooks/ViewHook';
 import type { ViewLoaderFn } from 'views/logic/views/ViewLoader';
 import ViewLoader from 'views/logic/views/ViewLoader';
+import { SearchActions } from 'views/stores/SearchStore';
 
 import ExtendedSearchPage from './ExtendedSearchPage';
 
@@ -82,6 +84,8 @@ class ShowViewPage extends React.Component<Props, State> {
     ).then((results) => {
       this.setState({ loaded: true });
       return results;
+    }).then(() => {
+      SearchActions.executeWithCurrentState();
     }).catch(e => e);
   };
 
@@ -99,7 +103,9 @@ class ShowViewPage extends React.Component<Props, State> {
     const { route } = this.props;
 
     return (
-      <ExtendedSearchPage route={route} />
+      <ViewLoaderContext.Provider value={this.loadView}>
+        <ExtendedSearchPage route={route} />
+      </ViewLoaderContext.Provider>
     );
   }
 }

--- a/graylog2-web-interface/src/views/pages/ShowViewPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ShowViewPage.jsx
@@ -84,7 +84,7 @@ class ShowViewPage extends React.Component<Props, State> {
     ).then((results) => {
       this.setState({ loaded: true });
       return results;
-    }).then(() => {
+    }).then(() => SearchActions.executeWithCurrentState())
       SearchActions.executeWithCurrentState();
     }).catch(e => e);
   };

--- a/graylog2-web-interface/src/views/pages/ShowViewPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ShowViewPage.jsx
@@ -84,7 +84,7 @@ class ShowViewPage extends React.Component<Props, State> {
     ).then((results) => {
       this.setState({ loaded: true });
       return results;
-    }).then(() => SearchActions.executeWithCurrentState())
+    }).then(() => {
       SearchActions.executeWithCurrentState();
     }).catch(e => e);
   };

--- a/graylog2-web-interface/src/views/pages/ShowViewPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ShowViewPage.jsx
@@ -84,8 +84,9 @@ class ShowViewPage extends React.Component<Props, State> {
     ).then((results) => {
       this.setState({ loaded: true });
       return results;
-    }).then(() => {
+    }).then((results) => {
       SearchActions.executeWithCurrentState();
+      return results;
     }).catch(e => e);
   };
 

--- a/graylog2-web-interface/src/views/pages/ShowViewPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/ShowViewPage.test.jsx
@@ -27,6 +27,11 @@ jest.mock('views/stores/ViewManagementStore', () => ({
   },
 }));
 jest.mock('views/logic/views/ViewDeserializer', () => jest.fn(x => Promise.resolve(x)));
+jest.mock('views/stores/SearchStore', () => ({
+  SearchActions: {
+    execute: mockAction(jest.fn()),
+  },
+}))
 jest.mock('views/stores/SearchExecutionStateStore', () => ({
   SearchExecutionStateActions: {},
   SearchExecutionStateStore: { listen: jest.fn() },

--- a/graylog2-web-interface/src/views/pages/ShowViewPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/ShowViewPage.test.jsx
@@ -31,7 +31,7 @@ jest.mock('views/stores/SearchStore', () => ({
   SearchActions: {
     execute: mockAction(jest.fn()),
   },
-}))
+}));
 jest.mock('views/stores/SearchExecutionStateStore', () => ({
   SearchExecutionStateActions: {},
   SearchExecutionStateStore: { listen: jest.fn() },


### PR DESCRIPTION
## Motivation and Context
Prior this change, after the user loaded a bookmarked search
the id was not shown in the url. So the user could not create
a browser bookmark for that search.

## Description
This change adds browserHistory.push at the points where a bookmarked
search will be loaded.

## How Has This Been Tested?
- Add a new bookmark and checked for the ID in the url bar of the browser
- Loaded a old bookmark and checked for the url
- Cleared the view and checked that I got back to `/search`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
