### PR TITLE
Include `messages` field if empty in message list search type result.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/MessageList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/MessageList.java
@@ -153,7 +153,7 @@ public abstract class MessageList implements SearchType {
     }
 
     @AutoValue
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public abstract static class Result implements SearchType.Result {
 
         @Override


### PR DESCRIPTION
## Description
## Motivation and Context

In 5ee5115642dd0c8d6a1f7ed58f68317a9ccda3f0 an optional name attribute defined by the caller for a search type, which is passed through to its results, was introduced. To leave it out when it is empty, the `@JsonInclude(NON_EMPTY)` annotation was added. Unfortunately, this also leaves out the `messages` in the result if it is empty, breaking consumer logic which expects it to be present.

This change turns it into `NON_ABSENT` which skips `Optional`s which are empty, but includes empty collections.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)