### PR TITLE
Improve flow config: exclude `node_modules`, include `test` completely.

### DIFF
--- a/graylog2-web-interface/.flowconfig
+++ b/graylog2-web-interface/.flowconfig
@@ -5,6 +5,7 @@ src
 .*/build/.*
 .*/target/.*
 .*json$
+.*/node_modules/.*
 
 [libs]
 flow-typed
@@ -16,8 +17,8 @@ sketchy-number
 
 [options]
 emoji=true
-module.name_mapper='^helpers' -> '<PROJECT_ROOT>/test/helpers'
 module.name_mapper='^\([A-Za-z]+\)' -> '<PROJECT_ROOT>/src/\1'
+module.name_mapper='^\([A-Za-z]+\)' -> '<PROJECT_ROOT>/test/\1'
 module.name_mapper='^!style/useable!.*\.css$' -> '<PROJECT_ROOT>/src/flow/css-useable-modules.js'
 module.name_mapper='.*\.css$' -> '<PROJECT_ROOT>/src/flow/css-modules.js'
 


### PR DESCRIPTION
## Description
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is improving our flow config in two ways:

1.) excluding the `node_modules` folder from flow's type checks,
improving runtime by ~40%
2.) including `test` folder completely, instead of only `test/helpers`.
files in `src` have precedence when an absolute import is used and there
is ambiguity.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.