### PR TITLE
Guard against empty metrics array

### DIFF
--- a/graylog2-web-interface/src/components/metrics/MetricContainer.jsx
+++ b/graylog2-web-interface/src/components/metrics/MetricContainer.jsx
@@ -59,7 +59,7 @@ const MetricContainer = createReactClass({
       .map(nodeId => MetricsExtractor.getValuesForNode(this.state.metrics[nodeId], { throughput: fullName }))
       .reduce((one, two) => {
         return { throughput: (one.throughput || 0) + (two.throughput || 0) };
-      });
+      }, {});
     if (this.props.zeroOnMissing && (!throughput || !throughput.throughput)) {
       throughput = { throughput: 0 };
     }

--- a/graylog2-web-interface/src/logic/metrics/MetricsExtractor.js
+++ b/graylog2-web-interface/src/logic/metrics/MetricsExtractor.js
@@ -1,10 +1,13 @@
+// @flow strict
+import type { NodeMetric } from 'stores/metrics/MetricsStore';
+
 const MetricsExtractor = {
   /*
    * Returns an object containing a short name and the metric value for it.
    * Short names are the keys of the metricNames object, which should look like:
    * { shortName: "metricFullName" }
    */
-  getValuesForNode(nodeMetrics, metricNames) {
+  getValuesForNode(nodeMetrics: NodeMetric, metricNames: { [string]: string }): { [string]: ?number } {
     if (nodeMetrics === null || nodeMetrics === undefined || Object.keys(nodeMetrics).length === 0) {
       return {};
     }


### PR DESCRIPTION
Ensure `MetricsContainer` can handle an empty metrics array with `reduce()` by setting an initial value to the function.

I also fixed linter errors and included basic flow type information for metrics, which lead to fixing another couple things.

Fixes #6864