### PR TITLE
Make aggregation field clearable

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationForm.jsx
@@ -181,7 +181,8 @@ class AggregationForm extends React.Component {
                           onChange={this.handleAggregationFieldChange}
                           options={formattedFields}
                           value={series.field}
-                          allowCreate />
+                          allowCreate
+                          isClearable />
                 </Col>
               </Row>
               {validation.errors.series && (


### PR DESCRIPTION
Add `isClearable` option to select, making it really possible to remove the selected option.

Fixes #6933 

This should be backported to 3.1.