### PR TITLE
Adding ESLint rule to forbid usage of `create-react-class`.

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -23,6 +23,9 @@ module.exports = {
       paths: [{
         name: 'react-bootstrap',
         message: 'Please use `components/graylog` instead.',
+      }, {
+        name: 'create-react-class',
+        message: 'Please use an ES6 or functional component instead.',
       }],
     }],
     'no-underscore-dangle': 'off',


### PR DESCRIPTION
There is a general agreement that any React components that still use `createReactClass` should be rewritten to ES6 classes or functional components.

This PR is adding an ESLint rule forbidding imports of the `create-react-class` module indicating the necessity to rewrite it.