### PR TITLE
Prevent logo click from breaking back button

### DIFF
--- a/graylog2-web-interface/src/pages/StartPage.jsx
+++ b/graylog2-web-interface/src/pages/StartPage.jsx
@@ -46,16 +46,17 @@ const StartPage = createReactClass({
   },
 
   _redirectToStartpage() {
+    const { currentUser, currentUser: { startpage }, gettingStarted } = this.state;
+    
     // Show getting started page if user is an admin and getting started wasn't dismissed
-    if (PermissionsMixin.isPermitted(this.state.currentUser.permissions, ['inputs:create'])) {
-      if (this.state.gettingStarted.show) {
+    if (PermissionsMixin.isPermitted(currentUser.permissions, ['inputs:create'])) {
+      if (gettingStarted.show) {
         this._redirect(Routes.GETTING_STARTED);
         return;
       }
     }
 
     // Show custom startpage if it was set
-    const { startpage } = this.state.currentUser;
     if (startpage !== null && Object.keys(startpage).length > 0) {
       if (startpage.type === 'stream') {
         this._redirect(Routes.stream_search(startpage.id));
@@ -66,7 +67,7 @@ const StartPage = createReactClass({
     }
 
     // Show search page if permitted, or streams page in other case
-    if (PermissionsMixin.isAnyPermitted(this.state.currentUser.permissions, ['searches:absolute', 'searches:keyword', 'searches:relative'])) {
+    if (PermissionsMixin.isAnyPermitted(currentUser.permissions, ['searches:absolute', 'searches:keyword', 'searches:relative'])) {
       this._redirect(Routes.SEARCH);
     } else {
       this._redirect(Routes.STREAMS);
@@ -74,7 +75,8 @@ const StartPage = createReactClass({
   },
 
   _isLoading() {
-    return !this.state.currentUser || !this.state.gettingStarted;
+    const { currentUser, gettingStarted } = this.state;
+    return !currentUser || !gettingStarted;
   },
 
   render() {

--- a/graylog2-web-interface/src/pages/StartPage.jsx
+++ b/graylog2-web-interface/src/pages/StartPage.jsx
@@ -42,7 +42,7 @@ const StartPage = createReactClass({
   },
 
   _redirect(page) {
-    history.push(page);
+    history.replace(page);
   },
 
   _redirectToStartpage() {

--- a/graylog2-web-interface/src/pages/StartPage.jsx
+++ b/graylog2-web-interface/src/pages/StartPage.jsx
@@ -47,7 +47,6 @@ const StartPage = createReactClass({
 
   _redirectToStartpage() {
     const { currentUser, currentUser: { startpage }, gettingStarted } = this.state;
-    
     // Show getting started page if user is an admin and getting started wasn't dismissed
     if (PermissionsMixin.isPermitted(currentUser.permissions, ['inputs:create'])) {
       if (gettingStarted.show) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change allow the use of the `back` button to return to previous state after clicking on the Logo in the Header.
 
Before this change clicking on the `logo` on the header navigated to `/` which redirected to `/search`. This was breaking the `Back` button as the browser tries to go back to `/` which redirects to `/search`.
(#5975)
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
