### PR TITLE
Sorting streams options in streams filter.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/StreamsFilter.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/StreamsFilter.jsx
@@ -2,10 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Select from 'components/common/Select';
+import { defaultCompare } from 'views/logic/DefaultCompare';
 
 const StreamsFilter = ({ disabled, value, streams, onChange }) => {
   const selectedStreams = value.join(',');
   const placeholder = 'Select streams the search should include. Searches in all streams if empty.';
+  const options = streams.sort(({ key: key1 }, { key: key2 }) => defaultCompare(key1, key2));
   return (
     <div style={{ position: 'relative', zIndex: 10 }} data-testid="streams-filter" title={placeholder}>
       <Select placeholder={placeholder}
@@ -13,7 +15,7 @@ const StreamsFilter = ({ disabled, value, streams, onChange }) => {
               displayKey="key"
               inputId="streams-filter"
               onChange={selected => onChange(selected === '' ? [] : selected.split(','))}
-              options={streams}
+              options={options}
               multi
               style={{ width: '100%' }}
               value={selectedStreams} />

--- a/graylog2-web-interface/src/views/components/searchbar/StreamsFilter.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/StreamsFilter.test.jsx
@@ -1,0 +1,25 @@
+// @flow strict
+import * as React from 'react';
+import { mount } from 'enzyme';
+
+import StreamsFilter from './StreamsFilter';
+
+describe('StreamsFilter', () => {
+  it('sorts stream names', () => {
+    const streams = [
+      { key: 'One Stream', value: 'streamId1' },
+      { key: 'another Stream', value: 'streamId2' },
+      { key: 'Yet another Stream', value: 'streamId3' },
+      { key: '101 Stream', value: 'streamId4' },
+    ];
+    const wrapper = mount(<StreamsFilter streams={streams} onChange={() => {}} />);
+    const { options } = wrapper.find('Select').first().props();
+
+    expect(options).toEqual([
+      { key: '101 Stream', value: 'streamId4' },
+      { key: 'another Stream', value: 'streamId2' },
+      { key: 'One Stream', value: 'streamId1' },
+      { key: 'Yet another Stream', value: 'streamId3' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Description
## Motivation and Context

Before this change, streams options appeared in the order they were received from the backend. This change is now applying natural sorting to the options before displaying them.

Needs backport to `3.1` after merging.

Fixes #6514.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.