### PR TITLE
Add delay for displaying the loading spinner

### DIFF
--- a/graylog2-web-interface/src/components/common/Spinner.jsx
+++ b/graylog2-web-interface/src/components/common/Spinner.jsx
@@ -1,22 +1,52 @@
-import React from 'react';
+// @flow
+import React, { useState, useEffect } from 'react';
+import type { ComponentType } from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
 import Icon from './Icon';
+
+const Wrapper: ComponentType<{ visible: boolean }> = styled.span`
+  visibility: ${({ visible }) => (visible ? 'visible' : 'hidden')};
+`;
+
+type Props = {
+  delay?: number,
+  name?: string,
+  text?: string,
+}
 
 /**
  * Simple spinner to use while waiting for something to load.
  */
-const Spinner = ({ name, text, ...props }) => <span><Icon name={name} spin {...props} /> {text}</span>;
+const Spinner = ({ name, text, delay, ...rest }: Props) => {
+  const [delayFinished, setDelayFinished] = useState(false);
+
+  useEffect(() => {
+    const delayTimeout = window.setTimeout(() => {
+      setDelayFinished(true);
+    }, delay);
+
+    return () => clearTimeout(delayTimeout);
+  }, []);
+
+  return <Wrapper visible={delayFinished}><Icon name={name} spin {...rest} /> {text}</Wrapper>;
+};
+
 
 Spinner.propTypes = {
+  /** Delay in ms before displaying the spinner */
+  delay: PropTypes.number,
   /** Name of the Icon to use. */
   name: PropTypes.string,
   /** Text to show while loading. */
   text: PropTypes.string,
 };
+
 Spinner.defaultProps = {
   name: 'spinner',
   text: 'Loading...',
+  delay: 200,
 };
 
 export default Spinner;

--- a/graylog2-web-interface/src/components/common/__snapshots__/Spinner.test.jsx.snap
+++ b/graylog2-web-interface/src/components/common/__snapshots__/Spinner.test.jsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Spinner /> should render with a different text string 1`] = `
-<span>
+<span
+  className="Spinner__Wrapper-hg0ct4-0 hyHIAb"
+>
   <i
     className="fa fa-spinner fa-spin"
   />
@@ -11,7 +13,9 @@ exports[`<Spinner /> should render with a different text string 1`] = `
 `;
 
 exports[`<Spinner /> should render without props 1`] = `
-<span>
+<span
+  className="Spinner__Wrapper-hg0ct4-0 hyHIAb"
+>
   <i
     className="fa fa-spinner fa-spin"
   />

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
@@ -471,7 +471,9 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
 `;
 
 exports[`<ContentPackEdit /> should render spinner with no content pack 1`] = `
-<span>
+<span
+  className="Spinner__Wrapper-hg0ct4-0 hyHIAb"
+>
   <i
     className="fa fa-spinner fa-spin"
   />

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstallEntityList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstallEntityList.test.jsx.snap
@@ -153,7 +153,9 @@ exports[`<ContentPackInstallEntityList /> should render with uninstall and entit
 `;
 
 exports[`<ContentPackInstallEntityList /> should render without entities 1`] = `
-<span>
+<span
+  className="Spinner__Wrapper-hg0ct4-0 hyHIAb"
+>
   <i
     className="fa fa-spinner fa-spin"
   />

--- a/graylog2-web-interface/src/pages/ShowMessagePage.test.jsx
+++ b/graylog2-web-interface/src/pages/ShowMessagePage.test.jsx
@@ -3,6 +3,9 @@ import { mount } from 'enzyme';
 import { StoreMock } from 'helpers/mocking';
 
 jest.mock('components/search/MessageDetail', () => 'message-detail');
+// We need to mock the spinner here, because it's a hook component, which gets returned by the ShowMessagePage.
+// This does not work in combination with the require() we are using in beforeEach()
+jest.mock('components/common/Spinner', () => 'div');
 
 const message = {
   id: '20f683d2-a874-11e9-8a11-0242ac130004',


### PR DESCRIPTION
Adding a 200ms delay for displaying the loading spinner is a simple change to improve the look and feel.

The idea:
Everything that loads faster than 200ms does not need a loading spinner. When something takes longer than 200ms to load, the user will not really see the delay, because it is so short.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
