### PR TITLE
Sorting streams options in streams filter.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/StreamsFilter.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/StreamsFilter.jsx
@@ -2,15 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Select from 'components/common/Select';
+import { defaultCompare } from 'views/logic/DefaultCompare';
 
 const StreamsFilter = ({ value, streams, onChange }) => {
   const selectedStreams = value.join(',');
+  const placeholder = 'Select streams the search should include. Searches in all streams if empty.';
+  const options = streams.sort(({ key: key1 }, { key: key2 }) => defaultCompare(key1, key2));
   return (
-    <div style={{ position: 'relative', zIndex: 10 }}>
-      <Select placeholder="Select streams the search should include. Searches in all streams if empty."
+    <div style={{ position: 'relative', zIndex: 10 }} title={placeholder}>
+      <Select placeholder={placeholder}
               displayKey="key"
               onChange={selected => onChange(selected === '' ? [] : selected.split(','))}
-              options={streams}
+              options={options}
               multi
               style={{ width: '100%' }}
               value={selectedStreams} />

--- a/graylog2-web-interface/src/views/components/searchbar/StreamsFilter.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/StreamsFilter.test.jsx
@@ -1,0 +1,25 @@
+// @flow strict
+import * as React from 'react';
+import { mount } from 'enzyme';
+
+import StreamsFilter from './StreamsFilter';
+
+describe('StreamsFilter', () => {
+  it('sorts stream names', () => {
+    const streams = [
+      { key: 'One Stream', value: 'streamId1' },
+      { key: 'another Stream', value: 'streamId2' },
+      { key: 'Yet another Stream', value: 'streamId3' },
+      { key: '101 Stream', value: 'streamId4' },
+    ];
+    const wrapper = mount(<StreamsFilter streams={streams} onChange={() => {}} />);
+    const { options } = wrapper.find('Select').first().props();
+
+    expect(options).toEqual([
+      { key: '101 Stream', value: 'streamId4' },
+      { key: 'another Stream', value: 'streamId2' },
+      { key: 'One Stream', value: 'streamId1' },
+      { key: 'Yet another Stream', value: 'streamId3' },
+    ]);
+  });
+});


### PR DESCRIPTION
Before this change, streams options appeared in the order they were
received from the backend. This change is now applying natural sorting to
the options before displaying them.

Fixes #6514.

(cherry picked from commit 33e0d8bf337d75d19a2670314f0d691a94b4b5e3)