### PR TITLE
Ignore case when deserializing dashboard widgets in migration.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/Widget.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/Widget.java
@@ -19,20 +19,12 @@ package org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsTo
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 import com.google.auto.value.AutoValue;
-import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.FieldChartConfig;
-import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.QuickValuesConfig;
-import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.QuickValuesHistogramConfig;
-import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.SearchResultChartConfig;
-import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.SearchResultCountConfig;
-import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.StackedChartConfig;
-import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.StatsCountConfig;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.UnknownWidget;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.WidgetConfig;
-import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.WorldMapConfig;
 
 import java.util.Set;
 
@@ -72,17 +64,7 @@ public abstract class Widget {
         public abstract Builder creatorUserId(String creatorUserId);
         @JsonProperty(FIELD_CONFIG)
         @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "type", defaultImpl = UnknownWidget.class)
-        @JsonSubTypes({
-                @JsonSubTypes.Type(value = FieldChartConfig.class, name = "FIELD_CHART"),
-                @JsonSubTypes.Type(value = SearchResultChartConfig.class, name = "SEARCH_RESULT_CHART"),
-                @JsonSubTypes.Type(value = SearchResultCountConfig.class, name = "SEARCH_RESULT_COUNT"),
-                @JsonSubTypes.Type(value = SearchResultCountConfig.class, name = "STREAM_SEARCH_RESULT_COUNT"),
-                @JsonSubTypes.Type(value = StackedChartConfig.class, name = "STACKED_CHART"),
-                @JsonSubTypes.Type(value = StatsCountConfig.class, name = "STATS_COUNT"),
-                @JsonSubTypes.Type(value = QuickValuesConfig.class, name = "QUICKVALUES"),
-                @JsonSubTypes.Type(value = QuickValuesHistogramConfig.class, name = "QUICKVALUES_HISTOGRAM"),
-                @JsonSubTypes.Type(value = WorldMapConfig.class, name = "org.graylog.plugins.map.widget.strategy.MapWidgetStrategy")
-        })
+        @JsonTypeIdResolver(WidgetConfigResolver.class)
         public abstract Builder config(WidgetConfig config);
 
         public abstract Widget build();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/WidgetConfigResolver.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/WidgetConfigResolver.java
@@ -30,9 +30,9 @@ import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToV
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.UnknownWidget;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.WidgetConfig;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.WorldMapConfig;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.io.IOException;
+import java.util.Locale;
 
 public class WidgetConfigResolver implements TypeIdResolver {
     private JavaType superType;
@@ -43,7 +43,7 @@ public class WidgetConfigResolver implements TypeIdResolver {
     }
 
     private Class<? extends WidgetConfig> resolveTypeId(String id) {
-        switch (id.toUpperCase()) {
+        switch (id.toUpperCase(Locale.ENGLISH)) {
             case "FIELD_CHART": return FieldChartConfig.class;
             case "SEARCH_RESULT_CHART": return SearchResultChartConfig.class;
             case "SEARCH_RESULT_COUNT": return SearchResultCountConfig.class;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/WidgetConfigResolver.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/WidgetConfigResolver.java
@@ -1,0 +1,73 @@
+package org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.jsontype.TypeIdResolver;
+import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.FieldChartConfig;
+import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.QuickValuesConfig;
+import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.QuickValuesHistogramConfig;
+import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.SearchResultChartConfig;
+import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.SearchResultCountConfig;
+import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.StackedChartConfig;
+import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.StatsCountConfig;
+import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.UnknownWidget;
+import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.WidgetConfig;
+import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.dashboardwidgets.WorldMapConfig;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+
+import java.io.IOException;
+
+public class WidgetConfigResolver implements TypeIdResolver {
+    private JavaType superType;
+
+    @Override
+    public void init(JavaType baseType) {
+        this.superType = baseType;
+    }
+
+    private Class<? extends WidgetConfig> resolveTypeId(String id) {
+        switch (id.toUpperCase()) {
+            case "FIELD_CHART": return FieldChartConfig.class;
+            case "SEARCH_RESULT_CHART": return SearchResultChartConfig.class;
+            case "SEARCH_RESULT_COUNT": return SearchResultCountConfig.class;
+            case "STREAM_SEARCH_RESULT_COUNT": return SearchResultCountConfig.class;
+            case "STACKED_CHART": return StackedChartConfig.class;
+            case "STATS_COUNT": return StatsCountConfig.class;
+            case "QUICKVALUES": return QuickValuesConfig.class;
+            case "QUICKVALUES_HISTOGRAM": return QuickValuesHistogramConfig.class;
+            case "ORG.GRAYLOG.PLUGINS.MAP.WIDGET.STRATEGY.MAPWIDGETSTRATEGY": return WorldMapConfig.class;
+
+            default: return UnknownWidget.class;
+        }
+    }
+    @Override
+    public JavaType typeFromId(DatabindContext context, String id) throws IOException {
+        return context.constructSpecializedType(superType, resolveTypeId(id));
+    }
+
+    @Override
+    public String idFromValue(Object value) {
+        throw new IllegalStateException("This type resolver is meant for deserialization only!");
+    }
+
+    @Override
+    public String idFromValueAndType(Object value, Class<?> suggestedType) {
+        throw new IllegalStateException("This type resolver is meant for deserialization only!");
+    }
+
+    @Override
+    public String idFromBaseType() {
+        throw new IllegalStateException("This type resolver is meant for deserialization only!");
+    }
+
+    @Override
+    public String getDescForKnownTypeIds() {
+        throw new IllegalStateException("This type resolver is meant for deserialization only!");
+    }
+
+    @Override
+    public JsonTypeInfo.Id getMechanism() {
+        throw new IllegalStateException("This type resolver is meant for deserialization only!");
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/WidgetConfigResolver.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/WidgetConfigResolver.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/V20191125144500_MigrateDashboardsToViewsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/V20191125144500_MigrateDashboardsToViewsTest.java
@@ -171,6 +171,49 @@ public class V20191125144500_MigrateDashboardsToViewsTest {
     }
 
     @Test
+    @MongoDBFixtures("sample_dashboard_installed_from_content_pack.json")
+    public void migrateSampleDashboardInstalledFromContentPack() throws Exception {
+        this.migration.upgrade();
+
+        final MigrationCompleted migrationCompleted = captureMigrationCompleted();
+        assertThat(migrationCompleted.migratedDashboardIds()).containsExactly("5c7fc3f9f38ed741ac154697");
+        assertThat(migrationCompleted.widgetMigrationIds()).containsAllEntriesOf(
+                ImmutableMap.<String, Set<String>>builder()
+                        .put("05b03c7b-fe23-4789-a1c8-a38a583d3ba6", ImmutableSet.of("0000016e-b690-426f-0000-016eb690426f"))
+                        .put("10c1b3f9-6b34-4b34-9457-892d12b84151", ImmutableSet.of("0000016e-b690-4270-0000-016eb690426f"))
+                        .put("2afb1838-24ee-489f-929f-ef7d47485021", ImmutableSet.of("0000016e-b690-4271-0000-016eb690426f"))
+                        .put("40c9cf4e-0956-4dc1-9ccd-83868fa83277", ImmutableSet.of("0000016e-b690-4272-0000-016eb690426f"))
+                        .put("4a192616-51d3-474e-9e18-a680f2577769", ImmutableSet.of("0000016e-b690-4273-0000-016eb690426f"))
+                        .put("5020d62d-24a0-4b0c-8819-78e668cc2428", ImmutableSet.of("0000016e-b690-4274-0000-016eb690426f"))
+                        .put("6f2cc355-bcbb-4b3f-be01-bfba299aa51a", ImmutableSet.of("0000016e-b690-4275-0000-016eb690426f", "0000016e-b690-4276-0000-016eb690426f"))
+                        .put("76b7f7e1-76ac-486b-894b-bc31bf4808f1", ImmutableSet.of("0000016e-b690-4277-0000-016eb690426f"))
+                        .put("91b37752-e3a8-4274-910f-3d66d19f1028", ImmutableSet.of("0000016e-b690-4278-0000-016eb690426f"))
+                        .put("9b55d975-a5d4-4df6-8b2e-6fc7b48d52c3", ImmutableSet.of("0000016e-b690-4279-0000-016eb690426f"))
+                        .put("a8eadf94-6494-4271-8c0e-3c8d08e65623", ImmutableSet.of("0000016e-b690-427a-0000-016eb690426f"))
+                        .put("d9be20a1-82d7-427b-8a2d-c7ea9cd114de", ImmutableSet.of("0000016e-b690-427b-0000-016eb690426f"))
+                        .put("da111daa-0d0a-47b9-98ed-8b8aa8a4f575", ImmutableSet.of("0000016e-b690-427c-0000-016eb690426f"))
+                        .put("e9efdfaf-f7be-47ca-97fe-871c05a24d3c", ImmutableSet.of("0000016e-b690-427d-0000-016eb690426f"))
+                        .put("f6e9d960-9cc8-4d16-b3c8-770501b2709f", ImmutableSet.of("0000016e-b690-427e-0000-016eb690426f"))
+                        .build()
+        );
+
+        final ArgumentCaptor<View> newViewsCaptor = ArgumentCaptor.forClass(View.class);
+        final ArgumentCaptor<Search> newSearchesCaptor = ArgumentCaptor.forClass(Search.class);
+
+        verify(viewService, times(1)).save(newViewsCaptor.capture());
+        verify(searchService, times(1)).save(newSearchesCaptor.capture());
+
+        final List<View> newViews = newViewsCaptor.getAllValues();
+        final List<Search> newSearches = newSearchesCaptor.getAllValues();
+
+        assertThat(newViews).hasSize(1);
+        assertThat(newSearches).hasSize(1);
+
+        JSONAssert.assertEquals(toJSON(newViews), resourceFile("sample_dashboard-expected_views.json"), false);
+        JSONAssert.assertEquals(toJSON(newSearches), resourceFile("sample_dashboard-expected_searches.json"), false);
+    }
+
+    @Test
     @MongoDBFixtures("sample_dashboard_with_unknown_widget.json")
     public void migrateSampleDashboardWithUnknownWidget() {
         this.migration.upgrade();

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/sample_dashboard_installed_from_content_pack.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/sample_dashboard_installed_from_content_pack.json
@@ -1,0 +1,395 @@
+{
+  "dashboards": [
+    {
+      "_id": { "$oid": "5c7fc3f9f38ed741ac154697" },
+      "creator_user_id": "admin",
+      "description": "Hey!",
+      "created_at": { "$date": "2019-03-06T12:58:33.610Z" },
+      "positions": {
+        "da111daa-0d0a-47b9-98ed-8b8aa8a4f575": {
+          "width": 2,
+          "col": 5,
+          "row": 5,
+          "height": 2
+        },
+        "40c9cf4e-0956-4dc1-9ccd-83868fa83277": {
+          "width": 6,
+          "col": 7,
+          "row": 4,
+          "height": 3
+        },
+        "a8eadf94-6494-4271-8c0e-3c8d08e65623": {
+          "width": 6,
+          "col": 7,
+          "row": 7,
+          "height": 5
+        },
+        "6f2cc355-bcbb-4b3f-be01-bfba299aa51a": {
+          "width": 3,
+          "col": 1,
+          "row": 7,
+          "height": 5
+        },
+        "9b55d975-a5d4-4df6-8b2e-6fc7b48d52c3": {
+          "width": 4,
+          "col": 1,
+          "row": 14,
+          "height": 2
+        },
+        "5020d62d-24a0-4b0c-8819-78e668cc2428": {
+          "width": 4,
+          "col": 1,
+          "row": 1,
+          "height": 2
+        },
+        "91b37752-e3a8-4274-910f-3d66d19f1028": {
+          "width": 4,
+          "col": 1,
+          "row": 12,
+          "height": 2
+        },
+        "05b03c7b-fe23-4789-a1c8-a38a583d3ba6": {
+          "width": 2,
+          "col": 5,
+          "row": 1,
+          "height": 2
+        },
+        "76b7f7e1-76ac-486b-894b-bc31bf4808f1": {
+          "width": 3,
+          "col": 4,
+          "row": 7,
+          "height": 5
+        },
+        "10c1b3f9-6b34-4b34-9457-892d12b84151": {
+          "width": 2,
+          "col": 5,
+          "row": 3,
+          "height": 2
+        },
+        "4a192616-51d3-474e-9e18-a680f2577769": {
+          "width": 4,
+          "col": 1,
+          "row": 5,
+          "height": 2
+        },
+        "e9efdfaf-f7be-47ca-97fe-871c05a24d3c": {
+          "width": 4,
+          "col": 1,
+          "row": 3,
+          "height": 2
+        },
+        "2afb1838-24ee-489f-929f-ef7d47485021": {
+          "width": 6,
+          "col": 7,
+          "row": 1,
+          "height": 3
+        }
+      },
+      "title": "Sample Dashboard",
+      "widgets": [
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "KPI",
+          "id": "a8eadf94-6494-4271-8c0e-3c8d08e65623",
+          "type": "field_chart",
+          "config": {
+            "valuetype": "total",
+            "renderer": "line",
+            "interpolation": "linear",
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "rangeType": "relative",
+            "field": "nf_bytes",
+            "query": "",
+            "interval": "minute",
+            "relative": 300
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Field graph",
+          "id": "40c9cf4e-0956-4dc1-9ccd-83868fa83277",
+          "type": "field_chart",
+          "config": {
+            "valuetype": "total",
+            "renderer": "line",
+            "interpolation": "linear",
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "rangeType": "relative",
+            "field": "nf_bytes",
+            "query": "",
+            "interval": "minute",
+            "relative": 300
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Search result graph",
+          "id": "e9efdfaf-f7be-47ca-97fe-871c05a24d3c",
+          "type": "search_result_chart",
+          "config": {
+            "interval": "minute",
+            "timerange": {
+              "type": "relative",
+              "range": 28800
+            },
+            "query": ""
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Important!",
+          "id": "5020d62d-24a0-4b0c-8819-78e668cc2428",
+          "type": "field_chart",
+          "config": {
+            "valuetype": "total",
+            "renderer": "line",
+            "interpolation": "linear",
+            "timerange": {
+              "type": "relative",
+              "range": 28800
+            },
+            "rangeType": "relative",
+            "field": "nf_bytes",
+            "query": "",
+            "interval": "minute",
+            "relative": 28800
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Search result count",
+          "id": "05b03c7b-fe23-4789-a1c8-a38a583d3ba6",
+          "type": "search_result_count",
+          "config": {
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "lower_is_better": true,
+            "trend": true,
+            "query": ""
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Quick values",
+          "id": "6f2cc355-bcbb-4b3f-be01-bfba299aa51a",
+          "type": "quickvalues",
+          "config": {
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "field": "facility",
+            "query": "",
+            "show_data_table": true,
+            "limit": 5,
+            "show_pie_chart": true,
+            "sort_order": "desc",
+            "stacked_fields": "",
+            "data_table_limit": 50
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Statistical value",
+          "id": "10c1b3f9-6b34-4b34-9457-892d12b84151",
+          "type": "stats_count",
+          "config": {
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "field": "nf_src_address_geolocation",
+            "trend": false,
+            "query": "",
+            "stats_function": "cardinality",
+            "lower_is_better": false
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Search result graph",
+          "id": "2afb1838-24ee-489f-929f-ef7d47485021",
+          "type": "search_result_chart",
+          "config": {
+            "interval": "minute",
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "query": ""
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "World Map Example",
+          "id": "76b7f7e1-76ac-486b-894b-bc31bf4808f1",
+          "type": "org.graylog.plugins.map.widget.strategy.MapWidgetStrategy",
+          "config": {
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "field": "nf_dst_address_geolocation",
+            "stream_id": "5c2e07eeba33a9681ad6070a",
+            "query": ""
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Some Statistical values",
+          "id": "da111daa-0d0a-47b9-98ed-8b8aa8a4f575",
+          "type": "stats_count",
+          "config": {
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "field": "nf_proto",
+            "stream_id": "5c2e07eeba33a9681ad6070a",
+            "trend": true,
+            "query": "",
+            "stats_function": "cardinality",
+            "lower_is_better": true
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Field Chart with absolute time range",
+          "id": "9b55d975-a5d4-4df6-8b2e-6fc7b48d52c3",
+          "type": "field_chart",
+          "config": {
+            "valuetype": "count",
+            "renderer": "bar",
+            "interpolation": "linear",
+            "timerange": {
+              "from": { "$date": "2019-11-25T00:00:00.000Z" },
+              "to": { "$date": "2019-11-26T00:00:00.000Z" },
+              "type": "absolute"
+            },
+            "rangeType": "absolute",
+            "field": "nf_bytes",
+            "query": "",
+            "interval": "minute",
+            "from": "2019-11-25T00:00:00.000Z",
+            "to": "2019-11-26T00:00:00.000Z"
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Field chart with keyword time range",
+          "id": "91b37752-e3a8-4274-910f-3d66d19f1028",
+          "type": "field_chart",
+          "config": {
+            "valuetype": "count",
+            "renderer": "bar",
+            "interpolation": "linear",
+            "timerange": {
+              "type": "keyword",
+              "keyword": "yesterday"
+            },
+            "rangeType": "keyword",
+            "field": "nf_bytes",
+            "query": "",
+            "interval": "minute",
+            "keyword": "yesterday"
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Quick values Histogram",
+          "id": "4a192616-51d3-474e-9e18-a680f2577769",
+          "type": "quickvalues_histogram",
+          "config": {
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "field": "facility",
+            "query": "",
+            "limit": 5,
+            "interval": "hour",
+            "sort_order": "desc",
+            "stacked_fields": ""
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Stacked Field graph",
+          "id": "f6e9d960-9cc8-4d16-b3c8-770501b2709f",
+          "type": "stacked_chart",
+          "config": {
+            "interval": "minute",
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "renderer": "bar",
+            "interpolation": "linear",
+            "series": [
+              {
+                "query": "",
+                "field": "dns_client",
+                "statistical_function": "count"
+              },
+              {
+                "query": "",
+                "field": "nf_bytes",
+                "statistical_function": "count"
+              }
+            ]
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Stacked graph with custom timerange & query",
+          "id": "d9be20a1-82d7-427b-8a2d-c7ea9cd114de",
+          "type": "stacked_chart",
+          "config": {
+            "interval": "minute",
+            "timerange": {
+              "type": "relative",
+              "range": 7200
+            },
+            "renderer": "bar",
+            "interpolation": "linear",
+            "series": [
+              {
+                "query": "",
+                "field": "dns_client",
+                "statistical_function": "count"
+              },
+              {
+                "query": "",
+                "field": "nf_bytes",
+                "statistical_function": "count"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, the case of a widget's type field must be in upper
case for its config subclass to be resolved properly. Content packs use
lowercase for these when installing a dashboard, so these dashboards are
not migrated properly.

This PR is adding a custom type resolver for deserializing widget config
subclasses, which is uppercasing type ids before resolving them.

Fixes #7035.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.