### PR TITLE
Publish GrokPatternsUpdatedEvent on pattern import

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/grok/MongoDbGrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/MongoDbGrokPatternService.java
@@ -186,6 +186,8 @@ public class MongoDbGrokPatternService implements GrokPatternService {
             patternNames.add(savedGrokPattern.name());
         }
 
+        clusterBus.post(patternNames.build());
+
         return savedPatterns.build();
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/grok/MongoDbGrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/MongoDbGrokPatternService.java
@@ -186,7 +186,7 @@ public class MongoDbGrokPatternService implements GrokPatternService {
             patternNames.add(savedGrokPattern.name());
         }
 
-        clusterBus.post(patternNames.build());
+        clusterBus.post(GrokPatternsUpdatedEvent.create(patternNames.build()));
 
         return savedPatterns.build();
     }


### PR DESCRIPTION
This ensures the reload of running extractors to use the imported grok
patterns.
