### PR TITLE
Adding interpolation options for line/area visualizations.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -65,8 +65,10 @@ import org.graylog.plugins.views.search.views.sharing.SpecificRolesStrategy;
 import org.graylog.plugins.views.search.views.sharing.SpecificUsers;
 import org.graylog.plugins.views.search.views.sharing.SpecificUsersStrategy;
 import org.graylog.plugins.views.search.views.widgets.aggregation.AggregationConfigDTO;
+import org.graylog.plugins.views.search.views.widgets.aggregation.AreaVisualizationConfigDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.AutoIntervalDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.BarVisualizationConfigDTO;
+import org.graylog.plugins.views.search.views.widgets.aggregation.LineVisualizationConfigDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.NumberVisualizationConfigDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.TimeHistogramConfigDTO;
 import org.graylog.plugins.views.search.views.widgets.aggregation.TimeUnitIntervalDTO;
@@ -175,6 +177,8 @@ public class ViewsBindings extends ViewsModule {
         registerJacksonSubtype(WorldMapVisualizationConfigDTO.class);
         registerJacksonSubtype(BarVisualizationConfigDTO.class);
         registerJacksonSubtype(NumberVisualizationConfigDTO.class);
+        registerJacksonSubtype(LineVisualizationConfigDTO.class);
+        registerJacksonSubtype(AreaVisualizationConfigDTO.class);
     }
 
     private void registerViewSharingSubtypes() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/AreaVisualizationConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/AreaVisualizationConfigDTO.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.views.search.views.widgets.aggregation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/AreaVisualizationConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/AreaVisualizationConfigDTO.java
@@ -1,0 +1,32 @@
+package org.graylog.plugins.views.search.views.widgets.aggregation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+@JsonTypeName(AreaVisualizationConfigDTO.NAME)
+@JsonDeserialize(builder = AreaVisualizationConfigDTO.Builder.class)
+public abstract class AreaVisualizationConfigDTO implements VisualizationConfigDTO {
+    public static final String NAME = "area";
+    private static final String FIELD_INTERPOLATION = "interpolation";
+
+    @JsonProperty(FIELD_INTERPOLATION)
+    public abstract Interpolation interpolation();
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        @JsonProperty(FIELD_INTERPOLATION)
+        public abstract Builder interpolation(Interpolation interpolation);
+
+        public abstract AreaVisualizationConfigDTO build();
+
+        @JsonCreator
+        public static Builder builder() {
+            return new AutoValue_AreaVisualizationConfigDTO.Builder()
+                    .interpolation(Interpolation.defaultValue());
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/Interpolation.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/Interpolation.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.views.search.views.widgets.aggregation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/Interpolation.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/Interpolation.java
@@ -1,0 +1,25 @@
+package org.graylog.plugins.views.search.views.widgets.aggregation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum Interpolation {
+    linear("linear"),
+    stepAfter("step-after"),
+    spline("spline");
+
+    private final String value;
+    @JsonValue
+    public String value() {
+        return this.value;
+    }
+
+    public static Interpolation defaultValue() {
+        return linear;
+    }
+
+    @JsonCreator
+    Interpolation(String value) {
+        this.value = value;
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/LineVisualizationConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/LineVisualizationConfigDTO.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.views.search.views.widgets.aggregation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/LineVisualizationConfigDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/LineVisualizationConfigDTO.java
@@ -1,0 +1,32 @@
+package org.graylog.plugins.views.search.views.widgets.aggregation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+@JsonTypeName(LineVisualizationConfigDTO.NAME)
+@JsonDeserialize(builder = LineVisualizationConfigDTO.Builder.class)
+public abstract class LineVisualizationConfigDTO implements VisualizationConfigDTO {
+    public static final String NAME = "line";
+    private static final String FIELD_INTERPOLATION = "interpolation";
+
+    @JsonProperty(FIELD_INTERPOLATION)
+    public abstract Interpolation interpolation();
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        @JsonProperty(FIELD_INTERPOLATION)
+        public abstract Builder interpolation(Interpolation interpolation);
+
+        public abstract LineVisualizationConfigDTO build();
+
+        @JsonCreator
+        public static Builder builder() {
+            return new AutoValue_LineVisualizationConfigDTO.Builder()
+                    .interpolation(Interpolation.defaultValue());
+        }
+    }
+}

--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -77,6 +77,10 @@ import NumberVisualizationConfig from './logic/aggregationbuilder/visualizations
 import BarVisualizationConfiguration from './components/aggregationbuilder/BarVisualizationConfiguration';
 import NumberVisualizationConfiguration from './components/aggregationbuilder/NumberVisualizationConfiguration';
 import AreaVisualization from './components/visualizations/area/AreaVisualization';
+import LineVisualizationConfig from './logic/aggregationbuilder/visualizations/LineVisualizationConfig';
+import AreaVisualizationConfig from './logic/aggregationbuilder/visualizations/AreaVisualizationConfig';
+import LineVisualizationConfiguration from './components/aggregationbuilder/LineVisualizationConfiguration';
+import AreaVisualizationConfiguration from './components/aggregationbuilder/AreaVisualizationConfiguration';
 
 Widget.registerSubtype(AggregationWidget.type, AggregationWidget);
 Widget.registerSubtype(MessagesWidget.type, MessagesWidget);
@@ -85,6 +89,10 @@ VisualizationConfig.registerSubtype(WorldMapVisualization.type, WorldMapVisualiz
 // $FlowFixMe: type is not undefined in this case.
 VisualizationConfig.registerSubtype(BarVisualization.type, BarVisualizationConfig);
 VisualizationConfig.registerSubtype(NumberVisualization.type, NumberVisualizationConfig);
+// $FlowFixMe: type is not undefined in this case.
+VisualizationConfig.registerSubtype(LineVisualization.type, LineVisualizationConfig);
+// $FlowFixMe: type is not undefined in this case.
+VisualizationConfig.registerSubtype(AreaVisualization.type, AreaVisualizationConfig);
 
 ViewSharing.registerSubtype(AllUsersOfInstance.Type, AllUsersOfInstance);
 ViewSharing.registerSubtype(SpecificRoles.Type, SpecificRoles);
@@ -296,8 +304,16 @@ export default {
   ],
   visualizationConfigTypes: [
     {
+      type: AreaVisualization.type,
+      component: AreaVisualizationConfiguration,
+    },
+    {
       type: BarVisualization.type,
       component: BarVisualizationConfiguration,
+    },
+    {
+      type: LineVisualization.type,
+      component: LineVisualizationConfiguration,
     },
     {
       type: NumberVisualization.type,

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AreaVisualizationConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AreaVisualizationConfiguration.jsx
@@ -1,0 +1,29 @@
+// @flow strict
+import React, { useCallback } from 'react';
+import { capitalize } from 'lodash';
+
+import AreaVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig';
+import Select from '../Select';
+
+type Props = {
+  onChange: (config: AreaVisualizationConfig) => void,
+  config: AreaVisualizationConfig,
+};
+
+const _makeOption = value => ({ label: capitalize(value), value });
+const interpolationOptions = ['linear', 'step-after', 'spline'].map(_makeOption);
+
+const AreaVisualizationConfiguration = ({ config = AreaVisualizationConfig.empty(), onChange }: Props) => {
+  const _onChange = useCallback(({ value }) => onChange(config.toBuilder().interpolation(value).build()), [config, onChange]);
+  return (
+    <React.Fragment>
+      <span>Interpolation:</span>
+      <Select placeholder="Select Interpolation Mode"
+              onChange={_onChange}
+              options={interpolationOptions}
+              value={_makeOption(config.interpolation)} />
+    </React.Fragment>
+  );
+};
+
+export default AreaVisualizationConfiguration;

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/LineVisualizationConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/LineVisualizationConfiguration.jsx
@@ -1,0 +1,29 @@
+// @flow strict
+import React, { useCallback } from 'react';
+import { capitalize } from 'lodash';
+
+import LineVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/LineVisualizationConfig';
+import Select from '../Select';
+
+type Props = {
+  onChange: (config: LineVisualizationConfig) => void,
+  config: LineVisualizationConfig,
+};
+
+const _makeOption = value => ({ label: capitalize(value), value });
+const interpolationOptions = ['linear', 'step-after', 'spline'].map(_makeOption);
+
+const LineVisualizationConfiguration = ({ config = LineVisualizationConfig.empty(), onChange }: Props) => {
+  const _onChange = useCallback(({ value }) => onChange(config.toBuilder().interpolation(value).build()), [config, onChange]);
+  return (
+    <React.Fragment>
+      <span>Interpolation:</span>
+      <Select placeholder="Select Interpolation Mode"
+              onChange={_onChange}
+              options={interpolationOptions}
+              value={_makeOption(config.interpolation)} />
+    </React.Fragment>
+  );
+};
+
+export default LineVisualizationConfiguration;

--- a/graylog2-web-interface/src/views/components/visualizations/XYPlot.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/XYPlot.jsx
@@ -1,5 +1,5 @@
 // @flow strict
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment-timezone';
 import { get, merge } from 'lodash';
@@ -48,7 +48,8 @@ const XYPlot = ({
 
   const layout = merge({}, { yaxis }, plotLayout);
 
-  const _onZoom = config.isTimeline ? (from, to) => onZoom(currentQuery, from, to) : () => true;
+  const _onZoom = useCallback(config.isTimeline ? (from, to) => onZoom(currentQuery, from, to) : () => true, [config.isTimeline, onZoom]);
+
   if (config.isTimeline) {
     const normalizedFrom = moment.tz(effectiveTimerange.from, timezone).format();
     const normalizedTo = moment.tz(effectiveTimerange.to, timezone).format();

--- a/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.jsx
@@ -1,21 +1,14 @@
 // @flow strict
-import * as React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 
+import toPlotly from 'views/logic/aggregationbuilder/visualizations/Interpolation';
+import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
+import { AggregationType } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
+import AreaVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig';
 import type { ChartDefinition } from '../ChartData';
-import type { VisualizationComponent, VisualizationComponentProps } from '../../aggregationbuilder/AggregationBuilder';
-import { AggregationType } from '../../aggregationbuilder/AggregationBuilderPropTypes';
 import XYPlot from '../XYPlot';
 import { chartData } from '../ChartData';
-
-const chartGenerator = (type, name, labels, values): ChartDefinition => ({
-  type,
-  name,
-  x: labels,
-  y: values,
-  fill: 'tozeroy',
-  line: { shape: 'linear' },
-});
 
 const getChartColor = (fullData, name) => {
   const data = fullData.find(d => (d.name === name));
@@ -28,13 +21,27 @@ const getChartColor = (fullData, name) => {
 
 const setChartColor = (chart, colors) => ({ line: { color: colors[chart.name] } });
 
-const AreaVisualization: VisualizationComponent = ({ config, data, effectiveTimerange }: VisualizationComponentProps) => (
-  <XYPlot config={config}
-          effectiveTimerange={effectiveTimerange}
-          getChartColor={getChartColor}
-          setChartColor={setChartColor}
-          chartData={chartData(config, data.chart || Object.values(data)[0], 'scatter', chartGenerator)} />
-);
+const AreaVisualization: VisualizationComponent = ({ config, data, effectiveTimerange }: VisualizationComponentProps) => {
+  // $FlowFixMe: We need to assume it is a LineVisualizationConfig instance
+  const visualizationConfig: AreaVisualizationConfig = config.visualizationConfig || AreaVisualizationConfig.empty();
+  const { interpolation = 'linear' } = visualizationConfig;
+  const chartGenerator = useCallback((type, name, labels, values): ChartDefinition => ({
+    type,
+    name,
+    x: labels,
+    y: values,
+    fill: 'tozeroy',
+    line: { shape: toPlotly(interpolation) },
+  }), [interpolation]);
+
+  return (
+    <XYPlot config={config}
+            effectiveTimerange={effectiveTimerange}
+            getChartColor={getChartColor}
+            setChartColor={setChartColor}
+            chartData={chartData(config, data.chart || Object.values(data)[0], 'scatter', chartGenerator)} />
+  );
+};
 
 AreaVisualization.propTypes = {
   config: AggregationType.isRequired,

--- a/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.jsx
@@ -1,15 +1,15 @@
 // @flow strict
-import * as React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 import { AggregationType } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
-import type { ChartDefinition } from '../ChartData';
+import LineVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/LineVisualizationConfig';
+import toPlotly from 'views/logic/aggregationbuilder/visualizations/Interpolation';
 
+import type { ChartDefinition } from '../ChartData';
 import { chartData } from '../ChartData';
 import XYPlot from '../XYPlot';
-
-const chartGenerator = (type, name, labels, values): ChartDefinition => ({ type, name, x: labels, y: values, line: { shape: 'linear' } });
 
 const getChartColor = (fullData, name) => {
   const data = fullData.find(d => (d.name === name));
@@ -22,13 +22,25 @@ const getChartColor = (fullData, name) => {
 
 const setChartColor = (chart, colors) => ({ line: { color: colors[chart.name] } });
 
-const LineVisualization: VisualizationComponent = ({ config, data, effectiveTimerange }: VisualizationComponentProps) => (
-  <XYPlot config={config}
-          effectiveTimerange={effectiveTimerange}
-          getChartColor={getChartColor}
-          setChartColor={setChartColor}
-          chartData={chartData(config, data.chart || Object.values(data)[0], 'scatter', chartGenerator)} />
-);
+const LineVisualization: VisualizationComponent = ({ config, data, effectiveTimerange }: VisualizationComponentProps) => {
+  // $FlowFixMe: We need to assume it is a LineVisualizationConfig instance
+  const visualizationConfig: LineVisualizationConfig = config.visualizationConfig || LineVisualizationConfig.empty();
+  const { interpolation = 'linear' } = visualizationConfig;
+  const chartGenerator = useCallback((type, name, labels, values): ChartDefinition => ({
+    type,
+    name,
+    x: labels,
+    y: values,
+    line: { shape: toPlotly(interpolation) },
+  }), [interpolation]);
+  return (
+    <XYPlot config={config}
+            effectiveTimerange={effectiveTimerange}
+            getChartColor={getChartColor}
+            setChartColor={setChartColor}
+            chartData={chartData(config, data.chart || Object.values(data)[0], 'scatter', chartGenerator)} />
+  );
+};
 
 LineVisualization.propTypes = {
   config: AggregationType.isRequired,

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig.js
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig.js
@@ -1,0 +1,68 @@
+// @flow strict
+import * as Immutable from 'immutable';
+import VisualizationConfig from './VisualizationConfig';
+import type { InterpolationMode } from './Interpolation';
+
+type InternalState = {
+  interpolation: InterpolationMode,
+};
+
+export type AreaVisualizationConfigJSON = {
+  interpolation: InterpolationMode,
+};
+
+export default class AreaVisualizationConfig extends VisualizationConfig {
+  _value: InternalState;
+
+  constructor(interpolation: $PropertyType<InternalState, 'interpolation'>) {
+    super();
+    this._value = { interpolation };
+  }
+
+  get interpolation() {
+    return this._value.interpolation;
+  }
+
+  toBuilder() {
+    // eslint-disable-next-line no-use-before-define
+    return new Builder(Immutable.Map(this._value));
+  }
+
+  static create(interpolation: $PropertyType<InternalState, 'interpolation'>) {
+    return new AreaVisualizationConfig(interpolation);
+  }
+
+  static empty() {
+    return new AreaVisualizationConfig('linear');
+  }
+
+  toJSON() {
+    const { interpolation } = this._value;
+
+    return { interpolation };
+  }
+
+  static fromJSON(type: string, value: AreaVisualizationConfigJSON = { interpolation: 'linear' }) {
+    const { interpolation = 'linear' } = value;
+    return AreaVisualizationConfig.create(interpolation);
+  }
+}
+
+type BuilderState = Immutable.Map<string, any>;
+
+class Builder {
+  value: BuilderState;
+
+  constructor(value: BuilderState = Immutable.Map()) {
+    this.value = value;
+  }
+
+  interpolation(value: $PropertyType<InternalState, 'interpolation'>) {
+    return new Builder(this.value.set('interpolation', value));
+  }
+
+  build() {
+    const { interpolation } = this.value.toObject();
+    return new AreaVisualizationConfig(interpolation);
+  }
+}

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/BarVisualizationConfig.js
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/BarVisualizationConfig.js
@@ -31,7 +31,7 @@ export default class BarVisualizationConfig extends VisualizationConfig {
     return new Builder(Immutable.Map({ barmode }));
   }
 
-  static create(barmode : BarMode) {
+  static create(barmode: BarMode) {
     return new BarVisualizationConfig(barmode);
   }
 

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/BarVisualizationConfig.js
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/BarVisualizationConfig.js
@@ -52,11 +52,11 @@ export default class BarVisualizationConfig extends VisualizationConfig {
 class Builder {
   value: Immutable.Map<BarVisualizationConfigType>;
 
-  constructor(value : BarVisualizationConfigType = Immutable.Map()) {
+  constructor(value: BarVisualizationConfigType = Immutable.Map()) {
     this.value = value;
   }
 
-  barmode(value : BarMode) {
+  barmode(value: BarMode) {
     return new Builder(this.value.set('barmode', value));
   }
 

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/Interpolation.js
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/Interpolation.js
@@ -1,0 +1,11 @@
+// @flow strict
+export type InterpolationMode = 'linear' | 'step-after' | 'spline';
+
+const toPlotly = (value: InterpolationMode) => {
+  switch (value) {
+    case 'step-after': return 'hv';
+    default: return value;
+  }
+};
+
+export default toPlotly;

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/LineVisualizationConfig.js
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/LineVisualizationConfig.js
@@ -1,0 +1,68 @@
+// @flow strict
+import * as Immutable from 'immutable';
+import VisualizationConfig from './VisualizationConfig';
+import type { InterpolationMode } from './Interpolation';
+
+type InternalState = {
+  interpolation: InterpolationMode,
+};
+
+export type LineVisualizationConfigJSON = {
+  interpolation: InterpolationMode,
+};
+
+export default class LineVisualizationConfig extends VisualizationConfig {
+  _value: InternalState;
+
+  constructor(interpolation: $PropertyType<InternalState, 'interpolation'>) {
+    super();
+    this._value = { interpolation };
+  }
+
+  get interpolation() {
+    return this._value.interpolation;
+  }
+
+  toBuilder() {
+    // eslint-disable-next-line no-use-before-define
+    return new Builder(Immutable.Map(this._value));
+  }
+
+  static create(interpolation: $PropertyType<InternalState, 'interpolation'>) {
+    return new LineVisualizationConfig(interpolation);
+  }
+
+  static empty() {
+    return new LineVisualizationConfig('linear');
+  }
+
+  toJSON() {
+    const { interpolation } = this._value;
+
+    return { interpolation };
+  }
+
+  static fromJSON(type: string, value: LineVisualizationConfigJSON = { interpolation: 'linear' }) {
+    const { interpolation = 'linear' } = value;
+    return LineVisualizationConfig.create(interpolation);
+  }
+}
+
+type BuilderState = Immutable.Map<string, any>;
+
+class Builder {
+  value: BuilderState;
+
+  constructor(value: BuilderState = Immutable.Map()) {
+    this.value = value;
+  }
+
+  interpolation(value: $PropertyType<InternalState, 'interpolation'>) {
+    return new Builder(this.value.set('interpolation', value));
+  }
+
+  build() {
+    const { interpolation } = this.value.toObject();
+    return new LineVisualizationConfig(interpolation);
+  }
+}


### PR DESCRIPTION
## Description
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The current search offers options to define the interpolation used in
line/area charts. In order to migrate dashboard widgets using these,
this PR adds functionality to define the interpolation used. Due to the
differences between rickshaw/d3 (used in the current search) and plotly
(used in the views), lesser (but still sufficient) interpolation options
can be offered. The mapping looks like this (rickshaw/d3 -> plotly):

        * linear -> linear
        * step-after -> hv
        * cardinal/basis/bundle/monotone -> spline

Requires #6893 to be merged before.

## Screenshots (if appropriate):
![Screen Shot 2019-11-29 at 14 44 31](https://user-images.githubusercontent.com/41929/69873037-83562f00-12b7-11ea-8f6e-a9ad1950247a.png)
![Screen Shot 2019-11-29 at 14 50 27](https://user-images.githubusercontent.com/41929/69873071-9b2db300-12b7-11ea-8dd5-3f9c188e21cb.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.