### PR TITLE
Remove "tests have passed" option from PR template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,4 +29,4 @@
 - [ ] I have updated the documentation accordingly.
 - [ ] I have read the **CONTRIBUTING** document.
 - [ ] I have added tests to cover my changes.
-- [ ] All new and existing tests passed.
+


### PR DESCRIPTION
This PR removes the checkbox saying that all new and existing tests have
passed. This should not be filled by the user, but is determined by our
status checks.