### PR TITLE
 Add type to DataAdapter and Cache edit pages

### DIFF
--- a/graylog2-web-interface/src/components/lookup-tables/CacheCreate.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CacheCreate.jsx
@@ -28,6 +28,7 @@ class CacheCreate extends React.Component {
   };
 
   _onTypeSelect = (cacheType) => {
+    const { types } = this.props;
     this.setState({
       type: cacheType,
       cache: {
@@ -35,20 +36,27 @@ class CacheCreate extends React.Component {
         title: '',
         name: '',
         description: '',
-        config: ObjectUtils.clone(this.props.types[cacheType].default_config),
+        config: ObjectUtils.clone(types[cacheType].default_config),
       },
     });
   };
 
   render() {
+    const {
+      types,
+      validate,
+      validationErrors,
+      saved,
+    } = this.props;
+    const { type, cache } = this.state;
     const cachePlugins = {};
     PluginStore.exports('lookupTableCaches').forEach((p) => {
       cachePlugins[p.type] = p;
     });
 
-    const sortedCaches = Object.keys(this.props.types).map((key) => {
-      const type = this.props.types[key];
-      return { value: type.type, label: cachePlugins[type.type].displayName };
+    const sortedCaches = Object.keys(types).map((key) => {
+      const typeItem = types[key];
+      return { value: typeItem.type, label: cachePlugins[typeItem.type].displayName };
     }).sort((a, b) => naturalSort(a.label.toLowerCase(), b.label.toLowerCase()));
 
     return (
@@ -73,16 +81,16 @@ class CacheCreate extends React.Component {
             </form>
           </Col>
         </Row>
-        {this.state.cache && (
+        {cache && (
         <Row className="content">
           <Col lg={12}>
-            <h3>Configure Cache</h3>
-            <CacheForm cache={this.state.cache}
-                       type={this.state.type}
+            <CacheForm cache={cache}
+                       type={type}
+                       title="Configure Cache"
                        create
-                       saved={this.props.saved}
-                       validationErrors={this.props.validationErrors}
-                       validate={this.props.validate} />
+                       saved={saved}
+                       validationErrors={validationErrors}
+                       validate={validate} />
           </Col>
         </Row>
         )}

--- a/graylog2-web-interface/src/components/lookup-tables/CacheForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CacheForm.jsx
@@ -14,9 +14,12 @@ import CombinedProvider from 'injection/CombinedProvider';
 const { LookupTableCachesActions } = CombinedProvider.get('LookupTableCaches');
 
 class CacheForm extends React.Component {
+  validationCheckTimer = undefined;
+
   static propTypes = {
     type: PropTypes.string.isRequired,
     saved: PropTypes.func.isRequired,
+    title: PropTypes.string.isRequired,
     create: PropTypes.bool,
     cache: PropTypes.object,
     validate: PropTypes.func,
@@ -35,8 +38,6 @@ class CacheForm extends React.Component {
     validate: null,
     validationErrors: {},
   };
-
-  validationCheckTimer = undefined;
 
   constructor(props) {
     super(props);
@@ -184,17 +185,28 @@ class CacheForm extends React.Component {
     return <span>{defaultText}</span>;
   };
 
+  _renderTitle = (title, typeName, create) => {
+    const TagName = create ? 'h3' : 'h2';
+    return <TagName>{title} <small>({typeName && typeName})</small></TagName>;
+  };
+
   render() {
     const { cache } = this.state;
-    const { create, type } = this.props;
+    const {
+      create,
+      type,
+      title,
+    } = this.props;
 
     const cachePlugins = PluginStore.exports('lookupTableCaches');
 
     const plugin = cachePlugins.filter(p => p.type === type);
     let configFieldSet = null;
     let documentationComponent = null;
+    let pluginDisplayName = null;
     if (plugin && plugin.length > 0) {
       const p = plugin[0];
+      pluginDisplayName = p.displayName;
       configFieldSet = React.createElement(p.formComponent, {
         config: cache.config,
         handleFormEvent: this._onConfigChange,
@@ -219,56 +231,59 @@ class CacheForm extends React.Component {
     }
 
     return (
-      <Row>
-        <Col lg={formRowWidth}>
-          <form className="form form-horizontal" onSubmit={this._save}>
-            <fieldset>
-              <Input type="text"
-                     id="title"
-                     name="title"
-                     label="Title"
-                     autoFocus
-                     required
-                     onChange={this._onChange}
-                     help="A short title for this cache."
-                     value={cache.title}
-                     labelClassName="col-sm-3"
-                     wrapperClassName="col-sm-9" />
+      <>
+        {this._renderTitle(title, pluginDisplayName, create)}
+        <Row>
+          <Col lg={formRowWidth}>
+            <form className="form form-horizontal" onSubmit={this._save}>
+              <fieldset>
+                <Input type="text"
+                       id="title"
+                       name="title"
+                       label="Title"
+                       autoFocus
+                       required
+                       onChange={this._onChange}
+                       help="A short title for this cache."
+                       value={cache.title}
+                       labelClassName="col-sm-3"
+                       wrapperClassName="col-sm-9" />
 
-              <Input type="text"
-                     id="description"
-                     name="description"
-                     label="Description"
-                     onChange={this._onChange}
-                     help="Cache description."
-                     value={cache.description}
-                     labelClassName="col-sm-3"
-                     wrapperClassName="col-sm-9" />
+                <Input type="text"
+                       id="description"
+                       name="description"
+                       label="Description"
+                       onChange={this._onChange}
+                       help="Cache description."
+                       value={cache.description}
+                       labelClassName="col-sm-3"
+                       wrapperClassName="col-sm-9" />
 
-              <Input type="text"
-                     id="name"
-                     name="name"
-                     label="Name"
-                     required
-                     onChange={this._onChange}
-                     help={this._validationMessage('name', 'The name that is being used to refer to this cache. Must be unique.')}
-                     bsStyle={this._validationState('name')}
-                     value={cache.name}
-                     labelClassName="col-sm-3"
-                     wrapperClassName="col-sm-9" />
-            </fieldset>
-            {configFieldSet}
-            <fieldset>
-              <Row>
-                <Col mdOffset={3} md={9}>
-                  <Button type="submit" bsStyle="success">{create ? 'Create Cache' : 'Update Cache'}</Button>
-                </Col>
-              </Row>
-            </fieldset>
-          </form>
-        </Col>
-        {documentationColumn}
-      </Row>
+                <Input type="text"
+                       id="name"
+                       name="name"
+                       label="Name"
+                       required
+                       onChange={this._onChange}
+                       help={this._validationMessage('name', 'The name that is being used to refer to this cache. Must be unique.')}
+                       bsStyle={this._validationState('name')}
+                       value={cache.name}
+                       labelClassName="col-sm-3"
+                       wrapperClassName="col-sm-9" />
+              </fieldset>
+              {configFieldSet}
+              <fieldset>
+                <Row>
+                  <Col mdOffset={3} md={9}>
+                    <Button type="submit" bsStyle="success">{create ? 'Create Cache' : 'Update Cache'}</Button>
+                  </Col>
+                </Row>
+              </fieldset>
+            </form>
+          </Col>
+          {documentationColumn}
+        </Row>
+      </>
     );
   }
 }

--- a/graylog2-web-interface/src/components/lookup-tables/CacheForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CacheForm.jsx
@@ -187,7 +187,7 @@ class CacheForm extends React.Component {
 
   _renderTitle = (title, typeName, create) => {
     const TagName = create ? 'h3' : 'h2';
-    return <TagName>{title} <small>({typeName && typeName})</small></TagName>;
+    return <TagName>{title} <small>({typeName})</small></TagName>;
   };
 
   render() {
@@ -203,7 +203,7 @@ class CacheForm extends React.Component {
     const plugin = cachePlugins.filter(p => p.type === type);
     let configFieldSet = null;
     let documentationComponent = null;
-    let pluginDisplayName = null;
+    let pluginDisplayName = cache.config.type;
     if (plugin && plugin.length > 0) {
       const p = plugin[0];
       pluginDisplayName = p.displayName;
@@ -218,7 +218,6 @@ class CacheForm extends React.Component {
         documentationComponent = React.createElement(p.documentationComponent);
       }
     }
-
     let documentationColumn = null;
     let formRowWidth = 8; // If there is no documentation component, we don't use the complete page width
     if (documentationComponent) {

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.jsx
@@ -57,7 +57,6 @@ class DataAdapterCreate extends React.Component {
     const sortedAdapters = Object.keys(types).map((key) => {
       const typeItem = types[key];
       if (adapterPlugins[typeItem.type] === undefined) {
-        console.error(`Plugin component for data adapter type ${typeItem.type} is missing - invalid or missing plugin?`);
         return { value: typeItem.type, disabled: true, label: `${typeItem.type} - missing or invalid plugin` };
       }
       return { value: typeItem.type, label: adapterPlugins[typeItem.type].displayName };

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.jsx
@@ -58,7 +58,7 @@ class DataAdapterCreate extends React.Component {
       const typeItem = types[key];
       if (adapterPlugins[typeItem.type] === undefined) {
         // eslint-disable-next-line no-console
-        console.error(`Plugin component for data adapter type ${type.type} is missing - invalid or missing plugin?`);
+        console.error(`Plugin component for data adapter type ${typeItem.type} is missing - invalid or missing plugin?`);
         return { value: typeItem.type, disabled: true, label: `${typeItem.type} - missing or invalid plugin` };
       }
       return { value: typeItem.type, label: adapterPlugins[typeItem.type].displayName };

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.jsx
@@ -57,6 +57,8 @@ class DataAdapterCreate extends React.Component {
     const sortedAdapters = Object.keys(types).map((key) => {
       const typeItem = types[key];
       if (adapterPlugins[typeItem.type] === undefined) {
+        // eslint-disable-next-line no-console
+        console.error(`Plugin component for data adapter type ${type.type} is missing - invalid or missing plugin?`);
         return { value: typeItem.type, disabled: true, label: `${typeItem.type} - missing or invalid plugin` };
       }
       return { value: typeItem.type, label: adapterPlugins[typeItem.type].displayName };

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterCreate.jsx
@@ -28,6 +28,7 @@ class DataAdapterCreate extends React.Component {
   };
 
   _onTypeSelect = (adapterType) => {
+    const { types } = this.props;
     this.setState({
       type: adapterType,
       dataAdapter: {
@@ -35,24 +36,31 @@ class DataAdapterCreate extends React.Component {
         title: '',
         name: '',
         description: '',
-        config: ObjectUtils.clone(this.props.types[adapterType].default_config),
+        config: ObjectUtils.clone(types[adapterType].default_config),
       },
     });
   };
 
   render() {
+    const {
+      types,
+      validate,
+      validationErrors,
+      saved,
+    } = this.props;
+    const { type, dataAdapter } = this.state;
     const adapterPlugins = {};
     PluginStore.exports('lookupTableAdapters').forEach((p) => {
       adapterPlugins[p.type] = p;
     });
 
-    const sortedAdapters = Object.keys(this.props.types).map((key) => {
-      const type = this.props.types[key];
-      if (adapterPlugins[type.type] === undefined) {
-        console.error(`Plugin component for data adapter type ${type.type} is missing - invalid or missing plugin?`);
-        return { value: type.type, disabled: true, label: `${type.type} - missing or invalid plugin` };
+    const sortedAdapters = Object.keys(types).map((key) => {
+      const typeItem = types[key];
+      if (adapterPlugins[typeItem.type] === undefined) {
+        console.error(`Plugin component for data adapter type ${typeItem.type} is missing - invalid or missing plugin?`);
+        return { value: typeItem.type, disabled: true, label: `${typeItem.type} - missing or invalid plugin` };
       }
-      return { value: type.type, label: adapterPlugins[type.type].displayName };
+      return { value: typeItem.type, label: adapterPlugins[typeItem.type].displayName };
     }).sort((a, b) => naturalSort(a.label.toLowerCase(), b.label.toLowerCase()));
 
     return (
@@ -77,16 +85,16 @@ class DataAdapterCreate extends React.Component {
             </form>
           </Col>
         </Row>
-        {this.state.dataAdapter && (
+        {dataAdapter && (
         <Row className="content">
           <Col lg={12}>
-            <h3>Configure Adapter</h3>
-            <DataAdapterForm dataAdapter={this.state.dataAdapter}
-                             type={this.state.type}
+            <DataAdapterForm dataAdapter={dataAdapter}
+                             type={type}
                              create
-                             validate={this.props.validate}
-                             validationErrors={this.props.validationErrors}
-                             saved={this.props.saved} />
+                             title="Configure Adapter"
+                             validate={validate}
+                             validationErrors={validationErrors}
+                             saved={saved} />
           </Col>
         </Row>
         )}

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
@@ -181,19 +181,18 @@ class DataAdapterForm extends React.Component {
 
   _renderTitle = (title, typeName, create) => {
     const TagName = create ? 'h3' : 'h2';
-    return <TagName>{title} <small>({typeName && typeName})</small></TagName>;
+    return <TagName>{title} <small>({typeName})</small></TagName>;
   };
 
   render() {
     const { dataAdapter } = this.state;
     const { create, type, title } = this.props;
-
     const adapterPlugins = PluginStore.exports('lookupTableAdapters');
 
     const plugin = adapterPlugins.filter(p => p.type === type);
     let configFieldSet = null;
     let documentationComponent = null;
-    let pluginDisplayName = null;
+    let pluginDisplayName = dataAdapter.config.type;
     if (plugin && plugin.length > 0) {
       const p = plugin[0];
       pluginDisplayName = p.displayName;
@@ -210,7 +209,6 @@ class DataAdapterForm extends React.Component {
         });
       }
     }
-
     let documentationColumn = null;
     let formRowWidth = 8; // If there is no documentation component, we don't use the complete page
     // width

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
@@ -12,8 +12,11 @@ import CombinedProvider from 'injection/CombinedProvider';
 const { LookupTableDataAdaptersActions } = CombinedProvider.get('LookupTableDataAdapters');
 
 class DataAdapterForm extends React.Component {
+  validationCheckTimer = undefined;
+
   static propTypes = {
     type: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
     saved: PropTypes.func.isRequired,
     create: PropTypes.bool,
     dataAdapter: PropTypes.object,
@@ -33,8 +36,6 @@ class DataAdapterForm extends React.Component {
     validate: null,
     validationErrors: {},
   };
-
-  validationCheckTimer = undefined;
 
   constructor(props) {
     super(props);
@@ -178,17 +179,24 @@ class DataAdapterForm extends React.Component {
     return <span>{defaultText}</span>;
   };
 
+  _renderTitle = (title, typeName, create) => {
+    const TagName = create ? 'h3' : 'h2';
+    return <TagName>{title} <small>({typeName && typeName})</small></TagName>;
+  };
+
   render() {
     const { dataAdapter } = this.state;
-    const { create, type } = this.props;
+    const { create, type, title } = this.props;
 
     const adapterPlugins = PluginStore.exports('lookupTableAdapters');
 
     const plugin = adapterPlugins.filter(p => p.type === type);
     let configFieldSet = null;
     let documentationComponent = null;
+    let pluginDisplayName = null;
     if (plugin && plugin.length > 0) {
       const p = plugin[0];
+      pluginDisplayName = p.displayName;
       configFieldSet = React.createElement(p.formComponent, {
         config: dataAdapter.config,
         handleFormEvent: this._onConfigChange,
@@ -214,61 +222,63 @@ class DataAdapterForm extends React.Component {
         </Col>
       );
     }
-
     return (
-      <Row>
-        <Col lg={formRowWidth}>
-          <form className="form form-horizontal" onSubmit={this._save}>
-            <fieldset>
-              <Input type="text"
-                     id="title"
-                     name="title"
-                     label="Title"
-                     autoFocus
-                     required
-                     onChange={this._onChange}
-                     help="A short title for this data adapter."
-                     value={dataAdapter.title}
-                     labelClassName="col-sm-3"
-                     wrapperClassName="col-sm-9" />
+      <>
+        {this._renderTitle(title, pluginDisplayName, create)}
+        <Row>
+          <Col lg={formRowWidth}>
+            <form className="form form-horizontal" onSubmit={this._save}>
+              <fieldset>
+                <Input type="text"
+                       id="title"
+                       name="title"
+                       label="Title"
+                       autoFocus
+                       required
+                       onChange={this._onChange}
+                       help="A short title for this data adapter."
+                       value={dataAdapter.title}
+                       labelClassName="col-sm-3"
+                       wrapperClassName="col-sm-9" />
 
-              <Input type="text"
-                     id="description"
-                     name="description"
-                     label="Description"
-                     onChange={this._onChange}
-                     help="Data adapter description."
-                     value={dataAdapter.description}
-                     labelClassName="col-sm-3"
-                     wrapperClassName="col-sm-9" />
+                <Input type="text"
+                       id="description"
+                       name="description"
+                       label="Description"
+                       onChange={this._onChange}
+                       help="Data adapter description."
+                       value={dataAdapter.description}
+                       labelClassName="col-sm-3"
+                       wrapperClassName="col-sm-9" />
 
-              <Input type="text"
-                     id="name"
-                     name="name"
-                     label="Name"
-                     required
-                     onChange={this._onChange}
-                     help={this._validationMessage('name',
-                       'The name that is being used to refer to this data adapter. Must be unique.')}
-                     value={dataAdapter.name}
-                     labelClassName="col-sm-3"
-                     wrapperClassName="col-sm-9"
-                     bsStyle={this._validationState('name')} />
-            </fieldset>
-            {configFieldSet}
-            <fieldset>
-              <Row>
-                <Col mdOffset={3} md={9}>
-                  <Button type="submit" bsStyle="success">{create ? 'Create Adapter'
-                    : 'Update Adapter'}
-                  </Button>
-                </Col>
-              </Row>
-            </fieldset>
-          </form>
-        </Col>
-        {documentationColumn}
-      </Row>
+                <Input type="text"
+                       id="name"
+                       name="name"
+                       label="Name"
+                       required
+                       onChange={this._onChange}
+                       help={this._validationMessage('name',
+                         'The name that is being used to refer to this data adapter. Must be unique.')}
+                       value={dataAdapter.name}
+                       labelClassName="col-sm-3"
+                       wrapperClassName="col-sm-9"
+                       bsStyle={this._validationState('name')} />
+              </fieldset>
+              {configFieldSet}
+              <fieldset>
+                <Row>
+                  <Col mdOffset={3} md={9}>
+                    <Button type="submit" bsStyle="success">{create ? 'Create Adapter'
+                      : 'Update Adapter'}
+                    </Button>
+                  </Col>
+                </Row>
+              </fieldset>
+            </form>
+          </Col>
+          {documentationColumn}
+        </Row>
+      </>
     );
   }
 }

--- a/graylog2-web-interface/src/pages/LUTCachesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTCachesPage.jsx
@@ -40,7 +40,6 @@ class LUTCachesPage extends React.Component {
   };
 
   _saved = () => {
-    // reset detail state
     history.push(Routes.SYSTEM.LOOKUPTABLES.CACHES.OVERVIEW);
   }
 

--- a/graylog2-web-interface/src/pages/LUTCachesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTCachesPage.jsx
@@ -1,7 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
-import Reflux from 'reflux';
 import { LinkContainer } from 'react-router-bootstrap';
 import connect from 'stores/connect';
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';

--- a/graylog2-web-interface/src/pages/LUTCachesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTCachesPage.jsx
@@ -18,15 +18,16 @@ const { LookupTableCachesStore, LookupTableCachesActions } = CombinedProvider.ge
 );
 
 class LUTCachesPage extends React.Component {
-
   componentDidMount() {
     this._loadData(this.props);
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.location.pathname !== prevProps.location.pathname) {
+    const { location: { pathname } } = this.props;
+    const { location: { pathname: prevPathname } } = prevProps;
+    if (pathname !== prevPathname) {
       this._loadData(this.props);
-    } 
+    }
   }
 
   _loadData = (props) => {
@@ -138,8 +139,8 @@ LUTCachesPage.propTypes = {
   validationErrors: PropTypes.object,
   types: PropTypes.object,
   caches: PropTypes.array,
+  location: PropTypes.object.isRequired,
   pagination: PropTypes.object.isRequired,
-  params: PropTypes.object.isRequired,
   route: PropTypes.object.isRequired,
 };
 

--- a/graylog2-web-interface/src/pages/LUTCachesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTCachesPage.jsx
@@ -29,7 +29,7 @@ class LUTCachesPage extends React.Component {
   }
 
   _loadData = (props) => {
-    const { pagination } = this.props;
+    const { pagination } = props;
     if (props.params && props.params.cacheName) {
       LookupTableCachesActions.get(props.params.cacheName);
     } else if (this._isCreating(props)) {

--- a/graylog2-web-interface/src/pages/LUTCachesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTCachesPage.jsx
@@ -39,13 +39,13 @@ const LUTCachesPage = createReactClass({
   },
 
   _loadData(props) {
+    const { pagination } = this.state;
     if (props.params && props.params.cacheName) {
       LookupTableCachesActions.get(props.params.cacheName);
     } else if (this._isCreating(props)) {
       LookupTableCachesActions.getTypes();
     } else {
-      const p = this.state.pagination;
-      LookupTableCachesActions.searchPaginated(p.page, p.per_page, p.query);
+      LookupTableCachesActions.searchPaginated(pagination.page, pagination.per_page, pagination.query);
     }
   },
 
@@ -64,47 +64,55 @@ const LUTCachesPage = createReactClass({
   },
 
   render() {
+    const { route: { action } } = this.props;
+    const {
+      cache,
+      validationErrors,
+      types,
+      caches,
+      pagination,
+    } = this.state;
     let content;
-    const isShowing = this.props.route.action === 'show';
-    const isEditing = this.props.route.action === 'edit';
+    const isShowing = action === 'show';
+    const isEditing = action === 'edit';
 
     if (isShowing || isEditing) {
-      if (!this.state.cache) {
+      if (!cache) {
         content = <Spinner text="Loading data cache" />;
       } else if (isEditing) {
         content = (
           <Row className="content">
             <Col lg={12}>
-              <h2>Data Cache</h2>
-              <CacheForm cache={this.state.cache}
-                         type={this.state.cache.config.type}
+              <CacheForm cache={cache}
+                         type={cache.config.type}
+                         title="Data Cache"
                          create={false}
                          saved={this._saved}
                          validate={this._validateCache}
-                         validationErrors={this.state.validationErrors} />
+                         validationErrors={validationErrors} />
             </Col>
           </Row>
         );
       } else {
-        content = <Cache cache={this.state.cache} />;
+        content = <Cache cache={cache} />;
       }
     } else if (this._isCreating(this.props)) {
-      if (!this.state.types) {
+      if (!types) {
         content = <Spinner text="Loading data cache types" />;
       } else {
         content = (
-          <CacheCreate types={this.state.types}
+          <CacheCreate types={types}
                        saved={this._saved}
                        validate={this._validateCache}
-                       validationErrors={this.state.validationErrors} />
+                       validationErrors={validationErrors} />
         );
       }
-    } else if (!this.state.caches) {
+    } else if (!caches) {
       content = <Spinner text="Loading caches" />;
     } else {
       content = (
-        <CachesOverview caches={this.state.caches}
-                        pagination={this.state.pagination} />
+        <CachesOverview caches={caches}
+                        pagination={pagination} />
       );
     }
 

--- a/graylog2-web-interface/src/pages/LUTCachesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTCachesPage.jsx
@@ -53,8 +53,8 @@ class LUTCachesPage extends React.Component {
   };
 
   render() {
-    const { route: { action } } = this.props;
     const {
+      route: { action },
       cache,
       validationErrors,
       types,

--- a/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
@@ -50,9 +50,10 @@ const LUTDataAdaptersPage = createReactClass({
     this._stopErrorStatesTimer();
 
     this.errorStatesTimer = setInterval(() => {
+      const { dataAdapters } = this.state;
       let names = null;
-      if (this.state.dataAdapters) {
-        names = this.state.dataAdapters.map(t => t.name);
+      if (dataAdapters) {
+        names = dataAdapters.map(t => t.name);
       }
       if (names) {
         LookupTablesActions.getErrors(null, null, names || null);
@@ -68,14 +69,14 @@ const LUTDataAdaptersPage = createReactClass({
   },
 
   _loadData(props) {
+    const { pagination } = this.state;
     this._stopErrorStatesTimer();
     if (props.params && props.params.adapterName) {
       LookupTableDataAdaptersActions.get(props.params.adapterName);
     } else if (this._isCreating(props)) {
       LookupTableDataAdaptersActions.getTypes();
     } else {
-      const p = this.state.pagination;
-      LookupTableDataAdaptersActions.searchPaginated(p.page, p.per_page, p.query);
+      LookupTableDataAdaptersActions.searchPaginated(pagination.page, pagination.per_page, pagination.query);
       this._startErrorStatesTimer();
     }
   },
@@ -95,48 +96,58 @@ const LUTDataAdaptersPage = createReactClass({
   },
 
   render() {
+    const { route: { action } } = this.props;
+    const {
+      dataAdapter,
+      validationErrors,
+      types,
+      dataAdapters,
+      pagination,
+      tableStore,
+    } = this.state;
     let content;
-    const isShowing = this.props.route.action === 'show';
-    const isEditing = this.props.route.action === 'edit';
+    const isShowing = action === 'show';
+    const isEditing = action === 'edit';
 
     if (isShowing || isEditing) {
-      if (!this.state.dataAdapter) {
+      if (!dataAdapter) {
         content = <Spinner text="Loading data adapter" />;
       } else if (isEditing) {
         content = (
           <Row className="content">
             <Col lg={12}>
-              <h2>Data Adapter</h2>
-              <DataAdapterForm dataAdapter={this.state.dataAdapter}
-                               type={this.state.dataAdapter.config.type}
+              {/* <h2>Data Adapter</h2> */}
+              <DataAdapterForm dataAdapter={dataAdapter}
+                               type={dataAdapter.config.type}
                                create={false}
+                               title="Data Adapter"
                                saved={this._saved}
                                validate={this._validateAdapter}
-                               validationErrors={this.state.validationErrors} />
+                               validationErrors={validationErrors} />
             </Col>
           </Row>
         );
       } else {
-        content = <DataAdapter dataAdapter={this.state.dataAdapter} />;
+        content = <DataAdapter dataAdapter={dataAdapter} />;
       }
     } else if (this._isCreating(this.props)) {
-      if (!this.state.types) {
+      if (!types) {
         content = <Spinner text="Loading data adapter types" />;
       } else {
         content = (
-          <DataAdapterCreate types={this.state.types}
+          <DataAdapterCreate types={types}
                              saved={this._saved}
                              validate={this._validateAdapter}
-                             validationErrors={this.state.validationErrors} />
+                             validationErrors={validationErrors} />
         );
       }
-    } else if (!this.state.dataAdapters) {
+    } else if (!dataAdapters) {
       content = <Spinner text="Loading data adapters" />;
     } else {
       content = (
-        <DataAdaptersOverview dataAdapters={this.state.dataAdapters}
-                              pagination={this.state.pagination}
-                              errorStates={this.state.tableStore.errorStates} />
+        <DataAdaptersOverview dataAdapters={dataAdapters}
+                              pagination={pagination}
+                              errorStates={tableStore.errorStates} />
       );
     }
 

--- a/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
@@ -116,7 +116,6 @@ const LUTDataAdaptersPage = createReactClass({
         content = (
           <Row className="content">
             <Col lg={12}>
-              {/* <h2>Data Adapter</h2> */}
               <DataAdapterForm dataAdapter={dataAdapter}
                                type={dataAdapter.config.type}
                                create={false}

--- a/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
@@ -1,7 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
-import Reflux from 'reflux';
 import { LinkContainer } from 'react-router-bootstrap';
 import connect from 'stores/connect';
 import Routes from 'routing/Routes';
@@ -27,7 +25,9 @@ class LUTDataAdaptersPage extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.location.pathname !== prevProps.location.pathname) {
+    const { location: { pathname } } = this.props;
+    const { location: { pathname: prevPathname } } = prevProps;
+    if (pathname !== prevPathname) {
       this._loadData(this.props);
     }
   }
@@ -59,7 +59,7 @@ class LUTDataAdaptersPage extends React.Component {
   }
 
   _loadData = (props) => {
-    const { pagination } = this.props;
+    const { pagination } = props;
     this._stopErrorStatesTimer();
     if (props.params && props.params.adapterName) {
       LookupTableDataAdaptersActions.get(props.params.adapterName);

--- a/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
@@ -73,7 +73,6 @@ class LUTDataAdaptersPage extends React.Component {
 
   _saved = () => {
     // reset detail state
-    this.setState({ dataAdapter: undefined });
     history.push(Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.OVERVIEW);
   }
 
@@ -94,7 +93,6 @@ class LUTDataAdaptersPage extends React.Component {
       types,
       dataAdapters,
       pagination,
-      tableStore,
     } = this.props;
     let content;
     const isShowing = action === 'show';
@@ -171,13 +169,28 @@ class LUTDataAdaptersPage extends React.Component {
 
 LUTDataAdaptersPage.propTypes = {
   // eslint-disable-next-line react/no-unused-prop-types
-  params: PropTypes.object.isRequired,
+  errorStates: PropTypes.object,
+  dataAdapter: PropTypes.object,
+  validationErrors: PropTypes.object,
+  types: PropTypes.object,
+  pagination: PropTypes.object,
+  dataAdapters: PropTypes.array,
+  location: PropTypes.object.isRequired,
   route: PropTypes.object.isRequired,
 };
 
-export default connect(LUTDataAdaptersPage, { lookupTableStore: LookupTablesStore, dataAdaptersStore: LookupTableDataAdaptersStore }, 
-  ({ dataAdaptersStore, lookupTableStore,...otherProps }) => ({
-  ...otherProps,
-  ...dataAdaptersStore,
-   errorStates: lookupTableStore.errorStates,
-}));
+LUTDataAdaptersPage.defaultProps = {
+  errorStates: null,
+  validationErrors: {},
+  dataAdapters: null,
+  types: null,
+  pagination: null,
+  dataAdapter: null,
+};
+
+export default connect(LUTDataAdaptersPage, { lookupTableStore: LookupTablesStore, dataAdaptersStore: LookupTableDataAdaptersStore },
+  ({ dataAdaptersStore, lookupTableStore, ...otherProps }) => ({
+    ...otherProps,
+    ...dataAdaptersStore,
+    errorStates: lookupTableStore.errorStates,
+  }));

--- a/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
@@ -168,7 +168,6 @@ class LUTDataAdaptersPage extends React.Component {
 }
 
 LUTDataAdaptersPage.propTypes = {
-  // eslint-disable-next-line react/no-unused-prop-types
   errorStates: PropTypes.object,
   dataAdapter: PropTypes.object,
   validationErrors: PropTypes.object,

--- a/graylog2-web-interface/src/pages/LUTTablesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTTablesPage.jsx
@@ -1,9 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
-import Reflux from 'reflux';
 import { LinkContainer } from 'react-router-bootstrap';
-
+import connect from 'stores/connect';
 import Routes from 'routing/Routes';
 import history from 'util/History';
 
@@ -15,36 +13,29 @@ import CombinedProvider from 'injection/CombinedProvider';
 
 const { LookupTablesStore, LookupTablesActions } = CombinedProvider.get('LookupTables');
 
-const LUTTablesPage = createReactClass({
-  displayName: 'LUTTablesPage',
+class LUTTablesPage extends React.Component {
+  errorStatesTimer = undefined;
 
-  propTypes: {
-    // eslint-disable-next-line react/no-unused-prop-types
-    params: PropTypes.object.isRequired,
-    route: PropTypes.object.isRequired,
-  },
-
-  mixins: [
-    Reflux.connect(LookupTablesStore),
-  ],
+  errorStatesInterval = 1000;
 
   componentDidMount() {
     this._loadData(this.props);
-  },
+  }
 
-  componentWillReceiveProps(nextProps) {
-    this._loadData(nextProps);
-  },
+  componentDidUpdate(prevProps) {
+    const { location: { pathname } } = this.props;
+    const { location: { pathname: prevPathname } } = prevProps;
+    if (pathname !== prevPathname) {
+      this._loadData(this.props);
+    }
+  }
 
   componentWillUnmount() {
     clearInterval(this.errorStatesTimer);
-  },
+  }
 
-  errorStatesTimer: undefined,
-  errorStatesInterval: 1000,
-
-  _startErrorStatesTimer() {
-    const { tables, dataAdapters } = this.state;
+  _startErrorStatesTimer = () => {
+    const { tables, dataAdapters } = this.props;
     this._stopErrorStatesTimer();
     this.errorStatesTimer = setInterval(() => {
       let tableNames = null;
@@ -56,17 +47,17 @@ const LUTTablesPage = createReactClass({
         LookupTablesActions.getErrors(tableNames, null, adapterNames || null);
       }
     }, this.errorStatesInterval);
-  },
+  }
 
-  _stopErrorStatesTimer() {
+  _stopErrorStatesTimer = () => {
     if (this.errorStatesTimer) {
       clearInterval(this.errorStatesTimer);
       this.errorStatesTimer = undefined;
     }
-  },
+  }
 
-  _loadData(props) {
-    const { pagination } = this.state;
+  _loadData = (props) => {
+    const { pagination } = this.props;
     this._stopErrorStatesTimer();
     if (props.params && props.params.tableName) {
       LookupTablesActions.get(props.params.tableName);
@@ -76,25 +67,24 @@ const LUTTablesPage = createReactClass({
       LookupTablesActions.searchPaginated(pagination.page, pagination.per_page, pagination.query);
       this._startErrorStatesTimer();
     }
-  },
+  }
 
-  _saved() {
+  _saved = () => {
     // reset detail state
-    this.setState({ table: undefined });
     history.push(Routes.SYSTEM.LOOKUPTABLES.OVERVIEW);
-  },
+  }
 
-  _isCreating(props) {
+  _isCreating = (props) => {
     return props.route.action === 'create';
-  },
+  }
 
-  _validateTable(table) {
+  _validateTable = (table) => {
     LookupTablesActions.validate(table);
-  },
+  }
 
   render() {
-    const { route: { action } } = this.props;
     const {
+      route: { action },
       table,
       validationErrors,
       dataAdapter,
@@ -104,7 +94,7 @@ const LUTTablesPage = createReactClass({
       dataAdapters,
       pagination,
       errorStates,
-    } = this.state;
+    } = this.props;
     let content;
     const isShowing = action === 'show';
     const isEditing = action === 'edit';
@@ -138,7 +128,7 @@ const LUTTablesPage = createReactClass({
                            validate={this._validateTable}
                            validationErrors={validationErrors} />
       );
-    } else if (!this.state || !tables) {
+    } else if (!tables) {
       content = <Spinner text="Loading lookup tables" />;
     } else {
       content = (
@@ -175,7 +165,36 @@ const LUTTablesPage = createReactClass({
         </span>
       </DocumentTitle>
     );
-  },
-});
+  }
+}
 
-export default LUTTablesPage;
+LUTTablesPage.propTypes = {
+  table: PropTypes.object,
+  validationErrors: PropTypes.object,
+  dataAdapter: PropTypes.object,
+  cache: PropTypes.object,
+  tables: PropTypes.array,
+  caches: PropTypes.object,
+  dataAdapters: PropTypes.object,
+  pagination: PropTypes.object,
+  location: PropTypes.object,
+  errorStates: PropTypes.object,
+  route: PropTypes.object.isRequired,
+};
+LUTTablesPage.defaultProps = {
+  errorStates: null,
+  validationErrors: {},
+  dataAdapters: null,
+  table: null,
+  cache: null,
+  caches: null,
+  tables: null,
+  location: null,
+  pagination: null,
+  dataAdapter: null,
+};
+
+export default connect(LUTTablesPage, { lookupTableStore: LookupTablesStore }, ({ lookupTableStore, ...otherProps }) => ({
+  ...otherProps,
+  ...lookupTableStore,
+}));

--- a/graylog2-web-interface/src/pages/LUTTablesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTTablesPage.jsx
@@ -44,14 +44,15 @@ const LUTTablesPage = createReactClass({
   errorStatesInterval: 1000,
 
   _startErrorStatesTimer() {
+    const { tables, dataAdapters } = this.state;
     this._stopErrorStatesTimer();
     this.errorStatesTimer = setInterval(() => {
       let tableNames = null;
-      if (this.state.tables) {
-        tableNames = this.state.tables.map(t => t.name);
+      if (tables) {
+        tableNames = tables.map(t => t.name);
       }
       if (tableNames) {
-        const adapterNames = Object.values(this.state.dataAdapters).map(a => a.name);
+        const adapterNames = Object.values(dataAdapters).map(a => a.name);
         LookupTablesActions.getErrors(tableNames, null, adapterNames || null);
       }
     }, this.errorStatesInterval);
@@ -65,14 +66,14 @@ const LUTTablesPage = createReactClass({
   },
 
   _loadData(props) {
+    const { pagination } = this.state;
     this._stopErrorStatesTimer();
     if (props.params && props.params.tableName) {
       LookupTablesActions.get(props.params.tableName);
     } else if (this._isCreating(props)) {
       // nothing to do, the intermediate data container will take care of loading the caches and adapters
     } else {
-      const p = this.state.pagination;
-      LookupTablesActions.searchPaginated(p.page, p.per_page, p.query);
+      LookupTablesActions.searchPaginated(pagination.page, pagination.per_page, pagination.query);
       this._startErrorStatesTimer();
     }
   },
@@ -92,48 +93,60 @@ const LUTTablesPage = createReactClass({
   },
 
   render() {
+    const { route: { action } } = this.props;
+    const {
+      table,
+      validationErrors,
+      dataAdapter,
+      cache,
+      tables,
+      caches,
+      dataAdapters,
+      pagination,
+      errorStates,
+    } = this.state;
     let content;
-    const isShowing = this.props.route.action === 'show';
-    const isEditing = this.props.route.action === 'edit';
+    const isShowing = action === 'show';
+    const isEditing = action === 'edit';
 
     if (isShowing || isEditing) {
-      if (!this.state.table) {
+      if (!table) {
         content = <Spinner text="Loading lookup table" />;
       } else if (isEditing) {
         content = (
           <Row className="content">
             <Col lg={8}>
               <h2>Lookup Table</h2>
-              <LookupTableForm table={this.state.table}
+              <LookupTableForm table={table}
                                create={false}
                                saved={this._saved}
                                validate={this._validateTable}
-                               validationErrors={this.state.validationErrors} />
+                               validationErrors={validationErrors} />
             </Col>
           </Row>
         );
       } else {
         content = (
-          <LookupTable dataAdapter={this.state.dataAdapter}
-                       cache={this.state.cache}
-                       table={this.state.table} />
+          <LookupTable dataAdapter={dataAdapter}
+                       cache={cache}
+                       table={table} />
         );
       }
     } else if (this._isCreating(this.props)) {
       content = (
         <LookupTableCreate saved={this._saved}
                            validate={this._validateTable}
-                           validationErrors={this.state.validationErrors} />
+                           validationErrors={validationErrors} />
       );
-    } else if (!this.state || !this.state.tables) {
+    } else if (!this.state || !tables) {
       content = <Spinner text="Loading lookup tables" />;
     } else {
       content = (
-        <LookupTablesOverview tables={this.state.tables}
-                              caches={this.state.caches}
-                              dataAdapters={this.state.dataAdapters}
-                              pagination={this.state.pagination}
-                              errorStates={this.state.errorStates} />
+        <LookupTablesOverview tables={tables}
+                              caches={caches}
+                              dataAdapters={dataAdapters}
+                              pagination={pagination}
+                              errorStates={errorStates} />
       );
     }
 

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTableCachesStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTableCachesStore.js
@@ -13,26 +13,17 @@ const LookupTableCachesStore = Reflux.createStore({
   cache: null,
   caches: null,
   types: null,
-  pagination: null,
+  pagination: {
+    page: 1,
+    per_page: 10,
+    total: 0,
+    count: 0,
+    query: null,
+  },
   validationErrors: {},
 
-  init() {
-    this.pagination = {
-      page: 1,
-      per_page: 10,
-      total: 0,
-      count: 0,
-      query: null,
-    };
-  },
-
   getInitialState() {
-    return {
-      cache: this.cache,
-      caches: this.caches,
-      pagination: this.pagination,
-      validationErrors: this.validationErrors,
-    };
+    return this.getState();
   },
 
   getState() {
@@ -72,7 +63,6 @@ const LookupTableCachesStore = Reflux.createStore({
         per_page: response.per_page,
         query: response.query,
       };
-      // this.trigger({ pagination: this.pagination, caches: response.caches });
       this.caches = response.caches;
       this.propagateChanges();
     }, this._errorHandler('Fetching lookup table caches failed', 'Could not retrieve the lookup caches'));
@@ -125,7 +115,6 @@ const LookupTableCachesStore = Reflux.createStore({
     const promise = fetch('GET', url);
 
     promise.then((response) => {
-      // this.trigger({ types: response });
       this.types = response;
       this.propagateChanges();
     }, this._errorHandler('Fetching available types failed', 'Could not fetch the available lookup table cache types'));

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTableCachesStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTableCachesStore.js
@@ -65,7 +65,7 @@ const LookupTableCachesStore = Reflux.createStore({
     const promise = fetch('GET', url);
 
     promise.then((response) => {
-      const pagination = {
+      this.pagination = {
         count: response.count,
         total: response.total,
         page: response.page,
@@ -73,7 +73,6 @@ const LookupTableCachesStore = Reflux.createStore({
         query: response.query,
       };
       // this.trigger({ pagination: this.pagination, caches: response.caches });
-      this.pagination = pagination;
       this.caches = response.caches;
       this.propagateChanges();
     }, this._errorHandler('Fetching lookup table caches failed', 'Could not retrieve the lookup caches'));

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTableDataAdaptersStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTableDataAdaptersStore.js
@@ -10,7 +10,12 @@ const LookupTableDataAdaptersActions = ActionsProvider.getActions('LookupTableDa
 
 const LookupTableDataAdaptersStore = Reflux.createStore({
   listenables: [LookupTableDataAdaptersActions],
-
+  dataAdapter: null,
+  dataAdapters: undefined,
+  types: null,
+  pagination: null,
+  lookupResult: null,
+  validationErrors: {},
   init() {
     this.pagination = {
       page: 1,
@@ -27,6 +32,21 @@ const LookupTableDataAdaptersStore = Reflux.createStore({
       pagination: this.pagination,
       validationErrors: {},
     };
+  },
+
+  getState() {
+    return {
+      dataAdapter: this.dataAdapter,
+      dataAdapters: this.dataAdapters,
+      lookupResult: this.lookupResult,
+      types: this.types,
+      pagination: this.pagination,
+      validationErrors: this.validationErrors,
+    };
+  },
+
+  propagateChanges() {
+    this.trigger(this.getState());
   },
 
   reloadPage() {
@@ -52,7 +72,8 @@ const LookupTableDataAdaptersStore = Reflux.createStore({
         per_page: response.per_page,
         query: response.query,
       };
-      this.trigger({ pagination: this.pagination, dataAdapters: response.data_adapters });
+      this.dataAdapters = response.data_adapters;
+      this.propagateChanges();
     }, this._errorHandler('Fetching lookup table data adapters failed', 'Could not retrieve the lookup dataAdapters'));
 
     LookupTableDataAdaptersActions.searchPaginated.promise(promise);
@@ -64,7 +85,8 @@ const LookupTableDataAdaptersStore = Reflux.createStore({
     const promise = fetch('GET', url);
 
     promise.then((response) => {
-      this.trigger({ dataAdapter: response });
+      this.dataAdapter = response;
+      this.propagateChanges();
     }, this._errorHandler(`Fetching lookup table data adapter ${idOrName} failed`, 'Could not retrieve lookup table data adapter'));
 
     LookupTableDataAdaptersActions.get.promise(promise);
@@ -76,7 +98,8 @@ const LookupTableDataAdaptersStore = Reflux.createStore({
     const promise = fetch('POST', url, dataAdapter);
 
     promise.then((response) => {
-      this.trigger({ dataAdapter: response });
+      this.dataAdapter = response;
+      this.propagateChanges();
     }, this._errorHandler('Creating lookup table data adapter failed', `Could not create lookup table data adapter "${dataAdapter.name}"`));
 
     LookupTableDataAdaptersActions.create.promise(promise);
@@ -88,7 +111,8 @@ const LookupTableDataAdaptersStore = Reflux.createStore({
     const promise = fetch('PUT', url, dataAdapter);
 
     promise.then((response) => {
-      this.trigger({ dataAdapter: response });
+      this.dataAdapter = response;
+      this.propagateChanges();
     }, this._errorHandler('Updating lookup table data adapter failed', `Could not update lookup table data adapter "${dataAdapter.name}"`));
 
     LookupTableDataAdaptersActions.update.promise(promise);
@@ -100,7 +124,8 @@ const LookupTableDataAdaptersStore = Reflux.createStore({
     const promise = fetch('GET', url);
 
     promise.then((response) => {
-      this.trigger({ types: response });
+      this.types = response;
+      this.propagateChanges();
     }, this._errorHandler('Fetching available types failed', 'Could not fetch the available lookup table data adapter types'));
 
     LookupTableDataAdaptersActions.getTypes.promise(promise);
@@ -121,9 +146,8 @@ const LookupTableDataAdaptersStore = Reflux.createStore({
     const promise = fetch('GET', this._url(`adapters/${adapterName}/query?key=${encodeURIComponent(key)}`));
 
     promise.then((response) => {
-      this.trigger({
-        lookupResult: response,
-      });
+      this.lookupResult = response;
+      this.propagateChanges();
     }, this._errorHandler('Lookup failed', `Could not lookup value for key "${key}" in lookup table data adapter "${adapterName}"`));
 
     LookupTableDataAdaptersActions.lookup.promise(promise);
@@ -136,9 +160,8 @@ const LookupTableDataAdaptersStore = Reflux.createStore({
     const promise = fetch('POST', url, adapter);
 
     promise.then((response) => {
-      this.trigger({
-        validationErrors: response.errors,
-      });
+      this.validationErrors = response.errors;
+      this.propagateChanges();
     }, this._errorHandler('Lookup table data adapter validation failed', `Could not validate lookup table data adapter "${adapter.name}"`));
     LookupTableDataAdaptersActions.validate.promise(promise);
     return promise;

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTableDataAdaptersStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTableDataAdaptersStore.js
@@ -13,25 +13,18 @@ const LookupTableDataAdaptersStore = Reflux.createStore({
   dataAdapter: null,
   dataAdapters: undefined,
   types: null,
-  pagination: null,
+  pagination: {
+    page: 1,
+    per_page: 10,
+    total: 0,
+    count: 0,
+    query: null,
+  },
   lookupResult: null,
   validationErrors: {},
-  init() {
-    this.pagination = {
-      page: 1,
-      per_page: 10,
-      total: 0,
-      count: 0,
-      query: null,
-    };
-  },
 
   getInitialState() {
-    return {
-      dataAdapters: undefined,
-      pagination: this.pagination,
-      validationErrors: {},
-    };
+    return this.getState();
   },
 
   getState() {

--- a/graylog2-web-interface/src/stores/lookup-tables/LookupTablesStore.js
+++ b/graylog2-web-interface/src/stores/lookup-tables/LookupTablesStore.js
@@ -10,7 +10,13 @@ const LookupTablesActions = ActionsProvider.getActions('LookupTables');
 
 const LookupTablesStore = Reflux.createStore({
   listenables: [LookupTablesActions],
-  pagination: null,
+  pagination: {
+    page: 1,
+    per_page: 10,
+    total: 0,
+    count: 0,
+    query: null,
+  },
   errorStates: {
     tables: {},
     caches: {},
@@ -25,25 +31,8 @@ const LookupTablesStore = Reflux.createStore({
   lookupResult: null,
   validationErrors: {},
 
-  init() {
-    this.pagination = {
-      page: 1,
-      per_page: 10,
-      total: 0,
-      count: 0,
-      query: null,
-    };
-  },
-
   getInitialState() {
-    return {
-      pagination: this.pagination,
-      errorStates: {
-        tables: {},
-        caches: {},
-        dataAdapters: {},
-      },
-    };
+    return this.getState();
   },
 
   getState() {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
With these change DataAdapter and Cache edit pages will show the
corresponding type chosen for the DataAdapter or Cache.
To show the type as "subtext for Header" (react bootstrap) title for the
form is taken as a prop and rendered inside DataAdapterForm and
  CacheForm.
* Get typename from plugin displayName
* Add title props to CacheForm and DataAdapterForm
* Add function to render title with appropriate tag depending on
creation or editing
* Fix linter
Fix #6517  
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
