### PR TITLE
Reset aggregation builder series title to metric function name, on empty title save

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesConfiguration.jsx
@@ -20,12 +20,11 @@ export default class SeriesConfiguration extends React.Component {
   }
 
   _onSubmit = () => {
-    const { series, name } = this.state;
+    const { name, series, series: { config, function: functionName, effectiveName } } = this.state;
     const { onClose } = this.props;
-    const newName = name || series.function;
+    const newName = name || functionName;
 
-    if (newName && newName !== series.effectiveName) {
-      const { config } = series;
+    if (newName && newName !== effectiveName) {
       const newConfig = config.toBuilder().name(newName).build();
       const newSeries = series.toBuilder().config(newConfig).build();
       onClose(newSeries);

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesConfiguration.jsx
@@ -22,8 +22,7 @@ export default class SeriesConfiguration extends React.Component {
   _onSubmit = () => {
     const { series, name } = this.state;
     const { onClose } = this.props;
-    let newName = name;
-    if (!newName) newName = series.function;
+    const newName = name || series.function;
 
     if (newName && newName !== series.effectiveName) {
       const { config } = series;

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesConfiguration.jsx
@@ -21,17 +21,23 @@ export default class SeriesConfiguration extends React.Component {
 
   _onSubmit = () => {
     const { series, name } = this.state;
-    if (name && name !== series.effectiveName) {
+    const { onClose } = this.props;
+    let newName = name;
+    if (!newName) newName = series.function;
+
+    if (newName && newName !== series.effectiveName) {
       const { config } = series;
-      const newConfig = config.toBuilder().name(name).build();
+      const newConfig = config.toBuilder().name(newName).build();
       const newSeries = series.toBuilder().config(newConfig).build();
-      this.props.onClose(newSeries);
+      onClose(newSeries);
     } else {
-      this.props.onClose(series);
+      onClose(series);
     }
   };
 
-  _changeName = e => this.setState({ name: e.target.value });
+  _changeName = (e) => {
+    this.setState({ name: e.target.value });
+  };
 
   render() {
     const { name } = this.state;

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesConfiguration.jsx
@@ -33,9 +33,7 @@ export default class SeriesConfiguration extends React.Component {
     }
   };
 
-  _changeName = (e) => {
-    this.setState({ name: e.target.value });
-  };
+  _changeName = e => this.setState({ name: e.target.value });
 
   render() {
     const { name } = this.state;

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesConfiguration.test.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesConfiguration.test.jsx
@@ -7,18 +7,18 @@ import SeriesConfig from 'views/logic/aggregationbuilder/SeriesConfig';
 import SeriesConfiguration from './SeriesConfiguration';
 
 describe('SeriesConfiguration', () => {
-  const createNewSeries = (series, name) => {
+  const createNewSeries = (series = Series.forFunction('count()'), name) => {
     const newConfig = series.config.toBuilder().name(name).build();
     return series.toBuilder().config(newConfig).build();
   };
 
   it('renders the configuration dialog', () => {
-    const wrapper = renderer.create(<SeriesConfiguration series={Series.forFunction('count()')} onClose={() => {}} />);
+    const wrapper = renderer.create(<SeriesConfiguration series={createNewSeries()} onClose={() => {}} />);
     expect(wrapper.toJSON()).toMatchSnapshot();
   });
 
   it('renders an input to change the series name', () => {
-    const wrapper = mount(<SeriesConfiguration series={Series.forFunction('count()')} onClose={() => {}} />);
+    const wrapper = mount(<SeriesConfiguration series={createNewSeries()} onClose={() => {}} />);
     expect(wrapper.find('input')).toHaveProp('value', 'count()');
   });
 
@@ -33,7 +33,7 @@ describe('SeriesConfiguration', () => {
 
   it('submit button calls onClose callback', () => {
     const onClose = jest.fn();
-    const series = Series.forFunction('count()');
+    const series = createNewSeries();
     const wrapper = mount(<SeriesConfiguration series={series} onClose={onClose} />);
 
     const submit = wrapper.find('button');
@@ -46,7 +46,7 @@ describe('SeriesConfiguration', () => {
 
   it('returns changed name upon submit', () => {
     const onClose = jest.fn();
-    const series = Series.forFunction('count()');
+    const series = createNewSeries();
     const wrapper = mount(<SeriesConfiguration series={series} onClose={onClose} />);
     const input = wrapper.find('input');
     const submit = wrapper.find('button');
@@ -64,7 +64,7 @@ describe('SeriesConfiguration', () => {
 
   it('returns original metric function name upon submit, when no name is defined', () => {
     const onClose = jest.fn();
-    const series = createNewSeries(Series.forFunction('count()'), 'Some other value');
+    const series = createNewSeries(undefined, 'Some other value');
     const wrapper = mount(<SeriesConfiguration series={series} onClose={onClose} />);
     const input = wrapper.find('input');
     const submit = wrapper.find('button');

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesConfiguration.test.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesConfiguration.test.jsx
@@ -7,6 +7,11 @@ import SeriesConfig from 'views/logic/aggregationbuilder/SeriesConfig';
 import SeriesConfiguration from './SeriesConfiguration';
 
 describe('SeriesConfiguration', () => {
+  const createNewSeries = (series, name) => {
+    const newConfig = series.config.toBuilder().name(name).build();
+    return series.toBuilder().config(newConfig).build();
+  };
+
   it('renders the configuration dialog', () => {
     const wrapper = renderer.create(<SeriesConfiguration series={Series.forFunction('count()')} onClose={() => {}} />);
     expect(wrapper.toJSON()).toMatchSnapshot();
@@ -44,16 +49,33 @@ describe('SeriesConfiguration', () => {
     const series = Series.forFunction('count()');
     const wrapper = mount(<SeriesConfiguration series={series} onClose={onClose} />);
     const input = wrapper.find('input');
-    expect(input).toHaveProp('value', 'count()');
     const submit = wrapper.find('button');
+
+    expect(input).toHaveProp('value', 'count()');
 
     input.simulate('change', { target: { value: 'Some other value' } });
 
     submit.simulate('click');
 
-    const newSeries = series.toBuilder()
-      .config(series.config.toBuilder().name('Some other value').build())
-      .build();
+    const newSeries = createNewSeries(series, 'Some other value');
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledWith(newSeries);
+  });
+
+  it('returns function name upon submit, when no name is defined', () => {
+    const onClose = jest.fn();
+    const series = createNewSeries(Series.forFunction('count()'), 'Some other value');
+    const wrapper = mount(<SeriesConfiguration series={series} onClose={onClose} />);
+    const input = wrapper.find('input');
+    const submit = wrapper.find('button');
+
+    expect(input).toHaveProp('value', 'Some other value');
+
+    input.simulate('change', { target: { value: '' } });
+
+    submit.simulate('click');
+
+    const newSeries = createNewSeries(series, 'count()');
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledWith(newSeries);
   });

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesConfiguration.test.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesConfiguration.test.jsx
@@ -62,7 +62,7 @@ describe('SeriesConfiguration', () => {
     expect(onClose).toHaveBeenCalledWith(newSeries);
   });
 
-  it('returns function name upon submit, when no name is defined', () => {
+  it('returns original metric function name upon submit, when no name is defined', () => {
     const onClose = jest.fn();
     const series = createNewSeries(Series.forFunction('count()'), 'Some other value');
     const wrapper = mount(<SeriesConfiguration series={series} onClose={onClose} />);


### PR DESCRIPTION
When you are changing the name of a metric inside the aggregation builder, there is currently no way to reset it to the original metric function name. With this PR, you can reset the title, by submitting an empty input.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
