### PR TITLE
Improve styled-components performance with useMemo

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/__snapshots__/Input.test.jsx.snap
+++ b/graylog2-web-interface/src/components/bootstrap/__snapshots__/Input.test.jsx.snap
@@ -325,7 +325,7 @@ exports[`Input renders a button after the input if buttonAfter is passed 1`] = `
                       <ForwardRef
                         bsStyle="default"
                       >
-                        <Button__StyledButton
+                        <Button
                           bsStyle="default"
                         >
                           <StyledComponent
@@ -349,17 +349,17 @@ exports[`Input renders a button after the input if buttonAfter is passed 1`] = `
                                 ],
                                 "attrs": Array [],
                                 "componentStyle": ComponentStyle {
-                                  "componentId": "Button__StyledButton-c9cbmb-0",
+                                  "componentId": "Button-c9cbmb-0",
                                   "isStatic": false,
-                                  "lastClassName": "kRDLih",
+                                  "lastClassName": "GLfOY",
                                   "rules": Array [
                                     [Function],
                                   ],
                                 },
-                                "displayName": "Button__StyledButton",
+                                "displayName": "Button",
                                 "foldedComponentIds": Array [],
                                 "render": [Function],
-                                "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                                "styledComponentId": "Button-c9cbmb-0",
                                 "target": [Function],
                                 "toString": [Function],
                                 "warnTooManyClasses": [Function],
@@ -373,17 +373,17 @@ exports[`Input renders a button after the input if buttonAfter is passed 1`] = `
                               block={false}
                               bsClass="btn"
                               bsStyle="default"
-                              className="Button__StyledButton-c9cbmb-0 kRDLih"
+                              className="Button-c9cbmb-0 GLfOY"
                               disabled={false}
                             >
                               <button
-                                className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                                className="Button-c9cbmb-0 GLfOY btn btn-default"
                                 disabled={false}
                                 type="button"
                               />
                             </Button>
                           </StyledComponent>
-                        </Button__StyledButton>
+                        </Button>
                       </ForwardRef>
                     </span>
                   </InputGroupButton>

--- a/graylog2-web-interface/src/components/common/__snapshots__/Wizard.test.jsx.snap
+++ b/graylog2-web-interface/src/components/common/__snapshots__/Wizard.test.jsx.snap
@@ -15,7 +15,7 @@ exports[`<Wizard /> should render in horizontal mode with 3 steps 1`] = `
         role="toolbar"
       >
         <button
-          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-info"
+          className="Button-c9cbmb-0 GLfOY btn btn-xs btn-info"
           disabled={true}
           onClick={[Function]}
           type="button"
@@ -25,7 +25,7 @@ exports[`<Wizard /> should render in horizontal mode with 3 steps 1`] = `
           />
         </button>
         <button
-          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-info"
+          className="Button-c9cbmb-0 GLfOY btn btn-xs btn-info"
           disabled={false}
           onClick={[Function]}
           type="button"
@@ -106,7 +106,7 @@ exports[`<Wizard /> should render in horizontal mode with 3 steps and children 1
         role="toolbar"
       >
         <button
-          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-info"
+          className="Button-c9cbmb-0 GLfOY btn btn-xs btn-info"
           disabled={true}
           onClick={[Function]}
           type="button"
@@ -116,7 +116,7 @@ exports[`<Wizard /> should render in horizontal mode with 3 steps and children 1
           />
         </button>
         <button
-          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-info"
+          className="Button-c9cbmb-0 GLfOY btn btn-xs btn-info"
           disabled={false}
           onClick={[Function]}
           type="button"
@@ -248,7 +248,7 @@ exports[`<Wizard /> should render with 3 steps 1`] = `
         className="col-xs-6"
       >
         <button
-          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+          className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
           disabled={true}
           onClick={[Function]}
           type="button"
@@ -260,7 +260,7 @@ exports[`<Wizard /> should render with 3 steps 1`] = `
         className="text-right col-xs-6"
       >
         <button
-          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+          className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
           disabled={false}
           onClick={[Function]}
           type="button"
@@ -339,7 +339,7 @@ exports[`<Wizard /> should render with 3 steps and children 1`] = `
         className="col-xs-6"
       >
         <button
-          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+          className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
           disabled={true}
           onClick={[Function]}
           type="button"
@@ -351,7 +351,7 @@ exports[`<Wizard /> should render with 3 steps and children 1`] = `
         className="text-right col-xs-6"
       >
         <button
-          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+          className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
           disabled={false}
           onClick={[Function]}
           type="button"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackApplyParameter.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackApplyParameter.test.jsx.snap
@@ -112,7 +112,7 @@ exports[`<ContentPackApplyParameter /> should render with full props 1`] = `
         className="col-sm-2 col-sm-offset-10"
       >
         <button
-          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
+          className="Button-c9cbmb-0 GLfOY btn btn-primary"
           disabled={true}
           type="submit"
         >
@@ -164,7 +164,7 @@ exports[`<ContentPackApplyParameter /> should render with full props 1`] = `
                     </td>
                     <td>
                       <button
-                        className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+                        className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
                         disabled={false}
                         onClick={[Function]}
                         type="button"
@@ -293,7 +293,7 @@ exports[`<ContentPackApplyParameter /> should render with minimal props 1`] = `
         className="col-sm-2 col-sm-offset-10"
       >
         <button
-          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
+          className="Button-c9cbmb-0 GLfOY btn btn-primary"
           disabled={true}
           type="submit"
         >
@@ -443,7 +443,7 @@ exports[`<ContentPackApplyParameter /> should render with readOnly 1`] = `
         className="col-sm-2 col-sm-offset-10"
       >
         <button
-          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
+          className="Button-c9cbmb-0 GLfOY btn btn-primary"
           disabled={true}
           type="submit"
         >

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackConstraints.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackConstraints.test.jsx.snap
@@ -50,7 +50,7 @@ exports[`<ContentPackConstraints /> should render with created constraints 1`] =
                 </td>
                 <td>
                   <span
-                    className="failure Badge__StyledBadge-sc-4gzqz0-0 gDhrrS badge badge-default"
+                    className="failure Badge-sc-4gzqz0-0 iRhcGJ badge badge-default"
                   >
                     <i
                       className="fa fa-times"
@@ -70,7 +70,7 @@ exports[`<ContentPackConstraints /> should render with created constraints 1`] =
                 </td>
                 <td>
                   <span
-                    className="success Badge__StyledBadge-sc-4gzqz0-0 gDhrrS badge badge-default"
+                    className="success Badge-sc-4gzqz0-0 iRhcGJ badge badge-default"
                   >
                     <i
                       className="fa fa-check"
@@ -137,7 +137,7 @@ exports[`<ContentPackConstraints /> should render with new constraints with forc
                 </td>
                 <td>
                   <span
-                    className="success Badge__StyledBadge-sc-4gzqz0-0 gDhrrS badge badge-default"
+                    className="success Badge-sc-4gzqz0-0 iRhcGJ badge badge-default"
                   >
                     <i
                       className="fa fa-check"
@@ -157,7 +157,7 @@ exports[`<ContentPackConstraints /> should render with new constraints with forc
                 </td>
                 <td>
                   <span
-                    className="success Badge__StyledBadge-sc-4gzqz0-0 gDhrrS badge badge-default"
+                    className="success Badge-sc-4gzqz0-0 iRhcGJ badge badge-default"
                   >
                     <i
                       className="fa fa-check"
@@ -224,7 +224,7 @@ exports[`<ContentPackConstraints /> should render with new constraints without f
                 </td>
                 <td>
                   <span
-                    className="failure Badge__StyledBadge-sc-4gzqz0-0 gDhrrS badge badge-default"
+                    className="failure Badge-sc-4gzqz0-0 iRhcGJ badge badge-default"
                   >
                     <i
                       className="fa fa-times"
@@ -244,7 +244,7 @@ exports[`<ContentPackConstraints /> should render with new constraints without f
                 </td>
                 <td>
                   <span
-                    className="failure Badge__StyledBadge-sc-4gzqz0-0 gDhrrS badge badge-default"
+                    className="failure Badge-sc-4gzqz0-0 iRhcGJ badge badge-default"
                   >
                     <i
                       className="fa fa-times"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
@@ -72,7 +72,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
           className="col-xs-6"
         >
           <button
-            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+            className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
             disabled={true}
             onClick={[Function]}
             type="button"
@@ -84,7 +84,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
           className="text-right col-xs-6"
         >
           <button
-            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+            className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
             disabled={true}
             onClick={[Function]}
             type="button"
@@ -318,7 +318,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                   }
                 >
                   <button
-                    className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    className="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
                     disabled={false}
                     type="submit"
                   >
@@ -334,7 +334,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                   }
                 >
                   <button
-                    className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    className="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
                     disabled={false}
                     onClick={[Function]}
                     type="reset"
@@ -546,7 +546,7 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
           className="col-xs-6"
         >
           <button
-            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+            className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
             disabled={true}
             onClick={[Function]}
             type="button"
@@ -558,7 +558,7 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
           className="text-right col-xs-6"
         >
           <button
-            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+            className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
             disabled={false}
             onClick={[Function]}
             type="button"
@@ -792,7 +792,7 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
                   }
                 >
                   <button
-                    className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    className="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
                     disabled={false}
                     type="submit"
                   >
@@ -808,7 +808,7 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
                   }
                 >
                   <button
-                    className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    className="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
                     disabled={false}
                     onClick={[Function]}
                     type="reset"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntitiesList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntitiesList.test.jsx.snap
@@ -46,7 +46,7 @@ exports[`<ContentPackEntitiesList /> should render with empty entities 1`] = `
         }
       >
         <button
-          className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+          className="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
           disabled={false}
           type="submit"
         >
@@ -62,7 +62,7 @@ exports[`<ContentPackEntitiesList /> should render with empty entities 1`] = `
         }
       >
         <button
-          className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+          className="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
           disabled={false}
           onClick={[Function]}
           type="reset"
@@ -139,7 +139,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
         }
       >
         <button
-          className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+          className="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
           disabled={false}
           type="submit"
         >
@@ -155,7 +155,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
         }
       >
         <button
-          className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+          className="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
           disabled={false}
           onClick={[Function]}
           type="reset"
@@ -233,7 +233,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
                     role="toolbar"
                   >
                     <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-primary"
+                      className="Button-c9cbmb-0 GLfOY btn btn-xs btn-primary"
                       disabled={false}
                       onClick={[Function]}
                       type="button"
@@ -241,7 +241,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
                       Edit
                     </button>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-info"
+                      className="Button-c9cbmb-0 GLfOY btn btn-xs btn-info"
                       disabled={false}
                       onClick={[Function]}
                       type="button"
@@ -282,7 +282,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
                     role="toolbar"
                   >
                     <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-primary"
+                      className="Button-c9cbmb-0 GLfOY btn btn-xs btn-primary"
                       disabled={false}
                       onClick={[Function]}
                       type="button"
@@ -290,7 +290,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
                       Edit
                     </button>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-info"
+                      className="Button-c9cbmb-0 GLfOY btn btn-xs btn-info"
                       disabled={false}
                       onClick={[Function]}
                       type="button"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstall.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstall.test.jsx.snap
@@ -132,7 +132,7 @@ exports[`<ContentPackInstall /> should render a install 1`] = `
               }
             >
               <button
-                className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                className="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
                 disabled={false}
                 type="submit"
               >
@@ -148,7 +148,7 @@ exports[`<ContentPackInstall /> should render a install 1`] = `
               }
             >
               <button
-                className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                className="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
                 disabled={false}
                 onClick={[Function]}
                 type="reset"
@@ -209,7 +209,7 @@ exports[`<ContentPackInstall /> should render a install 1`] = `
                           role="toolbar"
                         >
                           <button
-                            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-info"
+                            className="Button-c9cbmb-0 GLfOY btn btn-xs btn-info"
                             disabled={false}
                             onClick={[Function]}
                             type="button"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstallations.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstallations.test.jsx.snap
@@ -47,7 +47,7 @@ exports[`<ContentPackInstallations /> should render with a installation 1`] = `
                     role="toolbar"
                   >
                     <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-primary"
+                      className="Button-c9cbmb-0 GLfOY btn btn-sm btn-primary"
                       disabled={false}
                       onClick={[Function]}
                       type="button"
@@ -55,7 +55,7 @@ exports[`<ContentPackInstallations /> should render with a installation 1`] = `
                       Uninstall
                     </button>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+                      className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
                       disabled={false}
                       onClick={[Function]}
                       type="button"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameterList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameterList.test.jsx.snap
@@ -46,7 +46,7 @@ exports[`<ContentPackParameterList /> should render with empty parameters with r
         }
       >
         <button
-          className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+          className="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
           disabled={false}
           type="submit"
         >
@@ -62,7 +62,7 @@ exports[`<ContentPackParameterList /> should render with empty parameters with r
         }
       >
         <button
-          className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+          className="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
           disabled={false}
           onClick={[Function]}
           type="reset"
@@ -100,7 +100,7 @@ exports[`<ContentPackParameterList /> should render with empty parameters withou
   </h2>
   <br />
   <button
-    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+    className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
     disabled={false}
     onClick={[Function]}
     title="Edit Modal"
@@ -152,7 +152,7 @@ exports[`<ContentPackParameterList /> should render with empty parameters withou
         }
       >
         <button
-          className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+          className="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
           disabled={false}
           type="submit"
         >
@@ -168,7 +168,7 @@ exports[`<ContentPackParameterList /> should render with empty parameters withou
         }
       >
         <button
-          className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+          className="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
           disabled={false}
           onClick={[Function]}
           type="reset"
@@ -245,7 +245,7 @@ exports[`<ContentPackParameterList /> should render with parameters with readOnl
         }
       >
         <button
-          className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+          className="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
           disabled={false}
           type="submit"
         >
@@ -261,7 +261,7 @@ exports[`<ContentPackParameterList /> should render with parameters with readOnl
         }
       >
         <button
-          className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+          className="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
           disabled={false}
           onClick={[Function]}
           type="reset"
@@ -330,7 +330,7 @@ exports[`<ContentPackParameterList /> should render with parameters with readOnl
                 </td>
                 <td>
                   <span
-                    className="failure Badge__StyledBadge-sc-4gzqz0-0 gDhrrS badge badge-default"
+                    className="failure Badge-sc-4gzqz0-0 iRhcGJ badge badge-default"
                   >
                     <i
                       className="fa fa-times"
@@ -354,7 +354,7 @@ exports[`<ContentPackParameterList /> should render with parameters without read
   </h2>
   <br />
   <button
-    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+    className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
     disabled={false}
     onClick={[Function]}
     title="Edit Modal"
@@ -406,7 +406,7 @@ exports[`<ContentPackParameterList /> should render with parameters without read
         }
       >
         <button
-          className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+          className="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
           disabled={false}
           type="submit"
         >
@@ -422,7 +422,7 @@ exports[`<ContentPackParameterList /> should render with parameters without read
         }
       >
         <button
-          className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+          className="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
           disabled={false}
           onClick={[Function]}
           type="reset"
@@ -494,7 +494,7 @@ exports[`<ContentPackParameterList /> should render with parameters without read
                 </td>
                 <td>
                   <span
-                    className="failure Badge__StyledBadge-sc-4gzqz0-0 gDhrrS badge badge-default"
+                    className="failure Badge-sc-4gzqz0-0 iRhcGJ badge badge-default"
                   >
                     <i
                       className="fa fa-times"
@@ -507,7 +507,7 @@ exports[`<ContentPackParameterList /> should render with parameters without read
                     role="toolbar"
                   >
                     <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-primary"
+                      className="Button-c9cbmb-0 GLfOY btn btn-xs btn-primary"
                       disabled={false}
                       onClick={[Function]}
                       title="Delete Parameter"
@@ -516,7 +516,7 @@ exports[`<ContentPackParameterList /> should render with parameters without read
                       Delete
                     </button>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-info"
+                      className="Button-c9cbmb-0 GLfOY btn btn-xs btn-info"
                       disabled={false}
                       onClick={[Function]}
                       title="Edit Modal"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameters.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameters.test.jsx.snap
@@ -14,7 +14,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
         </h2>
         <br />
         <button
-          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+          className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
           disabled={false}
           onClick={[Function]}
           title="Edit Modal"
@@ -66,7 +66,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
               }
             >
               <button
-                className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                className="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
                 disabled={false}
                 type="submit"
               >
@@ -82,7 +82,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
               }
             >
               <button
-                className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                className="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
                 disabled={false}
                 onClick={[Function]}
                 type="reset"
@@ -154,7 +154,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                       </td>
                       <td>
                         <span
-                          className="failure Badge__StyledBadge-sc-4gzqz0-0 gDhrrS badge badge-default"
+                          className="failure Badge-sc-4gzqz0-0 iRhcGJ badge badge-default"
                         >
                           <i
                             className="fa fa-times"
@@ -167,7 +167,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                           role="toolbar"
                         >
                           <button
-                            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-primary"
+                            className="Button-c9cbmb-0 GLfOY btn btn-xs btn-primary"
                             disabled={false}
                             onClick={[Function]}
                             title="Delete Parameter"
@@ -176,7 +176,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                             Delete
                           </button>
                           <button
-                            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-info"
+                            className="Button-c9cbmb-0 GLfOY btn btn-xs btn-info"
                             disabled={false}
                             onClick={[Function]}
                             title="Edit Modal"
@@ -247,7 +247,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
               }
             >
               <button
-                className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                className="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
                 disabled={false}
                 type="submit"
               >
@@ -263,7 +263,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
               }
             >
               <button
-                className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                className="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
                 disabled={false}
                 onClick={[Function]}
                 type="reset"
@@ -341,7 +341,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                           role="toolbar"
                         >
                           <button
-                            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-primary"
+                            className="Button-c9cbmb-0 GLfOY btn btn-xs btn-primary"
                             disabled={false}
                             onClick={[Function]}
                             type="button"
@@ -349,7 +349,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                             Edit
                           </button>
                           <button
-                            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-info"
+                            className="Button-c9cbmb-0 GLfOY btn btn-xs btn-info"
                             disabled={false}
                             onClick={[Function]}
                             type="button"
@@ -385,7 +385,7 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
         </h2>
         <br />
         <button
-          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+          className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
           disabled={false}
           onClick={[Function]}
           title="Edit Modal"
@@ -437,7 +437,7 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
               }
             >
               <button
-                className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                className="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
                 disabled={false}
                 type="submit"
               >
@@ -453,7 +453,7 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
               }
             >
               <button
-                className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                className="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
                 disabled={false}
                 onClick={[Function]}
                 type="reset"
@@ -535,7 +535,7 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
               }
             >
               <button
-                className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                className="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
                 disabled={false}
                 type="submit"
               >
@@ -551,7 +551,7 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
               }
             >
               <button
-                className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                className="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
                 disabled={false}
                 onClick={[Function]}
                 type="reset"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackPreview.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackPreview.test.jsx.snap
@@ -180,7 +180,7 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
               }
             >
               <button
-                className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                className="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
                 disabled={false}
                 type="submit"
               >
@@ -196,7 +196,7 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
               }
             >
               <button
-                className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                className="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
                 disabled={false}
                 onClick={[Function]}
                 type="reset"
@@ -270,7 +270,7 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
               }
             >
               <button
-                className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                className="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
                 disabled={false}
                 type="submit"
               >
@@ -286,7 +286,7 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
               }
             >
               <button
-                className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                className="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
                 disabled={false}
                 onClick={[Function]}
                 type="reset"
@@ -324,7 +324,7 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
       className="col-sm-6"
     >
       <button
-        className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
+        className="Button-c9cbmb-0 GLfOY btn btn-primary"
         disabled={false}
         id="create"
         onClick={[Function]}
@@ -338,7 +338,7 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
         href="data:text/plain;charset=utf-8,%7B%0A%20%20%22v%22%3A%201%2C%0A%20%20%22id%22%3A%20%22dead-beef%22%2C%0A%20%20%22rev%22%3A%201%2C%0A%20%20%22name%22%3A%20%22%22%2C%0A%20%20%22summary%22%3A%20%22%22%2C%0A%20%20%22description%22%3A%20%22%22%2C%0A%20%20%22vendor%22%3A%20%22%22%2C%0A%20%20%22url%22%3A%20%22%22%2C%0A%20%20%22parameters%22%3A%20%5B%5D%2C%0A%20%20%22entities%22%3A%20%5B%5D%0A%7D"
       >
         <button
-          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-info"
+          className="Button-c9cbmb-0 GLfOY btn btn-info"
           disabled={false}
           id="download"
           onClick={[Function]}
@@ -548,7 +548,7 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
               }
             >
               <button
-                className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                className="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
                 disabled={false}
                 type="submit"
               >
@@ -564,7 +564,7 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
               }
             >
               <button
-                className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                className="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
                 disabled={false}
                 onClick={[Function]}
                 type="reset"
@@ -638,7 +638,7 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
               }
             >
               <button
-                className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                className="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
                 disabled={false}
                 type="submit"
               >
@@ -654,7 +654,7 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
               }
             >
               <button
-                className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                className="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
                 disabled={false}
                 onClick={[Function]}
                 type="reset"
@@ -692,7 +692,7 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
       className="col-sm-6"
     >
       <button
-        className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
+        className="Button-c9cbmb-0 GLfOY btn btn-primary"
         disabled={false}
         id="create"
         onClick={[Function]}
@@ -706,7 +706,7 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
         href="data:text/plain;charset=utf-8,%7B%0A%20%20%22v%22%3A%201%2C%0A%20%20%22id%22%3A%20%22dead-beef%22%2C%0A%20%20%22rev%22%3A%201%2C%0A%20%20%22name%22%3A%20%22name%22%2C%0A%20%20%22summary%22%3A%20%22summary%22%2C%0A%20%20%22description%22%3A%20%22descr%22%2C%0A%20%20%22vendor%22%3A%20%22vendor%22%2C%0A%20%20%22url%22%3A%20%22http%3A%2F%2Fexample.com%22%2C%0A%20%20%22parameters%22%3A%20%5B%5D%2C%0A%20%20%22entities%22%3A%20%5B%5D%0A%7D"
       >
         <button
-          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-info"
+          className="Button-c9cbmb-0 GLfOY btn btn-info"
           disabled={false}
           id="download"
           onClick={[Function]}

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
@@ -222,7 +222,7 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
             }
           >
             <button
-              className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+              className="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
               disabled={false}
               type="submit"
             >
@@ -238,7 +238,7 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
             }
           >
             <button
-              className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+              className="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
               disabled={false}
               onClick={[Function]}
               type="reset"
@@ -499,7 +499,7 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
             }
           >
             <button
-              className="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+              className="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
               disabled={false}
               type="submit"
             >
@@ -515,7 +515,7 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
             }
           >
             <button
-              className="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+              className="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
               disabled={false}
               onClick={[Function]}
               type="reset"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackUploadControls.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackUploadControls.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`<ContentPackUploadControls /> should render 1`] = `
 <span>
   <button
-    className="button Button__StyledButton-c9cbmb-0 kRDLih btn btn-success"
+    className="button Button-c9cbmb-0 GLfOY btn btn-success"
     disabled={false}
     id="upload-content-pack-button"
     onClick={[Function]}

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackVersions.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackVersions.test.jsx.snap
@@ -51,7 +51,7 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                   role="toolbar"
                 >
                   <button
-                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-success"
+                    className="Button-c9cbmb-0 GLfOY btn btn-sm btn-success"
                     disabled={false}
                     onClick={[Function]}
                     type="button"
@@ -156,7 +156,7 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                   role="toolbar"
                 >
                   <button
-                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-success"
+                    className="Button-c9cbmb-0 GLfOY btn btn-sm btn-success"
                     disabled={false}
                     onClick={[Function]}
                     type="button"
@@ -261,7 +261,7 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                   role="toolbar"
                 >
                   <button
-                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-success"
+                    className="Button-c9cbmb-0 GLfOY btn btn-sm btn-success"
                     disabled={false}
                     onClick={[Function]}
                     type="button"
@@ -366,7 +366,7 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                   role="toolbar"
                 >
                   <button
-                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-success"
+                    className="Button-c9cbmb-0 GLfOY btn btn-sm btn-success"
                     disabled={false}
                     onClick={[Function]}
                     type="button"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPacksList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPacksList.test.jsx.snap
@@ -44,7 +44,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             </div>
           </div>
           <button
-            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+            className="Button-c9cbmb-0 GLfOY btn btn-default"
             disabled={false}
             style={
               Object {
@@ -56,7 +56,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             Filter
           </button>
           <button
-            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+            className="Button-c9cbmb-0 GLfOY btn btn-default"
             disabled={true}
             onClick={[Function]}
             style={
@@ -212,7 +212,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
       className="list-group"
     >
       <span
-        className="listGroupHeader ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+        className="listGroupHeader ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
       >
         <div
           className="headerWrapper"
@@ -221,7 +221,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
         </div>
       </span>
       <span
-        className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
       >
         <div
           className="row-sm row"
@@ -245,7 +245,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                     style={Object {}}
                   >
                     <span
-                      className="Badge__StyledBadge-sc-4gzqz0-0 gDhrrS badge installed badge installed-default"
+                      className="Badge-sc-4gzqz0-0 iRhcGJ badge installed badge installed-default"
                     >
                       installed
                     </span>
@@ -261,7 +261,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             
              
             <button
-              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+              className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -373,7 +373,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
         </div>
       </span>
       <span
-        className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
       >
         <div
           className="row-sm row"
@@ -397,7 +397,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                     style={Object {}}
                   >
                     <span
-                      className="Badge__StyledBadge-sc-4gzqz0-0 gDhrrS badge installed badge installed-default"
+                      className="Badge-sc-4gzqz0-0 iRhcGJ badge installed badge installed-default"
                     >
                       installed
                     </span>
@@ -413,7 +413,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             
              
             <button
-              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+              className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -525,7 +525,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
         </div>
       </span>
       <span
-        className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
       >
         <div
           className="row-sm row"
@@ -554,7 +554,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             
              
             <button
-              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+              className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -666,7 +666,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
         </div>
       </span>
       <span
-        className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
       >
         <div
           className="row-sm row"
@@ -695,7 +695,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             
              
             <button
-              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+              className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -807,7 +807,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
         </div>
       </span>
       <span
-        className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
       >
         <div
           className="row-sm row"
@@ -836,7 +836,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             
              
             <button
-              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+              className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -948,7 +948,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
         </div>
       </span>
       <span
-        className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
       >
         <div
           className="row-sm row"
@@ -977,7 +977,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             
              
             <button
-              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+              className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -1089,7 +1089,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
         </div>
       </span>
       <span
-        className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
       >
         <div
           className="row-sm row"
@@ -1118,7 +1118,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             
              
             <button
-              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+              className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -1230,7 +1230,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
         </div>
       </span>
       <span
-        className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
       >
         <div
           className="row-sm row"
@@ -1259,7 +1259,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             
              
             <button
-              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+              className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -1371,7 +1371,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
         </div>
       </span>
       <span
-        className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
       >
         <div
           className="row-sm row"
@@ -1400,7 +1400,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             
              
             <button
-              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+              className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -1512,7 +1512,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
         </div>
       </span>
       <span
-        className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
       >
         <div
           className="row-sm row"
@@ -1541,7 +1541,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
             
              
             <button
-              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-sm btn-info"
+              className="Button-c9cbmb-0 GLfOY btn btn-sm btn-info"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -1840,7 +1840,7 @@ exports[`<ContentPacksList /> should render with empty content packs 1`] = `
             </div>
           </div>
           <button
-            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+            className="Button-c9cbmb-0 GLfOY btn btn-default"
             disabled={false}
             style={
               Object {
@@ -1852,7 +1852,7 @@ exports[`<ContentPacksList /> should render with empty content packs 1`] = `
             Filter
           </button>
           <button
-            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+            className="Button-c9cbmb-0 GLfOY btn btn-default"
             disabled={true}
             onClick={[Function]}
             style={

--- a/graylog2-web-interface/src/components/graylog/Alert.jsx
+++ b/graylog2-web-interface/src/components/graylog/Alert.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback } from 'react';
+import React, { forwardRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import { darken, lighten } from 'polished';
@@ -25,9 +25,14 @@ const alertStyles = (hex) => {
 };
 
 const Alert = forwardRef(({ bsStyle, ...props }, ref) => {
-  const StyledAlert = useCallback(styled(BootstrapAlert)`
-    ${bsStyleThemeVariant(alertStyles)}
-  `, [bsStyle]);
+  const StyledAlert = useMemo(
+    () => {
+      return styled(BootstrapAlert)`
+        ${bsStyleThemeVariant(alertStyles)}
+      `;
+    },
+    [bsStyle],
+  );
 
   return (
     <StyledAlert bsStyle={bsStyle} ref={ref} {...props} />

--- a/graylog2-web-interface/src/components/graylog/Alert.jsx
+++ b/graylog2-web-interface/src/components/graylog/Alert.jsx
@@ -26,11 +26,7 @@ const alertStyles = (hex) => {
 
 const Alert = forwardRef(({ bsStyle, ...props }, ref) => {
   const StyledAlert = useMemo(
-    () => {
-      return styled(BootstrapAlert)`
-        ${bsStyleThemeVariant(alertStyles)}
-      `;
-    },
+    () => styled(BootstrapAlert)`${bsStyleThemeVariant(alertStyles)}`,
     [bsStyle],
   );
 

--- a/graylog2-web-interface/src/components/graylog/Badge.jsx
+++ b/graylog2-web-interface/src/components/graylog/Badge.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback } from 'react';
+import React, { forwardRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 // eslint-disable-next-line no-restricted-imports
@@ -9,9 +9,14 @@ import badgeStyles from './styles/badge';
 
 const Badge = forwardRef((props, ref) => {
   const { bsStyle } = props;
-  const StyledBadge = useCallback(styled(BootstrapBadge)`
-    ${badgeStyles(props)}
-  `, [bsStyle]);
+  const StyledBadge = useMemo(
+    () => {
+      return styled(BootstrapBadge)`
+        ${badgeStyles(props)}
+      `;
+    },
+    [bsStyle],
+  );
 
   return (
     <StyledBadge ref={ref} {...props} />

--- a/graylog2-web-interface/src/components/graylog/Badge.jsx
+++ b/graylog2-web-interface/src/components/graylog/Badge.jsx
@@ -10,11 +10,7 @@ import badgeStyles from './styles/badge';
 const Badge = forwardRef((props, ref) => {
   const { bsStyle } = props;
   const StyledBadge = useMemo(
-    () => {
-      return styled(BootstrapBadge)`
-        ${badgeStyles(props)}
-      `;
-    },
+    () => styled(BootstrapBadge)`${badgeStyles(props)}`,
     [bsStyle],
   );
 

--- a/graylog2-web-interface/src/components/graylog/Button.jsx
+++ b/graylog2-web-interface/src/components/graylog/Button.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback } from 'react';
+import React, { forwardRef, useMemo } from 'react';
 import styled from 'styled-components';
 // eslint-disable-next-line no-restricted-imports
 import { Button as BootstrapButton } from 'react-bootstrap';
@@ -8,9 +8,14 @@ import { propTypes, defaultProps } from './props/button';
 
 const Button = forwardRef((props, ref) => {
   const { active, bsStyle, disabled } = props;
-  const StyledButton = useCallback(styled(BootstrapButton)`
-    ${buttonStyles(props)}
-  `, [active, bsStyle, disabled]);
+  const StyledButton = useMemo(
+    () => {
+      return styled(BootstrapButton)`
+        ${buttonStyles(props)}
+      `;
+    },
+    [active, bsStyle, disabled],
+  );
 
   return (
     <StyledButton ref={ref} {...props} />

--- a/graylog2-web-interface/src/components/graylog/Button.jsx
+++ b/graylog2-web-interface/src/components/graylog/Button.jsx
@@ -9,11 +9,7 @@ import { propTypes, defaultProps } from './props/button';
 const Button = forwardRef((props, ref) => {
   const { active, bsStyle, disabled } = props;
   const StyledButton = useMemo(
-    () => {
-      return styled(BootstrapButton)`
-        ${buttonStyles(props)}
-      `;
-    },
+    () => styled(BootstrapButton)`${buttonStyles(props)}`,
     [active, bsStyle, disabled],
   );
 

--- a/graylog2-web-interface/src/components/graylog/FormControl.jsx
+++ b/graylog2-web-interface/src/components/graylog/FormControl.jsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { FormControl as BootstrapFormControl } from 'react-bootstrap';
 import styled from 'styled-components';
@@ -5,7 +6,7 @@ import { lighten, transparentize } from 'polished';
 
 import teinte from 'theme/teinte';
 
-const FormControl = styled(BootstrapFormControl)`
+const FormControl = memo(styled(BootstrapFormControl)`
   color: ${teinte.primary.tre};
   background-color: ${teinte.primary.due};
   border-color: ${teinte.secondary.tre};
@@ -28,6 +29,6 @@ const FormControl = styled(BootstrapFormControl)`
   }
 
   ~ .form-control-feedback.glyphicon { display: none; }
-`;
+`);
 
 export default FormControl;

--- a/graylog2-web-interface/src/components/graylog/FormControl.jsx
+++ b/graylog2-web-interface/src/components/graylog/FormControl.jsx
@@ -31,4 +31,7 @@ const FormControl = memo(styled(BootstrapFormControl)`
   ~ .form-control-feedback.glyphicon { display: none; }
 `);
 
+FormControl.Static = BootstrapFormControl.Static;
+FormControl.Feedback = BootstrapFormControl.Feedback;
+
 export default FormControl;

--- a/graylog2-web-interface/src/components/graylog/Jumbotron.jsx
+++ b/graylog2-web-interface/src/components/graylog/Jumbotron.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback } from 'react';
+import React, { forwardRef, useMemo } from 'react';
 import styled from 'styled-components';
 // eslint-disable-next-line no-restricted-imports
 import { Jumbotron as BootstrapJumbotron } from 'react-bootstrap';
@@ -7,10 +7,14 @@ import { useTheme } from 'theme/GraylogThemeContext';
 
 const Jumbotron = forwardRef((props, ref) => {
   const { colors } = useTheme();
-  const StyledJumbotron = useCallback(styled(BootstrapJumbotron)`
-    color: ${colors.primary.tre};
-    background-color: ${colors.primary.due};
-  `, []);
+  const StyledJumbotron = useMemo(
+    () => {
+      return styled(BootstrapJumbotron)`
+        color: ${colors.primary.tre};
+        background-color: ${colors.primary.due};
+      `;
+    }, [],
+  );
 
   return (
     <StyledJumbotron ref={ref} {...props} />

--- a/graylog2-web-interface/src/components/graylog/Label.jsx
+++ b/graylog2-web-interface/src/components/graylog/Label.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback } from 'react';
+import React, { forwardRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 // eslint-disable-next-line no-restricted-imports
@@ -17,9 +17,14 @@ const labelStyles = (hex) => {
 };
 
 const Label = forwardRef(({ bsStyle, ...props }, ref) => {
-  const StyledLabel = useCallback(styled(BootstrapLabel)`
-    ${bsStyleThemeVariant(labelStyles)}
-  `, [bsStyle]);
+  const StyledLabel = useMemo(
+    () => {
+      return styled(BootstrapLabel)`
+        ${bsStyleThemeVariant(labelStyles)}
+      `;
+    },
+    [bsStyle],
+  );
 
   return (
     <StyledLabel bsStyle={bsStyle} ref={ref} {...props} />

--- a/graylog2-web-interface/src/components/graylog/Label.jsx
+++ b/graylog2-web-interface/src/components/graylog/Label.jsx
@@ -18,11 +18,7 @@ const labelStyles = (hex) => {
 
 const Label = forwardRef(({ bsStyle, ...props }, ref) => {
   const StyledLabel = useMemo(
-    () => {
-      return styled(BootstrapLabel)`
-        ${bsStyleThemeVariant(labelStyles)}
-      `;
-    },
+    () => styled(BootstrapLabel)`${bsStyleThemeVariant(labelStyles)}`,
     [bsStyle],
   );
 

--- a/graylog2-web-interface/src/components/graylog/ListGroupItem.jsx
+++ b/graylog2-web-interface/src/components/graylog/ListGroupItem.jsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback } from 'react';
+import React, { forwardRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 // eslint-disable-next-line no-restricted-imports
@@ -46,35 +46,40 @@ const listGroupItemStyles = (hex) => {
 
 const ListGroupItem = forwardRef(({ bsStyle, ...props }, ref) => {
   const { colors } = useTheme();
-  const StyledListGroupItem = useCallback(styled(BootstrapListGroupItem)`
-    &.list-group-item-action {
-      color: ${colors.primary.tre};
+  const StyledListGroupItem = useMemo(
+    () => {
+      return styled(BootstrapListGroupItem)`
+        &.list-group-item-action {
+          color: ${colors.primary.tre};
 
-      &:hover,
-      &:focus {
-        color: ${colors.primary.tre};
-        background-color: ${colors.secondary.due};
-      }
+          &:hover,
+          &:focus {
+            color: ${colors.primary.tre};
+            background-color: ${colors.secondary.due};
+          }
 
-      &:active {
-        color: ${contrastingColor(colors.secondary.tre)};
-        background-color: ${colors.secondary.tre};
-      }
-    }
+          &:active {
+            color: ${contrastingColor(colors.secondary.tre)};
+            background-color: ${colors.secondary.tre};
+          }
+        }
 
-    &.list-group-item {
-      background-color: ${colors.primary.due};
-      border-color: ${colors.secondary.tre};
+        &.list-group-item {
+          background-color: ${colors.primary.due};
+          border-color: ${colors.secondary.tre};
 
-      &.disabled,
-      &:disabled {
-        color: ${colors.primary.tre};
-        background-color: ${colors.primary.due};
-      }
-    }
+          &.disabled,
+          &:disabled {
+            color: ${colors.primary.tre};
+            background-color: ${colors.primary.due};
+          }
+        }
 
-    ${bsStyleThemeVariant(listGroupItemStyles)}
-  `, [bsStyle, colors]);
+        ${bsStyleThemeVariant(listGroupItemStyles)}
+      `;
+    },
+    [bsStyle, colors],
+  );
 
   return (
     <StyledListGroupItem bsStyle={bsStyle} ref={ref} {...props} />

--- a/graylog2-web-interface/src/components/grok-patterns/__snapshots__/GrokPatternInput.test.jsx.snap
+++ b/graylog2-web-interface/src/components/grok-patterns/__snapshots__/GrokPatternInput.test.jsx.snap
@@ -69,7 +69,7 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
       className="resultList"
     >
       <span
-        className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
         id="list-item-0"
         onKeyDown={[Function]}
       >
@@ -90,7 +90,7 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
             className="addButton"
           >
             <button
-              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-primary"
+              className="Button-c9cbmb-0 GLfOY btn btn-xs btn-primary"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -101,7 +101,7 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
         </p>
       </span>
       <span
-        className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
         id="list-item-1"
         onKeyDown={[Function]}
       >
@@ -122,7 +122,7 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
             className="addButton"
           >
             <button
-              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-primary"
+              className="Button-c9cbmb-0 GLfOY btn btn-xs btn-primary"
               disabled={false}
               onClick={[Function]}
               type="button"
@@ -133,7 +133,7 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
         </p>
       </span>
       <span
-        className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
         id="list-item-2"
         onKeyDown={[Function]}
       >
@@ -154,7 +154,7 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
             className="addButton"
           >
             <button
-              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-primary"
+              className="Button-c9cbmb-0 GLfOY btn btn-xs btn-primary"
               disabled={false}
               onClick={[Function]}
               type="button"

--- a/graylog2-web-interface/src/components/navigation/__snapshots__/NotificationBadge.test.jsx.snap
+++ b/graylog2-web-interface/src/components/navigation/__snapshots__/NotificationBadge.test.jsx.snap
@@ -92,7 +92,7 @@ exports[`NotificationBadge renders count when there are notifications 1`] = `
                         bsStyle="danger"
                         id="notification-badge"
                       >
-                        <Badge__StyledBadge
+                        <Badge
                           bsStyle="danger"
                           id="notification-badge"
                         >
@@ -103,17 +103,17 @@ exports[`NotificationBadge renders count when there are notifications 1`] = `
                                 "$$typeof": Symbol(react.forward_ref),
                                 "attrs": Array [],
                                 "componentStyle": ComponentStyle {
-                                  "componentId": "Badge__StyledBadge-sc-4gzqz0-0",
+                                  "componentId": "Badge-sc-4gzqz0-0",
                                   "isStatic": false,
-                                  "lastClassName": "gDhrrS",
+                                  "lastClassName": "iRhcGJ",
                                   "rules": Array [
                                     [Function],
                                   ],
                                 },
-                                "displayName": "Badge__StyledBadge",
+                                "displayName": "Badge",
                                 "foldedComponentIds": Array [],
                                 "render": [Function],
-                                "styledComponentId": "Badge__StyledBadge-sc-4gzqz0-0",
+                                "styledComponentId": "Badge-sc-4gzqz0-0",
                                 "target": [Function],
                                 "toString": [Function],
                                 "warnTooManyClasses": [Function],
@@ -126,19 +126,19 @@ exports[`NotificationBadge renders count when there are notifications 1`] = `
                             <Badge
                               bsClass="badge"
                               bsStyle="danger"
-                              className="Badge__StyledBadge-sc-4gzqz0-0 gDhrrS"
+                              className="Badge-sc-4gzqz0-0 iRhcGJ"
                               id="notification-badge"
                               pullRight={false}
                             >
                               <span
-                                className="Badge__StyledBadge-sc-4gzqz0-0 gDhrrS badge badge-danger"
+                                className="Badge-sc-4gzqz0-0 iRhcGJ badge badge-danger"
                                 id="notification-badge"
                               >
                                 42
                               </span>
                             </Badge>
                           </StyledComponent>
-                        </Badge__StyledBadge>
+                        </Badge>
                       </ForwardRef>
                     </a>
                   </SafeAnchor>

--- a/graylog2-web-interface/src/components/search/__snapshots__/MessageTableEntry.test.jsx.snap
+++ b/graylog2-web-interface/src/components/search/__snapshots__/MessageTableEntry.test.jsx.snap
@@ -41,7 +41,7 @@ exports[`<MessageTableEntry /> rendering should render a MessageTableEntry 1`] =
               className="pull-right btn-group btn-group-sm"
             >
               <a
-                className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                className="Button-c9cbmb-0 GLfOY btn btn-default"
                 href="/messages/01/01"
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -49,7 +49,7 @@ exports[`<MessageTableEntry /> rendering should render a MessageTableEntry 1`] =
                 Permalink
               </a>
               <button
-                className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                className="Button-c9cbmb-0 GLfOY btn btn-default"
                 data-clipboard-action="copy"
                 data-clipboard-button={true}
                 data-clipboard-text="01"

--- a/graylog2-web-interface/src/components/users/__snapshots__/PermissionSelector.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/PermissionSelector.test.jsx.snap
@@ -104,7 +104,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                       </div>
                     </div>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                      className="Button-c9cbmb-0 GLfOY btn btn-default"
                       disabled={false}
                       style={
                         Object {
@@ -116,7 +116,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                       Filter
                     </button>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                      className="Button-c9cbmb-0 GLfOY btn btn-default"
                       disabled={true}
                       onClick={[Function]}
                       style={
@@ -140,7 +140,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                 className="list-group"
               >
                 <span
-                  className="listGroupHeader ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+                  className="listGroupHeader ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
                 >
                   <div
                     className="form-group"
@@ -171,7 +171,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                   </div>
                 </span>
                 <span
-                  className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+                  className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
                 >
                   <div
                     className="itemWrapper "
@@ -183,7 +183,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                         className="btn-group btn-group-sm"
                       >
                         <button
-                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                          className="Button-c9cbmb-0 GLfOY btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -191,7 +191,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                           Allow reading
                         </button>
                         <button
-                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                          className="Button-c9cbmb-0 GLfOY btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -235,7 +235,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                   </div>
                 </span>
                 <span
-                  className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+                  className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
                 >
                   <div
                     className="itemWrapper "
@@ -247,7 +247,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                         className="btn-group btn-group-sm"
                       >
                         <button
-                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                          className="Button-c9cbmb-0 GLfOY btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -255,7 +255,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                           Allow reading
                         </button>
                         <button
-                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                          className="Button-c9cbmb-0 GLfOY btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -360,7 +360,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                       </div>
                     </div>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                      className="Button-c9cbmb-0 GLfOY btn btn-default"
                       disabled={false}
                       style={
                         Object {
@@ -372,7 +372,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                       Filter
                     </button>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                      className="Button-c9cbmb-0 GLfOY btn btn-default"
                       disabled={true}
                       onClick={[Function]}
                       style={
@@ -396,7 +396,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                 className="list-group"
               >
                 <span
-                  className="listGroupHeader ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+                  className="listGroupHeader ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
                 >
                   <div
                     className="form-group"
@@ -427,7 +427,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                   </div>
                 </span>
                 <span
-                  className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+                  className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
                 >
                   <div
                     className="itemWrapper "
@@ -439,7 +439,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                         className="btn-group btn-group-sm"
                       >
                         <button
-                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                          className="Button-c9cbmb-0 GLfOY btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -447,7 +447,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                           Allow reading
                         </button>
                         <button
-                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                          className="Button-c9cbmb-0 GLfOY btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -491,7 +491,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                   </div>
                 </span>
                 <span
-                  className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+                  className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
                 >
                   <div
                     className="itemWrapper "
@@ -503,7 +503,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                         className="btn-group btn-group-sm"
                       >
                         <button
-                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                          className="Button-c9cbmb-0 GLfOY btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -511,7 +511,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                           Allow reading
                         </button>
                         <button
-                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                          className="Button-c9cbmb-0 GLfOY btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -668,7 +668,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                       </div>
                     </div>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                      className="Button-c9cbmb-0 GLfOY btn btn-default"
                       disabled={false}
                       style={
                         Object {
@@ -680,7 +680,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                       Filter
                     </button>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                      className="Button-c9cbmb-0 GLfOY btn btn-default"
                       disabled={true}
                       onClick={[Function]}
                       style={
@@ -704,7 +704,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                 className="list-group"
               >
                 <span
-                  className="listGroupHeader ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+                  className="listGroupHeader ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
                 >
                   <div
                     className="form-group"
@@ -735,7 +735,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                   </div>
                 </span>
                 <span
-                  className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+                  className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
                 >
                   <div
                     className="itemWrapper "
@@ -747,7 +747,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                         className="btn-group btn-group-sm"
                       >
                         <button
-                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-info active"
+                          className="Button-c9cbmb-0 GLfOY btn btn-info active"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -755,7 +755,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                           Allow reading
                         </button>
                         <button
-                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                          className="Button-c9cbmb-0 GLfOY btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -799,7 +799,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                   </div>
                 </span>
                 <span
-                  className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+                  className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
                 >
                   <div
                     className="itemWrapper "
@@ -811,7 +811,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                         className="btn-group btn-group-sm"
                       >
                         <button
-                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                          className="Button-c9cbmb-0 GLfOY btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -819,7 +819,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                           Allow reading
                         </button>
                         <button
-                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-info active"
+                          className="Button-c9cbmb-0 GLfOY btn btn-info active"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -924,7 +924,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                       </div>
                     </div>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                      className="Button-c9cbmb-0 GLfOY btn btn-default"
                       disabled={false}
                       style={
                         Object {
@@ -936,7 +936,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                       Filter
                     </button>
                     <button
-                      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                      className="Button-c9cbmb-0 GLfOY btn btn-default"
                       disabled={true}
                       onClick={[Function]}
                       style={
@@ -960,7 +960,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                 className="list-group"
               >
                 <span
-                  className="listGroupHeader ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+                  className="listGroupHeader ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
                 >
                   <div
                     className="form-group"
@@ -991,7 +991,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                   </div>
                 </span>
                 <span
-                  className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+                  className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
                 >
                   <div
                     className="itemWrapper "
@@ -1003,7 +1003,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                         className="btn-group btn-group-sm"
                       >
                         <button
-                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                          className="Button-c9cbmb-0 GLfOY btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -1011,7 +1011,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                           Allow reading
                         </button>
                         <button
-                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                          className="Button-c9cbmb-0 GLfOY btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -1055,7 +1055,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                   </div>
                 </span>
                 <span
-                  className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+                  className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
                 >
                   <div
                     className="itemWrapper "
@@ -1067,7 +1067,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                         className="btn-group btn-group-sm"
                       >
                         <button
-                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-info active"
+                          className="Button-c9cbmb-0 GLfOY btn btn-info active"
                           disabled={false}
                           onClick={[Function]}
                           type="button"
@@ -1075,7 +1075,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                           Allow reading
                         </button>
                         <button
-                          className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                          className="Button-c9cbmb-0 GLfOY btn btn-default"
                           disabled={false}
                           onClick={[Function]}
                           type="button"

--- a/graylog2-web-interface/src/components/users/__snapshots__/TokenList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/TokenList.test.jsx.snap
@@ -36,7 +36,7 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
           className="col-sm-2"
         >
           <button
-            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
+            className="Button-c9cbmb-0 GLfOY btn btn-primary"
             disabled={true}
             id="create-token"
             type="submit"
@@ -91,7 +91,7 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
               </div>
             </div>
             <button
-              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+              className="Button-c9cbmb-0 GLfOY btn btn-default"
               disabled={false}
               style={
                 Object {
@@ -103,7 +103,7 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
               Filter
             </button>
             <button
-              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+              className="Button-c9cbmb-0 GLfOY btn btn-default"
               disabled={true}
               onClick={[Function]}
               style={
@@ -127,7 +127,7 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
         className="list-group"
       >
         <span
-          className="listGroupHeader ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+          className="listGroupHeader ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
         >
           <div
             className="headerWrapper"
@@ -136,7 +136,7 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
           </div>
         </span>
         <span
-          className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+          className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
         >
           No items to display
         </span>
@@ -198,7 +198,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
           className="col-sm-2"
         >
           <button
-            className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
+            className="Button-c9cbmb-0 GLfOY btn btn-primary"
             disabled={true}
             id="create-token"
             type="submit"
@@ -253,7 +253,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
               </div>
             </div>
             <button
-              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+              className="Button-c9cbmb-0 GLfOY btn btn-default"
               disabled={false}
               style={
                 Object {
@@ -265,7 +265,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
               Filter
             </button>
             <button
-              className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+              className="Button-c9cbmb-0 GLfOY btn btn-default"
               disabled={true}
               onClick={[Function]}
               style={
@@ -289,7 +289,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
         className="list-group"
       >
         <span
-          className="listGroupHeader ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+          className="listGroupHeader ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
         >
           <div
             className="headerWrapper"
@@ -298,7 +298,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
           </div>
         </span>
         <span
-          className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+          className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
         >
           <div
             className="itemWrapper itemWrapperStatic"
@@ -315,7 +315,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
                   title="Copy to clipboard"
                 />
                 <button
-                  className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-primary"
+                  className="Button-c9cbmb-0 GLfOY btn btn-xs btn-primary"
                   disabled={false}
                   onClick={[Function]}
                   type="button"
@@ -333,7 +333,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
           </div>
         </span>
         <span
-          className="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+          className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
         >
           <div
             className="itemWrapper itemWrapperStatic"
@@ -350,7 +350,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
                   title="Copy to clipboard"
                 />
                 <button
-                  className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-xs btn-primary"
+                  className="Button-c9cbmb-0 GLfOY btn btn-xs btn-primary"
                   disabled={false}
                   onClick={[Function]}
                   type="button"

--- a/graylog2-web-interface/src/components/users/__snapshots__/UserPreferencesButton.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/UserPreferencesButton.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`UserPreferencesButton should load user data when user clicks edit butto
 <div>
   <span>
     <button
-      class="Button__StyledButton-c9cbmb-0 kRDLih btn btn-success"
+      class="Button-c9cbmb-0 GLfOY btn btn-success"
       data-testid="user-preferences-button"
       type="button"
     >

--- a/graylog2-web-interface/src/components/widgets/__snapshots__/WidgetFooter.test.jsx.snap
+++ b/graylog2-web-interface/src/components/widgets/__snapshots__/WidgetFooter.test.jsx.snap
@@ -32,7 +32,7 @@ exports[`<WidgetFooter /> should render a widget footer locked and disabled repl
         className="widget-info"
       >
         <button
-          className="btn-text Button__StyledButton-c9cbmb-0 kRDLih btn btn-link"
+          className="btn-text Button-c9cbmb-0 GLfOY btn btn-link"
           disabled={false}
           onClick={[Function]}
           title="Show widget configuration"
@@ -80,7 +80,7 @@ exports[`<WidgetFooter /> should render a widget footer locked and enabled repla
         className="widget-replay"
       >
         <a
-          className="btn-text Button__StyledButton-c9cbmb-0 kRDLih btn btn-link"
+          className="btn-text Button-c9cbmb-0 GLfOY btn btn-link"
           href="http://example.org"
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -95,7 +95,7 @@ exports[`<WidgetFooter /> should render a widget footer locked and enabled repla
         className="widget-info"
       >
         <button
-          className="btn-text Button__StyledButton-c9cbmb-0 kRDLih btn btn-link"
+          className="btn-text Button-c9cbmb-0 GLfOY btn btn-link"
           disabled={false}
           onClick={[Function]}
           title="Show widget configuration"
@@ -143,7 +143,7 @@ exports[`<WidgetFooter /> should render a widget footer with unlocked 1`] = `
         className="widget-delete"
       >
         <button
-          className="btn-text Button__StyledButton-c9cbmb-0 kRDLih btn btn-link"
+          className="btn-text Button-c9cbmb-0 GLfOY btn btn-link"
           disabled={false}
           onClick={[Function]}
           title="Delete widget"
@@ -158,7 +158,7 @@ exports[`<WidgetFooter /> should render a widget footer with unlocked 1`] = `
         className="widget-edit"
       >
         <button
-          className="btn-text Button__StyledButton-c9cbmb-0 kRDLih btn btn-link"
+          className="btn-text Button-c9cbmb-0 GLfOY btn btn-link"
           disabled={false}
           onClick={[Function]}
           title="Edit widget"

--- a/graylog2-web-interface/src/pages/ErrorJumbotron.jsx
+++ b/graylog2-web-interface/src/pages/ErrorJumbotron.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Col, Jumbotron, Row } from 'components/graylog';
 import styled, { createGlobalStyle } from 'styled-components';
@@ -18,12 +18,17 @@ const ContainerRow = styled(Row)`
   height: 82vh;
 `;
 
-const StyledJumbotron = color => useCallback(styled(Jumbotron)`
-  && {
-    background-color: ${rgba(color, 0.8)};
-    text-align: center;
-  }
-`, [color]);
+const StyledJumbotron = color => useMemo(
+  () => {
+    return styled(Jumbotron)`
+      && {
+        background-color: ${rgba(color, 0.8)};
+        text-align: center;
+      }
+    `;
+  },
+  [color],
+);
 
 export const H1 = styled.h1`
   font-size: 52px;

--- a/graylog2-web-interface/src/views/components/__snapshots__/WidgetQueryControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/__snapshots__/WidgetQueryControls.test.jsx.snap
@@ -192,7 +192,7 @@ exports[`WidgetQueryControls should do something 1`] = `
         </a>
       </div>
       <button
-        class="pull-left search-button-execute Button__StyledButton-c9cbmb-0 kRDLih btn btn-success"
+        class="pull-left search-button-execute Button-c9cbmb-0 GLfOY btn btn-success"
         type="submit"
       >
         <i

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/ColumnPivotConfiguration.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/ColumnPivotConfiguration.test.jsx.snap
@@ -41,7 +41,7 @@ exports[`<ColumnPivotConfiguraiton /> should render as expected 1`] = `
     }
   >
     <button
-      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-success"
+      className="Button-c9cbmb-0 GLfOY btn btn-success"
       disabled={false}
       onClick={[Function]}
       type="button"

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/SeriesConfiguration.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/SeriesConfiguration.test.jsx.snap
@@ -31,7 +31,7 @@ exports[`SeriesConfiguration renders the configuration dialog 1`] = `
     }
   >
     <button
-      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-success"
+      className="Button-c9cbmb-0 GLfOY btn btn-success"
       disabled={false}
       onClick={[Function]}
       type="button"

--- a/graylog2-web-interface/src/views/components/searchbar/__snapshots__/RefreshControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/__snapshots__/RefreshControls.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: fa
     className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 etyOYS btn-group"
   >
     <button
-      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+      className="Button-c9cbmb-0 GLfOY btn btn-default"
       disabled={false}
       onClick={[Function]}
       type="button"
@@ -158,7 +158,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: fa
     className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 etyOYS btn-group"
   >
     <button
-      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+      className="Button-c9cbmb-0 GLfOY btn btn-default"
       disabled={false}
       onClick={[Function]}
       type="button"
@@ -308,7 +308,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
     className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 etyOYS btn-group"
   >
     <button
-      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+      className="Button-c9cbmb-0 GLfOY btn btn-default"
       disabled={false}
       onClick={[Function]}
       type="button"
@@ -465,7 +465,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
     className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 etyOYS btn-group"
   >
     <button
-      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+      className="Button-c9cbmb-0 GLfOY btn btn-default"
       disabled={false}
       onClick={[Function]}
       type="button"
@@ -622,7 +622,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
     className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 etyOYS btn-group"
   >
     <button
-      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+      className="Button-c9cbmb-0 GLfOY btn btn-default"
       disabled={false}
       onClick={[Function]}
       type="button"
@@ -779,7 +779,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
     className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 etyOYS btn-group"
   >
     <button
-      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+      className="Button-c9cbmb-0 GLfOY btn btn-default"
       disabled={false}
       onClick={[Function]}
       type="button"
@@ -936,7 +936,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
     className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 etyOYS btn-group"
   >
     <button
-      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+      className="Button-c9cbmb-0 GLfOY btn btn-default"
       disabled={false}
       onClick={[Function]}
       type="button"
@@ -1093,7 +1093,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
     className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 etyOYS btn-group"
   >
     <button
-      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+      className="Button-c9cbmb-0 GLfOY btn btn-default"
       disabled={false}
       onClick={[Function]}
       type="button"
@@ -1250,7 +1250,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
     className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 etyOYS btn-group"
   >
     <button
-      className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+      className="Button-c9cbmb-0 GLfOY btn btn-default"
       disabled={false}
       onClick={[Function]}
       type="button"

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkControls.test.jsx.snap
@@ -58,7 +58,7 @@ exports[`BookmarkControls render the BookmarkControls should render dirty 1`] = 
             onClick={[Function]}
             title="Export to new dashboard"
           >
-            <Button__StyledButton
+            <Button
               bsStyle="default"
               onClick={[Function]}
               title="Export to new dashboard"
@@ -84,17 +84,17 @@ exports[`BookmarkControls render the BookmarkControls should render dirty 1`] = 
                     ],
                     "attrs": Array [],
                     "componentStyle": ComponentStyle {
-                      "componentId": "Button__StyledButton-c9cbmb-0",
+                      "componentId": "Button-c9cbmb-0",
                       "isStatic": false,
-                      "lastClassName": "kRDLih",
+                      "lastClassName": "GLfOY",
                       "rules": Array [
                         [Function],
                       ],
                     },
-                    "displayName": "Button__StyledButton",
+                    "displayName": "Button",
                     "foldedComponentIds": Array [],
                     "render": [Function],
-                    "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                    "styledComponentId": "Button-c9cbmb-0",
                     "target": [Function],
                     "toString": [Function],
                     "warnTooManyClasses": [Function],
@@ -110,13 +110,13 @@ exports[`BookmarkControls render the BookmarkControls should render dirty 1`] = 
                   block={false}
                   bsClass="btn"
                   bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 kRDLih"
+                  className="Button-c9cbmb-0 GLfOY"
                   disabled={false}
                   onClick={[Function]}
                   title="Export to new dashboard"
                 >
                   <button
-                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    className="Button-c9cbmb-0 GLfOY btn btn-default"
                     disabled={false}
                     onClick={[Function]}
                     title="Export to new dashboard"
@@ -136,7 +136,7 @@ exports[`BookmarkControls render the BookmarkControls should render dirty 1`] = 
                   </button>
                 </Button>
               </StyledComponent>
-            </Button__StyledButton>
+            </Button>
           </ForwardRef>
           <ForwardRef
             bsStyle="default"
@@ -144,7 +144,7 @@ exports[`BookmarkControls render the BookmarkControls should render dirty 1`] = 
             onClick={[Function]}
             title="Empty search"
           >
-            <Button__StyledButton
+            <Button
               bsStyle="default"
               disabled={false}
               onClick={[Function]}
@@ -172,17 +172,17 @@ exports[`BookmarkControls render the BookmarkControls should render dirty 1`] = 
                     ],
                     "attrs": Array [],
                     "componentStyle": ComponentStyle {
-                      "componentId": "Button__StyledButton-c9cbmb-0",
+                      "componentId": "Button-c9cbmb-0",
                       "isStatic": false,
-                      "lastClassName": "kRDLih",
+                      "lastClassName": "GLfOY",
                       "rules": Array [
                         [Function],
                       ],
                     },
-                    "displayName": "Button__StyledButton",
+                    "displayName": "Button",
                     "foldedComponentIds": Array [],
                     "render": [Function],
-                    "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                    "styledComponentId": "Button-c9cbmb-0",
                     "target": [Function],
                     "toString": [Function],
                     "warnTooManyClasses": [Function],
@@ -198,13 +198,13 @@ exports[`BookmarkControls render the BookmarkControls should render dirty 1`] = 
                   block={false}
                   bsClass="btn"
                   bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 kRDLih"
+                  className="Button-c9cbmb-0 GLfOY"
                   disabled={false}
                   onClick={[Function]}
                   title="Empty search"
                 >
                   <button
-                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    className="Button-c9cbmb-0 GLfOY btn btn-default"
                     disabled={false}
                     onClick={[Function]}
                     title="Empty search"
@@ -224,14 +224,14 @@ exports[`BookmarkControls render the BookmarkControls should render dirty 1`] = 
                   </button>
                 </Button>
               </StyledComponent>
-            </Button__StyledButton>
+            </Button>
           </ForwardRef>
           <ForwardRef
             bsStyle="default"
             onClick={[Function]}
             title="Unsaved changes"
           >
-            <Button__StyledButton
+            <Button
               bsStyle="default"
               onClick={[Function]}
               title="Unsaved changes"
@@ -257,17 +257,17 @@ exports[`BookmarkControls render the BookmarkControls should render dirty 1`] = 
                     ],
                     "attrs": Array [],
                     "componentStyle": ComponentStyle {
-                      "componentId": "Button__StyledButton-c9cbmb-0",
+                      "componentId": "Button-c9cbmb-0",
                       "isStatic": false,
-                      "lastClassName": "kRDLih",
+                      "lastClassName": "GLfOY",
                       "rules": Array [
                         [Function],
                       ],
                     },
-                    "displayName": "Button__StyledButton",
+                    "displayName": "Button",
                     "foldedComponentIds": Array [],
                     "render": [Function],
-                    "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                    "styledComponentId": "Button-c9cbmb-0",
                     "target": [Function],
                     "toString": [Function],
                     "warnTooManyClasses": [Function],
@@ -283,13 +283,13 @@ exports[`BookmarkControls render the BookmarkControls should render dirty 1`] = 
                   block={false}
                   bsClass="btn"
                   bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 kRDLih"
+                  className="Button-c9cbmb-0 GLfOY"
                   disabled={false}
                   onClick={[Function]}
                   title="Unsaved changes"
                 >
                   <button
-                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    className="Button-c9cbmb-0 GLfOY btn btn-default"
                     disabled={false}
                     onClick={[Function]}
                     title="Unsaved changes"
@@ -319,14 +319,14 @@ exports[`BookmarkControls render the BookmarkControls should render dirty 1`] = 
                   </button>
                 </Button>
               </StyledComponent>
-            </Button__StyledButton>
+            </Button>
           </ForwardRef>
           <ForwardRef
             bsStyle="default"
             onClick={[Function]}
             title="List of saved searches"
           >
-            <Button__StyledButton
+            <Button
               bsStyle="default"
               onClick={[Function]}
               title="List of saved searches"
@@ -352,17 +352,17 @@ exports[`BookmarkControls render the BookmarkControls should render dirty 1`] = 
                     ],
                     "attrs": Array [],
                     "componentStyle": ComponentStyle {
-                      "componentId": "Button__StyledButton-c9cbmb-0",
+                      "componentId": "Button-c9cbmb-0",
                       "isStatic": false,
-                      "lastClassName": "kRDLih",
+                      "lastClassName": "GLfOY",
                       "rules": Array [
                         [Function],
                       ],
                     },
-                    "displayName": "Button__StyledButton",
+                    "displayName": "Button",
                     "foldedComponentIds": Array [],
                     "render": [Function],
-                    "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                    "styledComponentId": "Button-c9cbmb-0",
                     "target": [Function],
                     "toString": [Function],
                     "warnTooManyClasses": [Function],
@@ -378,13 +378,13 @@ exports[`BookmarkControls render the BookmarkControls should render dirty 1`] = 
                   block={false}
                   bsClass="btn"
                   bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 kRDLih"
+                  className="Button-c9cbmb-0 GLfOY"
                   disabled={false}
                   onClick={[Function]}
                   title="List of saved searches"
                 >
                   <button
-                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    className="Button-c9cbmb-0 GLfOY btn btn-default"
                     disabled={false}
                     onClick={[Function]}
                     title="List of saved searches"
@@ -404,7 +404,7 @@ exports[`BookmarkControls render the BookmarkControls should render dirty 1`] = 
                   </button>
                 </Button>
               </StyledComponent>
-            </Button__StyledButton>
+            </Button>
           </ForwardRef>
         </div>
       </ButtonGroup>
@@ -471,7 +471,7 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty 1`
             onClick={[Function]}
             title="Export to new dashboard"
           >
-            <Button__StyledButton
+            <Button
               bsStyle="default"
               onClick={[Function]}
               title="Export to new dashboard"
@@ -497,17 +497,17 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty 1`
                     ],
                     "attrs": Array [],
                     "componentStyle": ComponentStyle {
-                      "componentId": "Button__StyledButton-c9cbmb-0",
+                      "componentId": "Button-c9cbmb-0",
                       "isStatic": false,
-                      "lastClassName": "kRDLih",
+                      "lastClassName": "GLfOY",
                       "rules": Array [
                         [Function],
                       ],
                     },
-                    "displayName": "Button__StyledButton",
+                    "displayName": "Button",
                     "foldedComponentIds": Array [],
                     "render": [Function],
-                    "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                    "styledComponentId": "Button-c9cbmb-0",
                     "target": [Function],
                     "toString": [Function],
                     "warnTooManyClasses": [Function],
@@ -523,13 +523,13 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty 1`
                   block={false}
                   bsClass="btn"
                   bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 kRDLih"
+                  className="Button-c9cbmb-0 GLfOY"
                   disabled={false}
                   onClick={[Function]}
                   title="Export to new dashboard"
                 >
                   <button
-                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    className="Button-c9cbmb-0 GLfOY btn btn-default"
                     disabled={false}
                     onClick={[Function]}
                     title="Export to new dashboard"
@@ -549,7 +549,7 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty 1`
                   </button>
                 </Button>
               </StyledComponent>
-            </Button__StyledButton>
+            </Button>
           </ForwardRef>
           <ForwardRef
             bsStyle="default"
@@ -557,7 +557,7 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty 1`
             onClick={[Function]}
             title="Empty search"
           >
-            <Button__StyledButton
+            <Button
               bsStyle="default"
               disabled={false}
               onClick={[Function]}
@@ -585,17 +585,17 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty 1`
                     ],
                     "attrs": Array [],
                     "componentStyle": ComponentStyle {
-                      "componentId": "Button__StyledButton-c9cbmb-0",
+                      "componentId": "Button-c9cbmb-0",
                       "isStatic": false,
-                      "lastClassName": "kRDLih",
+                      "lastClassName": "GLfOY",
                       "rules": Array [
                         [Function],
                       ],
                     },
-                    "displayName": "Button__StyledButton",
+                    "displayName": "Button",
                     "foldedComponentIds": Array [],
                     "render": [Function],
-                    "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                    "styledComponentId": "Button-c9cbmb-0",
                     "target": [Function],
                     "toString": [Function],
                     "warnTooManyClasses": [Function],
@@ -611,13 +611,13 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty 1`
                   block={false}
                   bsClass="btn"
                   bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 kRDLih"
+                  className="Button-c9cbmb-0 GLfOY"
                   disabled={false}
                   onClick={[Function]}
                   title="Empty search"
                 >
                   <button
-                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    className="Button-c9cbmb-0 GLfOY btn btn-default"
                     disabled={false}
                     onClick={[Function]}
                     title="Empty search"
@@ -637,14 +637,14 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty 1`
                   </button>
                 </Button>
               </StyledComponent>
-            </Button__StyledButton>
+            </Button>
           </ForwardRef>
           <ForwardRef
             bsStyle="default"
             onClick={[Function]}
             title="Saved search"
           >
-            <Button__StyledButton
+            <Button
               bsStyle="default"
               onClick={[Function]}
               title="Saved search"
@@ -670,17 +670,17 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty 1`
                     ],
                     "attrs": Array [],
                     "componentStyle": ComponentStyle {
-                      "componentId": "Button__StyledButton-c9cbmb-0",
+                      "componentId": "Button-c9cbmb-0",
                       "isStatic": false,
-                      "lastClassName": "kRDLih",
+                      "lastClassName": "GLfOY",
                       "rules": Array [
                         [Function],
                       ],
                     },
-                    "displayName": "Button__StyledButton",
+                    "displayName": "Button",
                     "foldedComponentIds": Array [],
                     "render": [Function],
-                    "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                    "styledComponentId": "Button-c9cbmb-0",
                     "target": [Function],
                     "toString": [Function],
                     "warnTooManyClasses": [Function],
@@ -696,13 +696,13 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty 1`
                   block={false}
                   bsClass="btn"
                   bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 kRDLih"
+                  className="Button-c9cbmb-0 GLfOY"
                   disabled={false}
                   onClick={[Function]}
                   title="Saved search"
                 >
                   <button
-                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    className="Button-c9cbmb-0 GLfOY btn btn-default"
                     disabled={false}
                     onClick={[Function]}
                     title="Saved search"
@@ -732,14 +732,14 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty 1`
                   </button>
                 </Button>
               </StyledComponent>
-            </Button__StyledButton>
+            </Button>
           </ForwardRef>
           <ForwardRef
             bsStyle="default"
             onClick={[Function]}
             title="List of saved searches"
           >
-            <Button__StyledButton
+            <Button
               bsStyle="default"
               onClick={[Function]}
               title="List of saved searches"
@@ -765,17 +765,17 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty 1`
                     ],
                     "attrs": Array [],
                     "componentStyle": ComponentStyle {
-                      "componentId": "Button__StyledButton-c9cbmb-0",
+                      "componentId": "Button-c9cbmb-0",
                       "isStatic": false,
-                      "lastClassName": "kRDLih",
+                      "lastClassName": "GLfOY",
                       "rules": Array [
                         [Function],
                       ],
                     },
-                    "displayName": "Button__StyledButton",
+                    "displayName": "Button",
                     "foldedComponentIds": Array [],
                     "render": [Function],
-                    "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                    "styledComponentId": "Button-c9cbmb-0",
                     "target": [Function],
                     "toString": [Function],
                     "warnTooManyClasses": [Function],
@@ -791,13 +791,13 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty 1`
                   block={false}
                   bsClass="btn"
                   bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 kRDLih"
+                  className="Button-c9cbmb-0 GLfOY"
                   disabled={false}
                   onClick={[Function]}
                   title="List of saved searches"
                 >
                   <button
-                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    className="Button-c9cbmb-0 GLfOY btn btn-default"
                     disabled={false}
                     onClick={[Function]}
                     title="List of saved searches"
@@ -817,7 +817,7 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty 1`
                   </button>
                 </Button>
               </StyledComponent>
-            </Button__StyledButton>
+            </Button>
           </ForwardRef>
         </div>
       </ButtonGroup>
@@ -884,7 +884,7 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty wi
             onClick={[Function]}
             title="Export to new dashboard"
           >
-            <Button__StyledButton
+            <Button
               bsStyle="default"
               onClick={[Function]}
               title="Export to new dashboard"
@@ -910,17 +910,17 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty wi
                     ],
                     "attrs": Array [],
                     "componentStyle": ComponentStyle {
-                      "componentId": "Button__StyledButton-c9cbmb-0",
+                      "componentId": "Button-c9cbmb-0",
                       "isStatic": false,
-                      "lastClassName": "kRDLih",
+                      "lastClassName": "GLfOY",
                       "rules": Array [
                         [Function],
                       ],
                     },
-                    "displayName": "Button__StyledButton",
+                    "displayName": "Button",
                     "foldedComponentIds": Array [],
                     "render": [Function],
-                    "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                    "styledComponentId": "Button-c9cbmb-0",
                     "target": [Function],
                     "toString": [Function],
                     "warnTooManyClasses": [Function],
@@ -936,13 +936,13 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty wi
                   block={false}
                   bsClass="btn"
                   bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 kRDLih"
+                  className="Button-c9cbmb-0 GLfOY"
                   disabled={false}
                   onClick={[Function]}
                   title="Export to new dashboard"
                 >
                   <button
-                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    className="Button-c9cbmb-0 GLfOY btn btn-default"
                     disabled={false}
                     onClick={[Function]}
                     title="Export to new dashboard"
@@ -962,7 +962,7 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty wi
                   </button>
                 </Button>
               </StyledComponent>
-            </Button__StyledButton>
+            </Button>
           </ForwardRef>
           <ForwardRef
             bsStyle="default"
@@ -970,7 +970,7 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty wi
             onClick={[Function]}
             title="Empty search"
           >
-            <Button__StyledButton
+            <Button
               bsStyle="default"
               disabled={true}
               onClick={[Function]}
@@ -998,17 +998,17 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty wi
                     ],
                     "attrs": Array [],
                     "componentStyle": ComponentStyle {
-                      "componentId": "Button__StyledButton-c9cbmb-0",
+                      "componentId": "Button-c9cbmb-0",
                       "isStatic": false,
-                      "lastClassName": "kRDLih",
+                      "lastClassName": "GLfOY",
                       "rules": Array [
                         [Function],
                       ],
                     },
-                    "displayName": "Button__StyledButton",
+                    "displayName": "Button",
                     "foldedComponentIds": Array [],
                     "render": [Function],
-                    "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                    "styledComponentId": "Button-c9cbmb-0",
                     "target": [Function],
                     "toString": [Function],
                     "warnTooManyClasses": [Function],
@@ -1024,13 +1024,13 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty wi
                   block={false}
                   bsClass="btn"
                   bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 kRDLih"
+                  className="Button-c9cbmb-0 GLfOY"
                   disabled={true}
                   onClick={[Function]}
                   title="Empty search"
                 >
                   <button
-                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    className="Button-c9cbmb-0 GLfOY btn btn-default"
                     disabled={true}
                     onClick={[Function]}
                     title="Empty search"
@@ -1050,14 +1050,14 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty wi
                   </button>
                 </Button>
               </StyledComponent>
-            </Button__StyledButton>
+            </Button>
           </ForwardRef>
           <ForwardRef
             bsStyle="default"
             onClick={[Function]}
             title="Save search"
           >
-            <Button__StyledButton
+            <Button
               bsStyle="default"
               onClick={[Function]}
               title="Save search"
@@ -1083,17 +1083,17 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty wi
                     ],
                     "attrs": Array [],
                     "componentStyle": ComponentStyle {
-                      "componentId": "Button__StyledButton-c9cbmb-0",
+                      "componentId": "Button-c9cbmb-0",
                       "isStatic": false,
-                      "lastClassName": "kRDLih",
+                      "lastClassName": "GLfOY",
                       "rules": Array [
                         [Function],
                       ],
                     },
-                    "displayName": "Button__StyledButton",
+                    "displayName": "Button",
                     "foldedComponentIds": Array [],
                     "render": [Function],
-                    "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                    "styledComponentId": "Button-c9cbmb-0",
                     "target": [Function],
                     "toString": [Function],
                     "warnTooManyClasses": [Function],
@@ -1109,13 +1109,13 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty wi
                   block={false}
                   bsClass="btn"
                   bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 kRDLih"
+                  className="Button-c9cbmb-0 GLfOY"
                   disabled={false}
                   onClick={[Function]}
                   title="Save search"
                 >
                   <button
-                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    className="Button-c9cbmb-0 GLfOY btn btn-default"
                     disabled={false}
                     onClick={[Function]}
                     title="Save search"
@@ -1145,14 +1145,14 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty wi
                   </button>
                 </Button>
               </StyledComponent>
-            </Button__StyledButton>
+            </Button>
           </ForwardRef>
           <ForwardRef
             bsStyle="default"
             onClick={[Function]}
             title="List of saved searches"
           >
-            <Button__StyledButton
+            <Button
               bsStyle="default"
               onClick={[Function]}
               title="List of saved searches"
@@ -1178,17 +1178,17 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty wi
                     ],
                     "attrs": Array [],
                     "componentStyle": ComponentStyle {
-                      "componentId": "Button__StyledButton-c9cbmb-0",
+                      "componentId": "Button-c9cbmb-0",
                       "isStatic": false,
-                      "lastClassName": "kRDLih",
+                      "lastClassName": "GLfOY",
                       "rules": Array [
                         [Function],
                       ],
                     },
-                    "displayName": "Button__StyledButton",
+                    "displayName": "Button",
                     "foldedComponentIds": Array [],
                     "render": [Function],
-                    "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                    "styledComponentId": "Button-c9cbmb-0",
                     "target": [Function],
                     "toString": [Function],
                     "warnTooManyClasses": [Function],
@@ -1204,13 +1204,13 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty wi
                   block={false}
                   bsClass="btn"
                   bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 kRDLih"
+                  className="Button-c9cbmb-0 GLfOY"
                   disabled={false}
                   onClick={[Function]}
                   title="List of saved searches"
                 >
                   <button
-                    className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    className="Button-c9cbmb-0 GLfOY btn btn-default"
                     disabled={false}
                     onClick={[Function]}
                     title="List of saved searches"
@@ -1230,7 +1230,7 @@ exports[`BookmarkControls render the BookmarkControls should render not dirty wi
                   </button>
                 </Button>
               </StyledComponent>
-            </Button__StyledButton>
+            </Button>
           </ForwardRef>
         </div>
       </ButtonGroup>

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkForm.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkForm.test.jsx.snap
@@ -54,7 +54,7 @@ exports[`BookmarkForm render the BookmarkForm should render create new 1`] = `
             />
           </div>
           <button
-            className="button Button__StyledButton-c9cbmb-0 kRDLih btn btn-info"
+            className="button Button-c9cbmb-0 GLfOY btn btn-info"
             disabled={false}
             onClick={[Function]}
             type="submit"
@@ -62,7 +62,7 @@ exports[`BookmarkForm render the BookmarkForm should render create new 1`] = `
             Create new
           </button>
           <button
-            className="button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+            className="button Button-c9cbmb-0 GLfOY btn btn-default"
             disabled={false}
             onClick={[Function]}
             type="button"
@@ -130,7 +130,7 @@ exports[`BookmarkForm render the BookmarkForm should render disabled create new 
             />
           </div>
           <button
-            className="button Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
+            className="button Button-c9cbmb-0 GLfOY btn btn-primary"
             disabled={false}
             onClick={[Function]}
             type="submit"
@@ -138,7 +138,7 @@ exports[`BookmarkForm render the BookmarkForm should render disabled create new 
             Save
           </button>
           <button
-            className="button Button__StyledButton-c9cbmb-0 kRDLih btn btn-info"
+            className="button Button-c9cbmb-0 GLfOY btn btn-info"
             disabled={true}
             onClick={[Function]}
             type="submit"
@@ -146,7 +146,7 @@ exports[`BookmarkForm render the BookmarkForm should render disabled create new 
             Save as
           </button>
           <button
-            className="button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+            className="button Button-c9cbmb-0 GLfOY btn btn-default"
             disabled={false}
             onClick={[Function]}
             type="button"
@@ -214,7 +214,7 @@ exports[`BookmarkForm render the BookmarkForm should render save 1`] = `
             />
           </div>
           <button
-            className="button Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
+            className="button Button-c9cbmb-0 GLfOY btn btn-primary"
             disabled={false}
             onClick={[Function]}
             type="submit"
@@ -222,7 +222,7 @@ exports[`BookmarkForm render the BookmarkForm should render save 1`] = `
             Save
           </button>
           <button
-            className="button Button__StyledButton-c9cbmb-0 kRDLih btn btn-info"
+            className="button Button-c9cbmb-0 GLfOY btn btn-info"
             disabled={false}
             onClick={[Function]}
             type="submit"
@@ -230,7 +230,7 @@ exports[`BookmarkForm render the BookmarkForm should render save 1`] = `
             Save as
           </button>
           <button
-            className="button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+            className="button Button-c9cbmb-0 GLfOY btn btn-default"
             disabled={false}
             onClick={[Function]}
             type="button"

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkList.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkList.test.jsx.snap
@@ -56,7 +56,7 @@ exports[`BookmarkList render the BookmarkList should render empty 1`] = `
                   style="margin-left: 5px;"
                 >
                   <button
-                    class="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    class="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
                     type="submit"
                   >
                     Search
@@ -67,7 +67,7 @@ exports[`BookmarkList render the BookmarkList should render empty 1`] = `
                   style="margin-left: 5px;"
                 >
                   <button
-                    class="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    class="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
                     type="reset"
                   >
                     Reset
@@ -199,21 +199,21 @@ exports[`BookmarkList render the BookmarkList should render empty 1`] = `
             class="modal-footer"
           >
             <button
-              class="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
+              class="Button-c9cbmb-0 GLfOY btn btn-primary"
               disabled=""
               type="button"
             >
               Load
             </button>
             <button
-              class="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+              class="Button-c9cbmb-0 GLfOY btn btn-default"
               disabled=""
               type="button"
             >
               Delete
             </button>
             <button
-              class="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+              class="Button-c9cbmb-0 GLfOY btn btn-default"
               type="button"
             >
               Cancel
@@ -282,7 +282,7 @@ exports[`BookmarkList render the BookmarkList should render with views 1`] = `
                   style="margin-left: 5px;"
                 >
                   <button
-                    class="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    class="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
                     type="submit"
                   >
                     Search
@@ -293,7 +293,7 @@ exports[`BookmarkList render the BookmarkList should render with views 1`] = `
                   style="margin-left: 5px;"
                 >
                   <button
-                    class="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    class="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
                     type="reset"
                   >
                     Reset
@@ -348,7 +348,7 @@ exports[`BookmarkList render the BookmarkList should render with views 1`] = `
                 class="list-group"
               >
                 <button
-                  class="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+                  class="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
                   type="button"
                 >
                   <h4
@@ -449,21 +449,21 @@ exports[`BookmarkList render the BookmarkList should render with views 1`] = `
             class="modal-footer"
           >
             <button
-              class="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
+              class="Button-c9cbmb-0 GLfOY btn btn-primary"
               disabled=""
               type="button"
             >
               Load
             </button>
             <button
-              class="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+              class="Button-c9cbmb-0 GLfOY btn btn-default"
               disabled=""
               type="button"
             >
               Delete
             </button>
             <button
-              class="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+              class="Button-c9cbmb-0 GLfOY btn btn-default"
               type="button"
             >
               Cancel

--- a/graylog2-web-interface/src/views/components/widgets/__snapshots__/CopyToDashboardForm.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/widgets/__snapshots__/CopyToDashboardForm.test.jsx.snap
@@ -56,7 +56,7 @@ exports[`CopyToDashboardForm should render the modal minimal 1`] = `
                   style="margin-left: 5px;"
                 >
                   <button
-                    class="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    class="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
                     type="submit"
                   >
                     Search
@@ -67,7 +67,7 @@ exports[`CopyToDashboardForm should render the modal minimal 1`] = `
                   style="margin-left: 5px;"
                 >
                   <button
-                    class="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    class="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
                     type="reset"
                   >
                     Reset
@@ -199,14 +199,14 @@ exports[`CopyToDashboardForm should render the modal minimal 1`] = `
             class="modal-footer"
           >
             <button
-              class="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
+              class="Button-c9cbmb-0 GLfOY btn btn-primary"
               disabled=""
               type="button"
             >
               Select
             </button>
             <button
-              class="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+              class="Button-c9cbmb-0 GLfOY btn btn-default"
               type="button"
             >
               Cancel
@@ -275,7 +275,7 @@ exports[`CopyToDashboardForm should render the modal with entries 1`] = `
                   style="margin-left: 5px;"
                 >
                   <button
-                    class="submit-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    class="submit-button Button-c9cbmb-0 GLfOY btn btn-default"
                     type="submit"
                   >
                     Search
@@ -286,7 +286,7 @@ exports[`CopyToDashboardForm should render the modal with entries 1`] = `
                   style="margin-left: 5px;"
                 >
                   <button
-                    class="reset-button Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+                    class="reset-button Button-c9cbmb-0 GLfOY btn btn-default"
                     type="reset"
                   >
                     Reset
@@ -341,7 +341,7 @@ exports[`CopyToDashboardForm should render the modal with entries 1`] = `
                 class="list-group"
               >
                 <button
-                  class="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+                  class="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
                   type="button"
                 >
                   <h4
@@ -354,7 +354,7 @@ exports[`CopyToDashboardForm should render the modal with entries 1`] = `
                   />
                 </button>
                 <button
-                  class="ListGroupItem__StyledListGroupItem-sc-1ky0joo-0 THrbj list-group-item"
+                  class="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
                   type="button"
                 >
                   <h4
@@ -455,14 +455,14 @@ exports[`CopyToDashboardForm should render the modal with entries 1`] = `
             class="modal-footer"
           >
             <button
-              class="Button__StyledButton-c9cbmb-0 kRDLih btn btn-primary"
+              class="Button-c9cbmb-0 GLfOY btn btn-primary"
               disabled=""
               type="button"
             >
               Select
             </button>
             <button
-              class="Button__StyledButton-c9cbmb-0 kRDLih btn btn-default"
+              class="Button-c9cbmb-0 GLfOY btn btn-default"
               type="button"
             >
               Cancel

--- a/graylog2-web-interface/src/views/hooks/__snapshots__/RequirementsProvided.test.jsx.snap
+++ b/graylog2-web-interface/src/views/hooks/__snapshots__/RequirementsProvided.test.jsx.snap
@@ -109,7 +109,7 @@ exports[`RequirementsProvided throws Component if not all requirements are provi
                 onClick={[Function]}
                 type="submit"
               >
-                <Button__StyledButton
+                <Button
                   action="push"
                   bsStyle="success"
                   onClick={[Function]}
@@ -137,17 +137,17 @@ exports[`RequirementsProvided throws Component if not all requirements are provi
                         ],
                         "attrs": Array [],
                         "componentStyle": ComponentStyle {
-                          "componentId": "Button__StyledButton-c9cbmb-0",
+                          "componentId": "Button-c9cbmb-0",
                           "isStatic": false,
-                          "lastClassName": "kRDLih",
+                          "lastClassName": "GLfOY",
                           "rules": Array [
                             [Function],
                           ],
                         },
-                        "displayName": "Button__StyledButton",
+                        "displayName": "Button",
                         "foldedComponentIds": Array [],
                         "render": [Function],
-                        "styledComponentId": "Button__StyledButton-c9cbmb-0",
+                        "styledComponentId": "Button-c9cbmb-0",
                         "target": [Function],
                         "toString": [Function],
                         "warnTooManyClasses": [Function],
@@ -164,14 +164,14 @@ exports[`RequirementsProvided throws Component if not all requirements are provi
                       block={false}
                       bsClass="btn"
                       bsStyle="success"
-                      className="Button__StyledButton-c9cbmb-0 kRDLih"
+                      className="Button-c9cbmb-0 GLfOY"
                       disabled={false}
                       onClick={[Function]}
                       type="submit"
                     >
                       <button
                         action="push"
-                        className="Button__StyledButton-c9cbmb-0 kRDLih btn btn-success"
+                        className="Button-c9cbmb-0 GLfOY btn btn-success"
                         disabled={false}
                         onClick={[Function]}
                         type="submit"
@@ -180,7 +180,7 @@ exports[`RequirementsProvided throws Component if not all requirements are provi
                       </button>
                     </Button>
                   </StyledComponent>
-                </Button__StyledButton>
+                </Button>
               </ForwardRef>
             </LinkContainer>
           </div>


### PR DESCRIPTION
Replace `useCallback` hook with `useMemo`, which memoizes the results of the function until some of the given values change.

This is a first step to help with performance problems described in #6881.