### PR TITLE
Fix worldmap error when row pivot is set, metric is not set and the widget result is empty.

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/MapVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/MapVisualization.jsx
@@ -141,8 +141,8 @@ class MapVisualization extends React.Component {
     const markers = [];
     data.forEach(({ keys, name, values }, idx) => {
       const y = Object.values(values);
-      const min = y.reduce((prev, next) => Math.min(prev, next));
-      const max = y.reduce((prev, next) => Math.max(prev, next));
+      const min = Math.min(...y);
+      const max = Math.max(...y);
       const color = chromaScale(idx * (1 / noOfKeys));
       Object.entries(values)
         .forEach(([coord, value], valueIdx) => markers

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/WorldMapVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/WorldMapVisualization.jsx
@@ -21,7 +21,10 @@ const _mergeObject = (prev, last) => Object.assign({}, prev, last);
 const _createSeriesWithoutMetric = (rows: Rows) => {
   const leafs = getLeafsFromRows(rows);
   const xLabels = getXLabelsFromLeafs(leafs);
-  return { valuesBySeries: { 'No metric defined': xLabels.map(() => null) }, xLabels };
+  if (!isEmpty(xLabels)) {
+    return { valuesBySeries: { 'No metric defined': xLabels.map(() => null) }, xLabels };
+  }
+  return {};
 };
 const _formatSeriesForMap = (rowPivots: Array<Pivot>) => {
   return result => result.map(({ name, x, y }) => {


### PR DESCRIPTION
The main problem is, we are passing data ("No metric set" Info) to the `MapVisualization`, even when there are no results. This resulted in an error like `Cannot reduce an empty array`. 
I fixed this case. Because I found initially a solution to prevent the `.reduce` error inside the `MapVisualization`, I've added these changes as well.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
