### PR TITLE
Fix BenchmarkOutput

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/outputs/BenchmarkOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/BenchmarkOutput.java
@@ -107,9 +107,9 @@ public class BenchmarkOutput implements MessageOutput {
         messagesWritten.mark(messages.size());
     }
 
-    public interface Factory extends MessageOutput.Factory<GelfOutput> {
+    public interface Factory extends MessageOutput.Factory<BenchmarkOutput> {
         @Override
-        GelfOutput create(Stream stream, Configuration configuration);
+        BenchmarkOutput create(Stream stream, Configuration configuration);
 
         @Override
         Config getConfig();


### PR DESCRIPTION
Change the `BenchmarkOutput.Factory` return type to the actual class.
Otherwise we cannot bind the plugin.
