### PR TITLE
Adjust ErrorWidget layout gabs and add basic component test

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/ErrorWidget.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/ErrorWidget.jsx
@@ -1,6 +1,7 @@
 // @flow strict
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
 import { Icon } from 'components/common';
 import { WidgetErrorsList } from './WidgetPropTypes';
@@ -16,16 +17,32 @@ type Props = {
   title?: string,
 };
 
+const Description = styled.div`
+  max-width: 700px;
+`;
+
+const ErrorList = styled.ul`
+  padding: 0;
+`;
+
+const Row = styled.div`
+  margin-bottom: 5px;
+  :last-child {
+    margin-bottom: 0;
+  }
+`;
+
 const ErrorWidget = ({ errors, title }: Props) => (
   <div className={styles.spinnerContainer}>
     <Icon name="exclamation-triangle" size="3x" className={styles.iconMargin} />
-    <span>
-      <strong>{title}</strong>
-
-      <ul>
-        {errors.map(e => <li key={e.description}>{e.description}</li>)}
-      </ul>
-    </span>
+    <Description>
+      <Row>
+        <strong>{title}</strong>
+      </Row>
+      <ErrorList>
+        {errors.map(e => <Row as="li" key={e.description}>{e.description}</Row>)}
+      </ErrorList>
+    </Description>
   </div>
 );
 

--- a/graylog2-web-interface/src/views/components/widgets/ErrorWidget.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/ErrorWidget.test.jsx
@@ -1,3 +1,4 @@
+// @flow strict
 import React from 'react';
 import { mount } from 'enzyme';
 

--- a/graylog2-web-interface/src/views/components/widgets/ErrorWidget.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/ErrorWidget.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import SearchError from 'views/logic/SearchError';
+import ErrorWidget from './ErrorWidget';
+
+describe('<ErrorWidget />', () => {
+  it('should display a list item for every provided error', () => {
+    const errors = [
+      new SearchError({ description: 'The first error' }),
+      new SearchError({ description: 'The second error' }),
+    ];
+
+    const wrapper = mount(<ErrorWidget errors={errors} />);
+    const firstListItem = wrapper.find('li').at(0);
+    const secondListItem = wrapper.find('li').at(1);
+
+    expect(firstListItem.text()).toContain(errors[0].description);
+    expect(secondListItem.text()).toContain(errors[1].description);
+  });
+});

--- a/graylog2-web-interface/src/views/components/widgets/MessageWidgets.css
+++ b/graylog2-web-interface/src/views/components/widgets/MessageWidgets.css
@@ -6,5 +6,6 @@
 }
 
 :local(.iconMargin) {
-    margin-right: 1rem;
+    margin-right: 15px;
+    margin: 3px 15px 0 0;
 }


### PR DESCRIPTION
Right now the ErrorWidget error list has a big gab to the left. This PR improves all gabs. It also adds flow and a basic unit test.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
