### PR TITLE
Consolidating different handling of query strings in searches/dashboards.

### DIFF
--- a/graylog2-web-interface/src/stores/StoreTypes.js
+++ b/graylog2-web-interface/src/stores/StoreTypes.js
@@ -13,3 +13,8 @@ export type ListenableAction<R> = R & {
 export type RefluxAction = <Fn>(Fn) => ListenableAction<Fn>;
 
 export type RefluxActions<A> = $ObjMap<A, RefluxAction>;
+
+export type Store<State> = {
+  listen: ((State) => mixed) => () => void,
+  getInitialState: () => State,
+};

--- a/graylog2-web-interface/src/views/components/Query.jsx
+++ b/graylog2-web-interface/src/views/components/Query.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Immutable from 'immutable';
 import DocsHelper from 'util/DocsHelper';
 
+import connect from 'stores/connect';
 import { Jumbotron } from 'components/graylog';
 import { CurrentViewStateActions } from 'views/stores/CurrentViewStateStore';
 import { Spinner } from 'components/common';
@@ -11,9 +12,11 @@ import DocumentationLink from 'components/support/DocumentationLink';
 import IfDashboard from 'views/components/dashboard/IfDashboard';
 import IfSearch from 'views/components/search/IfSearch';
 import WidgetGrid from 'views/components/WidgetGrid';
+import { AdditionalContext } from 'views/logic/ActionContext';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import { PositionsMap, ImmutableWidgetsMap } from './widgets/WidgetPropTypes';
 import InteractiveContext from './contexts/InteractiveContext';
+import { QueriesStore } from '../stores/QueriesStore';
 
 const MAXIMUM_GRID_SIZE = 12;
 
@@ -96,6 +99,22 @@ const EmptyDashboardInfo = () => (
   </Jumbotron>
 );
 
+const _QueryContextProvider = ({ children, queryId, queries = Immutable.Map() }) => (
+  <AdditionalContext.Provider value={{ query: queries.get(queryId) }}>
+    {children}
+  </AdditionalContext.Provider>
+);
+
+_QueryContextProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+  queryId: PropTypes.string.isRequired,
+  queries: PropTypes.object.isRequired,
+};
+
+const QueryContextProvider = connect(
+  _QueryContextProvider,
+  { queries: QueriesStore },
+);
 
 const Query = ({ allFields, fields, results, positions, widgetMapping, widgets, queryId }) => {
   if (!widgets || widgets.isEmpty()) {
@@ -104,7 +123,7 @@ const Query = ({ allFields, fields, results, positions, widgetMapping, widgets, 
 
   if (results) {
     const content = _renderWidgetGrid(widgets, widgetMapping.toJS(), results, positions, queryId, fields, allFields);
-    return (<span>{content}</span>);
+    return (<QueryContextProvider queryId={queryId}>{content}</QueryContextProvider>);
   }
 
   return <Spinner />;

--- a/graylog2-web-interface/src/views/components/Query.jsx
+++ b/graylog2-web-interface/src/views/components/Query.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import Immutable from 'immutable';
 import DocsHelper from 'util/DocsHelper';
 
-import connect from 'stores/connect';
 import { Jumbotron } from 'components/graylog';
 import { CurrentViewStateActions } from 'views/stores/CurrentViewStateStore';
 import { Spinner } from 'components/common';
@@ -12,11 +11,9 @@ import DocumentationLink from 'components/support/DocumentationLink';
 import IfDashboard from 'views/components/dashboard/IfDashboard';
 import IfSearch from 'views/components/search/IfSearch';
 import WidgetGrid from 'views/components/WidgetGrid';
-import { AdditionalContext } from 'views/logic/ActionContext';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import { PositionsMap, ImmutableWidgetsMap } from './widgets/WidgetPropTypes';
 import InteractiveContext from './contexts/InteractiveContext';
-import { QueriesStore } from '../stores/QueriesStore';
 
 const MAXIMUM_GRID_SIZE = 12;
 
@@ -99,22 +96,6 @@ const EmptyDashboardInfo = () => (
   </Jumbotron>
 );
 
-const _QueryContextProvider = ({ children, queryId, queries = Immutable.Map() }) => (
-  <AdditionalContext.Provider value={{ query: queries.get(queryId) }}>
-    {children}
-  </AdditionalContext.Provider>
-);
-
-_QueryContextProvider.propTypes = {
-  children: PropTypes.node.isRequired,
-  queryId: PropTypes.string.isRequired,
-  queries: PropTypes.object.isRequired,
-};
-
-const QueryContextProvider = connect(
-  _QueryContextProvider,
-  { queries: QueriesStore },
-);
 
 const Query = ({ allFields, fields, results, positions, widgetMapping, widgets, queryId }) => {
   if (!widgets || widgets.isEmpty()) {
@@ -123,7 +104,7 @@ const Query = ({ allFields, fields, results, positions, widgetMapping, widgets, 
 
   if (results) {
     const content = _renderWidgetGrid(widgets, widgetMapping.toJS(), results, positions, queryId, fields, allFields);
-    return (<QueryContextProvider queryId={queryId}>{content}</QueryContextProvider>);
+    return (<span>{content}</span>);
   }
 
   return <Spinner />;

--- a/graylog2-web-interface/src/views/components/actions/ActionHandler.jsx
+++ b/graylog2-web-interface/src/views/components/actions/ActionHandler.jsx
@@ -18,7 +18,7 @@ export type ActionHandlerArguments = {|
   contexts: ActionContexts
 |};
 
-export type ActionHandler = (ActionHandlerArguments) => Promise<void | *>;
+export type ActionHandler = (ActionHandlerArguments) => Promise<mixed>;
 export type ActionHandlerCondition = (ActionHandlerArguments) => boolean;
 
 export type ActionHandlerConditions = {

--- a/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.js
+++ b/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.js
@@ -1,16 +1,10 @@
 // @flow strict
 import moment from 'moment-timezone';
 
-import { QueriesActions } from 'views/stores/QueriesStore';
 import FieldType from 'views/logic/fieldtypes/FieldType';
-import Query from 'views/logic/queries/Query';
-import View from 'views/logic/views/View';
 import { escape, addToQuery } from 'views/logic/queries/QueryHelper';
-import { GlobalOverrideActions, GlobalOverrideStore } from 'views/stores/GlobalOverrideStore';
-import type { ElasticsearchQueryString } from 'views/logic/queries/Query';
 import type { ActionHandler } from 'views/components/actions/ActionHandler';
 import QueryManipulationHandler from './QueryManipulationHandler';
-import GlobalOverride from '../search/GlobalOverride';
 
 export default class AddToQueryHandler extends QueryManipulationHandler {
   formatTimestampForES = (value: string) => {
@@ -19,31 +13,18 @@ export default class AddToQueryHandler extends QueryManipulationHandler {
   };
 
   formatNewQuery = (oldQuery: string, field: string, value: string, type: FieldType) => {
-    let predicateValue;
-    if (type.type === 'date') {
-      predicateValue = this.formatTimestampForES(value);
-    } else {
-      predicateValue = escape(value);
-    }
+    const predicateValue = type.type === 'date'
+      ? this.formatTimestampForES(value)
+      : escape(value);
     const fieldPredicate = `${field}:${predicateValue}`;
 
     return addToQuery(oldQuery, fieldPredicate);
   };
 
-  handle: ActionHandler = ({ queryId, field, value = '', type, contexts: { view } }) => {
-    if (view.type === View.Type.Search) {
-      const query: Query = this.queries.get(queryId);
-      const oldQuery = query.query.query_string;
-      const newQuery = this.formatNewQuery(oldQuery, field, value, type);
-      return QueriesActions.query(queryId, newQuery);
-    }
-
-    const globalOverride: ?GlobalOverride = GlobalOverrideStore.getInitialState();
-    const { query_string: oldQuery }: ElasticsearchQueryString = globalOverride && globalOverride.query
-      ? globalOverride.query
-      : { type: 'elasticsearch', query_string: '' };
+  handle: ActionHandler = ({ queryId, field, value = '', type }) => {
+    const oldQuery = this.currentQueryString(queryId);
     const newQuery = this.formatNewQuery(oldQuery, field, value, type);
 
-    return GlobalOverrideActions.query(newQuery);
+    return this.updateQueryString(queryId, newQuery);
   };
 }

--- a/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.test.js
+++ b/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.test.js
@@ -2,22 +2,39 @@
 import * as Immutable from 'immutable';
 
 import mockAction from 'helpers/mocking/MockAction';
+import asMock from 'helpers/mocking/AsMock';
 import { QueriesActions, QueriesStore } from 'views/stores/QueriesStore';
+import { ViewStore } from 'views/stores/ViewStore';
 import FieldType from 'views/logic/fieldtypes/FieldType';
 import Query from 'views/logic/queries/Query';
+import { GlobalOverrideActions, GlobalOverrideStore } from 'views/stores/GlobalOverrideStore';
+import SearchActions from 'views/actions/SearchActions';
 import AddToQueryHandler from './AddToQueryHandler';
 import View from '../views/View';
+import GlobalOverride from '../search/GlobalOverride';
 
 jest.mock('views/stores/QueriesStore', () => ({ QueriesStore: {}, QueriesActions: {} }));
+jest.mock('views/stores/ViewStore', () => ({ ViewStore: {} }));
+jest.mock('views/stores/GlobalOverrideStore', () => ({ GlobalOverrideStore: {}, GlobalOverrideActions: {} }));
+jest.mock('views/actions/SearchActions', () => ({}));
 
 describe('AddToQueryHandler', () => {
   const view = View.create().toBuilder().type(View.Type.Search).build();
   let queriesStoreListen;
   let queries;
   beforeEach(() => {
-    QueriesStore.listen = jest.fn((cb) => { queriesStoreListen = cb; });
+    QueriesStore.listen = jest.fn((cb) => { queriesStoreListen = cb; return () => {}; });
     QueriesStore.getInitialState = jest.fn(() => queries);
     QueriesActions.query = mockAction(jest.fn(() => Promise.resolve()));
+    ViewStore.listen = jest.fn(() => () => {});
+    ViewStore.getInitialState = jest.fn(() => ({
+      view,
+      activeQuery: 'queryId',
+      dirty: false,
+      isNew: false,
+    }));
+    GlobalOverrideStore.listen = jest.fn(() => () => {});
+    GlobalOverrideStore.getInitialState = jest.fn(() => undefined);
   });
   it('formats date field for ES', () => {
     const query = Query.builder()
@@ -56,5 +73,30 @@ describe('AddToQueryHandler', () => {
       .then(() => {
         expect(QueriesActions.query).toHaveBeenCalledWith('anotherQueryId', 'foo:23 AND bar:42');
       });
+  });
+  describe('for dashboards', () => {
+    beforeEach(() => {
+      asMock(ViewStore.getInitialState).mockReturnValue({
+        view: View.builder().type(View.Type.Dashboard).build(),
+        activeQuery: 'queryId',
+        dirty: false,
+        isNew: false,
+      });
+      asMock(GlobalOverrideStore.getInitialState).mockReturnValue(GlobalOverride.empty()
+        .toBuilder()
+        .query({ type: 'elasticsearch', query_string: 'something' })
+        .build());
+      GlobalOverrideActions.query = mockAction(jest.fn(() => Promise.resolve(undefined)));
+      SearchActions.refresh = mockAction(jest.fn(() => Promise.resolve()));
+    });
+    it('retrieves query string from global override', () => {
+      const addToQueryHandler = new AddToQueryHandler();
+
+      return addToQueryHandler.handle({ queryId: 'queryId', field: 'bar', value: 42, type: new FieldType('keyword', [], []), contexts: { view } })
+        .then(() => {
+          expect(GlobalOverrideActions.query).toHaveBeenCalledWith('something AND bar:42');
+          expect(SearchActions.refresh).toHaveBeenCalled();
+        });
+    });
   });
 });

--- a/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.js
+++ b/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.js
@@ -1,19 +1,19 @@
+// @flow strict
 import { escape, addToQuery } from 'views/logic/queries/QueryHelper';
-import { QueriesActions } from 'views/stores/QueriesStore';
+import type { ActionHandler } from 'views/components/actions/ActionHandler';
 import QueryManipulationHandler from './QueryManipulationHandler';
-import type { ActionHandler } from '../../components/actions/ActionHandler';
 
 export default class ExcludeFromQueryHandler extends QueryManipulationHandler {
-  formatNewQuery = (oldQuery, field, value) => {
+  formatNewQuery = (oldQuery: string, field: string, value: any) => {
     const fieldPredicate = `NOT ${field}:${escape(value)}`;
 
     return addToQuery(oldQuery, fieldPredicate);
   };
 
   handle: ActionHandler = ({ queryId, field, value }) => {
-    const query = this.queries.get(queryId);
-    const oldQuery = query.query.query_string;
+    const oldQuery = this.currentQueryString(queryId);
     const newQuery = this.formatNewQuery(oldQuery, field, value);
-    QueriesActions.query(queryId, newQuery);
+
+    return this.updateQueryString(queryId, newQuery);
   };
 }

--- a/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.test.js
+++ b/graylog2-web-interface/src/views/logic/valueactions/ExcludeFromQueryHandler.test.js
@@ -1,9 +1,17 @@
 // @flow strict
 import * as Immutable from 'immutable';
 
+import asMock from 'helpers/mocking/AsMock';
+import mockAction from 'helpers/mocking/MockAction';
+import { GlobalOverrideActions, GlobalOverrideStore } from 'views/stores/GlobalOverrideStore';
 import { QueriesActions, QueriesStore } from 'views/stores/QueriesStore';
-import Query from '../queries/Query';
+import SearchActions from 'views/actions/SearchActions';
+import { ViewStore } from 'views/stores/ViewStore';
 
+import FieldType from '../fieldtypes/FieldType';
+import GlobalOverride from '../search/GlobalOverride';
+import Query from '../queries/Query';
+import View from '../views/View';
 import ExcludeFromQueryHandler from './ExcludeFromQueryHandler';
 
 jest.mock('views/stores/QueriesStore', () => ({
@@ -15,49 +23,88 @@ jest.mock('views/stores/QueriesStore', () => ({
     query: jest.fn(),
   },
 }));
+jest.mock('views/stores/ViewStore', () => ({ ViewStore: {} }));
+jest.mock('views/stores/GlobalOverrideStore', () => ({ GlobalOverrideStore: {}, GlobalOverrideActions: {} }));
+jest.mock('views/actions/SearchActions', () => ({}));
 
 const queryWithQueryString = queryString => Query.builder().query({ type: 'elasticsearch', query_string: queryString }).build();
 
 const mockQueries = (queryId: string, queryString: string) => Immutable.Map({ [queryId]: queryWithQueryString(queryString) });
 
 describe('ExcludeFromQueryHandler', () => {
+  const view = View.create().toBuilder().type(View.Type.Search).build();
   afterEach(() => {
     jest.resetAllMocks();
   });
+  beforeEach(() => {
+    ViewStore.listen = jest.fn(() => () => {});
+    ViewStore.getInitialState = jest.fn(() => ({
+      view,
+      activeQuery: 'queryId',
+      dirty: false,
+      isNew: false,
+    }));
+    GlobalOverrideStore.listen = jest.fn(() => () => {});
+    GlobalOverrideStore.getInitialState = jest.fn(() => undefined);
+  });
 
   it('adds exclusion term to query', () => {
-    QueriesStore.getInitialState.mockReturnValue(mockQueries('queryId', ''));
+    asMock(QueriesStore.getInitialState).mockReturnValue(mockQueries('queryId', ''));
 
     const handler = new ExcludeFromQueryHandler();
-    handler.handle({ queryId: 'queryId', field: 'something', value: 'other' });
+    handler.handle({ queryId: 'queryId', field: 'something', value: 'other', type: FieldType.Unknown, contexts: {} });
 
     expect(QueriesActions.query).toHaveBeenCalledWith('queryId', 'NOT something:other');
   });
 
   it('replaces `*` query completely', () => {
-    QueriesStore.getInitialState.mockReturnValue(mockQueries('queryId', '*'));
+    asMock(QueriesStore.getInitialState).mockReturnValue(mockQueries('queryId', '*'));
 
     const handler = new ExcludeFromQueryHandler();
-    handler.handle({ queryId: 'queryId', field: 'foo', value: 'bar' });
+    handler.handle({ queryId: 'queryId', field: 'foo', value: 'bar', type: FieldType.Unknown, contexts: {} });
 
     expect(QueriesActions.query).toHaveBeenCalledWith('queryId', 'NOT foo:bar');
   });
 
   it('appends negated term to existing query', () => {
-    QueriesStore.getInitialState.mockReturnValue(mockQueries('queryId', 'answer:42'));
+    asMock(QueriesStore.getInitialState).mockReturnValue(mockQueries('queryId', 'answer:42'));
 
     const handler = new ExcludeFromQueryHandler();
-    handler.handle({ queryId: 'queryId', field: 'do', value: 'panic' });
+    handler.handle({ queryId: 'queryId', field: 'do', value: 'panic', type: FieldType.Unknown, contexts: {} });
 
     expect(QueriesActions.query).toHaveBeenCalledWith('queryId', 'answer:42 AND NOT do:panic');
   });
 
   it('escapes special characters in field value', () => {
-    QueriesStore.getInitialState.mockReturnValue(mockQueries('queryId', '*'));
+    asMock(QueriesStore.getInitialState).mockReturnValue(mockQueries('queryId', '*'));
 
     const handler = new ExcludeFromQueryHandler();
-    handler.handle({ queryId: 'queryId', field: 'something', value: 'foo && || : \\ / + - ! ( ) { } [ ] ^ " ~ * ? bar' });
+    handler.handle({ queryId: 'queryId', field: 'something', value: 'foo && || : \\ / + - ! ( ) { } [ ] ^ " ~ * ? bar', type: FieldType.Unknown, contexts: {} });
 
     expect(QueriesActions.query).toHaveBeenCalledWith('queryId', 'NOT something:"foo && || : \\\\ / + - ! ( ) { } [ ] ^ \\" ~ * ? bar"');
+  });
+  describe('for dashboards', () => {
+    beforeEach(() => {
+      asMock(ViewStore.getInitialState).mockReturnValue({
+        view: View.builder().type(View.Type.Dashboard).build(),
+        activeQuery: 'queryId',
+        dirty: false,
+        isNew: false,
+      });
+      asMock(GlobalOverrideStore.getInitialState).mockReturnValue(GlobalOverride.empty()
+        .toBuilder()
+        .query({ type: 'elasticsearch', query_string: 'something' })
+        .build());
+      GlobalOverrideActions.query = mockAction(jest.fn(() => Promise.resolve(undefined)));
+      SearchActions.refresh = mockAction(jest.fn(() => Promise.resolve()));
+    });
+    it('retrieves query string from global override', () => {
+      const handler = new ExcludeFromQueryHandler();
+      return handler.handle({ queryId: 'queryId', field: 'do', value: 'panic', type: FieldType.Unknown, contexts: {} })
+        .then(() => {
+          expect(GlobalOverrideActions.query).toHaveBeenCalledWith('something AND NOT do:panic');
+          expect(SearchActions.refresh).toHaveBeenCalled();
+        });
+    });
   });
 });

--- a/graylog2-web-interface/src/views/logic/valueactions/QueryManipulationHandler.js
+++ b/graylog2-web-interface/src/views/logic/valueactions/QueryManipulationHandler.js
@@ -1,14 +1,52 @@
 // @flow strict
 import * as Immutable from 'immutable';
-import { QueriesStore } from 'views/stores/QueriesStore';
+
+import type { Store } from 'stores/StoreTypes';
+import { QueriesActions, QueriesStore } from 'views/stores/QueriesStore';
+import { ViewStore } from 'views/stores/ViewStore';
+import { GlobalOverrideActions, GlobalOverrideStore } from 'views/stores/GlobalOverrideStore';
+import SearchActions from 'views/actions/SearchActions';
 import Query from '../queries/Query';
-import type { QueryId } from '../queries/Query';
+import View from '../views/View';
+import GlobalOverride from '../search/GlobalOverride';
+import type { ElasticsearchQueryString, QueryId } from '../queries/Query';
+
+function connectToStore<State>(store: Store<State>, updateFn: (State) => mixed): void {
+  updateFn(store.getInitialState());
+  store.listen(updateFn);
+}
 
 export default class QueryManipulationHandler {
   queries: Immutable.OrderedMap<QueryId, Query>;
 
+  view: View;
+
+  globalOverride: ?GlobalOverride;
+
   constructor() {
-    this.queries = QueriesStore.getInitialState();
-    QueriesStore.listen((queries) => { this.queries = queries; });
+    connectToStore(QueriesStore, (queries) => { this.queries = queries; });
+    connectToStore(ViewStore, ({ view }) => { this.view = view; });
+    connectToStore(GlobalOverrideStore, (globalOverride) => { this.globalOverride = globalOverride; });
   }
+
+  _queryStringFromActiveQuery = (queryId: QueryId): string => {
+    const query = this.queries.get(queryId);
+    return query.query.query_string;
+  };
+
+  _queryStringFromGlobalOverride = () => {
+    const { query_string: queryString }: ElasticsearchQueryString = this.globalOverride && this.globalOverride.query
+      ? this.globalOverride.query
+      : { type: 'elasticsearch', query_string: '' };
+
+    return queryString;
+  };
+
+  currentQueryString = (queryId: QueryId) => (this.view.type === View.Type.Search
+    ? this._queryStringFromActiveQuery(queryId)
+    : this._queryStringFromGlobalOverride());
+
+  updateQueryString = (queryId: QueryId, queryString: string) => (this.view.type === View.Type.Search
+    ? QueriesActions.query(queryId, queryString)
+    : GlobalOverrideActions.query(queryString).then(SearchActions.refresh));
 }

--- a/graylog2-web-interface/src/views/stores/GlobalOverrideStore.js
+++ b/graylog2-web-interface/src/views/stores/GlobalOverrideStore.js
@@ -7,7 +7,7 @@ import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import GlobalOverride from 'views/logic/search/GlobalOverride';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
 import type { TimeRange } from 'views/logic/queries/Query';
-import type { RefluxActions } from 'stores/StoreTypes';
+import type { RefluxActions, Store } from 'stores/StoreTypes';
 import { SearchExecutionStateStore, SearchExecutionStateActions } from './SearchExecutionStateStore';
 
 export type GlobalOverrideActionsType = RefluxActions<{
@@ -27,7 +27,10 @@ export const GlobalOverrideActions: GlobalOverrideActionsType = singletonActions
   }),
 );
 
-export const GlobalOverrideStore = singletonStore(
+type GlobalOverrideStoreState = ?GlobalOverride;
+type GlobalOverrideStoreType = Store<GlobalOverrideStoreState>;
+
+export const GlobalOverrideStore: GlobalOverrideStoreType = singletonStore(
   'views.GlobalOverride',
   () => Reflux.createStore({
     listenables: [GlobalOverrideActions],

--- a/graylog2-web-interface/src/views/stores/QueriesStore.js
+++ b/graylog2-web-interface/src/views/stores/QueriesStore.js
@@ -12,9 +12,15 @@ import { singletonStore } from 'views/logic/singleton';
 
 import { ViewActions, ViewStore } from './ViewStore';
 import { ViewStatesActions } from './ViewStatesStore';
+import type { Store } from '../../stores/StoreTypes';
 
 export { QueriesActions } from 'views/actions/QueriesActions';
-export const QueriesStore = singletonStore(
+
+type QueriesStoreState = Immutable.OrderedMap<QueryId, Query>;
+
+type QueriesStoreType = Store<QueriesStoreState>;
+
+export const QueriesStore: QueriesStoreType = singletonStore(
   'views.Queries',
   () => Reflux.createStore({
     listenables: [QueriesActions],

--- a/graylog2-web-interface/src/views/stores/ViewStore.js
+++ b/graylog2-web-interface/src/views/stores/ViewStore.js
@@ -17,6 +17,7 @@ import SearchActions from 'views/actions/SearchActions';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
 import type { QueryId } from 'views/logic/queries/Query';
 import { ViewManagementActions } from './ViewManagementStore';
+import type { Store } from '../../stores/StoreTypes';
 
 export type ViewStoreState = {
   activeQuery: QueryId,
@@ -54,12 +55,7 @@ export const ViewActions: ViewActionsType = singletonActions(
   }),
 );
 
-type ViewStoreUnsubscribe = () => void;
-
-type ViewStoreType = {
-  listen: ((ViewStoreState) => void) => ViewStoreUnsubscribe,
-  getInitialState: () => ViewStoreState,
-};
+type ViewStoreType = Store<ViewStoreState>;
 
 export const ViewStore: ViewStoreType = singletonStore(
   'views.View',


### PR DESCRIPTION
## Description
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, using the "Exclude from results" value action did not
work properly when used on a dashboard. It was setting the query string
of the current active query, while on dashboards the global override
must be used.

This change is consolidating commonly used functionality to set a new
query string in the `QueryManipulationHandler` class and employs that to
achieve consistent query updating from the "Exclude from results"
action.

Fixes #7004.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.