### PR TITLE
Do not limit terms size when determining stream ids contained in index.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -716,7 +716,7 @@ public class Indices {
         final FilterAggregationBuilder builder = AggregationBuilders.filter("agg", QueryBuilders.existsQuery(Message.FIELD_TIMESTAMP))
                 .subAggregation(AggregationBuilders.min("ts_min").field(Message.FIELD_TIMESTAMP))
                 .subAggregation(AggregationBuilders.max("ts_max").field(Message.FIELD_TIMESTAMP))
-                .subAggregation(AggregationBuilders.terms("streams").field(Message.FIELD_STREAMS));
+                .subAggregation(AggregationBuilders.terms("streams").size(Integer.MAX_VALUE).field(Message.FIELD_STREAMS));
         final String query = searchSource()
                 .aggregation(builder)
                 .size(0)


### PR DESCRIPTION
## Description
## Motivation and Context

When rotating an index, the following details are calculated and stored
in an index range:

  * the smallest timestamp (oldest document)
  * the largest timestamp (youngest document)
  * the set of stream ids contained in documents in this index

For the latter, a terms query is used. Unfortunately, no specific size
was set for it, so it used the default size of 10. This meant that all
index ranges calculated before did not contain more than 10 stream ids.

In the current search, this did not lead to imminent problems. The logic
used to determine the indices which are used for the search was lenient
enough to only consider either the set of stream ids containing the
current stream id or the index being managed by the index set of the
stream.

The new search is stricter and expects the set of stream ids to contain
the current stream being searched for. It only checks if the index set
of the stream manages the index if it is the deflector.

This change is now calculating the stream id set for a give index
correctly, by specifying a `size` parameter for the terms aggregation
that is hopefully high enough (`Integer.MAX_VALUE`) to handle all cases.

After applying the patch, it is required to recalculate all index ranges
once to benefit from its effectes.

Fixes #6828.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.