### PR TITLE
Fall back to first search type result to extract effective timerange.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.jsx
@@ -61,7 +61,7 @@ const AggregationBuilder = ({ config, data, editing = false, fields, onVisualiza
   }
 
   const VisComponent = _visualizationForType(config.visualization || defaultVisualizationType);
-  const { effective_timerange: effectiveTimerange } = data && data.chart ? data.chart : {};
+  const { effective_timerange: effectiveTimerange } = data.chart || Object.values(data)[0] || {};
   const rows = Object.entries(data)
     .map(
       // $FlowFixMe: map claims it's `mixed`, we know it's `Result`

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.test.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.test.jsx
@@ -63,4 +63,18 @@ describe('AggregationBuilder', () => {
     expect(wrapper.find(EmptyAggregationContent)).toHaveLength(1);
     expect(wrapper.find(EmptyAggregationContent)).toHaveProp('editing', false);
   });
+  it('falls back to retrieving effective timerange from first result if no `chart` result present', () => {
+    const data = {
+      '524d182c-8e32-4372-b30d-a40d99efe55d': {
+        total: 42,
+        rows: [{ value: 3.1415926 }],
+        effective_timerange: 42,
+      },
+    };
+    const wrapper = mount(<AggregationBuilder config={AggregationWidgetConfig.builder().rowPivots([rowPivot]).visualization('dummy').build()}
+                                              fields={{}}
+                                              data={data} />);
+    const dummyVisualization = wrapper.find(mockDummyVisualization);
+    expect(dummyVisualization).toHaveProp('effectiveTimerange', 42);
+  });
 });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In 81107aacbc827a4c2d3d207685b4b544541338cb we introduced the capability to set names for search types which are piped through to the results, allowing a widget to generate multiple search types and address the results by name. Searches created before this, result in the search type id being used instead of the name when generating the result object.

Prior to this PR, extracting the effective timerange from the result object incorrectly assumed that it has a `chart` key. This does not hold true for aforementioned searches created before the introduction of the `name` property. This introduced a regression, where a widget relying on the effective timerange failed.

This PR is addressing this, by falling back to the first search type result from the result object for the extraction of the effective timerange.

Fixes #6944 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.