### PR TITLE
Generate unique aggregation ids for multiple percentile metrics

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Percentile.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Percentile.java
@@ -48,7 +48,7 @@ public abstract class Percentile implements SeriesSpec {
 
     @Override
     public String literal() {
-        return type() + "(" + percentile() + "," + field() + ")";
+        return type() + "(" + field() + "," + percentile() + ")";
     }
 
     public static Builder builder() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Percentile.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Percentile.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.TypedBuilder;
 
@@ -44,6 +45,11 @@ public abstract class Percentile implements SeriesSpec {
 
     @JsonProperty
     public abstract Double percentile();
+
+    @Override
+    public String literal() {
+        return type() + "(" + percentile() + "," + field() + ")";
+    }
 
     public static Builder builder() {
         return new AutoValue_Percentile.Builder().type(NAME);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Percentile.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/series/Percentile.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
-import com.google.common.base.Strings;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.TypedBuilder;
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/searchtypes/pivot/series/PercentileTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/searchtypes/pivot/series/PercentileTest.java
@@ -1,0 +1,24 @@
+package org.graylog.plugins.views.search.searchtypes.pivot.series;
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PercentileTest {
+
+    @Test
+    public void testLiteral() {
+        final Percentile percentile1 = Percentile.builder()
+                .percentile(25.0)
+                .field("cloverfield")
+                .id("dead-beef")
+                .build();
+        assertThat(percentile1.literal()).isEqualTo("percentile(cloverfield,25.0)");
+
+        final Percentile percentile2 = Percentile.builder()
+                .percentile(99.0)
+                .field("nostromo")
+                .id("dead-beef")
+                .build();
+        assertThat(percentile2.literal()).isEqualTo("percentile(nostromo,99.0)");
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/searchtypes/pivot/series/PercentileTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/searchtypes/pivot/series/PercentileTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.views.search.searchtypes.pivot.series;
 
 import org.junit.Test;


### PR DESCRIPTION
## Motivation and Context
Prior to this change, the user was unable to create more than one
percentile metric for same field in aggregation. Since the aggregation
series name was matching on aggregation name and field.

## Description
This change will add the percentile to the aggregation name. That way
the user can add more then one percentile aggergation.

## How Has This Been Tested?
Add more than one percentile series

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
