### PR TITLE
Including optional stream from saved searches when generating query.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/V20191203120602_MigrateSavedSearchesToViews.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/V20191203120602_MigrateSavedSearchesToViews.java
@@ -125,10 +125,12 @@ public class V20191203120602_MigrateSavedSearchesToViews extends Migration {
                     return widgetSearchTypes.stream();
                 })
                 .collect(Collectors.toSet());
-        final Query query = Query.create(randomUUIDProvider.get(),
-                savedSearch.query().toTimeRange(),
-                savedSearch.query().query(),
-                searchTypes);
+        final Query.Builder queryBuilder = Query.builder()
+                .id(randomUUIDProvider.get())
+                .timerange(savedSearch.query().toTimeRange())
+                .query(savedSearch.query().query())
+                .searchTypes(searchTypes);
+        final Query query = savedSearch.query().streamId().map(queryBuilder::streamId).orElse(queryBuilder).build();
         final Search newSearch = Search.create(randomObjectIdProvider.get(), Collections.singleton(query), savedSearch.creatorUserId(), savedSearch.createdAt());
 
         final Titles titles = Titles.ofWidgetTitles(ImmutableMap.of(

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/AbsoluteTimeRangeQuery.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/AbsoluteTimeRangeQuery.java
@@ -24,6 +24,9 @@ import org.graylog.plugins.views.migrations.V20191203120602_MigrateSavedSearches
 import org.graylog.plugins.views.migrations.V20191203120602_MigrateSavedSearchesToViewsSupport.view.TimeRange;
 import org.joda.time.DateTime;
 
+import javax.annotation.Nullable;
+import java.util.Optional;
+
 @AutoValue
 @JsonAutoDetect
 public abstract class AbsoluteTimeRangeQuery implements Query {
@@ -47,8 +50,9 @@ public abstract class AbsoluteTimeRangeQuery implements Query {
             @JsonProperty("fields") String fields,
             @JsonProperty("query") String query,
             @JsonProperty("from") DateTime from,
-            @JsonProperty("to") DateTime to
+            @JsonProperty("to") DateTime to,
+            @JsonProperty("streamId") @Nullable String streamId
     ) {
-        return new AutoValue_AbsoluteTimeRangeQuery(rangeType, fields, query, from, to);
+        return new AutoValue_AbsoluteTimeRangeQuery(Optional.ofNullable(streamId), rangeType, fields, query, from, to);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/KeywordTimeRangeQuery.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/KeywordTimeRangeQuery.java
@@ -23,6 +23,9 @@ import com.google.auto.value.AutoValue;
 import org.graylog.plugins.views.migrations.V20191203120602_MigrateSavedSearchesToViewsSupport.view.KeywordRange;
 import org.graylog.plugins.views.migrations.V20191203120602_MigrateSavedSearchesToViewsSupport.view.TimeRange;
 
+import javax.annotation.Nullable;
+import java.util.Optional;
+
 @AutoValue
 @JsonAutoDetect
 public abstract class KeywordTimeRangeQuery implements Query {
@@ -44,8 +47,9 @@ public abstract class KeywordTimeRangeQuery implements Query {
             @JsonProperty("rangeType") String rangeType,
             @JsonProperty("fields") String fields,
             @JsonProperty("query") String query,
-            @JsonProperty("keyword") String keyword
+            @JsonProperty("keyword") String keyword,
+            @JsonProperty("streamId") @Nullable String streamId
     ) {
-        return new AutoValue_KeywordTimeRangeQuery(rangeType, fields, query, keyword);
+        return new AutoValue_KeywordTimeRangeQuery(Optional.ofNullable(streamId), rangeType, fields, query, keyword);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/Query.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/Query.java
@@ -23,6 +23,7 @@ import org.graylog.plugins.views.migrations.V20191203120602_MigrateSavedSearches
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
@@ -36,6 +37,7 @@ public interface Query {
     String rangeType();
     String fields();
     String query();
+    Optional<String> streamId();
 
     TimeRange toTimeRange();
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/RelativeTimeRangeQuery.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/RelativeTimeRangeQuery.java
@@ -23,6 +23,9 @@ import com.google.auto.value.AutoValue;
 import org.graylog.plugins.views.migrations.V20191203120602_MigrateSavedSearchesToViewsSupport.view.RelativeRange;
 import org.graylog.plugins.views.migrations.V20191203120602_MigrateSavedSearchesToViewsSupport.view.TimeRange;
 
+import javax.annotation.Nullable;
+import java.util.Optional;
+
 @AutoValue
 @JsonAutoDetect
 public abstract class RelativeTimeRangeQuery implements Query {
@@ -43,8 +46,9 @@ public abstract class RelativeTimeRangeQuery implements Query {
             @JsonProperty("rangeType") String rangeType,
             @JsonProperty("fields") String fields,
             @JsonProperty("query") String query,
-            @JsonProperty("relative") int relative
+            @JsonProperty("relative") int relative,
+            @JsonProperty("streamId") @Nullable String streamId
     ) {
-        return new AutoValue_RelativeTimeRangeQuery(rangeType, fields, query, relative);
+        return new AutoValue_RelativeTimeRangeQuery(Optional.ofNullable(streamId), rangeType, fields, query, relative);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/search/Query.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/search/Query.java
@@ -24,12 +24,12 @@ import org.graylog.plugins.views.migrations.V20191203120602_MigrateSavedSearches
 import org.graylog.plugins.views.migrations.V20191203120602_MigrateSavedSearchesToViewsSupport.view.TimeRange;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import java.util.Optional;
 import java.util.Set;
 
 @AutoValue
 @JsonAutoDetect
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_ABSENT)
 public abstract class Query {
     @JsonProperty
     public abstract String id();
@@ -37,9 +37,8 @@ public abstract class Query {
     @JsonProperty
     public abstract TimeRange timerange();
 
-    @Nullable
     @JsonProperty
-    public Object filter() { return null; }
+    public abstract Optional<StreamFilter> filter();
 
     @Nonnull
     @JsonProperty
@@ -49,7 +48,29 @@ public abstract class Query {
     @JsonProperty("search_types")
     public abstract Set<SearchType> searchTypes();
 
-    public static Query create(String id, TimeRange timeRange, String query, Set<SearchType> searchTypes) {
-        return new AutoValue_Query(id, timeRange, ElasticsearchQueryString.create(query), searchTypes);
+    public static Builder builder() {
+        return new AutoValue_Query.Builder();
+    }
+
+    @AutoValue.Builder
+    public static abstract class Builder {
+        public abstract Builder id(String id);
+
+        public abstract Builder timerange(TimeRange timeRange);
+
+        abstract Builder query(ElasticsearchQueryString query);
+        public Builder query(String query) {
+            return this.query(ElasticsearchQueryString.create(query));
+        }
+
+        public abstract Builder searchTypes(Set<SearchType> searchTypes);
+
+        public abstract Builder filter(StreamFilter filter);
+
+        public Builder streamId(String streamId) {
+            return filter(StreamFilter.create(streamId));
+        }
+
+        public abstract Query build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/search/StreamFilter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/search/StreamFilter.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.views.migrations.V20191203120602_MigrateSavedSearchesToViewsSupport.search;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/search/StreamFilter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/search/StreamFilter.java
@@ -1,0 +1,32 @@
+package org.graylog.plugins.views.migrations.V20191203120602_MigrateSavedSearchesToViewsSupport.search;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Map;
+
+@AutoValue
+@JsonAutoDetect
+abstract class StreamFilter {
+    abstract String streamId();
+
+    @JsonValue
+    public Map<String, Object> value() {
+        return ImmutableMap.of(
+                "type", "or",
+                "filters", ImmutableSet.of(
+                        ImmutableMap.of(
+                                "type", "stream",
+                                "id", streamId()
+                                )
+                )
+        );
+    }
+
+    public static StreamFilter create(String streamId) {
+        return new AutoValue_StreamFilter(streamId);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/V20191203120602_MigrateSavedSearchesToViewsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/V20191203120602_MigrateSavedSearchesToViewsTest.java
@@ -130,20 +130,8 @@ public class V20191203120602_MigrateSavedSearchesToViewsTest {
         assertThat(migrationCompleted.savedSearchIds())
                 .containsExactly(new AbstractMap.SimpleEntry<>("5c7e5499f38ed7e1d8d6a613", "5de0e98900002a0017000002"));
 
-        final ArgumentCaptor<View> newViewsCaptor = ArgumentCaptor.forClass(View.class);
-        final ArgumentCaptor<Search> newSearchesCaptor = ArgumentCaptor.forClass(Search.class);
-
-        verify(viewService, times(1)).save(newViewsCaptor.capture());
-        verify(searchService, times(1)).save(newSearchesCaptor.capture());
-
-        final List<View> newViews = newViewsCaptor.getAllValues();
-        final List<Search> newSearches = newSearchesCaptor.getAllValues();
-
-        assertThat(newViews).hasSize(1);
-        assertThat(newSearches).hasSize(1);
-
-        JSONAssert.assertEquals(toJSON(newViews), resourceFile("sample_saved_search_relative-expected_views.json"), false);
-        JSONAssert.assertEquals(toJSON(newSearches), resourceFile("sample_saved_search_relative-expected_searches.json"), false);
+        assertViewServiceCreatedViews(1, resourceFile("sample_saved_search_relative-expected_views.json"));
+        assertSearchServiceCreated(1, resourceFile("sample_saved_search_relative-expected_searches.json"));
     }
 
     @Test
@@ -155,20 +143,8 @@ public class V20191203120602_MigrateSavedSearchesToViewsTest {
         assertThat(migrationCompleted.savedSearchIds())
                 .containsExactly(new AbstractMap.SimpleEntry<>("5de660b7b2d44b5813c1d7f6", "5de0e98900002a0017000002"));
 
-        final ArgumentCaptor<View> newViewsCaptor = ArgumentCaptor.forClass(View.class);
-        final ArgumentCaptor<Search> newSearchesCaptor = ArgumentCaptor.forClass(Search.class);
-
-        verify(viewService, times(1)).save(newViewsCaptor.capture());
-        verify(searchService, times(1)).save(newSearchesCaptor.capture());
-
-        final List<View> newViews = newViewsCaptor.getAllValues();
-        final List<Search> newSearches = newSearchesCaptor.getAllValues();
-
-        assertThat(newViews).hasSize(1);
-        assertThat(newSearches).hasSize(1);
-
-        JSONAssert.assertEquals(toJSON(newViews), resourceFile("sample_saved_search_absolute-expected_views.json"), false);
-        JSONAssert.assertEquals(toJSON(newSearches), resourceFile("sample_saved_search_absolute-expected_searches.json"), false);
+        assertViewServiceCreatedViews(1, resourceFile("sample_saved_search_absolute-expected_views.json"));
+        assertSearchServiceCreated(1, resourceFile("sample_saved_search_absolute-expected_searches.json"));
     }
 
     @Test
@@ -180,20 +156,42 @@ public class V20191203120602_MigrateSavedSearchesToViewsTest {
         assertThat(migrationCompleted.savedSearchIds())
                 .containsExactly(new AbstractMap.SimpleEntry<>("5de660c6b2d44b5813c1d806", "5de0e98900002a0017000002"));
 
+        assertViewServiceCreatedViews(1, resourceFile("sample_saved_search_keyword-expected_views.json"));
+        assertSearchServiceCreated(1, resourceFile("sample_saved_search_keyword-expected_searches.json"));
+    }
+
+    @Test
+    @MongoDBFixtures("sample_saved_search_with_stream.json")
+    public void migrateSavedSearchWithStreamId() throws Exception {
+        this.migration.upgrade();
+
+        final MigrationCompleted migrationCompleted = captureMigrationCompleted();
+        assertThat(migrationCompleted.savedSearchIds())
+                .containsExactly(new AbstractMap.SimpleEntry<>("5de660b7b2d44b5813c1d7f6", "5de0e98900002a0017000002"));
+
+        assertViewServiceCreatedViews(1, resourceFile("sample_saved_search_with_stream-expected_views.json"));
+        assertSearchServiceCreated(1, resourceFile("sample_saved_search_with_stream-expected_searches.json"));
+    }
+
+    private void assertViewServiceCreatedViews(int count, String viewsCollection) throws Exception {
         final ArgumentCaptor<View> newViewsCaptor = ArgumentCaptor.forClass(View.class);
+        verify(viewService, times(count)).save(newViewsCaptor.capture());
+        final List<View> newViews = newViewsCaptor.getAllValues();
+        assertThat(newViews).hasSize(count);
+
+        JSONAssert.assertEquals(toJSON(newViews), viewsCollection, true);
+    }
+
+    private void assertSearchServiceCreated(int count, String searchCollection) throws Exception {
         final ArgumentCaptor<Search> newSearchesCaptor = ArgumentCaptor.forClass(Search.class);
 
-        verify(viewService, times(1)).save(newViewsCaptor.capture());
-        verify(searchService, times(1)).save(newSearchesCaptor.capture());
+        verify(searchService, times(count)).save(newSearchesCaptor.capture());
 
-        final List<View> newViews = newViewsCaptor.getAllValues();
         final List<Search> newSearches = newSearchesCaptor.getAllValues();
 
-        assertThat(newViews).hasSize(1);
-        assertThat(newSearches).hasSize(1);
+        assertThat(newSearches).hasSize(count);
 
-        JSONAssert.assertEquals(toJSON(newViews), resourceFile("sample_saved_search_keyword-expected_views.json"), false);
-        JSONAssert.assertEquals(toJSON(newSearches), resourceFile("sample_saved_search_keyword-expected_searches.json"), false);
+        JSONAssert.assertEquals(toJSON(newSearches), searchCollection, true);
     }
 
     private MigrationCompleted captureMigrationCompleted() {

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_relative-expected_views.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_relative-expected_views.json
@@ -93,7 +93,6 @@
     "created_at": "2019-03-05T10:51:05.900Z",
     "type": "SEARCH",
     "requires": {},
-    "content_pack": null,
     "properties": []
   }
 ]

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_with_stream-expected_searches.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_with_stream-expected_searches.json
@@ -1,0 +1,62 @@
+[ {
+  "id" : "5de0e98900002a0017000001",
+  "queries" : [ {
+    "id" : "0000016e-b690-4273-0000-016eb690426f",
+    "timerange" : {
+      "type" : "absolute",
+      "from" : "2019-12-02T13:18:28.000Z",
+      "to" : "2019-12-03T13:18:29.000Z"
+    },
+    "filter" : {
+      "type" : "or",
+      "filters" : [
+        {
+          "type" : "stream",
+          "id" : "5ddf8ed5b2d44b2e0447298c"
+        }
+      ]
+    },
+    "query" : {
+      "type" : "elasticsearch",
+      "query_string" : "source:sophon"
+    },
+    "search_types" : [ {
+      "id" : "0000016e-b690-4272-0000-016eb690426f",
+      "name" : null,
+      "type" : "messages",
+      "limit" : 150,
+      "offset" : 0,
+      "query" : null,
+      "timerange" : null,
+      "streams" : [ ]
+    }, {
+      "id" : "0000016e-b690-4271-0000-016eb690426f",
+      "series" : [ {
+        "type" : "count",
+        "id" : "count()",
+        "field" : null
+      } ],
+      "name" : "chart",
+      "type" : "pivot",
+      "query" : null,
+      "sort" : [ ],
+      "filter" : null,
+      "timerange" : null,
+      "rollup" : true,
+      "streams" : [ ],
+      "row_groups" : [ {
+        "field" : "timestamp",
+        "interval" : {
+          "scaling" : 1.0,
+          "type" : "auto"
+        },
+        "type" : "time"
+      } ],
+      "column_groups" : [ ]
+    } ]
+  } ],
+  "parameters" : [ ],
+  "owner" : "admin",
+  "created_at" : "2019-12-03T13:18:47.602Z",
+  "requires" : { }
+} ]

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_with_stream-expected_views.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_with_stream-expected_views.json
@@ -1,0 +1,82 @@
+[ {
+  "id" : "5de0e98900002a0017000002",
+  "title" : "Saved Search: The Absolute Search on a stream",
+  "summary" : "This Search was migrated automatically from the \"The Absolute Search on a stream\" saved search.",
+  "description" : "",
+  "search_id" : "5de0e98900002a0017000001",
+  "state" : {
+    "0000016e-b690-4273-0000-016eb690426f" : {
+      "titles" : {
+        "widget" : {
+          "0000016e-b690-426f-0000-016eb690426f" : "Message Count",
+          "0000016e-b690-4270-0000-016eb690426f" : "All Messages"
+        }
+      },
+      "widgets" : [ {
+        "id" : "0000016e-b690-426f-0000-016eb690426f",
+        "config" : {
+          "sort" : [ ],
+          "row_pivots" : [ {
+            "field" : "timestamp",
+            "config" : {
+              "interval" : {
+                "type" : "auto",
+                "scaling" : null
+              }
+            },
+            "type" : "time"
+          } ],
+          "series" : [ {
+            "function" : "count()",
+            "config" : { }
+          } ],
+          "column_pivots" : [ ],
+          "visualization" : "bar",
+          "formatting_settings" : null,
+          "rollup" : true
+        },
+        "type" : "aggregation",
+        "query" : null,
+        "filter" : null,
+        "timerange" : null,
+        "streams" : [ ]
+      }, {
+        "id" : "0000016e-b690-4270-0000-016eb690426f",
+        "config" : {
+          "fields" : [ "message", "source" ],
+          "show_message_row" : true
+        },
+        "type" : "messages",
+        "query" : null,
+        "timerange" : null,
+        "streams" : [ ]
+      } ],
+      "widget_mapping" : {
+        "0000016e-b690-426f-0000-016eb690426f" : [ "0000016e-b690-4271-0000-016eb690426f" ],
+        "0000016e-b690-4270-0000-016eb690426f" : [ "0000016e-b690-4272-0000-016eb690426f" ]
+      },
+      "positions" : {
+        "0000016e-b690-426f-0000-016eb690426f" : {
+          "col" : 1,
+          "row" : 1,
+          "height" : 2,
+          "width" : "Infinity"
+        },
+        "0000016e-b690-4270-0000-016eb690426f" : {
+          "col" : 1,
+          "row" : 3,
+          "height" : 6,
+          "width" : "Infinity"
+        }
+      },
+      "static_message_list_id" : null,
+      "display_mode_settings" : { },
+      "selected_fields" : null
+    }
+  },
+  "owner" : "admin",
+  "created_at" : "2019-12-03T13:18:47.602Z",
+  "type" : "SEARCH",
+  "requires" : { },
+  "properties" : [ ]
+} ]

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_with_stream.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_with_stream.json
@@ -1,0 +1,22 @@
+{
+  "saved_searches": [
+    {
+      "_id": {
+        "$oid": "5de660b7b2d44b5813c1d7f6"
+      },
+      "creator_user_id": "admin",
+      "created_at": {
+        "$date": "2019-12-03T13:18:47.602Z"
+      },
+      "title": "The Absolute Search on a stream",
+      "query": {
+        "from": "2019-12-02T13:18:28.000Z",
+        "to": "2019-12-03T13:18:29.000Z",
+        "rangeType": "absolute",
+        "fields": "message,source",
+        "query": "source:sophon",
+        "streamId": "5ddf8ed5b2d44b2e0447298c"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, the saved search migration introduced in #6925 did not
consider that saved searches also contain an optional stream id and
failed if it existed.

This PR introduces support for optional stream ids for saved searches
which are constrained to one stream.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.