### PR TITLE
Fix "COMMONAPACHELOG" grok pattern.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
@@ -40,5 +40,6 @@ public class MigrationsModule extends PluginModule {
         addMigration(V20190705071400_AddEventIndexSetsMigration.class);
         addMigration(V20190730100900_AddAlertsManagerRole.class);
         addMigration(V20190730000000_CreateDefaultEventsConfiguration.class);
+        addMigration(V20191121145100_FixDefaultGrokPatterns.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20191121145100_FixDefaultGrokPatterns.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20191121145100_FixDefaultGrokPatterns.java
@@ -1,0 +1,150 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.migrations;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import org.graylog.autovalue.WithBeanGetter;
+import org.graylog2.grok.GrokPattern;
+import org.graylog2.grok.GrokPatternService;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.database.ValidationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Fixes errors in the default grok patterns that have been installed by the
+ * {@link V20180924111644_AddDefaultGrokPatterns} migration.
+ * <p>
+ * At the moment this is only the COMMONAPACHELOG pattern, but if we find more issues with the default patterns we
+ * <em>should</em> be able to adjust this migration by adding more patterns instead of having to write additional
+ * migrations.
+ *
+ */
+public class V20191121145100_FixDefaultGrokPatterns extends Migration {
+    private static final Logger log = LoggerFactory.getLogger(V20191121145100_FixDefaultGrokPatterns.class);
+
+    private final ClusterConfigService configService;
+    private final GrokPatternService grokPatternService;
+
+    @VisibleForTesting
+    static final List<PatternToMigrate> patternsToMigrate = ImmutableList.of(
+        PatternToMigrate.builder()
+                      .name("COMMONAPACHELOG")
+                      .migrateFrom("%{IPORHOST:clientip} %{HTTPDUSER:ident} %{USER:auth} \\[%{HTTPDATE:timestamp}\\] \"(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})\" %{NUMBER:response} (?:%{NUMBER:bytes}|-)")
+                      .migrateTo("%{IPORHOST:clientip} %{HTTPDUSER:ident} %{USER:auth} \\[%{HTTPDATE:timestamp;date;dd/MMM/yyyy:HH:mm:ss Z}\\] \"(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})\" %{NUMBER:response} (?:%{NUMBER:bytes}|-)")
+                      .build()
+    );
+
+    @Inject
+    public V20191121145100_FixDefaultGrokPatterns(final ClusterConfigService clusterConfigService,
+                                                  GrokPatternService grokPatternService) {
+        this.grokPatternService = grokPatternService;
+        this.configService = clusterConfigService;
+    }
+
+    @Override
+    public ZonedDateTime createdAt() {
+        return ZonedDateTime.parse("2019-11-21T14:51:00Z");
+    }
+
+    @Override
+    public void upgrade() {
+        final MigrationCompleted migrationCompleted = configService.get(MigrationCompleted.class);
+
+        final Set<String> patternNames = patternsToMigrate.stream()
+                .map(PatternToMigrate::name)
+                .collect(Collectors.toSet());
+
+        if (migrationCompleted != null && migrationCompleted.patterns().containsAll(patternNames)) {
+            log.debug("Migration already completed.");
+            return;
+        }
+
+        try {
+            for (PatternToMigrate patternToMigrate : patternsToMigrate) {
+                migratePattern(patternToMigrate);
+            }
+            configService.write(MigrationCompleted.create(patternNames));
+        } catch (ValidationException e) {
+            log.error("Unable to migrate Grok Pattern.", e);
+        }
+    }
+
+    private void migratePattern(PatternToMigrate patternToMigrate) throws ValidationException {
+        final Optional<GrokPattern> currentPattern = grokPatternService.loadByName(patternToMigrate.name());
+        if (!currentPattern.isPresent()) {
+            log.debug("Couldn't find default pattern '{}'. Skipping migration.", patternToMigrate.name());
+            return;
+        }
+
+        final GrokPattern pattern = currentPattern.get();
+
+        if (!patternToMigrate.migrateFrom().equals(pattern.pattern())) {
+            log.info("Skipping migration of modified default Grok Pattern '{}'.", pattern.name());
+        } else {
+            log.info("Migrating default Grok Pattern '{}'.", pattern.name());
+            final GrokPattern migratedPattern = pattern.toBuilder()
+                    .pattern(patternToMigrate.migrateTo())
+                    .build();
+            grokPatternService.update(migratedPattern);
+        }
+    }
+
+    @JsonAutoDetect
+    @AutoValue
+    @WithBeanGetter
+    public static abstract class MigrationCompleted {
+        @JsonProperty("patterns")
+        public abstract Set<String> patterns();
+
+        @JsonCreator
+        public static MigrationCompleted create(@JsonProperty("patterns") Set<String> patterns) {
+            return new AutoValue_V20191121145100_FixDefaultGrokPatterns_MigrationCompleted(patterns);
+        }
+    }
+
+    @AutoValue
+    public static abstract class PatternToMigrate {
+        public abstract String name();
+        public abstract String migrateFrom();
+        public abstract String migrateTo();
+
+        public static Builder builder() {
+            return new AutoValue_V20191121145100_FixDefaultGrokPatterns_PatternToMigrate.Builder();
+        }
+
+        @AutoValue.Builder
+        public abstract static class Builder {
+            public abstract Builder name(String name);
+            public abstract Builder migrateFrom(String migrateFrom);
+            public abstract Builder migrateTo(String migrateTo);
+            public abstract PatternToMigrate build();
+        }
+    }
+}

--- a/graylog2-server/src/main/resources/org/graylog2/migrations/V20180924111644_AddDefaultGrokPatterns_Default_Grok_Patterns.json
+++ b/graylog2-server/src/main/resources/org/graylog2/migrations/V20180924111644_AddDefaultGrokPatterns_Default_Grok_Patterns.json
@@ -612,7 +612,7 @@
       "v": "1",
       "data": {
         "name": "COMMONAPACHELOG",
-        "pattern": "%{IPORHOST:clientip} %{HTTPDUSER:ident} %{USER:auth} \\[%{HTTPDATE:timestamp}\\] \"(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})\" %{NUMBER:response} (?:%{NUMBER:bytes}|-)"
+        "pattern": "%{IPORHOST:clientip} %{HTTPDUSER:ident} %{USER:auth} \\[%{HTTPDATE:timestamp;date;dd/MMM/yyyy:HH:mm:ss Z}\\] \"(?:%{WORD:verb} %{NOTSPACE:request}(?: HTTP/%{NUMBER:httpversion})?|%{DATA:rawrequest})\" %{NUMBER:response} (?:%{NUMBER:bytes}|-)"
       },
       "constraints": [
         {

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20191121145100_FixDefaultGrokPatternsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20191121145100_FixDefaultGrokPatternsTest.java
@@ -1,0 +1,97 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.migrations;
+
+import org.graylog2.grok.GrokPattern;
+import org.graylog2.grok.GrokPatternService;
+import org.graylog2.migrations.V20191121145100_FixDefaultGrokPatterns.MigrationCompleted;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.plugin.database.ValidationException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+
+public class V20191121145100_FixDefaultGrokPatternsTest {
+    private static final String PATTERN_NAME = "COMMONAPACHELOG";
+
+    @Mock
+    private ClusterConfigService configService;
+    @Mock
+    private GrokPatternService grokPatternService;
+
+    @InjectMocks
+    private V20191121145100_FixDefaultGrokPatterns migration;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void alreadyMigrated() {
+        final MigrationCompleted migrationCompleted = MigrationCompleted.create(Collections.singleton(PATTERN_NAME));
+        when(configService.get(MigrationCompleted.class)).thenReturn(migrationCompleted);
+
+        migration.upgrade();
+
+        verifyZeroInteractions(grokPatternService);
+    }
+
+    @Test
+    public void patternWasModified() throws ValidationException {
+        final GrokPattern pattern = GrokPattern.builder()
+                .name(PATTERN_NAME)
+                .pattern("modified")
+                .build();
+        when(grokPatternService.loadByName(PATTERN_NAME)).thenReturn(Optional.of(pattern));
+        migration.upgrade();
+        verify(grokPatternService, never()).update(any(GrokPattern.class));
+        verify(configService).write(MigrationCompleted.create(Collections.singleton(PATTERN_NAME)));
+    }
+
+    @Test
+    public void upgrade() throws ValidationException {
+        final V20191121145100_FixDefaultGrokPatterns.PatternToMigrate patternToMigrate =
+                V20191121145100_FixDefaultGrokPatterns.patternsToMigrate.stream()
+                        .filter(p -> PATTERN_NAME.equals(p.name()))
+                        .findFirst()
+                        .orElseThrow(() -> new IllegalStateException(
+                                "Test expects pattern with name " + PATTERN_NAME + " to " + "be migrated."));
+        final GrokPattern pattern = GrokPattern.builder()
+                .name(PATTERN_NAME)
+                .pattern(patternToMigrate.migrateFrom())
+                .build();
+        when(grokPatternService.loadByName(PATTERN_NAME)).thenReturn(Optional.of(pattern));
+        migration.upgrade();
+        verify(grokPatternService).update(argThat(p -> PATTERN_NAME.equals(p.name()) && patternToMigrate.migrateTo()
+                .equals(p.pattern())));
+        verify(configService).write(MigrationCompleted.create(Collections.singleton(PATTERN_NAME)));
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The COMMONAPACHELOG grok pattern uses the original date string found in the source to propagate the "timestamp" message field. When the extractor tries to use this value to set the field on the message, it will be ignored, as it is not a proper date.

We adjust the pattern so that it creates a date object which the message accepts as a valid value for the "timestamp" field.

The pattern is fixed in the content pack which is installed automatically for a new graylog setup. For existing setups, a migration is provided which fixes the pattern if it is still in the original, broken state. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1647

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Started a fresh graylog setup. Started an existing graylog setup with the original content pack already installed. Both setups ended up with the fixed pattern.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
