### PR TITLE
Publish GrokPatternsUpdatedEvent on pattern import (#6666)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/grok/MongoDbGrokPatternService.java
+++ b/graylog2-server/src/main/java/org/graylog2/grok/MongoDbGrokPatternService.java
@@ -186,6 +186,8 @@ public class MongoDbGrokPatternService implements GrokPatternService {
             patternNames.add(savedGrokPattern.name());
         }
 
+        clusterBus.post(GrokPatternsUpdatedEvent.create(patternNames.build()));
+
         return savedPatterns.build();
     }
 


### PR DESCRIPTION
This ensures the reload of running extractors to use the imported grok
patterns.

Co-Authored-By: Marco Pfatschbacher <marco@graylog.com>

(cherry picked from commit 142d149fabb922aa8d2ef4102984f9c87dc4b0a3)
