### PR TITLE
Change `Show documents for value` to use widget query instead of filter

### DIFF
--- a/graylog2-web-interface/src/views/logic/queries/Query.js
+++ b/graylog2-web-interface/src/views/logic/queries/Query.js
@@ -29,6 +29,8 @@ export type ElasticsearchQueryString = {
   query_string: string,
 };
 
+export const createElasticsearchQueryString = (query: string = ''): ElasticsearchQueryString => ({ type: 'elasticsearch', query_string: query });
+
 export type QueryString = ElasticsearchQueryString;
 
 export type TimeRangeTypes = 'relative' | 'absolute' | 'keyword';

--- a/graylog2-web-interface/src/views/logic/queries/QueryGenerator.js
+++ b/graylog2-web-interface/src/views/logic/queries/QueryGenerator.js
@@ -1,13 +1,13 @@
 // @flow strict
 import uuid from 'uuid/v4';
 import { DEFAULT_TIMERANGE } from 'views/Constants';
-import Query from './Query';
+import Query, { createElasticsearchQueryString } from './Query';
 import type { QueryId } from './Query';
 
 export default (id: QueryId = uuid()): Query => {
   return Query.builder()
     .id(id)
-    .query({ type: 'elasticsearch', query_string: '' })
+    .query(createElasticsearchQueryString())
     .timerange(DEFAULT_TIMERANGE)
     .build();
 };

--- a/graylog2-web-interface/src/views/logic/queries/QueryHelper.js
+++ b/graylog2-web-interface/src/views/logic/queries/QueryHelper.js
@@ -1,10 +1,6 @@
 // @flow strict
 import { trim } from 'lodash';
 
-const queryContainsTerm = (query: string, termInQuestion: string) => {
-  return query.indexOf(termInQuestion) !== -1;
-};
-
 const isPhrase = (searchTerm: ?string) => {
   return String(searchTerm).indexOf(' ') !== -1;
 };
@@ -29,10 +25,6 @@ const escape = (searchTerm: ?string) => {
 };
 
 const addToQuery = (oldQuery: string, newTerm: string, operator: string = 'AND') => {
-  if (queryContainsTerm(oldQuery, newTerm)) {
-    return oldQuery;
-  }
-
   if (trim(oldQuery) === '*' || trim(oldQuery) === '') {
     return newTerm;
   }
@@ -40,4 +32,4 @@ const addToQuery = (oldQuery: string, newTerm: string, operator: string = 'AND')
   return `${oldQuery} ${operator} ${newTerm}`;
 };
 
-export { queryContainsTerm, isPhrase, escape, addToQuery };
+export { isPhrase, escape, addToQuery };

--- a/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.js
+++ b/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.js
@@ -1,31 +1,43 @@
 // @flow strict
-import { get } from 'lodash';
-
 import { DEFAULT_MESSAGE_FIELDS } from 'views/Constants';
 import { WidgetActions } from 'views/stores/WidgetStore';
 import { escape, addToQuery } from 'views/logic/queries/QueryHelper';
+import TitleTypes from 'views/stores/TitleTypes';
 
 import MessagesWidget from '../widgets/MessagesWidget';
 import MessagesWidgetConfig from '../widgets/MessagesWidgetConfig';
 import type { ValueActionHandler, ValuePath } from './ValueActionHandler';
+import View from '../views/View';
+import Widget from '../widgets/Widget';
+import { createElasticsearchQueryString } from '../queries/Query';
+import { TitlesActions } from '../../stores/TitlesStore';
 
-const ShowDocumentsHandler: ValueActionHandler = ({ contexts }) => {
-  const valuePath: ValuePath = contexts.valuePath || [];
+type Contexts = {
+  valuePath: ValuePath,
+  view: View,
+  widget: Widget,
+};
+
+type Arguments = {
+  contexts: Contexts;
+};
+
+const ShowDocumentsHandler: ValueActionHandler = ({ contexts: { valuePath, widget } }: Arguments) => {
   const mergedObject = valuePath.reduce((elem, acc) => ({ ...acc, ...elem }), {});
-  const widgetFilter = get(contexts, 'widget.filter', '');
+  const widgetQuery = widget && widget.query ? widget.query.query_string : '';
   const filter = Object.entries(mergedObject)
     .map(([k, v]) => `${k}:${escape(String(v))}`)
-    .reduce((prev: string, next: string) => addToQuery(prev, next), widgetFilter);
-  const widget = MessagesWidget.builder()
-    .filter(filter)
+    .reduce((prev: string, next: string) => addToQuery(prev, next), widgetQuery);
+  const newWidget = MessagesWidget.builder()
+    .query(createElasticsearchQueryString(filter))
     .newId()
     .config(new MessagesWidgetConfig.builder()
       .fields([...DEFAULT_MESSAGE_FIELDS, ...(Object.keys(mergedObject))])
       .showMessageRow(true).build())
     .build();
-  return WidgetActions.create(widget);
+  return WidgetActions.create(newWidget).then(() => TitlesActions.set(TitleTypes.Widget, newWidget.id, `Messages for ${filter}`));
 };
 
-ShowDocumentsHandler.isEnabled = ({ contexts: { valuePath } }) => (valuePath !== undefined);
+ShowDocumentsHandler.isEnabled = ({ contexts: { valuePath, widget } }) => (valuePath !== undefined && widget !== undefined);
 
 export default ShowDocumentsHandler;

--- a/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.js
+++ b/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.js
@@ -25,17 +25,18 @@ type Arguments = {
 const ShowDocumentsHandler: ValueActionHandler = ({ contexts: { valuePath, widget } }: Arguments) => {
   const mergedObject = valuePath.reduce((elem, acc) => ({ ...acc, ...elem }), {});
   const widgetQuery = widget && widget.query ? widget.query.query_string : '';
-  const filter = Object.entries(mergedObject)
+  const valuePathQuery = Object.entries(mergedObject)
     .map(([k, v]) => `${k}:${escape(String(v))}`)
-    .reduce((prev: string, next: string) => addToQuery(prev, next), widgetQuery);
+    .reduce((prev: string, next: string) => addToQuery(prev, next), '');
+  const query = addToQuery(widgetQuery, valuePathQuery);
   const newWidget = MessagesWidget.builder()
-    .query(createElasticsearchQueryString(filter))
+    .query(createElasticsearchQueryString(query))
     .newId()
     .config(new MessagesWidgetConfig.builder()
       .fields([...DEFAULT_MESSAGE_FIELDS, ...(Object.keys(mergedObject))])
       .showMessageRow(true).build())
     .build();
-  return WidgetActions.create(newWidget).then(() => TitlesActions.set(TitleTypes.Widget, newWidget.id, `Messages for ${filter}`));
+  return WidgetActions.create(newWidget).then(() => TitlesActions.set(TitleTypes.Widget, newWidget.id, `Messages for ${valuePathQuery}`));
 };
 
 ShowDocumentsHandler.isEnabled = ({ contexts: { valuePath, widget } }) => (valuePath !== undefined && widget !== undefined);

--- a/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.test.js
+++ b/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.test.js
@@ -7,6 +7,7 @@ import ShowDocumentsHandler from './ShowDocumentsHandler';
 import AggregationWidget from '../aggregationbuilder/AggregationWidget';
 import AggregationWidgetConfig from '../aggregationbuilder/AggregationWidgetConfig';
 import PivotGenerator from '../searchtypes/aggregation/PivotGenerator';
+import { createElasticsearchQueryString } from '../queries/Query';
 
 jest.mock('views/stores/WidgetStore', () => ({
   WidgetActions: {
@@ -40,7 +41,7 @@ describe('ShowDocumentsHandler', () => {
       .then(() => {
         expect(WidgetActions.create).toHaveBeenCalled();
         const newWidget = asMock(WidgetActions.create).mock.calls[0][0];
-        expect(newWidget.filter).toEqual('');
+        expect(newWidget.query).toEqual(createElasticsearchQueryString());
       });
   });
   it('adds the given value path as widget filter for new message widget', () => {
@@ -48,25 +49,25 @@ describe('ShowDocumentsHandler', () => {
       .then(() => {
         expect(WidgetActions.create).toHaveBeenCalled();
         const newWidget = asMock(WidgetActions.create).mock.calls[0][0];
-        expect(newWidget.filter).toEqual('foo:Hello\\! AND bar:42');
+        expect(newWidget.query).toEqual(createElasticsearchQueryString('foo:Hello\\! AND bar:42'));
       });
   });
-  it('adds the given value path to an existing widget filter', () => {
-    const widgetWithFilter = widget.toBuilder().filter('baz:23').build();
+  it('adds the given value path to an existing widget query', () => {
+    const widgetWithFilter = widget.toBuilder().query(createElasticsearchQueryString('baz:23')).build();
     return ShowDocumentsHandler({ queryId, field, value: 42, type: FieldType.Unknown, contexts: { widget: widgetWithFilter, valuePath: [{ bar: 42 }, { [field]: 'Hello!' }] } })
       .then(() => {
         expect(WidgetActions.create).toHaveBeenCalled();
         const newWidget = asMock(WidgetActions.create).mock.calls[0][0];
-        expect(newWidget.filter).toEqual('baz:23 AND foo:Hello\\! AND bar:42');
+        expect(newWidget.query).toEqual(createElasticsearchQueryString('baz:23 AND foo:Hello\\! AND bar:42'));
       });
   });
   it('deduplicates widget filter', () => {
-    const widgetWithFilter = widget.toBuilder().filter('bar:42').build();
+    const widgetWithFilter = widget.toBuilder().query(createElasticsearchQueryString('bar:42')).build();
     return ShowDocumentsHandler({ queryId, field, value: 42, type: FieldType.Unknown, contexts: { widget: widgetWithFilter, valuePath: [{ bar: 42 }, { [field]: 'Hello!' }] } })
       .then(() => {
         expect(WidgetActions.create).toHaveBeenCalled();
         const newWidget = asMock(WidgetActions.create).mock.calls[0][0];
-        expect(newWidget.filter).toEqual('bar:42 AND foo:Hello\\!');
+        expect(newWidget.query).toEqual(createElasticsearchQueryString('bar:42 AND foo:Hello\\!'));
       });
   });
 });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

With the introduction of separate queries per widget, widget filters are becoming deprecated. They are usable from the API, but there are no features in the UI enabling to use them. Therefore, this PR changes the `Show documents for value` action to use widget queries instead of widget filters. In addition, it creates a helpful title for the newly created message table.

Fixes #7020.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.