### PR TITLE
Provide optional render completion callback to views widgets.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationbuilder/EmptyAggregationContent.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/EmptyAggregationContent.jsx
@@ -1,13 +1,22 @@
 // @flow strict
-import * as React from 'react';
+import React, { useContext, useEffect } from 'react';
 import { Jumbotron, Button } from 'components/graylog';
+import RenderCompletionCallback from 'views/components/widgets/RenderCompletionCallback';
+import InteractiveContext from '../contexts/InteractiveContext';
 
 type Props = {|
   toggleEdit: () => void,
   editing: boolean,
-|}
+|};
 
 const EmptyAggregationContent = ({ toggleEdit, editing = false }: Props) => {
+  const onRenderComplete = useContext(RenderCompletionCallback);
+  useEffect(() => {
+    if (onRenderComplete) {
+      onRenderComplete();
+    }
+  }, [onRenderComplete]);
+  const interactive = useContext(InteractiveContext);
   const text = editing
     ? (
       <p>You are now editing the widget.<br />
@@ -15,7 +24,7 @@ const EmptyAggregationContent = ({ toggleEdit, editing = false }: Props) => {
         To finish, click &quot;Save&quot; to save, &quot;Cancel&quot; to abandon changes.
       </p>
     )
-    : (<p>Please <Button bsStyle="info" onClick={toggleEdit}>Edit</Button> the widget to see results here.</p>);
+    : (<p>Please {interactive ? <Button bsStyle="info" onClick={toggleEdit}>Edit</Button> : 'edit'} the widget to see results here.</p>);
   return (
     <Jumbotron>
       <h2>Empty Aggregation</h2>

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/EmptyAggregationContent.test.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/EmptyAggregationContent.test.jsx
@@ -1,0 +1,19 @@
+// @flow strict
+import * as React from 'react';
+import { mount } from 'enzyme';
+
+import EmptyAggregationContent from './EmptyAggregationContent';
+import RenderCompletionCallback from '../widgets/RenderCompletionCallback';
+
+describe('EmptyAggregationContext', () => {
+  it('calls render completion callback after first render', () => {
+    const onRenderComplete = jest.fn();
+    mount((
+      <RenderCompletionCallback.Provider value={onRenderComplete}>
+        <EmptyAggregationContent toggleEdit={() => {}} editing={false} />
+      </RenderCompletionCallback.Provider>
+    ));
+
+    expect(onRenderComplete).toHaveBeenCalled();
+  });
+});

--- a/graylog2-web-interface/src/views/components/contexts/InteractiveContext.js
+++ b/graylog2-web-interface/src/views/components/contexts/InteractiveContext.js
@@ -1,6 +1,7 @@
 // @flow strict
 import * as React from 'react';
+import { singleton } from '../../logic/singleton';
 
 const InteractiveContext = React.createContext<boolean>(true);
 
-export default InteractiveContext;
+export default singleton('views.components.contexts.InteractiveContext', () => InteractiveContext);

--- a/graylog2-web-interface/src/views/components/datatable/DataTable.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTable.jsx
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { useContext, useEffect } from 'react';
 import * as Immutable from 'immutable';
 import { flatten, isEqual, uniqWith } from 'lodash';
 
@@ -16,6 +16,7 @@ import DataTableEntry from './DataTableEntry';
 import deduplicateValues from './DeduplicateValues';
 import Headers from './Headers';
 import styles from './DataTable.css';
+import RenderCompletionCallback from '../widgets/RenderCompletionCallback';
 
 type Props = {
   config: AggregationWidgetConfig,
@@ -63,6 +64,9 @@ const _extractColumnPivotValues = (rows): Array<Array<string>> => {
 };
 
 const DataTable = ({ config, currentView, data, fields }: Props) => {
+  const onRenderComplete = useContext(RenderCompletionCallback);
+  useEffect(onRenderComplete, [onRenderComplete]);
+
   const { columnPivots, rowPivots, series, rollup } = config;
   const rows = data || [];
 

--- a/graylog2-web-interface/src/views/components/datatable/DataTable.test.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTable.test.jsx
@@ -12,6 +12,7 @@ import Series from 'views/logic/aggregationbuilder/Series';
 import { FieldTypes } from 'views/logic/fieldtypes/FieldType';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import DataTable from 'views/components/datatable/DataTable';
+import RenderCompletionCallback from '../widgets/RenderCompletionCallback';
 
 jest.mock('stores/users/CurrentUserStore', () => MockStore('listen', 'get'));
 
@@ -180,5 +181,29 @@ describe('DataTable', () => {
 
     expectFieldType('Value[field="max(timestamp)"]', FieldTypes.DATE());
     expectFieldType('Field[name="max(timestamp)"]', FieldTypes.DATE());
+  });
+
+  it('calls render completion callback after first render', () => {
+    const config = AggregationWidgetConfig.builder()
+      .rowPivots([])
+      .columnPivots([])
+      .series([])
+      .sort([])
+      .visualization('table')
+      .rollup(true)
+      .build();
+    const Component = () => (
+      <DataTable config={config}
+                 currentView={currentView}
+                 data={[]}
+                 fields={Immutable.List([])} />
+    );
+    const onRenderComplete = jest.fn();
+    mount((
+      <RenderCompletionCallback.Provider value={onRenderComplete}>
+        <Component />
+      </RenderCompletionCallback.Provider>
+    ));
+    expect(onRenderComplete).toHaveBeenCalled();
   });
 });

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.jsx
@@ -11,6 +11,7 @@ import ChartColorContext from './ChartColorContext';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import styles from '!style/useable!css!./GenericPlot.css';
 import InteractiveContext from '../contexts/InteractiveContext';
+import RenderCompletionCallback from '../widgets/RenderCompletionCallback';
 
 type LegendConfig = {
   name: string,
@@ -23,18 +24,18 @@ type ChartMarker = {
   color?: string,
 };
 
-type ChartConfig = {
+export type ChartConfig = {
   name: string,
   labels: Array<string>,
   line?: ChartMarker,
   marker?: ChartMarker,
 };
 
-type ColorMap = {
+export type ColorMap = {
   [string]: string,
 };
 
-type ChartColor = {
+export type ChartColor = {
   line?: ChartMarker,
   marker?: ChartMarker,
 };
@@ -163,31 +164,36 @@ class GenericPlot extends React.Component<Props, State> {
           return (
             <InteractiveContext.Consumer>
               {interactive => (
-                <React.Fragment>
-                  <Plot data={newChartData}
-                        useResizeHandler
-                        layout={interactive ? plotLayout : merge(nonInteractiveLayout, plotLayout)}
-                        style={style}
-                        onClick={interactive ? null : () => false}
-                        onLegendClick={interactive ? this._onLegendClick : () => false}
-                        onRelayout={interactive ? this._onRelayout : () => false}
-                        config={config} />
-                  {legendConfig && (
-                    <RootCloseWrapper event="mousedown"
-                                      onRootClose={this._onCloseColorPopup}>
-                      <Overlay show
-                               placement="top"
-                               target={legendConfig.target}>
-                        <Popover id="legend-config"
-                                 title={`Configuration for ${legendConfig.name}`}
-                                 className={styles.locals.customPopover}>
-                          <ColorPicker color={legendConfig.color}
-                                       onChange={newColor => this._onColorSelect(setColor, legendConfig.name, newColor)} />
-                        </Popover>
-                      </Overlay>
-                    </RootCloseWrapper>
+                <RenderCompletionCallback.Consumer>
+                  {onRenderComplete => (
+                    <>
+                      <Plot data={newChartData}
+                            useResizeHandler
+                            layout={interactive ? plotLayout : merge(nonInteractiveLayout, plotLayout)}
+                            style={style}
+                            onAfterPlot={onRenderComplete}
+                            onClick={interactive ? null : () => false}
+                            onLegendClick={interactive ? this._onLegendClick : () => false}
+                            onRelayout={interactive ? this._onRelayout : () => false}
+                            config={config} />
+                      {legendConfig && (
+                        <RootCloseWrapper event="mousedown"
+                                          onRootClose={this._onCloseColorPopup}>
+                          <Overlay show
+                                   placement="top"
+                                   target={legendConfig.target}>
+                            <Popover id="legend-config"
+                                     title={`Configuration for ${legendConfig.name}`}
+                                     className={styles.locals.customPopover}>
+                              <ColorPicker color={legendConfig.color}
+                                           onChange={newColor => this._onColorSelect(setColor, legendConfig.name, newColor)} />
+                            </Popover>
+                          </Overlay>
+                        </RootCloseWrapper>
+                      )}
+                    </>
                   )}
-                </React.Fragment>
+                </RenderCompletionCallback.Consumer>
               )}
             </InteractiveContext.Consumer>
           );

--- a/graylog2-web-interface/src/views/components/visualizations/XYPlot.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/XYPlot.jsx
@@ -14,10 +14,36 @@ import Query from 'views/logic/queries/Query';
 import GenericPlot from './GenericPlot';
 import OnZoom from './OnZoom';
 import CustomPropTypes from '../CustomPropTypes';
+import type { ChartColor, ChartConfig, ColorMap } from './GenericPlot';
 
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
-const XYPlot = ({ config, chartData, currentQuery, timezone, effectiveTimerange, getChartColor, setChartColor, plotLayout = {}, onZoom = OnZoom }) => {
+type Props = {
+  config: AggregationWidgetConfig,
+  chartData: any,
+  currentQuery: Query,
+  timezone: string,
+  effectiveTimerange: {
+    from: string,
+    to: string,
+  },
+  getChartColor?: (Array<ChartConfig>, string) => ?string,
+  setChartColor?: (ChartConfig, ColorMap) => ChartColor,
+  plotLayout?: any,
+  onZoom: (Query, string, string) => boolean,
+};
+
+const XYPlot = ({
+  config,
+  chartData,
+  currentQuery,
+  timezone,
+  effectiveTimerange,
+  getChartColor,
+  setChartColor,
+  plotLayout = {},
+  onZoom = OnZoom,
+}: Props) => {
   const yaxis = { fixedrange: true, rangemode: 'tozero' };
 
   const layout = merge({ yaxis }, plotLayout);

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/GenericPlot.test.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/GenericPlot.test.jsx
@@ -4,6 +4,7 @@ import { mount } from 'enzyme';
 
 import ChartColorContext from '../ChartColorContext';
 import GenericPlot from '../GenericPlot';
+import RenderCompletionCallback from '../../widgets/RenderCompletionCallback';
 
 jest.mock('components/common/ColorPicker', () => 'color-picker');
 // eslint-disable-next-line global-require
@@ -170,5 +171,16 @@ describe('GenericPlot', () => {
 
       expect(lens.setColor).toHaveBeenCalledWith('x', '#141414');
     });
+  });
+  it('calls render completion callback after plotting', () => {
+    const onRenderComplete = jest.fn();
+    const wrapper = mount((
+      <RenderCompletionCallback.Provider value={onRenderComplete}>
+        <GenericPlot chartData={[{ x: 23, name: 'count()' }, { x: 42, name: 'sum(bytes)' }]} />
+      </RenderCompletionCallback.Provider>
+    ));
+    const { onAfterPlot } = wrapper.find('PlotlyComponent').props();
+    onAfterPlot();
+    expect(onRenderComplete).toHaveBeenCalled();
   });
 });

--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.jsx
@@ -12,6 +12,7 @@ import { ViewStore } from 'views/stores/ViewStore';
 import DecoratedValue from 'views/components/messagelist/decoration/DecoratedValue';
 import CustomHighlighting from 'views/components/messagelist/CustomHighlighting';
 import style from './NumberVisualization.css';
+import RenderCompletionCallback from '../../widgets/RenderCompletionCallback';
 
 type Props = {
   data: Rows,
@@ -34,6 +35,8 @@ class NumberVisualization extends React.Component<Props, State> {
     fields: PropTypes.object.isRequired,
   };
 
+  static contextType = RenderCompletionCallback;
+
   container: HTMLElement | null;
 
   constructor(props) {
@@ -41,6 +44,13 @@ class NumberVisualization extends React.Component<Props, State> {
     this.state = {
       fontSize: 20,
     };
+  }
+
+  componentDidMount() {
+    const onRenderComplete = this.context;
+    if (onRenderComplete) {
+      onRenderComplete();
+    }
   }
 
   componentDidUpdate() {

--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.test.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.test.jsx
@@ -5,6 +5,7 @@ import { List } from 'immutable';
 import renderer from 'react-test-renderer';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import { FieldTypes } from 'views/logic/fieldtypes/FieldType';
+import RenderCompletionCallback from 'views/components/widgets/RenderCompletionCallback';
 import NumberVisualization from './NumberVisualization';
 
 jest.mock('stores/connect', () => x => x);
@@ -45,6 +46,23 @@ describe('NumberVisualization', () => {
                                                          fields={fields}
                                                          currentView={currentView} />);
     expect(wrapper.toJSON()).toMatchSnapshot();
+  });
+
+  it('calls render completion callback after first render', () => {
+    const Component = () => (
+      <NumberVisualization data={data}
+                           width={200}
+                           height={200}
+                           fields={fields}
+                           currentView={currentView} />
+    );
+    const onRenderComplete = jest.fn();
+    renderer.create((
+      <RenderCompletionCallback.Provider value={onRenderComplete}>
+        <Component />
+      </RenderCompletionCallback.Provider>
+    ));
+    expect(onRenderComplete).toHaveBeenCalled();
   });
 
   it('changes font size upon resize', () => {

--- a/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.jsx
@@ -3,7 +3,10 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 
 import { AggregationType } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
-import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
+import type {
+  VisualizationComponent,
+  VisualizationComponentProps,
+} from 'views/components/aggregationbuilder/AggregationBuilder';
 
 import GenericPlot from '../GenericPlot';
 import { chartData } from '../ChartData';

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/WorldMapVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/WorldMapVisualization.jsx
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { flow, fromPairs, get, zip } from 'lodash';
 
@@ -11,12 +11,14 @@ import type { VisualizationComponent, VisualizationComponentProps } from 'views/
 import MapVisualization from './MapVisualization';
 import { extractSeries } from '../ChartData';
 import transformKeys from '../TransformKeys';
+import RenderCompletionCallback from '../../widgets/RenderCompletionCallback';
 
 const arrayToMap = ([name, x, y]) => ({ name, x, y });
 const lastKey = keys => keys[keys.length - 1];
 const mergeObject = (prev, last) => Object.assign({}, prev, last);
 
 const WorldMapVisualization: VisualizationComponent = ({ config, data, editing, onChange, width, ...rest }: VisualizationComponentProps) => {
+  const onRenderComplete = useContext(RenderCompletionCallback);
   const { rowPivots } = config;
   const pipeline = flow([
     transformKeys(config.rowPivots, config.columnPivots),
@@ -53,6 +55,7 @@ const WorldMapVisualization: VisualizationComponent = ({ config, data, editing, 
                       id="world-map"
                       viewport={viewport}
                       width={width}
+                      onRenderComplete={onRenderComplete}
                       onChange={_onChange} />
   );
 };

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/__tests__/WorldMapVisualization.test.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/__tests__/WorldMapVisualization.test.jsx
@@ -6,6 +6,7 @@ import { mount } from 'enzyme';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import Viewport from 'views/logic/aggregationbuilder/visualizations/Viewport';
 import WorldMapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/WorldMapVisualizationConfig';
+import RenderCompletionCallback from 'views/components/widgets/RenderCompletionCallback';
 import WorldMapVisualization from '../WorldMapVisualization';
 
 jest.mock('../MapVisualization', () => 'map-visualization');
@@ -59,5 +60,26 @@ describe('WorldMapVisualization', () => {
     _onChange(viewport);
 
     expect(onChange).toHaveBeenCalledWith(WorldMapVisualizationConfig.create(viewport));
+  });
+  it('calls render completion callback after first render', () => {
+    const renderCompletionCallback = jest.fn();
+    const wrapper = mount((
+      <RenderCompletionCallback.Provider value={renderCompletionCallback}>
+        <WorldMapVisualization config={config}
+                               data={[]}
+                               editing
+                               effectiveTimerange={effectiveTimerange}
+                               fields={Immutable.List()}
+                               onChange={() => {}}
+                               toggleEdit={() => {}}
+                               height={1024}
+                               width={800} />
+      </RenderCompletionCallback.Provider>
+    ));
+
+    const { onRenderComplete } = wrapper.find('map-visualization').props();
+    onRenderComplete();
+
+    expect(renderCompletionCallback).toHaveBeenCalled();
   });
 });

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -20,6 +20,7 @@ import { RefreshActions } from 'views/stores/RefreshStore';
 import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
 
 import styles from './MessageList.css';
+import RenderCompletionCallback from './RenderCompletionCallback';
 
 const { InputsActions } = CombinedProvider.get('Inputs');
 
@@ -64,13 +65,16 @@ class MessageList extends React.Component<Props, State> {
     config: undefined,
   };
 
+  static contextType = RenderCompletionCallback;
+
   state = {
     currentPage: 1,
     expandedMessages: Immutable.Set(),
   };
 
   componentDidMount() {
-    InputsActions.list();
+    const onRenderComplete = this.context;
+    InputsActions.list().then(() => (onRenderComplete && onRenderComplete()));
   }
 
   _getSelectedFields = () => {

--- a/graylog2-web-interface/src/views/components/widgets/RenderCompletionCallback.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/RenderCompletionCallback.jsx
@@ -1,0 +1,9 @@
+// @flow strict
+import * as React from 'react';
+import { singleton } from '../../logic/singleton';
+
+export type TRenderCompletionCallback = () => void;
+
+const RenderCompletionCallback = React.createContext<TRenderCompletionCallback>(() => {});
+
+export default singleton('views.components.widgets.RenderCompletionCallback', () => RenderCompletionCallback);

--- a/graylog2-web-interface/src/views/logic/singleton.js
+++ b/graylog2-web-interface/src/views/logic/singleton.js
@@ -1,21 +1,23 @@
 // @flow strict
 
-const singleton = (key: string, supplier: () => any) => {
+// eslint-disable-next-line arrow-parens
+const singleton = <R>(key: string, supplier: () => R): R => {
   if (!window.singletons[key]) {
     window.singletons[key] = supplier();
   }
   return window.singletons[key];
 };
 
-const singletonActions = (key: string, supplier: () => any) => singleton(`${key}Actions`, supplier);
+const singletonActions = <R>(key: string, supplier: () => R): R => singleton(`${key}Actions`, supplier);
 
-const singletonStore = (key: string, supplier: () => any) => singleton(`${key}Store`, supplier);
+const singletonStore = <R>(key: string, supplier: () => any): R => singleton(`${key}Store`, supplier);
 
 if (typeof window.singletons === 'undefined') {
   window.singletons = {};
 }
 
 export {
+  singleton,
   singletonActions,
   singletonStore,
 };


### PR DESCRIPTION
## Description
## Motivation and Context

In some circumstances, parent components of views widgets need to be
notified when one or more widgets have completed rendering. This change
is implementing the required infrastructure for this by implementing a
`RenderCompletionCallback` context containing a function that is
consumed by widgets and executed after first and subsequent renders.

A widget needs to take care that upon a first meaningful render this
function needs to be called, which is implemented for all currently
existing widgets. All Widgets that do use the `GenericPlot` component
are automatically handled by it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.