### PR TITLE
Adding helper methods to `ViewDTO` & `ViewStateDTO` classes.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/Titles.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/Titles.java
@@ -1,0 +1,30 @@
+package org.graylog.plugins.views.search.views;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.auto.value.AutoValue;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+@AutoValue
+public abstract class Titles {
+    private static final String KEY_WIDGETS = "widget";
+
+    @JsonValue
+    public abstract Map<String, Map<String, String>> titles();
+
+    @JsonCreator
+    public static Titles of(Map<String, Map<String, String>> titles) {
+        return new AutoValue_Titles(titles);
+    }
+
+    public static Titles empty() {
+        return of(Collections.emptyMap());
+    }
+
+    public Optional<String> widgetTitle(String widgetId) {
+        return Optional.ofNullable(titles().getOrDefault(KEY_WIDGETS, Collections.emptyMap()).get(widgetId));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/Titles.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/Titles.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.views.search.views;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewDTO.java
@@ -108,6 +108,26 @@ public abstract class ViewDTO {
         return views.stream().map(ViewDTO::id).collect(Collectors.toSet());
     }
 
+    public Optional<ViewStateDTO> findQueryContainingWidgetId(String widgetId) {
+        return state()
+                .values()
+                .stream()
+                .filter(viewStateDTO -> viewStateDTO.widgets()
+                        .stream()
+                        .map(WidgetDTO::id)
+                        .collect(Collectors.toSet())
+                        .contains(widgetId))
+                .findFirst();
+    }
+
+    public Optional<WidgetDTO> findWidgetById(String widgetId) {
+        return state().values()
+                .stream()
+                .flatMap(q -> q.widgets().stream())
+                .filter(w -> w.id().equals(widgetId))
+                .findFirst();
+    }
+
     @AutoValue.Builder
     public static abstract class Builder {
         @ObjectId

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewStateDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewStateDTO.java
@@ -23,7 +23,6 @@ import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
 
 import javax.annotation.Nullable;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -50,7 +49,7 @@ public abstract class ViewStateDTO {
     public abstract Optional<String> staticMessageListId();
 
     @JsonProperty(FIELD_TITLES)
-    public abstract Map<String, Map<String, String>> titles();
+    public abstract Titles titles();
 
     @JsonProperty(FIELD_WIDGETS)
     public abstract Set<WidgetDTO> widgets();
@@ -79,7 +78,7 @@ public abstract class ViewStateDTO {
         public abstract Builder staticMessageListId(String staticMessageListId);
 
         @JsonProperty(FIELD_TITLES)
-        public abstract Builder titles(Map<String, Map<String, String>> titles);
+        public abstract Builder titles(Titles titles);
 
         @JsonProperty(FIELD_WIDGETS)
         public abstract Builder widgets(Set<WidgetDTO> widgets);
@@ -101,7 +100,7 @@ public abstract class ViewStateDTO {
         @JsonCreator
         public static Builder create() {
             return new AutoValue_ViewStateDTO.Builder()
-                    .titles(Collections.emptyMap())
+                    .titles(Titles.empty())
                     .displayModeSettings(DisplayModeSettings.empty());
         }
     }


### PR DESCRIPTION
This is a small support PR adding:

  - `findWidgetById` to `ViewDTO` allowing to extract a widget from a
view by its id
  - `findQueryContainingWidgetId` allowing to extract a query
(`ViewStateDTO`) containing a widget by its id
  - wrapping the `titles` map of a `ViewStateDTO` instance in a `Titles`
class to decouple title lookup from its internal structure