### PR TITLE
Roll back complete widget when pressing cancel in widget edit modal.

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.jsx
@@ -17,7 +17,6 @@ import type { ViewStoreState } from 'views/stores/ViewStore';
 import { RefreshActions } from 'views/stores/RefreshStore';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import WidgetModel from 'views/logic/widgets/Widget';
-import WidgetConfig from 'views/logic/widgets/WidgetConfig';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import SearchActions from 'views/actions/SearchActions';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
@@ -63,10 +62,9 @@ type Props = {
   onPositionsChange: () => void,
 };
 type State = {
-  configChanged?: boolean,
   editing: boolean,
   loading: boolean;
-  oldConfig?: WidgetConfig,
+  oldWidget?: WidgetModel,
   showCopyToDashboard: boolean,
 };
 
@@ -136,7 +134,7 @@ class Widget extends React.Component<Props, State> {
       showCopyToDashboard: false,
     };
     if (editing) {
-      this.state = { ...this.state, oldConfig: props.widget.config };
+      this.state = { ...this.state, oldWidget: props.widget };
     }
   }
 
@@ -195,36 +193,29 @@ class Widget extends React.Component<Props, State> {
       if (state.editing) {
         return {
           editing: false,
-          oldConfig: undefined,
-          configChanged: undefined,
+          oldWidget: undefined,
         };
       }
       RefreshActions.disable();
       return {
         editing: true,
-        oldConfig: widget.config,
+        oldWidget: widget,
       };
     });
   };
 
   _onCancelEdit = () => {
-    const { configChanged } = this.state;
-    if (configChanged) {
+    const { oldWidget } = this.state;
+    if (oldWidget) {
       const { id } = this.props;
-      const { oldConfig } = this.state;
-      WidgetActions.updateConfig(id, oldConfig);
+      WidgetActions.update(id, oldWidget);
     }
     this._onToggleEdit();
   };
 
-  _onWidgetConfigChange = (widgetId, config) => {
-    this.setState({ configChanged: true });
-    WidgetActions.updateConfig(widgetId, config);
-  };
+  _onWidgetConfigChange = (widgetId, config) => WidgetActions.updateConfig(widgetId, config);
 
-  _setLoadingState = (loading: boolean) => {
-    this.setState({ loading });
-  }
+  _setLoadingState = (loading: boolean) => this.setState({ loading });
 
   visualize = () => {
     const { data, errors, title } = this.props;

--- a/graylog2-web-interface/src/views/components/widgets/Widget.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.test.jsx
@@ -229,6 +229,7 @@ describe('<Widget />', () => {
     const { getByText } = render(<DummyWidget editing widget={widgetWithConfig} />);
 
     WidgetActions.updateConfig = mockAction(jest.fn());
+    WidgetActions.update = mockAction(jest.fn());
     const onChangeBtn = getByText('Click me');
     fireEvent.click(onChangeBtn);
     expect(WidgetActions.updateConfig).toHaveBeenCalledWith('widgetId', { foo: 23 });
@@ -236,12 +237,14 @@ describe('<Widget />', () => {
     const cancelButton = getByText('Cancel');
     fireEvent.click(cancelButton);
 
-    expect(WidgetActions.updateConfig).toHaveBeenCalledWith('widgetId', { foo: 42 });
+    expect(WidgetActions.update).toHaveBeenCalledWith('widgetId', { config: { foo: 42 }, id: 'widgetId', type: 'dummy' });
   });
-  it('does not restores original state of widget config when clicking "Finish Editing"', () => {
+  it('does not restore original state of widget config when clicking "Finish Editing"', () => {
     const widgetWithConfig = { config: { foo: 42 }, id: 'widgetId', type: 'dummy' };
     const { getByText } = render(<DummyWidget editing widget={widgetWithConfig} />);
 
+    WidgetActions.updateConfig = mockAction(jest.fn());
+    WidgetActions.update = mockAction(jest.fn());
     const onChangeBtn = getByText('Click me');
     fireEvent.click(onChangeBtn);
     expect(WidgetActions.updateConfig).toHaveBeenCalledWith('widgetId', { foo: 23 });
@@ -249,7 +252,7 @@ describe('<Widget />', () => {
     const saveButton = getByText('Save');
     fireEvent.click(saveButton);
 
-    expect(WidgetActions.updateConfig).not.toHaveBeenCalledWith('widgetId', { foo: 42 });
+    expect(WidgetActions.update).not.toHaveBeenCalledWith('widgetId', { config: { foo: 42 }, id: 'widgetId', type: 'dummy' });
   });
 
   describe('copy widget to dashboard', () => {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, pressing cancel in the widget edit modal rolled
back changes to the widget's config. Due to the introduction of widget
queries/streams/time ranges which are part of the widget model (and not
in its config, which is contained in a key in the widget model), changes
to these would not have been reverted when clicking cancel.

This PR is now rolling back the complete widget. Before this change,
changes were rolled back only if the configs differed, now this is being
done unconditionally. Due to our logic in the stores cancelling editing
without having made changes will not lead to a search refresh though.

Fixes #7013.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.