### PR TITLE
Fix error on adding field to Event Definition

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/FieldForm.jsx
@@ -11,13 +11,12 @@ import {
   FormControl,
   FormGroup,
   HelpBlock,
-  Icon,
   InputGroup,
   OverlayTrigger,
   Row,
 } from 'components/graylog';
 import { Input } from 'components/bootstrap';
-import { Select } from 'components/common';
+import { Icon, Select } from 'components/common';
 import EventKeyHelpPopover from 'components/event-definitions/common/EventKeyHelpPopover';
 
 import FormsUtils from 'util/FormsUtils';


### PR DESCRIPTION
Correct module used to import `Icon`. I also did a quick look and it seems all other imports for `Icon` are fine.

Fixes #6884
