### PR TITLE
Pluggable login form

### DIFF
--- a/graylog2-web-interface/src/components/login/LoginForm.jsx
+++ b/graylog2-web-interface/src/components/login/LoginForm.jsx
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Button, FormGroup } from 'components/graylog';
+
+import { Input } from 'components/bootstrap';
+import CombinedProvider from 'injection/CombinedProvider';
+
+const { SessionActions } = CombinedProvider.get('Session');
+
+const LoginForm = ({ onErrorChange }) => {
+  const [isLoading, setIsLoading] = useState(false);
+  let promise;
+  let usernameInput;
+  let passwordInput;
+
+  useEffect(() => {
+    return () => {
+      if (promise) {
+        promise.cancel();
+      }
+    };
+  }, []);
+
+  const onSignInClicked = (event) => {
+    event.preventDefault();
+    onErrorChange();
+    setIsLoading(true);
+    const username = usernameInput.getValue();
+    const password = passwordInput.getValue();
+    const location = document.location.host;
+    promise = SessionActions.login(username, password, location);
+    promise.catch((error) => {
+      if (error.additional.status === 401) {
+        onErrorChange('Invalid credentials, please verify them and retry.');
+      } else {
+        onErrorChange(`Error - the server returned: ${error.additional.status} - ${error.message}`);
+      }
+    });
+    promise.finally(() => {
+      if (!promise.isCancelled()) {
+        setIsLoading(false);
+      }
+    });
+  };
+
+  return (
+    <form onSubmit={onSignInClicked}>
+      <Input ref={(username) => { usernameInput = username; }} id="username" type="text" placeholder="Username" autoFocus />
+      <Input ref={(password) => { passwordInput = password; }} id="password" type="password" placeholder="Password" />
+
+      <FormGroup>
+        <Button type="submit" bsStyle="info" disabled={isLoading}>
+          {isLoading ? 'Signing in...' : 'Sign in'}
+        </Button>
+      </FormGroup>
+    </form>
+  );
+};
+
+LoginForm.propTypes = {
+  onErrorChange: PropTypes.func.isRequired,
+};
+
+export default LoginForm;

--- a/graylog2-web-interface/src/pages/LoginPage.jsx
+++ b/graylog2-web-interface/src/pages/LoginPage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
+import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import { DocumentTitle, Icon } from 'components/common';
 import { Alert, Col, Row } from 'components/graylog';
@@ -61,6 +62,17 @@ const LoginPage = createReactClass({
     return null;
   },
 
+  renderLoginForm() {
+    const loginComponent = PluginStore.exports('loginProviderType');
+
+    if (loginComponent.length === 1) {
+      return React.createElement(loginComponent[0].formComponent, {
+        onErrorChange: this.handleErrorChange,
+      });
+    }
+
+    return <LoginForm onErrorChange={this.handleErrorChange} />;
+  },
 
   render() {
     const { lastError, didValidateSession } = this.state;
@@ -81,7 +93,7 @@ const LoginPage = createReactClass({
                 <legend><Icon name="group" /> Welcome to Graylog</legend>
                 {alert}
 
-                <LoginForm onErrorChange={this.handleErrorChange} />
+                {this.renderLoginForm()}
               </Col>
             </Row>
           </div>

--- a/graylog2-web-interface/src/pages/LoginPage.jsx
+++ b/graylog2-web-interface/src/pages/LoginPage.jsx
@@ -20,10 +20,19 @@ const LoginPage = createReactClass({
   displayName: 'LoginPage',
   mixins: [Reflux.connect(SessionStore), Reflux.ListenerMethods],
 
+  getInitialState() {
+    return {
+      didValidateSession: false,
+    };
+  },
+
   componentDidMount() {
     disconnectedStyle.use();
     authStyle.use();
-    SessionActions.validate();
+    SessionActions.validate().then((response) => {
+      this.setState({ didValidateSession: true });
+      return response;
+    });
   },
 
   componentWillUnmount() {
@@ -54,9 +63,9 @@ const LoginPage = createReactClass({
 
 
   render() {
-    const { lastError, validatingSession } = this.state;
+    const { lastError, didValidateSession } = this.state;
 
-    if (validatingSession) {
+    if (!didValidateSession) {
       return (
         <LoadingPage />
       );

--- a/graylog2-web-interface/src/stores/sessions/SessionStore.js
+++ b/graylog2-web-interface/src/stores/sessions/SessionStore.js
@@ -51,7 +51,7 @@ const SessionStore = Reflux.createStore({
     const username = Store.get('username');
     this.validatingSession = true;
     this._propagateState();
-    this._validateSession(sessionId)
+    const promise = this._validateSession(sessionId)
       .then((response) => {
         if (response.is_valid) {
           return SessionActions.login.completed({
@@ -69,6 +69,8 @@ const SessionStore = Reflux.createStore({
         this.validatingSession = false;
         this._propagateState();
       });
+
+    SessionActions.validate.promise(promise);
   },
   _validateSession(sessionId) {
     return new Builder('GET', URLUtils.qualifyUrl(ApiRoutes.SessionsApiController.validate().url))


### PR DESCRIPTION
Extracts login form into its own component, independent from `LoginPage`, and lets one plugin to display an alternative login page.

I decided not to migrate `LoginPage` to a functional component to not pollute the PR with that, but I can also make the change if you consider it appropriate.

---
Update to include how to use a plugin to log into Graylog. I don't see a good place in the code to add this information, so I will leave it here for now.

The plugin needs to register a form component in `loginProviderType` taking care of displaying a form, or button, the user can use to log into Graylog. Only one plugin can do that at the time, so far we don't need to support any number of custom login forms.

The form may talk to an authenticator provided by the plugin API and/or an external system to handle the login. Once the user is authenticated, we need to ensure the session information is stored in the browser, like we do in the regular log in. This can be accomplished by calling `SessionActions.login.completed()` with the session ID and usernames returned from the server:

```
const session = { sessionId: session_id, username: username };
SessionActions.login.completed(session);
```

That will also take care of propagating the changes to other stores and components listening to it.