### PR TITLE
Disable selecting dropdown value in select when using the tab key

### DIFF
--- a/graylog2-web-interface/src/views/components/Select.jsx
+++ b/graylog2-web-interface/src/views/components/Select.jsx
@@ -64,7 +64,7 @@ const Select = ({ components, styles, ...rest }: Props) => {
     valueContainer,
     ...styles,
   };
-  return <ReactSelect {...rest} components={_components} styles={_styles} />;
+  return <ReactSelect {...rest} components={_components} styles={_styles} tabSelectsValue={false} />;
 };
 
 Select.propTypes = {


### PR DESCRIPTION
When an aggregation builder select dropdown is open and an option is focused, a tab will select the option in the same way the enter key does. We should disable this setting for a more intuitive tab navigation.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
