### PR TITLE
Increase ES client HTTP connection limits (#6675)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
@@ -42,10 +42,10 @@ public class ElasticsearchClientConfiguration {
     Duration elasticsearchIdleTimeout = Duration.seconds(-1L);
 
     @Parameter(value = "elasticsearch_max_total_connections", validators = {PositiveIntegerValidator.class})
-    int elasticsearchMaxTotalConnections = 20;
+    int elasticsearchMaxTotalConnections = 200;
 
     @Parameter(value = "elasticsearch_max_total_connections_per_route", validators = {PositiveIntegerValidator.class})
-    int elasticsearchMaxTotalConnectionsPerRoute = 2;
+    int elasticsearchMaxTotalConnectionsPerRoute = 20;
 
     @Parameter(value = "elasticsearch_max_retries", validators = {PositiveIntegerValidator.class})
     int elasticsearchMaxRetries = 2;

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -203,14 +203,14 @@ plugin_dir = plugin
 
 # Maximum number of total connections to Elasticsearch.
 #
-# Default: 20
-#elasticsearch_max_total_connections = 20
+# Default: 200
+#elasticsearch_max_total_connections = 200
 
 # Maximum number of total connections per Elasticsearch route (normally this means per
 # elasticsearch server).
 #
-# Default: 2
-#elasticsearch_max_total_connections_per_route = 2
+# Default: 20
+#elasticsearch_max_total_connections_per_route = 20
 
 # Maximum number of times Graylog will retry failed requests to Elasticsearch.
 #


### PR DESCRIPTION
This change is bumping the "elasticsearch_max_total_connections" and
"elasticsearch_max_total_connections_per_route" default settings to
avoid message processing stalls.

The default limit of 2 connections per ES server is way too low and can
cause delayed or event blocked message processing.

Example:

With a limit of 2 connections per ES server, 2 index optimization jobs
that are running in parallel will cause message processing to stall until
the optimization jobs are done.

Refs #4637

(cherry picked from commit d961d873a1386518fa05fae8ebf7299262351cfb)