### PR TITLE
Mute PropTypes warning in ViewActionsMenu

### DIFF
--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
@@ -79,9 +79,9 @@ const ViewActionsMenu = ({ view, isNewView, metadata, onSaveView, onSaveAsView, 
 ViewActionsMenu.propTypes = {
   currentUser: PropTypes.shape({
     currentUser: PropTypes.shape({
-      permissions: PropTypes.arrayOf(PropTypes.string).isRequired,
-    }).isRequired,
-  }).isRequired,
+      permissions: PropTypes.arrayOf(PropTypes.string),
+    }),
+  }),
   onSaveView: PropTypes.func.isRequired,
   onSaveAsView: PropTypes.func.isRequired,
   metadata: PropTypes.shape({
@@ -89,6 +89,14 @@ ViewActionsMenu.propTypes = {
   }).isRequired,
   view: PropTypes.instanceOf(View).isRequired,
   isNewView: PropTypes.bool.isRequired,
+};
+
+ViewActionsMenu.defaultProps = {
+  currentUser: {
+    currentUser: {
+      permissions: [],
+    },
+  },
 };
 
 export default connect(


### PR DESCRIPTION
## Motivation and Context
Prior to this change, PropTypes would raise a warning
when CurrentUser was not yet fetch from the store, but
ViewActionsMenu was already tried to be rendered.

## Description
This change will implement a default CurrentUser
with empty permissions to satisfy PropTypes once and for all.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
