### PR TITLE
Supporting decorators in new views-based Search.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/searchtypes/ESMessageList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/searchtypes/ESMessageList.java
@@ -42,6 +42,7 @@ import org.joda.time.DateTime;
 
 import javax.inject.Inject;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -123,6 +124,7 @@ public class ESMessageList implements ESSearchTypeHandler<MessageList> {
         }
         final List<SearchResponseDecorator> searchResponseDecorators = decorators
                 .stream()
+                .sorted(Comparator.comparing(Decorator::order))
                 .map(decorator -> this.searchResponseDecorators.get(decorator.type()).create(decorator))
                 .collect(Collectors.toList());
         return decoratorProcessor.decorate(searchResponse, searchResponseDecorators);

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/searchtypes/ESMessageListTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/searchtypes/ESMessageListTest.java
@@ -72,7 +72,7 @@ public class ESMessageListTest {
     }
 
     @Test
-    public void includesCustomNameinResultIfPresent() {
+    public void includesCustomNameinResultIfPresent() throws Exception {
         final ESMessageList esMessageList = new ESMessageList(new ESQueryDecorators(Collections.emptySet()));
         final MessageList messageList = MessageList.builder()
                 .id("amessagelist")
@@ -81,9 +81,19 @@ public class ESMessageListTest {
                 .offset(0)
                 .build();
 
+        final Query query = Query.builder()
+                .id("deadbeef")
+                .query(ElasticsearchQueryString.builder()
+                        .queryString("Something else")
+                        .build())
+                .timerange(RelativeRange.create(300))
+                .searchTypes(Collections.emptySet())
+                .build();
+
+
         final SearchResult result = new MockSearchResult(Collections.emptyList(), (long)0);
 
-        final SearchType.Result searchTypeResult = esMessageList.doExtractResult(null, null, messageList, result, null, null);
+        final SearchType.Result searchTypeResult = esMessageList.doExtractResult(null, query, messageList, result, null, null);
 
         assertThat(searchTypeResult.name()).contains("customResult");
     }

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import $ from 'jquery';
 
-import { Modal, Button } from 'components/graylog';
+import { Button, Modal } from 'components/graylog';
 import BootstrapModalWrapper from 'components/bootstrap/BootstrapModalWrapper';
 
 import { validate } from 'legacy/validations.js';
@@ -12,20 +12,6 @@ import { validate } from 'legacy/validations.js';
  * has, and providing form validation using HTML5 and our custom validation.
  */
 class BootstrapModalForm extends React.Component {
-  static defaultProps = {
-    backdrop: undefined,
-    formProps: {},
-    cancelButtonText: 'Cancel',
-    submitButtonText: 'Submit',
-    submitButtonDisabled: false,
-    onModalOpen: () => {},
-    onModalClose: () => {},
-    onSubmitForm: undefined,
-    onCancel: () => {},
-    bsSize: undefined,
-    show: false,
-  };
-
   static propTypes = {
     backdrop: PropTypes.oneOf([true, false, 'static']),
     bsSize: PropTypes.oneOf(['lg', 'large', 'sm', 'small']),
@@ -48,6 +34,20 @@ class BootstrapModalForm extends React.Component {
     submitButtonText: PropTypes.string,
     submitButtonDisabled: PropTypes.bool,
     show: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    backdrop: undefined,
+    formProps: {},
+    cancelButtonText: 'Cancel',
+    submitButtonText: 'Submit',
+    submitButtonDisabled: false,
+    onModalOpen: () => {},
+    onModalClose: () => {},
+    onSubmitForm: undefined,
+    onCancel: () => {},
+    bsSize: undefined,
+    show: false,
   };
 
   onModalCancel = () => {
@@ -80,37 +80,39 @@ class BootstrapModalForm extends React.Component {
     }
 
     // If function is not given, let the browser continue propagating the submit event
-    if (typeof this.props.onSubmitForm === 'function') {
+    const { onSubmitForm } = this.props;
+    if (typeof onSubmitForm === 'function') {
       event.preventDefault();
-      this.props.onSubmitForm(event);
+      onSubmitForm(event);
     }
   };
 
   render() {
+    const { submitButtonDisabled, formProps, show, bsSize, onModalClose, cancelButtonText, submitButtonText, onModalOpen, title, children } = this.props;
     const body = (
       <div className="container-fluid">
-        {this.props.children}
+        {children}
       </div>
     );
 
     return (
       <BootstrapModalWrapper ref={(c) => { this.modal = c; }}
-                             onOpen={this.props.onModalOpen}
-                             onClose={this.props.onModalClose}
-                             bsSize={this.props.bsSize}
-                             showModal={this.props.show}
+                             onOpen={onModalOpen}
+                             onClose={onModalClose}
+                             bsSize={bsSize}
+                             showModal={show}
                              backdrop={this.props.backdrop}
                              onHide={this.onModalCancel}>
         <Modal.Header closeButton>
-          <Modal.Title>{this.props.title}</Modal.Title>
+          <Modal.Title>{title}</Modal.Title>
         </Modal.Header>
-        <form ref={(c) => { this.form = c; }} onSubmit={this.submit} {...this.props.formProps}>
+        <form ref={(c) => { this.form = c; }} onSubmit={this.submit} {...formProps}>
           <Modal.Body>
             {body}
           </Modal.Body>
           <Modal.Footer>
-            <Button type="button" onClick={this.onModalCancel}>{this.props.cancelButtonText}</Button>
-            <Button type="submit" disabled={this.props.submitButtonDisabled} bsStyle="primary">{this.props.submitButtonText}</Button>
+            <Button type="button" onClick={this.onModalCancel}>{cancelButtonText}</Button>
+            <Button type="submit" disabled={submitButtonDisabled} bsStyle="primary">{submitButtonText}</Button>
           </Modal.Footer>
         </form>
       </BootstrapModalWrapper>

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
@@ -85,7 +85,7 @@ class BootstrapModalForm extends React.Component {
   };
 
   render() {
-    const { submitButtonDisabled, formProps, bsSize, onModalClose, cancelButtonText, show, submitButtonText, onModalOpen, title, children } = this.props;
+    const { backdrop, submitButtonDisabled, formProps, bsSize, onModalClose, cancelButtonText, show, submitButtonText, onModalOpen, title, children } = this.props;
     const body = (
       <div className="container-fluid">
         {children}
@@ -98,7 +98,7 @@ class BootstrapModalForm extends React.Component {
                              onClose={onModalClose}
                              bsSize={bsSize}
                              showModal={show}
-                             backdrop={this.props.backdrop}
+                             backdrop={backdrop}
                              onHide={this.onModalCancel}>
         <Modal.Header closeButton>
           <Modal.Title>{title}</Modal.Title>

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
@@ -56,13 +56,9 @@ class BootstrapModalForm extends React.Component {
     this.close();
   };
 
-  open = () => {
-    this.modal.open();
-  };
+  open = () => this.modal.open();
 
-  close = () => {
-    this.modal.close();
-  };
+  close = () => this.modal.close();
 
   submit = (event) => {
     const formDOMNode = this.form;
@@ -89,7 +85,7 @@ class BootstrapModalForm extends React.Component {
   };
 
   render() {
-    const { submitButtonDisabled, formProps, show, bsSize, onModalClose, cancelButtonText, submitButtonText, onModalOpen, title, children } = this.props;
+    const { submitButtonDisabled, formProps, bsSize, onModalClose, cancelButtonText, show, submitButtonText, onModalOpen, title, children } = this.props;
     const body = (
       <div className="container-fluid">
         {children}

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
@@ -51,7 +51,8 @@ class BootstrapModalForm extends React.Component {
   };
 
   onModalCancel = () => {
-    this.props.onCancel();
+    const { onCancel } = this.props;
+    onCancel();
     this.close();
   };
 

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.jsx
@@ -31,12 +31,6 @@ class BootstrapModalWrapper extends React.Component {
     backdrop: 'static',
   };
 
-  static getDerivedStateFromProps({ showModal }) {
-    return {
-      showModal,
-    };
-  }
-
   state = {
     // eslint-disable-next-line react/destructuring-assignment
     showModal: this.props.showModal || false,

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalWrapper.jsx
@@ -7,15 +7,6 @@ import { Modal } from 'components/graylog';
  * Encapsulates a react-bootstrap modal, hiding the state handling for the modal
  */
 class BootstrapModalWrapper extends React.Component {
-  static defaultProps = {
-    showModal: false,
-    onOpen: () => {},
-    onClose: () => {},
-    onHide: () => {},
-    bsSize: undefined,
-    backdrop: 'static',
-  };
-
   static propTypes = {
     showModal: PropTypes.bool,
     children: PropTypes.oneOfType([
@@ -31,29 +22,50 @@ class BootstrapModalWrapper extends React.Component {
     backdrop: PropTypes.oneOf(['static', true, false]),
   };
 
+  static defaultProps = {
+    showModal: false,
+    onOpen: () => {},
+    onClose: () => {},
+    onHide: () => {},
+    bsSize: undefined,
+    backdrop: 'static',
+  };
+
+  static getDerivedStateFromProps({ showModal }) {
+    return {
+      showModal,
+    };
+  }
+
   state = {
+    // eslint-disable-next-line react/destructuring-assignment
     showModal: this.props.showModal || false,
   };
 
   open = () => {
-    this.setState({ showModal: true }, this.props.onOpen);
+    const { onOpen } = this.props;
+    this.setState({ showModal: true }, onOpen);
   };
 
   close = () => {
-    this.setState({ showModal: false }, this.props.onClose);
+    const { onClose } = this.props;
+    this.setState({ showModal: false }, onClose);
   };
 
   hide = () => {
-    this.setState({ showModal: false }, this.props.onHide);
+    const { onHide } = this.props;
+    this.setState({ showModal: false }, onHide);
   };
 
   render() {
+    const { showModal } = this.state;
+    const { children, bsSize, backdrop } = this.props;
     return (
-      <Modal show={this.state.showModal}
+      <Modal show={showModal}
              onHide={this.hide}
-             bsSize={this.props.bsSize}
-             backdrop={this.props.backdrop}>
-        {this.props.children}
+             bsSize={bsSize}
+             backdrop={backdrop}>
+        {children}
       </Modal>
     );
   }

--- a/graylog2-web-interface/src/components/common/Select.jsx
+++ b/graylog2-web-interface/src/components/common/Select.jsx
@@ -166,7 +166,7 @@ type Props = {
   value?: string,
   autoFocus?: boolean,
   size?: 'normal' | 'small',
-  optionRenderer: (any) => React.Node,
+  optionRenderer?: (any) => React.Node,
   disabled?: boolean,
   addLabelText?: string,
   allowCreate?: boolean,

--- a/graylog2-web-interface/src/components/common/Select.jsx
+++ b/graylog2-web-interface/src/components/common/Select.jsx
@@ -166,7 +166,6 @@ type Props = {
   value?: string,
   autoFocus?: boolean,
   size?: 'normal' | 'small',
-  optionRenderer?: (any) => React.Node,
   disabled?: boolean,
   addLabelText?: string,
   allowCreate?: boolean,

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
@@ -174,9 +174,7 @@ class ConfigurationForm extends React.Component {
     });
 
     return (
-      <WrapperComponent ref={(modal) => {
-        this.modal = modal;
-      }}
+      <WrapperComponent ref={(modal) => { this.modal = modal; }}
                         title={title}
                         onCancel={this._closeModal}
                         onSubmitForm={this._save}

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
@@ -90,11 +90,15 @@ const ConfigurationForm = createReactClass({
     const data = this.getValue();
 
     this.props.submitAction(data);
-    this.modal.close();
+    if (this.modal && this.modal.close) {
+      this.modal.close();
+    }
   },
 
   open() {
-    this.modal.open();
+    if (this.modal && this.modal.open) {
+      this.modal.open();
+    }
   },
 
   _closeModal() {

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
@@ -111,7 +111,7 @@ class ConfigurationForm extends React.Component {
 
   _closeModal = () => {
     const { cancelAction, titleValue } = this.props;
-    this.setState($.extend(this.getInitialState(), { titleValue: titleValue }));
+    this.setState($.extend(this._copyStateFromProps(this.props), { titleValue: titleValue }));
     if (cancelAction) {
       cancelAction();
     }

--- a/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/configurationforms/ConfigurationForm.jsx
@@ -157,7 +157,7 @@ const ConfigurationForm = createReactClass({
       return configField;
     });
 
-    const WrapperComponent = wrapperComponent
+    const WrapperComponent = wrapperComponent;
 
     return (
       <WrapperComponent ref={(modal) => { this.modal = modal; }}

--- a/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
@@ -12,6 +12,7 @@ import Decorator from 'views/components/messagelist/decorators/Decorator';
 import DecoratorList from 'views/components/messagelist/decorators/DecoratorList';
 import DecoratorsConfigUpdate from './decorators/DecoratorsConfigUpdate';
 import StreamSelect, { DEFAULT_SEARCH_ID, DEFAULT_STREAM_ID } from './decorators/StreamSelect';
+import DecoratorsUpdater from './decorators/DecoratorsUpdater';
 
 const { DecoratorsActions } = CombinedProvider.get('Decorators');
 
@@ -52,7 +53,10 @@ const DecoratorsConfig = () => {
     return <Spinner />;
   }
 
-  const onSave = (newDecorators) => { console.log('New Decorators: ', newDecorators); };
+  const onSave = newDecorators => DecoratorsUpdater(newDecorators, decorators)
+    .then(DecoratorsActions.list)
+    .then(setDecorators)
+    .then(closeModal);
 
   const decoratorsGroupedByStream = groupBy(decorators, decorator => (decorator.stream || DEFAULT_SEARCH_ID));
 

--- a/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
@@ -1,29 +1,102 @@
 // @flow strict
-import React, { useCallback, useState, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
+import { groupBy } from 'lodash';
 
 import { IfPermitted } from 'components/common';
 import { Button } from 'components/graylog';
 import { BootstrapModalForm } from 'components/bootstrap';
+import Spinner from 'components/common/Spinner';
+import Select from 'components/common/Select';
+import CombinedProvider from 'injection/CombinedProvider';
+import StreamsStore from 'stores/streams/StreamsStore';
+
+import Decorator from 'views/components/messagelist/decorators/Decorator';
+import DecoratorList from 'views/components/messagelist/decorators/DecoratorList';
+import { defaultCompare } from 'views/logic/DefaultCompare';
+import DecoratorsConfigUpdate from './decorators/DecoratorsConfigUpdate';
+import SelectContainer from './decorators/SelectContainer';
+
+const { DecoratorsActions } = CombinedProvider.get('Decorators');
+
+const _formatDecorator = (decorator, decorators, decoratorTypes, updateFn) => {
+  const typeDefinition = decoratorTypes[decorator.type] || { requested_configuration: {}, name: `Unknown type: ${decorator.type}` };
+  const onUpdate = updateFn
+    ? (id, updatedDecorator) => updateFn(decorators.map(curDecorator => (curDecorator.id === id ? updatedDecorator : curDecorator)))
+    : () => {};
+  const onDelete = updateFn
+    ? deletedDecoratorId => updateFn(decorators.filter(({ id }) => (id !== deletedDecoratorId)))
+    : () => {};
+  return ({
+    id: decorator.id,
+    title: <Decorator key={`decorator-${decorator.id}`}
+                      decorator={decorator}
+                      decoratorTypes={decoratorTypes}
+                      disableMenu={updateFn === undefined}
+                      onUpdate={onUpdate}
+                      onDelete={onDelete}
+                      typeDefinition={typeDefinition} />,
+  });
+};
+
+const DEFAULT_STREAM_ID = '000000000000000000000001';
+const DEFAULT_SEARCH_ID = 'DEFAULT_SEARCH';
 
 const DecoratorsConfig = () => {
+  const [streams, setStreams] = useState();
+  const [currentStream, setCurrentStream] = useState(DEFAULT_STREAM_ID);
+  const [decorators, setDecorators] = useState();
+  const [types, setTypes] = useState();
+  useEffect(() => StreamsStore.listStreams().then(setStreams), [setStreams]);
+  useEffect(() => DecoratorsActions.available().then(setTypes), [setTypes]);
+  useEffect(() => DecoratorsActions.list().then(setDecorators), [setDecorators]);
+
   const configModal = useRef();
   const openModal = useCallback(() => configModal.current.open(), [configModal]);
-  const closeModal = useCallback(() => configModal.current.close(), [configModal]);
+
+  if (!streams || !decorators || !types) {
+    return <Spinner />;
+  }
+
   const saveConfig = () => {};
+
+  const decoratorsGroupedByStream = groupBy(decorators, decorator => (decorator.stream || DEFAULT_SEARCH_ID));
+
+  const currentDecorators = decoratorsGroupedByStream[currentStream];
+  const sortedDecorators = currentDecorators
+    .sort((d1, d2) => d1.order - d2.order);
+  const readOnlyDecoratorItems = sortedDecorators.map(decorator => _formatDecorator(decorator, currentDecorators, types));
+
+  const options = [{ label: 'Default Search', value: DEFAULT_SEARCH_ID }, ...streams
+    .filter(({ id }) => Object.keys(decoratorsGroupedByStream).includes(id))
+    .sort(({ title: key1 }, { title: key2 }) => defaultCompare(key1, key2))
+    .map(({ title, id }) => ({ label: title, value: id }))];
+  const streamSelect = (
+    <SelectContainer>
+      <Select inputId="streams-filter"
+              onChange={setCurrentStream}
+              options={options}
+              clearable={false}
+              style={{ width: '100%' }}
+              placeholder="There are no decorators configured for any stream."
+              value={currentStream} />
+    </SelectContainer>
+  );
+
   return (
     <div>
       <h2>Decorators Configuration</h2>
+      <p>Select the stream for which you want to see the set of default decorators.</p>
+      {streamSelect}
+      <DecoratorList decorators={readOnlyDecoratorItems} disableDragging />
       <IfPermitted permissions="clusterconfigentry:edit">
         <Button bsStyle="info" bsSize="xs" onClick={openModal}>Update</Button>
       </IfPermitted>
       <BootstrapModalForm ref={configModal}
                           title="Update Search Configuration"
                           onSubmitForm={saveConfig}
-                          onModalClose={closeModal}
                           submitButtonText="Save">
-        <fieldset>
-        </fieldset>
+        <DecoratorsConfigUpdate streams={streams} decorators={decorators} types={types} />
       </BootstrapModalForm>
     </div>
   );

--- a/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
@@ -41,9 +41,9 @@ const DecoratorsConfig = () => {
   const [currentStream, setCurrentStream] = useState(DEFAULT_STREAM_ID);
   const [decorators, setDecorators] = useState();
   const [types, setTypes] = useState();
-  useEffect(() => StreamsStore.listStreams().then(setStreams), [setStreams]);
-  useEffect(() => DecoratorsActions.available().then(setTypes), [setTypes]);
-  useEffect(() => DecoratorsActions.list().then(setDecorators), [setDecorators]);
+  useEffect(() => { StreamsStore.listStreams().then(setStreams); }, [setStreams]);
+  useEffect(() => { DecoratorsActions.available().then(setTypes); }, [setTypes]);
+  useEffect(() => { DecoratorsActions.list().then(setDecorators); }, [setDecorators]);
 
   const configModal = useRef();
   const openModal = useCallback(() => configModal.current && configModal.current.open(), [configModal]);

--- a/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
@@ -14,6 +14,7 @@ import DecoratorList from 'views/components/messagelist/decorators/DecoratorList
 import DecoratorsConfigUpdate from './decorators/DecoratorsConfigUpdate';
 import StreamSelect, { DEFAULT_SEARCH_ID, DEFAULT_STREAM_ID } from './decorators/StreamSelect';
 import DecoratorsUpdater from './decorators/DecoratorsUpdater';
+import BootstrapModalWrapper from '../bootstrap/BootstrapModalWrapper';
 
 const { DecoratorsActions } = CombinedProvider.get('Decorators');
 
@@ -42,7 +43,7 @@ const DecoratorsConfig = () => {
   const [currentStream, setCurrentStream] = useState(DEFAULT_STREAM_ID);
   const [decorators, setDecorators] = useState();
   const [types, setTypes] = useState();
-  const configModal = useRef();
+  const configModal = useRef<BootstrapModalWrapper>();
 
   useEffect(() => { StreamsStore.listStreams().then(setStreams); }, [setStreams]);
   useEffect(() => { DecoratorsActions.available().then(setTypes); }, [setTypes]);

--- a/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { groupBy } from 'lodash';
 
 import { IfPermitted } from 'components/common';
@@ -42,13 +42,14 @@ const DecoratorsConfig = () => {
   const [currentStream, setCurrentStream] = useState(DEFAULT_STREAM_ID);
   const [decorators, setDecorators] = useState();
   const [types, setTypes] = useState();
-  const [showModal, setShowModal] = useState(false);
+  const configModal = useRef();
+
   useEffect(() => { StreamsStore.listStreams().then(setStreams); }, [setStreams]);
   useEffect(() => { DecoratorsActions.available().then(setTypes); }, [setTypes]);
   useEffect(() => { DecoratorsActions.list().then(setDecorators); }, [setDecorators]);
 
-  const openModal = useCallback(() => setShowModal(true), [setShowModal]);
-  const closeModal = useCallback(() => setShowModal(false), [setShowModal]);
+  const openModal = useCallback(() => configModal.current && configModal.current.open(), [configModal]);
+  const closeModal = useCallback(() => configModal.current && configModal.current.close(), [configModal]);
 
   if (!streams || !decorators || !types) {
     return <Spinner />;
@@ -82,7 +83,7 @@ const DecoratorsConfig = () => {
       <IfPermitted permissions="clusterconfigentry:edit">
         <Button bsStyle="info" bsSize="xs" onClick={openModal}>Update</Button>
       </IfPermitted>
-      <DecoratorsConfigUpdate show={showModal}
+      <DecoratorsConfigUpdate ref={configModal}
                               streams={streams}
                               decorators={decorators}
                               onCancel={closeModal}

--- a/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
@@ -1,22 +1,18 @@
 // @flow strict
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import PropTypes from 'prop-types';
 import { groupBy } from 'lodash';
 
 import { IfPermitted } from 'components/common';
 import { Button } from 'components/graylog';
 import { BootstrapModalForm } from 'components/bootstrap';
 import Spinner from 'components/common/Spinner';
-import Select from 'components/common/Select';
 import CombinedProvider from 'injection/CombinedProvider';
 import StreamsStore from 'stores/streams/StreamsStore';
 
 import Decorator from 'views/components/messagelist/decorators/Decorator';
 import DecoratorList from 'views/components/messagelist/decorators/DecoratorList';
-import { defaultCompare } from 'views/logic/DefaultCompare';
 import DecoratorsConfigUpdate from './decorators/DecoratorsConfigUpdate';
-import SelectContainer from './decorators/SelectContainer';
-import StreamSelect from './decorators/StreamSelect';
+import StreamSelect, { DEFAULT_SEARCH_ID, DEFAULT_STREAM_ID } from './decorators/StreamSelect';
 
 const { DecoratorsActions } = CombinedProvider.get('Decorators');
 

--- a/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
@@ -9,34 +9,14 @@ import CombinedProvider from 'injection/CombinedProvider';
 import StreamsStore from 'stores/streams/StreamsStore';
 import UserNotification from 'util/UserNotification';
 
-import Decorator from 'views/components/messagelist/decorators/Decorator';
 import DecoratorList from 'views/components/messagelist/decorators/DecoratorList';
 import DecoratorsConfigUpdate from './decorators/DecoratorsConfigUpdate';
 import StreamSelect, { DEFAULT_SEARCH_ID, DEFAULT_STREAM_ID } from './decorators/StreamSelect';
 import DecoratorsUpdater from './decorators/DecoratorsUpdater';
 import BootstrapModalWrapper from '../bootstrap/BootstrapModalWrapper';
+import formatDecorator from './decorators/FormatDecorator';
 
 const { DecoratorsActions } = CombinedProvider.get('Decorators');
-
-const _formatDecorator = (decorator, decorators, decoratorTypes, updateFn) => {
-  const typeDefinition = decoratorTypes[decorator.type] || { requested_configuration: {}, name: `Unknown type: ${decorator.type}` };
-  const onUpdate = updateFn
-    ? (id, updatedDecorator) => updateFn(decorators.map(curDecorator => (curDecorator.id === id ? updatedDecorator : curDecorator)))
-    : () => {};
-  const onDelete = updateFn
-    ? deletedDecoratorId => updateFn(decorators.filter(({ id }) => (id !== deletedDecoratorId)))
-    : () => {};
-  return ({
-    id: decorator.id,
-    title: <Decorator key={`decorator-${decorator.id}`}
-                      decorator={decorator}
-                      decoratorTypes={decoratorTypes}
-                      disableMenu={updateFn === undefined}
-                      onUpdate={onUpdate}
-                      onDelete={onDelete}
-                      typeDefinition={typeDefinition} />,
-  });
-};
 
 const DecoratorsConfig = () => {
   const [streams, setStreams] = useState();
@@ -70,7 +50,7 @@ const DecoratorsConfig = () => {
   const currentDecorators = decoratorsGroupedByStream[currentStream];
   const sortedDecorators = currentDecorators
     .sort((d1, d2) => d1.order - d2.order);
-  const readOnlyDecoratorItems = sortedDecorators.map(decorator => _formatDecorator(decorator, currentDecorators, types));
+  const readOnlyDecoratorItems = sortedDecorators.map(decorator => formatDecorator(decorator, currentDecorators, types));
 
   const streamOptions = streams
     .filter(({ id }) => Object.keys(decoratorsGroupedByStream).includes(id));

--- a/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
@@ -1,10 +1,9 @@
 // @flow strict
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { groupBy } from 'lodash';
 
 import { IfPermitted } from 'components/common';
 import { Button } from 'components/graylog';
-import { BootstrapModalForm } from 'components/bootstrap';
 import Spinner from 'components/common/Spinner';
 import CombinedProvider from 'injection/CombinedProvider';
 import StreamsStore from 'stores/streams/StreamsStore';
@@ -41,18 +40,19 @@ const DecoratorsConfig = () => {
   const [currentStream, setCurrentStream] = useState(DEFAULT_STREAM_ID);
   const [decorators, setDecorators] = useState();
   const [types, setTypes] = useState();
+  const [showModal, setShowModal] = useState(false);
   useEffect(() => { StreamsStore.listStreams().then(setStreams); }, [setStreams]);
   useEffect(() => { DecoratorsActions.available().then(setTypes); }, [setTypes]);
   useEffect(() => { DecoratorsActions.list().then(setDecorators); }, [setDecorators]);
 
-  const configModal = useRef();
-  const openModal = useCallback(() => configModal.current && configModal.current.open(), [configModal]);
+  const openModal = useCallback(() => setShowModal(true), [setShowModal]);
+  const closeModal = useCallback(() => setShowModal(false), [setShowModal]);
 
   if (!streams || !decorators || !types) {
     return <Spinner />;
   }
 
-  const saveConfig = () => {};
+  const onSave = (newDecorators) => { console.log('New Decorators: ', newDecorators); };
 
   const decoratorsGroupedByStream = groupBy(decorators, decorator => (decorator.stream || DEFAULT_SEARCH_ID));
 
@@ -73,12 +73,12 @@ const DecoratorsConfig = () => {
       <IfPermitted permissions="clusterconfigentry:edit">
         <Button bsStyle="info" bsSize="xs" onClick={openModal}>Update</Button>
       </IfPermitted>
-      <BootstrapModalForm ref={configModal}
-                          title="Update Search Configuration"
-                          onSubmitForm={saveConfig}
-                          submitButtonText="Save">
-        <DecoratorsConfigUpdate streams={streams} decorators={decorators} types={types} />
-      </BootstrapModalForm>
+      <DecoratorsConfigUpdate show={showModal}
+                              streams={streams}
+                              decorators={decorators}
+                              onCancel={closeModal}
+                              onSave={onSave}
+                              types={types} />
     </div>
   );
 };

--- a/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
@@ -7,6 +7,7 @@ import { Button } from 'components/graylog';
 import Spinner from 'components/common/Spinner';
 import CombinedProvider from 'injection/CombinedProvider';
 import StreamsStore from 'stores/streams/StreamsStore';
+import UserNotification from 'util/UserNotification';
 
 import Decorator from 'views/components/messagelist/decorators/Decorator';
 import DecoratorList from 'views/components/messagelist/decorators/DecoratorList';
@@ -54,6 +55,10 @@ const DecoratorsConfig = () => {
   }
 
   const onSave = newDecorators => DecoratorsUpdater(newDecorators, decorators)
+    .then(
+      () => UserNotification.success('Updated decorators configuration.', 'Success!'),
+      error => UserNotification.error(`Unable to save new decorators: ${error}`, 'Saving decorators failed'),
+    )
     .then(DecoratorsActions.list)
     .then(setDecorators)
     .then(closeModal);

--- a/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
@@ -47,7 +47,7 @@ const DecoratorsConfig = () => {
 
   const decoratorsGroupedByStream = groupBy(decorators, decorator => (decorator.stream || DEFAULT_SEARCH_ID));
 
-  const currentDecorators = decoratorsGroupedByStream[currentStream];
+  const currentDecorators = decoratorsGroupedByStream[currentStream] || [];
   const sortedDecorators = currentDecorators
     .sort((d1, d2) => d1.order - d2.order);
   const readOnlyDecoratorItems = sortedDecorators.map(decorator => formatDecorator(decorator, currentDecorators, types));

--- a/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
@@ -16,6 +16,7 @@ import DecoratorList from 'views/components/messagelist/decorators/DecoratorList
 import { defaultCompare } from 'views/logic/DefaultCompare';
 import DecoratorsConfigUpdate from './decorators/DecoratorsConfigUpdate';
 import SelectContainer from './decorators/SelectContainer';
+import StreamSelect from './decorators/StreamSelect';
 
 const { DecoratorsActions } = CombinedProvider.get('Decorators');
 
@@ -38,9 +39,6 @@ const _formatDecorator = (decorator, decorators, decoratorTypes, updateFn) => {
                       typeDefinition={typeDefinition} />,
   });
 };
-
-const DEFAULT_STREAM_ID = '000000000000000000000001';
-const DEFAULT_SEARCH_ID = 'DEFAULT_SEARCH';
 
 const DecoratorsConfig = () => {
   const [streams, setStreams] = useState();
@@ -67,27 +65,14 @@ const DecoratorsConfig = () => {
     .sort((d1, d2) => d1.order - d2.order);
   const readOnlyDecoratorItems = sortedDecorators.map(decorator => _formatDecorator(decorator, currentDecorators, types));
 
-  const options = [{ label: 'Default Search', value: DEFAULT_SEARCH_ID }, ...streams
-    .filter(({ id }) => Object.keys(decoratorsGroupedByStream).includes(id))
-    .sort(({ title: key1 }, { title: key2 }) => defaultCompare(key1, key2))
-    .map(({ title, id }) => ({ label: title, value: id }))];
-  const streamSelect = (
-    <SelectContainer>
-      <Select inputId="streams-filter"
-              onChange={setCurrentStream}
-              options={options}
-              clearable={false}
-              style={{ width: '100%' }}
-              placeholder="There are no decorators configured for any stream."
-              value={currentStream} />
-    </SelectContainer>
-  );
+  const streamOptions = streams
+    .filter(({ id }) => Object.keys(decoratorsGroupedByStream).includes(id));
 
   return (
     <div>
       <h2>Decorators Configuration</h2>
       <p>Select the stream for which you want to see the set of default decorators.</p>
-      {streamSelect}
+      <StreamSelect streams={streamOptions} onChange={setCurrentStream} value={currentStream} />
       <DecoratorList decorators={readOnlyDecoratorItems} disableDragging />
       <IfPermitted permissions="clusterconfigentry:edit">
         <Button bsStyle="info" bsSize="xs" onClick={openModal}>Update</Button>

--- a/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
@@ -52,7 +52,7 @@ const DecoratorsConfig = () => {
   useEffect(() => DecoratorsActions.list().then(setDecorators), [setDecorators]);
 
   const configModal = useRef();
-  const openModal = useCallback(() => configModal.current.open(), [configModal]);
+  const openModal = useCallback(() => configModal.current && configModal.current.open(), [configModal]);
 
   if (!streams || !decorators || !types) {
     return <Spinner />;

--- a/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/DecoratorsConfig.jsx
@@ -61,7 +61,7 @@ const DecoratorsConfig = () => {
       <p>Select the stream for which you want to see the set of default decorators.</p>
       <StreamSelect streams={streamOptions} onChange={setCurrentStream} value={currentStream} />
       <DecoratorList decorators={readOnlyDecoratorItems} disableDragging />
-      <IfPermitted permissions="clusterconfigentry:edit">
+      <IfPermitted permissions="decorators:edit">
         <Button bsStyle="info" bsSize="xs" onClick={openModal}>Update</Button>
       </IfPermitted>
       <DecoratorsConfigUpdate ref={configModal}

--- a/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
@@ -9,6 +9,7 @@ import AddDecoratorButton from 'views/components/messagelist/decorators/AddDecor
 import type { Decorator } from 'views/components/messagelist/decorators/Types';
 import StreamSelect, { DEFAULT_SEARCH_ID, DEFAULT_STREAM_ID } from './StreamSelect';
 import formatDecorator from './FormatDecorator';
+import { IfPermitted } from '../../common/index';
 
 type Props = {
   streams: Array<{ title: string, id: string }>,
@@ -45,8 +46,10 @@ const DecoratorsConfigUpdate = ({ streams, decorators, types, show = false, onCa
         <p>Select the stream for which you want to change the set of default decorators.</p>
         <StreamSelect onChange={setCurrentStream} value={currentStream} streams={streams} />
 
-        <p>Select the type to create a new decorator for this stream:</p>
-        <AddDecoratorButton stream={currentStream} nextOrder={nextOrder} decoratorTypes={types} onCreate={onCreate} showHelp={false} />
+        <IfPermitted permissions="decorators:create">
+          <p>Select the type to create a new decorator for this stream:</p>
+          <AddDecoratorButton stream={currentStream} nextOrder={nextOrder} decoratorTypes={types} onCreate={onCreate} showHelp={false} />
+        </IfPermitted>
 
         <p>Use drag and drop to change the execution order of the decorators.</p>
 

--- a/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
@@ -1,6 +1,5 @@
 // @flow strict
 import React, { useCallback, useState } from 'react';
-import PropTypes from 'prop-types';
 import { groupBy } from 'lodash';
 
 import Select from 'components/common/Select';
@@ -33,7 +32,13 @@ const _formatDecorator = (decorator, decorators, decoratorTypes, updateFn) => {
   });
 };
 
-const DecoratorsConfigUpdate = ({ streams, decorators, types }) => {
+type Props = {
+  streams: Array<{ title: string, id: string }>,
+  decorators: Array<{ id: string, order: number, type: string }>,
+  types: { [string]: any },
+};
+
+const DecoratorsConfigUpdate = ({ streams, decorators, types }: Props) => {
   const [currentStream, setCurrentStream] = useState(DEFAULT_STREAM_ID);
   const [updatedDecorators, setUpdatedDecorators] = useState(decorators);
 
@@ -49,7 +54,7 @@ const DecoratorsConfigUpdate = ({ streams, decorators, types }) => {
     .sort(({ title: key1 }, { title: key2 }) => defaultCompare(key1, key2))
     .map(({ title, id }) => ({ label: title, value: id }))];
 
-  const onCreate = useCallback(newDecorator => setUpdatedDecorators([ ...updatedDecorators, newDecorator]), [updatedDecorators, setUpdatedDecorators]);
+  const onCreate = useCallback(newDecorator => setUpdatedDecorators([...updatedDecorators, newDecorator]), [updatedDecorators, setUpdatedDecorators]);
 
   return (
     <React.Fragment>

--- a/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
@@ -5,44 +5,18 @@ import PropTypes from 'prop-types';
 import BootstrapModalWrapper from 'components/bootstrap/BootstrapModalWrapper';
 import { Button, Modal } from 'components/graylog';
 import DecoratorList from 'views/components/messagelist/decorators/DecoratorList';
-import Decorator from 'views/components/messagelist/decorators/Decorator';
 import AddDecoratorButton from 'views/components/messagelist/decorators/AddDecoratorButton';
+import type { Decorator } from 'views/components/messagelist/decorators/Types';
 import StreamSelect, { DEFAULT_SEARCH_ID, DEFAULT_STREAM_ID } from './StreamSelect';
-
-const _formatDecorator = (decorator, decorators, decoratorTypes, updateFn) => {
-  const typeDefinition = decoratorTypes[decorator.type] || { requested_configuration: {}, name: `Unknown type: ${decorator.type}` };
-  const onUpdate = updateFn
-    ? (id, updatedDecorator) => updateFn(decorators.map(curDecorator => (curDecorator.id === id ? updatedDecorator : curDecorator)))
-    : () => {};
-  const onDelete = updateFn
-    ? deletedDecoratorId => updateFn(decorators.filter(({ id }) => (id !== deletedDecoratorId)))
-    : () => {};
-  return ({
-    id: decorator.id,
-    title: <Decorator key={`decorator-${decorator.id || 'new'}`}
-                      decorator={decorator}
-                      decoratorTypes={decoratorTypes}
-                      disableMenu={updateFn === undefined}
-                      onUpdate={onUpdate}
-                      onDelete={onDelete}
-                      typeDefinition={typeDefinition} />,
-  });
-};
-
-export type DecoratorType = {
-  id?: string,
-  order: number,
-  type: string,
-  stream: ?string,
-};
+import formatDecorator from './FormatDecorator';
 
 type Props = {
   streams: Array<{ title: string, id: string }>,
-  decorators: Array<DecoratorType>,
+  decorators: Array<Decorator>,
   types: { [string]: any },
   show?: boolean,
   onCancel: () => void,
-  onSave: (Array<DecoratorType>) => mixed,
+  onSave: (Array<Decorator>) => mixed,
 };
 
 const DecoratorsConfigUpdate = ({ streams, decorators, types, show = false, onCancel, onSave }: Props, modalRef) => {
@@ -56,7 +30,7 @@ const DecoratorsConfigUpdate = ({ streams, decorators, types, show = false, onCa
   const currentDecorators = modifiedDecorators.filter(decorator => (decorator.stream || DEFAULT_SEARCH_ID) === currentStream);
   const decoratorItems = currentDecorators
     .sort((d1, d2) => d1.order - d2.order)
-    .map(decorator => _formatDecorator(decorator, modifiedDecorators, types, setModifiedDecorators));
+    .map(decorator => formatDecorator(decorator, modifiedDecorators, types, setModifiedDecorators));
 
   const nextOrder = currentDecorators.reduce((currentMax, decorator) => Math.max(currentMax, decorator.order), 0) + 1;
 

--- a/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
@@ -18,7 +18,7 @@ const _formatDecorator = (decorator, decorators, decoratorTypes, updateFn) => {
     : () => {};
   return ({
     id: decorator.id,
-    title: <Decorator key={`decorator-${decorator.id}`}
+    title: <Decorator key={`decorator-${decorator.id || 'new'}`}
                       decorator={decorator}
                       decoratorTypes={decoratorTypes}
                       disableMenu={updateFn === undefined}
@@ -39,12 +39,12 @@ type Props = {
   streams: Array<{ title: string, id: string }>,
   decorators: Array<DecoratorType>,
   types: { [string]: any },
-  show: boolean,
+  show?: boolean,
   onCancel: () => void,
   onSave: (Array<DecoratorType>) => mixed,
 };
 
-const DecoratorsConfigUpdate = React.forwardRef(({ streams, decorators, types, show = false, onCancel, onSave }: Props, modalRef) => {
+const DecoratorsConfigUpdate = ({ streams, decorators, types, show = false, onCancel, onSave }: Props, modalRef) => {
   const [currentStream, setCurrentStream] = useState(DEFAULT_STREAM_ID);
   const [modifiedDecorators, setModifiedDecorators] = useState(decorators);
   const onCreate = useCallback(
@@ -83,8 +83,8 @@ const DecoratorsConfigUpdate = React.forwardRef(({ streams, decorators, types, s
       </Modal.Footer>
     </BootstrapModalWrapper>
   );
-});
+};
 
 DecoratorsConfigUpdate.propTypes = {};
 
-export default DecoratorsConfigUpdate;
+export default React.forwardRef<Props, BootstrapModalWrapper>(DecoratorsConfigUpdate);

--- a/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
@@ -2,15 +2,10 @@
 import React, { useCallback, useState } from 'react';
 import { groupBy } from 'lodash';
 
-import Select from 'components/common/Select';
 import DecoratorList from 'views/components/messagelist/decorators/DecoratorList';
-import { defaultCompare } from 'views/logic/DefaultCompare';
 import Decorator from 'views/components/messagelist/decorators/Decorator';
 import AddDecoratorButton from 'views/components/messagelist/decorators/AddDecoratorButton';
-import SelectContainer from './SelectContainer';
-
-const DEFAULT_STREAM_ID = '000000000000000000000001';
-const DEFAULT_SEARCH_ID = 'DEFAULT_SEARCH';
+import StreamSelect, { DEFAULT_SEARCH_ID, DEFAULT_STREAM_ID } from './StreamSelect';
 
 const _formatDecorator = (decorator, decorators, decoratorTypes, updateFn) => {
   const typeDefinition = decoratorTypes[decorator.type] || { requested_configuration: {}, name: `Unknown type: ${decorator.type}` };
@@ -50,24 +45,12 @@ const DecoratorsConfigUpdate = ({ streams, decorators, types }: Props) => {
 
   const nextOrder = sortedDecorators.reduce((currentMax, decorator) => Math.max(currentMax, decorator.order), 0) + 1;
 
-  const options = [{ label: 'Default Search', value: DEFAULT_SEARCH_ID }, ...streams
-    .sort(({ title: key1 }, { title: key2 }) => defaultCompare(key1, key2))
-    .map(({ title, id }) => ({ label: title, value: id }))];
-
   const onCreate = useCallback(newDecorator => setUpdatedDecorators([...updatedDecorators, newDecorator]), [updatedDecorators, setUpdatedDecorators]);
 
   return (
     <React.Fragment>
       <p>Select the stream for which you want to change the set of default decorators.</p>
-      <SelectContainer>
-        <Select inputId="streams-filter"
-                onChange={setCurrentStream}
-                options={options}
-                clearable={false}
-                style={{ width: '100%' }}
-                placeholder="There are no decorators configured for any stream."
-                value={currentStream} />
-      </SelectContainer>
+      <StreamSelect onChange={setCurrentStream} value={currentStream} streams={streams} />
 
       <p>Select the type to create a new decorator for this stream:</p>
       <AddDecoratorButton stream={currentStream} nextOrder={nextOrder} decoratorTypes={types} onCreate={onCreate} showHelp={false} />

--- a/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
@@ -38,7 +38,7 @@ const DecoratorsConfigUpdate = ({ streams, decorators, types }) => {
   const [updatedDecorators, setUpdatedDecorators] = useState(decorators);
 
   const decoratorsGroupedByStream = groupBy(updatedDecorators, decorator => (decorator.stream || DEFAULT_SEARCH_ID));
-  const currentDecorators = decoratorsGroupedByStream[currentStream];
+  const currentDecorators = decoratorsGroupedByStream[currentStream] || [];
   const sortedDecorators = currentDecorators
     .sort((d1, d2) => d1.order - d2.order);
   const decoratorItems = sortedDecorators.map(decorator => _formatDecorator(decorator, updatedDecorators, types, setUpdatedDecorators));
@@ -46,7 +46,6 @@ const DecoratorsConfigUpdate = ({ streams, decorators, types }) => {
   const nextOrder = sortedDecorators.reduce((currentMax, decorator) => Math.max(currentMax, decorator.order), 0) + 1;
 
   const options = [{ label: 'Default Search', value: DEFAULT_SEARCH_ID }, ...streams
-    .filter(({ id }) => Object.keys(decoratorsGroupedByStream).includes(id))
     .sort(({ title: key1 }, { title: key2 }) => defaultCompare(key1, key2))
     .map(({ title, id }) => ({ label: title, value: id }))];
 

--- a/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
@@ -1,0 +1,73 @@
+// @flow strict
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { groupBy } from 'lodash';
+
+import Select from 'components/common/Select';
+import DecoratorList from 'views/components/messagelist/decorators/DecoratorList';
+import { defaultCompare } from 'views/logic/DefaultCompare';
+import SelectContainer from './SelectContainer';
+import Decorator from '../../../views/components/messagelist/decorators/Decorator';
+
+const DEFAULT_STREAM_ID = '000000000000000000000001';
+const DEFAULT_SEARCH_ID = 'DEFAULT_SEARCH';
+
+const _formatDecorator = (decorator, decorators, decoratorTypes, updateFn) => {
+  const typeDefinition = decoratorTypes[decorator.type] || { requested_configuration: {}, name: `Unknown type: ${decorator.type}` };
+  const onUpdate = updateFn
+    ? (id, updatedDecorator) => updateFn(decorators.map(curDecorator => (curDecorator.id === id ? updatedDecorator : curDecorator)))
+    : () => {};
+  const onDelete = updateFn
+    ? deletedDecoratorId => updateFn(decorators.filter(({ id }) => (id !== deletedDecoratorId)))
+    : () => {};
+  return ({
+    id: decorator.id,
+    title: <Decorator key={`decorator-${decorator.id}`}
+                      decorator={decorator}
+                      decoratorTypes={decoratorTypes}
+                      disableMenu={updateFn === undefined}
+                      onUpdate={onUpdate}
+                      onDelete={onDelete}
+                      typeDefinition={typeDefinition} />,
+  });
+};
+
+const DecoratorsConfigUpdate = ({ streams, decorators, types }) => {
+  const [currentStream, setCurrentStream] = useState(DEFAULT_STREAM_ID);
+  const [updatedDecorators, setUpdatedDecorators] = useState(decorators);
+
+  const decoratorsGroupedByStream = groupBy(updatedDecorators, decorator => (decorator.stream || DEFAULT_SEARCH_ID));
+  const currentDecorators = decoratorsGroupedByStream[currentStream];
+  const sortedDecorators = currentDecorators
+    .sort((d1, d2) => d1.order - d2.order);
+  const saveConfig = setUpdatedDecorators;
+  const decoratorItems = sortedDecorators.map(decorator => _formatDecorator(decorator, updatedDecorators, types, saveConfig));
+
+  const options = [{ label: 'Default Search', value: DEFAULT_SEARCH_ID }, ...streams
+    .filter(({ id }) => Object.keys(decoratorsGroupedByStream).includes(id))
+    .sort(({ title: key1 }, { title: key2 }) => defaultCompare(key1, key2))
+    .map(({ title, id }) => ({ label: title, value: id }))];
+
+  return (
+    <React.Fragment>
+      <p>Select the stream for which you want to change the set of default decorators.</p>
+      <SelectContainer>
+        <Select inputId="streams-filter"
+                onChange={setCurrentStream}
+                options={options}
+                clearable={false}
+                style={{ width: '100%' }}
+                placeholder="There are no decorators configured for any stream."
+                value={currentStream} />
+      </SelectContainer>
+
+      <p>Use drag and drop to change the execution order of the decorators.</p>
+
+      <DecoratorList decorators={decoratorItems} />
+    </React.Fragment>
+  );
+};
+
+DecoratorsConfigUpdate.propTypes = {};
+
+export default DecoratorsConfigUpdate;

--- a/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
@@ -1,13 +1,14 @@
 // @flow strict
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import { groupBy } from 'lodash';
 
 import Select from 'components/common/Select';
 import DecoratorList from 'views/components/messagelist/decorators/DecoratorList';
 import { defaultCompare } from 'views/logic/DefaultCompare';
+import Decorator from 'views/components/messagelist/decorators/Decorator';
+import AddDecoratorButton from 'views/components/messagelist/decorators/AddDecoratorButton';
 import SelectContainer from './SelectContainer';
-import Decorator from '../../../views/components/messagelist/decorators/Decorator';
 
 const DEFAULT_STREAM_ID = '000000000000000000000001';
 const DEFAULT_SEARCH_ID = 'DEFAULT_SEARCH';
@@ -40,13 +41,16 @@ const DecoratorsConfigUpdate = ({ streams, decorators, types }) => {
   const currentDecorators = decoratorsGroupedByStream[currentStream];
   const sortedDecorators = currentDecorators
     .sort((d1, d2) => d1.order - d2.order);
-  const saveConfig = setUpdatedDecorators;
-  const decoratorItems = sortedDecorators.map(decorator => _formatDecorator(decorator, updatedDecorators, types, saveConfig));
+  const decoratorItems = sortedDecorators.map(decorator => _formatDecorator(decorator, updatedDecorators, types, setUpdatedDecorators));
+
+  const nextOrder = sortedDecorators.reduce((currentMax, decorator) => Math.max(currentMax, decorator.order), 0) + 1;
 
   const options = [{ label: 'Default Search', value: DEFAULT_SEARCH_ID }, ...streams
     .filter(({ id }) => Object.keys(decoratorsGroupedByStream).includes(id))
     .sort(({ title: key1 }, { title: key2 }) => defaultCompare(key1, key2))
     .map(({ title, id }) => ({ label: title, value: id }))];
+
+  const onCreate = useCallback(newDecorator => setUpdatedDecorators([ ...updatedDecorators, newDecorator]), [updatedDecorators, setUpdatedDecorators]);
 
   return (
     <React.Fragment>
@@ -60,6 +64,9 @@ const DecoratorsConfigUpdate = ({ streams, decorators, types }) => {
                 placeholder="There are no decorators configured for any stream."
                 value={currentStream} />
       </SelectContainer>
+
+      <p>Select the type to create a new decorator for this stream:</p>
+      <AddDecoratorButton stream={currentStream} nextOrder={nextOrder} decoratorTypes={types} onCreate={onCreate} showHelp={false} />
 
       <p>Use drag and drop to change the execution order of the decorators.</p>
 

--- a/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
@@ -6,6 +6,7 @@ import { cloneDeep } from 'lodash';
 import BootstrapModalWrapper from 'components/bootstrap/BootstrapModalWrapper';
 import { Button, Modal } from 'components/graylog';
 import { IfPermitted } from 'components/common';
+import type { Stream } from 'stores/streams/StreamsStore';
 import DecoratorList from 'views/components/messagelist/decorators/DecoratorList';
 import AddDecoratorButton from 'views/components/messagelist/decorators/AddDecoratorButton';
 import type { Decorator } from 'views/components/messagelist/decorators/Types';
@@ -13,7 +14,7 @@ import StreamSelect, { DEFAULT_SEARCH_ID, DEFAULT_STREAM_ID } from './StreamSele
 import formatDecorator from './FormatDecorator';
 
 type Props = {
-  streams: Array<{ title: string, id: string }>,
+  streams: Array<Stream>,
   decorators: Array<Decorator>,
   types: { [string]: any },
   show?: boolean,

--- a/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
@@ -1,5 +1,6 @@
 // @flow strict
 import React, { useCallback, useState } from 'react';
+import PropTypes from 'prop-types';
 
 import BootstrapModalWrapper from 'components/bootstrap/BootstrapModalWrapper';
 import { Button, Modal } from 'components/graylog';
@@ -85,6 +86,17 @@ const DecoratorsConfigUpdate = ({ streams, decorators, types, show = false, onCa
   );
 };
 
-DecoratorsConfigUpdate.propTypes = {};
+DecoratorsConfigUpdate.propTypes = {
+  streams: PropTypes.array.isRequired,
+  decorators: PropTypes.array.isRequired,
+  types: PropTypes.object.isRequired,
+  show: PropTypes.bool,
+  onCancel: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
+};
+
+DecoratorsConfigUpdate.defaultProps = {
+  show: false,
+};
 
 export default React.forwardRef<Props, BootstrapModalWrapper>(DecoratorsConfigUpdate);

--- a/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
@@ -44,7 +44,7 @@ type Props = {
   onSave: (Array<DecoratorType>) => mixed,
 };
 
-const DecoratorsConfigUpdate = ({ streams, decorators, types, show = false, onCancel, onSave }: Props) => {
+const DecoratorsConfigUpdate = React.forwardRef(({ streams, decorators, types, show = false, onCancel, onSave }: Props, modalRef) => {
   const [currentStream, setCurrentStream] = useState(DEFAULT_STREAM_ID);
   const [modifiedDecorators, setModifiedDecorators] = useState(decorators);
   const onCreate = useCallback(
@@ -60,7 +60,8 @@ const DecoratorsConfigUpdate = ({ streams, decorators, types, show = false, onCa
   const nextOrder = currentDecorators.reduce((currentMax, decorator) => Math.max(currentMax, decorator.order), 0) + 1;
 
   return (
-    <BootstrapModalWrapper showModal={show}
+    <BootstrapModalWrapper ref={modalRef}
+                           showModal={show}
                            onHide={onCancel}>
       <Modal.Header closeButton>
         <Modal.Title>Update Default Decorators Configuration</Modal.Title>
@@ -82,7 +83,7 @@ const DecoratorsConfigUpdate = ({ streams, decorators, types, show = false, onCa
       </Modal.Footer>
     </BootstrapModalWrapper>
   );
-};
+});
 
 DecoratorsConfigUpdate.propTypes = {};
 

--- a/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
@@ -29,10 +29,10 @@ const _formatDecorator = (decorator, decorators, decoratorTypes, updateFn) => {
 };
 
 export type DecoratorType = {
-  id: string,
+  id?: string,
   order: number,
   type: string,
-  stream: string,
+  stream: ?string,
 };
 
 type Props = {

--- a/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/DecoratorsConfigUpdate.jsx
@@ -1,6 +1,5 @@
 // @flow strict
 import React, { useCallback, useState } from 'react';
-import { groupBy } from 'lodash';
 
 import BootstrapModalWrapper from 'components/bootstrap/BootstrapModalWrapper';
 import { Button, Modal } from 'components/graylog';
@@ -29,7 +28,7 @@ const _formatDecorator = (decorator, decorators, decoratorTypes, updateFn) => {
   });
 };
 
-type DecoratorType = {
+export type DecoratorType = {
   id: string,
   order: number,
   type: string,
@@ -42,13 +41,16 @@ type Props = {
   types: { [string]: any },
   show: boolean,
   onCancel: () => void,
-  onSave: (Array<DecoratorType>) => void,
+  onSave: (Array<DecoratorType>) => mixed,
 };
 
 const DecoratorsConfigUpdate = ({ streams, decorators, types, show = false, onCancel, onSave }: Props) => {
   const [currentStream, setCurrentStream] = useState(DEFAULT_STREAM_ID);
   const [modifiedDecorators, setModifiedDecorators] = useState(decorators);
-  const onCreate = useCallback(newDecorator => setModifiedDecorators([...modifiedDecorators, newDecorator]), [modifiedDecorators, setModifiedDecorators]);
+  const onCreate = useCallback(
+    ({ stream, ...rest }) => setModifiedDecorators([...modifiedDecorators, { ...rest, stream: stream === DEFAULT_SEARCH_ID ? null : stream }]),
+    [modifiedDecorators, setModifiedDecorators],
+  );
 
   const currentDecorators = modifiedDecorators.filter(decorator => (decorator.stream || DEFAULT_SEARCH_ID) === currentStream);
   const decoratorItems = currentDecorators

--- a/graylog2-web-interface/src/components/configurations/decorators/DecoratorsUpdater.js
+++ b/graylog2-web-interface/src/components/configurations/decorators/DecoratorsUpdater.js
@@ -2,11 +2,11 @@
 import { difference, isEqual } from 'lodash';
 
 import CombinedProvider from 'injection/CombinedProvider';
-import type { DecoratorType } from './DecoratorsConfigUpdate';
+import type { Decorator } from 'views/components/messagelist/decorators/Types';
 
 const { DecoratorsActions } = CombinedProvider.get('Decorators');
 
-const DecoratorsUpdater = (newDecorators: Array<DecoratorType>, oldDecorators: Array<DecoratorType>) => {
+const DecoratorsUpdater = (newDecorators: Array<Decorator>, oldDecorators: Array<Decorator>) => {
   const oldDecoratorsById = oldDecorators
     .reduce((prev, cur) => (cur.id ? { ...prev, [cur.id]: cur } : prev), {});
   const createdDecorators = newDecorators.filter(({ id }) => !id);

--- a/graylog2-web-interface/src/components/configurations/decorators/DecoratorsUpdater.js
+++ b/graylog2-web-interface/src/components/configurations/decorators/DecoratorsUpdater.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { difference } from 'lodash';
+import { difference, isEqual } from 'lodash';
 
 import CombinedProvider from 'injection/CombinedProvider';
 import type { DecoratorType } from './DecoratorsConfigUpdate';
@@ -7,9 +7,10 @@ import type { DecoratorType } from './DecoratorsConfigUpdate';
 const { DecoratorsActions } = CombinedProvider.get('Decorators');
 
 const DecoratorsUpdater = (newDecorators: Array<DecoratorType>, oldDecorators: Array<DecoratorType>) => {
+  const oldDecoratorsById = oldDecorators.reduce((prev, cur) => ({ ...prev, [cur.id]: cur }), {});
   const createdDecorators = newDecorators.filter(({ id }) => !id);
   const updatedDecorators = newDecorators.filter(({ id }) => id)
-    .filter(decorator => decorator !== oldDecorators.find(oldDecorator => oldDecorator.id === decorator.id));
+    .filter(decorator => !isEqual(decorator, oldDecoratorsById[decorator.id]));
   const deletedDecoratorIds = difference(oldDecorators.map(({ id }) => id).sort(), newDecorators.map(({ id }) => id).sort());
 
   return [

--- a/graylog2-web-interface/src/components/configurations/decorators/DecoratorsUpdater.js
+++ b/graylog2-web-interface/src/components/configurations/decorators/DecoratorsUpdater.js
@@ -1,0 +1,22 @@
+// @flow strict
+import { difference } from 'lodash';
+
+import CombinedProvider from 'injection/CombinedProvider';
+import type { DecoratorType } from './DecoratorsConfigUpdate';
+
+const { DecoratorsActions } = CombinedProvider.get('Decorators');
+
+const DecoratorsUpdater = (newDecorators: Array<DecoratorType>, oldDecorators: Array<DecoratorType>) => {
+  const createdDecorators = newDecorators.filter(({ id }) => !id);
+  const updatedDecorators = newDecorators.filter(({ id }) => id)
+    .filter(decorator => decorator !== oldDecorators.find(oldDecorator => oldDecorator.id === decorator.id));
+  const deletedDecoratorIds = difference(oldDecorators.map(({ id }) => id).sort(), newDecorators.map(({ id }) => id).sort());
+
+  return [
+    ...createdDecorators.map(newDecorator => () => DecoratorsActions.create(newDecorator)),
+    ...updatedDecorators.map(updatedDecorator => () => DecoratorsActions.update(updatedDecorator.id, updatedDecorator)),
+    ...deletedDecoratorIds.map(deletedID => () => DecoratorsActions.remove(deletedID)),
+  ].reduce((prev, cur) => prev.then(() => cur()), Promise.resolve());
+};
+
+export default DecoratorsUpdater;

--- a/graylog2-web-interface/src/components/configurations/decorators/DecoratorsUpdater.js
+++ b/graylog2-web-interface/src/components/configurations/decorators/DecoratorsUpdater.js
@@ -7,15 +7,21 @@ import type { Decorator } from 'views/components/messagelist/decorators/Types';
 const { DecoratorsActions } = CombinedProvider.get('Decorators');
 
 const DecoratorsUpdater = (newDecorators: Array<Decorator>, oldDecorators: Array<Decorator>) => {
+  const newDecoratorIds: Array<string> = newDecorators.filter(({ id }) => id !== undefined).map(({ id }) => id).sort();
+  const oldDecoratorIds: Array<string> = oldDecorators.map(({ id }) => id).sort();
+
   const oldDecoratorsById = oldDecorators
     .reduce((prev, cur) => (cur.id ? { ...prev, [cur.id]: cur } : prev), {});
-  const createdDecorators = newDecorators.filter(({ id }) => !id);
+  const newDecoratorsById = newDecorators
+    .reduce((prev, cur) => (cur.id ? { ...prev, [cur.id]: cur } : prev), {});
+
+  const createdDecorators = difference(newDecoratorIds, oldDecoratorIds).map(newDecoratorId => newDecoratorsById[newDecoratorId]);
   const updatedDecorators = newDecorators.filter(({ id }) => id)
-    .filter(decorator => decorator.id && !isEqual(decorator, oldDecoratorsById[decorator.id]));
-  const deletedDecoratorIds = difference(oldDecorators.map(({ id }) => id).sort(), newDecorators.map(({ id }) => id).sort());
+    .filter(decorator => decorator.id && oldDecoratorsById[decorator.id] && !isEqual(decorator, oldDecoratorsById[decorator.id]));
+  const deletedDecoratorIds = difference(oldDecoratorIds, newDecoratorIds);
 
   return [
-    ...createdDecorators.map(newDecorator => () => DecoratorsActions.create(newDecorator)),
+    ...createdDecorators.map(({ id, ...newDecorator }) => () => DecoratorsActions.create(newDecorator)),
     ...updatedDecorators.map(updatedDecorator => () => DecoratorsActions.update(updatedDecorator.id, updatedDecorator)),
     ...deletedDecoratorIds.map(deletedID => () => DecoratorsActions.remove(deletedID)),
   ].reduce((prev, cur) => prev.then(() => cur()), Promise.resolve());

--- a/graylog2-web-interface/src/components/configurations/decorators/DecoratorsUpdater.js
+++ b/graylog2-web-interface/src/components/configurations/decorators/DecoratorsUpdater.js
@@ -7,10 +7,11 @@ import type { DecoratorType } from './DecoratorsConfigUpdate';
 const { DecoratorsActions } = CombinedProvider.get('Decorators');
 
 const DecoratorsUpdater = (newDecorators: Array<DecoratorType>, oldDecorators: Array<DecoratorType>) => {
-  const oldDecoratorsById = oldDecorators.reduce((prev, cur) => ({ ...prev, [cur.id]: cur }), {});
+  const oldDecoratorsById = oldDecorators
+    .reduce((prev, cur) => (cur.id ? { ...prev, [cur.id]: cur } : prev), {});
   const createdDecorators = newDecorators.filter(({ id }) => !id);
   const updatedDecorators = newDecorators.filter(({ id }) => id)
-    .filter(decorator => !isEqual(decorator, oldDecoratorsById[decorator.id]));
+    .filter(decorator => decorator.id && !isEqual(decorator, oldDecoratorsById[decorator.id]));
   const deletedDecoratorIds = difference(oldDecorators.map(({ id }) => id).sort(), newDecorators.map(({ id }) => id).sort());
 
   return [

--- a/graylog2-web-interface/src/components/configurations/decorators/DecoratorsUpdater.test.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/DecoratorsUpdater.test.jsx
@@ -18,7 +18,7 @@ jest.mock('injection/CombinedProvider', () => ({
 }));
 
 const decorator = (id, type = 'dummy') => ({ id, type, order: 0, stream: 'dummystream' });
-const newDecorator = type => ({ type, order: 0, stream: 'anotherdummystream' });
+const newDecorator = type => ({ type, order: 0, stream: 'dummystream' });
 
 describe('DecoratorsUpdater', () => {
   beforeEach(() => {
@@ -31,7 +31,7 @@ describe('DecoratorsUpdater', () => {
       expect(mockRemove).not.toHaveBeenCalled();
     }));
   it('finds a created decorator', () => DecoratorsUpdater(
-    [decorator('decorator1'), newDecorator('a new decorator'), decorator('decorator3')],
+    [decorator('decorator1'), decorator('new1', 'a new decorator'), decorator('decorator3')],
     [decorator('decorator1'), decorator('decorator3')],
   )
     .then(() => {
@@ -59,7 +59,7 @@ describe('DecoratorsUpdater', () => {
     }));
 
   it('finds a combination of created, updated & removed decorators', () => DecoratorsUpdater(
-    [decorator('decorator2'), newDecorator('new type'), decorator('decorator3', 'bar!'), newDecorator('other new type'), decorator('decorator4', 'something else')],
+    [decorator('decorator2'), decorator('new1', 'new type'), decorator('decorator3', 'bar!'), decorator('new2', 'other new type'), decorator('decorator4', 'something else')],
     [decorator('decorator1'), decorator('decorator2'), decorator('decorator4', 'something'), decorator('decorator3', 'foo!')],
   )
     .then(() => {

--- a/graylog2-web-interface/src/components/configurations/decorators/DecoratorsUpdater.test.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/DecoratorsUpdater.test.jsx
@@ -1,0 +1,74 @@
+// @flow strict
+import DecoratorsUpdater from './DecoratorsUpdater';
+
+const mockCreate = jest.fn(() => Promise.resolve());
+const mockUpdate = jest.fn(() => Promise.resolve());
+const mockRemove = jest.fn(() => Promise.resolve());
+
+jest.mock('injection/CombinedProvider', () => ({
+  get: type => ({
+    Decorators: {
+      DecoratorsActions: {
+        create: (...args) => mockCreate(...args),
+        update: (...args) => mockUpdate(...args),
+        remove: (...args) => mockRemove(...args),
+      },
+    },
+  })[type],
+}));
+
+describe('DecoratorsUpdater', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+  it('works for empty arrays', () => DecoratorsUpdater([], [])
+    .then(() => {
+      expect(mockCreate).not.toHaveBeenCalled();
+      expect(mockUpdate).not.toHaveBeenCalled();
+      expect(mockRemove).not.toHaveBeenCalled();
+    }));
+  it('finds a created decorator', () => DecoratorsUpdater(
+    [{ id: 'decorator1' }, { value: 42 }, { id: 'decorator3' }],
+    [{ id: 'decorator1' }, { id: 'decorator3' }],
+  )
+    .then(() => {
+      expect(mockCreate).toHaveBeenCalledWith({ value: 42 });
+      expect(mockUpdate).not.toHaveBeenCalled();
+      expect(mockRemove).not.toHaveBeenCalled();
+    }));
+  it('finds an updated decorator', () => DecoratorsUpdater(
+    [{ id: 'decorator1' }, { id: 'decorator2', value: 42 }, { id: 'decorator3' }],
+    [{ id: 'decorator1' }, { id: 'decorator2', value: 23 }, { id: 'decorator3' }],
+  )
+    .then(() => {
+      expect(mockCreate).not.toHaveBeenCalled();
+      expect(mockUpdate).toHaveBeenCalledWith('decorator2', { id: 'decorator2', value: 42 });
+      expect(mockRemove).not.toHaveBeenCalled();
+    }));
+  it('finds a removed decorator', () => DecoratorsUpdater(
+    [{ id: 'decorator1' }, { id: 'decorator3' }],
+    [{ id: 'decorator1' }, { id: 'decorator2' }, { id: 'decorator3' }],
+  )
+    .then(() => {
+      expect(mockCreate).not.toHaveBeenCalled();
+      expect(mockUpdate).not.toHaveBeenCalled();
+      expect(mockRemove).toHaveBeenCalledWith('decorator2');
+    }));
+
+  it('finds a combination of created, updated & removed decorators', () => DecoratorsUpdater(
+    [{ id: 'decorator2' }, { value: 23 }, { id: 'decorator3', value: 'bar!' }, { value: 42 }, { id: 'decorator4', something: 'something else' }],
+    [{ id: 'decorator1' }, { id: 'decorator2' }, { id: 'decorator4', something: 'something' }, { id: 'decorator3', value: 'foo!' }],
+  )
+    .then(() => {
+      expect(mockCreate).toHaveBeenCalledTimes(2);
+      expect(mockCreate).toHaveBeenCalledWith({ value: 23 });
+      expect(mockCreate).toHaveBeenCalledWith({ value: 42 });
+
+      expect(mockUpdate).toHaveBeenCalledTimes(2);
+      expect(mockUpdate).toHaveBeenCalledWith('decorator3', { id: 'decorator3', value: 'bar!' });
+      expect(mockUpdate).toHaveBeenCalledWith('decorator4', { id: 'decorator4', something: 'something else' });
+
+      expect(mockRemove).toHaveBeenCalledTimes(1);
+      expect(mockRemove).toHaveBeenCalledWith('decorator1');
+    }));
+});

--- a/graylog2-web-interface/src/components/configurations/decorators/FormatDecorator.js
+++ b/graylog2-web-interface/src/components/configurations/decorators/FormatDecorator.js
@@ -1,0 +1,31 @@
+// @flow strict
+import DecoratorSummary from 'views/components/messagelist/decorators/DecoratorSummary';
+import type { Decorator, DecoratorType } from 'views/components/messagelist/decorators/types';
+
+const formatDecorator = (
+  decorator: Decorator,
+  decorators: Array<Decorator>,
+  decoratorTypes: { [string]: DecoratorType },
+  updateFn?: (Array<Decorator>) => mixed,
+) => {
+  const typeDefinition = decoratorTypes[decorator.type] || { requested_configuration: {}, name: `Unknown type: ${decorator.type}` };
+  const onUpdate = updateFn
+    ? (id, updatedDecorator) => updateFn(decorators.map(curDecorator => (curDecorator.id === id ? updatedDecorator : curDecorator)))
+    : () => {};
+  const onDelete = updateFn
+    ? deletedDecoratorId => updateFn(decorators.filter(({ id }) => (id !== deletedDecoratorId)))
+    : () => {};
+  return ({
+    id: decorator.id,
+    title: <DecoratorSummary key={`decorator-${decorator.id || 'new'}`}
+                             decorator={decorator}
+                             decoratorTypes={decoratorTypes}
+                             disableMenu={updateFn === undefined}
+                             onUpdate={onUpdate}
+                             onDelete={onDelete}
+                             typeDefinition={typeDefinition} />,
+  });
+};
+
+export default formatDecorator;
+

--- a/graylog2-web-interface/src/components/configurations/decorators/FormatDecorator.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/FormatDecorator.jsx
@@ -31,4 +31,3 @@ const formatDecorator = (
 };
 
 export default formatDecorator;
-

--- a/graylog2-web-interface/src/components/configurations/decorators/FormatDecorator.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/FormatDecorator.jsx
@@ -1,7 +1,7 @@
 // @flow strict
 import * as React from 'react';
 import DecoratorSummary from 'views/components/messagelist/decorators/DecoratorSummary';
-import type { Decorator, DecoratorType } from 'views/components/messagelist/decorators/types';
+import type { Decorator, DecoratorType } from 'views/components/messagelist/decorators/Types';
 
 const formatDecorator = (
   decorator: Decorator,

--- a/graylog2-web-interface/src/components/configurations/decorators/FormatDecorator.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/FormatDecorator.jsx
@@ -1,4 +1,5 @@
 // @flow strict
+import * as React from 'react';
 import DecoratorSummary from 'views/components/messagelist/decorators/DecoratorSummary';
 import type { Decorator, DecoratorType } from 'views/components/messagelist/decorators/types';
 

--- a/graylog2-web-interface/src/components/configurations/decorators/FormatDecorator.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/FormatDecorator.jsx
@@ -16,9 +16,11 @@ const formatDecorator = (
   const onDelete = updateFn
     ? deletedDecoratorId => updateFn(decorators.filter(({ id }) => (id !== deletedDecoratorId)))
     : () => {};
+  const { id, order } = decorator;
   return ({
-    id: decorator.id,
-    title: <DecoratorSummary key={`decorator-${decorator.id || 'new'}`}
+    id,
+    order,
+    title: <DecoratorSummary key={`decorator-${id || 'new'}`}
                              decorator={decorator}
                              decoratorTypes={decoratorTypes}
                              disableMenu={updateFn === undefined}

--- a/graylog2-web-interface/src/components/configurations/decorators/SelectContainer.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/SelectContainer.jsx
@@ -1,0 +1,8 @@
+// @flow strict
+import styled from 'styled-components';
+
+const SelectContainer: React.ComponentType<{}> = styled.div`
+  margin-bottom: 10px;
+`;
+
+export default SelectContainer;

--- a/graylog2-web-interface/src/components/configurations/decorators/SelectContainer.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/SelectContainer.jsx
@@ -1,8 +1,0 @@
-// @flow strict
-import styled from 'styled-components';
-
-const SelectContainer: React.ComponentType<{}> = styled.div`
-  margin-bottom: 10px;
-`;
-
-export default SelectContainer;

--- a/graylog2-web-interface/src/components/configurations/decorators/StreamSelect.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/StreamSelect.jsx
@@ -1,0 +1,30 @@
+// @flow strict
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import SelectContainer from './SelectContainer';
+import Select from '../../common/Select';
+import { defaultCompare } from '../../../views/logic/DefaultCompare';
+
+export const DEFAULT_STREAM_ID = '000000000000000000000001';
+export const DEFAULT_SEARCH_ID = 'DEFAULT_SEARCH';
+
+const StreamSelect = ({ onChange, value, streams }) => {
+  const options = [{ label: 'Default Search', value: DEFAULT_SEARCH_ID }, ...streams
+    .sort(({ title: key1 }, { title: key2 }) => defaultCompare(key1, key2))
+    .map(({ title, id }) => ({ label: title, value: id }))];
+  return (
+    <SelectContainer>
+      <Select inputId="streams-filter"
+              onChange={onChange}
+              options={streams}
+              clearable={false}
+              style={{ width: '100%' }}
+              placeholder="There are no decorators configured for any stream."
+              value={value} />
+    </SelectContainer>
+  );
+};
+
+StreamSelect.propTypes = {};
+
+export default StreamSelect;

--- a/graylog2-web-interface/src/components/configurations/decorators/StreamSelect.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/StreamSelect.jsx
@@ -1,14 +1,25 @@
 // @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import SelectContainer from './SelectContainer';
-import Select from '../../common/Select';
-import { defaultCompare } from '../../../views/logic/DefaultCompare';
+import styled from 'styled-components';
+
+import Select from 'components/common/Select';
+import { defaultCompare } from 'views/logic/DefaultCompare';
 
 export const DEFAULT_STREAM_ID = '000000000000000000000001';
 export const DEFAULT_SEARCH_ID = 'DEFAULT_SEARCH';
 
-const StreamSelect = ({ onChange, value, streams }) => {
+const SelectContainer: React.ComponentType<{}> = styled.div`
+  margin-bottom: 10px;
+`;
+
+type Props = {
+  onChange: string => void,
+  value: string,
+  streams: Array<{ id: string, title: string }>,
+};
+
+const StreamSelect = ({ onChange, value, streams }: Props) => {
   const options = [{ label: 'Default Search', value: DEFAULT_SEARCH_ID }, ...streams
     .sort(({ title: key1 }, { title: key2 }) => defaultCompare(key1, key2))
     .map(({ title, id }) => ({ label: title, value: id }))];
@@ -16,7 +27,7 @@ const StreamSelect = ({ onChange, value, streams }) => {
     <SelectContainer>
       <Select inputId="streams-filter"
               onChange={onChange}
-              options={streams}
+              options={options}
               clearable={false}
               style={{ width: '100%' }}
               placeholder="There are no decorators configured for any stream."
@@ -25,6 +36,10 @@ const StreamSelect = ({ onChange, value, streams }) => {
   );
 };
 
-StreamSelect.propTypes = {};
+StreamSelect.propTypes = {
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.string.isRequired,
+  streams: PropTypes.array.isRequired,
+};
 
 export default StreamSelect;

--- a/graylog2-web-interface/src/components/configurations/decorators/StreamSelect.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/StreamSelect.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 import Select from 'components/common/Select';
+import type { Stream } from 'stores/streams/StreamsStore';
 import { defaultCompare } from 'views/logic/DefaultCompare';
 
 export const DEFAULT_STREAM_ID = '000000000000000000000001';
@@ -16,7 +17,7 @@ const SelectContainer: React.ComponentType<{}> = styled.div`
 type Props = {
   onChange: string => void,
   value: string,
-  streams: Array<{ id: string, title: string }>,
+  streams: Array<Stream>,
 };
 
 const StreamSelect = ({ onChange, value, streams }: Props) => {

--- a/graylog2-web-interface/src/stores/streams/StreamsStore.js
+++ b/graylog2-web-interface/src/stores/streams/StreamsStore.js
@@ -10,7 +10,7 @@ import CombinedProvider from 'injection/CombinedProvider';
 
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
-type Stream = {
+export type Stream = {
   id: string,
   title: string,
   description: string,

--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -194,11 +194,12 @@ export default {
       type: 'aggregate',
       title: 'Aggregate',
       handler: AggregateActionHandler,
-      isEnabled: (({ type }) => !type.isCompound(): ActionHandlerCondition),
+      isEnabled: (({ type }) => (!type.isCompound() && !type.isDecorated()): ActionHandlerCondition),
     },
     {
       type: 'statistics',
       title: 'Statistics',
+      isEnabled: (({ type }) => !type.isDecorated(): ActionHandlerCondition),
       handler: FieldStatisticsHandler,
     },
     {
@@ -219,11 +220,13 @@ export default {
       type: 'add-to-all-tables',
       title: 'Add to all tables',
       handler: AddToAllTablesActionHandler,
+      isEnabled: (({ type }) => !type.isDecorated(): ActionHandlerCondition),
     },
     {
       type: 'remove-from-all-tables',
       title: 'Remove from all tables',
       handler: RemoveFromAllTablesActionHandler,
+      isEnabled: (({ type }) => !type.isDecorated(): ActionHandlerCondition),
     },
   ],
   valueActions: [
@@ -231,13 +234,13 @@ export default {
       type: 'exclude',
       title: 'Exclude from results',
       handler: new ExcludeFromQueryHandler().handle,
-      isEnabled: ({ field }: ActionHandlerArguments) => !isFunction(field),
+      isEnabled: ({ field, type }: ActionHandlerArguments) => (!isFunction(field) && !type.isDecorated()),
     },
     {
       type: 'add-to-query',
       title: 'Add to query',
       handler: new AddToQueryHandler().handle,
-      isEnabled: ({ field }: ActionHandlerArguments) => !isFunction(field),
+      isEnabled: ({ field, type }: ActionHandlerArguments) => (!isFunction(field) && !type.isDecorated()),
     },
     {
       type: 'new-query',
@@ -254,7 +257,7 @@ export default {
     {
       type: 'create-extractor',
       title: 'Create extractor',
-      isEnabled: (({ type }) => type.type === 'string': ActionHandlerCondition),
+      isEnabled: (({ type }) => (type.type === 'string' && !type.isDecorated()): ActionHandlerCondition),
       component: SelectExtractorType,
     },
     {

--- a/graylog2-web-interface/src/views/components/DecoratorValue.jsx
+++ b/graylog2-web-interface/src/views/components/DecoratorValue.jsx
@@ -1,0 +1,35 @@
+// @flow strict
+import * as React from 'react';
+import { isString, trim, truncate as trunc } from 'lodash';
+
+import FieldType from 'views/logic/fieldtypes/FieldType';
+import EmptyValue from './EmptyValue';
+import type { ValueRendererProps } from './messagelist/decoration/ValueRenderer';
+
+const _formatValue = (field, value, truncate, render, type) => {
+  const stringified = isString(value) ? value : JSON.stringify(value);
+  const Component = render;
+  return trim(stringified) === ''
+    ? <EmptyValue />
+    : <Component field={field} value={(truncate ? trunc(stringified) : stringified)} type={type} />;
+};
+
+
+type Props = {
+  field: string,
+  value: any,
+  truncate: boolean,
+  render: React.ComponentType<ValueRendererProps>,
+  type: FieldType,
+};
+
+const DecoratorValue = ({ field, value, truncate, render, type }: Props) => {
+  if (value && value.href && value.type) {
+    const formattedValue = _formatValue(field, value.href, truncate, render, type);
+    return <a href={value.href}>{formattedValue}</a>;
+  }
+
+  return _formatValue(field, value, truncate, render, type);
+};
+
+export default DecoratorValue;

--- a/graylog2-web-interface/src/views/components/TypeSpecificValue.jsx
+++ b/graylog2-web-interface/src/views/components/TypeSpecificValue.jsx
@@ -10,6 +10,7 @@ import FieldType from 'views/logic/fieldtypes/FieldType';
 import EmptyValue from './EmptyValue';
 import CustomPropTypes from './CustomPropTypes';
 import type { ValueRendererProps } from './messagelist/decoration/ValueRenderer';
+import DecoratorValue from './DecoratorValue';
 
 const _formatValue = (field, value, truncate, render, type) => {
   const stringified = isString(value) ? value : JSON.stringify(value);
@@ -32,6 +33,9 @@ const defaultComponent = ({ value }: ValueRendererProps) => value;
 const TypeSpecificValue = ({ field, value, render = defaultComponent, type = FieldType.Unknown, truncate = false }: Props) => {
   if (value === undefined) {
     return null;
+  }
+  if (type.isDecorated()) {
+    return <DecoratorValue value={value} field={field} render={render} type={type} truncate={truncate} />;
   }
   switch (type.type) {
     case 'date': return <UserTimezoneTimestamp dateTime={value} />;

--- a/graylog2-web-interface/src/views/components/Value.jsx
+++ b/graylog2-web-interface/src/views/components/Value.jsx
@@ -32,7 +32,7 @@ const Value = ({ children, field, value, queryId, render = defaultRenderer, type
             {field} = <TypeSpecificValue field={field} value={value} type={type} truncate />
           </ValueActions>
         )
-        : <span><TypeSpecificValue field={field} value={value} type={type} truncate /></span>)}
+        : <span><TypeSpecificValue field={field} value={value} type={type} /></span>)}
     </InteractiveContext.Consumer>
   );
 };

--- a/graylog2-web-interface/src/views/components/messagelist/MessageField.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageField.jsx
@@ -43,7 +43,8 @@ const MessageField = ({ fieldName, fieldType, message, value, currentView }: Pro
     },
   } = message;
 
-  const isDecoratedField = decorationStats.added_fields[fieldName] !== undefined || decorationStats.changed_fields[fieldName] !== undefined;
+  const isDecoratedField = decorationStats
+    && (decorationStats.added_fields[fieldName] !== undefined || decorationStats.changed_fields[fieldName] !== undefined);
 
   const ValueContext = isDecoratedField
     ? ({ children }) => (

--- a/graylog2-web-interface/src/views/components/messagelist/MessageField.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageField.jsx
@@ -1,6 +1,7 @@
 // @flow strict
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'styled-components';
 
 import connect from 'stores/connect';
 import Field from 'views/components/Field';
@@ -10,32 +11,57 @@ import FieldType from 'views/logic/fieldtypes/FieldType';
 
 import CustomPropTypes from '../CustomPropTypes';
 import DecoratedValue from './decoration/DecoratedValue';
+import InteractiveContext from '../contexts/InteractiveContext';
+import type { Message } from './Types';
 
 const SPECIAL_FIELDS = ['full_message', 'level'];
 
 type Props = {
   fieldName: string,
   fieldType: FieldType,
-  message: {
-    fields: { [string]: any },
-  },
+  message: Message,
   value: any,
   currentView: {
     activeQuery: string,
   },
 };
 
+const DecoratedField = styled.small`
+    color: #AAA;
+    font-weight: normal;
+`;
+
 const MessageField = ({ fieldName, fieldType, message, value, currentView }: Props) => {
   const innerValue = SPECIAL_FIELDS.indexOf(fieldName) !== -1 ? message.fields[fieldName] : value;
   const { activeQuery } = currentView;
 
+  const {
+    decoration_stats: decorationStats = {
+      added_fields: {},
+      changed_fields: {},
+      removed_fields: {},
+    },
+  } = message;
+
+  const isDecoratedField = decorationStats.added_fields[fieldName] !== undefined || decorationStats.changed_fields[fieldName] !== undefined;
+
+  const ValueContext = isDecoratedField
+    ? ({ children }) => (
+      <InteractiveContext.Provider value={false}>
+        {children} <DecoratedField>(decorated)</DecoratedField>
+      </InteractiveContext.Provider>
+    )
+    : ({ children }) => children;
+
   return (
     <React.Fragment>
       <dt>
-        <Field queryId={activeQuery} name={fieldName} type={fieldType}>{fieldName}</Field>
+        <Field queryId={activeQuery} name={fieldName} type={isDecoratedField ? FieldType.Decorated : fieldType}>{fieldName}</Field>
       </dt>
       <dd>
-        <Value queryId={activeQuery} field={fieldName} value={innerValue} type={fieldType} render={DecoratedValue} />
+        <ValueContext>
+          <Value queryId={activeQuery} field={fieldName} value={innerValue} type={fieldType} render={DecoratedValue} />
+        </ValueContext>
       </dd>
     </React.Fragment>
   );

--- a/graylog2-web-interface/src/views/components/messagelist/MessageField.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageField.jsx
@@ -61,7 +61,7 @@ const MessageField = ({ fieldName, fieldType, message, value, currentView }: Pro
       </dt>
       <dd>
         <ValueContext>
-          <Value queryId={activeQuery} field={fieldName} value={innerValue} type={fieldType} render={DecoratedValue} />
+          <Value queryId={activeQuery} field={fieldName} value={innerValue} type={isDecoratedField ? FieldType.Decorated : fieldType} render={DecoratedValue} />
         </ValueContext>
       </dd>
     </React.Fragment>

--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.jsx
@@ -125,7 +125,7 @@ const MessageTableEntry = ({
           <td colSpan={colSpanFixup}>
             <div className="message-wrapper">
               <CustomHighlighting field="message" value={message.fields.message}>
-                <DecoratedValue field="message" value={message.fields.message} type={fieldType('message', message, fields)} />
+                <TypeSpecificValue field="message" value={message.fields.message} type={fieldType('message', message, fields)} render={DecoratedValue} />
               </CustomHighlighting>
             </div>
           </td>

--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.jsx
@@ -63,9 +63,9 @@ type Props = {
 const isDecoratedField = (field, decorationStats) => decorationStats
   && (decorationStats.added_fields[field] !== undefined || decorationStats.changed_fields[field] !== undefined);
 
-const fieldType = (fieldName, { decoration_stats: decorationStats}, fields) => isDecoratedField(fieldName, decorationStats)
+const fieldType = (fieldName, { decoration_stats: decorationStats }, fields) => (isDecoratedField(fieldName, decorationStats)
   ? FieldType.Decorated
-  : fields.find(t => t.name === fieldName, undefined, FieldTypeMapping.create(fieldName, FieldType.Unknown)).type;
+  : fields.find(t => t.name === fieldName, undefined, FieldTypeMapping.create(fieldName, FieldType.Unknown)).type);
 
 const MessageTableEntry = ({
   disableSurroundingSearch,

--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.jsx
@@ -19,6 +19,7 @@ import DecoratedValue from './decoration/DecoratedValue';
 import CustomHighlighting from './CustomHighlighting';
 
 import style from './MessageTableEntry.css';
+import type { Message } from './Types';
 
 const { NodesStore } = CombinedProvider.get('Nodes');
 const { InputsStore } = CombinedProvider.get('Inputs');
@@ -46,12 +47,6 @@ const ConnectedMessageDetail = connect(
     });
   },
 );
-
-type Message = {|
-  id: string,
-  index: string,
-  fields: { [string]: any },
-|};
 
 type Props = {
   disableSurroundingSearch?: boolean,

--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.jsx
@@ -60,6 +60,13 @@ type Props = {
   toggleDetail: (string) => void,
 };
 
+const isDecoratedField = (field, decorationStats) => decorationStats
+  && (decorationStats.added_fields[field] !== undefined || decorationStats.changed_fields[field] !== undefined);
+
+const fieldType = (fieldName, { decoration_stats: decorationStats}, fields) => isDecoratedField(fieldName, decorationStats)
+  ? FieldType.Decorated
+  : fields.find(t => t.name === fieldName, undefined, FieldTypeMapping.create(fieldName, FieldType.Unknown)).type;
+
 const MessageTableEntry = ({
   disableSurroundingSearch,
   expandAllRenderAsync,
@@ -91,12 +98,11 @@ const MessageTableEntry = ({
   if (message.id === highlightMessage) {
     classes += ' message-highlight';
   }
-  const messageFieldType = fields.find(type => type.name === 'message', undefined, FieldTypeMapping.create('message', FieldType.Unknown)).type;
   return (
     <tbody className={classes}>
       <tr className="fields-row" onClick={_toggleDetail}>
         { selectedFields.toArray().map((selectedFieldName, idx) => {
-          const { type } = fields.find(t => t.name === selectedFieldName, undefined, FieldTypeMapping.create(selectedFieldName, FieldType.Unknown));
+          const type = fieldType(selectedFieldName, message, fields);
           return (
             <td className={style.fieldsRowField} key={selectedFieldName}>
               {_renderStrong(
@@ -119,7 +125,7 @@ const MessageTableEntry = ({
           <td colSpan={colSpanFixup}>
             <div className="message-wrapper">
               <CustomHighlighting field="message" value={message.fields.message}>
-                <DecoratedValue field="message" value={message.fields.message} type={messageFieldType} />
+                <DecoratedValue field="message" value={message.fields.message} type={fieldType('message', message, fields)} />
               </CustomHighlighting>
             </div>
           </td>
@@ -151,6 +157,11 @@ MessageTableEntry.propTypes = {
     highlight_ranges: PropTypes.object,
     id: PropTypes.string.isRequired,
     index: PropTypes.string.isRequired,
+    decoration_stats: PropTypes.shape({
+      added_fields: PropTypes.object,
+      changed_fields: PropTypes.object,
+      removed_fields: PropTypes.object,
+    }),
   }).isRequired,
   selectedFields: PropTypes.instanceOf(Immutable.OrderedSet),
   showMessageRow: PropTypes.bool,

--- a/graylog2-web-interface/src/views/components/messagelist/Types.js
+++ b/graylog2-web-interface/src/views/components/messagelist/Types.js
@@ -1,0 +1,11 @@
+// @flow strict
+export type Message = {|
+  id: string,
+  index: string,
+  fields: { [string]: any },
+  decoration_stats: {
+    added_fields: { [string]: any },
+    changed_fields: { [string]: any },
+    removed_fields: { [string]: any },
+  },
+|};

--- a/graylog2-web-interface/src/views/components/messagelist/Types.js
+++ b/graylog2-web-interface/src/views/components/messagelist/Types.js
@@ -3,7 +3,7 @@ export type Message = {|
   id: string,
   index: string,
   fields: { [string]: any },
-  decoration_stats: {
+  decoration_stats?: {
     added_fields: { [string]: any },
     changed_fields: { [string]: any },
     removed_fields: { [string]: any },

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
@@ -76,7 +76,7 @@ const AddDecoratorButton = createReactClass({
 
   render() {
     const { typeDefinition, typeName } = this.state;
-    const { decoratorTypes, disabled } = this.props;
+    const { decoratorTypes, disabled, showHelp = true } = this.props;
 
     const decoratorTypeOptions = jQuery.map(decoratorTypes, this._formatDecoratorType);
     const wrapperComponent = InlineForm();
@@ -106,7 +106,7 @@ const AddDecoratorButton = createReactClass({
                     value={typeName} />
           </div>
         </div>
-        <PopoverHelp />
+        {showHelp && <PopoverHelp />}
 
         <ConfigurationFormContainer>
           {typeName && configurationForm}

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
@@ -12,7 +12,15 @@ import InlineForm from './InlineForm';
 import PopoverHelp from './PopoverHelp';
 
 const ConfigurationFormContainer = styled.div`
+  margin-bottom: 10px;
+  margin-top: 10px;
+  margin-left: 5px;
   display: inline-block;
+  border-style: solid;
+  border-color: lightgray;
+  border-radius: 5px;
+  border-width: 1px;
+  padding: 10px;
 `;
 
 class AddDecoratorButton extends React.Component {
@@ -40,10 +48,7 @@ class AddDecoratorButton extends React.Component {
     return { value: typeName, label: typeDefinition.name };
   };
 
-  _handleCancel = () => {
-    this.select.clearValue();
-    this.setState(this.getInitialState());
-  };
+  _handleCancel = () => this.setState({ typeName: undefined, typeDefinition: undefined });
 
   _handleSubmit = (data) => {
     const { stream, nextOrder, onCreate } = this.props;
@@ -58,9 +63,7 @@ class AddDecoratorButton extends React.Component {
     this.setState({ typeName: this.PLACEHOLDER });
   };
 
-  _openModal = () => {
-    this.configurationForm.open();
-  };
+  _openModal = () => this.configurationForm.open();
 
   _onTypeChange = (decoratorType) => {
     const { decoratorTypes } = this.props;
@@ -107,9 +110,7 @@ class AddDecoratorButton extends React.Component {
         </div>
         {showHelp && <PopoverHelp />}
 
-        <ConfigurationFormContainer>
-          {typeName && configurationForm}
-        </ConfigurationFormContainer>
+        {typeName && <ConfigurationFormContainer>{configurationForm}</ConfigurationFormContainer>}
       </React.Fragment>
     );
   }

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import jQuery from 'jquery';
 import styled from 'styled-components';
 
@@ -16,35 +15,35 @@ const ConfigurationFormContainer = styled.div`
   display: inline-block;
 `;
 
-const AddDecoratorButton = createReactClass({
-  displayName: 'AddDecoratorButton',
-
-  propTypes: {
+class AddDecoratorButton extends React.Component {
+  static propTypes = {
+    decoratorTypes: PropTypes.object.isRequired,
     nextOrder: PropTypes.number.isRequired,
     stream: PropTypes.string.isRequired,
     disabled: PropTypes.bool,
-  },
+    onCreate: PropTypes.func.isRequired,
+    showHelp: PropTypes.bool,
+  };
 
-  getDefaultProps() {
-    return {
-      disabled: false,
-    };
-  },
+  static defaultProps = {
+    disabled: false,
+    showHelp: true,
+  };
 
   getInitialState() {
     return {
       typeDefinition: {},
     };
-  },
+  }
 
-  _formatDecoratorType(typeDefinition, typeName) {
+  _formatDecoratorType = (typeDefinition, typeName) => {
     return { value: typeName, label: typeDefinition.name };
-  },
+  };
 
   _handleCancel() {
     this.select.clearValue();
     this.setState(this.getInitialState());
-  },
+  }
 
   _handleSubmit(data) {
     const { stream, nextOrder, onCreate } = this.props;
@@ -57,11 +56,11 @@ const AddDecoratorButton = createReactClass({
     };
     onCreate(request);
     this.setState({ typeName: this.PLACEHOLDER });
-  },
+  }
 
   _openModal() {
     this.configurationForm.open();
-  },
+  }
 
   _onTypeChange(decoratorType) {
     const { decoratorTypes } = this.props;
@@ -72,7 +71,7 @@ const AddDecoratorButton = createReactClass({
     } else {
       this.setState({ typeDefinition: {} });
     }
-  },
+  }
 
   render() {
     const { typeDefinition, typeName } = this.state;
@@ -113,7 +112,7 @@ const AddDecoratorButton = createReactClass({
         </ConfigurationFormContainer>
       </React.Fragment>
     );
-  },
-});
+  }
+}
 
 export default AddDecoratorButton;

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
@@ -30,22 +30,21 @@ class AddDecoratorButton extends React.Component {
     showHelp: true,
   };
 
-  getInitialState() {
-    return {
-      typeDefinition: {},
-    };
+  constructor(props) {
+    super(props);
+    this.state = {};
   }
 
   _formatDecoratorType = (typeDefinition, typeName) => {
     return { value: typeName, label: typeDefinition.name };
   };
 
-  _handleCancel() {
+  _handleCancel = () => {
     this.select.clearValue();
     this.setState(this.getInitialState());
-  }
+  };
 
-  _handleSubmit(data) {
+  _handleSubmit = (data) => {
     const { stream, nextOrder, onCreate } = this.props;
 
     const request = {
@@ -56,13 +55,13 @@ class AddDecoratorButton extends React.Component {
     };
     onCreate(request);
     this.setState({ typeName: this.PLACEHOLDER });
-  }
+  };
 
-  _openModal() {
+  _openModal = () => {
     this.configurationForm.open();
-  }
+  };
 
-  _onTypeChange(decoratorType) {
+  _onTypeChange = (decoratorType) => {
     const { decoratorTypes } = this.props;
 
     this.setState({ typeName: decoratorType });
@@ -71,7 +70,7 @@ class AddDecoratorButton extends React.Component {
     } else {
       this.setState({ typeDefinition: {} });
     }
-  }
+  };
 
   render() {
     const { typeDefinition, typeName } = this.state;

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
@@ -22,6 +22,7 @@ const ConfigurationFormContainer = styled.div`
   border-radius: 5px;
   border-width: 1px;
   padding: 10px;
+  background: white;
 `;
 
 class AddDecoratorButton extends React.Component {

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import jQuery from 'jquery';
 
-import { Button } from 'components/graylog';
+import { Button, Modal } from 'components/graylog';
 import { ConfigurationForm } from 'components/configurationforms';
 import { Select } from 'components/common';
 

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import jQuery from 'jquery';
 import styled from 'styled-components';
+import ObjectID from 'bson-objectid';
 
 import { ConfigurationForm } from 'components/configurationforms';
 import { Select } from 'components/common';
@@ -54,6 +55,7 @@ class AddDecoratorButton extends React.Component {
     const { stream, nextOrder, onCreate } = this.props;
 
     const request = {
+      id: ObjectID().toString(),
       stream,
       type: data.type,
       config: data.configuration,

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
@@ -9,6 +9,8 @@ import { Select } from 'components/common';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import DecoratorStyles from '!style!css!./decoratorStyles.css';
+import $ from "jquery";
+import { validate } from '../../../../legacy/validations';
 
 const AddDecoratorButton = createReactClass({
   displayName: 'AddDecoratorButton',
@@ -72,13 +74,6 @@ const AddDecoratorButton = createReactClass({
     const { typeDefinition, typeName } = this.state;
     const { decoratorTypes, disabled } = this.props;
 
-    const divComponent = ({ children, onSubmitForm }) => (
-      <div>
-        {children}
-        <Button bsStyle="success" disabled={!typeName || disabled} onClick={onSubmitForm}>Create</Button>
-      </div>
-    );
-
     const decoratorTypeOptions = jQuery.map(decoratorTypes, this._formatDecoratorType);
     const configurationForm = (typeName !== this.PLACEHOLDER
       ? (
@@ -88,7 +83,7 @@ const AddDecoratorButton = createReactClass({
                            title={`Create new ${typeDefinition.name}`}
                            typeName={typeName}
                            includeTitleField={false}
-                           wrapperComponent={divComponent}
+                           wrapperComponent={InlineForm}
                            submitAction={this._handleSubmit}
                            cancelAction={this._handleCancel} />
       ) : null);

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
@@ -19,7 +19,7 @@ class AddDecoratorButton extends React.Component {
   static propTypes = {
     decoratorTypes: PropTypes.object.isRequired,
     nextOrder: PropTypes.number.isRequired,
-    stream: PropTypes.string.isRequired,
+    stream: PropTypes.string,
     disabled: PropTypes.bool,
     onCreate: PropTypes.func.isRequired,
     showHelp: PropTypes.bool,
@@ -28,6 +28,7 @@ class AddDecoratorButton extends React.Component {
   static defaultProps = {
     disabled: false,
     showHelp: true,
+    stream: null,
   };
 
   constructor(props) {

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
@@ -2,15 +2,19 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import jQuery from 'jquery';
+import styled from 'styled-components';
 
-import { Button, Modal } from 'components/graylog';
 import { ConfigurationForm } from 'components/configurationforms';
 import { Select } from 'components/common';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import DecoratorStyles from '!style!css!./decoratorStyles.css';
-import $ from "jquery";
-import { validate } from '../../../../legacy/validations';
+import InlineForm from './InlineForm';
+import PopoverHelp from './PopoverHelp';
+
+const ConfigurationFormContainer = styled.div`
+  display: inline-block;
+`;
 
 const AddDecoratorButton = createReactClass({
   displayName: 'AddDecoratorButton',
@@ -75,6 +79,7 @@ const AddDecoratorButton = createReactClass({
     const { decoratorTypes, disabled } = this.props;
 
     const decoratorTypeOptions = jQuery.map(decoratorTypes, this._formatDecoratorType);
+    const wrapperComponent = InlineForm();
     const configurationForm = (typeName !== this.PLACEHOLDER
       ? (
         <ConfigurationForm ref={(elem) => { this.configurationForm = elem; }}
@@ -83,7 +88,7 @@ const AddDecoratorButton = createReactClass({
                            title={`Create new ${typeDefinition.name}`}
                            typeName={typeName}
                            includeTitleField={false}
-                           wrapperComponent={InlineForm}
+                           wrapperComponent={wrapperComponent}
                            submitAction={this._handleSubmit}
                            cancelAction={this._handleCancel} />
       ) : null);
@@ -101,7 +106,11 @@ const AddDecoratorButton = createReactClass({
                     value={typeName} />
           </div>
         </div>
-        {typeName && configurationForm}
+        <PopoverHelp />
+
+        <ConfigurationFormContainer>
+          {typeName && configurationForm}
+        </ConfigurationFormContainer>
       </React.Fragment>
     );
   },

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/Decorator.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/Decorator.jsx
@@ -11,6 +11,8 @@ class Decorator extends React.Component {
   static propTypes = {
     decorator: PropTypes.object.isRequired,
     typeDefinition: PropTypes.object.isRequired,
+    onDelete: PropTypes.func.isRequired,
+    onUpdate: PropTypes.func.isRequired,
   };
 
   constructor(props) {
@@ -39,6 +41,7 @@ class Decorator extends React.Component {
     const { stream, id, order } = this.props.decorator;
     const { onUpdate } = this.props;
     onUpdate(id, {
+      id,
       type: data.type,
       config: data.configuration,
       order: order,

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/Decorator.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/Decorator.jsx
@@ -2,10 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 
-import { Button, DropdownButton, MenuItem } from 'components/graylog';
+import { DropdownButton, MenuItem } from 'components/graylog';
 import { ConfigurationForm, ConfigurationWell } from 'components/configurationforms';
 
 import DecoratorStyles from '!style!css!./decoratorStyles.css';
+import InlineForm from './InlineForm';
 
 const Decorator = createReactClass({
   displayName: 'Decorator',
@@ -86,27 +87,27 @@ const Decorator = createReactClass({
   },
 
   render() {
-    const { decorator, decoratorTypes, typeDefinition } = this.props;
+    const { disableMenu = false, decorator, decoratorTypes, typeDefinition } = this.props;
     const { editing } = this.state;
     const config = this._resolveConfigurationIds(decorator.config);
     const decoratorType = decoratorTypes[decorator.type] || this._decoratorTypeNotPresent();
 
-    const decoratorActionsMenu = this._formatActionsMenu();
+    const decoratorActionsMenu = disableMenu || this._formatActionsMenu();
     const { name, requested_configuration: requestedConfiguration } = typeDefinition;
+    const wrapperComponent = InlineForm('Update');
 
     const content = editing
       ? (
-          <ConfigurationForm ref={(editForm) => { this.editForm = editForm; }}
-                             key="configuration-form-decorator"
-                             configFields={requestedConfiguration}
-                             title={`Edit ${name}`}
-                             typeName={decorator.type}
-                             includeTitleField={false}
-                             submitAction={this._handleSubmit}
-                             cancelAction={this._closeEditForm}
-                             wrapperComponent={InlineForm}
-                             values={decorator.config} />
-        )
+        <ConfigurationForm key="configuration-form-decorator"
+                           configFields={requestedConfiguration}
+                           title={`Edit ${name}`}
+                           typeName={decorator.type}
+                           includeTitleField={false}
+                           submitAction={this._handleSubmit}
+                           cancelAction={this._closeEditForm}
+                           wrapperComponent={wrapperComponent}
+                           values={decorator.config} />
+      )
       : (
         <ConfigurationWell key={`configuration-well-decorator-${decorator.id}`}
                            id={decorator.id}

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/Decorator.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/Decorator.jsx
@@ -4,15 +4,22 @@ import React from 'react';
 import { DropdownButton, MenuItem } from 'components/graylog';
 import { ConfigurationForm, ConfigurationWell } from 'components/configurationforms';
 
+// eslint-disable-next-line import/no-webpack-loader-syntax
 import DecoratorStyles from '!style!css!./decoratorStyles.css';
 import InlineForm from './InlineForm';
 
 class Decorator extends React.Component {
   static propTypes = {
     decorator: PropTypes.object.isRequired,
+    decoratorTypes: PropTypes.object.isRequired,
+    disableMenu: PropTypes.bool,
     typeDefinition: PropTypes.object.isRequired,
     onDelete: PropTypes.func.isRequired,
     onUpdate: PropTypes.func.isRequired,
+  };
+
+  static defaultProps = {
+    disableMenu: false,
   };
 
   constructor(props) {
@@ -24,6 +31,7 @@ class Decorator extends React.Component {
 
   _handleDeleteClick = () => {
     const { onDelete, decorator } = this.props;
+    // eslint-disable-next-line no-alert
     if (window.confirm('Do you really want to delete this decorator?')) {
       onDelete(decorator.id);
     }
@@ -38,7 +46,8 @@ class Decorator extends React.Component {
   };
 
   _handleSubmit = (data) => {
-    const { stream, id, order } = this.props.decorator;
+    const { decorator } = this.props;
+    const { stream, id, order } = decorator;
     const { onUpdate } = this.props;
     onUpdate(id, {
       id,
@@ -59,7 +68,8 @@ class Decorator extends React.Component {
   // Attempts to resolve ID values in the decorator configuration against the type definition.
   // This allows users to see actual names for entities in drop-downs, instead of their IDs.
   _resolveConfigurationIds = (config) => {
-    const typeConfig = this.props.typeDefinition.requested_configuration;
+    const { typeDefinition } = this.props;
+    const typeConfig = typeDefinition.requested_configuration;
     const resolvedConfig = {};
     const configKeys = Object.keys(config);
 

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/Decorator.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/Decorator.jsx
@@ -93,13 +93,6 @@ const Decorator = createReactClass({
 
     const decoratorActionsMenu = this._formatActionsMenu();
     const { name, requested_configuration: requestedConfiguration } = typeDefinition;
-    const divComponent = ({ children, onCancel, onSubmitForm }) => (
-      <div>
-        {children}
-        <Button bsStyle="success" onClick={onSubmitForm}>Update</Button>{' '}
-        <Button type="button" onClick={onCancel}>Cancel</Button>
-      </div>
-    );
 
     const content = editing
       ? (
@@ -111,7 +104,7 @@ const Decorator = createReactClass({
                              includeTitleField={false}
                              submitAction={this._handleSubmit}
                              cancelAction={this._closeEditForm}
-                             wrapperComponent={divComponent}
+                             wrapperComponent={InlineForm}
                              values={decorator.config} />
         )
       : (

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/Decorator.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/Decorator.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 
 import { DropdownButton, MenuItem } from 'components/graylog';
 import { ConfigurationForm, ConfigurationWell } from 'components/configurationforms';
@@ -8,36 +7,35 @@ import { ConfigurationForm, ConfigurationWell } from 'components/configurationfo
 import DecoratorStyles from '!style!css!./decoratorStyles.css';
 import InlineForm from './InlineForm';
 
-const Decorator = createReactClass({
-  displayName: 'Decorator',
-
-  propTypes: {
+class Decorator extends React.Component {
+  static propTypes = {
     decorator: PropTypes.object.isRequired,
     typeDefinition: PropTypes.object.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
+  constructor(props) {
+    super(props);
+    this.state = {
       editing: false,
     };
-  },
+  }
 
-  _handleDeleteClick() {
+  _handleDeleteClick = () => {
     const { onDelete, decorator } = this.props;
     if (window.confirm('Do you really want to delete this decorator?')) {
       onDelete(decorator.id);
     }
-  },
+  };
 
-  _handleEditClick() {
+  _handleEditClick = () => {
     this.setState({ editing: true });
-  },
+  };
 
-  _closeEditForm() {
+  _closeEditForm = () => {
     this.setState({ editing: false });
-  },
+  };
 
-  _handleSubmit(data) {
+  _handleSubmit = (data) => {
     const { stream, id, order } = this.props.decorator;
     const { onUpdate } = this.props;
     onUpdate(id, {
@@ -47,17 +45,17 @@ const Decorator = createReactClass({
       stream: stream,
     });
     this._closeEditForm();
-  },
+  };
 
-  _decoratorTypeNotPresent() {
+  _decoratorTypeNotPresent = () => {
     return {
       name: 'Unknown decorator type',
     };
-  },
+  };
 
   // Attempts to resolve ID values in the decorator configuration against the type definition.
   // This allows users to see actual names for entities in drop-downs, instead of their IDs.
-  _resolveConfigurationIds(config) {
+  _resolveConfigurationIds = (config) => {
     const typeConfig = this.props.typeDefinition.requested_configuration;
     const resolvedConfig = {};
     const configKeys = Object.keys(config);
@@ -73,9 +71,9 @@ const Decorator = createReactClass({
     });
 
     return Object.assign({}, config, resolvedConfig);
-  },
+  };
 
-  _formatActionsMenu() {
+  _formatActionsMenu = () => {
     const { decorator } = this.props;
     return (
       <DropdownButton id={`decorator-${decorator.id}-actions`} bsStyle="default" bsSize="xsmall" title="Actions" pullRight>
@@ -84,7 +82,7 @@ const Decorator = createReactClass({
         <MenuItem onSelect={this._handleDeleteClick}>Delete</MenuItem>
       </DropdownButton>
     );
-  },
+  };
 
   render() {
     const { disableMenu = false, decorator, decoratorTypes, typeDefinition } = this.props;
@@ -124,7 +122,7 @@ const Decorator = createReactClass({
         {content}
       </span>
     );
-  },
-});
+  }
+}
 
 export default Decorator;

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorList.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorList.jsx
@@ -21,9 +21,7 @@ class DecoratorList extends React.Component {
 
   _onReorderWrapper = (...args) => {
     const { onReorder } = this.props;
-    if (onReorder) {
-      onReorder(...args);
-    }
+    onReorder(...args);
   };
 
   render() {

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorList.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorList.jsx
@@ -15,8 +15,13 @@ const AlertContainer: React.ComponentType<{}> = styled.div`
 `;
 
 type ReorderedItems = Array<{ id: string }>;
+type DecoratorSummary = {
+  id: string,
+  order: number,
+  title: React.Node,
+};
 type Props = {
-  decorators: Array<Decorator>,
+  decorators: Array<DecoratorSummary>,
   disableDragging?: boolean,
   onReorder: (ReorderedItems) => mixed,
 };

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorList.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorList.jsx
@@ -14,6 +14,11 @@ class DecoratorList extends React.Component {
     onReorder: PropTypes.func,
   };
 
+  static defaultProps = {
+    disableDragging: false,
+    onReorder: () => {},
+  };
+
   _onReorderWrapper = (...args) => {
     const { onReorder } = this.props;
     if (onReorder) {

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorList.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorList.jsx
@@ -8,7 +8,6 @@ import { Icon, SortableList } from 'components/common';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import DecoratorStyles from '!style!css!./decoratorStyles.css';
-import type { Decorator } from './Types';
 
 const AlertContainer: React.ComponentType<{}> = styled.div`
   margin-bottom: 20px;

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorList.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorList.jsx
@@ -1,13 +1,27 @@
+// @flow strict
 import PropTypes from 'prop-types';
-import React from 'react';
+import * as React from 'react';
+import styled from 'styled-components';
 
 import { Alert } from 'components/graylog';
 import { Icon, SortableList } from 'components/common';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import DecoratorStyles from '!style!css!./decoratorStyles.css';
+import type { Decorator } from './Types';
 
-class DecoratorList extends React.Component {
+const AlertContainer: React.ComponentType<{}> = styled.div`
+  margin-bottom: 20px;
+`;
+
+type ReorderedItems = Array<{ id: string }>;
+type Props = {
+  decorators: Array<Decorator>,
+  disableDragging?: boolean,
+  onReorder: (ReorderedItems) => mixed,
+};
+
+class DecoratorList extends React.Component<Props> {
   static propTypes = {
     decorators: PropTypes.arrayOf(PropTypes.object).isRequired,
     disableDragging: PropTypes.bool,
@@ -19,18 +33,20 @@ class DecoratorList extends React.Component {
     onReorder: () => {},
   };
 
-  _onReorderWrapper = (...args) => {
+  _onReorderWrapper = (orderedItems: ReorderedItems) => {
     const { onReorder } = this.props;
-    onReorder(...args);
+    onReorder(orderedItems);
   };
 
   render() {
     const { decorators, disableDragging } = this.props;
     if (!decorators || decorators.length === 0) {
       return (
-        <Alert bsStyle="info" className={DecoratorStyles.noDecoratorsAlert}>
-          <Icon name="info-circle" />&nbsp;No decorators configured.
-        </Alert>
+        <AlertContainer>
+          <Alert bsStyle="info" className={DecoratorStyles.noDecoratorsAlert}>
+            <Icon name="info-circle" />&nbsp;No decorators configured.
+          </Alert>
+        </AlertContainer>
       );
     }
     return (

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorSidebar.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorSidebar.jsx
@@ -3,10 +3,7 @@ import React from 'react';
 
 import CombinedProvider from 'injection/CombinedProvider';
 import connect from 'stores/connect';
-import DocsHelper from 'util/DocsHelper';
-import { Button, OverlayTrigger, Popover } from 'components/graylog';
 import { Spinner } from 'components/common';
-import DocumentationLink from 'components/support/DocumentationLink';
 
 import AddDecoratorButton from './AddDecoratorButton';
 import Decorator from './Decorator';
@@ -62,31 +59,12 @@ class DecoratorSidebar extends React.Component {
       .sort((d1, d2) => d1.order - d2.order);
     const nextDecoratorOrder = sortedDecorators.length > 0 ? sortedDecorators[sortedDecorators.length - 1].order + 1 : 0;
     const decoratorItems = sortedDecorators.map(this._formatDecorator);
-    const popoverHelp = (
-      <Popover id="decorators-help" className={DecoratorStyles.helpPopover}>
-        <p className="description">
-          Decorators can modify messages shown in the search results on the fly. These changes are not stored, but only
-          shown in the search results. Decorator config is stored <strong>per stream</strong>.
-        </p>
-        <p className="description">
-          Use drag and drop to modify the order in which decorators are processed.
-        </p>
-        <p>
-          Read more about message decorators in the <DocumentationLink page={DocsHelper.PAGES.DECORATORS} text="documentation" />.
-        </p>
-      </Popover>
-    );
 
     const addDecorator = decorator => onChange([...decorators, decorator]);
 
     return (
       <div>
         <AddDecoratorButton decoratorTypes={decoratorTypes} stream={stream} nextOrder={nextDecoratorOrder} onCreate={addDecorator} />
-        <div className={DecoratorStyles.helpLinkContainer}>
-          <OverlayTrigger trigger="click" rootClose placement="right" overlay={popoverHelp}>
-            <Button bsStyle="link" className={DecoratorStyles.helpLink}>What are message decorators?</Button>
-          </OverlayTrigger>
-        </div>
         <div ref={(decoratorsContainer) => { this.decoratorsContainer = decoratorsContainer; }} className={DecoratorStyles.decoratorListContainer}>
           <DecoratorList decorators={decoratorItems} onReorder={this._updateOrder} onChange={onChange} />
         </div>

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorSidebar.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorSidebar.jsx
@@ -6,7 +6,7 @@ import connect from 'stores/connect';
 import { Spinner } from 'components/common';
 
 import AddDecoratorButton from './AddDecoratorButton';
-import Decorator from './Decorator';
+import DecoratorSummary from './DecoratorSummary';
 import DecoratorList from './DecoratorList';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import DecoratorStyles from '!style!css!./decoratorStyles.css';
@@ -31,12 +31,12 @@ class DecoratorSidebar extends React.Component {
     const updateDecorator = (id, updatedDecorator) => onChange(decorators.map(_decorator => (_decorator.id === id ? updatedDecorator : _decorator)));
     return ({
       id: decorator.id,
-      title: <Decorator key={`decorator-${decorator.id}`}
-                        decorator={decorator}
-                        decoratorTypes={decoratorTypes}
-                        onDelete={deleteDecorator}
-                        onUpdate={updateDecorator}
-                        typeDefinition={typeDefinition} />,
+      title: <DecoratorSummary key={`decorator-${decorator.id}`}
+                               decorator={decorator}
+                               decoratorTypes={decoratorTypes}
+                               onDelete={deleteDecorator}
+                               onUpdate={updateDecorator}
+                               typeDefinition={typeDefinition} />,
     });
   };
 

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorSidebar.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorSidebar.jsx
@@ -18,7 +18,6 @@ class DecoratorSidebar extends React.Component {
     decorators: PropTypes.array.isRequired,
     decoratorTypes: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-    stream: PropTypes.string.isRequired,
   };
 
   componentDidMount() {
@@ -52,12 +51,11 @@ class DecoratorSidebar extends React.Component {
   };
 
   render() {
-    const { decoratorTypes, onChange, stream, decorators } = this.props;
+    const { decoratorTypes, onChange, decorators } = this.props;
     if (!decoratorTypes) {
       return <Spinner />;
     }
     const sortedDecorators = decorators
-      .filter(decorator => (stream ? decorator.stream === stream : !decorator.stream))
       .sort((d1, d2) => d1.order - d2.order);
     const nextDecoratorOrder = sortedDecorators.length > 0 ? sortedDecorators[sortedDecorators.length - 1].order + 1 : 0;
     const decoratorItems = sortedDecorators.map(this._formatDecorator);
@@ -66,7 +64,7 @@ class DecoratorSidebar extends React.Component {
 
     return (
       <div>
-        <AddDecoratorButton decoratorTypes={decoratorTypes} stream={stream} nextOrder={nextDecoratorOrder} onCreate={addDecorator} />
+        <AddDecoratorButton decoratorTypes={decoratorTypes} nextOrder={nextDecoratorOrder} onCreate={addDecorator} />
         <div ref={(decoratorsContainer) => { this.decoratorsContainer = decoratorsContainer; }} className={DecoratorStyles.decoratorListContainer}>
           <DecoratorList decorators={decoratorItems} onReorder={this._updateOrder} onChange={onChange} />
         </div>

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorSidebar.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorSidebar.jsx
@@ -16,6 +16,8 @@ const { DecoratorsActions, DecoratorsStore } = CombinedProvider.get('Decorators'
 class DecoratorSidebar extends React.Component {
   static propTypes = {
     decorators: PropTypes.array.isRequired,
+    decoratorTypes: PropTypes.object.isRequired,
+    onChange: PropTypes.func.isRequired,
     stream: PropTypes.string.isRequired,
   };
 

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorSummary.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorSummary.jsx
@@ -8,7 +8,7 @@ import { ConfigurationForm, ConfigurationWell } from 'components/configurationfo
 import DecoratorStyles from '!style!css!./decoratorStyles.css';
 import InlineForm from './InlineForm';
 
-class Decorator extends React.Component {
+class DecoratorSummary extends React.Component {
   static propTypes = {
     decorator: PropTypes.object.isRequired,
     decoratorTypes: PropTypes.object.isRequired,
@@ -138,4 +138,4 @@ class Decorator extends React.Component {
   }
 }
 
-export default Decorator;
+export default DecoratorSummary;

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorSummary.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/DecoratorSummary.jsx
@@ -106,6 +106,7 @@ class DecoratorSummary extends React.Component {
     const decoratorActionsMenu = disableMenu || this._formatActionsMenu();
     const { name, requested_configuration: requestedConfiguration } = typeDefinition;
     const wrapperComponent = InlineForm('Update');
+    const decoratorId = decorator.id || 'new';
 
     const content = editing
       ? (
@@ -120,8 +121,8 @@ class DecoratorSummary extends React.Component {
                            values={decorator.config} />
       )
       : (
-        <ConfigurationWell key={`configuration-well-decorator-${decorator.id}`}
-                           id={decorator.id}
+        <ConfigurationWell key={`configuration-well-decorator-${decoratorId}`}
+                           id={decoratorId}
                            configuration={config}
                            typeDefinition={typeDefinition} />
       );

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/InlineForm.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/InlineForm.jsx
@@ -11,37 +11,38 @@ type Props = {
   onSubmitForm: any => void,
 };
 
-const InlineForm = (submitTitle: string = 'Create'): React.ComponentType<Props> => ({ children, disabled, onCancel, onSubmitForm }) => {
-  const onSubmit = (event) => {
-    event.stopPropagation();
-    const { target: formDOMNode } = event;
+const InlineForm = (submitTitle: string = 'Create'): React.ComponentType<Props> => React.forwardRef(
+  ({ children, disabled, onCancel, onSubmitForm }: Props, ref) => {
+    const onSubmit = (event) => {
+      event.stopPropagation();
+      const { target: formDOMNode } = event;
 
-    if ((typeof formDOMNode.checkValidity === 'function' && !formDOMNode.checkValidity())) {
-      event.preventDefault();
-      return;
-    }
+      if ((typeof formDOMNode.checkValidity === 'function' && !formDOMNode.checkValidity())) {
+        event.preventDefault();
+        return;
+      }
 
-    // Check custom validation for plugin fields
-    if (!validate(formDOMNode)) {
-      event.preventDefault();
-      return;
-    }
+      // Check custom validation for plugin fields
+      if (!validate(formDOMNode)) {
+        event.preventDefault();
+        return;
+      }
 
-    // If function is not given, let the browser continue propagating the submit event
-    if (typeof onSubmitForm === 'function') {
-      event.preventDefault();
-      onSubmitForm(event);
-    }
-  };
-  return (
-    <form onSubmit={onSubmit}>
-      {children}
-      <Button type="submit" bsStyle="success" disabled={disabled}>{submitTitle}</Button>{' '}
-      <Button type="button" disabled={disabled} onClick={onCancel}>Cancel</Button>
-    </form>
-  );
-};
+      // If function is not given, let the browser continue propagating the submit event
+      if (typeof onSubmitForm === 'function') {
+        event.preventDefault();
+        onSubmitForm(event);
+      }
+    };
+    return (
+      <form onSubmit={onSubmit} ref={ref}>
+        {children}
+        <Button type="submit" bsStyle="success" disabled={disabled}>{submitTitle}</Button>{' '}
+        <Button type="button" disabled={disabled} onClick={onCancel}>Cancel</Button>
+      </form>
+    );
+  },
+);
 
-InlineForm.propTypes = {};
 
 export default InlineForm;

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/InlineForm.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/InlineForm.jsx
@@ -4,8 +4,9 @@ import * as React from 'react';
 import { validate } from 'legacy/validations';
 import { Button } from 'components/graylog/index';
 
-const InlineForm = ({ children, disabled, onSubmitForm }) => {
+const InlineForm = (submitTitle = 'Create') => ({ children, disabled, onCancel, onSubmitForm }) => {
   const onSubmit = (event) => {
+    event.stopPropagation();
     const { target: formDOMNode } = event;
 
     if ((typeof formDOMNode.checkValidity === 'function' && !formDOMNode.checkValidity())) {
@@ -28,9 +29,8 @@ const InlineForm = ({ children, disabled, onSubmitForm }) => {
   return (
     <form onSubmit={onSubmit}>
       {children}
-      <Button type="submit"
-              bsStyle="success"
-              disabled={disabled}>Create</Button>
+      <Button type="submit" bsStyle="success" disabled={disabled}>{submitTitle}</Button>{' '}
+      <Button type="button" disabled={disabled} onClick={onCancel}>Cancel</Button>
     </form>
   );
 };

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/InlineForm.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/InlineForm.jsx
@@ -4,7 +4,14 @@ import * as React from 'react';
 import { validate } from 'legacy/validations';
 import { Button } from 'components/graylog/index';
 
-const InlineForm = (submitTitle = 'Create') => ({ children, disabled, onCancel, onSubmitForm }) => {
+type Props = {
+  children: React.Node,
+  disabled: boolean,
+  onCancel: () => void,
+  onSubmitForm: any => void,
+};
+
+const InlineForm = (submitTitle: string = 'Create'): React.ComponentType<Props> => ({ children, disabled, onCancel, onSubmitForm }) => {
   const onSubmit = (event) => {
     event.stopPropagation();
     const { target: formDOMNode } = event;

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/InlineForm.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/InlineForm.jsx
@@ -1,0 +1,40 @@
+// @flow strict
+import * as React from 'react';
+
+import { validate } from 'legacy/validations';
+import { Button } from 'components/graylog/index';
+
+const InlineForm = ({ children, disabled, onSubmitForm }) => {
+  const onSubmit = (event) => {
+    const { target: formDOMNode } = event;
+
+    if ((typeof formDOMNode.checkValidity === 'function' && !formDOMNode.checkValidity())) {
+      event.preventDefault();
+      return;
+    }
+
+    // Check custom validation for plugin fields
+    if (!validate(formDOMNode)) {
+      event.preventDefault();
+      return;
+    }
+
+    // If function is not given, let the browser continue propagating the submit event
+    if (typeof onSubmitForm === 'function') {
+      event.preventDefault();
+      onSubmitForm(event);
+    }
+  };
+  return (
+    <form onSubmit={onSubmit}>
+      {children}
+      <Button type="submit"
+              bsStyle="success"
+              disabled={disabled}>Create</Button>
+    </form>
+  );
+};
+
+InlineForm.propTypes = {};
+
+export default InlineForm;

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/PopoverHelp.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/PopoverHelp.jsx
@@ -1,0 +1,37 @@
+// @flow strict
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+import { Button, OverlayTrigger, Popover } from 'components/graylog';
+import DocumentationLink from 'components/support/DocumentationLink';
+import DocsHelper from 'util/DocsHelper';
+
+import DecoratorStyles from './decoratorStyles.css';
+
+const PopoverHelp = () => {
+  const popoverHelp = (
+    <Popover id="decorators-help" className={DecoratorStyles.helpPopover}>
+      <p className="description">
+        Decorators can modify messages shown in the search results on the fly. These changes are not stored, but only
+        shown in the search results. Decorator config is stored <strong>per stream</strong>.
+      </p>
+      <p className="description">
+        Use drag and drop to modify the order in which decorators are processed.
+      </p>
+      <p>
+        Read more about message decorators in the <DocumentationLink page={DocsHelper.PAGES.DECORATORS} text="documentation" />.
+      </p>
+    </Popover>
+  );
+  return (
+    <div className={DecoratorStyles.helpLinkContainer}>
+      <OverlayTrigger trigger="click" rootClose placement="right" overlay={popoverHelp}>
+        <Button bsStyle="link" className={DecoratorStyles.helpLink}>What are message decorators?</Button>
+      </OverlayTrigger>
+    </div>
+  );
+};
+
+PopoverHelp.propTypes = {};
+
+export default PopoverHelp;

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/PopoverHelp.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/PopoverHelp.jsx
@@ -1,6 +1,5 @@
 // @flow strict
 import * as React from 'react';
-import PropTypes from 'prop-types';
 
 import { Button, OverlayTrigger, Popover } from 'components/graylog';
 import DocumentationLink from 'components/support/DocumentationLink';

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/Types.js
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/Types.js
@@ -1,6 +1,6 @@
 // @flow strict
 export type Decorator = {
-  id?: string,
+  id: string,
   order: number,
   type: string,
   stream: ?string,

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/Types.js
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/Types.js
@@ -1,0 +1,18 @@
+// @flow strict
+export type Decorator = {
+  id?: string,
+  order: number,
+  type: string,
+  stream: ?string,
+};
+
+// Not properly typed yet, but not needed for the current scope.
+export type RequestedConfiguration = {};
+
+export type DecoratorType = {
+  type: string,
+  name: string,
+  human_name: string,
+  requested_configuration: RequestedConfiguration,
+  link_to_docs: string,
+};

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/decoratorStyles.css
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/decoratorStyles.css
@@ -53,7 +53,7 @@
 
 :local(.decoratorListContainer) {
     display: inline-block;
-    overflow-y: auto;
+    overflow: visible;
     width: 100%;
 }
 

--- a/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.jsx
@@ -62,7 +62,7 @@ const BarVisualization: VisualizationComponent = ({ config, data, effectiveTimer
 
 BarVisualization.propTypes = {
   config: AggregationType.isRequired,
-  data: PropTypes.arrayOf(PropTypes.object).isRequired,
+  data: PropTypes.object.isRequired,
 };
 
 BarVisualization.type = 'bar';

--- a/graylog2-web-interface/src/views/components/widgets/EditMessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditMessageList.jsx
@@ -25,17 +25,14 @@ const _onShowMessageRowChanged = (config, onChange) => {
   return onChange(newConfig);
 };
 
-const _renderChildrenWithContainerHeight = (children, containerHeight) => React.Children.map(children, child => React.cloneElement(child, { containerHeight }));
-
 type Props = {
   children: React.Node,
   config: MessagesWidgetConfig,
-  containerHeight: number,
   fields: Immutable.Set<FieldTypeMapping>,
   onChange: (MessagesWidgetConfig) => void,
 };
 
-const EditMessageList = ({ children, config, containerHeight, fields, onChange }: Props) => {
+const EditMessageList = ({ children, config, fields, onChange }: Props) => {
   const fieldsForSelect = fields
     .map(fieldType => fieldType.name)
     .map(fieldName => ({ label: fieldName, value: fieldName }))
@@ -66,7 +63,7 @@ const EditMessageList = ({ children, config, containerHeight, fields, onChange }
         </DescriptionBox>
       </Col>
       <Col md={9}>
-        {_renderChildrenWithContainerHeight(children, containerHeight)}
+        {children}
       </Col>
     </Row>
   );
@@ -74,8 +71,7 @@ const EditMessageList = ({ children, config, containerHeight, fields, onChange }
 
 EditMessageList.propTypes = {
   children: CustomPropTypes.OneOrMoreChildren.isRequired,
-  config: PropTypes.instanceOf(MessagesWidgetConfig).isRequired,
-  containerHeight: PropTypes.number.isRequired,
+  config: PropTypes.object.isRequired,
   fields: CustomPropTypes.FieldListType.isRequired,
   onChange: PropTypes.func.isRequired,
 };

--- a/graylog2-web-interface/src/views/components/widgets/EditMessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditMessageList.jsx
@@ -44,10 +44,7 @@ const EditMessageList = ({ children, config, containerHeight, fields, onChange }
     .sort((v1, v2) => defaultCompare(v1.label, v2.label));
   const selectedFieldsForSelect = config.fields.map(fieldName => ({ field: fieldName }));
 
-  const onDecoratorsChange = newDecorators => {
-    console.log('New Decorators: ', newDecorators);
-    onChange(config.toBuilder().decorators(newDecorators).build());
-  };
+  const onDecoratorsChange = newDecorators => onChange(config.toBuilder().decorators(newDecorators).build());
 
   return (
     <Row>

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
@@ -156,6 +156,7 @@ class MessageTable extends React.Component<Props, State> {
       id: m.message._id,
       index: m.index,
       highlight_ranges: m.highlight_ranges,
+      decoration_stats: m.decoration_stats,
     }));
   };
 

--- a/graylog2-web-interface/src/views/logic/NewQueryActionHandler.js
+++ b/graylog2-web-interface/src/views/logic/NewQueryActionHandler.js
@@ -4,9 +4,9 @@ import { QueriesActions } from '../stores/QueriesStore';
 import QueryGenerator from './queries/QueryGenerator';
 import ViewStateGenerator from './views/ViewStateGenerator';
 
-export default () => {
+export default async () => {
   const { view } = ViewStore.getInitialState();
   const query = QueryGenerator();
-  const state = ViewStateGenerator(view.type);
+  const state = await ViewStateGenerator(view.type);
   return QueriesActions.create(query, state).then(() => query);
 };

--- a/graylog2-web-interface/src/views/logic/Widgets.js
+++ b/graylog2-web-interface/src/views/logic/Widgets.js
@@ -48,10 +48,11 @@ export const resultHistogram = (id: string = uuid()) => AggregationWidget.builde
   )
   .build();
 
-export const allMessagesTable = (id: string = uuid()) => MessageWidget.builder()
+export const allMessagesTable = (id: string = uuid(), decorators) => MessageWidget.builder()
   .id(id)
   .config(MessageWidgetConfig.builder()
     .fields(DEFAULT_MESSAGE_FIELDS)
     .showMessageRow(true)
+    .decorators(decorators)
     .build())
   .build();

--- a/graylog2-web-interface/src/views/logic/Widgets.js
+++ b/graylog2-web-interface/src/views/logic/Widgets.js
@@ -11,6 +11,7 @@ import MessageWidget from './widgets/MessagesWidget';
 import MessageWidgetConfig from './widgets/MessagesWidgetConfig.js';
 import Series from './aggregationbuilder/Series';
 import FieldType from './fieldtypes/FieldType';
+import type { Decorator } from './widgets/MessagesWidgetConfig';
 
 const widgetsKey = 'enterpriseWidgets';
 
@@ -48,7 +49,7 @@ export const resultHistogram = (id: string = uuid()) => AggregationWidget.builde
   )
   .build();
 
-export const allMessagesTable = (id: string = uuid(), decorators) => MessageWidget.builder()
+export const allMessagesTable = (id: string = uuid(), decorators: Array<Decorator>) => MessageWidget.builder()
   .id(id)
   .config(MessageWidgetConfig.builder()
     .fields(DEFAULT_MESSAGE_FIELDS)

--- a/graylog2-web-interface/src/views/logic/fieldtypes/FieldType.js
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/FieldType.js
@@ -1,13 +1,14 @@
 // @flow strict
 import * as Immutable from 'immutable';
 
-type Property = 'compound' | 'enumerable' | 'full-text-search' | 'numeric';
+type Property = 'compound' | 'enumerable' | 'full-text-search' | 'numeric' | 'decorated';
 
 export const Properties: { [string]: Property } = {
   Compound: 'compound',
   Enumerable: 'enumerable',
   FullTextSearch: 'full-text-search',
   Numeric: 'numeric',
+  Decorated: 'decorated',
 };
 
 export type FieldTypeJSON = {
@@ -28,7 +29,7 @@ class FieldType {
 
   static Unknown = new FieldType('unknown', [], []);
 
-  static Decorated = new FieldType('decorated field', [], []);
+  static Decorated = new FieldType('decorated field', [Properties.Decorated], []);
 
   get type(): string {
     return this.value.get('type');
@@ -48,6 +49,10 @@ class FieldType {
 
   isCompound(): boolean {
     return this.properties.has(Properties.Compound);
+  }
+
+  isDecorated(): boolean {
+    return this.properties.has(Properties.Decorated);
   }
 
   static fromJSON(value: FieldTypeJSON) {

--- a/graylog2-web-interface/src/views/logic/fieldtypes/FieldType.js
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/FieldType.js
@@ -28,6 +28,8 @@ class FieldType {
 
   static Unknown = new FieldType('unknown', [], []);
 
+  static Decorated = new FieldType('decorated field', [], []);
+
   get type(): string {
     return this.value.get('type');
   }

--- a/graylog2-web-interface/src/views/logic/searchtypes/MessageConfigGenerator.test.jsx
+++ b/graylog2-web-interface/src/views/logic/searchtypes/MessageConfigGenerator.test.jsx
@@ -17,8 +17,8 @@ describe('MessageConfigGenerator', () => {
   });
   it('adds decorators to search type', () => {
     const decorators = [
-      { id: 'decorator1', type: 'something' },
-      { id: 'decorator2', type: 'something else' },
+      { id: 'decorator1', type: 'something', config: {}, stream: null, order: 0 },
+      { id: 'decorator2', type: 'something else', config: {}, stream: null, order: 1 },
     ];
     const widget = MessagesWidget.builder().config(
       MessagesWidgetConfig.builder()
@@ -30,8 +30,8 @@ describe('MessageConfigGenerator', () => {
 
     expect(result).toEqual([{
       decorators: [
-        { id: 'decorator1', type: 'something' },
-        { id: 'decorator2', type: 'something else' },
+        { id: 'decorator1', type: 'something', config: {}, stream: null, order: 0 },
+        { id: 'decorator2', type: 'something else', config: {}, stream: null, order: 1 },
       ],
       type: 'messages',
     }]);

--- a/graylog2-web-interface/src/views/logic/searchtypes/MessageConfigGenerator.test.jsx
+++ b/graylog2-web-interface/src/views/logic/searchtypes/MessageConfigGenerator.test.jsx
@@ -1,0 +1,39 @@
+// @flow strict
+import MessageConfigGenerator from './MessageConfigGenerator';
+import MessagesWidget from '../widgets/MessagesWidget';
+import MessagesWidgetConfig from '../widgets/MessagesWidgetConfig';
+
+describe('MessageConfigGenerator', () => {
+  it('generates basic search type from message widget', () => {
+    const widget = MessagesWidget.builder().config(
+      MessagesWidgetConfig.builder()
+        .decorators([])
+        .build(),
+    ).build();
+
+    const result = MessageConfigGenerator(widget);
+
+    expect(result).toEqual([{ decorators: [], type: 'messages' }]);
+  });
+  it('adds decorators to search type', () => {
+    const decorators = [
+      { id: 'decorator1', type: 'something' },
+      { id: 'decorator2', type: 'something else' },
+    ];
+    const widget = MessagesWidget.builder().config(
+      MessagesWidgetConfig.builder()
+        .decorators(decorators)
+        .build(),
+    ).build();
+
+    const result = MessageConfigGenerator(widget);
+
+    expect(result).toEqual([{
+      decorators: [
+        { id: 'decorator1', type: 'something' },
+        { id: 'decorator2', type: 'something else' },
+      ],
+      type: 'messages',
+    }]);
+  });
+});

--- a/graylog2-web-interface/src/views/logic/valueactions/UseInNewQueryHandler.js
+++ b/graylog2-web-interface/src/views/logic/valueactions/UseInNewQueryHandler.js
@@ -9,11 +9,11 @@ import type { ValueActionHandler } from './ValueActionHandler';
 import View from '../views/View';
 import type { ActionHandlerCondition } from '../../components/actions/ActionHandler';
 
-const UseInNewQueryHandler: ValueActionHandler = ({ field, value, contexts: { view } }) => {
+const UseInNewQueryHandler: ValueActionHandler = async ({ field, value, contexts: { view } }) => {
   const query: Query = QueryGenerator().toBuilder()
     .query({ type: 'elasticsearch', query_string: `${field}:${escape(value)}` })
     .build();
-  const state: ViewState = ViewStateGenerator(view.type);
+  const state: ViewState = await ViewStateGenerator(view.type);
   return QueriesActions.create(query, state);
 };
 

--- a/graylog2-web-interface/src/views/logic/views/ViewGenerator.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewGenerator.js
@@ -1,12 +1,14 @@
+// @flow strict
 import View from './View';
 import Search from '../search/Search';
 import QueryGenerator from '../queries/QueryGenerator';
 import ViewStateGenerator from './ViewStateGenerator';
+import type { ViewType } from './View';
 
-export default (type) => {
+export default async (type: ViewType, streamId: ?string) => {
   const query = QueryGenerator();
   const search = Search.create().toBuilder().queries([query]).build();
-  const viewState = ViewStateGenerator(type);
+  const viewState = await ViewStateGenerator(type, streamId);
   return View.create()
     .toBuilder()
     .type(type)

--- a/graylog2-web-interface/src/views/logic/views/ViewStateGenerator.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewStateGenerator.js
@@ -12,14 +12,10 @@ const { DecoratorsActions } = CombinedProvider.get('Decorators');
 
 const _defaultWidgets = {
   [View.Type.Search]: async (streamId: ?string) => {
-    console.log('Generating new search for stream: ', streamId);
-    const decorators = await DecoratorsActions.list() || [];
-    console.log('Got decorators: ', decorators);
-    const streamDecorators = decorators.filter(decorator => decorator.stream === streamId);
-    console.log('Got stream decorators: ', streamDecorators);
+    const decorators = await DecoratorsActions.list();
+    const streamDecorators = decorators ? decorators.filter(decorator => decorator.stream === streamId) : [];
     const histogram = resultHistogram();
     const messageTable = allMessagesTable(undefined, streamDecorators);
-    console.log('Got message widget: ', messageTable);
     const widgets = [
       histogram,
       messageTable,

--- a/graylog2-web-interface/src/views/logic/views/ViewStateGenerator.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewStateGenerator.js
@@ -1,16 +1,25 @@
 // @flow strict
 import * as Immutable from 'immutable';
 
+import CombinedProvider from 'injection/CombinedProvider';
 import WidgetPosition from '../widgets/WidgetPosition';
 import View from './View';
 import ViewState from './ViewState';
 import { resultHistogram, allMessagesTable } from '../Widgets';
 import type { ViewType } from './View';
 
+const { DecoratorsActions } = CombinedProvider.get('Decorators');
+
 const _defaultWidgets = {
-  [View.Type.Search]: () => {
+  [View.Type.Search]: async (streamId: ?string) => {
+    console.log('Generating new search for stream: ', streamId);
+    const decorators = await DecoratorsActions.list() || [];
+    console.log('Got decorators: ', decorators);
+    const streamDecorators = decorators.filter(decorator => decorator.stream === streamId);
+    console.log('Got stream decorators: ', streamDecorators);
     const histogram = resultHistogram();
-    const messageTable = allMessagesTable();
+    const messageTable = allMessagesTable(undefined, streamDecorators);
+    console.log('Got message widget: ', messageTable);
     const widgets = [
       histogram,
       messageTable,
@@ -30,7 +39,8 @@ const _defaultWidgets = {
 
     return { titles, widgets, positions };
   },
-  [View.Type.Dashboard]: () => {
+  // eslint-disable-next-line no-unused-vars
+  [View.Type.Dashboard]: async (streamId: ?string) => {
     const widgets = [];
     const titles = {};
     const positions = {};
@@ -39,8 +49,8 @@ const _defaultWidgets = {
   },
 };
 
-export default (type: ViewType) => {
-  const { titles, widgets, positions } = _defaultWidgets[type]();
+export default async (type: ViewType, streamId: ?string) => {
+  const { titles, widgets, positions } = await _defaultWidgets[type](streamId);
   return ViewState.create()
     .toBuilder()
     .titles(titles)

--- a/graylog2-web-interface/src/views/logic/views/ViewStateGenerator.test.jsx
+++ b/graylog2-web-interface/src/views/logic/views/ViewStateGenerator.test.jsx
@@ -1,0 +1,73 @@
+// @flow strict
+import View from './View';
+import ViewStateGenerator from './ViewStateGenerator';
+import MessagesWidget from '../widgets/MessagesWidget';
+
+const mockList = jest.fn(() => Promise.resolve([]));
+jest.mock('injection/CombinedProvider', () => ({
+  get: type => ({
+    Decorators: {
+      DecoratorsActions: {
+        list: (...args) => mockList(...args),
+      },
+    },
+  })[type],
+}));
+
+describe('ViewStateGenerator', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+  it('adds message table to widgets', async () => {
+    const result = await ViewStateGenerator(View.Type.Search);
+    const messageTableWidget = result.widgets.find(widget => widget.type === MessagesWidget.type);
+    expect(messageTableWidget).toBeDefined();
+  });
+  it('adds decorators for current stream to message table', async () => {
+    mockList.mockReturnValue([
+      { id: 'decorator1', stream: 'foobar', order: 0, type: 'something' },
+      { id: 'decorator2', stream: 'different', order: 0, type: 'something' },
+    ]);
+    const result = await ViewStateGenerator(View.Type.Search, 'foobar');
+
+    expect(mockList).toHaveBeenCalledWith();
+    const messageTableWidget = result.widgets.find(widget => widget.type === MessagesWidget.type);
+    expect(messageTableWidget.config.decorators).toEqual([{ id: 'decorator1', stream: 'foobar', order: 0, type: 'something'}]);
+  });
+  it('adds decorators for default search to message table if stream id is `null`', async () => {
+    mockList.mockReturnValue([
+      { id: 'decorator1', stream: 'foobar', order: 0, type: 'something' },
+      { id: 'decorator2', stream: null, order: 0, type: 'something' },
+    ]);
+    const result = await ViewStateGenerator(View.Type.Search, null);
+
+    expect(mockList).toHaveBeenCalledWith();
+    const messageTableWidget = result.widgets.find(widget => widget.type === MessagesWidget.type);
+    expect(messageTableWidget.config.decorators).toEqual([{ id: 'decorator2', stream: null, order: 0, type: 'something'}]);
+  });
+  it('does not add decorators for current stream to message table if none exist for this stream', async () => {
+    mockList.mockReturnValue([
+      { id: 'decorator1', stream: 'foobar', order: 0, type: 'something' },
+      { id: 'decorator2', stream: null, order: 0, type: 'something' },
+    ]);
+    const result = await ViewStateGenerator(View.Type.Search, 'otherstream');
+
+    expect(mockList).toHaveBeenCalledWith();
+    const messageTableWidget = result.widgets.find(widget => widget.type === MessagesWidget.type);
+    expect(messageTableWidget.config.decorators).toEqual([]);
+  });
+  it('does not add decorators for current stream to message table if none exist at all', async () => {
+    const result = await ViewStateGenerator(View.Type.Search, 'otherstream');
+
+    expect(mockList).toHaveBeenCalledWith();
+    const messageTableWidget = result.widgets.find(widget => widget.type === MessagesWidget.type);
+    expect(messageTableWidget.config.decorators).toEqual([]);
+  });
+  it('does not add decorators for default search to message table if none exist at all', async () => {
+    const result = await ViewStateGenerator(View.Type.Search, null);
+
+    expect(mockList).toHaveBeenCalledWith();
+    const messageTableWidget = result.widgets.find(widget => widget.type === MessagesWidget.type);
+    expect(messageTableWidget.config.decorators).toEqual([]);
+  });
+});

--- a/graylog2-web-interface/src/views/logic/views/ViewStateGenerator.test.jsx
+++ b/graylog2-web-interface/src/views/logic/views/ViewStateGenerator.test.jsx
@@ -32,7 +32,7 @@ describe('ViewStateGenerator', () => {
 
     expect(mockList).toHaveBeenCalledWith();
     const messageTableWidget = result.widgets.find(widget => widget.type === MessagesWidget.type);
-    expect(messageTableWidget.config.decorators).toEqual([{ id: 'decorator1', stream: 'foobar', order: 0, type: 'something'}]);
+    expect(messageTableWidget.config.decorators).toEqual([{ id: 'decorator1', stream: 'foobar', order: 0, type: 'something' }]);
   });
   it('adds decorators for default search to message table if stream id is `null`', async () => {
     mockList.mockReturnValue([
@@ -43,7 +43,7 @@ describe('ViewStateGenerator', () => {
 
     expect(mockList).toHaveBeenCalledWith();
     const messageTableWidget = result.widgets.find(widget => widget.type === MessagesWidget.type);
-    expect(messageTableWidget.config.decorators).toEqual([{ id: 'decorator2', stream: null, order: 0, type: 'something'}]);
+    expect(messageTableWidget.config.decorators).toEqual([{ id: 'decorator2', stream: null, order: 0, type: 'something' }]);
   });
   it('does not add decorators for current stream to message table if none exist for this stream', async () => {
     mockList.mockReturnValue([

--- a/graylog2-web-interface/src/views/logic/views/ViewTransformer.test.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewTransformer.test.js
@@ -60,7 +60,7 @@ describe('ViewTransformer', () => {
       expect(dashboardView.id).not.toStrictEqual(searchView.id);
     });
 
-    it('should add the timerange to the widget', () => {
+    it('should add the timerange to the widget', async () => {
       const query = Query.builder()
         .id('query-id')
         .timerange({ type: 'relative', range: 365 })
@@ -71,7 +71,7 @@ describe('ViewTransformer', () => {
         .queries([query])
         .build();
 
-      const viewState: ViewState = ViewStateGenerator(View.Type.Search);
+      const viewState: ViewState = await ViewStateGenerator(View.Type.Search);
 
       const viewStateMap: ViewStateMap = Map.of('query-id', viewState);
       const searchView = View.builder()
@@ -85,7 +85,7 @@ describe('ViewTransformer', () => {
       expect(dashboardView.state.get('query-id').widgets.first().streams).toStrictEqual([]);
     });
 
-    it('should add the query to the widget', () => {
+    it('should add the query to the widget', async () => {
       const query = Query.builder()
         .id('query-id')
         .query({ type: 'elasticsearch', query_string: 'author: "Karl Marx"' })
@@ -96,7 +96,7 @@ describe('ViewTransformer', () => {
         .queries([query])
         .build();
 
-      const viewState: ViewState = ViewStateGenerator(View.Type.Search);
+      const viewState: ViewState = await ViewStateGenerator(View.Type.Search);
 
       const viewStateMap: ViewStateMap = Map.of('query-id', viewState);
       const searchView = View.builder()
@@ -110,7 +110,7 @@ describe('ViewTransformer', () => {
       expect(dashboardView.state.get('query-id').widgets.first().streams).toStrictEqual([]);
     });
 
-    it('should add the streams to the widget', () => {
+    it('should add the streams to the widget', async () => {
       const query = Query.builder()
         .id('query-id')
         .filter({ type: 'or', filters: List.of(Map.of('type', 'stream', 'id', '1234-abcd')) })
@@ -121,7 +121,7 @@ describe('ViewTransformer', () => {
         .queries([query])
         .build();
 
-      const viewState: ViewState = ViewStateGenerator(View.Type.Search);
+      const viewState: ViewState = await ViewStateGenerator(View.Type.Search);
 
       const viewStateMap: ViewStateMap = Map.of('query-id', viewState);
       const searchView = View.builder()

--- a/graylog2-web-interface/src/views/logic/views/ViewTransformer.test.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewTransformer.test.js
@@ -12,6 +12,17 @@ import ViewState from './ViewState';
 import ViewStateGenerator from './ViewStateGenerator';
 import viewTransformer from './ViewTransformer';
 
+const mockList = jest.fn(() => Promise.resolve([]));
+jest.mock('injection/CombinedProvider', () => ({
+  get: type => ({
+    Decorators: {
+      DecoratorsActions: {
+        list: (...args) => mockList(...args),
+      },
+    },
+  })[type],
+}));
+
 const cwd = dirname(__filename);
 
 const readFixture = filename => JSON.parse(readFileSync(`${cwd}/${filename}`).toString());

--- a/graylog2-web-interface/src/views/logic/widgets/MessagesWidgetConfig.js
+++ b/graylog2-web-interface/src/views/logic/widgets/MessagesWidgetConfig.js
@@ -2,7 +2,13 @@
 import * as Immutable from 'immutable';
 import WidgetConfig from './WidgetConfig';
 
-type Decorator = any;
+export type Decorator = {
+  id: string,
+  type: string,
+  config: any,
+  stream: ?string,
+  order: number,
+};
 
 type InternalState = {
   decorators: Array<Decorator>,

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.jsx
@@ -34,7 +34,7 @@ const StreamSearchPage = ({ params: { streamId }, route, loadingViewHooks, execu
 
   useEffect(() => {
     processHooks(
-      ViewActions.create(View.Type.Search)
+      ViewActions.create(View.Type.Search, streamId)
         .then(({ view, activeQuery }) => {
           return QueryFiltersActions.streams(activeQuery, [streamId]).then(() => view);
         }),

--- a/graylog2-web-interface/src/views/stores/SearchStore.test.js
+++ b/graylog2-web-interface/src/views/stores/SearchStore.test.js
@@ -1,6 +1,4 @@
 // @flow strict
-
-// $FlowFixMe: imports from core need to be fixed in flow
 import fetch from 'logic/rest/FetchProvider';
 
 import Search from 'views/logic/search/Search';
@@ -10,7 +8,7 @@ jest.mock('logic/rest/FetchProvider', () => jest.fn());
 
 describe('SearchStore', () => {
   it('assigns a new search id when creating a search', () => {
-    fetch.mockImplementation((method, url, body) => Promise.resolve(JSON.parse(body)));
+    fetch.mockImplementation((method, url, body) => Promise.resolve(body && JSON.parse(body)));
     const newSearch = Search.create();
     return SearchActions.create(newSearch).then(({ search }) => {
       expect(search.id).not.toEqual(newSearch.id);

--- a/graylog2-web-interface/src/views/stores/ViewStore.js
+++ b/graylog2-web-interface/src/views/stores/ViewStore.js
@@ -26,7 +26,7 @@ export type ViewStoreState = {
 };
 
 type ViewActionsType = RefluxActions<{
-  create: (ViewType) => Promise<ViewStoreState>,
+  create: (ViewType, ?string) => Promise<ViewStoreState>,
   description: (string) => Promise<ViewStoreState>,
   load: (View) => Promise<ViewStoreState>,
   properties: (Properties) => Promise<void>,
@@ -82,22 +82,25 @@ export const ViewStore: ViewStoreType = singletonStore(
       return this._state();
     },
 
-    create(type: ViewType) {
-      const [view] = this._updateSearch(ViewGenerator(type));
-      this.view = view;
-      const queries: QuerySet = get(view, 'search.queries', Immutable.Set());
-      this.activeQuery = queries.first().id;
+    create(type: ViewType, streamId: ?string = null) {
+      return ViewGenerator(type, streamId)
+        .then((newView) => {
+          const [view] = this._updateSearch(newView);
+          this.view = view;
+          const queries: QuerySet = get(view, 'search.queries', Immutable.Set());
+          this.activeQuery = queries.first().id;
+          return view;
+        }).then((view) => {
+          const promise = ViewActions.search(view.search)
+            .then(() => {
+              this.dirty = false;
+              this.isNew = true;
+            })
+            .then(() => this._trigger());
 
-      const promise = ViewActions.search(view.search)
-        .then(() => {
-          this.dirty = false;
-          this.isNew = true;
-        })
-        .then(() => this._trigger());
-
-      ViewActions.create.promise(promise.then(() => this._state()));
-
-      return promise;
+          ViewActions.create.promise(promise.then(() => this._state()));
+          return promise;
+        });
     },
     createQuery(query: Query, viewState: ViewState) {
       if (query.id === undefined) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is adding support for backend decorators to the new views-based search. In the existing search, backend decorators are added by someone with the required permission (`decorators:create`/`decorators:edit`/`decorators:read`) per stream, for which they are then added to all searches started for that stream for every user. They are effectively shared globally between all users, with some being able to modify them. The set of decorators created for a given stream are references as "default decorators" from now on.

For the views this concept seemed to be too unflexible. Instead, we are now retrieving the current set of decorators defined for the current stream (if a new search is started through the `Streams` page) or the default set (if a new search is started by clicking on `Search`) and added to the message table which is generated for a new search automatically. Decorator sets now function as templates, which can be modified by the search author. In addition, if no default decorators exist, a view author can add new decorators to an own search without owning any special permission by editing any message widget.

Default decorators can now be managed by anyone with the required permissions on the `System / Configurations` page, where a separate config component exists, which shows existing decorators, allows updating, creating and removing decorators.

The fact that a field was decorated, is shown in the message details by adding a small marker next to the field's value. Value actions are disabled for this value, because it is not a materialized value, so most actions will not return the expected results.

## Screenshots (if appropriate):
![Screen Shot 2019-12-11 at 15 59 30](https://user-images.githubusercontent.com/41929/70632512-4121db80-1c2f-11ea-9636-d9ae1de2e21a.png)
![Screen Shot 2019-12-11 at 16 03 37](https://user-images.githubusercontent.com/41929/70632826-da50f200-1c2f-11ea-96cb-90393c17ec44.png)
![Screen Shot 2019-12-11 at 16 03 51](https://user-images.githubusercontent.com/41929/70632828-dae98880-1c2f-11ea-9111-cc9f1ed11cad.png)
![Screen Shot 2019-12-11 at 16 41 46](https://user-images.githubusercontent.com/41929/70636022-281c2900-1c35-11ea-9661-406e6e8fdb0f.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.