### PR TITLE
Adapting Events Search Type to include `name` and new time range.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/searchtypes/ESEventList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/searchtypes/ESEventList.java
@@ -55,9 +55,11 @@ public class ESEventList implements ESSearchTypeHandler<EventList> {
                 .map(EventSummary::parse)
                 .filter(eventSummary -> effectiveStreams.containsAll(eventSummary.streams()))
                 .collect(Collectors.toList());
-        return EventList.Result.builder()
+        final EventList.Result.Builder resultBuilder = EventList.Result.builder()
                 .events(eventSummaries)
-                .id(searchType.id())
+                .id(searchType.id());
+        searchType.name().ifPresent(resultBuilder::name);
+        return resultBuilder
                 .build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/events/EventList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/events/EventList.java
@@ -27,7 +27,7 @@ import com.google.common.collect.ImmutableSet;
 import org.graylog.plugins.views.search.Filter;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.engine.BackendQuery;
-import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -89,13 +89,16 @@ public abstract class EventList implements SearchType {
         public abstract Builder id(String id);
 
         @JsonProperty
+        public abstract Builder name(@Nullable String name);
+
+        @JsonProperty
         public abstract Builder filter(@Nullable Filter filter);
 
         @JsonProperty
         public abstract Builder query(@Nullable BackendQuery query);
 
         @JsonProperty
-        public abstract Builder timerange(@Nullable TimeRange timeRange);
+        public abstract Builder timerange(@Nullable DerivedTimeRange timeRange);
 
         @JsonProperty
         public abstract Builder streams(Set<String> streams);
@@ -129,6 +132,8 @@ public abstract class EventList implements SearchType {
         @AutoValue.Builder
         public abstract static class Builder {
             public abstract Builder id(String id);
+
+            public abstract Builder name(String name);
 
             public abstract Builder events(List<EventSummary> events);
 


### PR DESCRIPTION
## Description
## Motivation and Context
This PR is fixing up required changes to the `events` search type which are now required due to the introduction of 5ee5115642dd0c8d6a1f7ed58f68317a9ccda3f0 and 75bd8ca28c2a672a646ea807e5a7acc7c63c81a0. These require a search type:

  - to handle an optional `name` argument and pass it through to its
results
  - to consume the time range wrapped in a `DerivedTimeRange` instance,
allowing `OffsetRange` instances to be used

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)