### PR TITLE
Adding `eslint-plugin-flowtype` for proper flow support in ESLint.

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -5,10 +5,12 @@ module.exports = {
     'plugin:import/errors',
     'plugin:import/warnings',
     'plugin:import/react',
+    'plugin:flowtype/recommended',
   ],
   plugins: [
     'import',
     'react-hooks',
+    'flowtype',
   ],
   rules: {
     'arrow-body-style': 'off',

--- a/graylog2-web-interface/packages/eslint-config-graylog/package.json
+++ b/graylog2-web-interface/packages/eslint-config-graylog/package.json
@@ -16,6 +16,7 @@
     "eslint": "5.16.0",
     "eslint-config-airbnb": "17.1.1",
     "eslint-import-resolver-webpack": "0.11.1",
+    "eslint-plugin-flowtype": "^4.5.2",
     "eslint-plugin-import": "2.18.2",
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-react": "7.16.0",

--- a/graylog2-web-interface/src/stores/StoreTypes.js
+++ b/graylog2-web-interface/src/stores/StoreTypes.js
@@ -1,21 +1,15 @@
 // @flow strict
 
-// eslint-disable-next-line no-undef
 type ExtractResultType = <R>((...any) => Promise<R>) => R;
 
 export type ListenableAction<R> = R & {
   $call: R,
-  // eslint-disable-next-line no-undef
   listen: (($Call<ExtractResultType, R>) => *) => () => void,
   completed: {
-    // eslint-disable-next-line no-undef
     listen: (($Call<ExtractResultType, R>) => *) => () => void,
   },
-  // eslint-disable-next-line no-undef
   promise: (Promise<$Call<ExtractResultType, R>>) => void,
 };
-// eslint-disable-next-line no-undef
 export type RefluxAction = <Fn>(Fn) => ListenableAction<Fn>;
 
-// eslint-disable-next-line no-undef
 export type RefluxActions<A> = $ObjMap<A, RefluxAction>;

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.jsx
@@ -40,7 +40,6 @@ export type VisualizationComponentProps = {|
   toggleEdit: () => void,
 |};
 
-// eslint-disable-next-line no-undef
 export type VisualizationComponent =
   { type?: string, propTypes?: any }
   & React.ComponentType<VisualizationComponentProps>;

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.jsx
@@ -48,28 +48,23 @@ export default class AggregationControls extends React.Component<Props, State> {
     };
   }
 
-  // eslint-disable-next-line no-undef
   _onColumnPivotChange = (columnPivots: $PropertyType<$PropertyType<Props, 'config'>, 'columnPivots'>) => {
     this._setAndPropagate(state => ({ config: state.config.toBuilder().columnPivots(columnPivots).build() }));
   };
 
-  // eslint-disable-next-line no-undef
   _onRowPivotChange = (rowPivots: $PropertyType<$PropertyType<Props, 'config'>, 'rowPivots'>) => {
     this._setAndPropagate(state => ({ config: state.config.toBuilder().rowPivots(rowPivots).build() }));
   };
 
-  // eslint-disable-next-line no-undef
   _onSeriesChange = (series: $PropertyType<$PropertyType<Props, 'config'>, 'series'>) => {
     this._setAndPropagate(state => ({ config: state.config.toBuilder().series(series).build() }));
     return true;
   };
 
-  // eslint-disable-next-line no-undef
   _onSortChange = (sort: $PropertyType<$PropertyType<Props, 'config'>, 'sort'>) => {
     this._setAndPropagate(state => ({ config: state.config.toBuilder().sort(sort).build() }));
   };
 
-  // eslint-disable-next-line no-undef
   _onSortDirectionChange = (direction: $PropertyType<$PropertyType<Props, 'config'>, 'direction'>) => {
     this._setAndPropagate(state => ({
       config: state.config.toBuilder().sort(state.config.sort
@@ -77,17 +72,14 @@ export default class AggregationControls extends React.Component<Props, State> {
     }));
   };
 
-  // eslint-disable-next-line no-undef
   _onRollupChange = (rollup: $PropertyType<$PropertyType<Props, 'config'>, 'rollup'>) => {
     this._setAndPropagate(state => ({ config: state.config.toBuilder().rollup(rollup).build() }));
   };
 
-  // eslint-disable-next-line no-undef
   _onVisualizationChange = (visualization: $PropertyType<$PropertyType<Props, 'config'>, 'visualization'>) => {
     this._setAndPropagate(state => ({ config: state.config.toBuilder().visualization(visualization).visualizationConfig(undefined).build() }));
   };
 
-  // eslint-disable-next-line no-undef
   _onVisualizationConfigChange = (visualizationConfig: $PropertyType<$PropertyType<Props, 'config'>, 'visualizationConfig'>) => {
     this._setAndPropagate(state => ({ config: state.config.toBuilder().visualizationConfig(visualizationConfig).build() }));
   };

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/pivottypes/AutoTimeHistogramPivot.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/pivottypes/AutoTimeHistogramPivot.jsx
@@ -15,7 +15,6 @@ type Props = {
   onChange: OnChange,
 };
 
-// eslint-disable-next-line no-undef
 const _changeScaling = (event: SyntheticInputEvent<HTMLInputElement>, interval: AutoInterval, onChange: OnChange) => {
   const scaling = 1 / FormsUtils.getValueFromInput(event.target);
   onChange({ ...interval, scaling });

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/pivottypes/TimeUnitTimeHistogramPivot.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/pivottypes/TimeUnitTimeHistogramPivot.jsx
@@ -24,7 +24,6 @@ const units = {
   months: 'Months',
 };
 
-// eslint-disable-next-line no-undef
 const _changeValue = (event: SyntheticInputEvent<HTMLInputElement>, interval: TimeUnitInterval, onChange: OnChange) => {
   const value = FormsUtils.getValueFromInput(event.target);
   onChange({ ...interval, value });

--- a/graylog2-web-interface/src/views/components/common/ActionDropdown.jsx
+++ b/graylog2-web-interface/src/views/components/common/ActionDropdown.jsx
@@ -13,7 +13,6 @@ import StopPropagation from './StopPropagation';
 
 type ActionToggleProps = {
   children: React.Node,
-  // eslint-disable-next-line no-undef
   onClick: (SyntheticInputEvent<HTMLButtonElement>) => void,
 };
 
@@ -71,6 +70,8 @@ type ActionDropdownState = {
 };
 
 class ActionDropdown extends React.Component<ActionDropdownProps, ActionDropdownState> {
+  target: ?HTMLElement;
+
   static defaultProps = {
     container: undefined,
   };
@@ -82,14 +83,11 @@ class ActionDropdown extends React.Component<ActionDropdownProps, ActionDropdown
     };
   }
 
-  // eslint-disable-next-line no-undef
   _onToggle = (e: SyntheticInputEvent<HTMLButtonElement>) => {
     e.preventDefault();
     e.stopPropagation();
     this.setState(({ show }) => ({ show: !show }));
   };
-
-  target: ?HTMLElement;
 
   render() {
     const { children, container, element } = this.props;

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
@@ -55,7 +55,6 @@ class QueryTitleEditModal extends React.Component<Props, State> {
     }
   };
 
-  // eslint-disable-next-line no-undef
   _onDraftChange = (evt: SyntheticInputEvent<HTMLInputElement>) => {
     this.setState({ titleDraft: evt.target.value });
   };

--- a/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
@@ -21,7 +21,6 @@ type Props = {
   disabled: boolean,
   value: string,
   completers: Array<Completer>,
-  // eslint-disable-next-line no-undef
   completerClass?: Class<AutoCompleter>,
   onBlur?: (string) => void,
   onChange: (string) => Promise<string>,

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.jsx
@@ -29,13 +29,11 @@ type State = {
 };
 
 class BookmarkControls extends React.Component<Props, State> {
+  formTarget: any;
+
   static propTypes = {
     viewStoreState: PropTypes.object.isRequired,
   };
-
-  static contextType = ViewLoaderContext;
-
-  formTarget: any;
 
   constructor(props: Props) {
     super(props);
@@ -60,7 +58,6 @@ class BookmarkControls extends React.Component<Props, State> {
     this.setState({ showList: !showList });
   };
 
-  // eslint-disable-next-line no-undef
   onChangeTitle = (e: SyntheticInputEvent<HTMLInputElement>) => {
     this.setState({ newTitle: e.target.value });
   };
@@ -148,6 +145,8 @@ class BookmarkControls extends React.Component<Props, State> {
       },
     });
   };
+
+  static contextType = ViewLoaderContext;
 
   render() {
     const { showForm, showList, newTitle } = this.state;

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkForm.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkForm.jsx
@@ -7,7 +7,6 @@ import { Button, ControlLabel, FormControl, FormGroup, Popover } from 'component
 import styles from './BookmarkForm.css';
 
 type Props = {
-  // eslint-disable-next-line no-undef
   onChangeTitle: (SyntheticInputEvent<HTMLInputElement>) => void,
   saveSearch: () => void,
   saveAsSearch: () => void,

--- a/graylog2-web-interface/src/views/components/views/ShareViewModal.jsx
+++ b/graylog2-web-interface/src/views/components/views/ShareViewModal.jsx
@@ -88,7 +88,6 @@ class ShareViewModal extends React.Component<Props, State> {
   // eslint-disable-next-line react/destructuring-assignment
   _onClose = () => this.props.onClose();
 
-  // eslint-disable-next-line no-undef
   _onChange = (e: SyntheticInputEvent<HTMLInputElement>) => {
     const { view } = this.props;
     const type = e.target.name;

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/WidgetFormattingSettings.js
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/WidgetFormattingSettings.js
@@ -14,7 +14,6 @@ export type WidgetFormattingSettingsJSON = {
 export default class WidgetFormattingSettings {
   _value: InternalState;
 
-  // eslint-disable-next-line no-undef
   constructor(chartColors: $PropertyType<InternalState, 'chartColors'>) {
     this._value = { chartColors };
   }
@@ -28,7 +27,6 @@ export default class WidgetFormattingSettings {
     return new Builder(Immutable.Map(this._value));
   }
 
-  // eslint-disable-next-line no-undef
   static create(chartColors: $PropertyType<InternalState, 'chartColors'>) {
     return new WidgetFormattingSettings(chartColors);
   }
@@ -66,7 +64,6 @@ class Builder {
     this.value = value;
   }
 
-  // eslint-disable-next-line no-undef
   chartColors(value: $PropertyType<InternalState, 'chartColors'>) {
     return new Builder(this.value.set('chartColors', value));
   }

--- a/graylog2-web-interface/src/views/logic/withPluginEntities.jsx
+++ b/graylog2-web-interface/src/views/logic/withPluginEntities.jsx
@@ -5,7 +5,6 @@ import { PluginStore } from 'graylog-web-plugin/plugin';
 function withPluginEntities<Props, Entities: {}>(
   Component: React.AbstractComponent<Props>,
   entityMapping: Entities,
-  // eslint-disable-next-line no-undef
 ): React.AbstractComponent<$Diff<Props, $ObjMapi<Entities, <Key: string>(Key) => $ElementType<Props, Key>>>> {
   const entities = Object.entries(entityMapping)
     .map(([targetKey, entityKey]) => ([targetKey, PluginStore.exports(entityKey)]))

--- a/graylog2-web-interface/src/views/stores/RefreshStore.js
+++ b/graylog2-web-interface/src/views/stores/RefreshStore.js
@@ -6,7 +6,6 @@ import { singletonActions, singletonStore } from 'views/logic/singleton';
 type RefreshActionsType = {
   enable: () => void,
   disable: () => void,
-  /* eslint-disable-next-line no-undef */
   setInterval: (number) => void,
 };
 

--- a/graylog2-web-interface/test/helpers/mocking/AsMock.js
+++ b/graylog2-web-interface/test/helpers/mocking/AsMock.js
@@ -1,8 +1,6 @@
 // @flow strict
 
-/* eslint-disable no-undef */
 // $FlowFixMe: Overriding type
 const asMock = (fn): JestMockFn<*, *> => fn;
-/* eslint-enable no-undef */
 
 export default asMock;

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -5331,6 +5331,7 @@ eslint-config-airbnb@17.1.1:
     eslint "5.16.0"
     eslint-config-airbnb "17.1.1"
     eslint-import-resolver-webpack "0.11.1"
+    eslint-plugin-flowtype "^4.5.2"
     eslint-plugin-import "2.18.2"
     eslint-plugin-jsx-a11y "6.2.3"
     eslint-plugin-react "7.16.0"
@@ -5378,6 +5379,13 @@ eslint-module-utils@^2.4.0:
   dependencies:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
+
+eslint-plugin-flowtype@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-4.5.2.tgz#5353449692663ef70e8fc8c2386cebdecac7e86b"
+  integrity sha512-ByV0EtEQOqiCl6bsrtXtTGnXlIXoyvDrvUq3Nz28huODAhnRDuMotyTrwP+TjAKZMPWbtaNGFHMoUxW3DktGOw==
+  dependencies:
+    lodash "^4.17.15"
 
 eslint-plugin-import@2.18.2:
   version "2.18.2"
@@ -7206,7 +7214,7 @@ gray-matter@^3.0.8:
   dependencies:
     "@babel/preset-env" "7.6.3"
     babel-eslint "9.0.0"
-    eslint-config-graylog "file:packages/eslint-config-graylog"
+    eslint-config-graylog "file:../../../../Library/Caches/Yarn/v4/npm-graylog-web-plugin-3.2.0-SNAPSHOT-6b5d27e0-4be5-43b5-b411-2a3e1c260a7b-1574687464651/node_modules/eslint-config-graylog"
     html-webpack-plugin "3.2.0"
     javascript-natural-sort "0.7.1"
     jquery "3.4.1"


### PR DESCRIPTION
Prior to this change, ESLint threw errors for undefined variables in some cases when flow utility types have been used. These required disabling the `no-undef` rule selectively when this was the case.

This PR adds the [`eslint-plugin-flowtype`](https://github.com/gajus/eslint-plugin-flowtype) ESLint plugin, which helps avoiding this. Right now it is using the recommended configuration, further fine-tuning according to our desires can be performed later.