### PR TITLE
Add missing HTTPJsonPath Data adapter type

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/lookup/LookupTableResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/lookup/LookupTableResource.java
@@ -89,6 +89,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Collections.singleton;
@@ -142,6 +143,7 @@ public class LookupTableResource extends RestResource {
     private final DBCacheService dbCacheService;
     private final Map<String, LookupCache.Factory> cacheTypes;
     private final Map<String, LookupDataAdapter.Factory> dataAdapterTypes;
+    private final Map<String, LookupDataAdapter.Factory2> dataAdapterTypes2;
     private final SearchQueryParser lutSearchQueryParser;
     private final SearchQueryParser adapterSearchQueryParser;
     private final SearchQueryParser cacheSearchQueryParser;
@@ -153,12 +155,14 @@ public class LookupTableResource extends RestResource {
                                DBCacheService dbCacheService,
                                Map<String, LookupCache.Factory> cacheTypes,
                                Map<String, LookupDataAdapter.Factory> dataAdapterTypes,
+                               Map<String, LookupDataAdapter.Factory2> dataAdapterTypes2,
                                LookupTableService lookupTableService) {
         this.dbTableService = dbTableService;
         this.dbDataAdapterService = dbDataAdapterService;
         this.dbCacheService = dbCacheService;
         this.cacheTypes = cacheTypes;
         this.dataAdapterTypes = dataAdapterTypes;
+        this.dataAdapterTypes2 = dataAdapterTypes2;
         this.lookupTableService = lookupTableService;
         this.lutSearchQueryParser = new SearchQueryParser(LookupTableDto.FIELD_TITLE, LUT_SEARCH_FIELD_MAPPING);
         this.adapterSearchQueryParser = new SearchQueryParser(DataAdapterDto.FIELD_TITLE, ADAPTER_SEARCH_FIELD_MAPPING);
@@ -461,8 +465,9 @@ public class LookupTableResource extends RestResource {
     @RequiresPermissions(RestPermissions.LOOKUP_TABLES_READ)
     public Map<String, LookupDataAdapter.Descriptor> availableAdapterTypes() {
 
-        return dataAdapterTypes.values().stream()
-                .map(LookupDataAdapter.Factory::getDescriptor)
+        final Stream<LookupDataAdapter.Descriptor> stream1 = dataAdapterTypes.values().stream().map(LookupDataAdapter.Factory::getDescriptor);
+        final Stream<LookupDataAdapter.Descriptor> stream2 = dataAdapterTypes2.values().stream().map(LookupDataAdapter.Factory2::getDescriptor);
+        return Stream.concat(stream1, stream2)
                 .collect(Collectors.toMap(LookupDataAdapter.Descriptor::getType, Function.identity()));
 
     }


### PR DESCRIPTION
While introducing a new Factory2 in PR #6518
we forgot to return the types for data adapters that
use this factory.
This prevented us from creating new HTTPJsonPath Data adapters.
