### PR TITLE
Reuse Elasticsearch container between test runs for integration tests

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchInstance.java
@@ -19,6 +19,7 @@ package org.graylog.testing.elasticsearch;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.joschi.jadconfig.util.Duration;
 import com.github.zafarkhaja.semver.Version;
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import io.searchbox.client.JestClient;
 import io.searchbox.cluster.State;
@@ -36,6 +37,7 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import static com.google.common.collect.Iterators.toArray;
 
@@ -97,13 +99,16 @@ public class ElasticsearchInstance extends ExternalResource {
     }
 
     private static ElasticsearchContainer startNewContainerInstance(String image) {
+        final Stopwatch sw = Stopwatch.createStarted();
+
         final ElasticsearchContainer container = new ElasticsearchContainer(image)
+                .withReuse(true)
                 .withEnv("ES_JAVA_OPTS", "-Xms512m -Xmx512m")
                 .withEnv("discovery.type", "single-node")
                 .withEnv("action.auto_create_index", "false")
                 .waitingFor(Wait.forHttp("/").forPort(9200));
         container.start();
-        LOG.debug("Started container {}{}", container.getContainerInfo().getId(), container.getContainerInfo().getName());
+        LOG.debug("Started container {} in {}ms", container.getContainerInfo().getName(), sw.elapsed(TimeUnit.MILLISECONDS));
         return container;
     }
 


### PR DESCRIPTION
## Description
Added the new `withReuse(true)` flag from this new testcontainers
feature: https://github.com/testcontainers/testcontainers-java/pull/1781

In order for this to work developers have to enable reuse in a config file: 
` echo 'testcontainers.reuse.enable=true' > ~/.testcontainers.properties`

Testcontainers uses a hash based on various container properties to determine reusability, so if any of these properties change, a new container is spun up and will be reused next time. Old ones remain running and _have to be cleaned up manually_. While this is the main drawback of this approach, I find it ok, because we don't change these properties too often. People who really hate it can just not enable reuse in their testcontainers config and go on without it.

## Motivation and Context
Our Elasticsearch container needs ~10s to start. While this is not a big deal when running many tests , it can get annoying when running a single test repeatedly.
This change brings the startup time down from ~10s to <3s.

## How Has This Been Tested?
- track and compare startup times using `Stopwatch`

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
