### PR TITLE
Fix DataTable filter to reapply filter after data updates

### DIFF
--- a/graylog2-web-interface/src/components/common/DataTable.jsx
+++ b/graylog2-web-interface/src/components/common/DataTable.jsx
@@ -82,9 +82,7 @@ class DataTable extends React.Component {
       rows: rows,
       filteredRows: rows,
     };
-    this.typeAheadRef = React.createRef();
   }
-
 
   componentDidUpdate(prevProps) {
     const { rows } = this.props;

--- a/graylog2-web-interface/src/components/common/DataTable.jsx
+++ b/graylog2-web-interface/src/components/common/DataTable.jsx
@@ -82,6 +82,7 @@ class DataTable extends React.Component {
   }
 
   componentDidUpdate() {
+    // We update the state with row if the filterKeys is empty other than that typeahead is handling the state
     const { filterKeys } = this.props;
     if (filterKeys.length === 0) {
       this._updateState();

--- a/graylog2-web-interface/src/components/common/DataTable.jsx
+++ b/graylog2-web-interface/src/components/common/DataTable.jsx
@@ -92,7 +92,6 @@ class DataTable extends React.Component {
 
   getFormattedHeaders = () => {
     let i = 0;
-    // const { headers } = this.props;
     const { headerCellFormatter, headers } = this.props;
     const formattedHeaders = headers.map((header) => {
       const el = <DataTableElement key={`header-${i}`} element={header} index={i} formatter={headerCellFormatter} />;

--- a/graylog2-web-interface/src/components/common/DataTable.jsx
+++ b/graylog2-web-interface/src/components/common/DataTable.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { isEqual } from 'lodash';
 import TypeAheadDataFilter from 'components/common/TypeAheadDataFilter';
 import DataTableElement from './DataTableElement';
 
@@ -81,10 +82,10 @@ class DataTable extends React.Component {
     };
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(previousProps) {
     // We update the state with row if the filterKeys is empty other than that typeahead is handling the state
-    const { filterKeys } = this.props;
-    if (filterKeys.length === 0) {
+    const { filterKeys, rows } = this.props;
+    if (filterKeys.length === 0 && !isEqual(previousProps.rows, rows)) {
       this._updateState();
     }
   }

--- a/graylog2-web-interface/src/components/common/DataTable.jsx
+++ b/graylog2-web-interface/src/components/common/DataTable.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-
+import { isEqual } from 'lodash';
 import TypeAheadDataFilter from 'components/common/TypeAheadDataFilter';
 import DataTableElement from './DataTableElement';
 
@@ -10,6 +10,8 @@ import DataTableElement from './DataTableElement';
  * input to the data table by using the the `TypeAheadDataFilter` component.
  */
 class DataTable extends React.Component {
+  typeAheadRef = React.createRef();
+
   static propTypes = {
     /** Adds a custom children element next to the data filter input. */
     children: PropTypes.node,
@@ -58,8 +60,11 @@ class DataTable extends React.Component {
      */
     useResponsiveTable: PropTypes.bool,
   };
-
+ 
   static defaultProps = {
+    children: undefined,
+    className: '',
+    filterBy: '',
     filterSuggestions: [],
     filterLabel: 'Filter',
     displayKey: 'value',
@@ -77,12 +82,17 @@ class DataTable extends React.Component {
     filteredRows: this.props.rows,
   };
 
-  componentWillReceiveProps(newProps) {
-    this.setState({
-      headers: newProps.headers,
-      rows: newProps.rows,
-      filteredRows: newProps.rows,
-    });
+  componentDidUpdate(prevProps) {
+    const { rows } = this.props;
+    if (!isEqual(prevProps.rows, rows)) {
+      this.setState({
+        headers: this.props.headers,
+        rows: this.props.rows,
+        filteredRows: this.props.rows,
+      }, () => {
+        this.typeAheadRef.current._onSearchTextChanged(window.event);
+      });
+    }
   }
 
   getFormattedHeaders = () => {
@@ -134,6 +144,7 @@ class DataTable extends React.Component {
                                  filterBy={this.props.filterBy}
                                  filterSuggestions={this.props.filterSuggestions}
                                  searchInKeys={this.props.filterKeys}
+                                 ref={this.typeAheadRef}
                                  onDataFiltered={this.filterDataRows} />
           </div>
           <div className="col-md-4">
@@ -175,5 +186,7 @@ class DataTable extends React.Component {
     );
   }
 }
+
+
 
 export default DataTable;

--- a/graylog2-web-interface/src/components/common/DataTable.jsx
+++ b/graylog2-web-interface/src/components/common/DataTable.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { isEqual } from 'lodash';
 import TypeAheadDataFilter from 'components/common/TypeAheadDataFilter';
 import DataTableElement from './DataTableElement';
 
@@ -76,25 +75,23 @@ class DataTable extends React.Component {
 
   constructor(props) {
     super(props);
-    const { headers, rows } = this.props;
+    const { rows } = this.props;
     this.state = {
-      headers: headers,
-      rows: rows,
       filteredRows: rows,
     };
   }
 
-  componentDidUpdate(prevProps) {
-    const { rows } = this.props;
-    if (!isEqual(prevProps.rows, rows)) {
+  componentDidUpdate() {
+    const { filterKeys } = this.props;
+    if (filterKeys.length === 0) {
       this._updateState();
     }
   }
 
   getFormattedHeaders = () => {
     let i = 0;
-    const { headers } = this.state;
-    const { headerCellFormatter } = this.props;
+    // const { headers } = this.props;
+    const { headerCellFormatter, headers } = this.props;
     const formattedHeaders = headers.map((header) => {
       const el = <DataTableElement key={`header-${i}`} element={header} index={i} formatter={headerCellFormatter} />;
       i += 1;
@@ -131,10 +128,8 @@ class DataTable extends React.Component {
   };
 
   _updateState() {
-    const { headers, rows } = this.props;
+    const { rows } = this.props;
     this.setState({
-      headers: headers,
-      rows: rows,
       filteredRows: rows,
     });
   }
@@ -153,8 +148,9 @@ class DataTable extends React.Component {
       className,
       rowClassName,
       useResponsiveTable,
+      rows,
     } = this.props;
-    const { rows, filteredRows } = this.state;
+    const { filteredRows } = this.state;
     if (filterKeys.length !== 0) {
       filter = (
         <div className="row">

--- a/graylog2-web-interface/src/components/common/TypeAheadDataFilter.jsx
+++ b/graylog2-web-interface/src/components/common/TypeAheadDataFilter.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Immutable from 'immutable';
-
+import { isEqual } from 'lodash';
 import { Button } from 'components/graylog';
 import TypeAheadInput from 'components/common/TypeAheadInput';
 
@@ -70,6 +70,11 @@ class TypeAheadDataFilter extends React.Component {
     filters: Immutable.OrderedSet(),
     filterByKey: `${this.props.filterBy}s`,
   };
+  componentDidUpdate(prevProps) {
+    if (!isEqual(prevProps.data, this.props.data)) {
+      this.filterData();
+    }
+  }
 
   _onSearchTextChanged = (event) => {
     event.preventDefault();

--- a/graylog2-web-interface/src/components/common/TypeAheadDataFilter.jsx
+++ b/graylog2-web-interface/src/components/common/TypeAheadDataFilter.jsx
@@ -172,6 +172,7 @@ class TypeAheadDataFilter extends React.Component {
     }, this);
 
     onDataFiltered(filteredData);
+    return true;
   };
 
   render() {

--- a/graylog2-web-interface/src/components/common/TypeAheadDataFilter.jsx
+++ b/graylog2-web-interface/src/components/common/TypeAheadDataFilter.jsx
@@ -65,13 +65,32 @@ class TypeAheadDataFilter extends React.Component {
     searchInKeys: PropTypes.array,
   };
 
-  state = {
-    filterText: '',
-    filters: Immutable.OrderedSet(),
-    filterByKey: `${this.props.filterBy}s`,
+  static defaultProps = {
+    id: '',
+    data: [],
+    displayKey: '',
+    filterBy: '',
+    filterData: undefined,
+    filterSuggestionAccessor: '',
+    filterSuggestions: [],
+    label: '',
+    onDataFiltered: undefined,
+    searchInKeys: [],
   };
+
+  constructor(props) {
+    super(props);
+    const { filterBy } = this.props;
+    this.state = {
+      filterText: '',
+      filters: Immutable.OrderedSet(),
+      filterByKey: `${filterBy}s`,
+    };
+  }
+
   componentDidUpdate(prevProps) {
-    if (!isEqual(prevProps.data, this.props.data)) {
+    const { data } = this.props;
+    if (!isEqual(prevProps.data, data)) {
       this.filterData();
     }
   }
@@ -82,24 +101,29 @@ class TypeAheadDataFilter extends React.Component {
   };
 
   _onFilterAdded = (event, suggestion) => {
+    const { filters } = this.state;
+    const { displayKey } = this.props;
     this.setState({
-      filters: this.state.filters.add(suggestion[this.props.displayKey]),
+      filters: filters.add(suggestion[displayKey]),
       filterText: '',
     }, this.filterData);
     this.typeAheadInput.clear();
   };
 
   _onFilterRemoved = (event) => {
+    const { filters } = this.state;
     event.preventDefault();
-    this.setState({ filters: this.state.filters.delete(event.target.getAttribute('data-target')) }, this.filterData);
+    this.setState({ filters: filters.delete(event.target.getAttribute('data-target')) }, this.filterData);
   };
 
   _matchFilters = (datum) => {
-    return this.state.filters.every((filter) => {
-      let dataToFilter = datum[this.state.filterByKey];
+    const { filters, filterByKey } = this.state;
+    const { filterSuggestionAccessor } = this.props;
+    return filters.every((filter) => {
+      let dataToFilter = datum[filterByKey];
 
-      if (this.props.filterSuggestionAccessor) {
-        dataToFilter = dataToFilter.map(data => data[this.props.filterSuggestionAccessor].toLocaleLowerCase());
+      if (filterSuggestionAccessor) {
+        dataToFilter = dataToFilter.map(data => data[filterSuggestionAccessor].toLocaleLowerCase());
       } else {
         dataToFilter = dataToFilter.map(data => data.toLocaleLowerCase());
       }
@@ -109,9 +133,11 @@ class TypeAheadDataFilter extends React.Component {
   };
 
   _matchStringSearch = (datum) => {
-    return this.props.searchInKeys.some((searchInKey) => {
+    const { filterText } = this.state;
+    const { searchInKeys } = this.props;
+    return searchInKeys.some((searchInKey) => {
       const key = datum[searchInKey];
-      const value = this.state.filterText;
+      const value = filterText;
 
       if (key === null) {
         return false;
@@ -136,24 +162,27 @@ class TypeAheadDataFilter extends React.Component {
   };
 
   filterData = () => {
-    if (typeof this.props.filterData === 'function') {
-      return this.props.filterData(this.props.data);
+    const { filterData, data, onDataFiltered } = this.props;
+    if (typeof filterData === 'function') {
+      return filterData(data);
     }
 
-    const filteredData = this.props.data.filter((datum) => {
+    const filteredData = data.filter((datum) => {
       return this._matchFilters(datum) && this._matchStringSearch(datum);
     }, this);
 
-    this.props.onDataFiltered(filteredData);
+    onDataFiltered(filteredData);
   };
 
   render() {
-    const filters = this.state.filters.map((filter) => {
+    const { filters, filterText } = this.state;
+    const { id, label, displayKey, filterBy, filterSuggestionAccessor, filterSuggestions } = this.props;
+    const filtersContent = filters.map((filter) => {
       return (
         <li key={`li-${filter}`}>
           <span className="pill label label-default">
-            {this.props.filterBy}: {filter}
-            <a className="tag-remove" data-target={filter} onClick={this._onFilterRemoved} />
+            {filterBy}: {filter}
+            <button type="button" className="tag-remove" data-target={filter} onClick={this._onFilterRemoved} />
           </span>
         </li>
       );
@@ -161,34 +190,34 @@ class TypeAheadDataFilter extends React.Component {
 
     let suggestions;
 
-    if (this.props.filterSuggestionAccessor) {
-      suggestions = this.props.filterSuggestions.map(filterSuggestion => filterSuggestion[this.props.filterSuggestionAccessor].toLocaleLowerCase());
+    if (filterSuggestionAccessor) {
+      suggestions = filterSuggestions.map(filterSuggestion => filterSuggestion[filterSuggestionAccessor].toLocaleLowerCase());
     } else {
-      suggestions = this.props.filterSuggestions.map(filterSuggestion => filterSuggestion.toLocaleLowerCase());
+      suggestions = filterSuggestions.map(filterSuggestion => filterSuggestion.toLocaleLowerCase());
     }
 
-    suggestions.filter(filterSuggestion => !this.state.filters.includes(filterSuggestion));
+    suggestions.filter(filterSuggestion => !filters.includes(filterSuggestion));
 
     return (
       <div className="filter">
         <form className="form-inline" onSubmit={this._onSearchTextChanged} style={{ display: 'inline' }}>
-          <TypeAheadInput id={this.props.id}
+          <TypeAheadInput id={id}
                           ref={(typeAheadInput) => { this.typeAheadInput = typeAheadInput; }}
                           onSuggestionSelected={this._onFilterAdded}
-                          suggestionText={`Filter by ${this.props.filterBy}: `}
+                          suggestionText={`Filter by ${filterBy}: `}
                           suggestions={suggestions}
-                          label={this.props.label}
-                          displayKey={this.props.displayKey} />
+                          label={label}
+                          displayKey={displayKey} />
           <Button type="submit" style={{ marginLeft: 5 }}>Filter</Button>
           <Button type="button"
                   style={{ marginLeft: 5 }}
                   onClick={this._resetFilters}
-                  disabled={this.state.filters.count() === 0 && this.state.filterText === ''}>
+                  disabled={filters.count() === 0 && filterText === ''}>
             Reset
           </Button>
         </form>
         <ul className="pill-list">
-          {filters}
+          {filtersContent}
         </ul>
       </div>
     );

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackApplyParameter.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackApplyParameter.test.jsx.snap
@@ -139,7 +139,7 @@ exports[`<ContentPackApplyParameter /> should render with full props 1`] = `
               id="config-key-list"
             >
               <table
-                className="table undefined"
+                className="table "
               >
                 <thead>
                   <tr>
@@ -470,7 +470,7 @@ exports[`<ContentPackApplyParameter /> should render with readOnly 1`] = `
               id="config-key-list"
             >
               <table
-                className="table undefined"
+                className="table "
               >
                 <thead>
                   <tr>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackConstraints.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackConstraints.test.jsx.snap
@@ -19,7 +19,7 @@ exports[`<ContentPackConstraints /> should render with created constraints 1`] =
           id="content-packs-constraints"
         >
           <table
-            className="table undefined"
+            className="table "
           >
             <thead>
               <tr>
@@ -106,7 +106,7 @@ exports[`<ContentPackConstraints /> should render with new constraints with forc
           id="content-packs-constraints"
         >
           <table
-            className="table undefined"
+            className="table "
           >
             <thead>
               <tr>
@@ -193,7 +193,7 @@ exports[`<ContentPackConstraints /> should render with new constraints without f
           id="content-packs-constraints"
         >
           <table
-            className="table undefined"
+            className="table "
           >
             <thead>
               <tr>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntityConfig.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntityConfig.test.jsx.snap
@@ -14,7 +14,7 @@ exports[`<ContentPackEntityConfig /> should render with a entity 1`] = `
           id="entiy-config-list"
         >
           <table
-            className="table undefined"
+            className="table "
           >
             <thead>
               <tr>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstallEntityList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstallEntityList.test.jsx.snap
@@ -43,7 +43,7 @@ exports[`<ContentPackInstallEntityList /> should render with entities 1`] = `
           id="installed-entities"
         >
           <table
-            className="table undefined"
+            className="table "
           >
             <thead>
               <tr>
@@ -106,7 +106,7 @@ exports[`<ContentPackInstallEntityList /> should render with uninstall and entit
           id="installed-entities"
         >
           <table
-            className="table undefined"
+            className="table "
           >
             <thead>
               <tr>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstallations.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstallations.test.jsx.snap
@@ -13,7 +13,7 @@ exports[`<ContentPackInstallations /> should render with a installation 1`] = `
         id="content-packs-versions"
       >
         <table
-          className="table undefined"
+          className="table "
         >
           <thead>
             <tr>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackVersions.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackVersions.test.jsx.snap
@@ -13,7 +13,7 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
         id="content-packs-versions"
       >
         <table
-          className="table undefined"
+          className="table "
         >
           <thead>
             <tr>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix DataTable filter to reapply filter after data updates
## Description
<!--- Describe your changes in detail -->

Before this change when filtering lists (such as pipeline rules) using the filter function, the filter is 'reset' when you perform an action against a selected object. Now the filter is re-applied if data is changed on component update.

Fix (#5965)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
