### PR TITLE
Reset DateTime at the end of a unit test which globally overrides it

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendUsingCorrectIndicesTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendUsingCorrectIndicesTest.java
@@ -140,6 +140,8 @@ public class ElasticsearchBackendUsingCorrectIndicesTest extends ElasticsearchBa
 
         assertThat(fromCapture.getValue().isEqual(new DateTime(datetimeFixture, DateTimeZone.UTC).minusSeconds(600))).isTrue();
         assertThat(toCapture.getValue().isEqual(new DateTime(datetimeFixture, DateTimeZone.UTC))).isTrue();
+
+        DateTimeUtils.setCurrentMillisSystem();
     }
 
     private Query dummyQuery(TimeRange timeRange) {


### PR DESCRIPTION
`org.joda.time.DateTimeUtils` is used in various unit tests to override the current time globally. In one of these tests it was forgotten to reset time at the end of the test, which led to failures of a completely unrelated, but also `DateTime`-dependent test (`DBJobTriggerServiceTest->deleteCompleted`). 

<!--- Provide a general summary of your changes in the Title above -->

## Description
Just added one line to the end of the test to reset `DateTime`. Didn't want to add a tear down method, because this was the only test in the class that used the override.

## Motivation and Context
The missing reset has led to consistent failure of the above mentioned unrelated test on my local machine. 
In the future we should remove such overrides and instead inject `now` in classes under test.

## How Has This Been Tested?
Running all backend tests, including the refactored integration tests from the [testcontainers pr](https://github.com/Graylog2/graylog2-server/pull/5391).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
