### PR TITLE
Fixed ES result size for MessageList with limit

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/searchtypes/ESMessageList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/searchtypes/ESMessageList.java
@@ -55,7 +55,7 @@ public class ESMessageList implements ESSearchTypeHandler<MessageList> {
         final String queryString = this.esQueryDecorators.decorate(((ElasticsearchQueryString)query.query()).queryString(), job, query, Collections.emptySet());
 
         final SearchSourceBuilder searchSourceBuilder = queryContext.searchSourceBuilder(messageList)
-                .size(messageList.limit() - messageList.offset())
+                .size(messageList.limit())
                 .from(messageList.offset())
                 .highlighter(new HighlightBuilder().requireFieldMatch(false)
                         .highlightQuery(QueryBuilders.queryStringQuery(queryString))


### PR DESCRIPTION
## Description
Use limit from `MessageList` as is instead of subtracting offset from it which has led to an exception whenever offset exceeds limit (and truncated results when 0 < offset < limit).

This never popped up before, because we had no pagination and offset and limit were hardcoded in the frontend.

## How Has This Been Tested?
I've only tested this manually to not delay our work on pagination. We should write comprehensive integration tests for search execution after the 3.2 release.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

