### PR TITLE
Ensure that aggregation events always have a "source_streams" value

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
@@ -43,8 +43,11 @@ import org.graylog2.indexer.messages.Messages;
 import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.MessageSummary;
+import org.graylog2.plugin.database.Persisted;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+import org.graylog2.streams.StreamImpl;
+import org.graylog2.streams.StreamService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,6 +77,7 @@ public class AggregationEventProcessor implements EventProcessor {
     private final EventProcessorDependencyCheck dependencyCheck;
     private final DBEventProcessorStateService stateService;
     private final MoreSearch moreSearch;
+    private final StreamService streamService;
     private final Messages messages;
 
     @Inject
@@ -82,6 +86,7 @@ public class AggregationEventProcessor implements EventProcessor {
                                      EventProcessorDependencyCheck dependencyCheck,
                                      DBEventProcessorStateService stateService,
                                      MoreSearch moreSearch,
+                                     StreamService streamService,
                                      Messages messages) {
         this.eventDefinition = eventDefinition;
         this.config = (AggregationEventProcessorConfig) eventDefinition.config();
@@ -89,6 +94,7 @@ public class AggregationEventProcessor implements EventProcessor {
         this.dependencyCheck = dependencyCheck;
         this.stateService = stateService;
         this.moreSearch = moreSearch;
+        this.streamService = streamService;
         this.messages = messages;
     }
 
@@ -231,9 +237,28 @@ public class AggregationEventProcessor implements EventProcessor {
         final ImmutableList.Builder<EventWithContext> eventsWithContext = ImmutableList.builder();
 
         final Set<String> searchStreams = getStreams(parameters);
-        // We don't want source streams in the event which are unrelated to the event definition.
-        // If the search streams is empty though, we search in all streams and so we include all source streams.
-        final Set<String> sourceStreams = searchStreams.isEmpty() ? result.sourceStreams() : Sets.intersection(searchStreams, result.sourceStreams());
+        final Set<String> sourceStreams;
+
+        if (searchStreams.isEmpty() && result.sourceStreams().isEmpty()) {
+            // This can happen if the user didn't select any stream in the event definition and an event should be
+            // created based on the absence of a search result. (e.g. count() < 1)
+            // When the source streams field of an event is empty, every user can see it. That's why we need to add
+            // streams to the field. We decided to use all currently existing streams (minus the default event streams)
+            // to make sure only users that have access to all message streams can see the event.
+            sourceStreams = streamService.loadAll().stream()
+                    .map(Persisted::getId)
+                    .filter(streamId -> !StreamImpl.DEFAULT_EVENT_STREAM_IDS.contains(streamId))
+                    .collect(Collectors.toSet());
+        } else if (searchStreams.isEmpty()) {
+            // If the search streams is empty, we search in all streams and so we include all source streams from the result.
+            sourceStreams = result.sourceStreams();
+        } else if (result.sourceStreams().isEmpty()) {
+            // With an empty result we just include all streams from the event definition.
+            sourceStreams = searchStreams;
+        } else {
+            // We don't want source streams in the event which are unrelated to the event definition.
+            sourceStreams = Sets.intersection(searchStreams, result.sourceStreams());
+        }
 
         for (final AggregationKeyResult keyResult : result.keyResults()) {
             if (!satisfiesConditions(keyResult)) {

--- a/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorTest.java
@@ -33,6 +33,9 @@ import org.graylog.events.search.MoreSearch;
 import org.graylog2.indexer.messages.Messages;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
+import org.graylog2.streams.StreamImpl;
+import org.graylog2.streams.StreamMock;
+import org.graylog2.streams.StreamService;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Rule;
@@ -40,6 +43,8 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
+
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -68,6 +73,8 @@ public class AggregationEventProcessorTest {
     private EventProcessorDependencyCheck eventProcessorDependencyCheck;
     @Mock
     private Messages messages;
+    @Mock
+    private StreamService streamService;
 
     @Test
     public void testEventsFromAggregationResult() {
@@ -103,7 +110,7 @@ public class AggregationEventProcessorTest {
                 .timerange(timerange)
                 .build();
 
-        final AggregationEventProcessor eventProcessor = new AggregationEventProcessor(eventDefinitionDto, searchFactory, eventProcessorDependencyCheck, stateService, moreSearch, messages);
+        final AggregationEventProcessor eventProcessor = new AggregationEventProcessor(eventDefinitionDto, searchFactory, eventProcessorDependencyCheck, stateService, moreSearch, streamService, messages);
 
         final AggregationResult result = AggregationResult.builder()
                 .effectiveTimerange(timerange)
@@ -215,7 +222,7 @@ public class AggregationEventProcessorTest {
                 .timerange(timerange)
                 .build();
 
-        final AggregationEventProcessor eventProcessor = new AggregationEventProcessor(eventDefinitionDto, searchFactory, eventProcessorDependencyCheck, stateService, moreSearch, messages);
+        final AggregationEventProcessor eventProcessor = new AggregationEventProcessor(eventDefinitionDto, searchFactory, eventProcessorDependencyCheck, stateService, moreSearch, streamService, messages);
 
         final AggregationResult result = AggregationResult.builder()
                 .effectiveTimerange(timerange)
@@ -327,7 +334,7 @@ public class AggregationEventProcessorTest {
                 .timerange(timerange)
                 .build();
 
-        final AggregationEventProcessor eventProcessor = new AggregationEventProcessor(eventDefinitionDto, searchFactory, eventProcessorDependencyCheck, stateService, moreSearch, messages);
+        final AggregationEventProcessor eventProcessor = new AggregationEventProcessor(eventDefinitionDto, searchFactory, eventProcessorDependencyCheck, stateService, moreSearch, streamService, messages);
 
         assertThatCode(() -> eventProcessor.createEvents(eventFactory, parameters, (events) -> {})).doesNotThrowAnyException();
 
@@ -369,7 +376,7 @@ public class AggregationEventProcessorTest {
                 .timerange(timerange)
                 .build();
 
-        final AggregationEventProcessor eventProcessor = new AggregationEventProcessor(eventDefinitionDto, searchFactory, eventProcessorDependencyCheck, stateService, moreSearch, messages);
+        final AggregationEventProcessor eventProcessor = new AggregationEventProcessor(eventDefinitionDto, searchFactory, eventProcessorDependencyCheck, stateService, moreSearch, streamService, messages);
 
         // If the dependency check returns true, there should be no exception raised and the state service should be called
         when(eventProcessorDependencyCheck.hasMessagesIndexedUpTo(timerange.to())).thenReturn(true);
@@ -406,5 +413,183 @@ public class AggregationEventProcessorTest {
                 eq(parameters.batchSize()),
                 any(MoreSearch.ScrollCallback.class)
         );
+    }
+
+    @Test
+    public void testEventsFromAggregationResultWithEmptyResultUsesEventDefinitionStreamAsSourceStreams() {
+        final DateTime now = DateTime.now(DateTimeZone.UTC);
+        final AbsoluteRange timerange = AbsoluteRange.create(now.minusHours(1), now.plusHours(1));
+
+        // We expect to get the end of the aggregation timerange as event time
+        final TestEvent event1 = new TestEvent(timerange.to());
+        final TestEvent event2 = new TestEvent(timerange.to());
+        when(eventFactory.createEvent(any(EventDefinition.class), eq(timerange.to()), anyString()))
+                .thenReturn(event1)  // first invocation return value
+                .thenReturn(event2); // second invocation return value
+
+        final EventDefinitionDto eventDefinitionDto = EventDefinitionDto.builder()
+                .id("dto-id-1")
+                .title("Test Aggregation")
+                .description("A test aggregation event processors")
+                .priority(1)
+                .alert(false)
+                .notificationSettings(EventNotificationSettings.withGracePeriod(60000))
+                .config(AggregationEventProcessorConfig.builder()
+                        .query("")
+                        .streams(ImmutableSet.of("stream-2"))
+                        .groupBy(ImmutableList.of("group_field_one", "group_field_two"))
+                        .series(ImmutableList.of())
+                        .conditions(null)
+                        .searchWithinMs(30000)
+                        .executeEveryMs(30000)
+                        .build())
+                .keySpec(ImmutableList.of())
+                .build();
+        final AggregationEventProcessorParameters parameters = AggregationEventProcessorParameters.builder()
+                .timerange(timerange)
+                .build();
+
+        final AggregationEventProcessor eventProcessor = new AggregationEventProcessor(eventDefinitionDto, searchFactory, eventProcessorDependencyCheck, stateService, moreSearch, streamService, messages);
+
+        final AggregationResult result = AggregationResult.builder()
+                .effectiveTimerange(timerange)
+                .totalAggregatedMessages(0)
+                .sourceStreams(ImmutableSet.of()) // No streams in result
+                .keyResults(ImmutableList.of(
+                        AggregationKeyResult.builder()
+                                .key(ImmutableList.of("one", "two"))
+                                .seriesValues(ImmutableList.of(
+                                        AggregationSeriesValue.builder()
+                                                .key(ImmutableList.of("a"))
+                                                .value(0.0d)
+                                                .series(AggregationSeries.builder()
+                                                        .id("abc123")
+                                                        .function(AggregationFunction.COUNT)
+                                                        .build())
+                                                .build()
+                                ))
+                                .build()
+                ))
+                .build();
+
+        final ImmutableList<EventWithContext> eventsWithContext = eventProcessor.eventsFromAggregationResult(eventFactory, parameters, result);
+
+        assertThat(eventsWithContext).hasSize(1);
+
+        assertThat(eventsWithContext.get(0)).satisfies(eventWithContext -> {
+            final Event event = eventWithContext.event();
+
+            assertThat(event.getId()).isEqualTo(event1.getId());
+            assertThat(event.getMessage()).isEqualTo(event1.getMessage());
+            assertThat(event.getEventTimestamp()).isEqualTo(timerange.to());
+            assertThat(event.getTimerangeStart()).isEqualTo(timerange.from());
+            assertThat(event.getTimerangeEnd()).isEqualTo(timerange.to());
+            // Must contain the stream from the event definition because there is none in the result
+            assertThat(event.getSourceStreams()).containsOnly("stream-2");
+
+            final Message message = eventWithContext.messageContext().orElse(null);
+
+            assertThat(message).isNotNull();
+            assertThat(message.getField("group_field_one")).isEqualTo("one");
+            assertThat(message.getField("group_field_two")).isEqualTo("two");
+            assertThat(message.getField("aggregation_key")).isEqualTo("one|two");
+            assertThat(message.getField("aggregation_value_count")).isEqualTo(0.0d);
+        });
+    }
+
+    @Test
+    public void testEventsFromAggregationResultWithEmptyResultAndNoConfiguredStreamsUsesAllStreamsAsSourceStreams() {
+        final DateTime now = DateTime.now(DateTimeZone.UTC);
+        final AbsoluteRange timerange = AbsoluteRange.create(now.minusHours(1), now.plusHours(1));
+
+        // We expect to get the end of the aggregation timerange as event time
+        final TestEvent event1 = new TestEvent(timerange.to());
+        final TestEvent event2 = new TestEvent(timerange.to());
+        when(eventFactory.createEvent(any(EventDefinition.class), eq(timerange.to()), anyString()))
+                .thenReturn(event1)  // first invocation return value
+                .thenReturn(event2); // second invocation return value
+
+        when(streamService.loadAll()).thenReturn(ImmutableList.of(
+                new StreamMock(Collections.singletonMap("_id", "stream-1"), Collections.emptyList()),
+                new StreamMock(Collections.singletonMap("_id", "stream-2"), Collections.emptyList()),
+                new StreamMock(Collections.singletonMap("_id", "stream-3"), Collections.emptyList()),
+                new StreamMock(Collections.singletonMap("_id", StreamImpl.DEFAULT_STREAM_ID), Collections.emptyList()),
+                new StreamMock(Collections.singletonMap("_id", StreamImpl.DEFAULT_EVENTS_STREAM_ID), Collections.emptyList()),
+                new StreamMock(Collections.singletonMap("_id", StreamImpl.DEFAULT_SYSTEM_EVENTS_STREAM_ID), Collections.emptyList())
+        ));
+
+        final EventDefinitionDto eventDefinitionDto = EventDefinitionDto.builder()
+                .id("dto-id-1")
+                .title("Test Aggregation")
+                .description("A test aggregation event processors")
+                .priority(1)
+                .alert(false)
+                .notificationSettings(EventNotificationSettings.withGracePeriod(60000))
+                .config(AggregationEventProcessorConfig.builder()
+                        .query("")
+                        .streams(ImmutableSet.of()) // No configured streams!
+                        .groupBy(ImmutableList.of("group_field_one", "group_field_two"))
+                        .series(ImmutableList.of())
+                        .conditions(null)
+                        .searchWithinMs(30000)
+                        .executeEveryMs(30000)
+                        .build())
+                .keySpec(ImmutableList.of())
+                .build();
+        final AggregationEventProcessorParameters parameters = AggregationEventProcessorParameters.builder()
+                .timerange(timerange)
+                .build();
+
+        final AggregationEventProcessor eventProcessor = new AggregationEventProcessor(eventDefinitionDto, searchFactory, eventProcessorDependencyCheck, stateService, moreSearch, streamService, messages);
+
+        final AggregationResult result = AggregationResult.builder()
+                .effectiveTimerange(timerange)
+                .totalAggregatedMessages(0)
+                .sourceStreams(ImmutableSet.of()) // No streams in result
+                .keyResults(ImmutableList.of(
+                        AggregationKeyResult.builder()
+                                .key(ImmutableList.of("one", "two"))
+                                .seriesValues(ImmutableList.of(
+                                        AggregationSeriesValue.builder()
+                                                .key(ImmutableList.of("a"))
+                                                .value(0.0d)
+                                                .series(AggregationSeries.builder()
+                                                        .id("abc123")
+                                                        .function(AggregationFunction.COUNT)
+                                                        .build())
+                                                .build()
+                                ))
+                                .build()
+                ))
+                .build();
+
+        final ImmutableList<EventWithContext> eventsWithContext = eventProcessor.eventsFromAggregationResult(eventFactory, parameters, result);
+
+        assertThat(eventsWithContext).hasSize(1);
+
+        assertThat(eventsWithContext.get(0)).satisfies(eventWithContext -> {
+            final Event event = eventWithContext.event();
+
+            assertThat(event.getId()).isEqualTo(event1.getId());
+            assertThat(event.getMessage()).isEqualTo(event1.getMessage());
+            assertThat(event.getEventTimestamp()).isEqualTo(timerange.to());
+            assertThat(event.getTimerangeStart()).isEqualTo(timerange.from());
+            assertThat(event.getTimerangeEnd()).isEqualTo(timerange.to());
+            // Must contain all existing streams but the default event streams!
+            assertThat(event.getSourceStreams()).containsOnly(
+                    "stream-1",
+                    "stream-2",
+                    "stream-3",
+                    StreamImpl.DEFAULT_STREAM_ID
+            );
+
+            final Message message = eventWithContext.messageContext().orElse(null);
+
+            assertThat(message).isNotNull();
+            assertThat(message.getField("group_field_one")).isEqualTo("one");
+            assertThat(message.getField("group_field_two")).isEqualTo("two");
+            assertThat(message.getField("aggregation_key")).isEqualTo("one|two");
+            assertThat(message.getField("aggregation_value_count")).isEqualTo(0.0d);
+        });
     }
 }


### PR DESCRIPTION
Fixes #6876

This needs to be backported to 3.1.