### PR TITLE
Don't loose the IndexSet TemplateType when updating

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
@@ -134,7 +134,7 @@ public abstract class IndexSetUpdateRequest {
                 .creationDate(oldConfig.creationDate())
                 .indexAnalyzer(oldConfig.indexAnalyzer())
                 .indexTemplateName(oldConfig.indexTemplateName())
-                .indexTemplateType(oldConfig.indexTemplateType().get())
+                .indexTemplateType(oldConfig.indexTemplateType().orElse(null))
                 .indexOptimizationMaxNumSegments(indexOptimizationMaxNumSegments())
                 .indexOptimizationDisabled(indexOptimizationDisabled())
                 .fieldTypeRefreshInterval(fieldTypeRefreshInterval())

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/requests/IndexSetUpdateRequest.java
@@ -134,6 +134,7 @@ public abstract class IndexSetUpdateRequest {
                 .creationDate(oldConfig.creationDate())
                 .indexAnalyzer(oldConfig.indexAnalyzer())
                 .indexTemplateName(oldConfig.indexTemplateName())
+                .indexTemplateType(oldConfig.indexTemplateType().get())
                 .indexOptimizationMaxNumSegments(indexOptimizationMaxNumSegments())
                 .indexOptimizationDisabled(indexOptimizationDisabled())
                 .fieldTypeRefreshInterval(fieldTypeRefreshInterval())


### PR DESCRIPTION
This would lead to errors in the AddEventIndexSetsMigration

Fixes #6507