### PR TITLE
Render events in timebased bar, line and scatter charts

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/AggregationConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/AggregationConfigDTO.java
@@ -41,6 +41,7 @@ public abstract class AggregationConfigDTO implements WidgetConfigDTO {
     static final String FIELD_VISUALIZATION_CONFIG = "visualization_config";
     static final String FIELD_ROLLUP = "rollup";
     static final String FIELD_FORMATTING_SETTINGS = "formatting_settings";
+    static final String FIELD_EVENT_ANNOTATION = "event_annotation";
 
     @JsonProperty(FIELD_ROW_PIVOTS)
     public abstract List<PivotDTO> rowPivots();
@@ -67,6 +68,9 @@ public abstract class AggregationConfigDTO implements WidgetConfigDTO {
 
     @JsonProperty(FIELD_ROLLUP)
     public abstract boolean rollup();
+
+    @JsonProperty(FIELD_EVENT_ANNOTATION)
+    public abstract boolean eventAnnotation();
 
     @AutoValue.Builder
     public static abstract class Builder {
@@ -101,11 +105,15 @@ public abstract class AggregationConfigDTO implements WidgetConfigDTO {
         @JsonProperty(FIELD_ROLLUP)
         public abstract Builder rollup(boolean roolup);
 
+        @JsonProperty(FIELD_EVENT_ANNOTATION)
+        public abstract Builder eventAnnotation(boolean eventAnnotation);
+
         public abstract AggregationConfigDTO build();
 
         @JsonCreator
         static Builder builder() {
             return new AutoValue_AggregationConfigDTO.Builder()
+                    .eventAnnotation(false)
                     .rollup(true);
         }
     }

--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -25,6 +25,8 @@ import PivotConfigGenerator from 'views/logic/searchtypes/aggregation/PivotConfi
 import PivotHandler from 'views/logic/searchtypes/pivot/PivotHandler';
 import PivotTransformer from 'views/logic/searchresulttransformers/PivotTransformer';
 
+import EventHandler from 'views/logic/searchtypes/events/EventHandler';
+
 import Widget from 'views/logic/widgets/Widget';
 import AggregationWidget from 'views/logic/aggregationbuilder/AggregationWidget';
 import MessagesWidget from 'views/logic/widgets/MessagesWidget';
@@ -171,6 +173,11 @@ export default {
     {
       type: 'pivot',
       handler: PivotHandler,
+      defaults: {},
+    },
+    {
+      type: 'events',
+      handler: EventHandler,
       defaults: {},
     },
   ],

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.jsx
@@ -63,7 +63,7 @@ const _visualizationForType = (type: string): VisualizationComponent => {
   return visualization.component;
 };
 
-const getResult = (value: RowResult|EventResult): Rows|Events => {
+const getResult = (value: RowResult | EventResult): Rows | Events => {
   if (value.type === 'events') {
     return value.events;
   }
@@ -80,7 +80,7 @@ const AggregationBuilder = ({ config, data, editing = false, fields, onVisualiza
   const rows = Object.entries(data)
     .map(
       // $FlowFixMe: map claims it's `mixed`, we know it's `RowResult`
-      ([key, value]: [string, RowResult]|['events', EventResult]) => [
+      ([key, value]: [string, RowResult] | ['events', EventResult]) => [
         key,
         getResult(value),
       ],

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.jsx
@@ -6,6 +6,7 @@ import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationW
 import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
 import type { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
+import type { Events } from 'views/logic/searchtypes/events/EventHandler';
 import type { TimeRange } from 'views/logic/queries/Query';
 
 import EmptyAggregationContent from './EmptyAggregationContent';
@@ -15,15 +16,22 @@ const defaultVisualizationType = 'table';
 
 type OnVisualizationConfigChange = (VisualizationConfig) => void;
 
-type Result = {
+type RowResult = {
+  type: 'pivot',
   total: number,
   rows: Rows,
   effective_timerange: TimeRange,
 };
 
+type EventResult = {
+  events: Events,
+  type: 'events',
+  name: 'events',
+};
+
 type Props = {
   config: AggregationWidgetConfig,
-  data: { [string]: Result },
+  data: { [string]: RowResult },
   editing?: boolean,
   toggleEdit: () => void,
   fields: FieldTypeMappingsList,
@@ -32,7 +40,7 @@ type Props = {
 
 export type VisualizationComponentProps = {|
   config: AggregationWidgetConfig,
-  data: { [string]: Rows },
+  data: { [string]: Rows, events?: Events },
   editing?: boolean,
   effectiveTimerange: TimeRange,
   fields: FieldTypeMappingsList,
@@ -55,6 +63,13 @@ const _visualizationForType = (type: string): VisualizationComponent => {
   return visualization.component;
 };
 
+const getResult = (value: RowResult|EventResult): Rows|Events => {
+  if (value.type === 'events') {
+    return value.events;
+  }
+  return value.rows;
+};
+
 const AggregationBuilder = ({ config, data, editing = false, fields, onVisualizationConfigChange = () => {}, toggleEdit }: Props) => {
   if (!config || config.isEmpty) {
     return <EmptyAggregationContent toggleEdit={toggleEdit} editing={editing} />;
@@ -64,10 +79,10 @@ const AggregationBuilder = ({ config, data, editing = false, fields, onVisualiza
   const { effective_timerange: effectiveTimerange } = data && data.chart ? data.chart : {};
   const rows = Object.entries(data)
     .map(
-      // $FlowFixMe: map claims it's `mixed`, we know it's `Result`
-      ([key, value]: [string, Result]) => [
+      // $FlowFixMe: map claims it's `mixed`, we know it's `RowResult`
+      ([key, value]: [string, RowResult]|['events', EventResult]) => [
         key,
-        value.rows,
+        getResult(value),
       ],
     )
     .reduce((prev, [key, value]) => ({ ...prev, [key]: value }), {});

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.jsx
@@ -116,7 +116,7 @@ export default class AggregationControls extends React.Component<Props, State> {
     const formattedFieldsOptions = formattedFields.map(v => ({ label: v, value: v }));
     const suggester = new SeriesFunctionsSuggester(formattedFields);
 
-    const showEventConfiguration = config.isTimeline && ['bar', 'line', 'scatter'].findIndex(x => x === visualization) >= 0;
+    const showEventConfiguration = config.isTimeline && ['bar', 'line', 'scatter', 'area'].findIndex(x => x === visualization) >= 0;
     const childrenWithCallback = React.Children.map(children, child => React.cloneElement(child, { onVisualizationConfigChange: this._onVisualizationConfigChange }));
     const VisualizationConfigType = _visualizationConfigFor(visualization);
     return (

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.jsx
@@ -116,6 +116,7 @@ export default class AggregationControls extends React.Component<Props, State> {
     const formattedFieldsOptions = formattedFields.map(v => ({ label: v, value: v }));
     const suggester = new SeriesFunctionsSuggester(formattedFields);
 
+    const showEventConfiguration = config.isTimeline && ['bar', 'line', 'scatter'].findIndex(x => x === visualization) >= 0;
     const childrenWithCallback = React.Children.map(children, child => React.cloneElement(child, { onVisualizationConfigChange: this._onVisualizationConfigChange }));
     const VisualizationConfigType = _visualizationConfigFor(visualization);
     return (
@@ -156,7 +157,7 @@ export default class AggregationControls extends React.Component<Props, State> {
             <DescriptionBox description="Metrics" help="The unit which is tracked for every row and subcolumn.">
               <SeriesSelect onChange={this._onSeriesChange} series={series} suggester={suggester} />
             </DescriptionBox>
-            {config.isTimeline && (
+            {showEventConfiguration && (
               <DescriptionBox description="Event Annotations"
                               help="Configuration to render event annotations to a timebased widget">
                 <EventListConfiguration enabled={config.eventAnnotation} onChange={this._onSetEventAnnotation} />

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.jsx
@@ -19,6 +19,7 @@ import SortSelect from './SortSelect';
 import SeriesSelect from './SeriesSelect';
 import DescriptionBox from './DescriptionBox';
 import SeriesFunctionsSuggester from './SeriesFunctionsSuggester';
+import EventListConfiguration from './EventListConfiguration';
 
 type Props = {
   children: React.Node,
@@ -75,6 +76,11 @@ export default class AggregationControls extends React.Component<Props, State> {
     }));
   };
 
+  _onSetEventAnnotation = (value: boolean) => {
+    this._setAndPropagate(state => ({ config: state.config.toBuilder().eventAnnotation(value).build() }));
+  };
+
+  // eslint-disable-next-line no-undef
   _onRollupChange = (rollup: $PropertyType<$PropertyType<Props, 'config'>, 'rollup'>) => {
     this._setAndPropagate(state => ({ config: state.config.toBuilder().rollup(rollup).build() }));
   };
@@ -150,6 +156,12 @@ export default class AggregationControls extends React.Component<Props, State> {
             <DescriptionBox description="Metrics" help="The unit which is tracked for every row and subcolumn.">
               <SeriesSelect onChange={this._onSeriesChange} series={series} suggester={suggester} />
             </DescriptionBox>
+            {config.isTimeline && (
+              <DescriptionBox description="Event Annotations"
+                              help="Configuration to render event annotations to a timebased widget">
+                <EventListConfiguration enabled={config.eventAnnotation} onChange={this._onSetEventAnnotation} />
+              </DescriptionBox>
+            )}
             {VisualizationConfigType && (
               <DescriptionBox description="Visualization config" help="Configuration specifically for the selected visualization type.">
                 <VisualizationConfigType.component onChange={this._onVisualizationConfigChange}

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/EventListConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/EventListConfiguration.jsx
@@ -1,0 +1,31 @@
+// @flow strict
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import { Checkbox, FormGroup } from 'components/graylog';
+
+type Props = {
+  enabled: boolean,
+  onChange: () => void,
+};
+
+const EventListConfiguration = ({ enabled, onChange }: Props) => {
+  return (
+    <form>
+      <FormGroup>
+        <Checkbox onChange={onChange} value={enabled}>Enable Event Annotation</Checkbox>
+      </FormGroup>
+    </form>
+  );
+};
+
+EventListConfiguration.propTypes = {
+  enabled: PropTypes.bool,
+  onChange: PropTypes.func,
+};
+
+EventListConfiguration.defaultProps = {
+  enabled: false,
+  onChange: () => {},
+};
+
+export default EventListConfiguration;

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/EventListConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/EventListConfiguration.jsx
@@ -12,8 +12,8 @@ const EventListConfiguration = ({ enabled, onChange }: Props) => {
   return (
     <form>
       <FormGroup>
-        {/* eslint-disable-next-line no-undef */ /* $FlowFixMe: checked is part of target */}
-        <Checkbox onChange={(event: SyntheticEvent<HTMLInputElement>) => onChange(event.target.checked)} checked={enabled}>
+        {/* eslint-disable-next-line no-undef */}
+        <Checkbox onChange={(event: SyntheticInputEvent<HTMLInputElement>) => onChange(event.target.checked)} checked={enabled}>
           Enable Event Annotation
         </Checkbox>
       </FormGroup>

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/EventListConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/EventListConfiguration.jsx
@@ -5,14 +5,17 @@ import { Checkbox, FormGroup } from 'components/graylog';
 
 type Props = {
   enabled: boolean,
-  onChange: () => void,
+  onChange: (value: boolean) => void,
 };
 
 const EventListConfiguration = ({ enabled, onChange }: Props) => {
   return (
     <form>
       <FormGroup>
-        <Checkbox onChange={onChange} value={enabled}>Enable Event Annotation</Checkbox>
+        {/* eslint-disable-next-line no-undef */ /* $FlowFixMe: checked is part of target */}
+        <Checkbox onChange={(event: SyntheticEvent<HTMLInputElement>) => onChange(event.target.checked)} checked={enabled}>
+          Enable Event Annotation
+        </Checkbox>
       </FormGroup>
     </form>
   );

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/EventListConfiguration.test.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/EventListConfiguration.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+
+import EventListConfiguration from './EventListConfiguration';
+
+describe('EventListConfiguration', () => {
+  afterEach(cleanup);
+
+  it('should render minimal', () => {
+    const { container } = render(<EventListConfiguration />);
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should fire event onClick', () => {
+    const onChange = jest.fn();
+    const { getByText } = render(<EventListConfiguration onChange={onChange} />);
+    const checkbox = getByText('Enable Event Annotation');
+    fireEvent.click(checkbox);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/EventListConfiguration.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/EventListConfiguration.test.jsx.snap
@@ -14,7 +14,6 @@ exports[`EventListConfiguration should render minimal 1`] = `
         >
           <input
             type="checkbox"
-            value="false"
           />
           Enable Event Annotation
         </label>

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/EventListConfiguration.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/EventListConfiguration.test.jsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EventListConfiguration should render minimal 1`] = `
+<div>
+  <form>
+    <div
+      class="form-group"
+    >
+      <div
+        class="checkbox"
+      >
+        <label
+          title=""
+        >
+          <input
+            type="checkbox"
+            value="false"
+          />
+          Enable Event Annotation
+        </label>
+      </div>
+    </div>
+  </form>
+</div>
+`;

--- a/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.jsx
@@ -2,6 +2,7 @@
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 
+import EventHandler from 'views/logic/searchtypes/events/EventHandler';
 import toPlotly from 'views/logic/aggregationbuilder/visualizations/Interpolation';
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { AggregationType } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
@@ -34,12 +35,21 @@ const AreaVisualization: VisualizationComponent = ({ config, data, effectiveTime
     line: { shape: toPlotly(interpolation) },
   }), [interpolation]);
 
+  const chartDataResult = chartData(config, data.chart || Object.values(data)[0], 'scatter', chartGenerator);
+  const layout = {};
+  if (config.eventAnnotation && data.events) {
+    const { eventChartData, shapes } = EventHandler.toVisualizationData(data.events, config.formattingSettings);
+    chartDataResult.push(eventChartData);
+    layout.shapes = shapes;
+  }
+
   return (
     <XYPlot config={config}
+            plotLayout={layout}
             effectiveTimerange={effectiveTimerange}
             getChartColor={getChartColor}
             setChartColor={setChartColor}
-            chartData={chartData(config, data.chart || Object.values(data)[0], 'scatter', chartGenerator)} />
+            chartData={chartDataResult} />
   );
 };
 

--- a/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { AggregationType } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 
+import EventHandler from 'views/logic/searchtypes/events/EventHandler';
 import { chartData } from '../ChartData';
 import XYPlot from '../XYPlot';
 
@@ -42,10 +43,16 @@ const BarVisualization: VisualizationComponent = ({ config, data, effectiveTimer
   const _seriesGenerator = (type, name, labels, values): ChartDefinition => ({ type, name, x: labels, y: values, opacity });
 
   const rows = data.chart || Object.values(data)[0];
+  const chartDataResult = chartData(config, rows, 'bar', _seriesGenerator);
+  if (config.eventAnnotation && data.events) {
+    const { eventChartData, shapes } = EventHandler.toVisualizationData(data.events, config.formattingSettings);
+    chartDataResult.push(eventChartData);
+    layout.shapes = shapes;
+  }
 
   return (
     <XYPlot config={config}
-            chartData={chartData(config, rows, 'bar', _seriesGenerator)}
+            chartData={chartDataResult}
             effectiveTimerange={effectiveTimerange}
             getChartColor={getChartColor}
             setChartColor={setChartColor}

--- a/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.jsx
@@ -6,6 +6,7 @@ import { AggregationType } from 'views/components/aggregationbuilder/Aggregation
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import LineVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/LineVisualizationConfig';
 import toPlotly from 'views/logic/aggregationbuilder/visualizations/Interpolation';
+import EventHandler from 'views/logic/searchtypes/events/EventHandler';
 
 import type { ChartDefinition } from '../ChartData';
 import { chartData } from '../ChartData';
@@ -33,12 +34,21 @@ const LineVisualization: VisualizationComponent = ({ config, data, effectiveTime
     y: values,
     line: { shape: toPlotly(interpolation) },
   }), [interpolation]);
+
+  const chartDataResult = chartData(config, data.chart || Object.values(data)[0], 'scatter', chartGenerator);
+  const layout = {};
+  if (config.eventAnnotation && data.events) {
+    const { eventChartData, shapes } = EventHandler.toVisualizationData(data.events, config.formattingSettings);
+    chartDataResult.push(eventChartData);
+    layout.shapes = shapes;
+  }
+
   return (
     <XYPlot config={config}
             effectiveTimerange={effectiveTimerange}
             getChartColor={getChartColor}
             setChartColor={setChartColor}
-            chartData={chartData(config, data.chart || Object.values(data)[0], 'scatter', chartGenerator)} />
+            chartData={chartDataResult} />
   );
 };
 

--- a/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.jsx
@@ -45,6 +45,7 @@ const LineVisualization: VisualizationComponent = ({ config, data, effectiveTime
 
   return (
     <XYPlot config={config}
+            plotLayout={layout}
             effectiveTimerange={effectiveTimerange}
             getChartColor={getChartColor}
             setChartColor={setChartColor}

--- a/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.jsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 
+import EventHandler from 'views/logic/searchtypes/events/EventHandler';
 import { AggregationType } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 
@@ -10,11 +11,21 @@ import XYPlot from '../XYPlot';
 
 const seriesGenerator = (type, name, labels, values) => ({ type, name, x: labels, y: values, mode: 'markers' });
 
-const ScatterVisualization: VisualizationComponent = ({ config, data, effectiveTimerange }: VisualizationComponentProps) => (
-  <XYPlot config={config}
-          chartData={chartData(config, data.chart || Object.values(data)[0], 'scatter', seriesGenerator)}
-          effectiveTimerange={effectiveTimerange} />
-);
+const ScatterVisualization: VisualizationComponent = ({ config, data, effectiveTimerange }: VisualizationComponentProps) => {
+  const chartDataResult = chartData(config, data.chart || Object.values(data)[0], 'scatter', seriesGenerator);
+  const layout = {};
+  if (config.eventAnnotation && data.events) {
+    const { eventChartData, shapes } = EventHandler.toVisualizationData(data.events, config.formattingSettings);
+    chartDataResult.push(eventChartData);
+    layout.shapes = shapes;
+  }
+  return (
+    <XYPlot config={config}
+            chartData={chartDataResult}
+            plotLayout={layout}
+            effectiveTimerange={effectiveTimerange} />
+  );
+};
 
 ScatterVisualization.propTypes = {
   config: AggregationType.isRequired,

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidgetConfig.js
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidgetConfig.js
@@ -23,6 +23,7 @@ type InternalState = {
   sort: Array<SortConfig>,
   visualization: string,
   visualizationConfig: ?VisualizationConfig,
+  eventAnnotation: boolean,
 };
 
 type AggregationWidgetConfigJson = {
@@ -34,6 +35,7 @@ type AggregationWidgetConfigJson = {
   sort: Array<SortConfigJson>,
   visualization: string,
   visualization_config: VisualizationConfigJson,
+  event_annotation: boolean,
 };
 
 export default class AggregationWidgetConfig extends WidgetConfig {
@@ -46,9 +48,10 @@ export default class AggregationWidgetConfig extends WidgetConfig {
     visualization: string,
     rollup: boolean,
     visualizationConfig: VisualizationConfig,
-    formattingSettings: WidgetFormattingSettings) {
+    formattingSettings: WidgetFormattingSettings,
+    eventAnnotation: boolean = false) {
     super();
-    this._value = { columnPivots, rowPivots, series, sort, visualization, rollup, visualizationConfig, formattingSettings };
+    this._value = { columnPivots, rowPivots, series, sort, visualization, rollup, visualizationConfig, formattingSettings, eventAnnotation };
   }
 
   get rowPivots() {
@@ -86,6 +89,10 @@ export default class AggregationWidgetConfig extends WidgetConfig {
     return this._value.formattingSettings;
   }
 
+  get eventAnnotation() {
+    return this._value.eventAnnotation;
+  }
+
   get isTimeline() {
     return this.rowPivots && this.rowPivots.length === 1 && this.rowPivots[0].field === TIMESTAMP_FIELD;
   }
@@ -102,6 +109,7 @@ export default class AggregationWidgetConfig extends WidgetConfig {
       .columnPivots([])
       .series([])
       .sort([])
+      .eventAnnotation(false)
       .rollup(true);
   }
 
@@ -120,6 +128,7 @@ export default class AggregationWidgetConfig extends WidgetConfig {
       sort,
       visualization,
       visualizationConfig,
+      eventAnnotation,
     } = this._value;
     return {
       column_pivots: columnPivots,
@@ -130,13 +139,14 @@ export default class AggregationWidgetConfig extends WidgetConfig {
       sort,
       visualization,
       visualization_config: visualizationConfig,
+      event_annotation: eventAnnotation,
     };
   }
 
   equals(other: any) {
     const { is } = Immutable;
     if (other instanceof AggregationWidgetConfig) {
-      return ['rowPivots', 'columnPivots', 'series', 'sort', 'rollup', 'visualizationConfig']
+      return ['rowPivots', 'columnPivots', 'series', 'sort', 'rollup', 'eventAnnotation', 'visualizationConfig']
         .every(key => is(Immutable.fromJS(this[key]), Immutable.fromJS(other[key])));
     }
     return false;
@@ -156,6 +166,8 @@ export default class AggregationWidgetConfig extends WidgetConfig {
       visualization,
       // eslint-disable-next-line camelcase
       visualization_config,
+      // eslint-disable-next-line camelcase
+      event_annotation,
     } = value;
 
     // eslint-disable-next-line no-use-before-define
@@ -170,6 +182,7 @@ export default class AggregationWidgetConfig extends WidgetConfig {
       .visualizationConfig(visualization_config !== null ? VisualizationConfig.fromJSON(visualization, visualization_config) : null)
       // eslint-disable-next-line camelcase
       .formattingSettings(formatting_settings === null ? undefined : WidgetFormattingSettings.fromJSON(formatting_settings))
+      .eventAnnotation(event_annotation)
       .build();
   }
 }
@@ -214,6 +227,10 @@ class Builder {
     return new Builder(this.value.set('formattingSettings', value));
   }
 
+  eventAnnotation(value: boolean) {
+    return new Builder(this.value.set('eventAnnotation', value));
+  }
+
   build() {
     const {
       rowPivots,
@@ -224,6 +241,7 @@ class Builder {
       rollup,
       visualizationConfig,
       formattingSettings,
+      eventAnnotation,
     } = this.value.toObject();
 
     const availableSorts = [].concat(rowPivots, columnPivots, series);
@@ -239,6 +257,7 @@ class Builder {
       computedRollup,
       visualizationConfig,
       formattingSettings,
+      eventAnnotation,
     );
   }
 }

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/WidgetFormattingSettings.js
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/WidgetFormattingSettings.js
@@ -14,6 +14,7 @@ export type WidgetFormattingSettingsJSON = {
 export default class WidgetFormattingSettings {
   _value: InternalState;
 
+  // eslint-disable-next-line no-undef
   constructor(chartColors: $PropertyType<InternalState, 'chartColors'>) {
     this._value = { chartColors };
   }
@@ -27,6 +28,7 @@ export default class WidgetFormattingSettings {
     return new Builder(Immutable.Map(this._value));
   }
 
+  // eslint-disable-next-line no-undef
   static create(chartColors: $PropertyType<InternalState, 'chartColors'>) {
     return new WidgetFormattingSettings(chartColors);
   }

--- a/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotConfigGenerator.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotConfigGenerator.js
@@ -1,7 +1,11 @@
+// @flow strict
 import uuid from 'uuid/v4';
+import { Set } from 'immutable';
 import { parseSeries } from 'views/logic/aggregationbuilder/Series';
+import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import Pivot from 'views/logic/aggregationbuilder/Pivot';
 
-const formatPivot = (pivot) => {
+const formatPivot = (pivot: Pivot) => {
   const { type, field, config } = pivot;
   const newConfig = Object.assign({}, config);
 
@@ -9,6 +13,7 @@ const formatPivot = (pivot) => {
     // eslint-disable-next-line no-case-declarations
     case 'time':
       if (newConfig.interval.type === 'timeunit') {
+        /* $FlowFixMe: newConfig.interval has unit and value since it is from type timeunit */
         const { unit, value } = newConfig.interval;
         newConfig.interval = { type: 'timeunit', timeunit: `${value}${unit[0]}` };
       }
@@ -23,7 +28,7 @@ const formatPivot = (pivot) => {
   };
 };
 
-const generateConfig = (id, name, { rollup, rowPivots, columnPivots, series, sort }) => ({
+const generateConfig = (id: string, name: string, { rollup, rowPivots, columnPivots, series, sort }: AggregationWidgetConfig) => ({
   id,
   name,
   type: 'pivot',
@@ -32,15 +37,56 @@ const generateConfig = (id, name, { rollup, rowPivots, columnPivots, series, sor
     rollup,
     row_groups: rowPivots.map(formatPivot),
     column_groups: columnPivots.map(formatPivot),
-    series: series.map(s => Object.assign({ id: s.effectiveName }, parseSeries(s.function))),
+    series: series.map(s => Object.assign({}, { id: s.effectiveName }, parseSeries(s.function))),
     sort: sort,
   },
 });
 
-export default ({ config }) => {
-  const chartSearchTypeId = uuid();
+export default ({ config }: { config: AggregationWidgetConfig }) => {
+  const chartConfig = generateConfig(uuid(), 'chart', config);
+
+  // eslint-disable-next-line no-use-before-define
+  const configBuilder = ConfigBuilder.create([chartConfig]);
+
   // TODO: This should go into a visualization config specific function
-  return config.visualization === 'numeric' && config.visualizationConfig && config.visualizationConfig.trend
-    ? [generateConfig(chartSearchTypeId, 'chart', config), { ...(generateConfig(uuid(), 'trend', config)), timerange: { type: 'offset', source: 'search_type', id: chartSearchTypeId } }]
-    : [generateConfig(chartSearchTypeId, 'chart', config)];
+  // $FlowFixMe: This is a NumberVisualizationConfig. We know so for config.visualization is 'numeric'.
+  if (config.visualization === 'numeric' && config.visualizationConfig && config.visualizationConfig.trend) {
+    const trendConfig = {
+      ...(generateConfig(uuid(), 'trend', config)),
+      timerange: { type: 'offset', source: 'search_type', id: chartConfig.id },
+    };
+    configBuilder.add(trendConfig);
+  }
+
+  if (config.eventAnnotation) {
+    const eventAnnotationConfig = {
+      id: uuid(),
+      name: 'events',
+      type: 'events',
+    };
+    configBuilder.add(eventAnnotationConfig);
+  }
+
+  return configBuilder.build();
 };
+
+class ConfigBuilder {
+  value: Set;
+
+  constructor(values: Array<any>) {
+    this.value = Set.of(...values);
+  }
+
+  add(val) {
+    this.value = this.value.add(val);
+    return this;
+  }
+
+  build() {
+    return this.value.toArray();
+  }
+
+  static create(values = []) {
+    return new ConfigBuilder(values);
+  }
+}

--- a/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotConfigGenerator.test.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotConfigGenerator.test.js
@@ -1,0 +1,54 @@
+// @flow strict
+import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import Pivot from 'views/logic/aggregationbuilder/Pivot';
+import Series from 'views/logic/aggregationbuilder/Series';
+import NumberVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/NumberVisualizationConfig';
+
+import PivotConfigGenerator from './PivotConfigGenerator';
+
+describe('PivotConfigGenerator', () => {
+  const widgetConfigBuilder = AggregationWidgetConfig.builder()
+    .rollup(true)
+    .rowPivots([Pivot.create('field', 'type')])
+    .columnPivots([])
+    .series([Series.forFunction('count')]);
+
+  it('should generate a chart config', () => {
+    const widgetConfig = widgetConfigBuilder.build();
+    const result = PivotConfigGenerator({ config: widgetConfig });
+    expect(result[0].config).toMatchSnapshot({
+      id: expect.any(String),
+    });
+  });
+
+  it('should generate a number config with trend', () => {
+    const widgetConfig = widgetConfigBuilder.visualization('numeric')
+      .visualizationConfig(
+        NumberVisualizationConfig.create(true),
+      ).build();
+    const result = PivotConfigGenerator({ config: widgetConfig });
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchSnapshot({
+      id: expect.any(String),
+    });
+    expect(result[1]).toMatchSnapshot({
+      id: expect.any(String),
+      timerange: {
+        id: expect.any(String),
+      },
+    });
+    expect(result[1].timerange.id).toEqual(result[0].id);
+  });
+
+  it('should add a event annotation config when configured', () => {
+    const widgetConfig = widgetConfigBuilder.eventAnnotation(true).build();
+    const result = PivotConfigGenerator({ config: widgetConfig });
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchSnapshot({
+      id: expect.any(String),
+    });
+    expect(result[1]).toMatchSnapshot({
+      id: expect.any(String),
+    });
+  });
+});

--- a/graylog2-web-interface/src/views/logic/searchtypes/aggregation/__snapshots__/PivotConfigGenerator.test.js.snap
+++ b/graylog2-web-interface/src/views/logic/searchtypes/aggregation/__snapshots__/PivotConfigGenerator.test.js.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PivotConfigGenerator should add a event annotation config when configured 1`] = `
+Object {
+  "config": Object {
+    "column_groups": Array [],
+    "id": "vals",
+    "rollup": true,
+    "row_groups": Array [
+      Object {
+        "field": "field",
+        "type": "type",
+      },
+    ],
+    "series": Array [
+      Object {
+        "id": "count",
+      },
+    ],
+    "sort": Array [],
+  },
+  "id": Any<String>,
+  "name": "chart",
+  "type": "pivot",
+}
+`;
+
+exports[`PivotConfigGenerator should add a event annotation config when configured 2`] = `
+Object {
+  "id": Any<String>,
+  "name": "events",
+  "type": "events",
+}
+`;
+
+exports[`PivotConfigGenerator should generate a chart config 1`] = `
+Object {
+  "column_groups": Array [],
+  "id": Any<String>,
+  "rollup": true,
+  "row_groups": Array [
+    Object {
+      "field": "field",
+      "type": "type",
+    },
+  ],
+  "series": Array [
+    Object {
+      "id": "count",
+    },
+  ],
+  "sort": Array [],
+}
+`;
+
+exports[`PivotConfigGenerator should generate a number config with trend 1`] = `
+Object {
+  "config": Object {
+    "column_groups": Array [],
+    "id": "vals",
+    "rollup": true,
+    "row_groups": Array [
+      Object {
+        "field": "field",
+        "type": "type",
+      },
+    ],
+    "series": Array [
+      Object {
+        "id": "count",
+      },
+    ],
+    "sort": Array [],
+  },
+  "id": Any<String>,
+  "name": "chart",
+  "type": "pivot",
+}
+`;
+
+exports[`PivotConfigGenerator should generate a number config with trend 2`] = `
+Object {
+  "config": Object {
+    "column_groups": Array [],
+    "id": "vals",
+    "rollup": true,
+    "row_groups": Array [
+      Object {
+        "field": "field",
+        "type": "type",
+      },
+    ],
+    "series": Array [
+      Object {
+        "id": "count",
+      },
+    ],
+    "sort": Array [],
+  },
+  "id": Any<String>,
+  "name": "trend",
+  "timerange": Object {
+    "id": Any<String>,
+    "source": "search_type",
+    "type": "offset",
+  },
+  "type": "pivot",
+}
+`;

--- a/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.js
@@ -1,7 +1,81 @@
 // @flow strict
+import { uniq } from 'lodash';
+import WidgetFormattingSettings from 'views/logic/aggregationbuilder/WidgetFormattingSettings';
+import type { ChartDefinition } from 'views/components/visualizations/ChartData';
+
+export type Event = {
+  id: string,
+  timestamp: string,
+  message: string,
+  alert: boolean,
+  streams: Array<string>,
+};
+
+export type Events = Array<Event>;
+
+type Shape = {
+  type: 'line',
+  y0: number,
+  y1: number,
+  x0: string,
+  x1: string,
+  opacity: number,
+  line: {
+    color: string,
+  }
+};
+
+export type Shapes = Array<Shape>;
+const eventsDisplayName = 'Alerts';
 
 export default {
-  convert(result: any) {
-    return result;
+  convert(events: Array<Event>) {
+    return events;
+  },
+
+  toVisualizationData(events: Events = [],
+    formattingSettings: WidgetFormattingSettings = WidgetFormattingSettings.create({})): { eventChartData: ChartDefinition, shapes: Shapes } {
+    return {
+      eventChartData: this.toChartData(events),
+      shapes: this.toShapeData(events, formattingSettings),
+    };
+  },
+
+  toChartData(events: Events = []): ChartDefinition {
+    const values: Array<[string, string]> = uniq(events.map(event => [event.timestamp, event.message]));
+    const xValues: Array<string> = values.map(v => v[0]);
+    const textValues: Array<string> = values.map(v => v[1]);
+    const yValues: Array<number> = values.map(() => 0);
+    return {
+      mode: 'markers',
+      name: eventsDisplayName,
+      type: 'scatter',
+      opacity: 0.5,
+      x: xValues,
+      y: yValues,
+      text: textValues,
+      marker: {
+        size: 3,
+        color: '#d3d3d3',
+      },
+    };
+  },
+
+  toShapeData(events: Events = [], formattingSettings: WidgetFormattingSettings = WidgetFormattingSettings.create({})): Shapes {
+    const { chartColors } = formattingSettings;
+    const shapeColor = chartColors[eventsDisplayName] || '#d3d3d3';
+    return events.map(event => ({
+      layer: 'below',
+      type: 'line',
+      yref: 'paper',
+      y0: 0,
+      y1: 1,
+      x0: event.timestamp,
+      x1: event.timestamp,
+      opacity: 0.5,
+      line: {
+        color: shapeColor,
+      },
+    }));
   },
 };

--- a/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.js
@@ -1,0 +1,7 @@
+// @flow strict
+
+export default {
+  convert(result: any) {
+    return result;
+  },
+};

--- a/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.js
@@ -29,6 +29,7 @@ type Shape = {
 
 export type Shapes = Array<Shape>;
 const eventsDisplayName = 'Alerts';
+const defaultColor = '#d3d3d3';
 
 export default {
   convert(events: Array<Event>) {
@@ -80,14 +81,14 @@ export default {
       text: textValues,
       marker: {
         size: 5,
-        color: '#d3d3d3',
+        color: defaultColor,
       },
     };
   },
 
   toShapeData(timestamps: Array<string>, formattingSettings: WidgetFormattingSettings = WidgetFormattingSettings.create({})): Shapes {
     const { chartColors } = formattingSettings;
-    const shapeColor = chartColors[eventsDisplayName] || '#d3d3d3';
+    const shapeColor = chartColors[eventsDisplayName] || defaultColor;
     return timestamps.map(timestamp => ({
       layer: 'below',
       type: 'line',

--- a/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.js
@@ -40,7 +40,7 @@ export default {
     formattingSettings: WidgetFormattingSettings = WidgetFormattingSettings.create({})): { eventChartData: ChartDefinition, shapes: Shapes } {
     const groupedEvents: GroupedEvents = groupBy(events, e => e.timestamp);
     return {
-      eventChartData: this.toChartData(groupedEvents),
+      eventChartData: this.toChartData(groupedEvents, formattingSettings),
       shapes: this.toShapeData(Object.keys(groupedEvents), formattingSettings),
     };
   },
@@ -60,7 +60,9 @@ export default {
     });
   },
 
-  toChartData(events: GroupedEvents): ChartDefinition {
+  toChartData(events: GroupedEvents, formattingSettings: WidgetFormattingSettings): ChartDefinition {
+    const { chartColors } = formattingSettings;
+    const chartColor = chartColors[eventsDisplayName] || defaultColor;
     const values = this.transformGroupedEvents(events);
     const xValues: Array<string> = values.map(v => v[0]);
     const textValues: Array<string> = values.map((e) => {
@@ -81,7 +83,7 @@ export default {
       text: textValues,
       marker: {
         size: 5,
-        color: defaultColor,
+        color: chartColor,
       },
     };
   },

--- a/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.js
@@ -70,6 +70,7 @@ export default {
     });
     const yValues: Array<number> = values.map(() => 0);
     return {
+      hovertemplate: '%{text}',
       mode: 'markers',
       name: eventsDisplayName,
       type: 'scatter',

--- a/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.test.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.test.js
@@ -1,0 +1,66 @@
+// @flow strict
+import WidgetFormattingSettings from 'views/logic/aggregationbuilder/WidgetFormattingSettings';
+import type { Event } from './EventHandler';
+import EventHandler from './EventHandler';
+
+describe('EventHandler convert', () => {
+  const event: Event = {
+    alert: false,
+    id: '01DSMMX5M4ER2MR02DDB2JS93W',
+    message: 'This is a emergency. Please stay calm.',
+    streams: ['5cdab2293d27467fbe9e8a72'],
+    timestamp: '2019-11-14T08:53:35.000Z',
+  };
+
+  it('should convert events to char data', () => {
+    const result = EventHandler.toChartData([event]);
+    expect(result).toEqual({
+      marker: {
+        color: '#d3d3d3',
+        size: 3,
+      },
+      mode: 'markers',
+      opacity: 0.5,
+      name: 'Alerts',
+      type: 'scatter',
+      x: ['2019-11-14T08:53:35.000Z'],
+      y: [0],
+      text: ['This is a emergency. Please stay calm.'],
+    });
+  });
+
+  it('should convert events to shape data', () => {
+    const result = EventHandler.toShapeData([event]);
+    expect(result[0]).toEqual({
+      layer: 'below',
+      type: 'line',
+      yref: 'paper',
+      y0: 0,
+      y1: 1,
+      x0: '2019-11-14T08:53:35.000Z',
+      x1: '2019-11-14T08:53:35.000Z',
+      opacity: 0.5,
+      line: {
+        color: '#d3d3d3',
+      },
+    });
+  });
+
+  it('should convert events to shape data with custom color', () => {
+    const widgetFormattingSettings = WidgetFormattingSettings.create({ Alerts: '#ffffff' });
+    const result = EventHandler.toShapeData([event], widgetFormattingSettings);
+    expect(result[0]).toEqual({
+      layer: 'below',
+      type: 'line',
+      yref: 'paper',
+      y0: 0,
+      y1: 1,
+      x0: '2019-11-14T08:53:35.000Z',
+      x1: '2019-11-14T08:53:35.000Z',
+      opacity: 0.5,
+      line: {
+        color: '#ffffff',
+      },
+    });
+  });
+});

--- a/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.test.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.test.js
@@ -21,7 +21,7 @@ describe('EventHandler convert', () => {
   });
 
   it('should convert events to char data', () => {
-    const result = EventHandler.toChartData(groupByTimestamp([event]));
+    const result = EventHandler.toChartData(groupByTimestamp([event]), WidgetFormattingSettings.builder().build());
     expect(result).toEqual({
       hovertemplate: '%{text}',
       marker: {
@@ -39,7 +39,7 @@ describe('EventHandler convert', () => {
   });
 
   it('should group duplicate events by timestamp and convert events to char data', () => {
-    const result = EventHandler.toChartData(groupByTimestamp([event, event, event]));
+    const result = EventHandler.toChartData(groupByTimestamp([event, event, event]), WidgetFormattingSettings.builder().build());
     expect(result).toEqual({
       hovertemplate: '%{text}',
       marker: {
@@ -53,6 +53,26 @@ describe('EventHandler convert', () => {
       x: ['2019-11-14T08:53:35.000Z'],
       y: [0],
       text: ['3 alerts occurred.'],
+    });
+  });
+
+  it('should keep the color set by the user', () => {
+    const result = EventHandler.toChartData(groupByTimestamp([event]), WidgetFormattingSettings.builder()
+      .chartColors({ Alerts: '#ffffff' })
+      .build());
+    expect(result).toEqual({
+      hovertemplate: '%{text}',
+      marker: {
+        color: '#ffffff',
+        size: 5,
+      },
+      mode: 'markers',
+      opacity: 0.5,
+      name: 'Alerts',
+      type: 'scatter',
+      x: ['2019-11-14T08:53:35.000Z'],
+      y: [0],
+      text: ['This is a emergency. Please stay calm.'],
     });
   });
 

--- a/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.test.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.test.js
@@ -23,6 +23,7 @@ describe('EventHandler convert', () => {
   it('should convert events to char data', () => {
     const result = EventHandler.toChartData(groupByTimestamp([event]));
     expect(result).toEqual({
+      hovertemplate: '%{text}',
       marker: {
         color: '#d3d3d3',
         size: 5,
@@ -40,6 +41,7 @@ describe('EventHandler convert', () => {
   it('should group duplicate events by timestamp and convert events to char data', () => {
     const result = EventHandler.toChartData(groupByTimestamp([event, event, event]));
     expect(result).toEqual({
+      hovertemplate: '%{text}',
       marker: {
         color: '#d3d3d3',
         size: 5,

--- a/graylog2-web-interface/src/views/logic/searchtypes/events/__snapshots__/EventHandler.test.js.snap
+++ b/graylog2-web-interface/src/views/logic/searchtypes/events/__snapshots__/EventHandler.test.js.snap
@@ -3,6 +3,7 @@
 exports[`EventHandler convert should convert events to chart data and shapes 1`] = `
 Object {
   "eventChartData": Object {
+    "hovertemplate": "%{text}",
     "marker": Object {
       "color": "#d3d3d3",
       "size": 5,

--- a/graylog2-web-interface/src/views/logic/searchtypes/events/__snapshots__/EventHandler.test.js.snap
+++ b/graylog2-web-interface/src/views/logic/searchtypes/events/__snapshots__/EventHandler.test.js.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EventHandler convert should convert events to chart data and shapes 1`] = `
+Object {
+  "eventChartData": Object {
+    "marker": Object {
+      "color": "#d3d3d3",
+      "size": 5,
+    },
+    "mode": "markers",
+    "name": "Alerts",
+    "opacity": 0.5,
+    "text": Array [
+      "This is a emergency. Please stay calm.",
+    ],
+    "type": "scatter",
+    "x": Array [
+      "2019-11-14T08:53:35.000Z",
+    ],
+    "y": Array [
+      0,
+    ],
+  },
+  "shapes": Array [
+    Object {
+      "layer": "below",
+      "line": Object {
+        "color": "#d3d3d3",
+      },
+      "opacity": 0.5,
+      "type": "line",
+      "x0": "2019-11-14T08:53:35.000Z",
+      "x1": "2019-11-14T08:53:35.000Z",
+      "y0": 0,
+      "y1": 1,
+      "yref": "paper",
+    },
+  ],
+}
+`;


### PR DESCRIPTION
## Description
A new configuration option is add to the aggregation controls when a timestamp is
selected for rows and the graph is either a bar, line or scatter graph.
When enabled the widget will add a new search type ('events') to the pivot
search type to retrieve all events to the timerange matching the streams the user
is able to see or selected.
The user then sees vertical lines for a timestamp where alerts occurred.
The user can choose a color for the alert annotation.

## Motivation and Context
The user wants to see when an alert occurred and wants to compare it to other data
to draw conclusions from it.

## How Has This Been Tested?
Add a event definition which will produce alerts and configure the rendering of events
on a timebased bar char.

## Screenshots (if appropriate):
![Graylog (30)](https://user-images.githubusercontent.com/448763/69807701-38b8b200-11e6-11ea-8a1d-b268a197291f.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
