### PR TITLE
Do not set state in `Footer` if already unmounted.

### DIFF
--- a/graylog2-web-interface/src/components/layout/Footer.jsx
+++ b/graylog2-web-interface/src/components/layout/Footer.jsx
@@ -1,49 +1,59 @@
-import React from 'react';
-import createReactClass from 'create-react-class';
-import Reflux from 'reflux';
-import Version from 'util/Version';
+// @flow strict
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
 
+import Version from 'util/Version';
+import connect from 'stores/connect';
 import StoreProvider from 'injection/StoreProvider';
 
 const SystemStore = StoreProvider.getStore('System');
 
-const Footer = createReactClass({
-  displayName: 'Footer',
-  mixins: [Reflux.connect(SystemStore)],
-  mounted: false,
+type Props = {
+  system?: {
+    version: string,
+    hostname: string
+  },
+};
 
-  componentDidMount() {
-    this.mounted = true;
+const Footer = ({ system }: Props) => {
+  const [jvm, setJvm] = useState();
+  useEffect(() => {
+    let mounted = true;
     SystemStore.jvm().then((jvmInfo) => {
-      if (this.mounted) {
-        this.setState({ jvm: jvmInfo });
+      if (mounted) {
+        setJvm(jvmInfo);
       }
     });
-  },
 
-  componentWillUnmount() {
-    this.mounted = false;
-  },
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
-  _isLoading() {
-    return !(this.state.system && this.state.jvm);
-  },
-
-  render() {
-    if (this._isLoading()) {
-      return (
-        <div id="footer">
-          Graylog {Version.getFullVersion()}
-        </div>
-      );
-    }
-
+  if (!(system && jvm)) {
     return (
       <div id="footer">
-        Graylog {this.state.system.version} on {this.state.system.hostname} ({this.state.jvm.info})
+        Graylog {Version.getFullVersion()}
       </div>
     );
-  },
-});
+  }
 
-export default Footer;
+  return (
+    <div id="footer">
+      Graylog {system.version} on {system.hostname} ({jvm.info})
+    </div>
+  );
+};
+
+Footer.propTypes = {
+  system: PropTypes.shape({
+    version: PropTypes.string,
+    hostname: PropTypes.string,
+  }),
+};
+
+Footer.defaultProps = {
+  system: undefined,
+};
+
+export default connect(Footer, { system: SystemStore });

--- a/graylog2-web-interface/src/components/layout/Footer.jsx
+++ b/graylog2-web-interface/src/components/layout/Footer.jsx
@@ -10,9 +10,19 @@ const SystemStore = StoreProvider.getStore('System');
 const Footer = createReactClass({
   displayName: 'Footer',
   mixins: [Reflux.connect(SystemStore)],
+  mounted: false,
 
   componentDidMount() {
-    SystemStore.jvm().then(jvmInfo => this.setState({ jvm: jvmInfo }));
+    this.mounted = true;
+    SystemStore.jvm().then((jvmInfo) => {
+      if (this.mounted) {
+        this.setState({ jvm: jvmInfo });
+      }
+    });
+  },
+
+  componentWillUnmount() {
+    this.mounted = false;
   },
 
   _isLoading() {


### PR DESCRIPTION
## Description
## Motivation and Context

Before this change, the `Footer` component unconditionally set state in
a promise handler retrieving jvm information from a remote endpoint.
This lead to flaky integration tests due to the component being mounted
and unmounted again immediately after (due to test completion) while the
promise handler has not completed yet, resulting in a rejected promise.

This change now checks if the component is not mounted anymore before
setting state.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.