### PR TITLE
Mapping months to `M` instead of `m` for time pivots.

### DIFF
--- a/graylog2-web-interface/src/views/Constants.js
+++ b/graylog2-web-interface/src/views/Constants.js
@@ -13,6 +13,17 @@ export const DEFAULT_TIMERANGE = { type: DEFAULT_RANGE_TYPE, range: 300 };
 export const DEFAULT_HIGHLIGHT_COLOR = '#ffec3d';
 export const DEFAULT_CUSTOM_HIGHLIGHT_RANGE = chroma.scale(['lightyellow', 'lightgreen', 'lightblue', 'red']).mode('lch').colors(40);
 
+export const TimeUnits = {
+  seconds: 'Seconds',
+  minutes: 'Minutes',
+  hours: 'Hours',
+  days: 'Days',
+  weeks: 'Weeks',
+  months: 'Months',
+};
+
+export type TimeUnit = $Keys<typeof TimeUnits>;
+
 export const dashboardsPath = '/dashboards';
 export const viewsPath = '/views';
 export const searchPath = '/search';

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/pivottypes/TimeUnitTimeHistogramPivot.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/pivottypes/TimeUnitTimeHistogramPivot.jsx
@@ -4,6 +4,7 @@ import { DropdownButton, FormControl, HelpBlock, InputGroup, MenuItem } from 'co
 
 import FormsUtils from 'util/FormsUtils';
 
+import { TimeUnits } from 'views/Constants';
 import type { Interval, TimeUnitInterval } from './Interval';
 
 import styles from './TimeUnitTimeHistogramPivot.css';
@@ -13,15 +14,6 @@ type OnChange = (Interval) => void;
 type Props = {
   interval: TimeUnitInterval,
   onChange: OnChange,
-};
-
-const units = {
-  seconds: 'Seconds',
-  minutes: 'Minutes',
-  hours: 'Hours',
-  days: 'Days',
-  weeks: 'Weeks',
-  months: 'Months',
 };
 
 const _changeValue = (event: SyntheticInputEvent<HTMLInputElement>, interval: TimeUnitInterval, onChange: OnChange) => {
@@ -41,9 +33,9 @@ const TimeUnitTimeHistogramPivot = ({ interval, onChange }: Props) => (
                    onChange={e => _changeValue(e, interval, onChange)} />
       <DropdownButton componentClass={InputGroup.Button}
                       id="input-dropdown-addon"
-                      title={units[interval.unit] || ''}
+                      title={TimeUnits[interval.unit] || ''}
                       onChange={newUnit => _changeUnit(newUnit, interval, onChange)}>
-        {Object.keys(units).map(unit => <MenuItem key={unit} onSelect={() => _changeUnit(unit, interval, onChange)}>{units[unit]}</MenuItem>)}
+        {Object.keys(TimeUnits).map(unit => <MenuItem key={unit} onSelect={() => _changeUnit(unit, interval, onChange)}>{TimeUnits[unit]}</MenuItem>)}
       </DropdownButton>
     </InputGroup>
     <HelpBlock>The size of the buckets for this timestamp type.</HelpBlock>

--- a/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotConfigGenerator.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotConfigGenerator.js
@@ -4,6 +4,19 @@ import { Set } from 'immutable';
 import { parseSeries } from 'views/logic/aggregationbuilder/Series';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
+import type { TimeUnit } from '../../../Constants';
+
+const mapTimeunit = (unit: TimeUnit) => {
+  switch (unit) {
+    case 'seconds': return 's';
+    case 'minutes': return 'm';
+    case 'hours': return 'h';
+    case 'days': return 'd';
+    case 'weeks': return 'w';
+    case 'months': return 'M';
+    default: throw new Error(`Invalid time unit: ${unit}`);
+  }
+};
 
 const formatPivot = (pivot: Pivot) => {
   const { type, field, config } = pivot;
@@ -15,7 +28,7 @@ const formatPivot = (pivot: Pivot) => {
       if (newConfig.interval.type === 'timeunit') {
         /* $FlowFixMe: newConfig.interval has unit and value since it is from type timeunit */
         const { unit, value } = newConfig.interval;
-        newConfig.interval = { type: 'timeunit', timeunit: `${value}${unit[0]}` };
+        newConfig.interval = { type: 'timeunit', timeunit: `${value}${mapTimeunit(unit)}` };
       }
       break;
     default:

--- a/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotConfigGenerator.test.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotConfigGenerator.test.js
@@ -51,4 +51,32 @@ describe('PivotConfigGenerator', () => {
       id: expect.any(String),
     });
   });
+  describe('maps time units for time pivots with timeunit intervals', () => {
+    const createWidgetConfigWithPivot = pivot => AggregationWidgetConfig.builder()
+      .rollup(true)
+      .rowPivots([pivot])
+      .columnPivots([])
+      .series([Series.forFunction('count')])
+      .build();
+    const generateConfigForPivotWithTimeUnit = ({ timeUnit, expectedMappedTimeUnit }) => {
+      const config = createWidgetConfigWithPivot(Pivot.create(
+        'foo',
+        'time',
+        { interval: { type: 'timeunit', unit: timeUnit, value: 1 } },
+      ));
+      const result = PivotConfigGenerator({ config });
+      const [{ config: { row_groups: [pivot] } }] = result;
+      const { interval: { timeunit } } = pivot;
+      expect(timeunit).toEqual(expectedMappedTimeUnit);
+    };
+    it.each`
+    timeUnit      | expectedMappedTimeUnit
+    ${'seconds'}  | ${'1s'}
+    ${'minutes'}  | ${'1m'}
+    ${'hours'}    | ${'1h'}
+    ${'days'}     | ${'1d'}
+    ${'weeks'}    | ${'1w'}
+    ${'months'}   | ${'1M'}
+  `('maps time unit $timeUnit to short name $expectedMappedTimeUnit', generateConfigForPivotWithTimeUnit);
+  });
 });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, a time-based pivot with an explicit bucketing
interval specified in multiples of months will not be properly mapped to
elasticsearch units. Instead of being mapped to `M` (Months), it will be
mapped to `m` (minutes).

This change is now explicitly mapping between units instead of taking
the first letter of the original unit.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.