### PR TITLE
Disable ace's indentation for `QueryInput`.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
@@ -35,13 +35,7 @@ type State = {
 };
 
 class QueryInput extends Component<Props, State> {
-  static defaultProps = {
-    disabled: false,
-    onBlur: () => {},
-    completerClass: SearchBarAutoCompletions,
-    value: '',
-    placeholder: '',
-  };
+  isFocussed: boolean;
 
   completer: AutoCompleter;
 
@@ -49,7 +43,13 @@ class QueryInput extends Component<Props, State> {
     editor: Editor,
   } | typeof undefined;
 
-  isFocussed: boolean;
+  static defaultProps = {
+    disabled: false,
+    onBlur: () => {},
+    completerClass: SearchBarAutoCompletions,
+    value: '',
+    placeholder: '',
+  };
 
   constructor(props: Props) {
     super(props);
@@ -72,6 +72,8 @@ class QueryInput extends Component<Props, State> {
         bindKey: { win: 'Enter', mac: 'Enter' },
         exec: this._onExecute,
       });
+
+      editor.commands.removeCommands(['indent', 'outdent']);
 
       editor.setFontSize(16);
 

--- a/graylog2-web-interface/src/views/components/searchbar/ace-types.js
+++ b/graylog2-web-interface/src/views/components/searchbar/ace-types.js
@@ -22,11 +22,13 @@ export type Command = {
     win: string,
     mac: string,
   },
+  // eslint-disable-next-line no-use-before-define
   exec: Editor => void,
 };
 
 export type Commands = {
   addCommand: Command => void,
+  removeCommands: Array<string> => void,
 };
 
 export type Popup = {
@@ -57,11 +59,11 @@ export type CompletionResult = {
 
 export type ResultsCallback = (null, Array<CompletionResult>) => void;
 
-export interface AutoCompleter {
-  getCompletions(editor: Editor, session: Session, position: Position, prefix: string, callback: ResultsCallback): void;
-}
-
 export type Position = {
   row: number,
   column: number,
 };
+
+export interface AutoCompleter {
+  getCompletions(editor: Editor, session: Session, position: Position, prefix: string, callback: ResultsCallback): void;
+}


### PR DESCRIPTION
This PR disables ace's integrated indentation feature, which captures
the tab key to indent text. As this does not make much sense for a
single line input, but does not allow the user to use the keyboard to
jump out of this input and the focus is trapped, this feature is
disabled.