### PR TITLE
Prevent stale objects in stream cache of route_to_stream function

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -18,7 +18,6 @@ package org.graylog.plugins.pipelineprocessor.functions;
 
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -125,7 +124,6 @@ import org.graylog.plugins.pipelineprocessor.functions.urls.UrlDecode;
 import org.graylog.plugins.pipelineprocessor.functions.urls.UrlEncode;
 import org.graylog.plugins.pipelineprocessor.parser.FunctionRegistry;
 import org.graylog.plugins.pipelineprocessor.parser.ParseException;
-import org.graylog2.database.NotFoundException;
 import org.graylog2.grok.GrokPattern;
 import org.graylog2.grok.GrokPatternRegistry;
 import org.graylog2.grok.GrokPatternService;
@@ -142,7 +140,6 @@ import org.joda.time.Duration;
 import org.joda.time.Period;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.mockito.ArgumentMatchers;
 
 import javax.inject.Provider;
 import java.util.Arrays;
@@ -156,7 +153,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -201,13 +197,6 @@ public class FunctionsSnippetsTest extends BaseParserTest {
 
         when(streamService.loadAll()).thenReturn(Lists.newArrayList(defaultStream, otherStream));
         when(streamService.loadAllEnabled()).thenReturn(Lists.newArrayList(defaultStream, otherStream));
-        try {
-            when(streamService.load(anyString())).thenThrow(new NotFoundException());
-            when(streamService.load(ArgumentMatchers.eq(Stream.DEFAULT_STREAM_ID))).thenReturn(defaultStream);
-            when(streamService.load(ArgumentMatchers.eq("id2"))).thenReturn(otherStream);
-        } catch (NotFoundException ignored) {
-            // oh well, checked exceptions <3
-        }
         streamCacheService = new StreamCacheService(eventBus, streamService, null);
         streamCacheService.startAsync().awaitRunning();
         final Provider<Stream> defaultStreamProvider = () -> defaultStream;
@@ -965,8 +954,6 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message.getStreams()).isNotEmpty();
         assertThat(message.getStreams().size()).isEqualTo(2);
 
-        streamCacheService.updateStreams(ImmutableSet.of("id"));
-
         final Message message2 = evaluateRule(rule);
         assertThat(message2).isNotNull();
         assertThat(message2.getStreams().size()).isEqualTo(2);
@@ -980,8 +967,6 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         assertThat(message).isNotNull();
         assertThat(message.getStreams()).isNotEmpty();
         assertThat(message.getStreams().size()).isEqualTo(1);
-
-        streamCacheService.updateStreams(ImmutableSet.of(Stream.DEFAULT_STREAM_ID));
 
         final Message message2 = evaluateRule(rule);
         assertThat(message2).isNotNull();

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/messages/StreamCacheServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/messages/StreamCacheServiceTest.java
@@ -16,28 +16,127 @@
  */
 package org.graylog.plugins.pipelineprocessor.functions.messages;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
-
+import org.bson.types.ObjectId;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.shared.SuppressForbidden;
+import org.graylog2.streams.StreamImpl;
 import org.graylog2.streams.StreamService;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog2.streams.StreamImpl.FIELD_INDEX_SET_ID;
+import static org.graylog2.streams.StreamImpl.FIELD_TITLE;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+@SuppressWarnings("UnstableApiUsage")
 public class StreamCacheServiceTest {
-    @Test
-    @SuppressForbidden("Allow using default thread factory")
-    public void getByName() throws Exception {
-        final StreamCacheService streamCacheService = new StreamCacheService(new EventBus(), mock(StreamService.class), Executors.newSingleThreadScheduledExecutor());
 
+    private StreamCacheService cacheService;
+
+    private StreamService streamService;
+
+    @Before
+    @SuppressForbidden("Allow using default thread factory")
+    public void setUp() throws Exception {
+        streamService = mock(StreamService.class);
+        cacheService = new StreamCacheService(new EventBus(), streamService,
+                                              Executors.newSingleThreadScheduledExecutor());
+    }
+
+    @Test
+    public void getByName() {
         // make sure getByName always returns a collection
-        final Collection<Stream> streams = streamCacheService.getByName("nonexisting");
+        final Collection<Stream> streams = cacheService.getByName("nonexisting");
         assertThat(streams).isNotNull().isEmpty();
     }
 
+    @Test
+    public void multipleStreamsBySameName() {
+        Stream stream1 = createStream(new ObjectId(), ImmutableMap.of(FIELD_TITLE, "title"));
+        Stream stream2 = createStream(new ObjectId(), ImmutableMap.of(FIELD_TITLE, "title"));
+        Stream stream3 = createStream(new ObjectId(), ImmutableMap.of(FIELD_TITLE, "different title"));
+
+        when(streamService.loadAllEnabled()).thenReturn(ImmutableList.of(stream1, stream2, stream3));
+
+        cacheService.updateStreams();
+
+        assertEquals(ImmutableSet.of(stream1, stream2), cacheService.getByName("title"));
+        assertEquals(ImmutableSet.of(stream3), cacheService.getByName("different title"));
+    }
+
+    @Test
+    public void updatesStreamByName() {
+        ObjectId streamId = new ObjectId();
+        Stream stream = createStream(streamId, ImmutableMap.of(FIELD_TITLE, "title"));
+
+        Stream modifiedStream = createStream(streamId, ImmutableMap.of(
+                FIELD_TITLE, "title", FIELD_INDEX_SET_ID, "index-set-id"));
+
+        when(streamService.loadAllEnabled()).thenReturn(ImmutableList.of(stream));
+        cacheService.updateStreams();
+
+        Collection<Stream> streams = cacheService.getByName("title");
+
+        // using assertEquals instead of assertThat(streams).containsExactlyInAnyOrder() here to avoid using the
+        // TreeSet comparator for containment checks
+        assertEquals(Collections.singleton(stream), streams);
+
+        when(streamService.loadAllEnabled()).thenReturn(ImmutableList.of(modifiedStream));
+        cacheService.updateStreams();
+
+        streams = cacheService.getByName("title");
+
+        assertEquals(Collections.singleton(modifiedStream), streams);
+    }
+
+    @Test
+    public void purgesStreamByName() {
+        ObjectId streamId = new ObjectId();
+        Stream stream = createStream(streamId, ImmutableMap.of(FIELD_TITLE, "title"));
+
+        when(streamService.loadAllEnabled()).thenReturn(ImmutableList.of(stream));
+        cacheService.updateStreams();
+
+        assertThat(cacheService.getByName("title")).isNotEmpty();
+
+        when(streamService.loadAllEnabled()).thenReturn(Collections.emptyList());
+        cacheService.updateStreams();
+
+        assertThat(cacheService.getByName("title")).isEmpty();
+    }
+
+    @Test
+    public void titleChanges() {
+        ObjectId streamId = new ObjectId();
+        Stream stream = createStream(streamId, ImmutableMap.of(FIELD_TITLE, "title"));
+        Stream modifiedStream = createStream(streamId, ImmutableMap.of(FIELD_TITLE, "new title"));
+
+        when(streamService.loadAllEnabled()).thenReturn(ImmutableList.of(stream));
+        cacheService.updateStreams();
+
+        when(streamService.loadAllEnabled()).thenReturn(ImmutableList.of(modifiedStream));
+        cacheService.updateStreams();
+
+        Collection<Stream> streams = cacheService.getByName("title");
+        assertThat(streams).isEmpty();
+
+        streams = cacheService.getByName("new title");
+        assertEquals(Collections.singleton(modifiedStream), streams);
+    }
+
+    private Stream createStream(ObjectId id, Map<String, Object> fields) {
+        return new StreamImpl(id, fields, Collections.emptyList(), Collections.emptySet(), null);
+    }
 }


### PR DESCRIPTION
Previously we were storing the stream itself in the nameToStream
MultiMap but were using only the id of the stream as the comparator for
the underlying set. This would lead to stale stream objects in that
cache if the cache was updated with a changed stream which was already
cached.

The implementation felt way to complicated for what it was doing. For
the benefit of having clearer semantics we simply reload all streams
when a stream changes. This will put additional load on the database for
cache updating but cache lookup times will stay stable.

Fixes #4954

(cherry picked from commit e9dc74a7cff40506f9c9831d210b905120f745e4)
