### PR TITLE
Mention missing support for old dashboards in content packs

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -13,6 +13,12 @@ Graylog 3.2 contains a massive overhaul of its dashboarding functionality, which
   * Stacked Charts containing multiple series with different queries are split up by query. If a stacked chart contains 5 series, 3 with query "foo", 2 with query "bar, it is split up into two widgets, one containing all 3 "foo"-series, the other containing the 2 "bar"-series.
   * Widgets created using 3rd party plugins are migrated with their config, but unless the plugin author creates a corresponding plugin for 3.2, a placeholder is shown.
 
+
+Known Bugs and Issues
+=====================
+
+  * Content Packs containing old Dashbords can not be installed in Graylog 3.2.
+
 **************************
 Upgrading to Graylog 3.0.x
 **************************

--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -14,8 +14,8 @@ Graylog 3.2 contains a massive overhaul of its dashboarding functionality, which
   * Widgets created using 3rd party plugins are migrated with their config, but unless the plugin author creates a corresponding plugin for 3.2, a placeholder is shown.
 
 
-Known Bugs and Issues
-=====================
+Known Bugs and Limitations
+==========================
 
   * Content Packs containing old Dashbords can not be installed in Graylog 3.2.
 


### PR DESCRIPTION
## Description
Mention missing support of old dashboards in content packs in the UPGRADING.rst.

## Motivation and Context
Since the structure of views is fundamentally different to the old dashboards
the content packs facade needs to be adjusted to it. 


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

