### PR TITLE
Defaulting to new search.

### DIFF
--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -61,8 +61,6 @@ const formatPluginRoute = (pluginRoute, permissions, location) => {
   return formatSinglePluginRoute(pluginRoute);
 };
 
-const enableNewSearch = AppConfig.isFeatureEnabled('search_3_2');
-
 const Navigation = ({ permissions, fullName, location, loginName }) => {
   const pluginNavigations = PluginStore.exports('navigation')
     .sort((route1, route2) => naturalSort(route1.description.toLowerCase(), route2.description.toLowerCase()))
@@ -90,13 +88,6 @@ const Navigation = ({ permissions, fullName, location, loginName }) => {
               <NavItem to="search">Search</NavItem>
             </LinkContainer>
           </IfPermitted>
-
-          {!enableNewSearch && (
-          <NavDropdown title="Views" id="views-dropdown">
-            <NavigationLink path={Routes.EXTENDEDSEARCH} description="Create new" />
-            <NavigationLink path={Routes.VIEWS.LIST} description="Load existing" />
-          </NavDropdown>
-          )}
 
           <LinkContainer to={Routes.STREAMS}>
             <NavItem>Streams</NavItem>

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -24,7 +24,6 @@ import {
   CreateEventNotificationPage,
   CreateExtractorsPage,
   CreateUsersPage,
-  DashboardsPage,
   DelegatedSearchPage,
   EditAlertConditionPage,
   EditEventDefinitionPage,
@@ -64,7 +63,6 @@ import {
   RulesPage,
   ShowAlertPage,
   ShowContentPackPage,
-  ShowDashboardPage,
   ShowMessagePage,
   ShowMetricsPage,
   ShowNodePage,
@@ -82,14 +80,12 @@ import {
   StreamAlertsOverviewPage,
   StreamEditPage,
   StreamOutputsPage,
-  StreamSearchPage,
   StreamsPage,
   SystemOutputsPage,
   SystemOverviewPage,
   ThreadDumpPage,
   UsersPage,
 } from 'pages';
-import AppConfig from 'util/AppConfig';
 import AppErrorBoundary from './AppErrorBoundary';
 
 const AppRouter = () => {
@@ -115,7 +111,6 @@ const AppRouter = () => {
              component={pluginRoute.component} />
     );
   });
-  const enableNewSearch = AppConfig.isFeatureEnabled('search_3_2');
 
   return (
     <Router history={history}>
@@ -127,11 +122,9 @@ const AppRouter = () => {
             {pluginRoutesWithParent}
             <Route component={AppWithSearchBar}>
               <Route path={Routes.SOURCES} component={SourcesPage} />
-              {enableNewSearch || <Route path={Routes.SEARCH} component={DelegatedSearchPage} />}
-              {enableNewSearch || <Route path={Routes.stream_search(':streamId')} component={StreamSearchPage} />}
             </Route>
             <Route component={AppWithExtendedSearchBar}>
-              {enableNewSearch && <Route path={Routes.SEARCH} component={DelegatedSearchPage} />}
+              <Route path={Routes.SEARCH} component={DelegatedSearchPage} />
             </Route>
             <Route component={AppWithoutSearchBar}>
               <Route path={Routes.message_show(':index', ':messageId')} component={ShowMessagePage} />
@@ -156,8 +149,6 @@ const AppRouter = () => {
               <Route path={Routes.show_alert_condition(':streamId', ':conditionId')}
                      component={EditAlertConditionPage} />
               <Route path={Routes.show_alert(':alertId')} component={ShowAlertPage} />
-              {enableNewSearch || <Route path={Routes.DASHBOARDS} component={DashboardsPage} />}
-              {enableNewSearch || <Route path={Routes.dashboard_show(':dashboardId')} component={ShowDashboardPage} />}
               <Route path={Routes.SYSTEM.INPUTS} component={InputsPage} />
               <Route path={Routes.node_inputs(':nodeId')} component={NodeInputsPage} />
               <Route path={Routes.global_input_extractors(':inputId')} component={ExtractorsPage} />

--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -76,7 +76,6 @@ import {
 import NewDashboardPage from 'views/pages/NewDashboardPage';
 import StreamSearchPage from 'views/pages/StreamSearchPage';
 import ShowDashboardInBigDisplayMode from 'views/pages/ShowDashboardInBigDisplayMode';
-import AppConfig from 'util/AppConfig';
 import LookupTableParameter from 'views/logic/parameters/LookupTableParameter';
 import type { ActionHandlerArguments, ActionHandlerCondition } from './components/actions/ActionHandler';
 import NumberVisualizationConfig from './logic/aggregationbuilder/visualizations/NumberVisualizationConfig';

--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -110,33 +110,19 @@ ViewSharing.registerSubtype(SpecificUsers.Type, SpecificUsers);
 Parameter.registerSubtype(ValueParameter.type, ValueParameter);
 Parameter.registerSubtype(LookupTableParameter.type, LookupTableParameter);
 
-const enableNewSearch = AppConfig.isFeatureEnabled('search_3_2');
+const hasLegacyFieldCharts = () => !Store.get('pinned-field-charts-migrated') && !!Store.get('pinned-field-charts');
 
-const searchRoutes = enableNewSearch
-  ? [
+export default {
+  pages: {
+    search: { component: NewSearchPage },
+  },
+  routes: [
     { path: newDashboardsPath, component: NewDashboardPage, parentComponent: AppWithExtendedSearchBar },
     { path: showSearchPath, component: ShowViewPage, parentComponent: AppWithExtendedSearchBar },
     { path: dashboardsTvPath, component: ShowDashboardInBigDisplayMode, parentComponent: null },
     { path: Routes.stream_search(':streamId'), component: StreamSearchPage, parentComponent: AppWithExtendedSearchBar },
     { path: dashboardsPath, component: DashboardsPage },
     { path: showDashboardsPath, component: ShowViewPage },
-  ]
-  : [];
-
-const searchPages = enableNewSearch
-  ? {
-    search: { component: NewSearchPage },
-  }
-  : {};
-
-const hasLegacyFieldCharts = () => !Store.get('pinned-field-charts-migrated') && !!Store.get('pinned-field-charts');
-
-export default {
-  pages: {
-    ...searchPages,
-  },
-  routes: [
-    ...searchRoutes,
     { path: extendedSearchPath, component: NewSearchPage, permissions: Permissions.ExtendedSearch.Use },
     { path: viewsPath, component: ViewManagementPage, permissions: Permissions.View.Use },
     { path: showViewsPath, component: ShowViewPage, parentComponent: AppWithExtendedSearchBar },


### PR DESCRIPTION
## Description
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR rolls back the changes made when introducing the `search_3_2`
feature flag and now defaults to the new search. `Search` & `Dashboard`
menu items are replaced with new search code while the `Views` top
navigation item is removed.

Fixes #6140.

Requires #6924 & #6936 to be merged before.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.