### PR TITLE
Handle optional fields when migrating widgets.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/FieldChartConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/FieldChartConfig.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.RandomUUIDProvider;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.TimeRange;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.ViewWidget;
@@ -86,13 +87,13 @@ public abstract class FieldChartConfig extends WidgetConfigBase implements Widge
             @JsonProperty("interpolation") String interpolation,
             @JsonProperty("field") String field,
             @JsonProperty("interval") String interval,
-            @JsonProperty("query") String query,
+            @JsonProperty("query") @Nullable String query,
             @JsonProperty("timerange") TimeRange timerange,
             @JsonProperty("stream_id") @Nullable String streamId
     ) {
         return new AutoValue_FieldChartConfig(
                 timerange,
-                query,
+                Strings.nullToEmpty(query),
                 Optional.ofNullable(streamId),
                 valuetype,
                 renderer,

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/SearchResultChartConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/SearchResultChartConfig.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.RandomUUIDProvider;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.TimeRange;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.ViewWidget;
@@ -71,13 +72,13 @@ public abstract class SearchResultChartConfig extends WidgetConfigBase implement
     @JsonCreator
     static SearchResultChartConfig create(
             @JsonProperty("interval") String interval,
-            @JsonProperty("query") String query,
+            @JsonProperty("query") @Nullable String query,
             @JsonProperty("timerange") TimeRange timerange,
             @JsonProperty("stream_id") @Nullable String streamId
     ) {
         return new AutoValue_SearchResultChartConfig(
                 timerange,
-                query,
+                Strings.nullToEmpty(query),
                 Optional.ofNullable(streamId),
                 interval
         );

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/SearchResultCountConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/SearchResultCountConfig.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.RandomUUIDProvider;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.TimeRange;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.ViewWidget;
@@ -38,9 +39,9 @@ import java.util.Set;
 public abstract class SearchResultCountConfig extends WidgetConfigBase implements WidgetConfigWithQueryAndStreams {
     private static final String NUMERIC_VISUALIZATION = "numeric";
 
-    public abstract Boolean lowerIsBetter();
+    public abstract Optional<Boolean> lowerIsBetter();
 
-    public abstract Boolean trend();
+    public abstract Optional<Boolean> trend();
 
     public abstract Optional<String> streamId();
 
@@ -63,7 +64,7 @@ public abstract class SearchResultCountConfig extends WidgetConfigBase implement
                                         .visualizationConfig(
                                                 NumberVisualizationConfig.builder()
                                                         .trend(true)
-                                                        .trendPreference(lowerIsBetter()
+                                                        .trendPreference(lowerIsBetter().orElse(false)
                                                                 ? NumberVisualizationConfig.TrendPreference.LOWER
                                                                 : NumberVisualizationConfig.TrendPreference.HIGHER)
                                                         .build()
@@ -75,17 +76,17 @@ public abstract class SearchResultCountConfig extends WidgetConfigBase implement
 
     @JsonCreator
     static SearchResultCountConfig create(
-            @JsonProperty("lower_is_better") Boolean lowerIsBetter,
-            @JsonProperty("trend") Boolean trend,
-            @JsonProperty("query") String query,
+            @JsonProperty("lower_is_better") @Nullable Boolean lowerIsBetter,
+            @JsonProperty("trend") @Nullable Boolean trend,
+            @JsonProperty("query") @Nullable String query,
             @JsonProperty("timerange") TimeRange timerange,
             @JsonProperty("stream_id") @Nullable String streamId
     ) {
         return new AutoValue_SearchResultCountConfig(
                 timerange,
-                query,
-                lowerIsBetter,
-                trend,
+                Strings.nullToEmpty(query),
+                Optional.ofNullable(lowerIsBetter),
+                Optional.ofNullable(trend),
                 Optional.ofNullable(streamId)
         );
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/StatsCountConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/StatsCountConfig.java
@@ -40,8 +40,8 @@ public abstract class StatsCountConfig extends WidgetConfigBase implements Widge
 
     public abstract String field();
     public abstract String statsFunction();
-    public abstract Boolean lowerIsBetter();
-    public abstract Boolean trend();
+    public abstract Optional<Boolean> lowerIsBetter();
+    public abstract Optional<Boolean> trend();
     public abstract Optional<String> streamId();
 
     private Series series() {
@@ -56,8 +56,8 @@ public abstract class StatsCountConfig extends WidgetConfigBase implements Widge
                         .visualization(NUMERIC_VISUALIZATION)
                         .visualizationConfig(
                                 NumberVisualizationConfig.builder()
-                                        .trend(trend())
-                                        .trendPreference(lowerIsBetter()
+                                        .trend(trend().orElse(false))
+                                        .trendPreference(lowerIsBetter().orElse(false)
                                                 ? NumberVisualizationConfig.TrendPreference.LOWER
                                                 : NumberVisualizationConfig.TrendPreference.HIGHER)
                                         .build()
@@ -81,8 +81,8 @@ public abstract class StatsCountConfig extends WidgetConfigBase implements Widge
                 query,
                 field,
                 statsFunction,
-                lowerIsBetter,
-                trend,
+                Optional.ofNullable(lowerIsBetter),
+                Optional.ofNullable(trend),
                 Optional.ofNullable(streamId)
         );
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/WorldMapConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/WorldMapConfig.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.RandomUUIDProvider;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.TimeRange;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.ViewWidget;
@@ -69,7 +70,7 @@ public abstract class WorldMapConfig extends WidgetConfigBase implements WidgetC
     ) {
         return new AutoValue_WorldMapConfig(
                 timerange,
-                query,
+                Strings.nullToEmpty(query),
                 field,
                 Optional.ofNullable(streamId)
         );

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/V20191125144500_MigrateDashboardsToViewsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/V20191125144500_MigrateDashboardsToViewsTest.java
@@ -154,20 +154,8 @@ public class V20191125144500_MigrateDashboardsToViewsTest {
                         .build()
         );
 
-        final ArgumentCaptor<View> newViewsCaptor = ArgumentCaptor.forClass(View.class);
-        final ArgumentCaptor<Search> newSearchesCaptor = ArgumentCaptor.forClass(Search.class);
-
-        verify(viewService, times(1)).save(newViewsCaptor.capture());
-        verify(searchService, times(1)).save(newSearchesCaptor.capture());
-
-        final List<View> newViews = newViewsCaptor.getAllValues();
-        final List<Search> newSearches = newSearchesCaptor.getAllValues();
-
-        assertThat(newViews).hasSize(1);
-        assertThat(newSearches).hasSize(1);
-
-        JSONAssert.assertEquals(toJSON(newViews), resourceFile("sample_dashboard-expected_views.json"), false);
-        JSONAssert.assertEquals(toJSON(newSearches), resourceFile("sample_dashboard-expected_searches.json"), false);
+        assertViewsWritten(1,resourceFile("sample_dashboard-expected_views.json"));
+        assertSearchesWritten(1, resourceFile("sample_dashboard-expected_searches.json"));
     }
 
     @Test
@@ -197,20 +185,25 @@ public class V20191125144500_MigrateDashboardsToViewsTest {
                         .build()
         );
 
-        final ArgumentCaptor<View> newViewsCaptor = ArgumentCaptor.forClass(View.class);
-        final ArgumentCaptor<Search> newSearchesCaptor = ArgumentCaptor.forClass(Search.class);
+        assertViewsWritten(1, resourceFile("sample_dashboard-expected_views.json"));
+        assertSearchesWritten(1, resourceFile("sample_dashboard-expected_searches.json"));
+    }
 
-        verify(viewService, times(1)).save(newViewsCaptor.capture());
-        verify(searchService, times(1)).save(newSearchesCaptor.capture());
+    @Test
+    @MongoDBFixtures("dashboard_with_minimal_quickvalues_widget.json")
+    public void migrateDashboardWithMinimalQuickValuesWidget() throws Exception {
+        this.migration.upgrade();
 
-        final List<View> newViews = newViewsCaptor.getAllValues();
-        final List<Search> newSearches = newSearchesCaptor.getAllValues();
+        final MigrationCompleted migrationCompleted = captureMigrationCompleted();
+        assertThat(migrationCompleted.migratedDashboardIds()).containsExactly("5c7fc3f9f38ed741ac154697");
+        assertThat(migrationCompleted.widgetMigrationIds()).containsAllEntriesOf(
+                ImmutableMap.<String, Set<String>>builder()
+                        .put("6f2cc355-bcbb-4b3f-be01-bfba299aa51a", ImmutableSet.of("0000016e-b690-426f-0000-016eb690426f", "0000016e-b690-4270-0000-016eb690426f"))
+                        .build()
+        );
 
-        assertThat(newViews).hasSize(1);
-        assertThat(newSearches).hasSize(1);
-
-        JSONAssert.assertEquals(toJSON(newViews), resourceFile("sample_dashboard-expected_views.json"), false);
-        JSONAssert.assertEquals(toJSON(newSearches), resourceFile("sample_dashboard-expected_searches.json"), false);
+        assertViewsWritten(1, resourceFile("dashboard_with_minimal_quickvalues_widget-expected_views.json"));
+        assertSearchesWritten(1, resourceFile("dashboard_with_minimal_quickvalues_widget-expected_searches.json"));
     }
 
     @Test
@@ -284,20 +277,8 @@ public class V20191125144500_MigrateDashboardsToViewsTest {
                         "5ddf8ed8b2d44b2e044729d8"
                 );
 
-        final ArgumentCaptor<View> newViewsCaptor = ArgumentCaptor.forClass(View.class);
-        final ArgumentCaptor<Search> newSearchesCaptor = ArgumentCaptor.forClass(Search.class);
-
-        verify(viewService, times(5)).save(newViewsCaptor.capture());
-        verify(searchService, times(5)).save(newSearchesCaptor.capture());
-
-        final List<View> newViews = newViewsCaptor.getAllValues();
-        final List<Search> newSearches = newSearchesCaptor.getAllValues();
-
-        assertThat(newViews).hasSize(5);
-        assertThat(newSearches).hasSize(5);
-
-        JSONAssert.assertEquals(toJSON(newViews), resourceFile("ops_dashboards-expected_views.json"), false);
-        JSONAssert.assertEquals(toJSON(newSearches), resourceFile("ops_dashboards-expected_searches.json"), false);
+        assertViewsWritten(1, resourceFile("ops_dashboards-expected_views.json"));
+        assertSearchesWritten(1, resourceFile("ops_dashboards-expected_searches.json"));
     }
 
     @Test
@@ -364,6 +345,24 @@ public class V20191125144500_MigrateDashboardsToViewsTest {
 
         verify(viewService, times(1)).save(any());
         verify(searchService, times(1)).save(any());
+    }
+
+    private void assertSearchesWritten(int count, String expectedEntities) throws Exception {
+        final ArgumentCaptor<Search> newSearchesCaptor = ArgumentCaptor.forClass(Search.class);
+        verify(searchService, times(count)).save(newSearchesCaptor.capture());
+        final List<Search> newSearches = newSearchesCaptor.getAllValues();
+        assertThat(newSearches).hasSize(count);
+
+        JSONAssert.assertEquals(toJSON(newSearches), expectedEntities, false);
+    }
+
+    private void assertViewsWritten(int count, String expectedEntities) throws Exception {
+        final ArgumentCaptor<View> newViewsCaptor = ArgumentCaptor.forClass(View.class);
+        verify(viewService, times(count)).save(newViewsCaptor.capture());
+        final List<View> newViews = newViewsCaptor.getAllValues();
+        assertThat(newViews).hasSize(count);
+
+        JSONAssert.assertEquals(toJSON(newViews), expectedEntities, false);
     }
 
     private MigrationCompleted captureMigrationCompleted() {

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/V20191125144500_MigrateDashboardsToViewsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/V20191125144500_MigrateDashboardsToViewsTest.java
@@ -277,8 +277,8 @@ public class V20191125144500_MigrateDashboardsToViewsTest {
                         "5ddf8ed8b2d44b2e044729d8"
                 );
 
-        assertViewsWritten(1, resourceFile("ops_dashboards-expected_views.json"));
-        assertSearchesWritten(1, resourceFile("ops_dashboards-expected_searches.json"));
+        assertViewsWritten(5, resourceFile("ops_dashboards-expected_views.json"));
+        assertSearchesWritten(5, resourceFile("ops_dashboards-expected_searches.json"));
     }
 
     @Test

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_minimal_quickvalues_widget-expected_searches.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_minimal_quickvalues_widget-expected_searches.json
@@ -1,0 +1,81 @@
+[ {
+  "id" : "5de0e98900002a0017000001",
+  "queries" : [ {
+    "id" : "0000016e-b690-4273-0000-016eb690426f",
+    "timerange" : {
+      "type" : "relative",
+      "range" : 300
+    },
+    "query" : {
+      "type" : "elasticsearch",
+      "query_string" : ""
+    },
+    "search_types" : [ {
+      "id" : "0000016e-b690-4272-0000-016eb690426f",
+      "timerange" : {
+        "type" : "relative",
+        "range" : 300
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : ""
+      },
+      "streams" : [ ],
+      "name" : "chart",
+      "series" : [ {
+        "type" : "count",
+        "id" : "count()",
+        "field" : null
+      } ],
+      "sort" : [ {
+        "type" : "series",
+        "field" : "facility",
+        "direction" : "Descending"
+      } ],
+      "rollup" : true,
+      "type" : "pivot",
+      "filter" : null,
+      "row_groups" : [ {
+        "field" : "facility",
+        "limit" : 15,
+        "type" : "values"
+      } ],
+      "column_groups" : [ ]
+    }, {
+      "id" : "0000016e-b690-4271-0000-016eb690426f",
+      "timerange" : {
+        "type" : "relative",
+        "range" : 300
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : ""
+      },
+      "streams" : [ ],
+      "name" : "chart",
+      "series" : [ {
+        "type" : "count",
+        "id" : "count()",
+        "field" : null
+      } ],
+      "sort" : [ {
+        "type" : "series",
+        "field" : "facility",
+        "direction" : "Descending"
+      } ],
+      "rollup" : true,
+      "type" : "pivot",
+      "filter" : null,
+      "row_groups" : [ {
+        "field" : "facility",
+        "limit" : 15,
+        "type" : "values"
+      } ],
+      "column_groups" : [ ]
+    } ]
+  } ],
+  "parameters" : [ ],
+  "owner" : "admin",
+  "created_at" : "2019-03-06T12:58:33.610Z",
+  "requires" : { }
+} ]

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_minimal_quickvalues_widget-expected_views.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_minimal_quickvalues_widget-expected_views.json
@@ -1,0 +1,125 @@
+[ {
+  "id" : "5c7fc3f9f38ed741ac154697",
+  "type" : "DASHBOARD",
+  "title" : "Sample Dashboard",
+  "summary" : "This dashboard was migrated automatically.",
+  "description" : "Hey!",
+  "search_id" : "5de0e98900002a0017000001",
+  "state" : {
+    "0000016e-b690-4273-0000-016eb690426f" : {
+      "titles" : {
+        "widget" : {
+          "0000016e-b690-426f-0000-016eb690426f" : "Quick values",
+          "0000016e-b690-4270-0000-016eb690426f" : "Quick values"
+        },
+        "tab" : {
+          "title" : "Sample Dashboard"
+        }
+      },
+      "widgets" : [ {
+        "id" : "0000016e-b690-426f-0000-016eb690426f",
+        "type" : "aggregation",
+        "filter" : null,
+        "timerange" : {
+          "type" : "relative",
+          "range" : 300
+        },
+        "query" : {
+          "type" : "elasticsearch",
+          "query_string" : ""
+        },
+        "streams" : [ ],
+        "config" : {
+          "row_pivots" : [ {
+            "field" : "facility",
+            "type" : "values",
+            "config" : {
+              "limit" : 15
+            }
+          } ],
+          "column_pivots" : [ ],
+          "series" : [ {
+            "config" : {
+              "name" : null
+            },
+            "function" : "count()"
+          } ],
+          "sort" : [ {
+            "type" : "series",
+            "field" : "facility",
+            "direction" : "Descending"
+          } ],
+          "visualization" : "pie",
+          "visualization_config" : null,
+          "rollup" : true,
+          "formatting_settings" : null
+        }
+      }, {
+        "id" : "0000016e-b690-4270-0000-016eb690426f",
+        "type" : "aggregation",
+        "filter" : null,
+        "timerange" : {
+          "type" : "relative",
+          "range" : 300
+        },
+        "query" : {
+          "type" : "elasticsearch",
+          "query_string" : ""
+        },
+        "streams" : [ ],
+        "config" : {
+          "row_pivots" : [ {
+            "field" : "facility",
+            "type" : "values",
+            "config" : {
+              "limit" : 15
+            }
+          } ],
+          "column_pivots" : [ ],
+          "series" : [ {
+            "config" : {
+              "name" : null
+            },
+            "function" : "count()"
+          } ],
+          "sort" : [ {
+            "type" : "series",
+            "field" : "facility",
+            "direction" : "Descending"
+          } ],
+          "visualization" : "table",
+          "visualization_config" : null,
+          "rollup" : true,
+          "formatting_settings" : null
+        }
+      } ],
+      "widget_mapping" : {
+        "0000016e-b690-4270-0000-016eb690426f" : [ "0000016e-b690-4272-0000-016eb690426f" ],
+        "0000016e-b690-426f-0000-016eb690426f" : [ "0000016e-b690-4271-0000-016eb690426f" ]
+      },
+      "positions" : {
+        "0000016e-b690-4270-0000-016eb690426f" : {
+          "col" : 1,
+          "row" : 10,
+          "height" : 2,
+          "width" : 3
+        },
+        "0000016e-b690-426f-0000-016eb690426f" : {
+          "col" : 1,
+          "row" : 7,
+          "height" : 3,
+          "width" : 3
+        }
+      },
+      "static_message_list_id" : null,
+      "display_mode_settings" : {
+        "positions" : { }
+      },
+      "selected_fields" : null
+    }
+  },
+  "owner" : "admin",
+  "created_at" : "2019-03-06T12:58:33.610Z",
+  "requires" : { },
+  "properties" : [ ]
+} ]

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_minimal_quickvalues_widget.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_minimal_quickvalues_widget.json
@@ -1,0 +1,38 @@
+{
+  "dashboards": [
+    {
+      "_id": { "$oid": "5c7fc3f9f38ed741ac154697" },
+      "creator_user_id": "admin",
+      "description": "Hey!",
+      "created_at": { "$date": "2019-03-06T12:58:33.610Z" },
+      "positions": {
+        "6f2cc355-bcbb-4b3f-be01-bfba299aa51a": {
+          "width": 3,
+          "col": 1,
+          "row": 7,
+          "height": 5
+        }
+      },
+      "title": "Sample Dashboard",
+      "widgets": [
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Quick values",
+          "id": "6f2cc355-bcbb-4b3f-be01-bfba299aa51a",
+          "type": "QUICKVALUES",
+          "config": {
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "field": "facility",
+            "query": "",
+            "show_data_table": true,
+            "show_pie_chart": true
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, widgets with empty query/limit/data table limit/sort order/stacked fields properties could lead to the migration failing.

This PR makes these fields optional and handles them appropriately, e.g.  defining defaults for limits, trends & sort order.

Requires #7036 to be merged before.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.