### PR TITLE
Include streams of search type when returning used streams of search.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
@@ -144,10 +144,15 @@ public abstract class Search {
     }
 
     Set<String> usedStreamIds() {
-        return queries().stream()
+        final Set<String> queryStreamIds = queries().stream()
                 .map(Query::usedStreamIds)
-                .reduce(Sets::union)
-                .orElseThrow(() -> new RuntimeException("Failed to get used stream IDs from query"));
+                .reduce(Collections.emptySet(), Sets::union);
+        final Set<String> searchTypeStreamIds = queries().stream()
+                .flatMap(q -> q.searchTypes().stream())
+                .map(SearchType::streams)
+                .reduce(Collections.emptySet(), Sets::union);
+
+        return Sets.union(queryStreamIds, searchTypeStreamIds);
     }
 
     @AutoValue.Builder

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchTest.java
@@ -23,12 +23,15 @@ import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class SearchTest {
     @Test
@@ -58,6 +61,33 @@ public class SearchTest {
         assertThat(before).isEqualTo(after);
     }
 
+    @Test
+    public void usedStreamIdsReturnsStreamIdsOfSearchTypes() {
+        final Query query1 = queryWithStreams("a,b,d").toBuilder()
+                .searchTypes(ImmutableSet.of(
+                        searchTypeWithStreams("e,f,g"),
+                        searchTypeWithStreams("a,h,b")
+                ))
+                .build();
+        final Search search = Search.builder().queries(ImmutableSet.of(query1)).build();
+
+        assertThat(search.usedStreamIds()).containsExactlyInAnyOrder("a", "b", "d", "e", "f", "g", "h");
+    }
+
+    @Test
+    public void usedStreamIdsReturnsEmptySetForMissingQueries() {
+        final Search search = Search.builder().build();
+
+        assertThat(search.usedStreamIds()).isEmpty();
+    }
+
+    @Test
+    public void usedStreamIdsReturnsQueryStreamsWhenSearchTypesAreMissing() {
+        final Search search = searchWithQueriesWithStreams("c,d,e");
+
+        assertThat(search.usedStreamIds()).containsExactlyInAnyOrder("c", "d", "e");
+    }
+
     private Search searchWithQueriesWithStreams(String... queriesWithStreams) {
         Set<Query> queries = Arrays.stream(queriesWithStreams).map(this::queryWithStreams).collect(Collectors.toSet());
 
@@ -76,5 +106,14 @@ public class SearchTest {
             builder = builder.filter(StreamFilter.anyIdOf(streamIds));
 
         return builder.build();
+    }
+
+    private SearchType searchTypeWithStreams(String streamIds) {
+        final SearchType searchType = mock(SearchType.class);
+        final Set<String> streamIdSet = streamIds.isEmpty() ? Collections.emptySet() : new HashSet<>(Arrays.asList(streamIds.split(",")));
+        when(searchType.streams()).thenReturn(streamIdSet);
+        when(searchType.id()).thenReturn(UUID.randomUUID().toString());
+
+        return searchType;
     }
 }


### PR DESCRIPTION
Before this change, `Search#usedStreamIds` only considered the referenced streams of `Query`'s. This led to an omission of permission checks for the search type's stream ids.

This change is now returning the stream ids referenced in the search types of a query as well for `Search#usedStreamIds`.

In addition, it now returns an empty set instead of throwing an exception when performed on a search with an empty set of queries (a pathological case, but returning an empty set seems to be the correct way to handle it).