### PR TITLE
Disable `Views` navigation menu if feature flag for new search is active

### DIFF
--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -60,6 +60,8 @@ const formatPluginRoute = (pluginRoute, permissions, location) => {
   return formatSinglePluginRoute(pluginRoute);
 };
 
+const enableNewSearch = AppConfig.isFeatureEnabled('search_3_2');
+
 const Navigation = ({ permissions, fullName, location, loginName }) => {
   const pluginNavigations = PluginStore.exports('navigation')
     .sort((route1, route2) => naturalSort(route1.description.toLowerCase(), route2.description.toLowerCase()))
@@ -88,10 +90,12 @@ const Navigation = ({ permissions, fullName, location, loginName }) => {
             </LinkContainer>
           </IfPermitted>
 
+          {!enableNewSearch && (
           <NavDropdown title="Views" id="views-dropdown">
             <NavigationLink path={Routes.EXTENDEDSEARCH} description="Create new" />
             <NavigationLink path={Routes.VIEWS.LIST} description="Load existing" />
           </NavDropdown>
+          )}
 
           <LinkContainer to={Routes.STREAMS}>
             <NavItem>Streams</NavItem>

--- a/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
@@ -15,6 +15,7 @@ jest.mock('util/AppConfig', () => ({
   gl2AppPathPrefix: jest.fn(() => ''),
   gl2ServerUrl: jest.fn(() => undefined),
   gl2DevMode: jest.fn(() => false),
+  isFeatureEnabled: jest.fn(() => false),
 }));
 
 const findLink = (wrapper, title) => wrapper.find(`NavigationLink[description="${title}"]`);


### PR DESCRIPTION
## Description
## Motivation and Context
If the `search_3_2` feature flag is present, this PR disables the
`Views` navigation menu as it is now replaced by the `Search` and
`Dashboard` functionality.