### PR TITLE
Implement bootstrap grid component for extended search page

### DIFF
--- a/graylog2-web-interface/public/stylesheets/graylog2.less
+++ b/graylog2-web-interface/public/stylesheets/graylog2.less
@@ -9,8 +9,8 @@ body {
   font-family: 'Open Sans', sans-serif;
   font-size: 12px;
   overflow-x: hidden;
-  margin-top: 45px;
-  min-height: calc(100vh - 45px);
+  margin-top: 50px;
+  min-height: calc(100vh - 50px);
 }
 
 ul {

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
@@ -45,7 +45,7 @@ const DashboardSearchBar = ({ config, currentQuery, disableSearch = false, onExe
 
   return (
     <ScrollToHint value={query.query_string || ''}>
-      <Row className="content" style={{ marginRight: 0, marginLeft: 0 }}>
+      <Row className="content">
         <Col md={12}>
           <form method="GET" onSubmit={submitForm}>
             <Row className="no-bm">

--- a/graylog2-web-interface/src/views/components/Query.jsx
+++ b/graylog2-web-interface/src/views/components/Query.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Immutable from 'immutable';
 import DocsHelper from 'util/DocsHelper';
 
-import { Col, Row, Jumbotron } from 'components/graylog';
+import { Jumbotron } from 'components/graylog';
 import { CurrentViewStateActions } from 'views/stores/CurrentViewStateStore';
 import { Spinner } from 'components/common';
 import { widgetDefinition } from 'views/logic/Widgets';
@@ -66,38 +66,34 @@ const _renderWidgetGrid = (widgetDefs, widgetMapping, results, positions, queryI
 };
 
 const EmptyDashboardInfo = () => (
-  <Row className="content" style={{ marginRight: 0, marginLeft: 0 }}>
-    <Col md={12}>
-      <Jumbotron style={{ marginBottom: 0 }}>
-        <h2>
-          <IfDashboard>
-            This dashboard has no widgets yet
-          </IfDashboard>
-          <IfSearch>
-            There are no widgets defined to visualize the search result
-          </IfSearch>
-        </h2>
-        <br />
-        <p>
-          Create a new widget by selecting a widget type in the left sidebar section &quot;Create&quot;.<br />
-        </p>
-        <p>
-          A few tips for creating searches and dashboards
-        </p>
-        <ul>
-          <li><p>1. Start with a <b>question</b> you want to answer. Define the problem you want to solve.</p></li>
-          <li><p>2. <b>Limit</b> the data to only the data points you want to see.</p></li>
-          <li><p>3. <b>Visualize</b> the data. Does it answer your question?</p></li>
-          <IfDashboard>
-            <li><p>4. <b>Share</b> the dashboard with your colleagues. Prepare it for <b>reuse</b> by using parameters (contained in <a href="https://www.graylog.org/graylog-enterprise-edition" target="_blank" rel="noopener noreferrer">Graylog Enterprise</a>).</p></li>
-          </IfDashboard>
-        </ul>
-        <p>
-          You can also have a look at the <DocumentationLink page={DocsHelper.PAGES.DASHBOARDS} text="documentation" />, to learn more about the widget creation.
-        </p>
-      </Jumbotron>
-    </Col>
-  </Row>
+  <Jumbotron style={{ marginBottom: 0 }}>
+    <h2>
+      <IfDashboard>
+        This dashboard has no widgets yet
+      </IfDashboard>
+      <IfSearch>
+        There are no widgets defined to visualize the search result
+      </IfSearch>
+    </h2>
+    <br />
+    <p>
+      Create a new widget by selecting a widget type in the left sidebar section &quot;Create&quot;.<br />
+    </p>
+    <p>
+      A few tips for creating searches and dashboards
+    </p>
+    <ul>
+      <li><p>1. Start with a <b>question</b> you want to answer. Define the problem you want to solve.</p></li>
+      <li><p>2. <b>Limit</b> the data to only the data points you want to see.</p></li>
+      <li><p>3. <b>Visualize</b> the data. Does it answer your question?</p></li>
+      <IfDashboard>
+        <li><p>4. <b>Share</b> the dashboard with your colleagues. Prepare it for <b>reuse</b> by using parameters (contained in <a href="https://www.graylog.org/graylog-enterprise-edition" target="_blank" rel="noopener noreferrer">Graylog Enterprise</a>).</p></li>
+      </IfDashboard>
+    </ul>
+    <p>
+      You can also have a look at the <DocumentationLink page={DocsHelper.PAGES.DASHBOARDS} text="documentation" />, to learn more about the widget creation.
+    </p>
+  </Jumbotron>
 );
 
 

--- a/graylog2-web-interface/src/views/components/QueryTabs.jsx
+++ b/graylog2-web-interface/src/views/components/QueryTabs.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import * as Immutable from 'immutable';
 import PropTypes from 'prop-types';
 
-import { Tab, Tabs } from 'components/graylog';
+import { Tab, Tabs, Col, Row } from 'components/graylog';
 import ViewActionsMenu from 'views/components/ViewActionsMenu';
 import QueryTitle from 'views/components/queries/QueryTitle';
 import QueryTitleEditModal from 'views/components/queries/QueryTitleEditModal';
@@ -27,6 +27,8 @@ type Props = {
 }
 
 class QueryTabs extends React.Component<Props> {
+  queryTitleEditModal: ?QueryTitleEditModal
+
   static propTypes = {
     children: PropTypes.node,
     onRemove: PropTypes.func.isRequired,
@@ -42,8 +44,6 @@ class QueryTabs extends React.Component<Props> {
   static defaultProps = {
     children: null,
   }
-
-  queryTitleEditModal: ?QueryTitleEditModal
 
   openTitleEditModal = (activeQueryTitle: string) => {
     if (this.queryTitleEditModal) {
@@ -87,24 +87,26 @@ class QueryTabs extends React.Component<Props> {
     const tabs = [queryTabs, newTab];
 
     return (
-      <span>
-        <span className="pull-right">
-          <ViewActionsMenu onSaveView={onSaveView} onSaveAsView={onSaveAsView} />
-        </span>
-        <Tabs activeKey={selectedQueryId}
-              animation={false}
-              id="QueryTabs"
-              onSelect={onSelect}>
-          {tabs}
-        </Tabs>
-        {/*
+      <Row style={{ marginBottom: 0 }}>
+        <Col>
+          <span className="pull-right">
+            <ViewActionsMenu onSaveView={onSaveView} onSaveAsView={onSaveAsView} />
+          </span>
+          <Tabs activeKey={selectedQueryId}
+                animation={false}
+                id="QueryTabs"
+                onSelect={onSelect}>
+            {tabs}
+          </Tabs>
+          {/*
           The title edit modal can't be part of the QueryTitle component,
           due to the react bootstrap tabs keybindings.
           The input would always lose the focus when using the arrow keys.
         */}
-        <QueryTitleEditModal onTitleChange={(newTitle: string) => onTitleChange(selectedQueryId, newTitle)}
-                             ref={(queryTitleEditModal) => { this.queryTitleEditModal = queryTitleEditModal; }} />
-      </span>
+          <QueryTitleEditModal onTitleChange={(newTitle: string) => onTitleChange(selectedQueryId, newTitle)}
+                               ref={(queryTitleEditModal) => { this.queryTitleEditModal = queryTitleEditModal; }} />
+        </Col>
+      </Row>
     );
   }
 }

--- a/graylog2-web-interface/src/views/components/SearchBar.jsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.jsx
@@ -57,7 +57,7 @@ const SearchBar = ({ availableStreams, config, currentQuery, disableSearch = fal
 
   return (
     <ScrollToHint value={query.query_string}>
-      <Row className="content" style={{ marginRight: 0, marginLeft: 0 }}>
+      <Row className="content">
         <Col md={12}>
           <Row className="no-bm">
             <Col md={12}>

--- a/graylog2-web-interface/src/views/components/SearchResult.jsx
+++ b/graylog2-web-interface/src/views/components/SearchResult.jsx
@@ -11,12 +11,13 @@ import { SearchStore } from 'views/stores/SearchStore';
 import { CurrentViewStateStore } from 'views/stores/CurrentViewStateStore';
 import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 import { WidgetStore } from 'views/stores/WidgetStore';
-import LoadingIndicator from 'components/common/LoadingIndicator';
 import { SearchLoadingStateStore } from 'views/stores/SearchLoadingStateStore';
 import type { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
 import type { QueryId } from 'views/logic/queries/Query';
 import ViewState from 'views/logic/views/ViewState';
 import TSearchResult from 'views/logic/SearchResult';
+import LoadingIndicator from 'components/common/LoadingIndicator';
+import { Row, Col } from 'components/graylog';
 
 const SearchLoadingIndicator = connect(
   ({ searchLoadingState }) => (searchLoadingState.isLoading && <LoadingIndicator text="Updating search results..." />),
@@ -58,10 +59,12 @@ const SearchResult = React.memo(({ fieldTypes, queryId, searches, viewState }: P
   ) : <Spinner />;
 
   return (
-    <React.Fragment>
-      {content}
-      <SearchLoadingIndicator />
-    </React.Fragment>
+    <Row>
+      <Col>
+        {content}
+        <SearchLoadingIndicator />
+      </Col>
+    </Row>
   );
 });
 

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -15,6 +15,7 @@ import type {
 } from 'views/logic/hooks/SearchRefreshCondition';
 import Footer from 'components/layout/Footer';
 
+import { Grid } from 'components/graylog';
 import { FieldTypesStore, FieldTypesActions } from 'views/stores/FieldTypesStore';
 import { SearchStore, SearchActions } from 'views/stores/SearchStore';
 import { SearchExecutionStateStore } from 'views/stores/SearchExecutionStateStore';
@@ -51,12 +52,17 @@ const GridContainer: ComponentType<{ interactive: boolean }> = styled.div`
   ` : '')}
 `;
 
-const SearchGrid = styled.div`
-  z-index: 1;
-  padding: 15px;
+const SearchArea = styled.div`
   grid-area: search;
   grid-column-start: 2;
   grid-column-end: 4;
+  padding: 15px;
+
+  z-index: 1;
+`;
+
+const SearchGrid = styled(Grid)`
+  width: 100%;
 `;
 
 const ConnectedSideBar = connect(SideBar, { viewMetadata: ViewMetadataStore, searches: SearchStore },
@@ -147,25 +153,27 @@ const ExtendedSearchPage = ({ route, searchRefreshHooks }: Props) => {
                 <ConnectedFieldList />
               </ConnectedSideBar>
             </IfInteractive>
-            <SearchGrid>
-              <IfInteractive>
-                <HeaderElements />
-                <IfDashboard>
-                  <DashboardSearchBarWithStatus onExecute={refreshIfNotUndeclared} />
-                  <QueryBar />
-                </IfDashboard>
-                <IfSearch>
-                  <SearchBarWithStatus onExecute={refreshIfNotUndeclared} />
-                </IfSearch>
+            <SearchArea>
+              <SearchGrid>
+                <IfInteractive>
+                  <HeaderElements />
+                  <IfDashboard>
+                    <DashboardSearchBarWithStatus onExecute={refreshIfNotUndeclared} />
+                    <QueryBar />
+                  </IfDashboard>
+                  <IfSearch>
+                    <SearchBarWithStatus onExecute={refreshIfNotUndeclared} />
+                  </IfSearch>
 
-                <QueryBarElements />
-              </IfInteractive>
+                  <QueryBarElements />
+                </IfInteractive>
 
-              <ViewAdditionalContextProvider>
-                <SearchResult />
-              </ViewAdditionalContextProvider>
-              <Footer />
-            </SearchGrid>
+                <ViewAdditionalContextProvider>
+                  <SearchResult />
+                </ViewAdditionalContextProvider>
+                <Footer />
+              </SearchGrid>
+            </SearchArea>
           </GridContainer>
         )}
       </InteractiveContext.Consumer>


### PR DESCRIPTION
I just had to deal with the extended search page grid once again, while implementing a new component. I already had a look at the grid in the past, when refactoring the SearchBar layout.

The main issue right now is, that we are using `<Row>` and `<Col>` components without the needed `<Grid>` component. This is also the reason we are using `margin-left: 0; margin-right 0;` for a few rows inside the extended search page.

I just added the `<Grid>` component and some `<Row>` and `<Col>` components, where needed.
This also resolves the padding issue with the parameters box.

Right now we are using the `<Row>` and `<Col>` components mostly inside each component. In this case we need keep in mind to add the outer `<Grid>` component. A different approach is to not use the row and col component inside each component, but inside the e.g. extended search page. But I think this discussion is something for the next frontend checkin.

After merging this PR, we can remove `marginRight: 0, marginLeft: 0` in ParameterBar in the enterprise plugin as well.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
