### PR TITLE
Include time range type when changing time range parameter for widget.

### DIFF
--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.jsx
@@ -66,7 +66,7 @@ const _updateRangeType = (oldTimerange: ?TimeRange, id: string, newRangeType: Ti
 type Delta = {| range: number |} | {| from: string |} | {| to: string |} | {| keyword: string |};
 
 // $FlowFixMe: Resulting time range could actually be inconsistent/incomplete at this point. Need to fix and improve.
-const _updateRangeParams = (currentTimerange: ?TimeRange, id: string, delta: Delta) => WidgetActions.timerange(id, { ...currentTimerange, ...delta });
+const _updateRangeParams = (rangeType: string, currentTimerange: ?TimeRange, id: string, delta: Delta) => WidgetActions.timerange(id, { ...currentTimerange, type: rangeType, ...delta });
 
 const _updateStreams = (id: string, streams: Array<string>) => WidgetActions.streams(id, streams);
 
@@ -121,7 +121,7 @@ const WidgetQueryControls = ({ availableStreams, config, globalOverride = {}, wi
             <TimeRangeTypeSelector onSelect={newRangeType => _updateRangeType(timerange, id, newRangeType)}
                                    disabled={isGloballyOverridden}
                                    value={rangeType} />
-            <TimeRangeInput onChange={(key, value) => _updateRangeParams(timerange, id, { [key]: value })}
+            <TimeRangeInput onChange={(key, value) => _updateRangeParams(rangeType, timerange, id, { [key]: value })}
                             disabled={isGloballyOverridden}
                             rangeType={rangeType}
                             rangeParams={rangeParams}

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.test.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.test.jsx
@@ -102,7 +102,7 @@ describe('WidgetQueryControls', () => {
 
     fireEvent.change(timeRangeSelect, { target: { value: optionForAllMessages.value } });
 
-    expect(WidgetActions.timerange).toHaveBeenCalledWith('deadbeef', { range: '0' });
+    expect(WidgetActions.timerange).toHaveBeenCalledWith('deadbeef', { type: 'relative', range: '0' });
     expect(getByDisplayValue('Search in all messages')).not.toBeNull();
   });
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
This change includes the current time range type when changing a time
range parameter for a widget. This forces the `relative` time range type
being set when it is implicitly derived from the absence of a time range
type.

Fixes #7014.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.