### PR TITLE
Cleaning up render completion callback handling in some places.

### DIFF
--- a/graylog2-web-interface/src/components/visualizations/RenderCompletionObserver.jsx
+++ b/graylog2-web-interface/src/components/visualizations/RenderCompletionObserver.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import RenderCompletionCallback from 'views/components/widgets/RenderCompletionCallback';
 
 class RenderCompletionObserver extends React.Component {
   static propTypes = {
@@ -21,12 +22,11 @@ class RenderCompletionObserver extends React.Component {
   };
 
   render() {
+    const { children } = this.props;
     return (
-      <div>
-        {React.Children.map(this.props.children, (child) => {
-          return React.cloneElement(child, { onRenderComplete: this._handleRenderComplete });
-        })}
-      </div>
+      <RenderCompletionCallback.Provider value={this._handleRenderComplete}>
+        {children}
+      </RenderCompletionCallback.Provider>
     );
   }
 }

--- a/graylog2-web-interface/src/components/visualizations/RenderCompletionObserver.jsx
+++ b/graylog2-web-interface/src/components/visualizations/RenderCompletionObserver.jsx
@@ -18,7 +18,8 @@ class RenderCompletionObserver extends React.Component {
       return;
     }
     this._renderComplete = true;
-    this.props.onRenderComplete();
+    const { onRenderComplete } = this.props;
+    onRenderComplete();
   };
 
   render() {

--- a/graylog2-web-interface/src/components/widgets/WidgetVisualizationNotFound.jsx
+++ b/graylog2-web-interface/src/components/widgets/WidgetVisualizationNotFound.jsx
@@ -1,30 +1,28 @@
+// @flow strict
+import React, { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import React from 'react';
+
 import { Alert } from 'components/graylog';
 import { Icon } from 'components/common';
+import RenderCompletionCallback from 'views/components/widgets/RenderCompletionCallback';
 
-class WidgetVisualizationNotFound extends React.Component {
-  static propTypes = {
-    widgetClassName: PropTypes.string.isRequired,
-    onRenderComplete: PropTypes.func,
-  };
+type Props = {
+  widgetClassName: string,
+};
 
-  static defaultProps = {
-    onRenderComplete: () => {},
-  };
+const WidgetVisualizationNotFound = ({ widgetClassName }: Props) => {
+  const onRenderComplete = useContext(RenderCompletionCallback);
+  useEffect(() => onRenderComplete(), [onRenderComplete]);
+  return (
+    <Alert bsStyle="danger">
+      <Icon name="exclamation-circle" /> Widget Visualization (<i>{widgetClassName}</i>) not found.
+      It looks like the plugin supplying this widget is not loaded.
+    </Alert>
+  );
+};
 
-  componentDidMount() {
-    this.props.onRenderComplete();
-  }
-
-  render() {
-    return (
-      <Alert bsStyle="danger">
-        <Icon name="exclamation-circle" /> Widget Visualization (<i>{this.props.widgetClassName}</i>) not found.
-        It looks like the plugin supplying this widget is not loaded.
-      </Alert>
-    );
-  }
-}
+WidgetVisualizationNotFound.propTypes = {
+  widgetClassName: PropTypes.string.isRequired,
+};
 
 export default WidgetVisualizationNotFound;

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.jsx
@@ -55,7 +55,7 @@ const _visualizationForType = (type: string): VisualizationComponent => {
 };
 
 const AggregationBuilder = ({ config, data, editing = false, fields, onVisualizationConfigChange = () => {}, toggleEdit }: Props) => {
-  if (config.isEmpty) {
+  if (!config || config.isEmpty) {
     return <EmptyAggregationContent toggleEdit={toggleEdit} editing={editing} />;
   }
 

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.jsx
@@ -139,7 +139,7 @@ class GenericPlot extends React.Component<Props, State> {
         namelength: -1,
       },
     };
-    const plotLayout = merge(defaultLayout, layout);
+    const plotLayout = merge({}, defaultLayout, layout);
 
     const style = { height: 'calc(100% - 10px)', width: '100%' };
 
@@ -169,7 +169,7 @@ class GenericPlot extends React.Component<Props, State> {
                     <>
                       <Plot data={newChartData}
                             useResizeHandler
-                            layout={interactive ? plotLayout : merge(nonInteractiveLayout, plotLayout)}
+                            layout={interactive ? plotLayout : merge({}, nonInteractiveLayout, plotLayout)}
                             style={style}
                             onAfterPlot={onRenderComplete}
                             onClick={interactive ? null : () => false}

--- a/graylog2-web-interface/src/views/components/visualizations/XYPlot.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/XYPlot.jsx
@@ -46,7 +46,7 @@ const XYPlot = ({
 }: Props) => {
   const yaxis = { fixedrange: true, rangemode: 'tozero' };
 
-  const layout = merge({ yaxis }, plotLayout);
+  const layout = merge({}, { yaxis }, plotLayout);
 
   const _onZoom = config.isTimeline ? (from, to) => onZoom(currentQuery, from, to) : () => true;
   if (config.isTimeline) {
@@ -54,6 +54,7 @@ const XYPlot = ({
     const normalizedTo = moment.tz(effectiveTimerange.to, timezone).format();
     layout.xaxis = {
       range: [normalizedFrom, normalizedTo],
+      type: 'date',
     };
   } else {
     layout.xaxis = {

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.jsx
@@ -74,7 +74,7 @@ describe('XYPlot', () => {
     const genericPlot = wrapper.find('GenericPlot');
     expect(genericPlot).toHaveProp('layout', {
       yaxis: { fixedrange: true, rangemode: 'tozero' },
-      xaxis: { range: ['2018-10-12T02:04:21Z', '2018-10-12T10:04:21Z'] },
+      xaxis: { range: ['2018-10-12T02:04:21Z', '2018-10-12T10:04:21Z'], type: 'date' },
     });
 
     genericPlot.get(0).props.onZoom('2018-10-12T04:04:21.723Z', '2018-10-12T08:04:21.723Z');
@@ -104,7 +104,7 @@ describe('XYPlot', () => {
     const genericPlot = wrapper.find('GenericPlot');
     expect(genericPlot).toHaveProp('layout', {
       yaxis: { fixedrange: true, rangemode: 'tozero' },
-      xaxis: { range: ['2018-10-12T02:04:21Z', '2018-10-12T10:04:21Z'] },
+      xaxis: { range: ['2018-10-12T02:04:21Z', '2018-10-12T10:04:21Z'], type: 'date' },
     });
   });
 });

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/Direction.js
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/Direction.js
@@ -6,18 +6,18 @@ export default class Direction {
 
   static Descending = new Direction('Descending');
 
-  direction: DirectionJson;
+  _direction: DirectionJson;
 
   constructor(direction: DirectionJson) {
-    this.direction = direction;
+    this._direction = direction;
   }
 
   toJSON(): DirectionJson {
-    return this.direction;
+    return this._direction;
   }
 
   get direction() {
-    return this.direction;
+    return this._direction;
   }
 
   static fromJSON(value: DirectionJson): Direction {

--- a/graylog2-web-interface/src/views/logic/widgets/Widget.js
+++ b/graylog2-web-interface/src/views/logic/widgets/Widget.js
@@ -3,6 +3,7 @@ import { Map } from 'immutable';
 import uuid from 'uuid/v4';
 
 import type { QueryString, TimeRange } from 'views/logic/queries/Query';
+import { singleton } from '../singleton';
 
 type State = {
   id: string,
@@ -150,4 +151,4 @@ class Builder {
 
 Widget.Builder = Builder;
 
-export default Widget;
+export default singleton('views.logic.widgets.Widget', () => Widget);


### PR DESCRIPTION
## Description
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is cleaning up some inconsistencies and issues that came up
during the reporting integration:

  * `GenericPlot`/`XYPlot` merged layout changes into the sources
itself, leading to subtle bugs with nondeterministic layouts if multiple
widgets are present
  * `RenderCompletionObserver` is now used the context for passing the
callback down to its children
  * `WidgetVisualizationNotFound` was now calling the render completion
callback to, so rendering will appear as completed in error cases too.
  * `Widget` is being exported as singleton to make it properly usable
from plugins if subclasses are present