### PR TITLE
Fix adding new converters to a extractor

### DIFF
--- a/graylog2-web-interface/src/components/extractors/EditExtractorConverters.jsx
+++ b/graylog2-web-interface/src/components/extractors/EditExtractorConverters.jsx
@@ -45,7 +45,9 @@ class EditExtractorConverters extends React.Component {
   };
 
   _onConverterAdd = () => {
-    this.setState({ selectedConverter: undefined });
+    const { displayedConverters, selectedConverter } = this.state;
+    const nextDisplayedConverters = displayedConverters.concat(selectedConverter);
+    this.setState({ selectedConverter: undefined, displayedConverters: nextDisplayedConverters });
   };
 
   _onConverterChange = (converterType, converter) => {


### PR DESCRIPTION
This seems to have been broken forever, at least I couldn't find the cause on a quick look at the file.

Before the change, adding an extractor converter didn't add anything to the list of converters, as you can see in the gif:
![converter](https://user-images.githubusercontent.com/716185/69237302-ac7b0f00-0b95-11ea-84dc-af7d40449b8f.gif)




