### PR TITLE
Implement MessageList pagination

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/ResultWindowLimitError.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/ResultWindowLimitError.java
@@ -21,25 +21,18 @@ import org.graylog.plugins.views.search.Query;
 
 import javax.annotation.Nonnull;
 
-public class SearchTypeError extends QueryError {
-    @Nonnull
-    private final String searchTypeId;
+public class ResultWindowLimitError extends SearchTypeError {
 
-    public SearchTypeError(@Nonnull Query query, @Nonnull String searchTypeId, Throwable throwable) {
-        super(query, throwable);
+    private final int resultWindowLimit;
 
-        this.searchTypeId = searchTypeId;
+    ResultWindowLimitError(@Nonnull Query query, @Nonnull String searchTypeId, int resultWindowLimit, Throwable throwable) {
+        super(query, searchTypeId, throwable);
+
+        this.resultWindowLimit = resultWindowLimit;
     }
 
-    public SearchTypeError(@Nonnull Query query, @Nonnull String searchTypeId, String description) {
-        super(query, description);
-
-        this.searchTypeId = searchTypeId;
-    }
-
-    @Nonnull
-    @JsonProperty("search_type_id")
-    public String searchTypeId() {
-        return searchTypeId;
+    @JsonProperty("result_window_limit")
+    public Integer getResultWindowLimit() {
+        return resultWindowLimit;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/SearchError.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/SearchError.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         @JsonSubTypes.Type(name = "query", value = QueryError.class),
         @JsonSubTypes.Type(name = "search_type", value = SearchTypeError.class),
         @JsonSubTypes.Type(name = "unbound_parameter", value = UnboundParameterError.class),
+        @JsonSubTypes.Type(name = "result_window_limit", value = ResultWindowLimitError.class),
 })
 @JsonTypeInfo(property = "type", visible = true, use= JsonTypeInfo.Id.NAME)
 @JsonInclude(value = JsonInclude.Include.NON_EMPTY)

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/SearchTypeError.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/SearchTypeError.java
@@ -18,27 +18,54 @@ package org.graylog.plugins.views.search.errors;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.graylog.plugins.views.search.Query;
-import org.graylog.plugins.views.search.Query;
 
 import javax.annotation.Nonnull;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class SearchTypeError extends QueryError {
     @Nonnull
     private final String searchTypeId;
 
+    private final Integer resultWindowLimit;
+
     public SearchTypeError(@Nonnull Query query, @Nonnull String searchTypeId, Throwable throwable) {
         super(query, throwable);
+
+        this.resultWindowLimit = parseResultLimit(throwable);
+
         this.searchTypeId = searchTypeId;
     }
 
     public SearchTypeError(@Nonnull Query query, @Nonnull String searchTypeId, String description) {
         super(query, description);
+
+        this.resultWindowLimit = parseResultLimit(description);
+
         this.searchTypeId = searchTypeId;
+    }
+
+    private Integer parseResultLimit(Throwable throwable) {
+        return parseResultLimit(throwable.getMessage());
+    }
+
+    private Integer parseResultLimit(String description) {
+        if (description.toLowerCase().contains("result window is too large")) {
+            final Matcher matcher = Pattern.compile("[0-9]+").matcher(description);
+            if (matcher.find())
+                return Integer.parseInt(matcher.group(0));
+        }
+        return null;
     }
 
     @Nonnull
     @JsonProperty("search_type_id")
     public String searchTypeId() {
         return searchTypeId;
+    }
+
+    @JsonProperty("result_window_limit")
+    public Integer getResultWindowLimit() {
+        return resultWindowLimit;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/SearchTypeError.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/SearchTypeError.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.graylog.plugins.views.search.Query;
 
 import javax.annotation.Nonnull;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -50,7 +51,7 @@ public class SearchTypeError extends QueryError {
     }
 
     private Integer parseResultLimit(String description) {
-        if (description.toLowerCase().contains("result window is too large")) {
+        if (description.toLowerCase(Locale.US).contains("result window is too large")) {
             final Matcher matcher = Pattern.compile("[0-9]+").matcher(description);
             if (matcher.find())
                 return Integer.parseInt(matcher.group(0));

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/SearchTypeErrorParser.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/errors/SearchTypeErrorParser.java
@@ -1,0 +1,50 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.views.search.errors;
+
+import org.graylog.plugins.views.search.Query;
+import org.graylog2.indexer.ElasticsearchException;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class SearchTypeErrorParser {
+    public static SearchTypeError parse(Query query, String searchTypeId, ElasticsearchException ex) {
+
+        final Integer resultWindowLimit = parseResultLimit(ex);
+
+        if (resultWindowLimit != null)
+            return new ResultWindowLimitError(query, searchTypeId, resultWindowLimit, ex);
+
+        return new SearchTypeError(query, searchTypeId, ex);
+    }
+
+    private static Integer parseResultLimit(Throwable throwable) {
+        return parseResultLimit(throwable.getMessage());
+    }
+
+    private static Integer parseResultLimit(String description) {
+        if (description.toLowerCase(Locale.US).contains("result window is too large")) {
+            final Matcher matcher = Pattern.compile("[0-9]+").matcher(description);
+            if (matcher.find())
+                return Integer.parseInt(matcher.group(0));
+        }
+        return null;
+    }
+
+}

--- a/graylog2-web-interface/public/stylesheets/graylog2.less
+++ b/graylog2-web-interface/public/stylesheets/graylog2.less
@@ -1060,7 +1060,9 @@ td.limited {
 .dashboard .widget {
   height: inherit;
   margin: 0;
-  padding: 15px;
+  padding: 20px;
+  display: grid;
+  grid-template-rows: max-content minmax(10px, 1fr);
 }
 
 .dashboard .widget .widget-top {
@@ -2056,7 +2058,6 @@ span.blob {
 
 .search-results-table {
   border-left: 2px solid #e3e3e3;
-  margin-left: -13px;
   overflow-y: auto;
   width: 100%;
 }

--- a/graylog2-web-interface/public/stylesheets/graylog2.less
+++ b/graylog2-web-interface/public/stylesheets/graylog2.less
@@ -2058,6 +2058,7 @@ span.blob {
   border-left: 2px solid #e3e3e3;
   margin-left: -13px;
   overflow-y: auto;
+  width: 100%;
 }
 
 .search-results-table > div {

--- a/graylog2-web-interface/src/components/common/PaginatedList.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.jsx
@@ -40,10 +40,14 @@ class PaginatedList extends React.Component {
     showPageSizeSelect: true,
   };
 
-  state = {
-    currentPage: this.props.activePage > 0 ? this.props.activePage : 1,
-    pageSize: this.props.pageSize,
-  };
+  constructor(props) {
+    super(props);
+    const { activePage, pageSize } = props;
+    this.state = {
+      currentPage: activePage > 0 ? activePage : 1,
+      pageSize: pageSize,
+    };
+  }
 
   componentWillReceiveProps(nextProps) {
     const { pageSize, activePage } = this.props;
@@ -57,46 +61,54 @@ class PaginatedList extends React.Component {
   }
 
   _onChangePageSize = (event) => {
+    const { onChange } = this.props;
+    const { currentPage } = this.state;
     event.preventDefault();
     const pageSize = Number(event.target.value);
     this.setState({ pageSize: pageSize });
-    this.props.onChange(this.state.currentPage, pageSize);
+    onChange(currentPage, pageSize);
   };
 
   _onChangePage = (eventKey, event) => {
+    const { onChange } = this.props;
+    const { pageSize } = this.state;
     event.preventDefault();
     const pageNo = Number(eventKey);
     this.setState({ currentPage: pageNo });
-    this.props.onChange(pageNo, this.state.pageSize);
+    onChange(pageNo, pageSize);
   };
 
   _pageSizeSelect = () => {
-    if (!this.props.showPageSizeSelect) {
+    const { showPageSizeSelect, pageSizes } = this.props;
+    const { pageSize } = this.state;
+    if (!showPageSizeSelect) {
       return null;
     }
     return (
       <div className="form-inline page-size" style={{ float: 'right' }}>
-        <Input id="page-size" type="select" bsSize="small" label="Show:" value={this.state.pageSize} onChange={this._onChangePageSize}>
-          {this.props.pageSizes.map(size => <option key={`option-${size}`} value={size}>{size}</option>)}
+        <Input id="page-size" type="select" bsSize="small" label="Show:" value={pageSize} onChange={this._onChangePageSize}>
+          {pageSizes.map(size => <option key={`option-${size}`} value={size}>{size}</option>)}
         </Input>
       </div>
     );
   };
 
   render() {
-    const numberPages = Math.ceil(this.props.totalItems / this.state.pageSize);
+    const { totalItems, children } = this.props;
+    const { pageSize, currentPage } = this.state;
+    const numberPages = Math.ceil(totalItems / pageSize);
 
     return (
       <>
         {this._pageSizeSelect()}
 
-        {this.props.children}
+        {children}
 
         <div className="text-center">
           <Pagination bsSize="small"
                       items={numberPages}
                       maxButtons={10}
-                      activePage={this.state.currentPage}
+                      activePage={currentPage}
                       onSelect={this._onChangePage}
                       prev
                       next

--- a/graylog2-web-interface/src/components/common/PaginatedList.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.jsx
@@ -77,7 +77,6 @@ class PaginatedList extends React.Component<Props, State> {
   }
 
   _onChangePageSize = (event) => {
-    console.log('_onChangePageSize', event);
     const { onChange } = this.props;
     const { currentPage } = this.state;
     event.preventDefault();

--- a/graylog2-web-interface/src/components/common/PaginatedList.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.jsx
@@ -87,7 +87,7 @@ class PaginatedList extends React.Component {
     const numberPages = Math.ceil(this.props.totalItems / this.state.pageSize);
 
     return (
-      <span>
+      <>
         {this._pageSizeSelect()}
 
         {this.props.children}
@@ -103,7 +103,7 @@ class PaginatedList extends React.Component {
                       first
                       last />
         </div>
-      </span>
+      </>
     );
   }
 }

--- a/graylog2-web-interface/src/components/common/PaginatedList.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.jsx
@@ -76,7 +76,7 @@ class PaginatedList extends React.Component<Props, State> {
     }
   }
 
-  _onChangePageSize = (event) => {
+  _onChangePageSize = (event: SyntheticInputEvent<HTMLLinkElement>) => {
     const { onChange } = this.props;
     const { currentPage } = this.state;
     event.preventDefault();

--- a/graylog2-web-interface/src/components/common/PaginatedList.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.jsx
@@ -1,16 +1,17 @@
+// @flow strict
 import PropTypes from 'prop-types';
-import React from 'react';
+import * as React from 'react';
 import { Pagination } from 'components/graylog';
 import { Input } from 'components/bootstrap';
 
 const defaultPageSizes = [10, 50, 100];
 
 type Props = {
-  children: React.node,
+  children: React.Node,
   onChange: (currentPage: number, pageSize: number) => void,
-  activePage?: number,
-  pageSize?: number,
-  pageSizes?: Array<number>,
+  activePage: number,
+  pageSize: number,
+  pageSizes: Array<number>,
   totalItems: number,
   showPageSizeSelect: boolean
 }
@@ -64,7 +65,7 @@ class PaginatedList extends React.Component<Props, State> {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps(nextProps: Props) {
     const { pageSize, activePage } = this.props;
 
     if (activePage !== nextProps.activePage) {
@@ -76,6 +77,7 @@ class PaginatedList extends React.Component<Props, State> {
   }
 
   _onChangePageSize = (event) => {
+    console.log('_onChangePageSize', event);
     const { onChange } = this.props;
     const { currentPage } = this.state;
     event.preventDefault();
@@ -84,11 +86,10 @@ class PaginatedList extends React.Component<Props, State> {
     onChange(currentPage, pageSize);
   };
 
-  _onChangePage = (eventKey, event) => {
+  _onChangePage = (pageNo: number, event: MouseEvent) => {
     const { onChange } = this.props;
     const { pageSize } = this.state;
     event.preventDefault();
-    const pageNo = Number(eventKey);
     this.setState({ currentPage: pageNo });
     onChange(pageNo, pageSize);
   };

--- a/graylog2-web-interface/src/components/common/PaginatedList.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.jsx
@@ -5,13 +5,28 @@ import { Input } from 'components/bootstrap';
 
 const defaultPageSizes = [10, 50, 100];
 
+type Props = {
+  children: React.node,
+  onChange: (currentPage: number, pageSize: number) => void,
+  activePage?: number,
+  pageSize?: number,
+  pageSizes?: Array<number>,
+  totalItems: number,
+  showPageSizeSelect: boolean
+}
+
+type State = {
+  currentPage: number,
+  pageSize: number
+}
+
 /**
  * Wrapper component around an element that renders pagination
  * controls and provides a callback when the page or page size change.
  * You still need to fetch or filter the data yourself to ensure that
  * the selected page is displayed on screen.
  */
-class PaginatedList extends React.Component {
+class PaginatedList extends React.Component<Props, State> {
   static propTypes = {
     /** React element containing items of the current selected page. */
     children: PropTypes.node.isRequired,
@@ -40,7 +55,7 @@ class PaginatedList extends React.Component {
     showPageSizeSelect: true,
   };
 
-  constructor(props) {
+  constructor(props: Props) {
     super(props);
     const { activePage, pageSize } = props;
     this.state = {

--- a/graylog2-web-interface/src/views/actions/SearchActions.js
+++ b/graylog2-web-interface/src/views/actions/SearchActions.js
@@ -10,6 +10,7 @@ import View from 'views/logic/views/View';
 import type { SearchJson } from 'views/logic/search/Search';
 import { singletonActions } from 'views/logic/singleton';
 import type { RefluxActions } from 'stores/StoreTypes';
+import type { TimeRange } from 'views/logic/queries/Query';
 
 export type CreateSearchResponse = {
   search: Search,
@@ -25,6 +26,7 @@ export type SearchExecutionResult = {
 type SearchActionsType = RefluxActions<{
   create: (Search) => Promise<CreateSearchResponse>,
   execute: (SearchExecutionState) => Promise<SearchExecutionResult>,
+  reexecuteSearchTypes: (searchTypes: {[searchTypeId: string]: { limit: number, offset: number }}, effectiveTimeRange?: TimeRange) => Promise<SearchExecutionResult>,
   executeWithCurrentState: () => Promise<SearchExecutionResult>,
   refresh: () => Promise<void>,
   get: (SearchId) => Promise<SearchJson>,
@@ -41,6 +43,9 @@ const SearchActions: SearchActionsType = singletonActions(
       asyncResult: true,
     },
     execute: {
+      asyncResult: true,
+    },
+    reexecuteSearchTypes: {
       asyncResult: true,
     },
     executeWithCurrentState: {

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.jsx
@@ -17,7 +17,7 @@ import { SearchConfigStore } from 'views/stores/SearchConfigStore';
 import { WidgetActions } from 'views/stores/WidgetStore';
 import type { TimeRange, TimeRangeTypes } from 'views/logic/queries/Query';
 import { GlobalOverrideActions, GlobalOverrideStore } from 'views/stores/GlobalOverrideStore';
-import type { GlobalOverride } from 'views/logic/search/SearchExecutionState';
+import GlobalOverride from 'views/logic/search/GlobalOverride';
 import TimeRangeTypeSelector from './searchbar/TimeRangeTypeSelector';
 import TimeRangeInput from './searchbar/TimeRangeInput';
 import StreamsFilter from './searchbar/StreamsFilter';

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkList.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkList.test.jsx.snap
@@ -75,125 +75,123 @@ exports[`BookmarkList render the BookmarkList should render empty 1`] = `
                 </div>
               </form>
             </div>
+            <div
+              class="form-inline page-size"
+              style="float: right;"
+            >
+              <div
+                class="form-group"
+              >
+                <label
+                  class="ControlLabel-sc-1edmum5-0 iZJNbd control-label"
+                  for="page-size"
+                >
+                  Show:
+                </label>
+                <span>
+                  <select
+                    class="FormControl-sc-1amoaox-0 hdNTyr form-control input-sm"
+                    id="page-size"
+                    label="Show:"
+                    name="page-size"
+                    placeholder=""
+                    type="select"
+                  >
+                    <option
+                      value="5"
+                    >
+                      5
+                    </option>
+                    <option
+                      value="10"
+                    >
+                      10
+                    </option>
+                    <option
+                      value="15"
+                    >
+                      15
+                    </option>
+                  </select>
+                  
+                </span>
+              </div>
+            </div>
             <span>
-              <div
-                class="form-inline page-size"
-                style="float: right;"
-              >
-                <div
-                  class="form-group"
-                >
-                  <label
-                    class="ControlLabel-sc-1edmum5-0 iZJNbd control-label"
-                    for="page-size"
-                  >
-                    Show:
-                  </label>
-                  <span>
-                    <select
-                      class="FormControl-sc-1amoaox-0 hdNTyr form-control input-sm"
-                      id="page-size"
-                      label="Show:"
-                      name="page-size"
-                      placeholder=""
-                      type="select"
-                    >
-                      <option
-                        value="5"
-                      >
-                        5
-                      </option>
-                      <option
-                        value="10"
-                      >
-                        10
-                      </option>
-                      <option
-                        value="15"
-                      >
-                        15
-                      </option>
-                    </select>
-                    
-                  </span>
-                </div>
-              </div>
-              <span>
-                No bookmarks found
-              </span>
-              <div
-                class="text-center"
-              >
-                <ul
-                  class="Pagination-sc-1u3exqe-0 gSmbxW pagination pagination-sm"
-                >
-                  <li
-                    class="disabled"
-                  >
-                    <a
-                      href="#"
-                      role="button"
-                      style="pointer-events: none;"
-                      tabindex="-1"
-                    >
-                      <span
-                        aria-label="First"
-                      >
-                        «
-                      </span>
-                    </a>
-                  </li>
-                  <li
-                    class="disabled"
-                  >
-                    <a
-                      href="#"
-                      role="button"
-                      style="pointer-events: none;"
-                      tabindex="-1"
-                    >
-                      <span
-                        aria-label="Previous"
-                      >
-                        ‹
-                      </span>
-                    </a>
-                  </li>
-                  <li
-                    class="disabled"
-                  >
-                    <a
-                      href="#"
-                      role="button"
-                      style="pointer-events: none;"
-                      tabindex="-1"
-                    >
-                      <span
-                        aria-label="Next"
-                      >
-                        ›
-                      </span>
-                    </a>
-                  </li>
-                  <li
-                    class="disabled"
-                  >
-                    <a
-                      href="#"
-                      role="button"
-                      style="pointer-events: none;"
-                      tabindex="-1"
-                    >
-                      <span
-                        aria-label="Last"
-                      >
-                        »
-                      </span>
-                    </a>
-                  </li>
-                </ul>
-              </div>
+              No bookmarks found
             </span>
+            <div
+              class="text-center"
+            >
+              <ul
+                class="Pagination-sc-1u3exqe-0 gSmbxW pagination pagination-sm"
+              >
+                <li
+                  class="disabled"
+                >
+                  <a
+                    href="#"
+                    role="button"
+                    style="pointer-events: none;"
+                    tabindex="-1"
+                  >
+                    <span
+                      aria-label="First"
+                    >
+                      «
+                    </span>
+                  </a>
+                </li>
+                <li
+                  class="disabled"
+                >
+                  <a
+                    href="#"
+                    role="button"
+                    style="pointer-events: none;"
+                    tabindex="-1"
+                  >
+                    <span
+                      aria-label="Previous"
+                    >
+                      ‹
+                    </span>
+                  </a>
+                </li>
+                <li
+                  class="disabled"
+                >
+                  <a
+                    href="#"
+                    role="button"
+                    style="pointer-events: none;"
+                    tabindex="-1"
+                  >
+                    <span
+                      aria-label="Next"
+                    >
+                      ›
+                    </span>
+                  </a>
+                </li>
+                <li
+                  class="disabled"
+                >
+                  <a
+                    href="#"
+                    role="button"
+                    style="pointer-events: none;"
+                    tabindex="-1"
+                  >
+                    <span
+                      aria-label="Last"
+                    >
+                      »
+                    </span>
+                  </a>
+                </li>
+              </ul>
+            </div>
           </div>
           <div
             class="modal-footer"
@@ -301,149 +299,147 @@ exports[`BookmarkList render the BookmarkList should render with views 1`] = `
                 </div>
               </form>
             </div>
-            <span>
+            <div
+              class="form-inline page-size"
+              style="float: right;"
+            >
               <div
-                class="form-inline page-size"
-                style="float: right;"
+                class="form-group"
               >
-                <div
-                  class="form-group"
+                <label
+                  class="ControlLabel-sc-1edmum5-0 iZJNbd control-label"
+                  for="page-size"
                 >
-                  <label
-                    class="ControlLabel-sc-1edmum5-0 iZJNbd control-label"
-                    for="page-size"
+                  Show:
+                </label>
+                <span>
+                  <select
+                    class="FormControl-sc-1amoaox-0 hdNTyr form-control input-sm"
+                    id="page-size"
+                    label="Show:"
+                    name="page-size"
+                    placeholder=""
+                    type="select"
                   >
-                    Show:
-                  </label>
-                  <span>
-                    <select
-                      class="FormControl-sc-1amoaox-0 hdNTyr form-control input-sm"
-                      id="page-size"
-                      label="Show:"
-                      name="page-size"
-                      placeholder=""
-                      type="select"
+                    <option
+                      value="5"
                     >
-                      <option
-                        value="5"
-                      >
-                        5
-                      </option>
-                      <option
-                        value="10"
-                      >
-                        10
-                      </option>
-                      <option
-                        value="15"
-                      >
-                        15
-                      </option>
-                    </select>
-                    
-                  </span>
-                </div>
+                      5
+                    </option>
+                    <option
+                      value="10"
+                    >
+                      10
+                    </option>
+                    <option
+                      value="15"
+                    >
+                      15
+                    </option>
+                  </select>
+                  
+                </span>
               </div>
-              <div
-                class="list-group"
+            </div>
+            <div
+              class="list-group"
+            >
+              <button
+                class="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                type="button"
               >
-                <button
-                  class="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
-                  type="button"
+                <h4
+                  class="list-group-item-heading"
                 >
-                  <h4
-                    class="list-group-item-heading"
-                  >
-                    test-0
-                  </h4>
-                  <p
-                    class="list-group-item-text"
-                  />
-                </button>
-              </div>
-              <div
-                class="text-center"
+                  test-0
+                </h4>
+                <p
+                  class="list-group-item-text"
+                />
+              </button>
+            </div>
+            <div
+              class="text-center"
+            >
+              <ul
+                class="Pagination-sc-1u3exqe-0 gSmbxW pagination pagination-sm"
               >
-                <ul
-                  class="Pagination-sc-1u3exqe-0 gSmbxW pagination pagination-sm"
+                <li
+                  class="disabled"
                 >
-                  <li
-                    class="disabled"
+                  <a
+                    href="#"
+                    role="button"
+                    style="pointer-events: none;"
+                    tabindex="-1"
                   >
-                    <a
-                      href="#"
-                      role="button"
-                      style="pointer-events: none;"
-                      tabindex="-1"
+                    <span
+                      aria-label="First"
                     >
-                      <span
-                        aria-label="First"
-                      >
-                        «
-                      </span>
-                    </a>
-                  </li>
-                  <li
-                    class="disabled"
+                      «
+                    </span>
+                  </a>
+                </li>
+                <li
+                  class="disabled"
+                >
+                  <a
+                    href="#"
+                    role="button"
+                    style="pointer-events: none;"
+                    tabindex="-1"
                   >
-                    <a
-                      href="#"
-                      role="button"
-                      style="pointer-events: none;"
-                      tabindex="-1"
+                    <span
+                      aria-label="Previous"
                     >
-                      <span
-                        aria-label="Previous"
-                      >
-                        ‹
-                      </span>
-                    </a>
-                  </li>
-                  <li
-                    class="active"
+                      ‹
+                    </span>
+                  </a>
+                </li>
+                <li
+                  class="active"
+                >
+                  <a
+                    href="#"
+                    role="button"
                   >
-                    <a
-                      href="#"
-                      role="button"
-                    >
-                      1
-                    </a>
-                  </li>
-                  <li
-                    class="disabled"
+                    1
+                  </a>
+                </li>
+                <li
+                  class="disabled"
+                >
+                  <a
+                    href="#"
+                    role="button"
+                    style="pointer-events: none;"
+                    tabindex="-1"
                   >
-                    <a
-                      href="#"
-                      role="button"
-                      style="pointer-events: none;"
-                      tabindex="-1"
+                    <span
+                      aria-label="Next"
                     >
-                      <span
-                        aria-label="Next"
-                      >
-                        ›
-                      </span>
-                    </a>
-                  </li>
-                  <li
-                    class="disabled"
+                      ›
+                    </span>
+                  </a>
+                </li>
+                <li
+                  class="disabled"
+                >
+                  <a
+                    href="#"
+                    role="button"
+                    style="pointer-events: none;"
+                    tabindex="-1"
                   >
-                    <a
-                      href="#"
-                      role="button"
-                      style="pointer-events: none;"
-                      tabindex="-1"
+                    <span
+                      aria-label="Last"
                     >
-                      <span
-                        aria-label="Last"
-                      >
-                        »
-                      </span>
-                    </a>
-                  </li>
-                </ul>
-              </div>
-            </span>
+                      »
+                    </span>
+                  </a>
+                </li>
+              </ul>
+            </div>
           </div>
           <div
             class="modal-footer"

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.css
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.css
@@ -1,7 +1,0 @@
-:local(.messageListTableHeader) table.messages thead th, :local(.messageListTableHeader) table.messages thead {
-    background-color: #eee;
-    color: #333;
-}
-:local(.messageListPaginator) #message-table-paginator-top {
-    margin-bottom: 12px;
-}

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -89,8 +89,15 @@ class MessageList extends React.Component<Props, State> {
   componentDidMount() {
     const onRenderComplete = this.context;
     InputsActions.list().then(() => (onRenderComplete && onRenderComplete()));
+    SearchActions.execute.completed.listen(this._resetPagination);
   }
 
+  _resetPagination = () => {
+    const { currentPage } = this.state;
+    if (currentPage !== 1) {
+      this.setState({ currentPage: 1 });
+    }
+  }
 
   _resultWindowLimitMessage = (errors = []) => {
     const { pageSize } = this.props;

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -148,7 +148,6 @@ class MessageList extends React.Component<Props, State> {
     const totalAmount = (data && data.total) || 0;
     const { currentPage, expandedMessages } = this.state;
     const messageSlice = messages
-      .slice((currentPage - 1) * pageSize, currentPage * pageSize)
       .map((m) => {
         return {
           fields: m.message,

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -135,6 +135,7 @@ class MessageList extends React.Component<Props, State> {
       },
       keep_search_types: [searchTypeId],
     };
+    RefreshActions.disable();
     SearchActions.execute(executionState).then(() => {
       this.setState({
         currentPage: newPage,

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -168,7 +168,7 @@ class MessageList extends React.Component<Props, State> {
                        showPageSizeSelect={false}
                        totalItems={totalAmount}
                        pageSize={pageSize}>
-          <div className="search-results-table" style={{ overflow: 'auto' }}>
+          <div className="search-results-table" key={`message-list-page-${currentPage}`}>
             <div className="table-responsive">
               <div className={`messages-container ${styles.messageListTableHeader}`}>
                 <table className="table table-condensed messages" style={{ marginTop: 0 }}>

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -43,7 +43,7 @@ type State = {
 
 type Props = {
   fields: {},
-  pageSize?: number,
+  pageSize: number,
   config?: MessagesWidgetConfig,
   data: { messages: Array<Object>, total: number, id: string },
   selectedFields?: {},

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -45,7 +45,7 @@ type Props = {
   fields: {},
   pageSize: number,
   config: MessagesWidgetConfig,
-  data: { messages: [], total: number, id: string },
+  data: { messages: Array<Object>, total: number, id: string },
   selectedFields: {},
   effectiveTimerange: TimeRange,
   currentView: {

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -99,17 +99,6 @@ class MessageList extends React.Component<Props, State> {
     }
   }
 
-  _resultWindowLimitMessage = (errors = []) => {
-    const { pageSize } = this.props;
-    const resultWindowLimitError = errors.find(error => error.resultWindowLimit);
-    if (resultWindowLimitError) {
-      const { resultWindowLimit } = resultWindowLimitError;
-      const validPages = Math.floor(resultWindowLimit / pageSize);
-      return { description: `Elasticsearch limits the search result to ${resultWindowLimit} messages. With a page size of ${pageSize} messages, you can use the first ${validPages} pages.` };
-    }
-    return undefined;
-  }
-
   _handlePageChange = (pageNo: number) => {
     // execute search with new offset
     const { pageSize, data: { id: searchTypeId }, effectiveTimerange, setLoadingState } = this.props;
@@ -118,18 +107,8 @@ class MessageList extends React.Component<Props, State> {
     setLoadingState(true);
     SearchActions.reexecuteSearchTypes(searchTypePayload, effectiveTimerange).then((response) => {
       setLoadingState(false);
-      let errors = [...response.result.errors];
-      if (!isEmpty(errors)) {
-        const validPagesInfo = this._resultWindowLimitMessage(response.result.errors);
-        if (validPagesInfo) {
-          errors = [
-            validPagesInfo,
-            ...errors,
-          ];
-        }
-      }
       this.setState({
-        errors,
+        errors: response.result.errors,
         currentPage: pageNo,
       });
     });

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -48,6 +48,7 @@ type Props = {
   data: { messages: Array<Object>, total: number, id: string },
   selectedFields?: {},
   effectiveTimerange: TimeRange,
+  showLoadingSpinner: (loading: boolean) => void,
   currentView: {
     activeQuery: string,
     view: {
@@ -72,6 +73,7 @@ class MessageList extends React.Component<Props, State> {
       type: PropTypes.string.isRequired,
     }).isRequired,
     selectedFields: PropTypes.object,
+    showLoadingSpinner: PropTypes.func.isRequired,
     currentView: PropTypes.object.isRequired,
   };
 
@@ -105,10 +107,12 @@ class MessageList extends React.Component<Props, State> {
 
   _handlePageChange = (pageNo: number) => {
     // execute search with new offset
-    const { pageSize, data: { id: searchTypeId }, effectiveTimerange } = this.props;
+    const { pageSize, data: { id: searchTypeId }, effectiveTimerange, showLoadingSpinner } = this.props;
     const searchTypePayload = { [searchTypeId]: { limit: pageSize, offset: pageSize * (pageNo - 1) } };
     RefreshActions.disable();
+    showLoadingSpinner(true);
     SearchActions.reexecuteSearchTypes(searchTypePayload, effectiveTimerange).then((response) => {
+      showLoadingSpinner(false);
       let errors = [...response.result.errors];
       if (!isEmpty(errors)) {
         const validPagesInfo = this._resultWindowLimitMessage(response.result.errors);

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -45,7 +45,7 @@ type Props = {
   fields: {},
   pageSize: number,
   config: MessagesWidgetConfig,
-  data: { messages: [], total: number },
+  data: { messages: [], total: number, id: string },
   selectedFields: {},
   currentView: {
     activeQuery: string,
@@ -63,6 +63,7 @@ class MessageList extends React.Component<Props, State> {
     data: PropTypes.shape({
       messages: PropTypes.arrayOf(PropTypes.object).isRequired,
       total: PropTypes.number.isRequired,
+      id: PropTypes.string.isRequired,
     }).isRequired,
     selectedFields: PropTypes.object,
     currentView: PropTypes.object,
@@ -122,22 +123,17 @@ class MessageList extends React.Component<Props, State> {
 
   _handlePageChange = (newPage: number) => {
     // execute search with new offset
-    const { pageSize, currentView: { activeQuery } } = this.props;
-    const searchTypeId = 'search-type-id';
+    const { pageSize, data: { id: searchTypeId } } = this.props;
     const executionState = {
-      partial_request: {
-        search_type: [searchTypeId],
-      },
       global_overwrite: {
-        [activeQuery]: {
-          search_types: {
-            searchTypeId: {
-              limit: pageSize,
-              offset: pageSize * (newPage - 1),
-            },
+        search_types: {
+          [searchTypeId]: {
+            limit: pageSize,
+            offset: pageSize * (newPage - 1),
           },
         },
       },
+      keep_search_types: [searchTypeId],
     };
     SearchActions.execute(executionState).then(() => {
       this.setState({

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import * as Immutable from 'immutable';
 import styled from 'styled-components';
 import connect from 'stores/connect';
-import { isEmpty } from 'lodash';
+import { isEmpty, get } from 'lodash';
 import CombinedProvider from 'injection/CombinedProvider';
 
 import { Messages } from 'views/Constants';
@@ -163,6 +163,6 @@ export default connect(MessageList,
     {},
     props,
     {
-      effectiveTimerange: props.searches.result.results[props.currentView.activeQuery].effectiveTimerange,
+      effectiveTimerange: get(props, ['searches', 'result', 'results', props.currentView.activeQuery, 'effectiveTimerange']),
     },
   ));

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -20,6 +20,7 @@ import { ViewStore } from 'views/stores/ViewStore';
 import { RefreshActions } from 'views/stores/RefreshStore';
 import { SearchActions, SearchStore } from 'views/stores/SearchStore';
 import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
+import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import type { TimeRange } from 'views/logic/queries/Query';
 
 import styles from './MessageList.css';
@@ -131,19 +132,17 @@ class MessageList extends React.Component<Props, State> {
   _handlePageChange = (newPage: number) => {
     // execute search with new offset
     const { pageSize, data: { id: searchTypeId }, effectiveTimerange } = this.props;
-
-    const executionState = {
-      global_override: {
-        search_types: {
-          [searchTypeId]: {
-            limit: pageSize,
-            offset: pageSize * (newPage - 1),
-          },
+    const globalOverride = {
+      searchTypes: {
+        [searchTypeId]: {
+          limit: pageSize,
+          offset: pageSize * (newPage - 1),
         },
-        keep_search_types: [searchTypeId],
-        timerange: effectiveTimerange,
       },
+      keepSearchTypes: [searchTypeId],
+      timerange: effectiveTimerange,
     };
+    const executionState = new SearchExecutionState(undefined, globalOverride);
     RefreshActions.disable();
     SearchActions.execute(executionState);
     this.setState({

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -25,7 +25,6 @@ import RenderCompletionCallback from './RenderCompletionCallback';
 
 const { InputsActions } = CombinedProvider.get('Inputs');
 
-
 const Wrapper = styled.div`
   display: grid;
   grid-template-rows: 1fr max-content;

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -44,7 +44,7 @@ type State = {
 type Props = {
   fields: {},
   pageSize: number,
-  config?: MessagesWidgetConfig,
+  config: MessagesWidgetConfig,
   data: { messages: Array<Object>, total: number, id: string },
   selectedFields?: {},
   effectiveTimerange: TimeRange,
@@ -61,7 +61,7 @@ class MessageList extends React.Component<Props, State> {
   static propTypes = {
     fields: CustomPropTypes.FieldListType.isRequired,
     pageSize: PropTypes.number,
-    config: CustomPropTypes.instanceOf(MessagesWidgetConfig),
+    config: CustomPropTypes.instanceOf(MessagesWidgetConfig).isRequired,
     data: PropTypes.shape({
       messages: PropTypes.arrayOf(PropTypes.object).isRequired,
       total: PropTypes.number.isRequired,
@@ -80,7 +80,6 @@ class MessageList extends React.Component<Props, State> {
   static defaultProps = {
     pageSize: Messages.DEFAULT_LIMIT,
     selectedFields: Immutable.Set(),
-    config: undefined,
   };
 
   state = {

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -43,10 +43,10 @@ type State = {
 
 type Props = {
   fields: {},
-  pageSize: number,
-  config: MessagesWidgetConfig,
+  pageSize?: number,
+  config?: MessagesWidgetConfig,
   data: { messages: Array<Object>, total: number, id: string },
-  selectedFields: {},
+  selectedFields?: {},
   effectiveTimerange: TimeRange,
   currentView: {
     activeQuery: string,
@@ -72,13 +72,12 @@ class MessageList extends React.Component<Props, State> {
       type: PropTypes.string.isRequired,
     }).isRequired,
     selectedFields: PropTypes.object,
-    currentView: PropTypes.object,
+    currentView: PropTypes.object.isRequired,
   };
 
   static defaultProps = {
     pageSize: Messages.DEFAULT_LIMIT,
     selectedFields: Immutable.Set(),
-    currentView: { view: {}, activeQuery: undefined },
     config: undefined,
   };
 

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -142,24 +142,25 @@ class MessageList extends React.Component<Props, State> {
     });
   }
 
-  render() {
-    const { data, fields, currentView, pageSize = 7, config } = this.props;
+  _getFormattedMessages = () => {
+    const { data } = this.props;
     const messages = (data && data.messages) || [];
-    const totalAmount = (data && data.total) || 0;
+    return messages.map(m => ({
+      fields: m.message,
+      formatted_fields: MessageFieldsFilter.filterFields(m.message),
+      id: m.message._id,
+      index: m.index,
+      highlight_ranges: m.highlight_ranges,
+    }));
+  };
+
+  render() {
+    const { data, fields, currentView: { activeQuery }, pageSize = 7, config } = this.props;
     const { currentPage, expandedMessages } = this.state;
-    const messageSlice = messages
-      .map((m) => {
-        return {
-          fields: m.message,
-          formatted_fields: MessageFieldsFilter.filterFields(m.message),
-          id: m.message._id,
-          index: m.index,
-          highlight_ranges: m.highlight_ranges,
-        };
-      });
+    const totalAmount = (data && data.total) || 0;
+    const formattedMessages = this._getFormattedMessages();
     const selectedFields = this._getSelectedFields();
     const selectedColumns = Immutable.OrderedSet(selectedFields);
-    const { activeQuery } = currentView;
     return (
       <Wrapper>
         <PaginatedList onChange={this._handlePageChange}
@@ -185,7 +186,7 @@ class MessageList extends React.Component<Props, State> {
                       })}
                     </tr>
                   </thead>
-                  {messageSlice.map((message) => {
+                  {formattedMessages.map((message) => {
                     const messageKey = `${message.index}-${message.id}`;
                     return (
                       <AdditionalContext.Provider key={messageKey}

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -125,7 +125,7 @@ class MessageList extends React.Component<Props, State> {
     // execute search with new offset
     const { pageSize, data: { id: searchTypeId } } = this.props;
     const executionState = {
-      global_overwrite: {
+      global_override: {
         search_types: {
           [searchTypeId]: {
             limit: pageSize,

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -114,6 +114,18 @@ class MessageList extends React.Component<Props, State> {
     });
   }
 
+  _getListKey = () => {
+    // When the component receives new messages, we want to reset the scroll position, by defining a new key or the MessageTable.
+    const { data: { messages } } = this.props;
+    const { currentPage } = this.state;
+    const defaultKey = `message-list-${currentPage}`;
+    if (!isEmpty(messages)) {
+      const firstMessageId = messages[0].message._id;
+      return `${defaultKey}-${firstMessageId}`;
+    }
+    return defaultKey;
+  }
+
   static contextType = RenderCompletionCallback;
 
   render() {
@@ -127,6 +139,7 @@ class MessageList extends React.Component<Props, State> {
     } = this.props;
     const { currentPage, errors } = this.state;
     const hasError = !isEmpty(errors);
+    const listKey = this._getListKey();
     return (
       <Wrapper>
         <PaginatedList onChange={this._handlePageChange}
@@ -134,7 +147,7 @@ class MessageList extends React.Component<Props, State> {
                        showPageSizeSelect={false}
                        totalItems={totalMessages}
                        pageSize={pageSize}>
-          {!hasError && <MessageTable messages={messages} fields={fields} config={config} selectedFields={selectedFields} activeQueryId={activeQueryId} key={`message-list-page-${currentPage}`} />}
+          {!hasError && <MessageTable messages={messages} fields={fields} config={config} selectedFields={selectedFields} activeQueryId={activeQueryId} key={listKey} />}
           {hasError && (<ErrorWidget errors={errors} />)}
         </PaginatedList>
       </Wrapper>

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -93,13 +93,13 @@ class MessageList extends React.Component<Props, State> {
   }
 
 
-  _validPagesErrorMessage = (errors = []) => {
+  _resultWindowLimitMessage = (errors = []) => {
     const { pageSize } = this.props;
-    const executionLimitError = errors.find(error => error.executionLimit);
-    if (executionLimitError) {
-      const { executionLimit } = executionLimitError;
-      const validPages = Math.floor(executionLimit / pageSize);
-      return { description: `With the current limit of ${executionLimit} and a page size of ${pageSize} messages, you can use the first ${validPages} pages.` };
+    const resultWindowLimitError = errors.find(error => error.resultWindowLimit);
+    if (resultWindowLimitError) {
+      const { resultWindowLimit } = resultWindowLimitError;
+      const validPages = Math.floor(resultWindowLimit / pageSize);
+      return { description: `Elasticsearch limits the search result to ${resultWindowLimit} messages. With a page size of ${pageSize} messages, you can use the first ${validPages} pages.` };
     }
     return undefined;
   }
@@ -111,12 +111,14 @@ class MessageList extends React.Component<Props, State> {
     RefreshActions.disable();
     SearchActions.reexecuteSearchTypes(searchTypePayload, effectiveTimerange).then((response) => {
       let errors = [...response.result.errors];
-      const validPagesInfo = this._validPagesErrorMessage(response.result.errors);
-      if (validPagesInfo) {
-        errors = [
-          validPagesInfo,
-          ...errors,
-        ];
+      if (!isEmpty(errors)) {
+        const validPagesInfo = this._resultWindowLimitMessage(response.result.errors);
+        if (validPagesInfo) {
+          errors = [
+            validPagesInfo,
+            ...errors,
+          ];
+        }
       }
       this.setState({
         errors,

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -3,13 +3,13 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import * as Immutable from 'immutable';
 import connect from 'stores/connect';
-import MessageTablePaginator from 'components/search/MessageTablePaginator';
 import CombinedProvider from 'injection/CombinedProvider';
 import MessageFieldsFilter from 'logic/message/MessageFieldsFilter';
 
 import { Messages } from 'views/Constants';
 import { MessageTableEntry } from 'views/components/messagelist';
 import Field from 'views/components/Field';
+import { PaginatedList } from 'components/common';
 
 import { AdditionalContext } from 'views/logic/ActionContext';
 import { SelectedFieldsStore } from 'views/stores/SelectedFieldsStore';
@@ -33,7 +33,7 @@ type Props = {
   fields: {},
   pageSize: number,
   config: MessagesWidgetConfig,
-  data: { messages: [] },
+  data: { messages: [], total: number },
   containerHeight: number,
   selectedFields: {},
   currentView: {
@@ -51,6 +51,7 @@ class MessageList extends React.Component<Props, State> {
     config: CustomPropTypes.instanceOf(MessagesWidgetConfig),
     data: PropTypes.shape({
       messages: PropTypes.arrayOf(PropTypes.object).isRequired,
+      total: PropTypes.number.isRequired,
     }).isRequired,
     containerHeight: PropTypes.number,
     selectedFields: PropTypes.object,
@@ -132,21 +133,12 @@ class MessageList extends React.Component<Props, State> {
     const selectedFields = this._getSelectedFields();
     const selectedColumns = Immutable.OrderedSet(selectedFields);
     const { activeQuery } = currentView;
-
     return (
-      <span>
-        { messages.length > pageSize
-        && (
-          <div className={styles.messageListPaginator}>
-            <MessageTablePaginator currentPage={Number(currentPage)}
-                                   onPageChange={newPage => this.setState({ currentPage: newPage })}
-                                   pageSize={pageSize}
-                                   position="top"
-                                   resultCount={messages.length} />
-          </div>
-        ) }
-
-        <div className="search-results-table" style={{ overflow: 'auto', height: 'calc(100% - 60px)', maxHeight: maxHeight }}>
+      <PaginatedList onChange={newPage => this.setState({ currentPage: newPage })}
+                     activePage={Number(currentPage)}
+                     totalItems={data.total}
+                     pageSize={pageSize}>
+        <div className="search-results-table" style={{ overflow: 'auto', height: 'calc(100% - 80px)', maxHeight: maxHeight }}>
           <div className="table-responsive">
             <div className={`messages-container ${styles.messageListTableHeader}`}>
               <table className="table table-condensed messages" style={{ marginTop: 0 }}>
@@ -185,7 +177,7 @@ class MessageList extends React.Component<Props, State> {
             </div>
           </div>
         </div>
-      </span>
+      </PaginatedList>
     );
   }
 }

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -47,7 +47,7 @@ type Props = {
   data: { messages: Array<Object>, total: number, id: string },
   selectedFields?: {},
   effectiveTimerange: TimeRange,
-  showLoadingSpinner: (loading: boolean) => void,
+  setLoadingState: (loading: boolean) => void,
   currentView: {
     activeQuery: string,
     view: {
@@ -72,7 +72,7 @@ class MessageList extends React.Component<Props, State> {
       type: PropTypes.string.isRequired,
     }).isRequired,
     selectedFields: PropTypes.object,
-    showLoadingSpinner: PropTypes.func.isRequired,
+    setLoadingState: PropTypes.func.isRequired,
     currentView: PropTypes.object.isRequired,
   };
 
@@ -105,12 +105,12 @@ class MessageList extends React.Component<Props, State> {
 
   _handlePageChange = (pageNo: number) => {
     // execute search with new offset
-    const { pageSize, data: { id: searchTypeId }, effectiveTimerange, showLoadingSpinner } = this.props;
+    const { pageSize, data: { id: searchTypeId }, effectiveTimerange, setLoadingState } = this.props;
     const searchTypePayload = { [searchTypeId]: { limit: pageSize, offset: pageSize * (pageNo - 1) } };
     RefreshActions.disable();
-    showLoadingSpinner(true);
+    setLoadingState(true);
     SearchActions.reexecuteSearchTypes(searchTypePayload, effectiveTimerange).then((response) => {
-      showLoadingSpinner(false);
+      setLoadingState(false);
       let errors = [...response.result.errors];
       if (!isEmpty(errors)) {
         const validPagesInfo = this._resultWindowLimitMessage(response.result.errors);

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -129,24 +129,14 @@ class MessageList extends React.Component<Props, State> {
     return (fields.find(f => f.name === fieldName) || { type: FieldType.Unknown }).type;
   };
 
-  _handlePageChange = (newPage: number) => {
+  _handlePageChange = (pageNo: number) => {
     // execute search with new offset
     const { pageSize, data: { id: searchTypeId }, effectiveTimerange } = this.props;
-    const globalOverride = {
-      searchTypes: {
-        [searchTypeId]: {
-          limit: pageSize,
-          offset: pageSize * (newPage - 1),
-        },
-      },
-      keepSearchTypes: [searchTypeId],
-      timerange: effectiveTimerange,
-    };
-    const executionState = new SearchExecutionState(undefined, globalOverride);
+    const searchTypePayload = { [searchTypeId]: { limit: pageSize, offset: pageSize * (pageNo - 1) } };
     RefreshActions.disable();
-    SearchActions.execute(executionState);
+    SearchActions.reexecuteSearchTypes(searchTypePayload, effectiveTimerange);
     this.setState({
-      currentPage: newPage,
+      currentPage: pageNo,
     });
   }
 

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -132,14 +132,13 @@ class MessageList extends React.Component<Props, State> {
             offset: pageSize * (newPage - 1),
           },
         },
+        keep_search_types: [searchTypeId],
       },
-      keep_search_types: [searchTypeId],
     };
     RefreshActions.disable();
-    SearchActions.execute(executionState).then(() => {
-      this.setState({
-        currentPage: newPage,
-      });
+    SearchActions.execute(executionState);
+    this.setState({
+      currentPage: newPage,
     });
   }
 

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
@@ -97,7 +97,7 @@ describe('MessageList', () => {
                                         data={data}
                                         config={config}
                                         fields={Immutable.List(fields)}
-                                        showLoadingSpinner={() => {}} />);
+                                        setLoadingState={() => {}} />);
 
     expect(wrapper1.find('span[role="presentation"]').length).toBe(2);
 
@@ -107,7 +107,7 @@ describe('MessageList', () => {
                                         data={data}
                                         config={emptyConfig}
                                         fields={Immutable.List(fields)}
-                                        showLoadingSpinner={() => {}} />);
+                                        setLoadingState={() => {}} />);
     expect(wrapper2.find('span[role="presentation"]').length).toBe(0);
   });
 
@@ -118,7 +118,7 @@ describe('MessageList', () => {
                                        data={data}
                                        fields={Immutable.List(fields)}
                                        config={config}
-                                       showLoadingSpinner={() => {}} />);
+                                       setLoadingState={() => {}} />);
     const messageTableEntry = wrapper.find('MessageTableEntry');
     const td = messageTableEntry.find('td').at(0);
     expect(td.props().children).toMatchSnapshot();
@@ -131,7 +131,7 @@ describe('MessageList', () => {
                        data={data}
                        fields={Immutable.List([])}
                        config={config}
-                       showLoadingSpinner={() => {}} />);
+                       setLoadingState={() => {}} />);
   });
 
   it('refreshs Inputs list upon mount', () => {
@@ -141,7 +141,7 @@ describe('MessageList', () => {
                    data={data}
                    fields={Immutable.List([])}
                    config={config}
-                   showLoadingSpinner={() => {}} />
+                   setLoadingState={() => {}} />
     );
     mount(<Component />);
     expect(InputsActions.list).toHaveBeenCalled();
@@ -160,7 +160,7 @@ describe('MessageList', () => {
                                        data={{ ...data, total: Messages.DEFAULT_LIMIT + secondPageSize }}
                                        fields={Immutable.List([])}
                                        config={config}
-                                       showLoadingSpinner={() => {}} />);
+                                       setLoadingState={() => {}} />);
     wrapper.find('[aria-label="Next"]').simulate('click');
     expect(SearchActions.reexecuteSearchTypes).toHaveBeenCalledWith(searchTypePayload, effectiveTimerange);
   });
@@ -172,7 +172,7 @@ describe('MessageList', () => {
                                        data={{ ...data, total: Messages.DEFAULT_LIMIT + secondPageSize }}
                                        fields={Immutable.List([])}
                                        config={config}
-                                       showLoadingSpinner={() => {}} />);
+                                       setLoadingState={() => {}} />);
     wrapper.find('[aria-label="Next"]').simulate('click');
     expect(RefreshActions.disable).toHaveBeenCalledTimes(1);
   });
@@ -184,7 +184,7 @@ describe('MessageList', () => {
                    data={data}
                    fields={Immutable.List([])}
                    config={config}
-                   showLoadingSpinner={() => {}} />
+                   setLoadingState={() => {}} />
     );
     return new Promise((resolve) => {
       const onRenderComplete = jest.fn(resolve);

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
@@ -94,14 +94,16 @@ describe('MessageList', () => {
     SelectedFieldsStore.getInitialState = jest.fn(() => Immutable.Set([TIMESTAMP_FIELD, 'file_name']));
     const wrapper1 = mount(<MessageList editing
                                         data={data}
-                                        fields={Immutable.List(fields)} />);
+                                        fields={Immutable.List(fields)}
+                                        showLoadingSpinner={() => {}} />);
 
     expect(wrapper1.find('span[role="presentation"]').length).toBe(2);
 
     SelectedFieldsStore.getInitialState = jest.fn(() => Immutable.Set([]));
     const wrapper2 = mount(<MessageList editing
                                         data={data}
-                                        fields={Immutable.List(fields)} />);
+                                        fields={Immutable.List(fields)}
+                                        showLoadingSpinner={() => {}} />);
     expect(wrapper2.find('span[role="presentation"]').length).toBe(0);
   });
 
@@ -111,7 +113,8 @@ describe('MessageList', () => {
     const wrapper = mount(<MessageList editing
                                        data={data}
                                        fields={Immutable.List(fields)}
-                                       config={config} />);
+                                       config={config}
+                                       showLoadingSpinner={() => {}} />);
     const messageTableEntry = wrapper.find('MessageTableEntry');
     const td = messageTableEntry.find('td').at(0);
     expect(td.props().children).toMatchSnapshot();
@@ -123,7 +126,8 @@ describe('MessageList', () => {
     mount(<MessageList editing
                        data={data}
                        fields={Immutable.List([])}
-                       config={config} />);
+                       config={config}
+                       showLoadingSpinner={() => {}} />);
   });
 
   it('refreshs Inputs list upon mount', () => {
@@ -132,7 +136,8 @@ describe('MessageList', () => {
       <MessageList editing
                    data={data}
                    fields={Immutable.List([])}
-                   config={config} />
+                   config={config}
+                   showLoadingSpinner={() => {}} />
     );
     mount(<Component />);
     expect(InputsActions.list).toHaveBeenCalled();
@@ -150,7 +155,8 @@ describe('MessageList', () => {
     const wrapper = mount(<MessageList editing
                                        data={{ ...data, total: Messages.DEFAULT_LIMIT + secondPageSize }}
                                        fields={Immutable.List([])}
-                                       config={config} />);
+                                       config={config}
+                                       showLoadingSpinner={() => {}} />);
     wrapper.find('[aria-label="Next"]').simulate('click');
     expect(SearchActions.reexecuteSearchTypes).toHaveBeenCalledWith(searchTypePayload, effectiveTimerange);
   });
@@ -161,7 +167,8 @@ describe('MessageList', () => {
     const wrapper = mount(<MessageList editing
                                        data={{ ...data, total: Messages.DEFAULT_LIMIT + secondPageSize }}
                                        fields={Immutable.List([])}
-                                       config={config} />);
+                                       config={config}
+                                       showLoadingSpinner={() => {}} />);
     wrapper.find('[aria-label="Next"]').simulate('click');
     expect(RefreshActions.disable).toHaveBeenCalledTimes(1);
   });
@@ -172,7 +179,8 @@ describe('MessageList', () => {
       <MessageList editing
                    data={data}
                    fields={Immutable.List([])}
-                   config={config} />
+                   config={config}
+                   showLoadingSpinner={() => {}} />
     );
     return new Promise((resolve) => {
       const onRenderComplete = jest.fn(resolve);

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
@@ -51,7 +51,7 @@ jest.mock('views/stores/SearchStore', () => ({
     ['getInitialState', () => ({ result: { results: { somequery: { effectiveTimerange: { from: '2019-11-15T14:40:48.666Z', to: '2019-11-29T14:40:48.666Z', type: 'absolute' } } } } })],
   ),
   SearchActions: {
-    reexecuteSearchTypes: jest.fn().mockReturnValue(Promise.resolve()),
+    reexecuteSearchTypes: jest.fn().mockReturnValue(Promise.resolve({ result: { errors: [] } })),
   },
 }));
 jest.mock('views/stores/RefreshStore', () => ({
@@ -92,16 +92,20 @@ describe('MessageList', () => {
   it('should render with and without fields', () => {
     const fields = [new FieldTypeMapping('file_name', new FieldType('string', ['full-text-search'], []))];
     SelectedFieldsStore.getInitialState = jest.fn(() => Immutable.Set([TIMESTAMP_FIELD, 'file_name']));
+    const config = MessagesWidgetConfig.builder().fields([TIMESTAMP_FIELD, 'file_name']).build();
     const wrapper1 = mount(<MessageList editing
                                         data={data}
+                                        config={config}
                                         fields={Immutable.List(fields)}
                                         showLoadingSpinner={() => {}} />);
 
     expect(wrapper1.find('span[role="presentation"]').length).toBe(2);
 
+    const emptyConfig = MessagesWidgetConfig.builder().fields([]).build();
     SelectedFieldsStore.getInitialState = jest.fn(() => Immutable.Set([]));
     const wrapper2 = mount(<MessageList editing
                                         data={data}
+                                        config={emptyConfig}
                                         fields={Immutable.List(fields)}
                                         showLoadingSpinner={() => {}} />);
     expect(wrapper2.find('span[role="presentation"]').length).toBe(0);

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
@@ -82,6 +82,7 @@ describe('MessageList', () => {
                                         fields={Immutable.List(fields)} />);
     expect(wrapper2.find('span[role="presentation"]').length).toBe(0);
   });
+
   it('provides a message context for each individual entry', () => {
     const fields = [new FieldTypeMapping('file_name', new FieldType('string', ['full-text-search'], []))];
     const config = MessagesWidgetConfig.builder().fields(['file_name']).build();
@@ -93,6 +94,7 @@ describe('MessageList', () => {
     const td = messageTableEntry.find('td').at(0);
     expect(td.props().children).toMatchSnapshot();
   });
+
   it('renders also when `inputs` is undefined', () => {
     InputsStore.getInitialState = jest.fn(() => ({ inputs: undefined }));
     const config = MessagesWidgetConfig.builder().fields([]).build();

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
@@ -52,6 +52,7 @@ jest.mock('views/stores/SearchStore', () => ({
   ),
   SearchActions: {
     reexecuteSearchTypes: jest.fn().mockReturnValue(Promise.resolve({ result: { errors: [] } })),
+    execute: { completed: { listen: jest.fn() } },
   },
 }));
 jest.mock('views/stores/RefreshStore', () => ({

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
@@ -60,7 +60,6 @@ jest.mock('views/stores/RefreshStore', () => ({
   },
 }));
 jest.mock('legacy/result-histogram', () => 'Histogram');
-jest.mock('components/search/MessageTablePaginator', () => 'message-table-paginator');
 jest.mock('views/components/messagelist');
 
 describe('MessageList', () => {

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
@@ -72,17 +72,6 @@ const Table = styled.table`
     overflow: hidden;
   }
 
-  tr.message-row .message-wrapper:after {
-    content: "";
-    text-align: right;
-    position: absolute;
-    width: 99%;
-    left: 5px;
-    top: 4.5em;
-    height: 1.5em;
-    background: linear-gradient(to bottom, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 95%);
-  }
-
   tr.message-detail-row {
     display: none;
   }

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
@@ -112,7 +112,7 @@ type State = {
 
 type Props = {
   fields: {},
-  config?: MessagesWidgetConfig,
+  config: MessagesWidgetConfig,
   selectedFields?: {},
   activeQueryId: string,
   messages: Array<Object>
@@ -121,14 +121,13 @@ type Props = {
 class MessageTable extends React.Component<Props, State> {
   static propTypes = {
     activeQueryId: PropTypes.string.isRequired,
-    config: CustomPropTypes.instanceOf(MessagesWidgetConfig),
+    config: CustomPropTypes.instanceOf(MessagesWidgetConfig).isRequired,
     fields: CustomPropTypes.FieldListType.isRequired,
     messages: PropTypes.arrayOf(PropTypes.object).isRequired,
     selectedFields: PropTypes.object,
   }
 
   static defaultProps = {
-    config: undefined,
     selectedFields: Immutable.Set(),
   };
 

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
@@ -1,5 +1,6 @@
 // @flow strict
 import React from 'react';
+import PropTypes from 'prop-types';
 import * as Immutable from 'immutable';
 import styled from 'styled-components';
 
@@ -7,6 +8,7 @@ import { AdditionalContext } from 'views/logic/ActionContext';
 import MessageFieldsFilter from 'logic/message/MessageFieldsFilter';
 import FieldType from 'views/logic/fieldtypes/FieldType';
 import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
+import CustomPropTypes from 'views/components/CustomPropTypes';
 
 import { RefreshActions } from 'views/stores/RefreshStore';
 
@@ -110,13 +112,26 @@ type State = {
 
 type Props = {
   fields: {},
-  config: MessagesWidgetConfig,
-  selectedFields: {},
+  config?: MessagesWidgetConfig,
+  selectedFields?: {},
   activeQueryId: string,
   messages: Array<Object>
 };
 
 class MessageTable extends React.Component<Props, State> {
+  static propTypes = {
+    activeQueryId: PropTypes.string.isRequired,
+    config: CustomPropTypes.instanceOf(MessagesWidgetConfig),
+    fields: CustomPropTypes.FieldListType.isRequired,
+    messages: PropTypes.arrayOf(PropTypes.object).isRequired,
+    selectedFields: PropTypes.object,
+  }
+
+  static defaultProps = {
+    config: undefined,
+    selectedFields: Immutable.Set(),
+  };
+
   state = {
     expandedMessages: Immutable.Set(),
   };

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
@@ -187,43 +187,42 @@ class MessageTable extends React.Component<Props, State> {
     const selectedFields = this._getSelectedFields();
     const selectedColumns = Immutable.OrderedSet(selectedFields);
     return (
-      <div className="search-results-table">
-        <div className="table-responsive">
-          <Table className="table table-condensed" style={{ marginTop: 0 }}>
-            <TableHead>
-              <tr>
-                {selectedColumns.toSeq().map((selectedFieldName) => {
-                  return (
-                    <th key={selectedFieldName}
-                        style={this._columnStyle(selectedFieldName)}>
-                      <Field type={this._fieldTypeFor(selectedFieldName, fields)}
-                             name={selectedFieldName}
-                             queryId={activeQueryId} />
-                    </th>
-                  );
-                })}
-              </tr>
-            </TableHead>
-            {formattedMessages.map((message) => {
-              const messageKey = `${message.index}-${message.id}`;
-              return (
-                <AdditionalContext.Provider key={messageKey}
-                                            value={{ message }}>
-                  <MessageTableEntry fields={fields}
-                                     disableSurroundingSearch
-                                     message={message}
-                                     showMessageRow={config && config.showMessageRow}
-                                     selectedFields={selectedColumns}
-                                     expanded={expandedMessages.contains(messageKey)}
-                                     toggleDetail={this._toggleMessageDetail}
-                                     highlight
-                                     expandAllRenderAsync={false} />
-                </AdditionalContext.Provider>
-              );
-            })}
-          </Table>
-        </div>
+      <div className="table-responsive">
+        <Table className="table table-condensed" style={{ marginTop: 0 }}>
+          <TableHead>
+            <tr>
+              {selectedColumns.toSeq().map((selectedFieldName) => {
+                return (
+                  <th key={selectedFieldName}
+                      style={this._columnStyle(selectedFieldName)}>
+                    <Field type={this._fieldTypeFor(selectedFieldName, fields)}
+                           name={selectedFieldName}
+                           queryId={activeQueryId} />
+                  </th>
+                );
+              })}
+            </tr>
+          </TableHead>
+          {formattedMessages.map((message) => {
+            const messageKey = `${message.index}-${message.id}`;
+            return (
+              <AdditionalContext.Provider key={messageKey}
+                                          value={{ message }}>
+                <MessageTableEntry fields={fields}
+                                   disableSurroundingSearch
+                                   message={message}
+                                   showMessageRow={config && config.showMessageRow}
+                                   selectedFields={selectedColumns}
+                                   expanded={expandedMessages.contains(messageKey)}
+                                   toggleDetail={this._toggleMessageDetail}
+                                   highlight
+                                   expandAllRenderAsync={false} />
+              </AdditionalContext.Provider>
+            );
+          })}
+        </Table>
       </div>
+
     );
   }
 }

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
@@ -113,7 +113,7 @@ type Props = {
   config: MessagesWidgetConfig,
   selectedFields: {},
   activeQueryId: string,
-  messages: []
+  messages: Array<Object>
 };
 
 class MessageTable extends React.Component<Props, State> {

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
@@ -1,0 +1,227 @@
+// @flow strict
+import React from 'react';
+import * as Immutable from 'immutable';
+import styled from 'styled-components';
+
+import { AdditionalContext } from 'views/logic/ActionContext';
+import MessageFieldsFilter from 'logic/message/MessageFieldsFilter';
+import FieldType from 'views/logic/fieldtypes/FieldType';
+import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
+
+import { RefreshActions } from 'views/stores/RefreshStore';
+
+import { MessageTableEntry } from 'views/components/messagelist';
+import Field from 'views/components/Field';
+
+const Table = styled.table`
+  position: relative;
+  font-size: 11px;
+  margin-top: 15px;
+  margin-bottom: 60px;
+  border-collapse: collapse;
+  padding-left: 13px;
+  width: 100%;
+  word-break: break-all;
+
+  table.messages td, table.messages th {
+    position: relative;
+    left: 13px;
+  }
+
+  tr {
+    border: 0 !important;
+  }
+
+  tbody.message-group {
+    border-top: 0;
+  }
+
+  tbody.message-group-toggled {
+    border-left: 7px solid #16ace3;
+  }
+
+  tbody.message-highlight {
+    border-left: 7px solid #8dc63f;
+  }
+
+  tr.fields-row {
+    cursor: pointer;
+  }
+
+  tr.fields-row td {
+    padding-top: 10px;
+  }
+
+  tr.message-row td {
+    border-top: 0;
+    padding-top: 0;
+    padding-bottom: 5px;
+    font-family: monospace;
+    color: #16ace3;
+  }
+
+  tr.message-row {
+    margin-bottom: 5px;
+    cursor: pointer;
+  }
+
+  tr.message-row .message-wrapper {
+    line-height: 1.5em;
+    white-space: pre-line;
+    max-height: 6em; /* show 4 lines: line-height * 4 */
+    overflow: hidden;
+  }
+
+  tr.message-row .message-wrapper:after {
+    content: "";
+    text-align: right;
+    position: absolute;
+    width: 99%;
+    left: 5px;
+    top: 4.5em;
+    height: 1.5em;
+    background: linear-gradient(to bottom, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1) 95%);
+  }
+
+  tr.message-detail-row {
+    display: none;
+  }
+
+  tr.message-detail-row td {
+    padding-top: 5px;
+    border-top: 0;
+  }
+
+  tr.message-detail-row .row {
+    margin-right: 0;
+  }
+
+  tr.message-detail-row div[class*="col-"] {
+    padding-right: 0;
+  }
+`;
+
+const TableHead = styled.thead`
+  &&, th {
+    background-color: #eee;
+    color: #333;
+  }
+
+  th {
+    border: 0;
+    font-size: 11px;
+    font-weight: normal;
+    white-space: nowrap;
+  }
+`;
+
+type State = {
+  expandedMessages: Immutable.Set,
+}
+
+type Props = {
+  fields: {},
+  config: MessagesWidgetConfig,
+  selectedFields: {},
+  activeQueryId: string,
+  messages: []
+};
+
+class MessageTable extends React.Component<Props, State> {
+  state = {
+    expandedMessages: Immutable.Set(),
+  };
+
+  _columnStyle = (fieldName: string) => {
+    const { fields } = this.props;
+    const selectedFields = Immutable.OrderedSet(fields);
+    if (fieldName.toLowerCase() === 'source' && selectedFields.size > 1) {
+      return { width: 180 };
+    }
+    return {};
+  };
+
+  _fieldTypeFor = (fieldName: string, fields: Immutable.List) => {
+    return (fields.find(f => f.name === fieldName) || { type: FieldType.Unknown }).type;
+  };
+
+  _getFormattedMessages = (): Array<Object> => {
+    const { messages } = this.props;
+    return messages.map(m => ({
+      fields: m.message,
+      formatted_fields: MessageFieldsFilter.filterFields(m.message),
+      id: m.message._id,
+      index: m.index,
+      highlight_ranges: m.highlight_ranges,
+    }));
+  };
+
+  _getSelectedFields = () => {
+    const { selectedFields, config } = this.props;
+    if (config) {
+      return Immutable.Set(config.fields);
+    }
+    return selectedFields;
+  };
+
+  _toggleMessageDetail = (id: string) => {
+    let newSet;
+    const { expandedMessages } = this.state;
+    if (expandedMessages.contains(id)) {
+      newSet = expandedMessages.delete(id);
+    } else {
+      newSet = expandedMessages.add(id);
+      RefreshActions.disable();
+    }
+    this.setState({ expandedMessages: newSet });
+  };
+
+  render() {
+    const { expandedMessages } = this.state;
+    const { fields, activeQueryId, config } = this.props;
+    const formattedMessages = this._getFormattedMessages();
+    const selectedFields = this._getSelectedFields();
+    const selectedColumns = Immutable.OrderedSet(selectedFields);
+    return (
+      <div className="search-results-table">
+        <div className="table-responsive">
+          <Table className="table table-condensed" style={{ marginTop: 0 }}>
+            <TableHead>
+              <tr>
+                {selectedColumns.toSeq().map((selectedFieldName) => {
+                  return (
+                    <th key={selectedFieldName}
+                        style={this._columnStyle(selectedFieldName)}>
+                      <Field type={this._fieldTypeFor(selectedFieldName, fields)}
+                             name={selectedFieldName}
+                             queryId={activeQueryId} />
+                    </th>
+                  );
+                })}
+              </tr>
+            </TableHead>
+            {formattedMessages.map((message) => {
+              const messageKey = `${message.index}-${message.id}`;
+              return (
+                <AdditionalContext.Provider key={messageKey}
+                                            value={{ message }}>
+                  <MessageTableEntry fields={fields}
+                                     disableSurroundingSearch
+                                     message={message}
+                                     showMessageRow={config && config.showMessageRow}
+                                     selectedFields={selectedColumns}
+                                     expanded={expandedMessages.contains(messageKey)}
+                                     toggleDetail={this._toggleMessageDetail}
+                                     highlight
+                                     expandAllRenderAsync={false} />
+                </AdditionalContext.Provider>
+              );
+            })}
+          </Table>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default MessageTable;

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.test.jsx
@@ -1,0 +1,49 @@
+// @flow strict
+import * as React from 'react';
+import { mount } from 'enzyme';
+import * as Immutable from 'immutable';
+
+import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
+import FieldType from 'views/logic/fieldtypes/FieldType';
+import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
+import MessageTable from './MessageTable';
+
+const messages = [
+  {
+    highlight_ranges: {},
+    index: 'graylog_42',
+    message: {
+      _id: 'message-id-1',
+      file_name: 'frank.txt',
+      timestamp: '2018-09-26T12:42:49.234Z',
+    },
+  },
+
+];
+const fields = [new FieldTypeMapping('file_name', new FieldType('string', ['full-text-search'], []))];
+const config = MessagesWidgetConfig.builder().fields(['file_name']).build();
+const activeQueryId = 'some-query-id';
+
+
+describe('MessageTable', () => {
+  it('lists provided field in table head', () => {
+    const wrapper = mount(<MessageTable messages={messages}
+                                        activeQueryId={activeQueryId}
+                                        fields={Immutable.List(fields)}
+                                        selectedFields={{}}
+                                        config={config} />);
+    const th = wrapper.find('th').at(0);
+    expect(th.text()).toContain('file_name');
+  });
+
+  it('renders a table entry for messages', () => {
+    const wrapper = mount(<MessageTable messages={messages}
+                                        activeQueryId={activeQueryId}
+                                        fields={Immutable.List(fields)}
+                                        selectedFields={{}}
+                                        config={config} />);
+    const messageTableEntry = wrapper.find('MessageTableEntry');
+    const td = messageTableEntry.find('td').at(0);
+    expect(td.text()).toContain('frank.txt');
+  });
+});

--- a/graylog2-web-interface/src/views/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.jsx
@@ -60,6 +60,7 @@ type Props = {
 type State = {
   configChanged?: boolean,
   editing: boolean,
+  loading: boolean;
   oldConfig?: WidgetConfig,
   showCopyToDashboard: boolean,
 };
@@ -108,6 +109,7 @@ class Widget extends React.Component<Props, State> {
     const { editing } = props;
     this.state = {
       editing,
+      loading: false,
       showCopyToDashboard: false,
     };
     if (editing) {
@@ -197,6 +199,10 @@ class Widget extends React.Component<Props, State> {
     WidgetActions.updateConfig(widgetId, config);
   };
 
+  _setLoadingState = (loading: boolean) => {
+    this.setState({ loading });
+  }
+
   visualize = () => {
     const { data, errors, title } = this.props;
     if (errors && errors.length > 0) {
@@ -217,6 +223,7 @@ class Widget extends React.Component<Props, State> {
                       height={height}
                       width={width}
                       filter={filter}
+                      showLoadingSpinner={this._setLoadingState}
                       toggleEdit={this._onToggleEdit} />
       );
     }
@@ -226,7 +233,7 @@ class Widget extends React.Component<Props, State> {
   // TODO: Clean up different code paths for normal/edit modes
   render() {
     const { id, widget, fields, onSizeChange, title, position, onPositionsChange } = this.props;
-    const { editing, showCopyToDashboard } = this.state;
+    const { editing, loading, showCopyToDashboard } = this.state;
     const { config } = widget;
     const visualization = this.visualize();
     if (editing) {
@@ -237,6 +244,7 @@ class Widget extends React.Component<Props, State> {
             <MeasureDimensions>
               <WidgetHeader title={title}
                             hideDragHandle
+                            loading={loading}
                             onRename={newTitle => TitlesActions.set('widget', id, newTitle)}
                             editing={editing} />
               <EditComponent config={config}
@@ -262,6 +270,7 @@ class Widget extends React.Component<Props, State> {
             {interactive => (
               <WidgetHeader title={title}
                             hideDragHandle={!interactive}
+                            loading={loading}
                             onRename={newTitle => TitlesActions.set('widget', id, newTitle)}
                             editing={editing}>
                 <IfInteractive>

--- a/graylog2-web-interface/src/views/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.jsx
@@ -258,43 +258,41 @@ class Widget extends React.Component<Props, State> {
     return (
       <WidgetColorContext id={id}>
         <WidgetFrame widgetId={id} onSizeChange={onSizeChange}>
-          <span>
-            <InteractiveContext.Consumer>
-              {interactive => (
-                <WidgetHeader title={title}
-                              hideDragHandle={!interactive}
-                              onRename={newTitle => TitlesActions.set('widget', id, newTitle)}
-                              editing={editing}>
-                  <IfInteractive>
-                    <WidgetHorizontalStretch widgetId={widget.id}
-                                             widgetType={widget.type}
-                                             onStretch={onPositionsChange}
-                                             position={position} />
-                    {' '}
-                    <WidgetActionDropdown>
-                      <MenuItem onSelect={this._onToggleEdit}>Edit</MenuItem>
-                      <MenuItem onSelect={() => this._onDuplicate(id)}>Duplicate</MenuItem>
-                      <IfSearch>
-                        <MenuItem onSelect={this._onToggleCopyToDashboard}>Copy to Dashboard</MenuItem>
-                      </IfSearch>
-                      <MenuItem divider />
-                      <MenuItem onSelect={() => this._onDelete(widget)}>Delete</MenuItem>
-                    </WidgetActionDropdown>
-                    {showCopyToDashboard
+          <InteractiveContext.Consumer>
+            {interactive => (
+              <WidgetHeader title={title}
+                            hideDragHandle={!interactive}
+                            onRename={newTitle => TitlesActions.set('widget', id, newTitle)}
+                            editing={editing}>
+                <IfInteractive>
+                  <WidgetHorizontalStretch widgetId={widget.id}
+                                           widgetType={widget.type}
+                                           onStretch={onPositionsChange}
+                                           position={position} />
+                  {' '}
+                  <WidgetActionDropdown>
+                    <MenuItem onSelect={this._onToggleEdit}>Edit</MenuItem>
+                    <MenuItem onSelect={() => this._onDuplicate(id)}>Duplicate</MenuItem>
+                    <IfSearch>
+                      <MenuItem onSelect={this._onToggleCopyToDashboard}>Copy to Dashboard</MenuItem>
+                    </IfSearch>
+                    <MenuItem divider />
+                    <MenuItem onSelect={() => this._onDelete(widget)}>Delete</MenuItem>
+                  </WidgetActionDropdown>
+                  {showCopyToDashboard
                     && (
                       <CopyToDashboard widgetId={id}
                                        onSubmit={this._onCopyToDashboard}
                                        onCancel={this._onToggleCopyToDashboard} />
                     )}
-                  </IfInteractive>
-                </WidgetHeader>
-              )}
-            </InteractiveContext.Consumer>
-            <WidgetErrorBoundary>
+                </IfInteractive>
+              </WidgetHeader>
+            )}
+          </InteractiveContext.Consumer>
+          <WidgetErrorBoundary>
 
-              {visualization}
-            </WidgetErrorBoundary>
-          </span>
+            {visualization}
+          </WidgetErrorBoundary>
         </WidgetFrame>
       </WidgetColorContext>
     );

--- a/graylog2-web-interface/src/views/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.jsx
@@ -223,7 +223,7 @@ class Widget extends React.Component<Props, State> {
                       height={height}
                       width={width}
                       filter={filter}
-                      showLoadingSpinner={this._setLoadingState}
+                      setLoadingState={this._setLoadingState}
                       toggleEdit={this._onToggleEdit} />
       );
     }

--- a/graylog2-web-interface/src/views/components/widgets/WidgetFrame.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetFrame.jsx
@@ -2,6 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 export default class extends React.Component {
+  WIDGET_HEADER_HEIGHT = 25;
+
+  WIDGET_FOOTER_HEIGHT = 40;
+
   static propTypes = {
     widgetId: PropTypes.string.isRequired,
     children: PropTypes.node.isRequired,
@@ -21,18 +25,6 @@ export default class extends React.Component {
     this._updateWidgetDimensionsIfChanged();
   }
 
-  _updateWidgetDimensionsIfChanged() {
-    const { height, width } = this._calculateWidgetSize();
-    if (height !== this.state.height || width !== this.state.width) {
-      this.setState({ height: height, width: width });
-      this.props.onSizeChange(this.props.widgetId, { height: height, width: width });
-    }
-  }
-
-  WIDGET_HEADER_HEIGHT = 25;
-
-  WIDGET_FOOTER_HEIGHT = 40;
-
   _calculateWidgetSize = () => {
     const widgetNode = this._widgetNode;
     // subtracting header, footer and padding from height & width.
@@ -41,12 +33,21 @@ export default class extends React.Component {
     return { height: height, width: width };
   };
 
+  _updateWidgetDimensionsIfChanged() {
+    const { onSizeChange, widgetId } = this.props;
+    const { width: currentWidth, height: currentHeight } = this.state;
+    const { height, width } = this._calculateWidgetSize();
+    if (height !== currentHeight || width !== currentWidth) {
+      this.setState({ height: height, width: width });
+      onSizeChange(widgetId, { height: height, width: width });
+    }
+  }
+
   render() {
+    const { children, widgetId } = this.props;
     return (
-      <div className="widget" ref={(elem) => { this._widgetNode = elem; }} style={{ overflow: 'hidden' }} data-widget-id={this.props.widgetId}>
-        <div style={{ height: '95%', padding: '5px' }}>
-          {this.props.children}
-        </div>
+      <div className="widget" ref={(elem) => { this._widgetNode = elem; }} style={{ overflow: 'hidden' }} data-widget-id={widgetId}>
+        {children}
       </div>
     );
   }

--- a/graylog2-web-interface/src/views/components/widgets/WidgetHeader.css
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetHeader.css
@@ -1,6 +1,5 @@
 :local(.widgetHeader) {
     font-size: 18px;
-    height: 25px;
     text-overflow: ellipsis;
     margin-bottom: 5px;
 }

--- a/graylog2-web-interface/src/views/components/widgets/WidgetHeader.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetHeader.jsx
@@ -1,15 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
-import { Icon } from 'components/common';
+import { Spinner, Icon } from 'components/common';
 import EditableTitle from 'views/components/common/EditableTitle';
 import styles from './WidgetHeader.css';
 import CustomPropTypes from '../CustomPropTypes';
 
-const WidgetHeader = ({ children, onRename, hideDragHandle, title }) => (
+const LoadingSpinner = styled(Spinner)`
+  margin-left: 10px;
+`;
+
+const WidgetHeader = ({ children, onRename, hideDragHandle, title, loading }) => (
   <div className={styles.widgetHeader}>
     {hideDragHandle || <Icon name="bars" className={`widget-drag-handle ${styles.widgetDragHandle}`} />}{' '}
     <EditableTitle disabled={!onRename} value={title} onChange={onRename} />
+    {loading && <LoadingSpinner text="" />}
     <span className={`pull-right ${styles.widgetActionDropdown}`}>
       {children}
     </span>
@@ -21,12 +27,14 @@ WidgetHeader.propTypes = {
   onRename: PropTypes.func,
   hideDragHandle: PropTypes.bool,
   title: PropTypes.node.isRequired,
+  loading: PropTypes.bool,
 };
 
 WidgetHeader.defaultProps = {
   children: null,
   onRename: undefined,
   hideDragHandle: false,
+  loading: false,
 };
 
 export default WidgetHeader;

--- a/graylog2-web-interface/src/views/components/widgets/__snapshots__/CopyToDashboardForm.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/widgets/__snapshots__/CopyToDashboardForm.test.jsx.snap
@@ -75,125 +75,123 @@ exports[`CopyToDashboardForm should render the modal minimal 1`] = `
                 </div>
               </form>
             </div>
+            <div
+              class="form-inline page-size"
+              style="float: right;"
+            >
+              <div
+                class="form-group"
+              >
+                <label
+                  class="ControlLabel-sc-1edmum5-0 iZJNbd control-label"
+                  for="page-size"
+                >
+                  Show:
+                </label>
+                <span>
+                  <select
+                    class="FormControl-sc-1amoaox-0 hdNTyr form-control input-sm"
+                    id="page-size"
+                    label="Show:"
+                    name="page-size"
+                    placeholder=""
+                    type="select"
+                  >
+                    <option
+                      value="5"
+                    >
+                      5
+                    </option>
+                    <option
+                      value="10"
+                    >
+                      10
+                    </option>
+                    <option
+                      value="15"
+                    >
+                      15
+                    </option>
+                  </select>
+                  
+                </span>
+              </div>
+            </div>
             <span>
-              <div
-                class="form-inline page-size"
-                style="float: right;"
-              >
-                <div
-                  class="form-group"
-                >
-                  <label
-                    class="ControlLabel-sc-1edmum5-0 iZJNbd control-label"
-                    for="page-size"
-                  >
-                    Show:
-                  </label>
-                  <span>
-                    <select
-                      class="FormControl-sc-1amoaox-0 hdNTyr form-control input-sm"
-                      id="page-size"
-                      label="Show:"
-                      name="page-size"
-                      placeholder=""
-                      type="select"
-                    >
-                      <option
-                        value="5"
-                      >
-                        5
-                      </option>
-                      <option
-                        value="10"
-                      >
-                        10
-                      </option>
-                      <option
-                        value="15"
-                      >
-                        15
-                      </option>
-                    </select>
-                    
-                  </span>
-                </div>
-              </div>
-              <span>
-                No dashboards found
-              </span>
-              <div
-                class="text-center"
-              >
-                <ul
-                  class="Pagination-sc-1u3exqe-0 gSmbxW pagination pagination-sm"
-                >
-                  <li
-                    class="disabled"
-                  >
-                    <a
-                      href="#"
-                      role="button"
-                      style="pointer-events: none;"
-                      tabindex="-1"
-                    >
-                      <span
-                        aria-label="First"
-                      >
-                        «
-                      </span>
-                    </a>
-                  </li>
-                  <li
-                    class="disabled"
-                  >
-                    <a
-                      href="#"
-                      role="button"
-                      style="pointer-events: none;"
-                      tabindex="-1"
-                    >
-                      <span
-                        aria-label="Previous"
-                      >
-                        ‹
-                      </span>
-                    </a>
-                  </li>
-                  <li
-                    class="disabled"
-                  >
-                    <a
-                      href="#"
-                      role="button"
-                      style="pointer-events: none;"
-                      tabindex="-1"
-                    >
-                      <span
-                        aria-label="Next"
-                      >
-                        ›
-                      </span>
-                    </a>
-                  </li>
-                  <li
-                    class="disabled"
-                  >
-                    <a
-                      href="#"
-                      role="button"
-                      style="pointer-events: none;"
-                      tabindex="-1"
-                    >
-                      <span
-                        aria-label="Last"
-                      >
-                        »
-                      </span>
-                    </a>
-                  </li>
-                </ul>
-              </div>
+              No dashboards found
             </span>
+            <div
+              class="text-center"
+            >
+              <ul
+                class="Pagination-sc-1u3exqe-0 gSmbxW pagination pagination-sm"
+              >
+                <li
+                  class="disabled"
+                >
+                  <a
+                    href="#"
+                    role="button"
+                    style="pointer-events: none;"
+                    tabindex="-1"
+                  >
+                    <span
+                      aria-label="First"
+                    >
+                      «
+                    </span>
+                  </a>
+                </li>
+                <li
+                  class="disabled"
+                >
+                  <a
+                    href="#"
+                    role="button"
+                    style="pointer-events: none;"
+                    tabindex="-1"
+                  >
+                    <span
+                      aria-label="Previous"
+                    >
+                      ‹
+                    </span>
+                  </a>
+                </li>
+                <li
+                  class="disabled"
+                >
+                  <a
+                    href="#"
+                    role="button"
+                    style="pointer-events: none;"
+                    tabindex="-1"
+                  >
+                    <span
+                      aria-label="Next"
+                    >
+                      ›
+                    </span>
+                  </a>
+                </li>
+                <li
+                  class="disabled"
+                >
+                  <a
+                    href="#"
+                    role="button"
+                    style="pointer-events: none;"
+                    tabindex="-1"
+                  >
+                    <span
+                      aria-label="Last"
+                    >
+                      »
+                    </span>
+                  </a>
+                </li>
+              </ul>
+            </div>
           </div>
           <div
             class="modal-footer"
@@ -294,162 +292,160 @@ exports[`CopyToDashboardForm should render the modal with entries 1`] = `
                 </div>
               </form>
             </div>
-            <span>
+            <div
+              class="form-inline page-size"
+              style="float: right;"
+            >
               <div
-                class="form-inline page-size"
-                style="float: right;"
+                class="form-group"
               >
-                <div
-                  class="form-group"
+                <label
+                  class="ControlLabel-sc-1edmum5-0 iZJNbd control-label"
+                  for="page-size"
                 >
-                  <label
-                    class="ControlLabel-sc-1edmum5-0 iZJNbd control-label"
-                    for="page-size"
+                  Show:
+                </label>
+                <span>
+                  <select
+                    class="FormControl-sc-1amoaox-0 hdNTyr form-control input-sm"
+                    id="page-size"
+                    label="Show:"
+                    name="page-size"
+                    placeholder=""
+                    type="select"
                   >
-                    Show:
-                  </label>
-                  <span>
-                    <select
-                      class="FormControl-sc-1amoaox-0 hdNTyr form-control input-sm"
-                      id="page-size"
-                      label="Show:"
-                      name="page-size"
-                      placeholder=""
-                      type="select"
+                    <option
+                      value="5"
                     >
-                      <option
-                        value="5"
-                      >
-                        5
-                      </option>
-                      <option
-                        value="10"
-                      >
-                        10
-                      </option>
-                      <option
-                        value="15"
-                      >
-                        15
-                      </option>
-                    </select>
-                    
-                  </span>
-                </div>
+                      5
+                    </option>
+                    <option
+                      value="10"
+                    >
+                      10
+                    </option>
+                    <option
+                      value="15"
+                    >
+                      15
+                    </option>
+                  </select>
+                  
+                </span>
               </div>
-              <div
-                class="list-group"
+            </div>
+            <div
+              class="list-group"
+            >
+              <button
+                class="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                type="button"
               >
-                <button
-                  class="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
-                  type="button"
+                <h4
+                  class="list-group-item-heading"
                 >
-                  <h4
-                    class="list-group-item-heading"
-                  >
-                    view 1
-                  </h4>
-                  <p
-                    class="list-group-item-text"
-                  />
-                </button>
-                <button
-                  class="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
-                  type="button"
-                >
-                  <h4
-                    class="list-group-item-heading"
-                  >
-                    view 2
-                  </h4>
-                  <p
-                    class="list-group-item-text"
-                  />
-                </button>
-              </div>
-              <div
-                class="text-center"
+                  view 1
+                </h4>
+                <p
+                  class="list-group-item-text"
+                />
+              </button>
+              <button
+                class="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                type="button"
               >
-                <ul
-                  class="Pagination-sc-1u3exqe-0 gSmbxW pagination pagination-sm"
+                <h4
+                  class="list-group-item-heading"
                 >
-                  <li
-                    class="disabled"
+                  view 2
+                </h4>
+                <p
+                  class="list-group-item-text"
+                />
+              </button>
+            </div>
+            <div
+              class="text-center"
+            >
+              <ul
+                class="Pagination-sc-1u3exqe-0 gSmbxW pagination pagination-sm"
+              >
+                <li
+                  class="disabled"
+                >
+                  <a
+                    href="#"
+                    role="button"
+                    style="pointer-events: none;"
+                    tabindex="-1"
                   >
-                    <a
-                      href="#"
-                      role="button"
-                      style="pointer-events: none;"
-                      tabindex="-1"
+                    <span
+                      aria-label="First"
                     >
-                      <span
-                        aria-label="First"
-                      >
-                        «
-                      </span>
-                    </a>
-                  </li>
-                  <li
-                    class="disabled"
+                      «
+                    </span>
+                  </a>
+                </li>
+                <li
+                  class="disabled"
+                >
+                  <a
+                    href="#"
+                    role="button"
+                    style="pointer-events: none;"
+                    tabindex="-1"
                   >
-                    <a
-                      href="#"
-                      role="button"
-                      style="pointer-events: none;"
-                      tabindex="-1"
+                    <span
+                      aria-label="Previous"
                     >
-                      <span
-                        aria-label="Previous"
-                      >
-                        ‹
-                      </span>
-                    </a>
-                  </li>
-                  <li
-                    class="active"
+                      ‹
+                    </span>
+                  </a>
+                </li>
+                <li
+                  class="active"
+                >
+                  <a
+                    href="#"
+                    role="button"
                   >
-                    <a
-                      href="#"
-                      role="button"
-                    >
-                      1
-                    </a>
-                  </li>
-                  <li
-                    class="disabled"
+                    1
+                  </a>
+                </li>
+                <li
+                  class="disabled"
+                >
+                  <a
+                    href="#"
+                    role="button"
+                    style="pointer-events: none;"
+                    tabindex="-1"
                   >
-                    <a
-                      href="#"
-                      role="button"
-                      style="pointer-events: none;"
-                      tabindex="-1"
+                    <span
+                      aria-label="Next"
                     >
-                      <span
-                        aria-label="Next"
-                      >
-                        ›
-                      </span>
-                    </a>
-                  </li>
-                  <li
-                    class="disabled"
+                      ›
+                    </span>
+                  </a>
+                </li>
+                <li
+                  class="disabled"
+                >
+                  <a
+                    href="#"
+                    role="button"
+                    style="pointer-events: none;"
+                    tabindex="-1"
                   >
-                    <a
-                      href="#"
-                      role="button"
-                      style="pointer-events: none;"
-                      tabindex="-1"
+                    <span
+                      aria-label="Last"
                     >
-                      <span
-                        aria-label="Last"
-                      >
-                        »
-                      </span>
-                    </a>
-                  </li>
-                </ul>
-              </div>
-            </span>
+                      »
+                    </span>
+                  </a>
+                </li>
+              </ul>
+            </div>
           </div>
           <div
             class="modal-footer"

--- a/graylog2-web-interface/src/views/components/widgets/__snapshots__/Widget.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/widgets/__snapshots__/Widget.test.jsx.snap
@@ -11,6 +11,7 @@ exports[`<Widget /> should render with empty props 1`] = `
       <widget-header
         editing="false"
         hidedraghandle="false"
+        loading="false"
         title="Widget Title"
       >
         <span>

--- a/graylog2-web-interface/src/views/components/widgets/__snapshots__/Widget.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/widgets/__snapshots__/Widget.test.jsx.snap
@@ -8,47 +8,41 @@ exports[`<Widget /> should render with empty props 1`] = `
       data-widget-id="widgetId"
       style="overflow: hidden;"
     >
-      <div
-        style="height: 95%; padding: 5px;"
+      <widget-header
+        editing="false"
+        hidedraghandle="false"
+        title="Widget Title"
       >
         <span>
-          <widget-header
-            editing="false"
-            hidedraghandle="false"
-            title="Widget Title"
+          <i
+            class="fa fa-arrows-h button"
+            role="link"
+            tabindex="0"
+          />
+        </span>
+         
+        <span
+          role="presentation"
+        >
+          <span
+            role="presentation"
           >
             <span>
               <i
-                class="fa fa-arrows-h button"
-                role="link"
-                tabindex="0"
+                class="fa fa-chevron-down widgetActionDropdownCaret tonedDown"
+                data-testid="widgetActionDropDown"
               />
             </span>
-             
-            <span
-              role="presentation"
-            >
-              <span
-                role="presentation"
-              >
-                <span>
-                  <i
-                    class="fa fa-chevron-down widgetActionDropdownCaret tonedDown"
-                    data-testid="widgetActionDropDown"
-                  />
-                </span>
-              </span>
-            </span>
-          </widget-header>
-          <div
-            class="spinnerContainer"
-          >
-            <i
-              class="fa fa-refresh spinner fa-3x"
-              data-testid="loading-widget"
-            />
-          </div>
+          </span>
         </span>
+      </widget-header>
+      <div
+        class="spinnerContainer"
+      >
+        <i
+          class="fa fa-refresh spinner fa-3x"
+          data-testid="loading-widget"
+        />
       </div>
     </div>
   </div>

--- a/graylog2-web-interface/src/views/logic/ResultWindowLimitError.js
+++ b/graylog2-web-interface/src/views/logic/ResultWindowLimitError.js
@@ -1,0 +1,28 @@
+import SearchError from './SearchError';
+
+export default class ResultWindowLimitError extends SearchError {
+  constructor(error, result) {
+    super(error);
+    const { result_window_limit: resultWindowLimit } = error;
+    this._state = {
+      ...this._state,
+      description: ResultWindowLimitError._extendDescription(result, this.description, this.queryId, this.searchTypeId, resultWindowLimit),
+      result_window_limit: resultWindowLimit,
+    };
+  }
+
+  static _extendDescription(result, description, queryId, searchTypeId, resultWindowLimit) {
+    const pageSize = ResultWindowLimitError._getPageSizeFromResult(result, queryId, searchTypeId);
+    const validPages = Math.floor(resultWindowLimit / pageSize);
+    const validPagesMessage = `Elasticsearch limits the search result to ${resultWindowLimit} messages. With a page size of ${pageSize} messages, you can use the first ${validPages} pages.`;
+    return `${validPagesMessage} ${description}`;
+  }
+
+  static _getPageSizeFromResult(result, queryId, searchTypeId) {
+    const searchTypes = result.results[queryId].query.search_types;
+    const searchType = searchTypes.find(({ id }) => id === searchTypeId);
+    return searchType.limit;
+  }
+
+  get resultWindowLimit() { return this._state.result_window_limit; }
+}

--- a/graylog2-web-interface/src/views/logic/SearchError.js
+++ b/graylog2-web-interface/src/views/logic/SearchError.js
@@ -1,12 +1,11 @@
 export default class SearchError {
   constructor(error) {
     // eslint-disable-next-line camelcase
-    const { backtrace, description, query_id, search_type_id, result_window_limit, type } = error;
+    const { backtrace, description, query_id, search_type_id, type } = error;
     this._state = {
       backtrace,
       description,
       query_id,
-      result_window_limit,
       search_type_id,
       type,
     };
@@ -20,7 +19,32 @@ export default class SearchError {
 
   get searchTypeId() { return this._state.search_type_id; }
 
-  get resultWindowLimit() { return this._state.result_window_limit; }
-
   get type() { return this._state.type; }
+}
+
+export class ResultWindowLimitError extends SearchError {
+  constructor(error, result) {
+    super(error);
+    const { result_window_limit: resultWindowLimit } = error;
+    this._state = {
+      ...this._state,
+      description: ResultWindowLimitError._extendDescription(result, this.description, this.queryId, this.searchTypeId, resultWindowLimit),
+      result_window_limit: resultWindowLimit,
+    };
+  }
+
+  static _extendDescription(result, description, queryId, searchTypeId, resultWindowLimit) {
+    const pageSize = ResultWindowLimitError._getPageSizeFromResult(result, queryId, searchTypeId);
+    const validPages = Math.floor(resultWindowLimit / pageSize);
+    const validPagesMessage = `Elasticsearch limits the search result to ${resultWindowLimit} messages. With a page size of ${pageSize} messages, you can use the first ${validPages} pages.`;
+    return `${validPagesMessage} ${description}`;
+  }
+
+  static _getPageSizeFromResult(result, queryId, searchTypeId) {
+    const searchTypes = result.results[queryId].query.search_types;
+    const searchType = searchTypes.find(({ id }) => id === searchTypeId);
+    return searchType.limit;
+  }
+
+  get resultWindowLimit() { return this._state.result_window_limit; }
 }

--- a/graylog2-web-interface/src/views/logic/SearchError.js
+++ b/graylog2-web-interface/src/views/logic/SearchError.js
@@ -1,11 +1,12 @@
 export default class SearchError {
   constructor(error) {
     // eslint-disable-next-line camelcase
-    const { backtrace, description, query_id, search_type_id, type } = error;
+    const { backtrace, description, query_id, search_type_id, result_window_limit, type } = error;
     this._state = {
       backtrace,
       description,
       query_id,
+      result_window_limit,
       search_type_id,
       type,
     };
@@ -18,6 +19,8 @@ export default class SearchError {
   get queryId() { return this._state.query_id; }
 
   get searchTypeId() { return this._state.search_type_id; }
+
+  get executionLimit() { return this._state.result_window_limit; }
 
   get type() { return this._state.type; }
 }

--- a/graylog2-web-interface/src/views/logic/SearchError.js
+++ b/graylog2-web-interface/src/views/logic/SearchError.js
@@ -20,7 +20,7 @@ export default class SearchError {
 
   get searchTypeId() { return this._state.search_type_id; }
 
-  get executionLimit() { return this._state.result_window_limit; }
+  get resultWindowLimit() { return this._state.result_window_limit; }
 
   get type() { return this._state.type; }
 }

--- a/graylog2-web-interface/src/views/logic/SearchError.js
+++ b/graylog2-web-interface/src/views/logic/SearchError.js
@@ -21,30 +21,3 @@ export default class SearchError {
 
   get type() { return this._state.type; }
 }
-
-export class ResultWindowLimitError extends SearchError {
-  constructor(error, result) {
-    super(error);
-    const { result_window_limit: resultWindowLimit } = error;
-    this._state = {
-      ...this._state,
-      description: ResultWindowLimitError._extendDescription(result, this.description, this.queryId, this.searchTypeId, resultWindowLimit),
-      result_window_limit: resultWindowLimit,
-    };
-  }
-
-  static _extendDescription(result, description, queryId, searchTypeId, resultWindowLimit) {
-    const pageSize = ResultWindowLimitError._getPageSizeFromResult(result, queryId, searchTypeId);
-    const validPages = Math.floor(resultWindowLimit / pageSize);
-    const validPagesMessage = `Elasticsearch limits the search result to ${resultWindowLimit} messages. With a page size of ${pageSize} messages, you can use the first ${validPages} pages.`;
-    return `${validPagesMessage} ${description}`;
-  }
-
-  static _getPageSizeFromResult(result, queryId, searchTypeId) {
-    const searchTypes = result.results[queryId].query.search_types;
-    const searchType = searchTypes.find(({ id }) => id === searchTypeId);
-    return searchType.limit;
-  }
-
-  get resultWindowLimit() { return this._state.result_window_limit; }
-}

--- a/graylog2-web-interface/src/views/logic/SearchResult.js
+++ b/graylog2-web-interface/src/views/logic/SearchResult.js
@@ -1,7 +1,8 @@
 import { fromJS } from 'immutable';
 import { mapValues, get, compact } from 'lodash';
 import QueryResult from './QueryResult';
-import SearchError, { ResultWindowLimitError } from './SearchError';
+import SearchError from './SearchError';
+import ResultWindowLimitError from './ResultWindowLimitError';
 
 class SearchResult {
   constructor(result) {

--- a/graylog2-web-interface/src/views/logic/SearchResult.js
+++ b/graylog2-web-interface/src/views/logic/SearchResult.js
@@ -1,13 +1,26 @@
+import { Map, List } from 'immutable';
 import { mapValues, get, compact } from 'lodash';
 import QueryResult from './QueryResult';
 import SearchError from './SearchError';
 
 class SearchResult {
   constructor(result) {
-    this.result = result;
+    this._result = new Map(result);
 
-    this.results = mapValues(result.results, queryResult => new QueryResult(queryResult));
-    this.errors = get(result, 'errors', []).map(error => new SearchError(error));
+    this._results = new Map(mapValues(result.results, queryResult => new QueryResult(queryResult)));
+    this._errors = new List(get(result, 'errors', []).map(error => new SearchError(error)));
+  }
+
+  get result() {
+    return this._result.toJS();
+  }
+
+  get results() {
+    return this._results.toJS();
+  }
+
+  get errors() {
+    return this._errors.toJS();
   }
 
   forId(queryId) {
@@ -15,7 +28,7 @@ class SearchResult {
   }
 
   updateSearchTypes(searchTypeResults) {
-    const updatedResult = new SearchResult(this.result).result;
+    const updatedResult = this.result;
     searchTypeResults.forEach((searchTypeResult) => {
       const searchQuery = this._getQueryBySearchTypeId(searchTypeResult.id);
       updatedResult.results[searchQuery.query.id].search_types[searchTypeResult.id] = searchTypeResult;

--- a/graylog2-web-interface/src/views/logic/SearchResult.js
+++ b/graylog2-web-interface/src/views/logic/SearchResult.js
@@ -46,7 +46,7 @@ class SearchResult {
       const relatedQuery = this._getQueryBySearchTypeId(searchTypeId);
       return SearchResult._getSearchTypeFromQuery(relatedQuery, searchTypeId);
     });
-    return compact(searchTypes);
+    return SearchResult._filterFailedSearchTypes(searchTypes);
   }
 
   _getQueryBySearchTypeId(searchTypeId) {
@@ -55,6 +55,10 @@ class SearchResult {
 
   static _getSearchTypeFromQuery(query, searchTypeId) {
     return (query && query.search_types) ? query.search_types[searchTypeId] : undefined;
+  }
+
+  static _filterFailedSearchTypes(searchTypes) {
+    return compact(searchTypes);
   }
 }
 

--- a/graylog2-web-interface/src/views/logic/SearchResult.js
+++ b/graylog2-web-interface/src/views/logic/SearchResult.js
@@ -1,14 +1,14 @@
-import { Map, List } from 'immutable';
+import { fromJS } from 'immutable';
 import { mapValues, get, compact } from 'lodash';
 import QueryResult from './QueryResult';
 import SearchError from './SearchError';
 
 class SearchResult {
   constructor(result) {
-    this._result = new Map(result);
+    this._result = fromJS(result);
 
-    this._results = new Map(mapValues(result.results, queryResult => new QueryResult(queryResult)));
-    this._errors = new List(get(result, 'errors', []).map(error => new SearchError(error)));
+    this._results = fromJS(mapValues(result.results, queryResult => new QueryResult(queryResult)));
+    this._errors = fromJS(get(result, 'errors', []).map(error => new SearchError(error)));
   }
 
   get result() {
@@ -24,7 +24,7 @@ class SearchResult {
   }
 
   forId(queryId) {
-    return this.results[queryId];
+    return this._results.get(queryId);
   }
 
   updateSearchTypes(searchTypeResults) {

--- a/graylog2-web-interface/src/views/logic/SearchResult.js
+++ b/graylog2-web-interface/src/views/logic/SearchResult.js
@@ -10,7 +10,7 @@ class SearchResult {
 
     this._results = fromJS(mapValues(result.results, queryResult => new QueryResult(queryResult)));
     this._errors = fromJS(get(result, 'errors', []).map((error) => {
-      if (error.result_window_limit) {
+      if (error.type === 'result_window_limit') {
         return new ResultWindowLimitError(error, this);
       }
       return new SearchError(error);

--- a/graylog2-web-interface/src/views/logic/SearchResult.js
+++ b/graylog2-web-interface/src/views/logic/SearchResult.js
@@ -1,14 +1,19 @@
 import { fromJS } from 'immutable';
 import { mapValues, get, compact } from 'lodash';
 import QueryResult from './QueryResult';
-import SearchError from './SearchError';
+import SearchError, { ResultWindowLimitError } from './SearchError';
 
 class SearchResult {
   constructor(result) {
     this._result = fromJS(result);
 
     this._results = fromJS(mapValues(result.results, queryResult => new QueryResult(queryResult)));
-    this._errors = fromJS(get(result, 'errors', []).map(error => new SearchError(error)));
+    this._errors = fromJS(get(result, 'errors', []).map((error) => {
+      if (error.result_window_limit) {
+        return new ResultWindowLimitError(error, this);
+      }
+      return new SearchError(error);
+    }));
   }
 
   get result() {

--- a/graylog2-web-interface/src/views/logic/SearchResult.js
+++ b/graylog2-web-interface/src/views/logic/SearchResult.js
@@ -15,7 +15,7 @@ class SearchResult {
   }
 
   updateSearchTypes(searchTypeResults) {
-    const updatedResult = this.result;
+    const updatedResult = new SearchResult(this.result).result;
     searchTypeResults.forEach((searchTypeResult) => {
       const searchQuery = this._getQueryBySearchTypeId(searchTypeResult.id);
       updatedResult.results[searchQuery.query.id].search_types[searchTypeResult.id] = searchTypeResult;

--- a/graylog2-web-interface/src/views/logic/SearchResult.js
+++ b/graylog2-web-interface/src/views/logic/SearchResult.js
@@ -1,4 +1,4 @@
-import { mapValues, get } from 'lodash';
+import { mapValues, get, compact } from 'lodash';
 import QueryResult from './QueryResult';
 import SearchError from './SearchError';
 
@@ -28,7 +28,7 @@ class SearchResult {
       const relatedQuery = this._getQueryBySearchTypeId(searchTypeId);
       return SearchResult._getSearchTypeFromQuery(relatedQuery, searchTypeId);
     });
-    return searchTypes;
+    return compact(searchTypes);
   }
 
   _getQueryBySearchTypeId(searchTypeId) {

--- a/graylog2-web-interface/src/views/logic/SearchResult.js
+++ b/graylog2-web-interface/src/views/logic/SearchResult.js
@@ -13,6 +13,16 @@ class SearchResult {
   forId(queryId) {
     return this.results[queryId];
   }
+
+  updateSearchTypes(searchTypeResults) {
+    const updatedResult = this.result;
+    _.forEach(searchTypeResults, (searchTypeResult) => {
+      const searchTypeId = searchTypeResult.id;
+      const searchQuery = Object.values(this.result.results).find(query => query.search_types[searchTypeId]);
+      updatedResult.results[searchQuery.query.id].search_types[searchTypeId] = searchTypeResult;
+    });
+    return new SearchResult(updatedResult);
+  }
 }
 
 export default SearchResult;

--- a/graylog2-web-interface/src/views/logic/search/GlobalOverride.js
+++ b/graylog2-web-interface/src/views/logic/search/GlobalOverride.js
@@ -1,0 +1,111 @@
+// @flow strict
+import * as Immutable from 'immutable';
+import type { QueryString, TimeRange } from '../queries/Query';
+
+export type MessageListOptions = {
+  [searchTypeId: string]: {
+    limit: number;
+    offset: number;
+  };
+}
+
+type InternalState = {
+  timerange?: TimeRange,
+  query?: QueryString,
+  keepSearchTypes?: string[],
+  searchTypes?: MessageListOptions
+};
+
+type JsonRepresentation = {
+  timerange?: TimeRange,
+  query?: QueryString,
+  keep_search_types?: string[],
+  search_types?: MessageListOptions
+};
+
+export default class GlobalOverride {
+  _value: InternalState;
+
+  constructor(timerange?: TimeRange, query?: QueryString, keepSearchTypes?: string[], searchTypes?: MessageListOptions) {
+    this._value = { timerange, query, keepSearchTypes, searchTypes };
+  }
+
+  get timerange(): ?TimeRange {
+    return this._value.timerange;
+  }
+
+  get query(): ?QueryString {
+    return this._value.query;
+  }
+
+  get keepSearchTypes(): ?string[] {
+    return this._value.keepSearchTypes;
+  }
+
+  get searchTypes(): ?MessageListOptions {
+    return this._value.searchTypes;
+  }
+
+  // eslint-disable-next-line no-use-before-define
+  toBuilder(): Builder {
+    const { timerange, query, keepSearchTypes, searchTypes } = this._value;
+    // eslint-disable-next-line no-use-before-define
+    return new Builder(Immutable.Map({ timerange, query, keepSearchTypes, searchTypes }));
+  }
+
+  static create(timerange?: TimeRange, query?: QueryString, keepSearchTypes?: string[], searchTypes?: MessageListOptions): GlobalOverride {
+    return new GlobalOverride(timerange, query, keepSearchTypes, searchTypes);
+  }
+
+  static empty(): GlobalOverride {
+    return new GlobalOverride();
+  }
+
+  toJSON(): JsonRepresentation {
+    const { timerange, query, keepSearchTypes, searchTypes } = this._value;
+
+    return {
+      timerange,
+      query,
+      keep_search_types: keepSearchTypes,
+      search_types: searchTypes,
+    };
+  }
+
+  static fromJSON(value: JsonRepresentation): GlobalOverride {
+    // eslint-disable-next-line camelcase
+    const { timerange, query, keep_search_types, search_types } = value;
+    return GlobalOverride.create(timerange, query, keep_search_types, search_types);
+  }
+}
+
+type InternalBuilderState = Immutable.Map<string, any>;
+
+class Builder {
+  value: InternalBuilderState;
+
+  constructor(value: Immutable.Map = Immutable.Map()) {
+    this.value = value;
+  }
+
+  timerange(timerange: TimeRange): Builder {
+    return new Builder(this.value.set('timerange', timerange));
+  }
+
+  query(query: QueryString): Builder {
+    return new Builder(this.value.set('query', query));
+  }
+
+  keepSearchTypes(keepSearchTypes: string[]): Builder {
+    return new Builder(this.value.set('keepSearchTypes', keepSearchTypes));
+  }
+
+  searchTypes(searchTypes: MessageListOptions): Builder {
+    return new Builder(this.value.set('searchTypes', searchTypes));
+  }
+
+  build(): GlobalOverride {
+    const { timerange, query, keepSearchTypes, searchTypes } = this.value.toObject();
+    return new GlobalOverride(timerange, query, keepSearchTypes, searchTypes);
+  }
+}

--- a/graylog2-web-interface/src/views/logic/search/SearchExecutionState.js
+++ b/graylog2-web-interface/src/views/logic/search/SearchExecutionState.js
@@ -6,6 +6,13 @@ import type { QueryString, TimeRange } from '../queries/Query';
 export type GlobalOverride = {
   timerange?: TimeRange,
   query?: QueryString,
+  keep_search_types?: string[],
+  search_types?: {
+    [searchTypeId: string]: {
+      limit: number;
+      offset: number;
+    };
+  }
 };
 
 export type ParameterBindings = Immutable.Map<string, ParameterBinding>;

--- a/graylog2-web-interface/src/views/logic/search/SearchExecutionState.js
+++ b/graylog2-web-interface/src/views/logic/search/SearchExecutionState.js
@@ -1,19 +1,7 @@
 // @flow strict
 import * as Immutable from 'immutable';
+import GlobalOverride from './GlobalOverride';
 import ParameterBinding from '../parameters/ParameterBinding';
-import type { QueryString, TimeRange } from '../queries/Query';
-
-export type GlobalOverride = {
-  timerange?: TimeRange,
-  query?: QueryString,
-  keep_search_types?: string[],
-  search_types?: {
-    [searchTypeId: string]: {
-      limit: number;
-      offset: number;
-    };
-  }
-};
 
 export type ParameterBindings = Immutable.Map<string, ParameterBinding>;
 

--- a/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.js
+++ b/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.js
@@ -10,7 +10,7 @@ import { GlobalOverrideActions, GlobalOverrideStore } from 'views/stores/GlobalO
 import type { ElasticsearchQueryString } from 'views/logic/queries/Query';
 import type { ActionHandler } from 'views/components/actions/ActionHandler';
 import QueryManipulationHandler from './QueryManipulationHandler';
-import type { GlobalOverride } from '../search/SearchExecutionState';
+import GlobalOverride from '../search/GlobalOverride';
 
 export default class AddToQueryHandler extends QueryManipulationHandler {
   formatTimestampForES = (value: string) => {

--- a/graylog2-web-interface/src/views/stores/GlobalOverrideStore.js
+++ b/graylog2-web-interface/src/views/stores/GlobalOverrideStore.js
@@ -4,8 +4,8 @@ import moment from 'moment';
 import { isEmpty } from 'lodash';
 
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
+import GlobalOverride from 'views/logic/search/GlobalOverride';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
-import type { GlobalOverride } from 'views/logic/search/SearchExecutionState';
 import type { TimeRange } from 'views/logic/queries/Query';
 import type { RefluxActions } from 'stores/StoreTypes';
 import { SearchExecutionStateStore, SearchExecutionStateActions } from './SearchExecutionStateStore';

--- a/graylog2-web-interface/src/views/stores/GlobalOverrideStore.js
+++ b/graylog2-web-interface/src/views/stores/GlobalOverrideStore.js
@@ -78,7 +78,7 @@ export const GlobalOverrideStore = singletonStore(
             };
             break;
         }
-        const newGlobalOverride: GlobalOverride = this.globalOverride ? { ...this.globalOverride, timerange: newTimerange } : { timerange: newTimerange };
+        const newGlobalOverride: GlobalOverride = this.globalOverride ? new GlobalOverride(newTimerange, this.globalOverride.query) : new GlobalOverride(newTimerange);
         const promise = this._propagateNewGlobalOverride(newGlobalOverride);
         GlobalOverrideActions.rangeType.promise(promise);
         return promise;
@@ -92,7 +92,7 @@ export const GlobalOverrideStore = singletonStore(
         ? { ...this.globalOverride.timerange, [key]: value }
         // $FlowFixMe: Flow is unable to validate that timerange is complete
         : { [key]: value };
-      const newGlobalOverride: GlobalOverride = this.globalOverride ? { ...this.globalOverride, timerange: newTimerange } : { timerange: newTimerange };
+      const newGlobalOverride: GlobalOverride = this.globalOverride ? new GlobalOverride(newTimerange, this.globalOverride.query) : new GlobalOverride(newTimerange);
       const promise = this._propagateNewGlobalOverride(newGlobalOverride);
       GlobalOverrideActions.rangeParams.promise(promise);
       return promise;
@@ -107,7 +107,7 @@ export const GlobalOverrideStore = singletonStore(
         type: 'elasticsearch',
         query_string: newQueryString,
       };
-      const newGlobalOverride: GlobalOverride = this.globalOverride ? { ...this.globalOverride, query: newQuery } : { query: newQuery };
+      const newGlobalOverride: GlobalOverride = this.globalOverride ? new GlobalOverride(this.globalOverride.newTimerange, newQuery) : new GlobalOverride(undefined, newQuery);
       const promise = this._propagateNewGlobalOverride(newGlobalOverride);
       GlobalOverrideActions.query.promise(promise);
       return promise;

--- a/graylog2-web-interface/src/views/stores/SearchExecutionStateStore.js
+++ b/graylog2-web-interface/src/views/stores/SearchExecutionStateStore.js
@@ -6,7 +6,7 @@ import type { RefluxActions } from 'stores/StoreTypes';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import ParameterBinding from 'views/logic/parameters/ParameterBinding';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
-import type { GlobalOverride } from 'views/logic/search/SearchExecutionState';
+import GlobalOverride from 'views/logic/search/GlobalOverride';
 import { ViewActions } from './ViewStore';
 
 const defaultExecutionState = SearchExecutionState.empty();

--- a/graylog2-web-interface/src/views/stores/SearchLoadingStateStore.js
+++ b/graylog2-web-interface/src/views/stores/SearchLoadingStateStore.js
@@ -16,8 +16,6 @@ export const SearchLoadingStateStore = singletonStore(
     init() {
       SearchActions.execute.listen(this.loading);
       SearchActions.execute.completed.listen(this.finished);
-      SearchActions.reexecuteSearchTypes.listen(this.loading);
-      SearchActions.reexecuteSearchTypes.completed.listen(this.finished);
     },
     getInitialState() {
       return this._state();

--- a/graylog2-web-interface/src/views/stores/SearchLoadingStateStore.js
+++ b/graylog2-web-interface/src/views/stores/SearchLoadingStateStore.js
@@ -16,6 +16,8 @@ export const SearchLoadingStateStore = singletonStore(
     init() {
       SearchActions.execute.listen(this.loading);
       SearchActions.execute.completed.listen(this.finished);
+      SearchActions.reexecuteSearchTypes.listen(this.loading);
+      SearchActions.reexecuteSearchTypes.completed.listen(this.finished);
     },
     getInitialState() {
       return this._state();

--- a/graylog2-web-interface/src/views/stores/SearchLoadingStateStore.test.js
+++ b/graylog2-web-interface/src/views/stores/SearchLoadingStateStore.test.js
@@ -5,6 +5,12 @@ const SearchActions = {
       listen: jest.fn(),
     },
   },
+  reexecuteSearchTypes: {
+    listen: jest.fn(),
+    completed: {
+      listen: jest.fn(),
+    },
+  },
 };
 
 // eslint-disable-next-line global-require
@@ -24,9 +30,10 @@ describe('SearchLoadingStateStore', () => {
   it('registers to SearchStore for search executions', () => {
     // eslint-disable-next-line no-unused-vars
     const { SearchLoadingStateStore } = loadSUT();
-
     expect(SearchActions.execute.listen).toHaveBeenCalledTimes(1);
     expect(SearchActions.execute.completed.listen).toHaveBeenCalledTimes(1);
+    expect(SearchActions.reexecuteSearchTypes.listen).toHaveBeenCalledTimes(1);
+    expect(SearchActions.reexecuteSearchTypes.completed.listen).toHaveBeenCalledTimes(1);
   });
 
   it('initial state is indicating that no loading is in progress', () => {
@@ -43,6 +50,18 @@ describe('SearchLoadingStateStore', () => {
     });
 
     const executeCallback = SearchActions.execute.listen.mock.calls[0][0];
+
+    executeCallback();
+  });
+
+  it('sets state to loading when search is reexecuted for search types', (done) => {
+    const { SearchLoadingStateStore } = loadSUT();
+    SearchLoadingStateStore.listen(({ isLoading }) => {
+      expect(isLoading).toBeTruthy();
+      done();
+    });
+
+    const executeCallback = SearchActions.reexecuteSearchTypes.listen.mock.calls[0][0];
 
     executeCallback();
   });

--- a/graylog2-web-interface/src/views/stores/SearchLoadingStateStore.test.js
+++ b/graylog2-web-interface/src/views/stores/SearchLoadingStateStore.test.js
@@ -5,12 +5,6 @@ const SearchActions = {
       listen: jest.fn(),
     },
   },
-  reexecuteSearchTypes: {
-    listen: jest.fn(),
-    completed: {
-      listen: jest.fn(),
-    },
-  },
 };
 
 // eslint-disable-next-line global-require
@@ -32,8 +26,6 @@ describe('SearchLoadingStateStore', () => {
     const { SearchLoadingStateStore } = loadSUT();
     expect(SearchActions.execute.listen).toHaveBeenCalledTimes(1);
     expect(SearchActions.execute.completed.listen).toHaveBeenCalledTimes(1);
-    expect(SearchActions.reexecuteSearchTypes.listen).toHaveBeenCalledTimes(1);
-    expect(SearchActions.reexecuteSearchTypes.completed.listen).toHaveBeenCalledTimes(1);
   });
 
   it('initial state is indicating that no loading is in progress', () => {
@@ -50,18 +42,6 @@ describe('SearchLoadingStateStore', () => {
     });
 
     const executeCallback = SearchActions.execute.listen.mock.calls[0][0];
-
-    executeCallback();
-  });
-
-  it('sets state to loading when search is reexecuted for search types', (done) => {
-    const { SearchLoadingStateStore } = loadSUT();
-    SearchLoadingStateStore.listen(({ isLoading }) => {
-      expect(isLoading).toBeTruthy();
-      done();
-    });
-
-    const executeCallback = SearchActions.reexecuteSearchTypes.listen.mock.calls[0][0];
 
     executeCallback();
   });

--- a/graylog2-web-interface/src/views/stores/SearchStore.js
+++ b/graylog2-web-interface/src/views/stores/SearchStore.js
@@ -118,7 +118,7 @@ export const SearchStore = singletonStore(
         const { widgetMapping, search } = this.view;
         this.executePromise = this.trackJob(search, executionState)
           .then((searchResult) => {
-            const updatedSearchTypeIds = get(executionState, 'global_override.keep_search_types');
+            const updatedSearchTypeIds = get(executionState, 'globalOverride.keep_search_types');
             if (updatedSearchTypeIds) {
               const updatedSearchTypes = searchResult.getSearchTypesFromResponse(updatedSearchTypeIds);
               this.result = this.result.updateSearchTypes(updatedSearchTypes);

--- a/graylog2-web-interface/src/views/stores/SearchStore.js
+++ b/graylog2-web-interface/src/views/stores/SearchStore.js
@@ -1,7 +1,7 @@
 // @flow strict
 import Reflux from 'reflux';
 import Bluebird from 'bluebird';
-import { debounce, get, isEqual, forEach, values } from 'lodash';
+import { debounce, get, isEqual } from 'lodash';
 
 import URLUtils from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
@@ -25,18 +25,6 @@ const createSearchUrl = URLUtils.qualifyUrl('/views/search');
 const displayError = (error) => {
   // eslint-disable-next-line no-console
   console.error(error);
-};
-
-const getSearchTypesFromResponse = (searchResult, searchTypeIds) => {
-  const searchTypes = {};
-  const apiResopnse = searchResult.result;
-  forEach(searchTypeIds, (searchTypeId) => {
-    const updatedSearchType = values(apiResopnse.results)
-      .find(query => query.search_types[searchTypeId])
-      .search_types[searchTypeId];
-    searchTypes[searchTypeId] = updatedSearchType;
-  });
-  return searchTypes;
 };
 
 Bluebird.config({ cancellation: true });
@@ -132,7 +120,7 @@ export const SearchStore = singletonStore(
           .then((searchResult) => {
             const updatedSearchTypeIds = get(executionState, 'global_override.keep_search_types');
             if (updatedSearchTypeIds) {
-              const updatedSearchTypes = getSearchTypesFromResponse(searchResult, updatedSearchTypeIds);
+              const updatedSearchTypes = searchResult.getSearchTypesFromResponse(updatedSearchTypeIds);
               this.result = this.result.updateSearchTypes(updatedSearchTypes);
             } else {
               this.result = searchResult;

--- a/graylog2-web-interface/src/views/stores/SearchStore.js
+++ b/graylog2-web-interface/src/views/stores/SearchStore.js
@@ -14,7 +14,8 @@ import SearchResult from 'views/logic/SearchResult';
 import SearchActions from 'views/actions/SearchActions';
 import Search from 'views/logic/search/Search';
 import type { CreateSearchResponse, SearchId, SearchExecutionResult } from 'views/actions/SearchActions';
-import type { GlobalOverride } from 'views/logic/search/SearchExecutionState';
+import GlobalOverride from 'views/logic/search/GlobalOverride';
+import type { MessageListOptions } from 'views/logic/search/GlobalOverride';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import View from 'views/logic/views/View';
 import Parameter from 'views/logic/parameters/Parameter';
@@ -118,13 +119,14 @@ export const SearchStore = singletonStore(
       return this._executePromise(executionState, startActionPromise, handleSearchResult);
     },
 
-    reexecuteSearchTypes(searchTypes: {[searchTypeId: string]: { limit: number, offset: number }}, effectiveTimerange?: TimeRange): Promise<SearchExecutionResult> {
+    reexecuteSearchTypes(searchTypes: MessageListOptions, effectiveTimerange?: TimeRange): Promise<SearchExecutionResult> {
       const searchTypeIds = Object.keys(searchTypes);
-      const globalOverride: GlobalOverride = {
-        search_types: searchTypes,
-        keep_search_types: searchTypeIds,
-        timerange: effectiveTimerange,
-      };
+      const globalOverride: GlobalOverride = new GlobalOverride(
+        effectiveTimerange,
+        undefined,
+        searchTypeIds,
+        searchTypes,
+      );
       const executionState = new SearchExecutionState(undefined, globalOverride);
       const handleSearchResult = (searchResult: SearchResult): SearchResult => {
         const updatedSearchTypes = searchResult.getSearchTypesFromResponse(searchTypeIds);

--- a/graylog2-web-interface/src/views/stores/SearchStore.js
+++ b/graylog2-web-interface/src/views/stores/SearchStore.js
@@ -19,6 +19,7 @@ import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import View from 'views/logic/views/View';
 import Parameter from 'views/logic/parameters/Parameter';
 import type { WidgetMapping } from 'views/logic/views/View';
+import type { TimeRange } from 'views/logic/queries/Query';
 import { singletonStore } from 'views/logic/singleton';
 
 const createSearchUrl = URLUtils.qualifyUrl('/views/search');


### PR DESCRIPTION
Some details for the implementation. We are:
-  replacing the `MessageTablePaginator` with the common `PaginatedList` component inside the MessageList component. When we are removing the old search, we can remove the `MessageTablePaginator` completely.
- refactoring the PaginatedList component
- creating a separate component (`MessageTable`) to abstract some logic from the `MessageList` component.
- implementing another SearchStore execute function (`reexecuteSearchTypes`) to reexecute the search for some specific search types. The implementation is able to reexecute multiple search types, but we are only doing it for one search type, when using the message list pagination. The only thing that does not work so far is providing an effective time ranges for each search type.
- sending the elastic search result window limit to the frontend to display a useful message for the user. By default elasticsearch has a limit of 10000 messages, when the user access page 500 with a page size of 150 messages, he will see a related error message the error message also contains an info which pages are working for his configuration.
- adjusting the general widget layout. It's now more dynamic and e.g. the header does not need a fixed height.

With the next changes I will create smaller PR's by creating separate ones for e.g. the `PageList` refactoring.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
