### PR TITLE
Add pluggable elements rendered in widget edit mode.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/QueryResult.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/QueryResult.java
@@ -48,7 +48,7 @@ public abstract class QueryResult {
     @JsonProperty("search_types")
     public abstract Map<String, SearchType.Result> searchTypes();
 
-    @JsonProperty("error")
+    @JsonProperty("errors")
     @Nullable
     @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public abstract Set<SearchError> errors();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackend.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackend.java
@@ -349,7 +349,7 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
         final String mainQueryString = ((ElasticsearchQueryString) query.query()).queryString();
         final java.util.stream.Stream<String> queryStringStreams = java.util.stream.Stream.concat(
                 java.util.stream.Stream.of(mainQueryString),
-                query.searchTypes().stream().flatMap(searchType -> queryStringsFromFilter(searchType.filter()).stream())
+                query.searchTypes().stream().flatMap(this::queryStringsFromSearchType)
         );
 
         final QueryMetadata metadataForParameters = queryStringStreams
@@ -360,5 +360,15 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
 
 
         return metadataForParameters;
+    }
+
+    private java.util.stream.Stream<String> queryStringsFromSearchType(SearchType searchType) {
+        return java.util.stream.Stream.concat(
+                searchType.query().filter(query -> query instanceof ElasticsearchQueryString)
+                        .map(query -> ((ElasticsearchQueryString) query).queryString())
+                        .map(java.util.stream.Stream::of)
+                        .orElse(java.util.stream.Stream.empty()),
+                queryStringsFromFilter(searchType.filter()).stream()
+        );
     }
 }

--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
@@ -13,6 +13,7 @@ import { validate } from 'legacy/validations.js';
  */
 class BootstrapModalForm extends React.Component {
   static defaultProps = {
+    backdrop: undefined,
     formProps: {},
     cancelButtonText: 'Cancel',
     submitButtonText: 'Submit',
@@ -26,6 +27,7 @@ class BootstrapModalForm extends React.Component {
   };
 
   static propTypes = {
+    backdrop: PropTypes.oneOf([true, false, 'static']),
     bsSize: PropTypes.oneOf(['lg', 'large', 'sm', 'small']),
     /* Modal title */
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
@@ -97,6 +99,7 @@ class BootstrapModalForm extends React.Component {
                              onClose={this.props.onModalClose}
                              bsSize={this.props.bsSize}
                              showModal={this.props.show}
+                             backdrop={this.props.backdrop}
                              onHide={this.onModalCancel}>
         <Modal.Header closeButton>
           <Modal.Title>{this.props.title}</Modal.Title>

--- a/graylog2-web-interface/src/routing/AppErrorBoundary.test.jsx
+++ b/graylog2-web-interface/src/routing/AppErrorBoundary.test.jsx
@@ -1,21 +1,11 @@
+// @flow strict
 import React from 'react';
 import { mount } from 'enzyme';
 
+import suppressConsole from 'helpers/suppressConsole';
 import AppErrorBoundary from './AppErrorBoundary';
 
 jest.mock('react-router', () => ({ withRouter: x => x }));
-
-const suppressConsole = (fn) => {
-  /* eslint-disable no-console */
-  const originalConsoleError = console.error;
-  console.error = () => {
-  };
-
-  fn();
-
-  console.error = originalConsoleError;
-  /* eslint-enable no-console */
-};
 
 const ErroneusComponent = () => {
   // eslint-disable-next-line no-throw-literal

--- a/graylog2-web-interface/src/views/components/WidgetOverrideElements.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetOverrideElements.jsx
@@ -1,0 +1,10 @@
+// @flow strict
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+const WidgetOverrideElements = () => {
+};
+
+WidgetOverrideElements.propTypes = {};
+
+export default WidgetOverrideElements;

--- a/graylog2-web-interface/src/views/components/WidgetOverrideElements.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetOverrideElements.jsx
@@ -8,7 +8,7 @@ type Props = {
   widgetOverrideElements: Array<React.ComponentType<{}>>,
 };
 
-export type OverrideComponentType = React.ComponentType<{ resetOverride: () => mixed }> | Error;
+export type OverrideComponentType = React.ComponentType<{ retry: () => mixed }> | Error;
 
 type State = {
   thrownComponent: ?OverrideComponentType,
@@ -31,8 +31,8 @@ class WidgetOverrideElements extends React.Component<Props, State> {
       if (OverrideComponent instanceof Error) {
         throw OverrideComponent;
       }
-      const resetOverride = () => this.setState({ thrownComponent: undefined });
-      return <OverrideComponent resetOverride={resetOverride} />;
+      const retry = () => this.setState({ thrownComponent: undefined });
+      return <OverrideComponent retry={retry} />;
     }
 
     const { children, widgetOverrideElements } = this.props;

--- a/graylog2-web-interface/src/views/components/WidgetOverrideElements.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetOverrideElements.jsx
@@ -8,8 +8,10 @@ type Props = {
   widgetOverrideElements: Array<React.ComponentType<{}>>,
 };
 
+export type OverrideComponentType = React.ComponentType<{ resetOverride: () => mixed }>;
+
 type State = {
-  thrownComponent: ?React.ComponentType<{}>,
+  thrownComponent: ?OverrideComponentType,
 };
 
 class WidgetOverrideElements extends React.Component<Props, State> {
@@ -26,7 +28,8 @@ class WidgetOverrideElements extends React.Component<Props, State> {
   render() {
     const { thrownComponent: OverrideComponent } = this.state;
     if (OverrideComponent) {
-      return <OverrideComponent />;
+      const resetOverride = () => this.setState({ thrownComponent: undefined });
+      return <OverrideComponent resetOverride={resetOverride} />;
     }
 
     const { children, widgetOverrideElements } = this.props;

--- a/graylog2-web-interface/src/views/components/WidgetOverrideElements.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetOverrideElements.jsx
@@ -10,6 +10,10 @@ type Props = {
 
 export type OverrideComponentType = React.ComponentType<{ retry: () => mixed }> | Error;
 
+export type OverrideProps = {
+  override: (OverrideComponentType) => void,
+};
+
 type State = {
   thrownComponent: ?OverrideComponentType,
 };
@@ -18,11 +22,6 @@ class WidgetOverrideElements extends React.Component<Props, State> {
   constructor(props) {
     super(props);
     this.state = { thrownComponent: undefined };
-  }
-
-  static getDerivedStateFromError(thrownComponent) {
-    // Update state so the next render will show the fallback UI.
-    return { thrownComponent };
   }
 
   render() {
@@ -35,10 +34,12 @@ class WidgetOverrideElements extends React.Component<Props, State> {
       return <OverrideComponent retry={retry} />;
     }
 
+    const override = thrownComponent => this.setState({ thrownComponent });
+
     const { children, widgetOverrideElements } = this.props;
     const widgetOverrideChecks = widgetOverrideElements
       // eslint-disable-next-line react/no-array-index-key
-      .map((Component, idx) => <Component key={idx} />);
+      .map((Component, idx) => <Component key={idx} override={override} />);
 
     return (
       <React.Fragment>
@@ -50,7 +51,7 @@ class WidgetOverrideElements extends React.Component<Props, State> {
 }
 
 const mapping = {
-  widgetOverrideElements: 'views.elements.widgetOverrides',
+  widgetOverrideElements: 'views.overrides.widgetEdit',
 };
 
 export default withPluginEntities<Props, typeof mapping>(WidgetOverrideElements, mapping);

--- a/graylog2-web-interface/src/views/components/WidgetOverrideElements.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetOverrideElements.jsx
@@ -8,7 +8,7 @@ type Props = {
   widgetOverrideElements: Array<React.ComponentType<{}>>,
 };
 
-export type OverrideComponentType = React.ComponentType<{ resetOverride: () => mixed }>;
+export type OverrideComponentType = React.ComponentType<{ resetOverride: () => mixed }> | Error;
 
 type State = {
   thrownComponent: ?OverrideComponentType,
@@ -28,6 +28,9 @@ class WidgetOverrideElements extends React.Component<Props, State> {
   render() {
     const { thrownComponent: OverrideComponent } = this.state;
     if (OverrideComponent) {
+      if (OverrideComponent instanceof Error) {
+        throw OverrideComponent;
+      }
       const resetOverride = () => this.setState({ thrownComponent: undefined });
       return <OverrideComponent resetOverride={resetOverride} />;
     }

--- a/graylog2-web-interface/src/views/components/WidgetOverrideElements.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetOverrideElements.jsx
@@ -1,10 +1,50 @@
 // @flow strict
 import * as React from 'react';
-import PropTypes from 'prop-types';
 
-const WidgetOverrideElements = () => {
+import withPluginEntities from 'views/logic/withPluginEntities';
+
+type Props = {
+  children: React.Node,
+  widgetOverrideElements: Array<React.ComponentType<{}>>,
 };
 
-WidgetOverrideElements.propTypes = {};
+type State = {
+  thrownComponent: ?React.ComponentType<{}>,
+};
 
-export default WidgetOverrideElements;
+class WidgetOverrideElements extends React.Component<Props, State> {
+  constructor(props) {
+    super(props);
+    this.state = { thrownComponent: undefined };
+  }
+
+  static getDerivedStateFromError(thrownComponent) {
+    // Update state so the next render will show the fallback UI.
+    return { thrownComponent };
+  }
+
+  render() {
+    const { thrownComponent: OverrideComponent } = this.state;
+    if (OverrideComponent) {
+      return <OverrideComponent />;
+    }
+
+    const { children, widgetOverrideElements } = this.props;
+    const widgetOverrideChecks = widgetOverrideElements
+      // eslint-disable-next-line react/no-array-index-key
+      .map((Component, idx) => <Component key={idx} />);
+
+    return (
+      <React.Fragment>
+        {widgetOverrideChecks}
+        {children}
+      </React.Fragment>
+    );
+  }
+}
+
+const mapping = {
+  widgetOverrideElements: 'views.elements.widgetOverrides',
+};
+
+export default withPluginEntities<Props, typeof mapping>(WidgetOverrideElements, mapping);

--- a/graylog2-web-interface/src/views/components/WidgetOverrideElements.test.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetOverrideElements.test.jsx
@@ -1,0 +1,63 @@
+// @flow strict
+import * as React from 'react';
+import { cleanup, render, waitForElement } from '@testing-library/react';
+
+import WidgetOverrideElements from './WidgetOverrideElements';
+
+jest.mock('views/logic/withPluginEntities', () => x => x);
+
+const suppressConsole = async (fn) => {
+  /* eslint-disable no-console */
+  const originalConsoleError = console.error;
+  console.error = () => {
+  };
+
+  await fn();
+
+  console.error = originalConsoleError;
+  /* eslint-enable no-console */
+};
+
+describe('WidgetOverrideElements', () => {
+  afterEach(cleanup);
+  it('renders original children if no elements are present', async () => {
+    const { getByText } = render((
+      <WidgetOverrideElements widgetOverrideElements={[]}>
+        <span>Hello world!</span>
+      </WidgetOverrideElements>
+    ));
+    await waitForElement(() => getByText('Hello world!'));
+  });
+  it('renders original children if element does not throw', async () => {
+    const { getByText } = render((
+      <WidgetOverrideElements widgetOverrideElements={[() => null]}>
+        <span>Hello world!</span>
+      </WidgetOverrideElements>
+    ));
+    await waitForElement(() => getByText('Hello world!'));
+  });
+  it('propagates thrown errors', async () => {
+    const throwElement = () => {
+      throw new Error('The dungeon collapses, you die!');
+    };
+    expect(() => render((
+      <WidgetOverrideElements widgetOverrideElements={[throwElement]}>
+        <span>Hello world!</span>
+      </WidgetOverrideElements>
+    ))).toThrowError('The dungeon collapses, you die!');
+  });
+  it('renders thrown component if element throws one', async () => {
+    suppressConsole(async () => {
+      const Component = () => <span>I was thrown!</span>;
+      const ThrowElement = () => {
+        throw Component;
+      };
+      const { getByText } = render((
+        <WidgetOverrideElements widgetOverrideElements={[() => <ThrowElement />]}>
+          <span>Hello world!</span>
+        </WidgetOverrideElements>
+      ));
+      await waitForElement(() => getByText('I was thrown!'));
+    });
+  });
+});

--- a/graylog2-web-interface/src/views/components/WidgetOverrideElements.test.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetOverrideElements.test.jsx
@@ -2,21 +2,10 @@
 import * as React from 'react';
 import { cleanup, render, waitForElement } from '@testing-library/react';
 
+import suppressConsole from 'helpers/suppressConsole';
 import WidgetOverrideElements from './WidgetOverrideElements';
 
 jest.mock('views/logic/withPluginEntities', () => x => x);
-
-const suppressConsole = async (fn) => {
-  /* eslint-disable no-console */
-  const originalConsoleError = console.error;
-  console.error = () => {
-  };
-
-  await fn();
-
-  console.error = originalConsoleError;
-  /* eslint-enable no-console */
-};
 
 describe('WidgetOverrideElements', () => {
   afterEach(cleanup);

--- a/graylog2-web-interface/src/views/components/WidgetOverrideElements.test.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetOverrideElements.test.jsx
@@ -49,6 +49,6 @@ describe('WidgetOverrideElements', () => {
       </WidgetOverrideElements>
     ));
     await waitForElement(() => getByText('I was thrown!'));
-    expect(queryByText('Hello world!')).toBeNull()
+    expect(queryByText('Hello world!')).toBeNull();
   });
 });

--- a/graylog2-web-interface/src/views/components/WidgetOverrideElements.test.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetOverrideElements.test.jsx
@@ -1,5 +1,5 @@
 // @flow strict
-import * as React from 'react';
+import React, { useEffect } from 'react';
 import { cleanup, render, waitForElement } from '@testing-library/react';
 
 import suppressConsole from 'helpers/suppressConsole';
@@ -38,15 +38,17 @@ describe('WidgetOverrideElements', () => {
   it('renders thrown component if element throws one', async () => {
     suppressConsole(async () => {
       const Component = () => <span>I was thrown!</span>;
-      const ThrowElement = () => {
-        throw Component;
+      const OverridingElement = ({ override }) => {
+        useEffect(() => override(Component), []);
+        return null;
       };
-      const { getByText } = render((
-        <WidgetOverrideElements widgetOverrideElements={[() => <ThrowElement />]}>
+      const { getByText, queryByText } = render((
+        <WidgetOverrideElements widgetOverrideElements={[OverridingElement]}>
           <span>Hello world!</span>
         </WidgetOverrideElements>
       ));
       await waitForElement(() => getByText('I was thrown!'));
+      expect(queryByText('Hello world!')).toBeNull()
     });
   });
 });

--- a/graylog2-web-interface/src/views/components/WidgetOverrideElements.test.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetOverrideElements.test.jsx
@@ -48,7 +48,7 @@ describe('WidgetOverrideElements', () => {
         </WidgetOverrideElements>
       ));
       await waitForElement(() => getByText('I was thrown!'));
-      expect(queryByText('Hello world!')).toBeNull()
+      expect(queryByText('Hello world!')).toBeNull();
     });
   });
 });

--- a/graylog2-web-interface/src/views/components/WidgetOverrideElements.test.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetOverrideElements.test.jsx
@@ -26,29 +26,29 @@ describe('WidgetOverrideElements', () => {
     await waitForElement(() => getByText('Hello world!'));
   });
   it('propagates thrown errors', async () => {
-    const throwElement = () => {
-      throw new Error('The dungeon collapses, you die!');
-    };
-    expect(() => render((
-      <WidgetOverrideElements widgetOverrideElements={[throwElement]}>
-        <span>Hello world!</span>
-      </WidgetOverrideElements>
-    ))).toThrowError('The dungeon collapses, you die!');
-  });
-  it('renders thrown component if element throws one', async () => {
     suppressConsole(async () => {
-      const Component = () => <span>I was thrown!</span>;
-      const OverridingElement = ({ override }) => {
-        useEffect(() => override(Component), []);
-        return null;
+      const throwElement = () => {
+        throw new Error('The dungeon collapses, you die!');
       };
-      const { getByText, queryByText } = render((
-        <WidgetOverrideElements widgetOverrideElements={[OverridingElement]}>
+      expect(() => render((
+        <WidgetOverrideElements widgetOverrideElements={[throwElement]}>
           <span>Hello world!</span>
         </WidgetOverrideElements>
-      ));
-      await waitForElement(() => getByText('I was thrown!'));
-      expect(queryByText('Hello world!')).toBeNull();
+      ))).toThrowError('The dungeon collapses, you die!');
     });
+  });
+  it('renders thrown component if element throws one', async () => {
+    const Component = () => <span>I was thrown!</span>;
+    const OverridingElement = ({ override }) => {
+      useEffect(() => override(Component), []);
+      return null;
+    };
+    const { getByText, queryByText } = render((
+      <WidgetOverrideElements widgetOverrideElements={[OverridingElement]}>
+        <span>Hello world!</span>
+      </WidgetOverrideElements>
+    ));
+    await waitForElement(() => getByText('I was thrown!'));
+    expect(queryByText('Hello world!')).toBeNull()
   });
 });

--- a/graylog2-web-interface/src/views/components/contexts/QueryEditModeContext.jsx
+++ b/graylog2-web-interface/src/views/components/contexts/QueryEditModeContext.jsx
@@ -1,0 +1,10 @@
+// @flow strict
+import * as React from 'react';
+
+import { singleton } from 'views/logic/singleton';
+
+export type QueryEditMode = 'query' | 'widget';
+
+const QueryEditModeContext = React.createContext<QueryEditMode>('query');
+
+export default singleton('views.components.contexts.QueryEditModeContext', () => QueryEditModeContext);

--- a/graylog2-web-interface/src/views/components/sidebar/SideBar.test.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/SideBar.test.jsx
@@ -45,8 +45,7 @@ describe('<Sidebar />', () => {
       title: 'Query Title',
     };
 
-    // eslint-disable-next-line camelcase
-    const effective_timerange = { type: 'absolute', from: '2018-08-28T14:34:26.192Z', to: '2018-08-28T14:39:26.192Z' };
+    const effectiveTimerange = { type: 'absolute', from: '2018-08-28T14:34:26.192Z', to: '2018-08-28T14:39:26.192Z' };
     const duration = 64;
     const timestamp = '2018-08-28T14:39:26.127Z';
     query = {
@@ -56,10 +55,9 @@ describe('<Sidebar />', () => {
       search_types: [],
       timerange: { type: 'relative', range: 300 },
     };
-    const error = [];
-    // eslint-disable-next-line camelcase
-    const execution_stats = { effective_timerange, duration, timestamp };
-    queryResult = new QueryResult({ execution_stats, query, error });
+    const errors = [];
+    const executionStats = { effective_timerange: effectiveTimerange, duration, timestamp };
+    queryResult = new QueryResult({ execution_stats: executionStats, query, errors });
 
     const currentUser = { timezone: 'UTC' };
     const CurrentUserStore = StoreMock('listen', ['get', () => currentUser], ['getInitialState', () => ({ currentUser })]);

--- a/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.jsx
@@ -14,6 +14,7 @@ import styles from '!style?insertAt=bottom!css!./EditWidgetFrame.css';
 import globalStyles from '!style/useable!css!./EditWidgetFrame.global.css';
 import HeaderElements from '../HeaderElements';
 import QueryBarElements from '../QueryBarElements';
+import WidgetOverrideElements from '../WidgetOverrideElements';
 
 
 type DialogProps = {
@@ -73,7 +74,9 @@ export default class EditWidgetFrame extends React.Component<Props> {
         </IfDashboard>
         <Modal.Body className={styles.Visualization}>
           <div role="presentation" style={{ height: '100%' }}>
-            {children[0]}
+            <WidgetOverrideElements>
+              {children[0]}
+            </WidgetOverrideElements>
           </div>
         </Modal.Body>
         <Modal.Footer className={styles.Footer}>

--- a/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Modal } from 'components/graylog';
 
 import WidgetContext from 'views/components/contexts/WidgetContext';
+import QueryEditModeContext from 'views/components/contexts/QueryEditModeContext';
 import WidgetQueryControls from '../WidgetQueryControls';
 import IfDashboard from '../dashboard/IfDashboard';
 
@@ -11,6 +12,8 @@ import IfDashboard from '../dashboard/IfDashboard';
 import styles from '!style?insertAt=bottom!css!./EditWidgetFrame.css';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import globalStyles from '!style/useable!css!./EditWidgetFrame.global.css';
+import HeaderElements from '../HeaderElements';
+import QueryBarElements from '../QueryBarElements';
 
 
 type DialogProps = {
@@ -58,11 +61,14 @@ export default class EditWidgetFrame extends React.Component<Props> {
              enforceFocus={false}>
         <IfDashboard>
           <Modal.Header className={styles.QueryControls}>
-            <WidgetContext.Consumer>
-              {widget => (
-                <WidgetQueryControls widget={widget} />
-              )}
-            </WidgetContext.Consumer>
+            <QueryEditModeContext.Provider value="widget">
+              <HeaderElements />
+              <WidgetContext.Consumer>
+                {widget => (
+                  <WidgetQueryControls widget={widget} />
+                )}
+              </WidgetContext.Consumer>
+            </QueryEditModeContext.Provider>
           </Modal.Header>
         </IfDashboard>
         <Modal.Body className={styles.Visualization}>

--- a/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.jsx
@@ -13,7 +13,6 @@ import styles from '!style?insertAt=bottom!css!./EditWidgetFrame.css';
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import globalStyles from '!style/useable!css!./EditWidgetFrame.global.css';
 import HeaderElements from '../HeaderElements';
-import QueryBarElements from '../QueryBarElements';
 import WidgetOverrideElements from '../WidgetOverrideElements';
 
 

--- a/graylog2-web-interface/src/views/logic/QueryResult.js
+++ b/graylog2-web-interface/src/views/logic/QueryResult.js
@@ -27,7 +27,7 @@ export default class QueryResult {
     const { duration, timestamp, effective_timerange } = queryResult.execution_stats;
     this._state = {
       query: queryResult.query,
-      errors: queryResult.error.map(error => new SearchError(error)),
+      errors: queryResult.errors.map(error => new SearchError(error)),
       duration,
       timestamp,
       effectiveTimerange: effective_timerange,

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -159,13 +159,16 @@ const ExtendedSearchPage = ({ route, searchRefreshHooks }: Props) => {
                   <HeaderElements />
                   <IfDashboard>
                     <DashboardSearchBarWithStatus onExecute={refreshIfNotUndeclared} />
-                    <QueryBar />
                   </IfDashboard>
                   <IfSearch>
                     <SearchBarWithStatus onExecute={refreshIfNotUndeclared} />
                   </IfSearch>
 
                   <QueryBarElements />
+
+                  <IfDashboard>
+                    <QueryBar />
+                  </IfDashboard>
                 </IfInteractive>
 
                 <ViewAdditionalContextProvider>

--- a/graylog2-web-interface/test/helpers/suppressConsole.js
+++ b/graylog2-web-interface/test/helpers/suppressConsole.js
@@ -1,0 +1,24 @@
+// @flow strict
+
+/**
+ * This helper function allows to suppress console errors which would lead to test failures in some, very rare cases.
+ *
+ * The only accepted situation at this moment is for testing react error boundaries, which inevitably log the error which
+ * was thrown to the console. Testing an error boundary currently requires using this function.
+ *
+ * @param {function} fn - the function which should be called after disabling `console.error` and before restoring it.
+ */
+const suppressConsole = (fn: () => mixed) => {
+  /* eslint-disable no-console */
+  const originalConsoleError = console.error;
+  // $FlowFixMe: We explicitly want to overwrite `error`
+  console.error = () => {};
+
+  fn();
+
+  // $FlowFixMe: We explicitly want to overwrite `error`
+  console.error = originalConsoleError;
+  /* eslint-enable no-console */
+};
+
+export default suppressConsole;

--- a/graylog2-web-interface/test/integration-environment.js
+++ b/graylog2-web-interface/test/integration-environment.js
@@ -56,7 +56,7 @@ class IntegrationEnvironment extends JSDomEnvironment {
     api.post(/views\/search\/(\w+)\/execute$/, (req, res) => {
       const search = searches[req.params[0]];
       const results = search.queries.map(({ id }) => [id, {
-        error: [],
+        errors: [],
         execution_stats: {
           timestamp: '2019-07-05T13:37:00Z',
           effective_timerange: {


### PR DESCRIPTION
## Description
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR adds a new plugin entity (registered as
`views.elements.widgetOverrides`), which is used to render components
when a widget is opened in edit mode. Those components usually return
`null`, but can `throw` a component that is rendered _instead_ of the
actual widget edit component. This allows any plugin to
intercept widget editing to e.g. check the current widget settings and
display a custom edit component for any widget, which supplies
additional functionality. If the component regularly returns controls,
they will be rendered next to the widget edit component, if the
component throws one, it will be inserted modally and a `retry` function
is passed in, which allows restarting the rendering cycle when the need
to display the component modally is not present anymore.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.