### PR TITLE
Parse error for missing required positional parameters with optional parameters present (#6716)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParser.java
@@ -381,6 +381,14 @@ public class PipelineRuleParser {
                         if (requiredAfterOptional) {
                             parseContext.addError(new OptionalParametersMustBeNamed(ctx, function));
                             hasError = true;
+                        } else {
+                            final long numberRequiredParams = params.stream()
+                                    .filter(p -> !p.optional())
+                                    .count();
+                            if (numberRequiredParams > positionalArgs.size()) {
+                                parseContext.addError(new WrongNumberOfArgs(ctx, function, positionalArgs.size()));
+                                hasError = true;
+                            }
                         }
                     }
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/parser/PipelineRuleParserTest.java
@@ -56,6 +56,7 @@ import org.graylog.plugins.pipelineprocessor.parser.errors.OptionalParametersMus
 import org.graylog.plugins.pipelineprocessor.parser.errors.SyntaxError;
 import org.graylog.plugins.pipelineprocessor.parser.errors.UndeclaredFunction;
 import org.graylog.plugins.pipelineprocessor.parser.errors.UndeclaredVariable;
+import org.graylog.plugins.pipelineprocessor.parser.errors.WrongNumberOfArgs;
 import org.graylog2.plugin.InstantMillisProvider;
 import org.graylog2.plugin.Message;
 import org.joda.time.DateTime;
@@ -95,6 +96,7 @@ public class PipelineRuleParserTest extends BaseParserTest {
         functions.put("concat", new ConcatFunction());
         functions.put("trigger_test", new TriggerTestFunction());
         functions.put("optional", new OptionalFunction());
+        functions.put("required", new RequiredFunction());
         functions.put("customObject", new CustomObjectFunction());
         functions.put("beanObject", new BeanObjectFunction());
         functions.put("keys", new KeysFunction());
@@ -247,6 +249,17 @@ public class PipelineRuleParserTest extends BaseParserTest {
             assertTrue(e.getErrors().stream().allMatch(error -> error instanceof OptionalParametersMustBeNamed));
         }
 
+    }
+
+    @Test
+    public void requiredParameter() {
+        try {
+            parseRuleWithOptionalCodegen();
+            fail("Should have thrown parse exception");
+        } catch (ParseException e) {
+            assertEquals(1, e.getErrors().size());
+            assertTrue(e.getErrors().stream().allMatch(error -> error instanceof WrongNumberOfArgs));
+        }
     }
 
     @Test
@@ -562,6 +575,25 @@ public class PipelineRuleParserTest extends BaseParserTest {
                             ParameterDescriptor.string("b").build(),
                             ParameterDescriptor.floating("c").optional().build(),
                             ParameterDescriptor.integer("d").build()
+                    ))
+                    .build();
+        }
+    }
+
+    public static class RequiredFunction extends AbstractFunction<Boolean> {
+        @Override
+        public Boolean evaluate(FunctionArgs args, EvaluationContext context) {
+            return true;
+        }
+
+        @Override
+        public FunctionDescriptor<Boolean> descriptor() {
+            return FunctionDescriptor.<Boolean>builder()
+                    .name("required")
+                    .returnType(Boolean.class)
+                    .params(of(
+                            ParameterDescriptor.integer("a").build(),
+                            ParameterDescriptor.string("b").build()
                     ))
                     .build();
         }

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/parser/requiredParameter.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/parser/requiredParameter.txt
@@ -1,0 +1,6 @@
+rule "required param missing"
+when
+  true
+then
+  set_field("foo");
+end


### PR DESCRIPTION
* Add parse error handling for missing required parameters when followed by optional parameters
* Set "hasError" when encountering WrongNumberOfArgs error

Fixes #6696

(cherry picked from commit eb392d9180e552723a1b9805c6a06f270a16a18d)
