### PR TITLE
Fix warnings tests of CopyWidgetToDashboard and UpdateSearchForWidgets

### DIFF
--- a/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.test.js
+++ b/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.test.js
@@ -8,8 +8,14 @@ import copyWidgetToDashboard from './CopyWidgetToDashboard';
 jest.mock('uuid/v4', () => jest.fn(() => 'dead-beef'));
 
 jest.mock('../Widgets', () => ({
-  widgetDefinition: () => ({ searchTypes: () => [{}] }),
+  widgetDefinition: () => ({ searchTypes: () => [{ type: 'pivot' }] }),
 }));
+
+jest.mock('../SearchType', () => jest.fn(() => ({
+  type: 'pivot',
+  handler: jest.fn(),
+  defaults: {},
+})));
 
 const cwd = dirname(__filename);
 const readFixture = filename => JSON.parse(readFileSync(`${cwd}/${filename}`).toString());

--- a/graylog2-web-interface/src/views/logic/views/UpdateSearchForWidgets.test.js
+++ b/graylog2-web-interface/src/views/logic/views/UpdateSearchForWidgets.test.js
@@ -12,8 +12,14 @@ const readFixture = filename => JSON.parse(readFileSync(`${cwd}/${filename}`).to
 jest.mock('uuid/v4', () => jest.fn(() => 'dead-beef'));
 
 jest.mock('../Widgets', () => ({
-  widgetDefinition: () => ({ searchTypes: () => [{}] }),
+  widgetDefinition: () => ({ searchTypes: () => [{ type: 'pivot' }] }),
 }));
+
+jest.mock('../SearchType', () => jest.fn(() => ({
+  type: 'pivot',
+  handler: jest.fn(),
+  defaults: {},
+})));
 
 describe('UpdateSearchForWidgets', () => {
   it('should generate a new search for the view', () => {


### PR DESCRIPTION
## Motivation and Context
Prior to this change, the tests of CopyWidgetToDashboard and
UpdateSearchForWidgets were throwing warnings:

`Unable to find type definition or defaults for search type undefined -
skipping!`

## Description
This change will mock the searchTypeDefinition function
to prevent the warning from raising.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
