### PR TITLE
Adding service to retrieve mapped field types per stream.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/FieldTypesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/FieldTypesResource.java
@@ -22,7 +22,6 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.audit.jersey.NoAuditEvent;
-import org.graylog2.database.NotFoundException;
 import org.graylog2.indexer.fieldtypes.FieldTypeDTO;
 import org.graylog2.indexer.fieldtypes.FieldTypeMapper;
 import org.graylog2.indexer.fieldtypes.FieldTypes;
@@ -137,15 +136,8 @@ public class FieldTypesResource extends RestResource implements PluginRestResour
 
     private Set<MappedFieldTypeDTO> fieldTypesByStreamIds(Set<String> streamIds) {
         return mergeCompoundFieldTypes(
-                streamIds
+                streamService.loadByIds(streamIds)
                         .stream()
-                        .map(streamId -> {
-                            try {
-                                return streamService.load(streamId);
-                            } catch (NotFoundException e) {
-                                throw new RuntimeException(e);
-                            }
-                        })
                         .filter(Objects::nonNull)
                         .map(indexSet -> indexSet.getIndexSet().getConfig().id())
                         .flatMap(indexSetId -> this.indexFieldTypesService.findForIndexSet(indexSetId).stream())

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/FieldTypesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/FieldTypesResource.java
@@ -16,22 +16,14 @@
  */
 package org.graylog.plugins.views.search.rest;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog2.audit.jersey.NoAuditEvent;
-import org.graylog2.indexer.fieldtypes.FieldTypeDTO;
-import org.graylog2.indexer.fieldtypes.FieldTypeMapper;
-import org.graylog2.indexer.fieldtypes.FieldTypes;
-import org.graylog2.indexer.fieldtypes.IndexFieldTypesDTO;
-import org.graylog2.indexer.fieldtypes.IndexFieldTypesService;
+import org.graylog2.indexer.fieldtypes.MappedFieldTypesService;
 import org.graylog2.plugin.rest.PluginRestResource;
-import org.graylog2.plugin.streams.Stream;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
-import org.graylog2.streams.StreamService;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -39,86 +31,27 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
-
-import static com.google.common.collect.ImmutableSet.of;
-import static org.graylog2.indexer.fieldtypes.FieldTypes.Type.createType;
 
 @Api(value = "Enterprise/Field Types", description = "Field Types")
 @Path("/views/fields")
 @Produces(MediaType.APPLICATION_JSON)
 @RequiresAuthentication
 public class FieldTypesResource extends RestResource implements PluginRestResource {
-    private final IndexFieldTypesService indexFieldTypesService;
-    private final StreamService streamService;
-    private final FieldTypeMapper fieldTypeMapper;
-    private static final FieldTypes.Type UNKNOWN_TYPE = createType("unknown", of());
-    private static final String PROP_COMPOUND_TYPE = "compound";
+    private final MappedFieldTypesService mappedFieldTypesService;
+    private final PermittedStreams permittedStreams;
 
     @Inject
-    public FieldTypesResource(IndexFieldTypesService indexFieldTypesService, StreamService streamService, FieldTypeMapper fieldTypeMapper) {
-        this.indexFieldTypesService = indexFieldTypesService;
-        this.streamService = streamService;
-        this.fieldTypeMapper = fieldTypeMapper;
-    }
-
-    private Set<MappedFieldTypeDTO> mergeCompoundFieldTypes(java.util.stream.Stream<MappedFieldTypeDTO> stream) {
-        return stream.collect(Collectors.groupingBy(MappedFieldTypeDTO::name, Collectors.toSet()))
-                .entrySet()
-                .stream()
-                .map(entry -> {
-                    final Set<MappedFieldTypeDTO> fieldTypes = entry.getValue();
-                    final String fieldName = entry.getKey();
-                    if (fieldTypes.size() == 1) {
-                        return fieldTypes.iterator().next();
-                    }
-
-                    final Set<String> distinctTypes = fieldTypes.stream()
-                            .map(mappedFieldTypeDTO -> mappedFieldTypeDTO.type().type())
-                            .sorted()
-                            .collect(Collectors.toCollection(LinkedHashSet::new));
-                    final String compoundFieldType = distinctTypes.size() > 1
-                            ? distinctTypes.stream().collect(Collectors.joining(",", "compound(", ")"))
-                            : distinctTypes.stream().findFirst().orElse("unknown");
-                    final ImmutableSet<String> commonProperties = fieldTypes.stream()
-                            .map(mappedFieldTypeDTO -> mappedFieldTypeDTO.type().properties())
-                            .reduce((s1, s2) -> Sets.intersection(s1, s2).immutableCopy())
-                            .orElse(ImmutableSet.of());
-
-                    final ImmutableSet<String> properties = ImmutableSet.<String>builder().addAll(commonProperties).add(PROP_COMPOUND_TYPE).build();
-                    return MappedFieldTypeDTO.create(fieldName, createType(compoundFieldType, properties));
-
-                })
-                .collect(Collectors.toSet());
-
-    }
-
-    private MappedFieldTypeDTO mapPhysicalFieldType(FieldTypeDTO fieldType) {
-        final FieldTypes.Type mappedFieldType = fieldTypeMapper.mapType(fieldType.physicalType()).orElse(UNKNOWN_TYPE);
-        return MappedFieldTypeDTO.create(fieldType.fieldName(), mappedFieldType);
+    public FieldTypesResource(MappedFieldTypesService mappedFieldTypesService,
+                              PermittedStreams permittedStreams) {
+        this.mappedFieldTypesService = mappedFieldTypesService;
+        this.permittedStreams = permittedStreams;
     }
 
     @GET
     @ApiOperation(value = "Retrieve the list of all fields present in the system")
     public Set<MappedFieldTypeDTO> allFieldTypes() {
-        if (allowedToReadStream("*")) {
-            return mergeCompoundFieldTypes(indexFieldTypesService.findAll()
-                    .stream()
-                    .map(IndexFieldTypesDTO::fields)
-                    .flatMap(Collection::stream)
-                    .map(this::mapPhysicalFieldType));
-        }
-        final Set<String> allowedStreams = streamService.loadAll()
-                .stream()
-                .map(Stream::getId)
-                .filter(this::allowedToReadStream)
-                .collect(Collectors.toSet());
-
-        return fieldTypesByStreamIds(allowedStreams);
+        return mappedFieldTypesService.fieldTypesByStreamIds(permittedStreams.load(this::allowedToReadStream));
     }
 
     private boolean allowedToReadStream(String streamId) {
@@ -131,19 +64,6 @@ public class FieldTypesResource extends RestResource implements PluginRestResour
     public Set<MappedFieldTypeDTO> byStreams(FieldTypesForStreamsRequest request) {
         request.streams().forEach(s -> checkPermission(RestPermissions.STREAMS_READ, s));
 
-        return fieldTypesByStreamIds(request.streams());
-    }
-
-    private Set<MappedFieldTypeDTO> fieldTypesByStreamIds(Set<String> streamIds) {
-        return mergeCompoundFieldTypes(
-                streamService.loadByIds(streamIds)
-                        .stream()
-                        .filter(Objects::nonNull)
-                        .map(indexSet -> indexSet.getIndexSet().getConfig().id())
-                        .flatMap(indexSetId -> this.indexFieldTypesService.findForIndexSet(indexSetId).stream())
-                        .map(IndexFieldTypesDTO::fields)
-                        .flatMap(Collection::stream)
-                        .map(this::mapPhysicalFieldType)
-        );
+        return mappedFieldTypesService.fieldTypesByStreamIds(request.streams());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/PermittedStreams.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/PermittedStreams.java
@@ -27,15 +27,15 @@ import java.util.function.Predicate;
 import static java.util.stream.Collectors.toSet;
 import static org.graylog2.plugin.streams.Stream.DEFAULT_EVENT_STREAM_IDS;
 
-class PermittedStreams {
+public class PermittedStreams {
     private final StreamService streamService;
 
     @Inject
-    PermittedStreams(StreamService streamService) {
+    public PermittedStreams(StreamService streamService) {
         this.streamService = streamService;
     }
 
-    ImmutableSet<String> load(Predicate<String> isStreamIdPermitted) {
+    public ImmutableSet<String> load(Predicate<String> isStreamIdPermitted) {
         final Set<String> result = streamService.loadAll().stream()
                 .map(org.graylog2.plugin.streams.Stream::getId)
                 // Unless explicitly queried, exclude event indices by defaulth

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesService.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.indexer.fieldtypes;
 
 import com.google.common.collect.ImmutableSet;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesService.java
@@ -51,7 +51,7 @@ public class MappedFieldTypesService {
                 streamService.loadByIds(streamIds)
                         .stream()
                         .filter(Objects::nonNull)
-                        .map(indexSet -> indexSet.getIndexSet().getConfig().id())
+                        .map(stream -> stream.getIndexSet().getConfig().id())
                         .flatMap(indexSetId -> this.indexFieldTypesService.findForIndexSet(indexSetId).stream())
                         .map(IndexFieldTypesDTO::fields)
                         .flatMap(Collection::stream)

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesService.java
@@ -59,12 +59,12 @@ public class MappedFieldTypesService {
         );
     }
 
-    public MappedFieldTypeDTO mapPhysicalFieldType(FieldTypeDTO fieldType) {
+    private MappedFieldTypeDTO mapPhysicalFieldType(FieldTypeDTO fieldType) {
         final FieldTypes.Type mappedFieldType = fieldTypeMapper.mapType(fieldType.physicalType()).orElse(UNKNOWN_TYPE);
         return MappedFieldTypeDTO.create(fieldType.fieldName(), mappedFieldType);
     }
 
-    public Set<MappedFieldTypeDTO> mergeCompoundFieldTypes(java.util.stream.Stream<MappedFieldTypeDTO> stream) {
+    private Set<MappedFieldTypeDTO> mergeCompoundFieldTypes(java.util.stream.Stream<MappedFieldTypeDTO> stream) {
         return stream.collect(Collectors.groupingBy(MappedFieldTypeDTO::name, Collectors.toSet()))
                 .entrySet()
                 .stream()

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesService.java
@@ -1,0 +1,81 @@
+package org.graylog2.indexer.fieldtypes;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import org.graylog.plugins.views.search.rest.MappedFieldTypeDTO;
+import org.graylog2.streams.StreamService;
+
+import javax.inject.Inject;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.google.common.collect.ImmutableSet.of;
+import static org.graylog2.indexer.fieldtypes.FieldTypes.Type.createType;
+
+public class MappedFieldTypesService {
+    private final StreamService streamService;
+    private final IndexFieldTypesService indexFieldTypesService;
+    private final FieldTypeMapper fieldTypeMapper;
+
+    private static final FieldTypes.Type UNKNOWN_TYPE = createType("unknown", of());
+    private static final String PROP_COMPOUND_TYPE = "compound";
+
+    @Inject
+    public MappedFieldTypesService(StreamService streamService, IndexFieldTypesService indexFieldTypesService, FieldTypeMapper fieldTypeMapper) {
+        this.streamService = streamService;
+        this.indexFieldTypesService = indexFieldTypesService;
+        this.fieldTypeMapper = fieldTypeMapper;
+    }
+
+    public Set<MappedFieldTypeDTO> fieldTypesByStreamIds(Collection<String> streamIds) {
+        return mergeCompoundFieldTypes(
+                streamService.loadByIds(streamIds)
+                        .stream()
+                        .filter(Objects::nonNull)
+                        .map(indexSet -> indexSet.getIndexSet().getConfig().id())
+                        .flatMap(indexSetId -> this.indexFieldTypesService.findForIndexSet(indexSetId).stream())
+                        .map(IndexFieldTypesDTO::fields)
+                        .flatMap(Collection::stream)
+                        .map(this::mapPhysicalFieldType)
+        );
+    }
+
+    public MappedFieldTypeDTO mapPhysicalFieldType(FieldTypeDTO fieldType) {
+        final FieldTypes.Type mappedFieldType = fieldTypeMapper.mapType(fieldType.physicalType()).orElse(UNKNOWN_TYPE);
+        return MappedFieldTypeDTO.create(fieldType.fieldName(), mappedFieldType);
+    }
+
+    public Set<MappedFieldTypeDTO> mergeCompoundFieldTypes(java.util.stream.Stream<MappedFieldTypeDTO> stream) {
+        return stream.collect(Collectors.groupingBy(MappedFieldTypeDTO::name, Collectors.toSet()))
+                .entrySet()
+                .stream()
+                .map(entry -> {
+                    final Set<MappedFieldTypeDTO> fieldTypes = entry.getValue();
+                    final String fieldName = entry.getKey();
+                    if (fieldTypes.size() == 1) {
+                        return fieldTypes.iterator().next();
+                    }
+
+                    final Set<String> distinctTypes = fieldTypes.stream()
+                            .map(mappedFieldTypeDTO -> mappedFieldTypeDTO.type().type())
+                            .sorted()
+                            .collect(Collectors.toCollection(LinkedHashSet::new));
+                    final String compoundFieldType = distinctTypes.size() > 1
+                            ? distinctTypes.stream().collect(Collectors.joining(",", "compound(", ")"))
+                            : distinctTypes.stream().findFirst().orElse("unknown");
+                    final ImmutableSet<String> commonProperties = fieldTypes.stream()
+                            .map(mappedFieldTypeDTO -> mappedFieldTypeDTO.type().properties())
+                            .reduce((s1, s2) -> Sets.intersection(s1, s2).immutableCopy())
+                            .orElse(ImmutableSet.of());
+
+                    final ImmutableSet<String> properties = ImmutableSet.<String>builder().addAll(commonProperties).add(PROP_COMPOUND_TYPE).build();
+                    return MappedFieldTypeDTO.create(fieldName, createType(compoundFieldType, properties));
+
+                })
+                .collect(Collectors.toSet());
+
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesServiceTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.indexer.fieldtypes;
 
 import com.google.common.collect.ImmutableList;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesServiceTest.java
@@ -1,0 +1,99 @@
+package org.graylog2.indexer.fieldtypes;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.graylog.plugins.views.search.rest.MappedFieldTypeDTO;
+import org.graylog2.plugin.streams.Stream;
+import org.graylog2.streams.StreamService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MappedFieldTypesServiceTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private StreamService streamService;
+
+    @Mock
+    private IndexFieldTypesService indexFieldTypesService;
+
+    private MappedFieldTypesService mappedFieldTypesService;
+
+    @Before
+    public void setUp() throws Exception {
+        this.mappedFieldTypesService = new MappedFieldTypesService(streamService, indexFieldTypesService, new FieldTypeMapper());
+        final Stream stream = mock(Stream.class, Answers.RETURNS_DEEP_STUBS);
+        when(stream.getIndexSet().getConfig().id()).thenReturn("indexSetId");
+        final Set<Stream> streams = Collections.singleton(stream);
+        when(streamService.loadByIds(Collections.singleton("stream1"))).thenReturn(streams);
+    }
+
+    @Test
+    public void fieldsOfSameTypeDoNotReturnCompoundTypeIfPropertiesAreDifferent() {
+        final List<IndexFieldTypesDTO> fieldTypes = ImmutableList.of(
+                createIndexTypes(
+                        "deadbeef",
+                        "testIndex",
+                        FieldTypeDTO.create("field1", "keyword"),
+                        FieldTypeDTO.create("field2", "long")
+                ),
+                createIndexTypes(
+                        "affeaffe",
+                        "testIndex2",
+                        FieldTypeDTO.create("field1", "text"),
+                        FieldTypeDTO.create("field2", "long")
+                )
+        );
+        when(indexFieldTypesService.findForIndexSet("indexSetId")).thenReturn(fieldTypes);
+
+        final Set<MappedFieldTypeDTO> result = this.mappedFieldTypesService.fieldTypesByStreamIds(Collections.singleton("stream1"));
+        assertThat(result).containsExactlyInAnyOrder(
+                MappedFieldTypeDTO.create("field2", FieldTypes.Type.createType("long", ImmutableSet.of("numeric", "enumerable"))),
+                MappedFieldTypeDTO.create("field1", FieldTypes.Type.createType("string", ImmutableSet.of("compound")))
+        );
+    }
+
+    @Test
+    public void fieldsOfDifferentTypesDoReturnCompoundType() {
+        final List<IndexFieldTypesDTO> fieldTypes = ImmutableList.of(
+                createIndexTypes(
+                        "deadbeef",
+                        "testIndex",
+                        FieldTypeDTO.create("field1", "long"),
+                        FieldTypeDTO.create("field2", "long")
+                ),
+                createIndexTypes(
+                        "affeaffe",
+                        "testIndex2",
+                        FieldTypeDTO.create("field1", "text"),
+                        FieldTypeDTO.create("field2", "long")
+                )
+        );
+        when(indexFieldTypesService.findForIndexSet("indexSetId")).thenReturn(fieldTypes);
+
+        final Set<MappedFieldTypeDTO> result = this.mappedFieldTypesService.fieldTypesByStreamIds(Collections.singleton("stream1"));
+        assertThat(result).containsExactlyInAnyOrder(
+                MappedFieldTypeDTO.create("field2", FieldTypes.Type.createType("long", ImmutableSet.of("numeric", "enumerable"))),
+                MappedFieldTypeDTO.create("field1", FieldTypes.Type.createType("compound(long,string)", ImmutableSet.of("compound")))
+        );
+    }
+
+    private IndexFieldTypesDTO createIndexTypes(String indexId, String indexName, FieldTypeDTO... fieldTypes) {
+        return IndexFieldTypesDTO.create(indexId, indexName, java.util.stream.Stream.of(fieldTypes).collect(Collectors.toSet()));
+    }
+}


### PR DESCRIPTION
## Description
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is adding a `MappedFieldTypesService` which allows its consumer to retrieve mapped field types for a given set of streams. This will be used in several places (reporting, views) to easily access field types in a scope that is limited to a set of streams.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.