### PR TITLE
Update to netty 4.1.43 and netty-tcnative-boringssl 2.0.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,8 +131,8 @@
         <mongodb-driver.version>3.6.4</mongodb-driver.version>
         <mongojack.version>2.10.0</mongojack.version>
         <natty.version>0.13</natty.version>
-        <netty.version>4.1.42.Final</netty.version>
-        <netty-tcnative-boringssl-static.version>2.0.26.Final</netty-tcnative-boringssl-static.version>
+        <netty.version>4.1.43.Final</netty.version>
+        <netty-tcnative-boringssl-static.version>2.0.28.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>3.14.2</okhttp.version>
         <opencsv.version>2.3</opencsv.version>
         <os-platform-finder.version>1.2.3</os-platform-finder.version>


### PR DESCRIPTION
Includes bug fixes and performance improvements.

https://netty.io/news/2019/10/24/4-1-43-Final.html