### PR TITLE
Add testcontainers based MongoDBBaseTest class

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/MongoDbConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/MongoDbConfiguration.java
@@ -47,6 +47,10 @@ public class MongoDbConfiguration {
         return uri;
     }
 
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
     public MongoClientURI getMongoClientURI() {
         final MongoClientOptions.Builder mongoClientOptionsBuilder = MongoClientOptions.builder()
                 .connectionsPerHost(getMaxConnections())

--- a/graylog2-server/src/main/java/org/graylog2/database/MongoConnection.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/MongoConnection.java
@@ -18,6 +18,7 @@ package org.graylog2.database;
 
 import com.mongodb.DB;
 import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
 import com.mongodb.client.MongoDatabase;
 
 public interface MongoConnection {
@@ -38,4 +39,11 @@ public interface MongoConnection {
      * @return The configured MongoDB database.
      */
     MongoDatabase getMongoDatabase();
+
+    /**
+     * Get the client for the configured MongoDB database.
+     *
+     * @return the MongoDB client
+     */
+    MongoClient getMongoClient();
 }

--- a/graylog2-server/src/main/java/org/graylog2/database/MongoConnectionForTests.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/MongoConnectionForTests.java
@@ -58,4 +58,9 @@ public class MongoConnectionForTests implements MongoConnection {
 
         return mongoDatabase;
     }
+
+    @Override
+    public MongoClient getMongoClient() {
+        return (MongoClient) mongoClient;
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/database/MongoConnectionImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/MongoConnectionImpl.java
@@ -133,4 +133,9 @@ public class MongoConnectionImpl implements MongoConnection {
     public MongoDatabase getMongoDatabase() {
         return mongoDatabase;
     }
+
+    @Override
+    public MongoClient getMongoClient() {
+        return m;
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBBaseTest.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBBaseTest.java
@@ -1,0 +1,59 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.testing.mongodb;
+
+import org.graylog2.database.MongoConnection;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+
+/**
+ * This class can be used as base class for MongoDB integration tests.
+ * <p>
+ * It starts a MongoDB instance for each implementing test class.
+ * <p>
+ * Use {@link MongoDBFixtures} annotations for your test methods to load fixture data into the database.
+ */
+public abstract class MongoDBBaseTest {
+    @ClassRule
+    public static final MongoDBInstance MONGODB = MongoDBInstance.create();
+
+    @Rule
+    public final MongoDBFixturesWatcher mongoDBFixturesWatcher = new MongoDBFixturesWatcher();
+
+    private final MongoDBFixtureImporter fixtureImporter = new MongoDBFixtureImporter();
+
+    @Before
+    public void mongoDBBaseTestBefore() {
+        fixtureImporter.importResources(mongoDBFixturesWatcher.fixtureResources(getClass()), MONGODB.mongoConnection().getMongoDatabase());
+    }
+
+    @After
+    public void mongoDBBaseTestAfter() {
+        MONGODB.dropDatabase();
+    }
+
+    /**
+     * Returns an established connection to the started MongoDB instance.
+     *
+     * @return the established connection object
+     */
+    public MongoConnection mongoConnection() {
+        return MONGODB.mongoConnection();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBBaseTestIT.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBBaseTestIT.java
@@ -1,0 +1,103 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.testing.mongodb;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MongoDBBaseTestIT extends MongoDBBaseTest {
+
+    private MongoCollection<Document> collection1;
+    private MongoCollection<Document> collection2;
+
+    @Before
+    public void setUp() throws Exception {
+        collection1 = mongoConnection().getMongoDatabase().getCollection("test_1");
+        collection2 = mongoConnection().getMongoDatabase().getCollection("test_2");
+    }
+
+    @Test
+    public void clientWorks() {
+        assertThat(mongoConnection()).isNotNull();
+        assertThat(mongoConnection().getMongoDatabase()).isNotNull();
+        assertThat(mongoConnection().getMongoDatabase().getName()).isEqualTo("graylog");
+
+        final Document document = new Document("hello", "world");
+
+        collection1.insertOne(document);
+
+        assertThat(collection1.count()).isEqualTo(1);
+        assertThat(collection1.find(Filters.eq("hello", "world")).first()).isEqualTo(document);
+        assertThat(collection1.find(Filters.eq("hello", "world2")).first()).isNull();
+    }
+
+    @Test
+    @MongoDBFixtures("MongoDBBaseTestIT.json")
+    public void fixturesWork() {
+        assertThat(collection1.count()).isEqualTo(2);
+        assertThat(collection1.find(Filters.eq("hello", "world")).first().get("_id"))
+                .isEqualTo(new ObjectId("54e3deadbeefdeadbeefaffe"));
+        assertThat(collection1.find(Filters.eq("hello", "world2")).first()).isNull();
+        assertThat(collection1.find(Filters.eq("another", "test")).first().get("_id"))
+                .isEqualTo(new ObjectId("54e3deadbeefdeadbeefafff"));
+
+        assertThat(collection2.count()).isEqualTo(1);
+        assertThat(collection2.find(Filters.eq("field_a", "content1")).first().get("_id"))
+                .isEqualTo(new ObjectId("54e3deadbeefdeadbeefaffe"));
+        assertThat(collection2.find(Filters.eq("field_a", "missing")).first()).isNull();
+
+        final Date date = new Date(ZonedDateTime.parse("2018-12-31T23:59:59.999Z").toInstant().toEpochMilli());
+        assertThat(collection2.find(Filters.gt("created_at", date)).first().get("_id"))
+                .isEqualTo(new ObjectId("54e3deadbeefdeadbeefaffe"));
+        assertThat(collection2.find(Filters.lte("created_at", date)).first()).isNull();
+    }
+
+    @Test
+    @MongoDBFixtures("MongoDBBaseTestIT.json")
+    public void indexFixturesWork() {
+        final List<Document> indexes = StreamSupport.stream(collection2.listIndexes().spliterator(), false)
+                .collect(Collectors.toList());
+
+        assertThat(indexes.get(1).get("key", Document.class).getInteger("field_a")).isEqualTo(1);
+        assertThat(indexes.get(1).getBoolean("unique")).isEqualTo(true);
+        assertThat(indexes.get(2).get("key", Document.class).getInteger("created_at")).isEqualTo(-1);
+        assertThat(indexes.get(2).getBoolean("unique")).isNull();
+    }
+
+    @Test
+    @MongoDBFixtures("mongodb-fixtures/mongodb-base-test-it.json")
+    public void globalFixturesWork() {
+        assertThat(collection1.count()).isEqualTo(2);
+        assertThat(collection1.find(Filters.eq("hello", "world")).first().get("_id"))
+                .isEqualTo(new ObjectId("54e3deadbeefdeadbeefaffe"));
+        assertThat(collection1.find(Filters.eq("hello", "world2")).first()).isNull();
+        assertThat(collection1.find(Filters.eq("another", "test")).first().get("_id"))
+                .isEqualTo(new ObjectId("54e3deadbeefdeadbeefafff"));
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBFixtureImporter.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBFixtureImporter.java
@@ -1,0 +1,220 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.testing.mongodb;
+
+import com.google.common.io.Resources;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.IndexOptions;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Imports data into a MongoDB instance based on JSON files.
+ * <p>
+ * The JSON files can look either like this:
+ * <pre>{@code
+ *  {
+ *      "<collection-name>": [
+ *          {
+ *              "_id": {"$oid": "54e3deadbeefdeadbeefaffe"},
+ *              "field_a": "content1",
+ *              "created_at": {"$date": "2019-01-01T00:00:00.000Z"}
+ *          }
+ *      ]
+ *  }
+ * }</pre>
+ * <p>
+ * Or alternatively like this:
+ * <pre>{@code
+ * {
+ *     "<collection-name>": {
+ *         "data": [
+ *             {
+ *                 "_id": {"$oid": "54e3deadbeefdeadbeefaffe"},
+ *                 "field_a": "content1",
+ *                 "created_at": {"$date": "2019-01-01T00:00:00.000Z"}
+ *             }
+ *         ],
+ *         "indexes": [
+ *             {
+ *                 "index": {"field_a": 1},
+ *                 "options": {"unique": true}
+ *             }
+ *         ]
+ *     }
+ * }
+ * }</pre>
+ */
+class MongoDBFixtureImporter {
+    private static final Logger LOG = LoggerFactory.getLogger(MongoDBFixtureImporter.class);
+    private static final String FIELD_DATA = "data";
+    private static final String FIELD_INDEX = "index";
+    private static final String FIELD_INDEXES = "indexes";
+    private static final String FIELD_INDEX_OPTIONS = "options";
+
+    /**
+     * Import the given resources using the given database connection.
+     *
+     * @param fixtureResources resources to import
+     * @param database         database connection
+     */
+    void importResources(List<URL> fixtureResources, MongoDatabase database) {
+        fixtureResources.forEach(resource -> importResource(resource, database));
+    }
+
+    private void importResource(URL resource, MongoDatabase database) {
+        LOG.debug("Importing fixture resource: {}", resource);
+        try {
+            importData(database, Resources.toString(resource, StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void importData(MongoDatabase database, String jsonData) {
+        final Document data = Document.parse(jsonData);
+
+        for (final String collectionName : data.keySet()) {
+            final Object document = data.get(collectionName, Object.class);
+
+            if (isListOfDocuments(document)) {
+                importDocuments(database, collectionName, data.get(collectionName, List.class));
+            } else {
+                final Document doc = (Document) document;
+                importIndexes(database, collectionName, doc);
+                importDocuments(database, collectionName, doc.get(FIELD_DATA, List.class));
+            }
+        }
+    }
+
+    private boolean isListOfDocuments(Object object) {
+        return List.class.isAssignableFrom(object.getClass());
+    }
+
+    private void importDocuments(MongoDatabase database, String collectionName, List<Document> dataObjects) {
+        final MongoCollection<Document> collection = database.getCollection(collectionName);
+
+        for (final Document dataObject : dataObjects) {
+            collection.insertOne(dataObject);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void importIndexes(MongoDatabase database, String collectionName, Document doc) {
+        if (!doc.containsKey(FIELD_INDEXES)) {
+            return;
+        }
+
+        final MongoCollection<Document> collection = database.getCollection(collectionName);
+        final List<Document> indexes = doc.get(FIELD_INDEXES, List.class);
+
+        for (final Document indexDoc : indexes) {
+            final Document indexFields = indexDoc.get(FIELD_INDEX, Document.class);
+
+            if (indexDoc.containsKey(FIELD_INDEX_OPTIONS)) {
+                collection.createIndex(indexFields, createIndexOptions(indexDoc.get(FIELD_INDEX_OPTIONS, Document.class)));
+            } else {
+                collection.createIndex(indexFields);
+            }
+        }
+    }
+
+    private IndexOptions createIndexOptions(Document indexOptionsDoc) {
+        final IndexOptions indexOptions = new IndexOptions();
+
+        if (indexOptionsDoc.containsKey("background")) {
+            indexOptions.background(indexOptionsDoc.getBoolean("background"));
+        }
+
+        if (indexOptionsDoc.containsKey("unique")) {
+            indexOptions.unique(indexOptionsDoc.getBoolean("unique"));
+        }
+
+        if (indexOptionsDoc.containsKey("name")) {
+            indexOptions.name(indexOptionsDoc.getString("name"));
+        }
+
+        if (indexOptionsDoc.containsKey("sparse")) {
+            indexOptions.sparse(indexOptionsDoc.getBoolean("sparse"));
+        }
+
+        if (indexOptionsDoc.containsKey("expireAfterSeconds")) {
+            indexOptions.expireAfter(indexOptionsDoc.getLong("expireAfterSeconds"), TimeUnit.SECONDS);
+        }
+
+        if (indexOptionsDoc.containsKey("version")) {
+            indexOptions.version(indexOptionsDoc.getInteger("version"));
+        }
+
+        if (indexOptionsDoc.containsKey("weights")) {
+            indexOptions.weights(indexOptionsDoc.get("weights", Bson.class));
+        }
+
+        if (indexOptionsDoc.containsKey("defaultLanguage")) {
+            indexOptions.defaultLanguage(indexOptionsDoc.getString("defaultLanguage"));
+        }
+
+        if (indexOptionsDoc.containsKey("languageOverride")) {
+            indexOptions.languageOverride(indexOptionsDoc.getString("languageOverride"));
+        }
+
+        if (indexOptionsDoc.containsKey("textVersion")) {
+            indexOptions.textVersion(indexOptionsDoc.getInteger("textVersion"));
+        }
+
+        if (indexOptionsDoc.containsKey("sphereVersion")) {
+            indexOptions.sphereVersion(indexOptionsDoc.getInteger("sphereVersion"));
+        }
+
+        if (indexOptionsDoc.containsKey("bits")) {
+            indexOptions.bits(indexOptionsDoc.getInteger("bits"));
+        }
+
+        if (indexOptionsDoc.containsKey("min")) {
+            indexOptions.min(indexOptionsDoc.getDouble("min"));
+        }
+
+        if (indexOptionsDoc.containsKey("max")) {
+            indexOptions.max(indexOptionsDoc.getDouble("max"));
+        }
+
+        if (indexOptionsDoc.containsKey("bucketSize")) {
+            indexOptions.bucketSize(indexOptionsDoc.getDouble("bucketSize"));
+        }
+
+        if (indexOptionsDoc.containsKey("storageEngine")) {
+            indexOptions.storageEngine(indexOptionsDoc.get("storageEngine", Bson.class));
+        }
+
+        if (indexOptionsDoc.containsKey("partialFilterExpression")) {
+            indexOptions.partialFilterExpression(indexOptionsDoc.get("partialFilterExpression", Bson.class));
+        }
+
+        return indexOptions;
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBFixtures.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBFixtures.java
@@ -1,0 +1,32 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.testing.mongodb;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation can be used with the {@link MongoDBBaseTest} to load the given MongoDB data fixtures into the
+ * database by using {@link MongoDBFixtureImporter}.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface MongoDBFixtures {
+    String[] value();
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBFixturesWatcher.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBFixturesWatcher.java
@@ -1,0 +1,49 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.testing.mongodb;
+
+import com.google.common.io.Resources;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class MongoDBFixturesWatcher extends TestWatcher {
+    private String[] resourceNames;
+
+    @Override
+    protected void starting(final Description description) {
+        final MongoDBFixtures fixtures = description.getAnnotation(MongoDBFixtures.class);
+        this.resourceNames = fixtures != null ? fixtures.value() : new String[]{};
+    }
+
+    List<URL> fixtureResources(final Class<?> contextClass) {
+        return Arrays.stream(resourceNames).map(resourceName -> toResource(resourceName, contextClass)).collect(Collectors.toList());
+    }
+
+    private URL toResource(final String resourceName, final Class<?> contextClass) {
+        if (Paths.get(resourceName).getNameCount() > 1) {
+            return Resources.getResource(resourceName);
+        } else {
+            return Resources.getResource(contextClass, resourceName);
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBInstance.java
@@ -1,0 +1,110 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.testing.mongodb;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import org.graylog2.configuration.MongoDbConfiguration;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.database.MongoConnectionImpl;
+import org.junit.rules.ExternalResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.util.Locale;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This rule starts a MongoDB instance and provides a configured {@link org.graylog2.database.MongoConnection}.
+ */
+public class MongoDBInstance extends ExternalResource implements AutoCloseable {
+    private static final Logger LOG = LoggerFactory.getLogger(MongoDBInstance.class);
+    private static final String DEFAULT_IMAGE = "mongo";
+    private static final String DEFAULT_VERSION = "3.6";
+    private static final String DEFAULT_DATABASE_NAME = "graylog";
+
+    private final String databaseName;
+    private final GenericContainer container;
+    private MongoConnection mongoConnection;
+
+    public static MongoDBInstance create() {
+        return new MongoDBInstance(DEFAULT_VERSION, DEFAULT_DATABASE_NAME);
+    }
+
+    private MongoDBInstance(String version, String databaseName) {
+        this.databaseName = databaseName;
+        this.container = new GenericContainer<>(String.format(Locale.US, "%s:%s", DEFAULT_IMAGE, version))
+                .withExposedPorts(27017)
+                .waitingFor(Wait.forListeningPort());
+    }
+
+    public MongoConnection mongoConnection() {
+        return requireNonNull(mongoConnection, "mongoConnection not initialized yet");
+    }
+
+    public String ipAddress() {
+        return container.getContainerIpAddress();
+    }
+
+    public String database() {
+        return databaseName;
+    }
+
+    public int port() {
+        return container.getFirstMappedPort();
+    }
+
+    public void dropDatabase() {
+        LOG.debug("Dropping database {}", database());
+        mongoConnection().getMongoDatabase().drop();
+    }
+
+    @Override
+    protected void before() {
+        LOG.debug("Attempting to start container for image: {}", container.getDockerImageName());
+        container.start();
+        LOG.debug("Started container: {}", containerInfoString());
+
+        final MongoDbConfiguration mongoConfiguration = new MongoDbConfiguration();
+        mongoConfiguration.setUri(String.format(Locale.US, "mongodb://%s:%d/%s",
+                ipAddress(), port(), database()));
+
+        this.mongoConnection = new MongoConnectionImpl(mongoConfiguration);
+        this.mongoConnection.connect();
+        this.mongoConnection.getMongoDatabase().drop();
+    }
+
+    @Override
+    protected void after() {
+        close();
+    }
+
+    @Override
+    public void close() {
+        if (container != null) {
+            LOG.debug("Stopping container: {}", containerInfoString());
+            container.close();
+        }
+    }
+
+    private String containerInfoString() {
+        final InspectContainerResponse containerInfo = container.getContainerInfo();
+        return String.format(Locale.US, "%s%s/%s", containerInfo.getId(), containerInfo.getName(), containerInfo.getConfig().getImage());
+    }
+}

--- a/graylog2-server/src/test/resources/mongodb-fixtures/mongodb-base-test-it.json
+++ b/graylog2-server/src/test/resources/mongodb-fixtures/mongodb-base-test-it.json
@@ -1,0 +1,16 @@
+{
+  "test_1": [
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeefaffe"
+      },
+      "hello": "world"
+    },
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeefafff"
+      },
+      "another": "test"
+    }
+  ]
+}

--- a/graylog2-server/src/test/resources/org/graylog/testing/mongodb/MongoDBBaseTestIT.json
+++ b/graylog2-server/src/test/resources/org/graylog/testing/mongodb/MongoDBBaseTestIT.json
@@ -1,0 +1,34 @@
+{
+  "test_1": [
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeefaffe"
+      },
+      "hello": "world"
+    },
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeefafff"
+      },
+      "another": "test"
+    }
+  ],
+  "test_2": {
+    "data": [
+      {
+        "_id": {"$oid": "54e3deadbeefdeadbeefaffe"},
+        "field_a": "content1",
+        "created_at": {"$date": "2019-01-01T00:00:00.000Z"}
+      }
+    ],
+    "indexes": [
+      {
+        "index": {"field_a": 1},
+        "options": {"unique": true}
+      },
+      {
+        "index": {"created_at": -1}
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This class can be used for integration tests that need a MongoDB
database. It is using the testcontainers library to start a database
instance for each test class.

It supports our standard database fixture files by using the
`MongoDBFixtures` annotation on test methods.
