### PR TITLE
Support existing search URLs in new search page

### DIFF
--- a/graylog2-web-interface/src/views/Constants.js
+++ b/graylog2-web-interface/src/views/Constants.js
@@ -7,7 +7,8 @@ export const Messages = {
   DEFAULT_LIMIT: 150,
 };
 
-export const DEFAULT_TIMERANGE = { type: 'relative', range: 300 };
+export const DEFAULT_RANGE_TYPE = 'relative';
+export const DEFAULT_TIMERANGE = { type: DEFAULT_RANGE_TYPE, range: 300 };
 
 export const DEFAULT_HIGHLIGHT_COLOR = '#ffec3d';
 export const DEFAULT_CUSTOM_HIGHLIGHT_RANGE = chroma.scale(['lightyellow', 'lightgreen', 'lightblue', 'red']).mode('lch').colors(40);

--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -64,6 +64,7 @@ import HighlightValueHandler from 'views/logic/valueactions/HighlightValueHandle
 import FieldNameCompletion from 'views/components/searchbar/completions/FieldNameCompletion';
 import OperatorCompletion from 'views/components/searchbar/completions/OperatorCompletion';
 import requirementsProvided from 'views/hooks/RequirementsProvided';
+import bindSearchParamsFromQuery from 'views/hooks/BindSearchParamsFromQuery';
 import {
   dashboardsPath, dashboardsTvPath,
   extendedSearchPath,
@@ -361,6 +362,7 @@ export default {
   ],
   'views.hooks.loadingView': [
     requirementsProvided,
+    bindSearchParamsFromQuery,
   ],
   'views.elements.header': [() => hasLegacyFieldCharts() && (
     <MigrateFieldCharts />

--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -38,7 +38,7 @@ import ExcludeFromQueryHandler from 'views/logic/valueactions/ExcludeFromQueryHa
 import { isFunction } from 'views/logic/aggregationbuilder/Series';
 import AggregationControls from 'views/components/aggregationbuilder/AggregationControls';
 import EditMessageList from 'views/components/widgets/EditMessageList';
-import { DashboardsPage, ShowViewPage, NewSearchPage, ViewManagementPage } from 'views/pages';
+import { DashboardsPage, ShowViewPage, NewSearchPage, ViewManagementPage, NewDashboardPage, StreamSearchPage } from 'views/pages';
 import AppWithExtendedSearchBar from 'routing/AppWithExtendedSearchBar';
 
 import AddMessageCountActionHandler from 'views/logic/fieldactions/AddMessageCountActionHandler';
@@ -74,8 +74,6 @@ import {
   showSearchPath,
   viewsPath,
 } from 'views/Constants';
-import NewDashboardPage from 'views/pages/NewDashboardPage';
-import StreamSearchPage from 'views/pages/StreamSearchPage';
 import ShowDashboardInBigDisplayMode from 'views/pages/ShowDashboardInBigDisplayMode';
 import AppConfig from 'util/AppConfig';
 import LookupTableParameter from 'views/logic/parameters/LookupTableParameter';

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
@@ -15,24 +15,28 @@ const _getTimerange = (query = {}) => {
   let timerange;
   const rangeType = query.rangetype || DEFAULT_RANGE_TYPE;
 
-  if (query.relative || query.absolute || query.keyword) {
-    switch (rangeType) {
-      case 'relative':
+  switch (rangeType) {
+    case 'relative':
+      if (query.relative) {
         timerange = { type: rangeType, range: query.relative };
-        break;
-      case 'absolute':
+      }
+      break;
+    case 'absolute':
+      if (query.from || query.to) {
         timerange = {
           type: rangeType,
           from: query.from,
           to: query.to,
         };
-        break;
-      case 'keyword':
-        timerange = { type: rangeType, keyword: query.relative };
-        break;
-      default:
-        throw new Error(`Unsupported range type ${rangeType}`);
-    }
+      }
+      break;
+    case 'keyword':
+      if (query.keyword) {
+        timerange = { type: rangeType, keyword: query.keyword };
+      }
+      break;
+    default:
+      throw new Error(`Unsupported range type ${rangeType}`);
   }
 
   return timerange;

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
@@ -1,7 +1,6 @@
 // @flow strict
 import { DEFAULT_RANGE_TYPE } from 'views/Constants';
 
-import { CurrentQueryStore } from 'views/stores/CurrentQueryStore';
 import { QueriesActions } from 'views/stores/QueriesStore';
 import type { ViewHook } from 'views/logic/hooks/ViewHook';
 import View from 'views/logic/views/View';

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
@@ -4,6 +4,7 @@ import { DEFAULT_RANGE_TYPE } from 'views/Constants';
 import { CurrentQueryStore } from 'views/stores/CurrentQueryStore';
 import { QueriesActions } from 'views/stores/QueriesStore';
 import type { ViewHook } from 'views/logic/hooks/ViewHook';
+import View from 'views/logic/views/View';
 
 const _getTimerange = (query = {}) => {
   let range;
@@ -48,7 +49,7 @@ const setQueryTimerange = (queryId, query) => {
 };
 
 const bindSearchParamsFromQuery: ViewHook = ({ query, view }) => {
-  if (view.type !== 'SEARCH') {
+  if (view.type !== View.Type.Search) {
     return Promise.resolve(true);
   }
   const { id: queryId } = CurrentQueryStore.getInitialState();

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
@@ -31,6 +31,17 @@ const _getTimerange = (query = {}) => {
   }
 };
 
+const _getQueryIdFromView = (view: View) => {
+  if (!view.search || !view.search.queries) {
+    throw new Error('Unable to extract queries from search!');
+  }
+  const { queries } = view.search;
+  if (queries.size !== 1) {
+    throw new Error('Searches must only have a single query!');
+  }
+  return queries.map(({ id }) => id).first();
+};
+
 const _setQueryString = (queryId, query) => {
   const queryString = query.q;
   if (!queryString) {
@@ -39,7 +50,7 @@ const _setQueryString = (queryId, query) => {
   return QueriesActions.query(queryId, queryString);
 };
 
-const setQueryTimerange = (queryId, query) => {
+const _setQueryTimerange = (queryId, query) => {
   const timerange = _getTimerange(query);
   if (!timerange) {
     return Promise.resolve();
@@ -51,8 +62,8 @@ const bindSearchParamsFromQuery: ViewHook = ({ query, view }) => {
   if (view.type !== View.Type.Search) {
     return Promise.resolve(true);
   }
-  const { id: queryId } = CurrentQueryStore.getInitialState();
-  return _setQueryString(queryId, query).then(() => setQueryTimerange(queryId, query)).then(() => true);
+  const queryId = _getQueryIdFromView(view);
+  return _setQueryString(queryId, query).then(() => _setQueryTimerange(queryId, query)).then(() => true);
 };
 
 export default bindSearchParamsFromQuery;

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
@@ -7,29 +7,28 @@ import type { ViewHook } from 'views/logic/hooks/ViewHook';
 import View from 'views/logic/views/View';
 
 const _getTimerange = (query = {}) => {
-  let range;
   const type = query.rangetype || DEFAULT_RANGE_TYPE;
-  const _setRange = (condition, newRange) => { if (condition); range = newRange; };
+  const _setRange = (condition, newRange) => {
+    if (condition) {
+      return newRange;
+    }
+    return undefined;
+  };
 
   switch (type) {
     case 'relative':
-      _setRange(query.relative, { type, range: query.relative });
-      break;
+      return _setRange(query.relative, { type, range: query.relative });
     case 'absolute':
-      _setRange((query.from || query.to), {
+      return _setRange((query.from || query.to), {
         type: type,
         from: query.from,
         to: query.to,
       });
-      break;
     case 'keyword':
-      _setRange(query.keyword, { type, keyword: query.keyword });
-      break;
+      return _setRange(query.keyword, { type, keyword: query.keyword });
     default:
       throw new Error(`Unsupported range type ${type}`);
   }
-
-  return range;
 };
 
 const _setQueryString = (queryId, query) => {

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.js
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.js
@@ -1,7 +1,7 @@
 // @flow strict
 import View from 'views/logic/views/View';
-import MockQuery from 'views/logic/queries/Query';
-import { StoreMock as MockStore } from 'helpers/mocking';
+import Query from 'views/logic/queries/Query';
+import Search from 'views/logic/search/Search';
 import { QueriesActions } from 'views/stores/QueriesStore';
 import bindSearchParamsFromQuery from './BindSearchParamsFromQuery';
 
@@ -14,14 +14,20 @@ jest.mock('views/stores/QueriesStore', () => ({
   },
 }));
 
-jest.mock('views/stores/CurrentQueryStore', () => ({
-  CurrentQueryStore: MockStore(['getInitialState', () => MockQuery.builder().id(MOCK_VIEW_QUERY_ID).build()], 'listen'),
-}));
-
 describe('BindSearchParamsFromQuery should', () => {
+  const query = Query.builder().id(MOCK_VIEW_QUERY_ID).build();
+  const search = Search.create()
+    .toBuilder()
+    .queries([query])
+    .build();
+  const view = View.create()
+    .toBuilder()
+    .type(View.Type.Search)
+    .search(search)
+    .build();
   const defaultInput = {
     query: {},
-    view: new View.create().toBuilder().type('SEARCH').build(),
+    view,
     retry: () => Promise.resolve(),
   };
 
@@ -32,7 +38,7 @@ describe('BindSearchParamsFromQuery should', () => {
   it('not update query when provided view is not a search', async () => {
     const input = {
       ...defaultInput,
-      view: new View.create().toBuilder().type('DASHBOARD').build(),
+      view: view.toBuilder().type(View.Type.Dashboard).build(),
     };
     await bindSearchParamsFromQuery(input);
     expect(QueriesActions.query).not.toHaveBeenCalled();

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.js
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.js
@@ -1,0 +1,51 @@
+import MockQuery from 'views/logic/queries/Query';
+import { StoreMock as MockStore } from 'helpers/mocking';
+import { QueriesActions } from 'views/stores/QueriesStore';
+import bindSearchParamsFromQuery from './BindSearchParamsFromQuery';
+
+jest.mock('views/stores/QueriesStore', () => ({
+  QueriesActions: {
+    query: jest.fn(() => Promise.resolve()),
+    timerange: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+jest.mock('views/stores/CurrentQueryStore', () => ({
+  CurrentQueryStore: MockStore(['getInitialState', () => MockQuery.builder().id('query-id').build()], 'listen'),
+}));
+
+describe('BindSearchParamsFromQuery should', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('not update query when provided view is not a search', async () => {
+    await bindSearchParamsFromQuery({ query: undefined, view: { type: 'DASHBOARD' } });
+    expect(QueriesActions.query).not.toHaveBeenCalled();
+  });
+
+  it('update query string with provided query param', async () => {
+    await bindSearchParamsFromQuery({ query: { q: 'gl2_source_input:source-input-id' }, view: { type: 'SEARCH' } });
+    expect(QueriesActions.query).toHaveBeenCalledWith('query-id', 'gl2_source_input:source-input-id');
+  });
+
+  it('not update query string when no query param is provided', async () => {
+    await bindSearchParamsFromQuery({ query: undefined, view: { type: 'SEARCH' } });
+    expect(QueriesActions.query).not.toHaveBeenCalled();
+  });
+
+  it('update query timerange when relative range value param is povided', async () => {
+    await bindSearchParamsFromQuery({ query: { relative: '0' }, view: { type: 'SEARCH' } });
+    expect(QueriesActions.timerange).toHaveBeenCalledWith('query-id', { type: 'relative', range: '0' });
+  });
+
+  it('update query timerange when provided query range param is absolute', async () => {
+    await bindSearchParamsFromQuery({ query: { rangetype: 'absolute', from: '2010-01-00 00:00:00', to: '2010-10-00 00:00:00' }, view: { type: 'SEARCH' } });
+    expect(QueriesActions.timerange).toHaveBeenCalledWith('query-id', { type: 'absolute', from: '2010-01-00 00:00:00', to: '2010-10-00 00:00:00' });
+  });
+
+  it('update query timerange when provided query range is keyword', async () => {
+    await bindSearchParamsFromQuery({ query: { rangetype: 'keyword', keyword: 'Last five days' }, view: { type: 'SEARCH' } });
+    expect(QueriesActions.timerange).toHaveBeenCalledWith('query-id', { type: 'keyword', keyword: 'Last five days' });
+  });
+});

--- a/graylog2-web-interface/src/views/logic/views/View.js
+++ b/graylog2-web-interface/src/views/logic/views/View.js
@@ -130,7 +130,7 @@ export default class View {
   }
 
   get requires(): Requirements {
-    return this._value.requires;
+    return this._value.requires || {};
   }
 
   // eslint-disable-next-line no-use-before-define

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
@@ -8,7 +8,7 @@ import { ViewActions } from 'views/stores/ViewStore';
 import type { ViewHook } from 'views/logic/hooks/ViewHook';
 import ViewLoaderContext from 'views/logic/ViewLoaderContext';
 import View from 'views/logic/views/View';
-import ViewLoader from 'views/logic/views/ViewLoader';
+import ViewLoader, { processHooks } from 'views/logic/views/ViewLoader';
 import { SearchActions } from 'views/stores/SearchStore';
 
 import { ExtendedSearchPage } from 'views/pages';
@@ -44,7 +44,12 @@ class NewSearchPage extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    ViewActions.create(View.Type.Search).then(() => this.setState({ loaded: true }));
+    const { location, loadingViewHooks, executingViewHooks } = this.props;
+    const { query } = location;
+    processHooks(
+      ViewActions.create(View.Type.Search)
+        .then(({ view }) => view), loadingViewHooks, executingViewHooks, query,
+    ).then(() => this.setState({ loaded: true }));
   }
 
   loadView = (viewId: string): Promise<?View> => {

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import UserNotification from 'util/UserNotification';
 import withPluginEntities from 'views/logic/withPluginEntities';
 import { Spinner } from 'components/common';
 import { ViewActions } from 'views/stores/ViewStore';
@@ -47,9 +48,15 @@ class NewSearchPage extends React.Component<Props, State> {
     const { location, loadingViewHooks, executingViewHooks } = this.props;
     const { query } = location;
     processHooks(
-      ViewActions.create(View.Type.Search)
-        .then(({ view }) => view), loadingViewHooks, executingViewHooks, query,
-    ).then(() => this.setState({ loaded: true }));
+      ViewActions.create(View.Type.Search).then(({ view }) => view),
+      loadingViewHooks,
+      executingViewHooks,
+      query,
+    ).then(
+      () => this.setState({ loaded: true }),
+    ).catch(
+      error => UserNotification.error(`Executing search failed with error: ${error}`, 'Could not execute search'),
+    );
   }
 
   loadView = (viewId: string): Promise<?View> => {

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.jsx
@@ -1,26 +1,55 @@
 // @flow strict
 import React, { useEffect, useState } from 'react';
 
-import { ViewActions } from 'views/stores/ViewStore';
+import UserNotification from 'util/UserNotification';
+
+import { processHooks } from 'views/logic/views/ViewLoader';
 import { QueryFiltersActions } from 'views/stores/QueryFiltersStore';
+import { ViewActions } from 'views/stores/ViewStore';
 import View from 'views/logic/views/View';
+import withPluginEntities from 'views/logic/withPluginEntities';
+import type { ViewHook } from 'views/logic/hooks/ViewHook';
+
 import Spinner from 'components/common/Spinner';
 import { ExtendedSearchPage } from 'views/pages';
+
 
 type Props = {
   params: {
     streamId: string,
   },
-  route: {}
+  location: {
+    query: { [string]: any },
+  },
+  route: {},
+  loadingViewHooks: Array<ViewHook>,
+  executingViewHooks: Array<ViewHook>,
 };
 
-export default ({ params: { streamId }, route }: Props) => {
+const StreamSearchPage = ({ params: { streamId }, route, loadingViewHooks, executingViewHooks, location }: Props) => {
   const [loaded, setLoaded] = useState(false);
+  const { query } = location;
   useEffect(() => {
-    ViewActions.create(View.Type.Search)
-      .then(({ activeQuery }) => QueryFiltersActions.streams(activeQuery, [streamId]))
-      .then(() => setLoaded(true));
+    processHooks(
+      ViewActions.create(View.Type.Search)
+        .then(({ view, activeQuery }) => {
+          return QueryFiltersActions.streams(activeQuery, [streamId]).then(() => view);
+        }),
+      loadingViewHooks,
+      executingViewHooks,
+      query,
+    ).then(
+      () => setLoaded(true),
+    ).catch(
+      (error) => { UserNotification.error(`Executing search failed with error: ${error}`, 'Could not execute search'); },
+    );
   }, []);
 
   return loaded ? <ExtendedSearchPage route={route} /> : <Spinner />;
 };
+
+const mapping = {
+  loadingViewHooks: 'views.hooks.loadingView',
+  executingViewHooks: 'views.hooks.executingView',
+};
+export default withPluginEntities(StreamSearchPage, mapping);

--- a/graylog2-web-interface/src/views/pages/index.js
+++ b/graylog2-web-interface/src/views/pages/index.js
@@ -2,11 +2,13 @@ import loadAsync from 'routing/loadAsync';
 
 const DashboardsPage = loadAsync(() => import(/* webpackChunkname: "DashboardsPage" */ './DashboardsPage'));
 const ExtendedSearchPage = loadAsync(() => import(/* webpackChunkName: "ExtendedSearchPage" */ './ExtendedSearchPage'));
+const ViewManagementPage = loadAsync(() => import(/* webpackChunkName: "ViewManagementPage" */ './ViewManagementPage'));
+/* eslint-disable import/no-cycle */
 const NewSearchPage = loadAsync(() => import(/* webpackChunkName: "NewSearchPage" */ './NewSearchPage'));
 const StreamSearchPage = loadAsync(() => import(/* webpackChunkName: "StreamSearchPage" */ './StreamSearchPage'));
 const NewDashboardPage = loadAsync(() => import(/* webpackChunkName: "NewDashboardPage" */ './NewDashboardPage'));
 const ShowViewPage = loadAsync(() => import(/* webpackChunkName: "ShowViewPage" */ './ShowViewPage'));
-const ViewManagementPage = loadAsync(() => import(/* webpackChunkName: "ViewManagementPage" */ './ViewManagementPage'));
+/* eslint-enable import/no-cycle */
 
 export {
   DashboardsPage,

--- a/graylog2-web-interface/src/views/pages/index.js
+++ b/graylog2-web-interface/src/views/pages/index.js
@@ -3,6 +3,8 @@ import loadAsync from 'routing/loadAsync';
 const DashboardsPage = loadAsync(() => import(/* webpackChunkname: "DashboardsPage" */ './DashboardsPage'));
 const ExtendedSearchPage = loadAsync(() => import(/* webpackChunkName: "ExtendedSearchPage" */ './ExtendedSearchPage'));
 const NewSearchPage = loadAsync(() => import(/* webpackChunkName: "NewSearchPage" */ './NewSearchPage'));
+const StreamSearchPage = loadAsync(() => import(/* webpackChunkName: "StreamSearchPage" */ './StreamSearchPage'));
+const NewDashboardPage = loadAsync(() => import(/* webpackChunkName: "NewDashboardPage" */ './NewDashboardPage'));
 const ShowViewPage = loadAsync(() => import(/* webpackChunkName: "ShowViewPage" */ './ShowViewPage'));
 const ViewManagementPage = loadAsync(() => import(/* webpackChunkName: "ViewManagementPage" */ './ViewManagementPage'));
 
@@ -11,5 +13,7 @@ export {
   ExtendedSearchPage,
   NewSearchPage,
   ShowViewPage,
+  StreamSearchPage,
+  NewDashboardPage,
   ViewManagementPage,
 };


### PR DESCRIPTION
This PR adds support for the existing search URL's in the new search page. We are using the parameters e.g. when clicking on "Show all Messages" in the inputs overview. Besides the query (parameter `q`) we support the time range, e.g.:
`?rangetype=absolute&from=[date]&to=[date]`
`?rangetype=keyword&keyword=[keyword]`
`?rangetype=relative&relative=0`
or just
`?relative=0`

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

