### PR TITLE
Implement pipeline rule timers that can be enabled/disabled at runtime

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/audit/PipelineProcessorAuditEventTypes.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/audit/PipelineProcessorAuditEventTypes.java
@@ -31,6 +31,7 @@ public class PipelineProcessorAuditEventTypes implements PluginAuditEventTypes {
     public static final String RULE_CREATE = NAMESPACE + "rule:create";
     public static final String RULE_UPDATE = NAMESPACE + "rule:update";
     public static final String RULE_DELETE = NAMESPACE + "rule:delete";
+    public static final String RULE_METRICS_UPDATE = NAMESPACE + "rulemetrics:update";
 
     private static final ImmutableSet<String> EVENT_TYPES = ImmutableSet.<String>builder()
             .add(PIPELINE_CONNECTION_UPDATE)
@@ -40,6 +41,7 @@ public class PipelineProcessorAuditEventTypes implements PluginAuditEventTypes {
             .add(RULE_CREATE)
             .add(RULE_UPDATE)
             .add(RULE_DELETE)
+            .add(RULE_METRICS_UPDATE)
             .build();
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/RuleMetricsConfigDto.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/RuleMetricsConfigDto.java
@@ -1,0 +1,52 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.db;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+@JsonDeserialize(builder = RuleMetricsConfigDto.Builder.class)
+public abstract class RuleMetricsConfigDto {
+    private static final String FIELD_METRICS_ENABLED = "metrics_enabled";
+
+    @JsonProperty(FIELD_METRICS_ENABLED)
+    public abstract boolean metricsEnabled();
+
+    public static Builder builder() {
+        return Builder.create();
+    }
+
+    public static RuleMetricsConfigDto createDefault() {
+        return builder().build();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        @JsonCreator
+        public static Builder create() {
+            return new AutoValue_RuleMetricsConfigDto.Builder().metricsEnabled(false);
+        }
+
+        @JsonProperty(FIELD_METRICS_ENABLED)
+        public abstract Builder metricsEnabled(boolean metricsEnabled);
+
+        public abstract RuleMetricsConfigDto build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/RuleMetricsConfigService.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/db/RuleMetricsConfigService.java
@@ -1,0 +1,45 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.db;
+
+import org.graylog.plugins.pipelineprocessor.events.RuleMetricsConfigChangedEvent;
+import org.graylog2.events.ClusterEventBus;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+
+import javax.inject.Inject;
+
+public class RuleMetricsConfigService {
+    private final ClusterConfigService clusterConfigService;
+    private final ClusterEventBus clusterEventBus;
+
+    @Inject
+    public RuleMetricsConfigService(ClusterConfigService clusterConfigService,
+                                    ClusterEventBus clusterEventBus) {
+        this.clusterConfigService = clusterConfigService;
+        this.clusterEventBus = clusterEventBus;
+    }
+
+    public RuleMetricsConfigDto save(RuleMetricsConfigDto config) {
+        clusterConfigService.write(config);
+        clusterEventBus.post(RuleMetricsConfigChangedEvent.create(config.metricsEnabled()));
+        return get();
+    }
+
+    public RuleMetricsConfigDto get() {
+        return clusterConfigService.getOrDefault(RuleMetricsConfigDto.class, RuleMetricsConfigDto.createDefault());
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/events/RuleMetricsConfigChangedEvent.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/events/RuleMetricsConfigChangedEvent.java
@@ -1,0 +1,32 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.events;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class RuleMetricsConfigChangedEvent {
+    @JsonProperty("enabled")
+    public abstract boolean enabled();
+
+    @JsonCreator
+    public static RuleMetricsConfigChangedEvent create(@JsonProperty("enabled") boolean enabled) {
+        return new AutoValue_RuleMetricsConfigChangedEvent(enabled);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/listeners/InterpreterListener.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/listeners/InterpreterListener.java
@@ -34,6 +34,7 @@ public interface InterpreterListener {
     void satisfyRule(Rule rule, Pipeline pipeline);
     void dissatisfyRule(Rule rule, Pipeline pipeline);
     void executeRule(Rule rule, Pipeline pipeline);
+    void finishExecuteRule(Rule rule, Pipeline pipeline);
     void failExecuteRule(Rule rule, Pipeline pipeline);
     void continuePipelineExecution(Pipeline pipeline, Stage stage);
     void stopPipelineExecution(Pipeline pipeline, Stage stage);

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/listeners/NoopInterpreterListener.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/listeners/NoopInterpreterListener.java
@@ -75,6 +75,11 @@ public class NoopInterpreterListener implements InterpreterListener {
     }
 
     @Override
+    public void finishExecuteRule(Rule rule, Pipeline pipeline) {
+
+    }
+
+    @Override
     public void failExecuteRule(Rule rule, Pipeline pipeline) {
 
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/listeners/RuleMetricsListener.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/processors/listeners/RuleMetricsListener.java
@@ -1,0 +1,189 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.processors.listeners;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import org.graylog.plugins.pipelineprocessor.ast.Pipeline;
+import org.graylog.plugins.pipelineprocessor.ast.Rule;
+import org.graylog.plugins.pipelineprocessor.ast.Stage;
+import org.graylog2.plugin.Message;
+import org.graylog2.shared.metrics.MetricUtils;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+/**
+ * This interpreter listener maintains timer metrics for rules.
+ */
+public class RuleMetricsListener implements InterpreterListener {
+    public enum Type {
+        EXECUTE, EVALUATE
+    }
+
+    private final MetricRegistry metricRegistry;
+    private final Map<TimerMapKey, Timer.Context> evaluateTimers = new HashMap<>();
+    private final Map<TimerMapKey, Timer.Context> executeTimers = new HashMap<>();
+
+    public RuleMetricsListener(MetricRegistry metricRegistry) {
+        this.metricRegistry = metricRegistry;
+    }
+
+    public static String getMetricName(String name, Type type) {
+        return name(Rule.class, name, "trace", type.toString().toLowerCase(Locale.US), "duration");
+    }
+
+    private void forEachStage(Rule rule, Pipeline pipeline, Consumer<Stage> consumer) {
+        pipeline.stages().forEach(stage -> {
+            stage.getRules().stream()
+                    .filter(stageRule -> Objects.equals(stageRule.id(), rule.id()))
+                    .forEach(stageRule -> consumer.accept(stage));
+        });
+    }
+
+    private void startTimerForKey(TimerMapKey key, String metricName, Map<TimerMapKey, Timer.Context> timers) {
+        final Timer timer = MetricUtils.getOrRegister(metricRegistry, metricName, new Timer());
+        timers.put(key, timer.time());
+    }
+
+    private void startTimer(Rule rule, Pipeline pipeline, Type type, Map<TimerMapKey, Timer.Context> timers) {
+        if (rule.id() != null && pipeline.id() != null) {
+            forEachStage(rule, pipeline, stage -> {
+                final String name = name(rule.id(), pipeline.id(), String.valueOf(stage.stage()));
+                startTimerForKey(new TimerMapKey(rule, pipeline, stage), getMetricName(name, type), timers);
+            });
+            startTimerForKey(new TimerMapKey(rule), getMetricName(rule.id(), type), timers);
+        }
+    }
+
+    private void stopTimerForKey(TimerMapKey key, Map<TimerMapKey, Timer.Context> timers) {
+        final Timer.Context timer = timers.get(key);
+        if (timer != null) {
+            timer.stop();
+        }
+    }
+
+    private void stopTimer(Rule rule, Pipeline pipeline, Map<TimerMapKey, Timer.Context> timers) {
+        if (rule.id() != null && pipeline.id() != null) {
+            forEachStage(rule, pipeline, stage -> stopTimerForKey(new TimerMapKey(rule, pipeline, stage), timers));
+            stopTimerForKey(new TimerMapKey(rule), timers);
+        }
+    }
+
+    @Override
+    public void startProcessing() {
+    }
+
+    @Override
+    public void finishProcessing() {
+    }
+
+    @Override
+    public void processStreams(Message message, Set<Pipeline> pipelines, Set<String> streams) {
+    }
+
+    @Override
+    public void enterStage(Stage stage) {
+    }
+
+    @Override
+    public void exitStage(Stage stage) {
+    }
+
+    @Override
+    public void evaluateRule(Rule rule, Pipeline pipeline) {
+        startTimer(rule, pipeline, Type.EVALUATE, evaluateTimers);
+    }
+
+    @Override
+    public void failEvaluateRule(Rule rule, Pipeline pipeline) {
+        stopTimer(rule, pipeline, evaluateTimers);
+    }
+
+    @Override
+    public void satisfyRule(Rule rule, Pipeline pipeline) {
+        stopTimer(rule, pipeline, evaluateTimers);
+    }
+
+    @Override
+    public void dissatisfyRule(Rule rule, Pipeline pipeline) {
+        stopTimer(rule, pipeline, evaluateTimers);
+    }
+
+    @Override
+    public void executeRule(Rule rule, Pipeline pipeline) {
+        startTimer(rule, pipeline, Type.EXECUTE, executeTimers);
+    }
+
+    @Override
+    public void finishExecuteRule(Rule rule, Pipeline pipeline) {
+        stopTimer(rule, pipeline, executeTimers);
+    }
+
+    @Override
+    public void failExecuteRule(Rule rule, Pipeline pipeline) {
+    }
+
+    @Override
+    public void continuePipelineExecution(Pipeline pipeline, Stage stage) {
+    }
+
+    @Override
+    public void stopPipelineExecution(Pipeline pipeline, Stage stage) {
+    }
+
+    /**
+     * Helper class to simplify timer map key handling.
+     */
+    private static class TimerMapKey {
+        private final String rule;
+        private final String pipeline;
+        private final int stage;
+
+        TimerMapKey(Rule rule) {
+            this(rule, null, null);
+        }
+
+        TimerMapKey(Rule rule, @Nullable Pipeline pipeline, @Nullable Stage stage) {
+            this.rule = rule.id();
+            this.pipeline = pipeline != null ? pipeline.id() : null;
+            this.stage = stage != null ? stage.stage() : 0;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            TimerMapKey that = (TimerMapKey) o;
+            return stage == that.stage &&
+                    rule.equals(that.rule) &&
+                    Objects.equals(pipeline, that.pipeline);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(rule, pipeline, stage);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/RuleResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/rest/RuleResource.java
@@ -25,6 +25,8 @@ import org.graylog.plugins.pipelineprocessor.ast.Rule;
 import org.graylog.plugins.pipelineprocessor.ast.functions.Function;
 import org.graylog.plugins.pipelineprocessor.audit.PipelineProcessorAuditEventTypes;
 import org.graylog.plugins.pipelineprocessor.db.RuleDao;
+import org.graylog.plugins.pipelineprocessor.db.RuleMetricsConfigDto;
+import org.graylog.plugins.pipelineprocessor.db.RuleMetricsConfigService;
 import org.graylog.plugins.pipelineprocessor.db.RuleService;
 import org.graylog.plugins.pipelineprocessor.parser.FunctionRegistry;
 import org.graylog.plugins.pipelineprocessor.parser.ParseException;
@@ -65,14 +67,17 @@ public class RuleResource extends RestResource implements PluginRestResource {
     private static final Logger log = LoggerFactory.getLogger(RuleResource.class);
 
     private final RuleService ruleService;
+    private final RuleMetricsConfigService ruleMetricsConfigService;
     private final PipelineRuleParser pipelineRuleParser;
     private final FunctionRegistry functionRegistry;
 
     @Inject
     public RuleResource(RuleService ruleService,
+                        RuleMetricsConfigService ruleMetricsConfigService,
                         PipelineRuleParser pipelineRuleParser,
                         FunctionRegistry functionRegistry) {
         this.ruleService = ruleService;
+        this.ruleMetricsConfigService = ruleMetricsConfigService;
         this.pipelineRuleParser = pipelineRuleParser;
         this.functionRegistry = functionRegistry;
     }
@@ -202,4 +207,18 @@ public class RuleResource extends RestResource implements PluginRestResource {
                 .collect(Collectors.toList());
     }
 
+    @ApiOperation("Get rule metrics configuration")
+    @Path("/config/metrics")
+    @GET
+    public RuleMetricsConfigDto metricsConfig() {
+        return ruleMetricsConfigService.get();
+    }
+
+    @ApiOperation("Update rule metrics configuration")
+    @Path("/config/metrics")
+    @PUT
+    @AuditEvent(type = PipelineProcessorAuditEventTypes.RULE_METRICS_UPDATE)
+    public RuleMetricsConfigDto updateMetricsConfig(RuleMetricsConfigDto config) {
+        return ruleMetricsConfigService.save(config);
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/simulator/SimulatorInterpreterListener.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/simulator/SimulatorInterpreterListener.java
@@ -82,6 +82,11 @@ class SimulatorInterpreterListener implements InterpreterListener {
     }
 
     @Override
+    public void finishExecuteRule(Rule rule, Pipeline pipeline) {
+        executionTrace.addTrace("Finished execution " + rule + " in " + pipeline);
+    }
+
+    @Override
     public void failExecuteRule(Rule rule, Pipeline pipeline) {
         executionTrace.addTrace("Failed execution " + rule + " in " + pipeline);
     }

--- a/graylog2-web-interface/src/actions/rules/RulesActions.jsx
+++ b/graylog2-web-interface/src/actions/rules/RulesActions.jsx
@@ -9,6 +9,8 @@ const RulesActions = Reflux.createActions({
   parse: { asyncResult: true },
   multiple: { asyncResult: true },
   loadFunctions: { asyncResult: true },
+  loadMetricsConfig: { asyncResult: true },
+  updateMetricsConfig: { asyncResult: true },
 });
 
 export default RulesActions;

--- a/graylog2-web-interface/src/components/rules/RuleList.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleList.jsx
@@ -1,21 +1,36 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Button } from 'react-bootstrap';
+import { Button, ButtonToolbar } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Link } from 'react-router';
 
+import connect from 'stores/connect';
 import { DataTable, Timestamp } from 'components/common';
 import { MetricContainer, CounterRate } from 'components/metrics';
 
 import Routes from 'routing/Routes';
 import CombinedProvider from 'injection/CombinedProvider';
+import RuleMetricsConfigContainer from './RuleMetricsConfigContainer';
 
-const { RulesActions } = CombinedProvider.get('Rules');
+const { RulesActions, RulesStore } = CombinedProvider.get('Rules');
 
 class RuleList extends React.Component {
   static propTypes = {
     rules: PropTypes.array.isRequired,
+    metricsConfig: PropTypes.object,
   };
+
+  static defaultProps = {
+    metricsConfig: undefined,
+  };
+
+  state = {
+    openMetricsConfig: false,
+  };
+
+  componentDidMount() {
+    RulesActions.loadMetricsConfig();
+  }
 
   _delete = (rule) => {
     return () => {
@@ -65,9 +80,24 @@ class RuleList extends React.Component {
     );
   };
 
+  toggleMetricsConfig = () => {
+    const { openMetricsConfig } = this.state;
+    this.setState({ openMetricsConfig: !openMetricsConfig });
+  };
+
+  renderDebugMetricsButton = (metricsConfig) => {
+    if (metricsConfig && metricsConfig.metrics_enabled) {
+      return <Button bsStyle="warning" onClick={this.toggleMetricsConfig}>Debug Metrics: ON</Button>;
+    } else {
+      return <Button onClick={this.toggleMetricsConfig}>Debug Metrics</Button>;
+    }
+  };
+
   render() {
+    const { rules, metricsConfig } = this.props;
     const filterKeys = ['title', 'description'];
     const headers = ['Title', 'Description', 'Created', 'Last modified', 'Throughput', 'Errors', 'Actions'];
+    const { openMetricsConfig } = this.state;
 
     return (
       <div>
@@ -76,20 +106,24 @@ class RuleList extends React.Component {
                    headers={headers}
                    headerCellFormatter={this._headerCellFormatter}
                    sortByKey="title"
-                   rows={this.props.rules}
+                   rows={rules}
                    filterBy="Title"
                    dataRowFormatter={this._ruleInfoFormatter}
                    filterLabel="Filter Rules"
                    filterKeys={filterKeys}>
-          <div className="pull-right">
+          <ButtonToolbar className="pull-right">
             <LinkContainer to={Routes.SYSTEM.PIPELINES.RULE('new')}>
               <Button bsStyle="success">Create Rule</Button>
             </LinkContainer>
-          </div>
+            {this.renderDebugMetricsButton(metricsConfig)}
+          </ButtonToolbar>
         </DataTable>
+        {openMetricsConfig && <RuleMetricsConfigContainer onClose={this.toggleMetricsConfig} />}
       </div>
     );
   }
 }
 
-export default RuleList;
+export default connect(RuleList, { rules: RulesStore }, ({ rules }) => {
+  return { metricsConfig: rules ? rules.metricsConfig : rules };
+});

--- a/graylog2-web-interface/src/components/rules/RuleMetricsConfig.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleMetricsConfig.jsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import lodash from 'lodash';
+
+import { Alert } from 'react-bootstrap';
+import { BootstrapModalForm, Input } from 'components/bootstrap';
+import { Spinner } from 'components/common';
+import FormsUtils from 'util/FormsUtils';
+
+export default class RuleMetricsConfig extends React.Component {
+  static propTypes = {
+    config: PropTypes.object,
+    onChange: PropTypes.func.isRequired,
+    onClose: PropTypes.func,
+  };
+
+  static defaultProps = {
+    config: undefined,
+    onClose: () => {},
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      nextConfig: props.config,
+    };
+  }
+
+  saveConfiguration = () => {
+    const { onChange } = this.props;
+    const { nextConfig } = this.state;
+
+    onChange(nextConfig).then(this.closeModal);
+  };
+
+  openModal = () => {
+    this.modal.open();
+  };
+
+  closeModal = () => {
+    this.modal.close();
+  };
+
+  propagateChange = (key, value) => {
+    const { config } = this.props;
+    const nextConfig = lodash.cloneDeep(config);
+    nextConfig[key] = value;
+    this.setState({ nextConfig });
+  };
+
+  handleChange = (event) => {
+    const { name } = event.target;
+    this.propagateChange(name, FormsUtils.getValueFromInput(event.target));
+  };
+
+  render() {
+    const { config, onClose } = this.props;
+    const { nextConfig } = this.state;
+
+    if (!config) {
+      return <p><Spinner text="Loading metrics config..." /></p>;
+    }
+
+    return (
+      <BootstrapModalForm ref={(modal) => { this.modal = modal; }}
+                          title="Rule Metrics Configuration"
+                          onSubmitForm={this.saveConfiguration}
+                          onModalClose={onClose}
+                          show
+                          submitButtonText="Save">
+        <Alert bsStyle="warning">
+          Rule metrics should only be enabled to debug a performance issue because collecting the
+          metrics will slow down message processing and increase memory usage.
+        </Alert>
+        <fieldset>
+          <Input type="radio"
+                 id="metrics-enabled"
+                 name="metrics_enabled"
+                 value="true"
+                 label="Enable rule metrics"
+                 onChange={this.handleChange}
+                 checked={nextConfig.metrics_enabled} />
+
+          <Input type="radio"
+                 id="metrics-disabled"
+                 name="metrics_enabled"
+                 value="false"
+                 label="Disable rule metrics"
+                 onChange={this.handleChange}
+                 checked={!nextConfig.metrics_enabled} />
+        </fieldset>
+        <p>
+          When enabled the system metrics will update two timers for every rule execution.
+        </p>
+        <strong>Rule evaluation timer</strong>
+        <p>
+          This timer measures the duration for the rule condition. (everything inside the <code>when</code> statement)
+        </p>
+        <p>
+          Example metric name with rule ID placeholder:<br />
+          <code>org.graylog.plugins.pipelineprocessor.ast.Rule.[rule-id].trace.evaluate.duration</code><br />
+          Example metric name with rule ID, pipeline ID and stage number placeholders:<br />
+          <code>org.graylog.plugins.pipelineprocessor.ast.Rule.[rule-id].[pipeline-id].[stage-num].trace.evaluate.duration</code>
+        </p>
+        <strong>Rule execution timer</strong>
+        <p>
+          This timer measures the duration for the rule execution. (everything inside the <code>then</code> statement)
+        </p>
+        <p>
+          Example metric name with rule ID placeholder:<br />
+          <code>org.graylog.plugins.pipelineprocessor.ast.Rule.[rule-id].trace.execute.duration</code><br />
+          Example metric name with rule ID, pipeline ID and stage number placeholders:<br />
+          <code>org.graylog.plugins.pipelineprocessor.ast.Rule.[rule-id].[pipeline-id].[stage-num].trace.execute.duration</code>
+        </p>
+      </BootstrapModalForm>
+    );
+  }
+}

--- a/graylog2-web-interface/src/components/rules/RuleMetricsConfigContainer.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleMetricsConfigContainer.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import connect from 'stores/connect';
+import CombinedProvider from 'injection/CombinedProvider';
+import RuleMetricsConfig from './RuleMetricsConfig';
+
+const { RulesStore, RulesActions } = CombinedProvider.get('Rules');
+
+class RuleMetricsConfigContainer extends React.Component {
+  static propTypes = {
+    metricsConfig: PropTypes.object,
+    onClose: PropTypes.func,
+  };
+
+  static defaultProps = {
+    metricsConfig: undefined,
+    onClose: () => {},
+  };
+
+  componentDidMount() {
+    RulesActions.loadMetricsConfig();
+  }
+
+  handleChange = (nextConfig) => {
+    return RulesActions.updateMetricsConfig(nextConfig);
+  };
+
+  render() {
+    const { metricsConfig, onClose } = this.props;
+
+    if (!metricsConfig) {
+      return null;
+    }
+
+    return (
+      <RuleMetricsConfig ref={(component) => { this.configComponent = component; }}
+                         config={metricsConfig}
+                         onChange={this.handleChange}
+                         onClose={onClose} />
+    );
+  }
+}
+
+export default connect(RuleMetricsConfigContainer, { rules: RulesStore }, ({ rules }) => {
+  return { metricsConfig: rules ? rules.metricsConfig : rules };
+});

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -371,6 +371,7 @@ const ApiRoutes = {
     multiple: () => { return { url: '/system/pipelines/rule/multiple' }; },
     functions: () => { return { url: '/system/pipelines/rule/functions' }; },
     parse: () => { return { url: '/system/pipelines/rule/parse' }; },
+    metricsConfig: () => { return { url: '/system/pipelines/rule/config/metrics' }; },
   },
   ConnectionsController: {
     list: () => { return { url: '/system/pipelines/connections' }; },

--- a/graylog2-web-interface/src/stores/rules/RulesStore.js
+++ b/graylog2-web-interface/src/stores/rules/RulesStore.js
@@ -12,9 +12,10 @@ const RulesStore = Reflux.createStore({
   listenables: [RulesActions],
   rules: undefined,
   functionDescriptors: undefined,
+  metricsConfig: undefined,
 
   getInitialState() {
-    return { rules: this.rules, functionDescriptors: this.functionDescriptors };
+    return { rules: this.rules, functionDescriptors: this.functionDescriptors, metricsConfig: this.metricsConfig };
   },
 
   _updateRulesState(rule) {
@@ -154,6 +155,39 @@ const RulesStore = Reflux.createStore({
     const url = URLUtils.qualifyUrl(ApiRoutes.RulesController.functions().url);
     return fetch('GET', url)
       .then(this._updateFunctionDescriptors);
+  },
+  loadMetricsConfig() {
+    const url = URLUtils.qualifyUrl(ApiRoutes.RulesController.metricsConfig().url);
+    const promise = fetch('GET', url);
+
+    promise.then(
+      (response) => {
+        this.metricsConfig = response;
+        this.trigger({ rules: this.rules, functionDescriptors: this.functionDescriptors, metricsConfig: this.metricsConfig });
+      },
+      (error) => {
+        UserNotification.error(`Couldn't load rule metrics config: ${error.message}`, "Couldn't load rule metrics config");
+      },
+    );
+
+    RulesActions.loadMetricsConfig.promise(promise);
+  },
+  updateMetricsConfig(nextConfig) {
+    const url = URLUtils.qualifyUrl(ApiRoutes.RulesController.metricsConfig().url);
+    const promise = fetch('PUT', url, nextConfig);
+
+    promise.then(
+      (response) => {
+        this.metricsConfig = response;
+        this.trigger({ rules: this.rules, functionDescriptors: this.functionDescriptors, metricsConfig: this.metricsConfig });
+        UserNotification.success('Successfully updated rule metrics config');
+      },
+      (error) => {
+        UserNotification.error(`Couldn't update rule metrics config: ${error.message}`, "Couldn't update rule metrics config");
+      },
+    );
+
+    RulesActions.updateMetricsConfig.promise(promise);
   },
 });
 


### PR DESCRIPTION
Not having timers for pipeline rules makes it really hard to debug
performance problems. This change adds a new interpreter listener that
tracks rule evaluation ("when" statement) and execution ("then"
statement) timers.

Since tracking timers for lots of rules can be impact processing
performance, the timers are disabled by default. Users can toggle the
rule timers on the rules management page.

Example metrics:

org.graylog.plugins.pipelineprocessor.ast.Rule.5d5161cb2c9287782b2826d5.trace.evaluate.duration
org.graylog.plugins.pipelineprocessor.ast.Rule.5d5161cb2c9287782b2826d5.trace.execute.duration

Closes #5494

(cherry picked from commit 157c9d1b1f177f7993d8ef36212428dc60b9dc38)
