### PR TITLE
Add support for lookup table backed parameters

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessor.java
@@ -39,6 +39,8 @@ import org.graylog.events.processor.EventProcessorException;
 import org.graylog.events.processor.EventProcessorParameters;
 import org.graylog.events.processor.EventProcessorPreconditionException;
 import org.graylog.events.search.MoreSearch;
+import org.graylog.plugins.views.search.errors.ParameterExpansionError;
+import org.graylog.plugins.views.search.errors.SearchException;
 import org.graylog2.indexer.messages.Messages;
 import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.plugin.Message;
@@ -113,10 +115,19 @@ public class AggregationEventProcessor implements EventProcessor {
 
         // The absence of a series indicates that the user doesn't want to do an aggregation but create events from
         // a simple search query. (one message -> one event)
-        if (config.series().isEmpty()) {
-            filterSearch(eventFactory, parameters, eventsConsumer);
-        } else {
-            aggregatedSearch(eventFactory, parameters, eventsConsumer);
+        try {
+            if (config.series().isEmpty()) {
+                filterSearch(eventFactory, parameters, eventsConsumer);
+            } else {
+                aggregatedSearch(eventFactory, parameters, eventsConsumer);
+            }
+        } catch (SearchException e) {
+            if (e.error() instanceof ParameterExpansionError) {
+                final String msg = String.format(Locale.ROOT, "Couldn't run aggregation <%s/%s>  because parameters failed to expand: %s",
+                        eventDefinition.title(), eventDefinition.id(), e.error().description());
+                LOG.error(msg);
+                throw new EventProcessorPreconditionException(msg, eventDefinition, e);
+            }
         }
 
         // Update the state for this processor! This state will be used for dependency checks between event processors.
@@ -156,7 +167,7 @@ public class AggregationEventProcessor implements EventProcessor {
                 messageConsumer.accept(summaries);
             };
             final TimeRange timeRange = AbsoluteRange.create(event.getTimerangeStart(), event.getTimerangeEnd());
-            moreSearch.scrollQuery(config.query(), config.streams(), timeRange, Math.min(500, Ints.saturatedCast(limit)), callback);
+            moreSearch.scrollQuery(config.query(), config.streams(), config.queryParameters(), timeRange, Math.min(500, Ints.saturatedCast(limit)), callback);
         }
 
     }
@@ -195,7 +206,7 @@ public class AggregationEventProcessor implements EventProcessor {
             eventsConsumer.accept(eventsWithContext.build());
         };
 
-        moreSearch.scrollQuery(config.query(), streams, parameters.timerange(), parameters.batchSize(), callback);
+        moreSearch.scrollQuery(config.query(), streams, config.queryParameters(), parameters.timerange(), parameters.batchSize(), callback);
     }
 
     private void aggregatedSearch(EventFactory eventFactory, AggregationEventProcessorParameters parameters,

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessorConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationEventProcessorConfig.java
@@ -28,6 +28,7 @@ import org.graylog.events.contentpack.entities.EventProcessorConfigEntity;
 import org.graylog.events.processor.EventDefinition;
 import org.graylog.events.processor.EventProcessorConfig;
 import org.graylog.events.processor.EventProcessorSchedulerConfig;
+import org.graylog.plugins.views.search.Parameter;
 import org.graylog.scheduler.clock.JobSchedulerClock;
 import org.graylog.events.processor.EventProcessorExecutionJob;
 import org.graylog.scheduler.schedule.IntervalJobSchedule;
@@ -56,6 +57,7 @@ public abstract class AggregationEventProcessorConfig implements EventProcessorC
     public static final String TYPE_NAME = "aggregation-v1";
 
     private static final String FIELD_QUERY = "query";
+    private static final String FIELD_QUERY_PARAMETERS = "query_parameters";
     private static final String FIELD_STREAMS = "streams";
     private static final String FIELD_GROUP_BY = "group_by";
     private static final String FIELD_SERIES = "series";
@@ -65,6 +67,9 @@ public abstract class AggregationEventProcessorConfig implements EventProcessorC
 
     @JsonProperty(FIELD_QUERY)
     public abstract String query();
+
+    @JsonProperty(FIELD_QUERY_PARAMETERS)
+    public abstract ImmutableSet<Parameter> queryParameters();
 
     @JsonProperty(FIELD_STREAMS)
     public abstract ImmutableSet<String> streams();
@@ -130,11 +135,15 @@ public abstract class AggregationEventProcessorConfig implements EventProcessorC
         @JsonCreator
         public static Builder create() {
             return new AutoValue_AggregationEventProcessorConfig.Builder()
+                    .queryParameters(ImmutableSet.of())
                     .type(TYPE_NAME);
         }
 
         @JsonProperty(FIELD_QUERY)
         public abstract Builder query(String query);
+
+        @JsonProperty(FIELD_QUERY_PARAMETERS)
+        public abstract Builder queryParameters(Set<Parameter> queryParameters);
 
         @JsonProperty(FIELD_STREAMS)
         public abstract Builder streams(Set<String> streams);

--- a/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationResult.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/aggregation/AggregationResult.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 
 import java.util.List;
@@ -28,6 +30,13 @@ import java.util.Set;
 @AutoValue
 @JsonDeserialize(builder = AggregationResult.Builder.class)
 public abstract class AggregationResult {
+    private static final AggregationResult EMPTY_AGGREGATION_RESULT = builder()
+            .keyResults(ImmutableList.of())
+            .effectiveTimerange(AbsoluteRange.create(Tools.nowUTC(), Tools.nowUTC()))
+            .totalAggregatedMessages(0)
+            .sourceStreams(ImmutableSet.of())
+            .build();
+
     public abstract ImmutableList<AggregationKeyResult> keyResults();
 
     public abstract AbsoluteRange effectiveTimerange();
@@ -58,5 +67,9 @@ public abstract class AggregationResult {
         public abstract Builder sourceStreams(Set<String> sourceStreams);
 
         public abstract AggregationResult build();
+    }
+
+    public static AggregationResult empty() {
+        return EMPTY_AGGREGATION_RESULT;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
@@ -319,7 +319,13 @@ public class MoreSearch extends Searches {
         return streams;
     }
 
+    /**
+     * Substitute query string parameters using ESQueryDecorators.
+     */
     private String decorateQuery(Set<Parameter> queryParameters, TimeRange timeRange, String queryString) {
+        // TODO
+        // We need to create a dummy SearchJob and a Query to use the decorator API.
+        // Maybe the decorate call could be refactored to make this easier.
         org.graylog.plugins.views.search.Search search = org.graylog.plugins.views.search.Search.builder()
                 .parameters(ImmutableSet.copyOf(queryParameters))
                 .build();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -27,6 +27,7 @@ import org.graylog.plugins.views.migrations.V20190805115800_RemoveDashboardState
 import org.graylog.plugins.views.migrations.V20191204000000_RemoveLegacyViewsPermissions;
 import org.graylog.plugins.views.search.SearchRequirements;
 import org.graylog.plugins.views.search.SearchRequiresParameterSupport;
+import org.graylog.plugins.views.search.ValueParameter;
 import org.graylog.plugins.views.search.db.InMemorySearchJobService;
 import org.graylog.plugins.views.search.db.SearchJobService;
 import org.graylog.plugins.views.search.db.SearchesCleanUpJob;
@@ -146,6 +147,7 @@ public class ViewsBindings extends ViewsModule {
         registerViewSharingSubtypes();
         registerSharingStrategies();
         registerSortConfigSubclasses();
+        registerParameterSubtypes();
 
         install(new FactoryModuleBuilder().build(ViewRequirements.Factory.class));
         install(new FactoryModuleBuilder().build(SearchRequirements.Factory.class));
@@ -189,13 +191,16 @@ public class ViewsBindings extends ViewsModule {
         registerJacksonSubtype(SpecificUsers.class);
     }
 
+    private void registerParameterSubtypes() {
+        registerJacksonSubtype(ValueParameter.class);
+    }
+
     private void registerSharingStrategies() {
         registerSharingStrategy(AllUsersOfInstance.TYPE, AllUsersOfInstanceStrategy.class);
         registerSharingStrategy(SpecificRoles.TYPE, SpecificRolesStrategy.class);
         registerSharingStrategy(SpecificUsers.TYPE, SpecificUsersStrategy.class);
     }
-
-    private void registerExceptionMappers() {
+private void registerExceptionMappers() {
         addJerseyExceptionMapper(MissingCapabilitiesExceptionMapper.class);
         addJerseyExceptionMapper(PermissionExceptionMapper.class);
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -200,7 +200,8 @@ public class ViewsBindings extends ViewsModule {
         registerSharingStrategy(SpecificRoles.TYPE, SpecificRolesStrategy.class);
         registerSharingStrategy(SpecificUsers.TYPE, SpecificUsersStrategy.class);
     }
-private void registerExceptionMappers() {
+
+    private void registerExceptionMappers() {
         addJerseyExceptionMapper(MissingCapabilitiesExceptionMapper.class);
         addJerseyExceptionMapper(PermissionExceptionMapper.class);
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Parameter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Parameter.java
@@ -60,22 +60,46 @@ public interface Parameter {
     @JsonProperty
     String description();
 
+    @JsonProperty("data_type")
+    String dataType();
+
     @Nullable
-    @JsonProperty
-    Binding binding();
+    @JsonProperty("default_value")
+    Object defaultValue();
 
     @JsonProperty
     boolean optional();
 
     @Nullable
-    @JsonProperty("default_value")
-    Object defaultValue();
+    @JsonProperty
+    Binding binding();
 
     Parameter applyExecutionState(ObjectMapper objectMapper, JsonNode jsonNode);
 
     interface Builder<SELF> {
         @JsonProperty(TYPE_FIELD)
         SELF type(String type);
+
+        @JsonProperty
+        SELF name(String name);
+
+        @JsonProperty
+        SELF title(String title);
+
+        @JsonProperty
+        SELF description(String description);
+
+        @JsonProperty("data_type")
+        SELF dataType(String dataType);
+
+        @JsonProperty("default_value")
+        SELF defaultValue(Object defaultValue);
+
+        @JsonProperty
+        SELF optional(boolean optional);
+
+        @JsonProperty
+        SELF binding(Binding binding);
     }
     interface Factory<TYPE extends Parameter> {
         TYPE create(Parameter parameter);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/ValueParameter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/ValueParameter.java
@@ -17,14 +17,11 @@
 package org.graylog.plugins.views.search;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
-
-import javax.annotation.Nullable;
 
 /**
  * Parameters describe variable inputs to queries.
@@ -40,34 +37,6 @@ import javax.annotation.Nullable;
 @JsonDeserialize(builder = ValueParameter.Builder.class)
 public abstract class ValueParameter implements Parameter {
     public static final String TYPE_NAME = "value-parameter-v1";
-
-    @Override
-    public abstract String type();
-
-    @JsonProperty
-    public abstract String name();
-
-    @Nullable
-    @JsonProperty
-    public abstract String title();
-
-    @Nullable
-    @JsonProperty
-    public abstract String description();
-
-    @JsonProperty("data_type")
-    public abstract String dataType();
-
-    @Nullable
-    @JsonProperty("default_value")
-    public abstract Object defaultValue();
-
-    @JsonProperty
-    public abstract boolean optional();
-
-    @Nullable
-    @JsonProperty
-    public abstract Binding binding();
 
     public static Builder builder() {
         return new AutoValue_ValueParameter.Builder().type(TYPE_NAME).optional(false);
@@ -93,26 +62,6 @@ public abstract class ValueParameter implements Parameter {
 
     @AutoValue.Builder
     public abstract static class Builder implements Parameter.Builder<Builder> {
-        @JsonProperty
-        public abstract Builder name(String name);
-
-        @JsonProperty
-        public abstract Builder title(String title);
-
-        @JsonProperty
-        public abstract Builder description(String description);
-
-        @JsonProperty
-        public abstract Builder dataType(String dataType);
-
-        @JsonProperty("default_value")
-        public abstract Builder defaultValue(Object defaultValue);
-
-        @JsonProperty
-        public abstract Builder optional(boolean optional);
-
-        @JsonProperty
-        public abstract Builder binding(Binding binding);
 
         public abstract ValueParameter build();
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/ValueParameter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/ValueParameter.java
@@ -1,0 +1,126 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.views.search;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+
+import javax.annotation.Nullable;
+
+/**
+ * Parameters describe variable inputs to queries.
+ * <p>
+ * They consist of a declaration and a binding. Parameters without a binding are called "free" or "unbound" parameters.
+ * In order to execute a query all of its non-optional parameters must have a binding associated with them, i.e. be "bound".
+ * <p>
+ * The caller is expected to provide a {@link ValueParameter} object when binding previously declared parameters.
+ * In that case the declaration elements do not need to be repeated, only its {@link ValueParameter#name() name} property.
+ */
+@AutoValue
+@JsonTypeName(ValueParameter.TYPE_NAME)
+@JsonDeserialize(builder = ValueParameter.Builder.class)
+public abstract class ValueParameter implements Parameter {
+    public static final String TYPE_NAME = "value-parameter-v1";
+
+    @Override
+    public abstract String type();
+
+    @JsonProperty
+    public abstract String name();
+
+    @Nullable
+    @JsonProperty
+    public abstract String title();
+
+    @Nullable
+    @JsonProperty
+    public abstract String description();
+
+    @JsonProperty("data_type")
+    public abstract String dataType();
+
+    @Nullable
+    @JsonProperty("default_value")
+    public abstract Object defaultValue();
+
+    @JsonProperty
+    public abstract boolean optional();
+
+    @Nullable
+    @JsonProperty
+    public abstract Binding binding();
+
+    public static Builder builder() {
+        return new AutoValue_ValueParameter.Builder().type(TYPE_NAME).optional(false);
+    }
+
+    public static ValueParameter any(String name) {
+        return builder().name(name).dataType("any").build();
+    }
+
+    public abstract Builder toBuilder();
+
+    public ValueParameter applyExecutionState(ObjectMapper objectMapper, JsonNode state) {
+        final JsonNode bindingState = state.path(name());
+
+        if (bindingState.isMissingNode()) {
+            return this;
+        }
+
+        final Binding binding = objectMapper.convertValue(bindingState, Binding.class);
+
+        return toBuilder().binding(binding).build();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder implements Parameter.Builder<Builder> {
+        @JsonProperty
+        public abstract Builder name(String name);
+
+        @JsonProperty
+        public abstract Builder title(String title);
+
+        @JsonProperty
+        public abstract Builder description(String description);
+
+        @JsonProperty
+        public abstract Builder dataType(String dataType);
+
+        @JsonProperty("default_value")
+        public abstract Builder defaultValue(Object defaultValue);
+
+        @JsonProperty
+        public abstract Builder optional(boolean optional);
+
+        @JsonProperty
+        public abstract Builder binding(Binding binding);
+
+        public abstract ValueParameter build();
+
+        // to fill the default values
+        @JsonCreator
+        public static Builder create() {
+            return ValueParameter.builder().type(TYPE_NAME).optional(false);
+        }
+    }
+
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/EmptyParameterError.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/EmptyParameterError.java
@@ -1,0 +1,28 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog.plugins.views.search.errors;
+
+import org.graylog.plugins.views.search.Query;
+
+import javax.annotation.Nonnull;
+
+public class EmptyParameterError extends QueryError {
+    public EmptyParameterError(@Nonnull Query query, String description) {
+        super(query, description);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/ParameterExpansionError.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/ParameterExpansionError.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+package org.graylog.plugins.views.search.errors;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class ParameterExpansionError implements SearchError {
+    private final String parameterName;
+    private final String description;
+
+    public ParameterExpansionError(String name) {
+        this.parameterName = name;
+        this.description = "Error while expanding parameter <" + parameterName + ">";
+    }
+
+    public ParameterExpansionError(String name, String msg) {
+        this.parameterName = name;
+        this.description = "Error while expanding parameter <" + parameterName + ">: " + msg;
+    }
+
+    @JsonProperty("parameter")
+    public String parameterName() {
+        return parameterName;
+    }
+
+    @Override
+    public String description() {
+        return description;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/ParameterExpansionError.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/ParameterExpansionError.java
@@ -14,23 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-/*
- * This file is part of Graylog.
- *
- * Graylog is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * Graylog is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
- */
-
 
 package org.graylog.plugins.views.search.errors;
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/ParameterExpansionError.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/ParameterExpansionError.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 /*
  * This file is part of Graylog.
  *

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTable.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTable.java
@@ -71,6 +71,9 @@ public abstract class LookupTable {
     public LookupResult lookup(@Nonnull Object key) {
         final LookupResult result = cache().get(LookupCacheKey.create(dataAdapter(), key), () -> dataAdapter().get(key));
 
+        if (result.hasError()) {
+            return result;
+        }
         // The default value will only be used if single, multi and list values are empty
         if (result.isEmpty()) {
             return LookupResult.addDefaults(defaultSingleValue(), defaultMultiValue()).hasError(result.hasError()).build();

--- a/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/AggregationEventProcessorTest.java
@@ -341,6 +341,7 @@ public class AggregationEventProcessorTest {
         verify(moreSearch, times(1)).scrollQuery(
                 eq(config.query()),
                 eq(config.streams()),
+                eq(config.queryParameters()),
                 eq(parameters.timerange()),
                 eq(parameters.batchSize()),
                 any(MoreSearch.ScrollCallback.class)
@@ -387,6 +388,7 @@ public class AggregationEventProcessorTest {
         verify(moreSearch, times(1)).scrollQuery(
                 eq(config.query()),
                 eq(config.streams()),
+                eq(config.queryParameters()),
                 eq(parameters.timerange()),
                 eq(parameters.batchSize()),
                 any(MoreSearch.ScrollCallback.class)
@@ -409,6 +411,7 @@ public class AggregationEventProcessorTest {
         verify(moreSearch, never()).scrollQuery(
                 eq(config.query()),
                 eq(config.streams()),
+                eq(config.queryParameters()),
                 eq(parameters.timerange()),
                 eq(parameters.batchSize()),
                 any(MoreSearch.ScrollCallback.class)

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/views/QualifyingViewsServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/views/QualifyingViewsServiceTest.java
@@ -18,13 +18,9 @@ package org.graylog.plugins.views.search.views;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.graylog.plugins.views.search.Parameter;
 import org.graylog.plugins.views.search.Search;
+import org.graylog.plugins.views.search.ValueParameter;
 import org.graylog.plugins.views.search.db.SearchDbService;
-import org.graylog.plugins.views.search.views.QualifyingViewsService;
-import org.graylog.plugins.views.search.views.ViewDTO;
-import org.graylog.plugins.views.search.views.ViewParameterSummaryDTO;
-import org.graylog.plugins.views.search.views.ViewService;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -93,7 +89,7 @@ public class QualifyingViewsServiceTest {
         when(view1.summary()).thenReturn("My Summary");
         when(view1.description()).thenReturn("My Description");
         when(search.id()).thenReturn(searchId);
-        when(search.parameters()).thenReturn(ImmutableSet.of(Parameter.any("foobar")));
+        when(search.parameters()).thenReturn(ImmutableSet.of(ValueParameter.any("foobar")));
         when(viewService.streamAll()).then(invocation -> Stream.of(view1));
         when(searchDbService.findByIds(any())).thenReturn(ImmutableList.of(search));
 
@@ -121,7 +117,7 @@ public class QualifyingViewsServiceTest {
         when(view1.summary()).thenReturn("My Summary");
         when(view1.description()).thenReturn("My Description");
         when(search1.id()).thenReturn(search1Id);
-        when(search1.parameters()).thenReturn(ImmutableSet.of(Parameter.any("foobar")));
+        when(search1.parameters()).thenReturn(ImmutableSet.of(ValueParameter.any("foobar")));
         when(search2.parameters()).thenReturn(ImmutableSet.of());
         when(viewService.streamAll()).then(invocation -> Stream.of(view1, view2));
         when(searchDbService.findByIds(any())).thenReturn(ImmutableList.of(search1, search2));

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/views/RequiresParameterSupportTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/views/RequiresParameterSupportTest.java
@@ -17,14 +17,10 @@
 package org.graylog.plugins.views.search.views;
 
 import com.google.common.collect.ImmutableSet;
-import org.graylog.plugins.views.search.Parameter;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchRequiresParameterSupport;
+import org.graylog.plugins.views.search.ValueParameter;
 import org.graylog.plugins.views.search.db.SearchDbService;
-import org.graylog.plugins.views.search.views.EnterpriseMetadataSummary;
-import org.graylog.plugins.views.search.views.PluginMetadataSummary;
-import org.graylog.plugins.views.search.views.RequiresParameterSupport;
-import org.graylog.plugins.views.search.views.ViewDTO;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
@@ -94,7 +90,7 @@ public class RequiresParameterSupportTest {
     @Test
     public void returnsParameterCapabilityIfViewDoesHaveParameters() {
         final Search search = Search.builder().parameters(ImmutableSet.of(
-                Parameter.builder()
+                ValueParameter.builder()
                         .name("foo")
                         .dataType("any")
                         .build()

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EditQueryParameterModal.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EditQueryParameterModal.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
 import React from 'react';
-import { Button, Panel } from 'react-bootstrap';
+import { Button, Panel } from 'components/graylog';
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { ControlLabel, FormGroup, HelpBlock } from 'components/graylog';
 import { Select } from 'components/common';

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EditQueryParameterModal.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EditQueryParameterModal.jsx
@@ -1,0 +1,179 @@
+import PropTypes from 'prop-types';
+import lodash from 'lodash';
+import React from 'react';
+import { Button, Panel } from 'react-bootstrap';
+import { BootstrapModalForm, Input } from 'components/bootstrap';
+import { ControlLabel, FormGroup, HelpBlock } from 'components/graylog';
+import { Select } from 'components/common';
+import FormsUtils from 'util/FormsUtils';
+import { naturalSortIgnoreCase } from 'util/SortUtils';
+
+
+class EditQueryParameterModal extends React.Component {
+  static propTypes = {
+    eventDefinition: PropTypes.object.isRequired,
+    queryParameter: PropTypes.object.isRequired,
+    lookupTables: PropTypes.array.isRequired,
+    onChange: PropTypes.func.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+
+    const { queryParameter } = this.props;
+    this.state = {
+      lastParameter: lodash.cloneDeep(queryParameter),
+      validation: {},
+    };
+  }
+
+  openModal = () => {
+    this.modal.open();
+  };
+
+  _saved = () => {
+    const { queryParameter } = this.props;
+    if (this._hasErrors()) {
+      return;
+    }
+    // TODO find a nicer way to handle this
+    this.setState({ lastParameter: queryParameter });
+    this.modal.close();
+  };
+
+  _cleanState = () => {
+    const { eventDefinition, onChange, queryParameter } = this.props;
+    const config = lodash.cloneDeep(eventDefinition.config);
+    const queryParameters = config.query_parameters;
+    const idx = queryParameters.findIndex(p => p.name === queryParameter.name);
+    if (idx === -1) {
+      throw new Error(`Query parameter "${queryParameter.name}" not found`);
+    }
+    const { lastParameter } = this.state;
+    queryParameters[idx] = lastParameter;
+    config.query_parameters = queryParameters;
+    onChange('config', config);
+  };
+
+  propagateChanges = (key, value) => {
+    const { eventDefinition, onChange, queryParameter } = this.props;
+    const config = lodash.cloneDeep(eventDefinition.config);
+    const queryParameters = config.query_parameters;
+    const idx = queryParameters.findIndex(p => p.name === queryParameter.name);
+    if (idx === -1) {
+      throw new Error(`Query parameter "${queryParameter.name}" not found`);
+    }
+
+    queryParameters[idx][key] = value;
+
+    if (this._validate(queryParameters[idx])) {
+      delete queryParameters[idx].embryonic;
+    } else {
+      queryParameters[idx].embryonic = true;
+    }
+    config.query_parameters = queryParameters;
+    onChange('config', config);
+  };
+
+  handleSelectChange = (key) => {
+    return (nextLookupTable) => {
+      this.propagateChanges(key, nextLookupTable);
+    };
+  };
+
+  handleChange = (event) => {
+    const { name } = event.target;
+    const value = FormsUtils.getValueFromInput(event.target);
+    this.propagateChanges(name, value);
+  };
+
+  _validate = (queryParameter) => {
+    const newValidation = {};
+    if (!queryParameter.lookup_table) {
+      newValidation.lookup_table = 'Cannot be empty';
+    }
+    if (!queryParameter.key) {
+      newValidation.key = 'Cannot be empty';
+    }
+    this.setState({ validation: newValidation });
+    return lodash.isEmpty(newValidation);
+  };
+
+  _hasErrors = () => {
+    const { validation } = this.state;
+    return !lodash.isEmpty(validation);
+  };
+
+  formatLookupTables = (lookupTables) => {
+    if (!lookupTables) {
+      return [];
+    }
+    return lookupTables
+      .sort((lt1, lt2) => naturalSortIgnoreCase(lt1.title, lt2.title))
+      .map(table => ({ label: table.title, value: table.name }));
+  };
+
+  render() {
+    const { queryParameter, lookupTables } = this.props;
+    const { validation } = this.state;
+    const parameterSyntax = `$${queryParameter.name}$`;
+    return (
+      <React.Fragment>
+        <Button bsSize="small"
+                bsStyle={queryParameter.embryonic ? 'warning' : 'info'}
+                onClick={() => this.openModal()}>
+          {queryParameter.name}
+        </Button>
+
+        <BootstrapModalForm ref={(ref) => { this.modal = ref; }}
+                            title={`Declare Query Parameter "${queryParameter.name}" from Lookup Table`}
+                            onSubmitForm={this._saved}
+                            onModalClose={this._cleanState}
+                            submitButtonDisabled={this._hasErrors()}
+                            submitButtonText="Save">
+
+          <FormGroup controlId="lookup-provider-table" validationState={validation.lookup_table ? 'error' : null}>
+            <ControlLabel>Select Lookup Table</ControlLabel>
+            <Select name="query-param-table-name"
+                    placeholder="Select Lookup Table"
+                    onChange={this.handleSelectChange('lookup_table')}
+                    options={this.formatLookupTables(lookupTables)}
+                    value={queryParameter.lookup_table}
+                    required />
+            <HelpBlock>
+              {validation.lookup_table || 'Select the Lookup Table Graylog should use to get the values.'}
+            </HelpBlock>
+          </FormGroup>
+          <Input type="text"
+                 id={`key-${queryParameter.name}`}
+                 label="Lookup Table Key"
+                 name="key"
+                 defaultValue={queryParameter.key}
+                 onChange={this.handleChange}
+                 bsStyle={validation.key ? 'error' : null}
+                 help={validation.key ? validation.key : 'Select the Lookup Table Key'}
+                 autoFocus
+                 spellCheck={false}
+                 required />
+          <Input id={`default-value-${queryParameter.name}`}
+                 type="text"
+                 name="default_value"
+                 label="Default Value"
+                 help="Select a default value in case the lookup result is empty"
+                 defaultValue={queryParameter.default_value}
+                 spellCheck={false}
+                 onChange={this.handleChange} />
+          <Panel header="How to use" style={{ marginTop: 20 }}>
+            After declaring it, the parameter {' '}
+            <span style={{ whiteSpace: 'nowrap' }}>
+              <code>{parameterSyntax}</code>
+            </span>{' '}
+            in your query, will be replaced with the results from the lookup table.
+          </Panel>
+        </BootstrapModalForm>
+      </React.Fragment>
+    );
+  }
+}
+
+export default EditQueryParameterModal;

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EditQueryParameterModal.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EditQueryParameterModal.jsx
@@ -164,11 +164,32 @@ class EditQueryParameterModal extends React.Component {
                  spellCheck={false}
                  onChange={this.handleChange} />
           <Panel header="How to use" style={{ marginTop: 20 }}>
-            After declaring it, the parameter {' '}
-            <span style={{ whiteSpace: 'nowrap' }}>
-              <code>{parameterSyntax}</code>
-            </span>{' '}
-            in your query, will be replaced with the results from the lookup table.
+            <p>
+              <h5>General Usage</h5>
+              After declaring it, the parameter {' '}
+              <span style={{ whiteSpace: 'nowrap' }}>
+                <code>{parameterSyntax}</code>
+              </span>{' '}
+              in your query, will be replaced with the list of results from the lookup table.
+              The list of results will be presented in the form of a Lucene BooleanQuery. E.g.:
+              <span style={{ whiteSpace: 'nowrap' }}>
+                <code>(&quot;foo&quot; OR &quot;bar&quot; OR &quot;baz&quot;)</code>
+              </span>
+            </p>
+            <p>
+              <h5>Behaviour on empty lookup result list</h5>
+              The event definition query is only executed if a value for the parameter is present.
+              If the lookup result is empty, the execution will be skipped and treated as if the <i>Search Query</i> found
+              no messages. If an execution is desired a <i>Default Value</i> that yields the desired search result needs to be provided.
+              For example, (depending on the use case) a wildcard like <span style={{ whiteSpace: 'nowrap' }}><code>*</code></span>
+              can be a meaningful Default Value.
+            </p>
+            <p>
+              <h5>Limitations</h5>
+              Please note that maximum number of supported results is 1024. If the lookup table returns
+              more results, the event definition is not executed.
+            </p>
+
           </Panel>
         </BootstrapModalForm>
       </React.Fragment>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.jsx
@@ -37,11 +37,6 @@ class FilterAggregationForm extends React.Component {
     currentUser: PropTypes.object.isRequired,
   };
 
-  static defaultConfig = {
-    ...initialFilterConfig,
-    ...initialAggregationConfig,
-  };
-
   constructor(props) {
     super(props);
 
@@ -94,6 +89,11 @@ class FilterAggregationForm extends React.Component {
   handleChange = (event) => {
     const { name } = event.target;
     this.propagateChange(name, FormsUtils.getValueFromInput(event.target));
+  };
+
+  static defaultConfig = {
+    ...initialFilterConfig,
+    ...initialAggregationConfig,
   };
 
   render() {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.jsx
@@ -15,6 +15,7 @@ const conditionTypes = {
 
 const initialFilterConfig = {
   query: '',
+  query_parameters: [],
   streams: [],
   search_within_ms: 60 * 1000,
   execute_every_ms: 60 * 1000,

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationForm.jsx
@@ -34,6 +34,7 @@ class FilterAggregationForm extends React.Component {
     entityTypes: PropTypes.object.isRequired,
     streams: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired,
+    currentUser: PropTypes.object.isRequired,
   };
 
   static defaultConfig = {
@@ -97,7 +98,7 @@ class FilterAggregationForm extends React.Component {
 
   render() {
     const { conditionType } = this.state;
-    const { allFieldTypes, entityTypes, eventDefinition, streams, validation } = this.props;
+    const { allFieldTypes, entityTypes, eventDefinition, streams, validation, currentUser } = this.props;
 
     return (
       <React.Fragment>
@@ -106,6 +107,7 @@ class FilterAggregationForm extends React.Component {
             <FilterForm eventDefinition={eventDefinition}
                         validation={validation}
                         streams={streams}
+                        currentUser={currentUser}
                         onChange={this.propagateChange} />
 
             <FormGroup>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationFormContainer.jsx
@@ -23,6 +23,7 @@ class FilterAggregationFormContainer extends React.Component {
     eventDefinition: PropTypes.object.isRequired,
     fieldTypes: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
+    currentUser: PropTypes.object.isRequired, // Prop is passed down to pluggable entities
   };
 
   render() {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
@@ -16,7 +16,7 @@ import { naturalSortIgnoreCase } from 'util/SortUtils';
 import FormsUtils from 'util/FormsUtils';
 
 import CombinedProvider from 'injection/CombinedProvider';
-import { SearchMetadataStore } from 'views/stores/SearchMetadataStore';
+import { SearchMetadataActions } from 'views/stores/SearchMetadataStore';
 import PermissionsMixin from 'util/PermissionsMixin';
 import EditQueryParameterModal from '../event-definition-form/EditQueryParameterModal';
 import commonStyles from '../common/commonStyles.css';
@@ -78,7 +78,7 @@ class FilterForm extends React.Component {
       .queries([query])
       .build();
 
-    SearchMetadataStore.parseSearch(search).then((res) => {
+    SearchMetadataActions.parseSearch(search).then((res) => {
       this._syncParamsWithQuery(res.undeclared);
     });
   }, 250);
@@ -199,9 +199,6 @@ class FilterForm extends React.Component {
   renderQueryParameters = () => {
     const { eventDefinition, onChange, lookupTables, validation } = this.props;
     const { query_parameters: queryParameters } = eventDefinition.config;
-    const debug = (key, val) => {
-      onChange(key, val);
-    };
     const parameterButtons = queryParameters.map((queryParam) => {
       return (
         <EditQueryParameterModal key={queryParam.name}
@@ -209,21 +206,23 @@ class FilterForm extends React.Component {
                                  eventDefinition={eventDefinition}
                                  lookupTables={lookupTables.tables || []}
                                  validation={validation}
-                                 onChange={debug} />
+                                 onChange={onChange} />
       );
     });
 
     if (lodash.isEmpty(parameterButtons)) {
       return null;
     }
+    const hasEmbryonicParameters = !lodash.isEmpty(queryParameters.filter(param => (param.embryonic)));
     return (
       <React.Fragment>
-        <ControlLabel>Query Parameters <small className="text-muted">(Optional)</small></ControlLabel>
+        <ControlLabel>Query Parameters</ControlLabel>
         <Well>
           <ButtonToolbar>
             {parameterButtons}
           </ButtonToolbar>
         </Well>
+        { hasEmbryonicParameters && <HelpBlock bsStyle="danger">Please define the missing query parameters by clicking on the buttons above.</HelpBlock> }
       </React.Fragment>
     );
   };

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
@@ -35,15 +35,6 @@ const PREVIEW_PERMISSIONS = [
 ];
 
 class FilterForm extends React.Component {
-  static propTypes = {
-    eventDefinition: PropTypes.object.isRequired,
-    lookupTables: PropTypes.object.isRequired,
-    validation: PropTypes.object.isRequired,
-    streams: PropTypes.array.isRequired,
-    onChange: PropTypes.func.isRequired,
-    currentUser: PropTypes.object.isRequired,
-  };
-
   formatStreamIds = lodash.memoize(
     (streamIds) => {
       const { streams } = this.props;
@@ -91,6 +82,15 @@ class FilterForm extends React.Component {
       this._syncParamsWithQuery(res.undeclared);
     });
   }, 250);
+
+  static propTypes = {
+    eventDefinition: PropTypes.object.isRequired,
+    lookupTables: PropTypes.object.isRequired,
+    validation: PropTypes.object.isRequired,
+    streams: PropTypes.array.isRequired,
+    onChange: PropTypes.func.isRequired,
+    currentUser: PropTypes.object.isRequired,
+  };
 
   constructor(props) {
     super(props);
@@ -203,13 +203,12 @@ class FilterForm extends React.Component {
     };
     const parameterButtons = eventDefinition.config.query_parameters.map((queryParam) => {
       return (
-        <EditQueryParameterModal
-          key={queryParam.name}
-          queryParameter={queryParam}
-          eventDefinition={eventDefinition}
-          lookupTables={lookupTables.tables || []}
-          validation={validation}
-          onChange={debug} />
+        <EditQueryParameterModal key={queryParam.name}
+                                 queryParameter={queryParam}
+                                 eventDefinition={eventDefinition}
+                                 lookupTables={lookupTables.tables || []}
+                                 validation={validation}
+                                 onChange={debug} />
       );
     });
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
@@ -215,15 +215,15 @@ class FilterForm extends React.Component {
     }
     const hasEmbryonicParameters = !lodash.isEmpty(queryParameters.filter(param => (param.embryonic)));
     return (
-      <React.Fragment>
+      <FormGroup validationState={hasEmbryonicParameters && 'error'}>
         <ControlLabel>Query Parameters</ControlLabel>
         <Well>
           <ButtonToolbar>
             {parameterButtons}
           </ButtonToolbar>
         </Well>
-        { hasEmbryonicParameters && <HelpBlock bsStyle="danger">Please define the missing query parameters by clicking on the buttons above.</HelpBlock> }
-      </React.Fragment>
+        { hasEmbryonicParameters && <HelpBlock>Please define the missing query parameters by clicking on the buttons above.</HelpBlock> }
+      </FormGroup>
     );
   };
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
@@ -198,10 +198,11 @@ class FilterForm extends React.Component {
 
   renderQueryParameters = () => {
     const { eventDefinition, onChange, lookupTables, validation } = this.props;
+    const { query_parameters: queryParameters } = eventDefinition.config;
     const debug = (key, val) => {
       onChange(key, val);
     };
-    const parameterButtons = eventDefinition.config.query_parameters.map((queryParam) => {
+    const parameterButtons = queryParameters.map((queryParam) => {
       return (
         <EditQueryParameterModal key={queryParam.name}
                                  queryParameter={queryParam}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterPreviewContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterPreviewContainer.jsx
@@ -58,6 +58,7 @@ class FilterPreviewContainer extends React.Component {
     const query = queryBuilder.build();
 
     const search = Search.create().toBuilder()
+      .parameters(config.query_parameters.filter(param => (!param.embryonic)))
       .queries([query])
       .build();
 
@@ -72,10 +73,10 @@ class FilterPreviewContainer extends React.Component {
   componentDidUpdate(prevProps) {
     const { eventDefinition } = this.props;
 
-    const { query: prevQuery, streams: prevStreams, search_within_ms: prevSearchWithin } = prevProps.eventDefinition.config;
-    const { query, streams, search_within_ms: searchWithin } = eventDefinition.config;
+    const { query: prevQuery, query_parameters: prevQueryParameters, streams: prevStreams, search_within_ms: prevSearchWithin } = prevProps.eventDefinition.config;
+    const { query, query_parameters: queryParameters, streams, search_within_ms: searchWithin } = eventDefinition.config;
 
-    if (query !== prevQuery || !lodash.isEqual(streams, prevStreams) || searchWithin !== prevSearchWithin) {
+    if (query !== prevQuery || queryParameters !== prevQueryParameters || !lodash.isEqual(streams, prevStreams) || searchWithin !== prevSearchWithin) {
       this.fetchSearch(eventDefinition.config);
     }
   }

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterPreviewContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterPreviewContainer.jsx
@@ -22,12 +22,6 @@ const PREVIEW_PERMISSIONS = [
 ];
 
 class FilterPreviewContainer extends React.Component {
-  static propTypes = {
-    eventDefinition: PropTypes.object.isRequired,
-    filterPreview: PropTypes.object.isRequired,
-    currentUser: PropTypes.object.isRequired,
-  };
-
   state = {
     queryId: uuid(),
     searchTypeId: uuid(),
@@ -64,6 +58,12 @@ class FilterPreviewContainer extends React.Component {
 
     FilterPreviewActions.search(search);
   }, 250);
+
+  static propTypes = {
+    eventDefinition: PropTypes.object.isRequired,
+    filterPreview: PropTypes.object.isRequired,
+    currentUser: PropTypes.object.isRequired,
+  };
 
   componentDidMount() {
     const { eventDefinition } = this.props;

--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -74,6 +74,7 @@ import NewDashboardPage from 'views/pages/NewDashboardPage';
 import StreamSearchPage from 'views/pages/StreamSearchPage';
 import ShowDashboardInBigDisplayMode from 'views/pages/ShowDashboardInBigDisplayMode';
 import AppConfig from 'util/AppConfig';
+import LookupTableParameter from 'views/logic/parameters/LookupTableParameter';
 import type { ActionHandlerArguments, ActionHandlerCondition } from './components/actions/ActionHandler';
 import NumberVisualizationConfig from './logic/aggregationbuilder/visualizations/NumberVisualizationConfig';
 import BarVisualizationConfiguration from './components/aggregationbuilder/BarVisualizationConfiguration';
@@ -83,6 +84,8 @@ import LineVisualizationConfig from './logic/aggregationbuilder/visualizations/L
 import AreaVisualizationConfig from './logic/aggregationbuilder/visualizations/AreaVisualizationConfig';
 import LineVisualizationConfiguration from './components/aggregationbuilder/LineVisualizationConfiguration';
 import AreaVisualizationConfiguration from './components/aggregationbuilder/AreaVisualizationConfiguration';
+import Parameter from './logic/parameters/Parameter';
+import ValueParameter from './logic/parameters/ValueParameter';
 
 Widget.registerSubtype(AggregationWidget.type, AggregationWidget);
 Widget.registerSubtype(MessagesWidget.type, MessagesWidget);
@@ -99,6 +102,9 @@ VisualizationConfig.registerSubtype(AreaVisualization.type, AreaVisualizationCon
 ViewSharing.registerSubtype(AllUsersOfInstance.Type, AllUsersOfInstance);
 ViewSharing.registerSubtype(SpecificRoles.Type, SpecificRoles);
 ViewSharing.registerSubtype(SpecificUsers.Type, SpecificUsers);
+
+Parameter.registerSubtype(ValueParameter.type, ValueParameter);
+Parameter.registerSubtype(LookupTableParameter.type, LookupTableParameter);
 
 const enableNewSearch = AppConfig.isFeatureEnabled('search_3_2');
 

--- a/graylog2-web-interface/src/views/logic/parameters/LookupTableParameter.js
+++ b/graylog2-web-interface/src/views/logic/parameters/LookupTableParameter.js
@@ -1,0 +1,140 @@
+// @flow strict
+
+import Parameter from 'views/logic/parameters/Parameter';
+import * as Immutable from 'immutable';
+import type { ParameterJson } from './Parameter';
+import ParameterBinding from './ParameterBinding';
+
+type InternalBuilderState = Immutable.Map<string, any>;
+
+type InternalState = {
+  lookupTable: string,
+  key: string,
+}
+
+export type LookupTableParameterJson = ParameterJson & {
+  lookup_table: string,
+  key: string,
+};
+
+
+export default class LookupTableParameter extends Parameter {
+  static type = 'lut-parameter-v1';
+
+  _value2: InternalState;
+
+  // eslint-disable-next-line no-use-before-define
+  static Builder: typeof Builder;
+
+  constructor(name: string, title: string, description: string, dataType: string, defaultValue: any, optional: boolean, lookupTable: string, key: string) {
+    super(LookupTableParameter.type, name, title, description, dataType, defaultValue, optional, ParameterBinding.empty());
+    this._value2 = { lookupTable, key };
+  }
+
+  static create(type: string, name: string, title: string, description: string, dataType: string, defaultValue: any, optional: boolean, lookupTable: string, key: string): LookupTableParameter {
+    return new LookupTableParameter(name, title, description, dataType, defaultValue, optional, lookupTable, key);
+  }
+
+  // eslint-disable-next-line no-use-before-define
+  toBuilder(): Builder {
+    const { type, name, title, description, dataType, defaultValue, optional, binding } = this._value;
+    const { lookupTable, key } = this._value2;
+    // eslint-disable-next-line no-use-before-define
+    return new Builder(Immutable.Map({ type, name, title, description, dataType, defaultValue, optional, binding, lookupTable, key }));
+  }
+
+  get lookupTable(): string {
+    return this._value2.lookupTable;
+  }
+
+  get key(): string {
+    return this._value2.key;
+  }
+
+  toJSON(): LookupTableParameterJson {
+    const { type, name, title, description, dataType, defaultValue, optional } = this._value;
+    const { lookupTable, key } = this._value2;
+
+    return {
+      type,
+      name,
+      title,
+      description,
+      data_type: dataType,
+      default_value: defaultValue,
+      optional,
+      binding: undefined,
+      lookup_table: lookupTable,
+      key,
+    };
+  }
+
+  // static fromJSON(json: LookupTableParameterJson): Parameter {
+  // $FlowFixMe Flow can't override statics https://github.com/facebook/flow/issues/4953
+  static fromJSON(json: LookupTableParameterJson): LookupTableParameter {
+    // eslint-disable-next-line camelcase
+    const { name, title, description, data_type, default_value, optional, lookup_table, key } = json;
+
+    return new LookupTableParameter(name, title, description, data_type, default_value, optional, lookup_table, key);
+  }
+
+  // eslint-disable-next-line no-use-before-define
+  static builder(): Builder {
+    // eslint-disable-next-line no-use-before-define
+    return new Builder()
+      .type(LookupTableParameter.type)
+      .optional(false)
+      .dataType('any');
+  }
+}
+
+class Builder {
+  value: InternalBuilderState;
+
+  constructor(value: Immutable.Map = Immutable.Map()) {
+    this.value = value;
+  }
+
+  type(value: string): Builder {
+    return new this.constructor(this.value.set('type', value));
+  }
+
+  name(value: string): Builder {
+    return new this.constructor(this.value.set('name', value));
+  }
+
+  title(value: string): Builder {
+    return new this.constructor(this.value.set('title', value));
+  }
+
+  description(value: string): Builder {
+    return new this.constructor(this.value.set('description', value));
+  }
+
+  dataType(value: string): Builder {
+    return new this.constructor(this.value.set('dataType', value));
+  }
+
+  defaultValue(value: any): Builder {
+    return new this.constructor(this.value.set('defaultValue', value));
+  }
+
+  optional(value: boolean): Builder {
+    return new this.constructor(this.value.set('optional', value));
+  }
+
+  lookupTable(value: string): Builder {
+    return new this.constructor(this.value.set('lookupTable', value));
+  }
+
+  key(value: string): Builder {
+    return new this.constructor(this.value.set('key', value));
+  }
+
+  build(): LookupTableParameter {
+    const { name, title, description, dataType, defaultValue, optional, lookupTable, key } = this.value.toObject();
+    return new LookupTableParameter(name, title, description, dataType, defaultValue, optional, lookupTable, key);
+  }
+}
+
+LookupTableParameter.Builder = Builder;

--- a/graylog2-web-interface/src/views/logic/parameters/LookupTableParameter.js
+++ b/graylog2-web-interface/src/views/logic/parameters/LookupTableParameter.js
@@ -43,6 +43,8 @@ export default class LookupTableParameter extends Parameter {
     return new Builder(Immutable.Map({ type, name, title, description, dataType, defaultValue, optional, binding, lookupTable, key }));
   }
 
+  // screw you eslint, using param.constructor.needsBinding() is ugly
+  // eslint-disable-next-line class-methods-use-this
   get needsBinding(): boolean {
     return false;
   }

--- a/graylog2-web-interface/src/views/logic/parameters/LookupTableParameter.js
+++ b/graylog2-web-interface/src/views/logic/parameters/LookupTableParameter.js
@@ -43,6 +43,10 @@ export default class LookupTableParameter extends Parameter {
     return new Builder(Immutable.Map({ type, name, title, description, dataType, defaultValue, optional, binding, lookupTable, key }));
   }
 
+  get needsBinding(): boolean {
+    return false;
+  }
+
   get lookupTable(): string {
     return this._value2.lookupTable;
   }

--- a/graylog2-web-interface/src/views/logic/parameters/Parameter.js
+++ b/graylog2-web-interface/src/views/logic/parameters/Parameter.js
@@ -64,6 +64,10 @@ class Parameter {
     return this._value.optional;
   }
 
+  get needsBinding(): boolean {
+    return true;
+  }
+
   get binding(): ?ParameterBinding {
     return this._value.binding;
   }

--- a/graylog2-web-interface/src/views/logic/parameters/Parameter.js
+++ b/graylog2-web-interface/src/views/logic/parameters/Parameter.js
@@ -64,6 +64,8 @@ class Parameter {
     return this._value.optional;
   }
 
+  // screw you eslint, using param.constructor.needsBinding() is ugly
+  // eslint-disable-next-line class-methods-use-this
   get needsBinding(): boolean {
     return true;
   }

--- a/graylog2-web-interface/src/views/logic/parameters/Parameter.js
+++ b/graylog2-web-interface/src/views/logic/parameters/Parameter.js
@@ -32,7 +32,6 @@ class Parameter {
 
   static __registrations: { [string]: typeof Parameter } = {};
 
-
   constructor(type: string, name: string, title: string, description: string, dataType: string, defaultValue: any, optional: boolean, binding: ?ParameterBinding) {
     this._value = { type, name, title, description, dataType, defaultValue, optional, binding };
   }
@@ -70,7 +69,7 @@ class Parameter {
   }
 
   static fromJSON(value: ParameterJson): Parameter {
-    const { type } = value;
+    const { type = 'value-parameter-v1' } = value; // default to ValueParameter in case type is empty
     const implementingClass = Parameter.__registrations[type.toLocaleLowerCase()];
 
     if (implementingClass) {

--- a/graylog2-web-interface/src/views/logic/parameters/Parameter.js
+++ b/graylog2-web-interface/src/views/logic/parameters/Parameter.js
@@ -1,35 +1,44 @@
 // @flow strict
 
 import * as Immutable from 'immutable';
-import ParameterBinding from './ParameterBinding';
+import ParameterBinding from 'views/logic/parameters/ParameterBinding';
+import type { ParameterBindingJsonRepresentation } from './ParameterBinding';
+import { singleton } from '../singleton';
 
 type InternalState = {
+  type: string,
   name: string,
   title: string,
   description: string,
   dataType: string,
   defaultValue: any,
   optional: boolean,
-  binding: ParameterBinding,
+  binding: ?ParameterBinding
 };
 
-type InternalBuilderState = Immutable.Map<string, any>;
-
 export type ParameterJson = {
+  type: string,
   name: string,
   title: string,
   description: string,
   data_type: string,
   default_value: any,
   optional: boolean,
-  binding: ParameterBinding,
+  binding: ?ParameterBindingJsonRepresentation,
 };
 
-export default class Parameter {
+class Parameter {
   _value: InternalState;
 
-  constructor(name: string, title: string, description: string, dataType: string, defaultValue: any, optional: boolean, binding: ParameterBinding) {
-    this._value = { name, title, description, dataType, defaultValue, optional, binding };
+  static __registrations: { [string]: typeof Parameter } = {};
+
+
+  constructor(type: string, name: string, title: string, description: string, dataType: string, defaultValue: any, optional: boolean, binding: ?ParameterBinding) {
+    this._value = { type, name, title, description, dataType, defaultValue, optional, binding };
+  }
+
+  get type(): string {
+    return this._value.type;
   }
 
   get name(): string {
@@ -56,90 +65,24 @@ export default class Parameter {
     return this._value.optional;
   }
 
-  get binding(): ParameterBinding {
+  get binding(): ?ParameterBinding {
     return this._value.binding;
   }
 
-  // eslint-disable-next-line no-use-before-define
-  toBuilder(): Builder {
-    const { name, title, description, dataType, defaultValue, optional, binding } = this._value;
-    // eslint-disable-next-line no-use-before-define
-    return new Builder(Immutable.Map({ name, title, description, dataType, defaultValue, optional, binding }));
-  }
-
-  static create(name: string, title: string, description: string, dataType: string, defaultValue: any, optional: boolean, binding: ParameterBinding): Parameter {
-    return new Parameter(name, title, description, dataType, defaultValue, optional, binding);
-  }
-
-  toJSON(): ParameterJson {
-    const { name, title, description, dataType, defaultValue, optional, binding } = this._value;
-
-    return {
-      name,
-      title,
-      description,
-      data_type: dataType,
-      default_value: defaultValue,
-      optional,
-      binding,
-    };
-  }
-
   static fromJSON(value: ParameterJson): Parameter {
-    // eslint-disable-next-line camelcase
-    const { name, title, description, data_type, default_value, optional, binding } = value;
-    return Parameter.create(name, title, description, data_type, default_value, optional, binding);
+    const { type } = value;
+    const implementingClass = Parameter.__registrations[type.toLocaleLowerCase()];
+
+    if (implementingClass) {
+      return implementingClass.fromJSON(value);
+    }
+    throw new Error(`No class found for type <${type}>`);
   }
 
-  // eslint-disable-next-line no-use-before-define
-  static builder(): Builder {
-    // eslint-disable-next-line no-use-before-define
-    return new Builder()
-      .optional(false)
-      .dataType('any')
-      .binding(ParameterBinding.empty());
-  }
-}
-
-class Builder {
-  value: InternalBuilderState;
-
-  constructor(value: Immutable.Map = Immutable.Map()) {
-    this.value = value;
-  }
-
-  name(value: string): Builder {
-    return new Builder(this.value.set('name', value));
-  }
-
-  title(value: string): Builder {
-    return new Builder(this.value.set('title', value));
-  }
-
-  description(value: string): Builder {
-    return new Builder(this.value.set('description', value));
-  }
-
-  dataType(value: string): Builder {
-    return new Builder(this.value.set('dataType', value));
-  }
-
-  defaultValue(value: any): Builder {
-    return new Builder(this.value.set('defaultValue', value));
-  }
-
-  optional(value: boolean): Builder {
-    return new Builder(this.value.set('optional', value));
-  }
-
-  binding(value: ParameterBinding): Builder {
-    return new Builder(this.value.set('binding', value));
-  }
-
-  build(): Parameter {
-    const { name, title, description, dataType, defaultValue, optional, binding } = this.value.toObject();
-    return new Parameter(name, title, description, dataType, defaultValue, optional, binding);
+  static registerSubtype(type: string, implementingClass: typeof Parameter) {
+    this.__registrations[type.toLocaleLowerCase()] = implementingClass;
   }
 }
+export default singleton('views.logic.parameters.Parameter', () => Parameter);
 
 export type ParameterMap = Immutable.Map<string, Parameter>;

--- a/graylog2-web-interface/src/views/logic/parameters/ParameterBinding.js
+++ b/graylog2-web-interface/src/views/logic/parameters/ParameterBinding.js
@@ -8,7 +8,7 @@ type InternalState = {
 
 type InternalStateBuilder = Immutable.Map<string, any>;
 
-type JsonRepresentation = {
+export type ParameterBindingJsonRepresentation = {
   type: string,
   value: any,
 };
@@ -47,7 +47,7 @@ export default class ParameterBinding {
     return ParameterBinding.create('value', '');
   }
 
-  toJSON(): JsonRepresentation {
+  toJSON(): ParameterBindingJsonRepresentation {
     const { type, value } = this._value;
 
     return {
@@ -56,7 +56,10 @@ export default class ParameterBinding {
     };
   }
 
-  static fromJSON(json: JsonRepresentation): ParameterBinding {
+  static fromJSON(json: ?ParameterBindingJsonRepresentation): ?ParameterBinding {
+    if (json == null) {
+      return null;
+    }
     const { type, value } = json;
     return ParameterBinding.create(type, value);
   }

--- a/graylog2-web-interface/src/views/logic/parameters/ValueParameter.js
+++ b/graylog2-web-interface/src/views/logic/parameters/ValueParameter.js
@@ -1,0 +1,108 @@
+// @flow strict
+
+import Parameter from 'views/logic/parameters/Parameter';
+import ParameterBinding from 'views/logic/parameters/ParameterBinding';
+import * as Immutable from 'immutable';
+import type { ParameterJson } from 'views/logic/parameters/Parameter';
+
+type InternalBuilderState = Immutable.Map<string, any>;
+
+export default class ValueParameter extends Parameter {
+  static type = 'value-parameter-v1';
+
+  // eslint-disable-next-line no-use-before-define
+  static Builder: typeof Builder;
+
+  constructor(name: string, title: string, description: string, dataType: string, defaultValue: any, optional: boolean, binding: ?ParameterBinding) {
+    super(ValueParameter.type, name, title, description, dataType, defaultValue, optional, binding);
+  }
+
+  static create(name: string, title: string, description: string, dataType: string, defaultValue: any, optional: boolean, binding: ?ParameterBinding): ValueParameter {
+    return new ValueParameter(name, title, description, dataType, defaultValue, optional, binding);
+  }
+
+  // eslint-disable-next-line no-use-before-define
+  toBuilder(): Builder {
+    const { type, name, title, description, dataType, defaultValue, optional, binding } = this._value;
+    // eslint-disable-next-line no-use-before-define
+    return new Builder(Immutable.Map({ type, name, title, description, dataType, defaultValue, optional, binding }));
+  }
+
+  toJSON(): ParameterJson {
+    const { type, name, title, description, dataType, defaultValue, optional, binding } = this._value;
+
+    return {
+      type,
+      name,
+      title,
+      description,
+      data_type: dataType,
+      default_value: defaultValue,
+      optional,
+      binding: binding ? binding.toJSON() : undefined,
+    };
+  }
+
+  static fromJSON(value: ParameterJson): ValueParameter {
+    // eslint-disable-next-line camelcase
+    const { name, title, description, data_type, default_value, optional, binding } = value;
+    return new ValueParameter(name, title, description, data_type, default_value, optional, ParameterBinding.fromJSON(binding));
+  }
+
+  // eslint-disable-next-line no-use-before-define
+  static builder(): Builder {
+    // eslint-disable-next-line no-use-before-define
+    return new Builder()
+      .type(ValueParameter.type)
+      .optional(false)
+      .dataType('any')
+      .binding(ParameterBinding.empty());
+  }
+}
+
+class Builder {
+  value: InternalBuilderState;
+
+  constructor(value: Immutable.Map = Immutable.Map()) {
+    this.value = value;
+  }
+
+  type(value: string): Builder {
+    return new this.constructor(this.value.set('type', value));
+  }
+
+  name(value: string): Builder {
+    return new this.constructor(this.value.set('name', value));
+  }
+
+  title(value: string): Builder {
+    return new this.constructor(this.value.set('title', value));
+  }
+
+  description(value: string): Builder {
+    return new this.constructor(this.value.set('description', value));
+  }
+
+  dataType(value: string): Builder {
+    return new this.constructor(this.value.set('dataType', value));
+  }
+
+  defaultValue(value: any): Builder {
+    return new this.constructor(this.value.set('defaultValue', value));
+  }
+
+  optional(value: boolean): Builder {
+    return new this.constructor(this.value.set('optional', value));
+  }
+
+  binding(value: ParameterBinding): Builder {
+    return new this.constructor(this.value.set('binding', value));
+  }
+
+  build(): ValueParameter {
+    const { name, title, description, dataType, defaultValue, optional, binding } = this.value.toObject();
+    return new ValueParameter(name, title, description, dataType, defaultValue, optional, binding);
+  }
+}
+
+ValueParameter.Builder = Builder;

--- a/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.Dashboard-Search.fixture.json
+++ b/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.Dashboard-Search.fixture.json
@@ -56,6 +56,7 @@
   ],
   "parameters": [
     {
+      "type": "value-parameter-v1",
       "name": "project",
       "title": "Project",
       "description": "",

--- a/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.test.js
+++ b/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.test.js
@@ -4,6 +4,8 @@ import { dirname } from 'path';
 import Search from 'views/logic/search/Search';
 import View from 'views/logic/views/View';
 import copyWidgetToDashboard from './CopyWidgetToDashboard';
+import ValueParameter from '../parameters/ValueParameter';
+import Parameter from '../parameters/Parameter';
 
 jest.mock('uuid/v4', () => jest.fn(() => 'dead-beef'));
 
@@ -21,12 +23,17 @@ const cwd = dirname(__filename);
 const readFixture = filename => JSON.parse(readFileSync(`${cwd}/${filename}`).toString());
 
 describe('copyWidgetToDashboard', () => {
+  beforeEach(() => {
+    Parameter.registerSubtype(ValueParameter.type, ValueParameter);
+  });
+
   it('should copy a Widget to a dashboard', () => {
     const searchViewFixture = View.fromJSON(readFixture('./CopyWidgetToDashboard.Search-View.fixture.json'));
     const searchSearchFixture = Search.fromJSON(readFixture('./CopyWidgetToDashboard.Search-Search.fixture.json'));
     const searchView = searchViewFixture.toBuilder()
       .search(searchSearchFixture)
       .build();
+
 
     const dashboardViewFixture = View.fromJSON(readFixture('./CopyWidgetToDashboard.Dashboard-View.fixture.json'));
     const dashboardSearchFixture = Search.fromJSON(readFixture('./CopyWidgetToDashboard.Dashboard-Search.fixture.json'));

--- a/graylog2-web-interface/src/views/logic/views/UpdateSearchForWidgets.Search.fixture.json
+++ b/graylog2-web-interface/src/views/logic/views/UpdateSearchForWidgets.Search.fixture.json
@@ -376,6 +376,7 @@
   ],
   "parameters": [
     {
+      "type": "value-parameter-v1",
       "name": "author",
       "title": "Author",
       "description": "",

--- a/graylog2-web-interface/src/views/logic/views/UpdateSearchForWidgets.test.js
+++ b/graylog2-web-interface/src/views/logic/views/UpdateSearchForWidgets.test.js
@@ -5,6 +5,8 @@ import Search from 'views/logic/search/Search';
 import View from 'views/logic/views/View';
 
 import UpdateSearchForWidgets from './UpdateSearchForWidgets';
+import Parameter from "../parameters/Parameter";
+import ValueParameter from "../parameters/ValueParameter";
 
 const cwd = dirname(__filename);
 const readFixture = filename => JSON.parse(readFileSync(`${cwd}/${filename}`).toString());
@@ -22,6 +24,10 @@ jest.mock('../SearchType', () => jest.fn(() => ({
 })));
 
 describe('UpdateSearchForWidgets', () => {
+  beforeEach(() => {
+    Parameter.registerSubtype(ValueParameter.type, ValueParameter);
+  });
+
   it('should generate a new search for the view', () => {
     const viewFixture = View.fromJSON(readFixture('./UpdateSearchForWidgets.View.fixture.json'));
     const searchFixture = Search.fromJSON(readFixture('./UpdateSearchForWidgets.Search.fixture.json'));

--- a/graylog2-web-interface/src/views/logic/views/UpdateSearchForWidgets.test.js
+++ b/graylog2-web-interface/src/views/logic/views/UpdateSearchForWidgets.test.js
@@ -5,8 +5,8 @@ import Search from 'views/logic/search/Search';
 import View from 'views/logic/views/View';
 
 import UpdateSearchForWidgets from './UpdateSearchForWidgets';
-import Parameter from "../parameters/Parameter";
-import ValueParameter from "../parameters/ValueParameter";
+import Parameter from '../parameters/Parameter';
+import ValueParameter from '../parameters/ValueParameter';
 
 const cwd = dirname(__filename);
 const readFixture = filename => JSON.parse(readFileSync(`${cwd}/${filename}`).toString());


### PR DESCRIPTION
Using lookup table parameters in event definition queries
allows us to create events in case a condition matches a list
that is fetched via lookup tables.

 - Split Parameters into two subtypes:
   ValueParameter and LookupTableParameter.

 - Allow Parameters without a Binding, since LookupTableParameters don't require one.

 - Add queryParameters to AggregationEventProcessorConfig

 - If the LUT does return an empty list and there is no default parameter value defined,
   just skip running the query and assume that we received no results.
   This avoids running queries with an invalid ES query string.

 - Add frontend code to create parameters for an event defintion

cf https://github.com/Graylog2/graylog-plugin-enterprise/issues/1195
