### PR TITLE
Execute search after resetting global filter inside widget edit modal

### DIFF
--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.jsx
@@ -18,6 +18,7 @@ import { WidgetActions } from 'views/stores/WidgetStore';
 import type { TimeRange, TimeRangeTypes } from 'views/logic/queries/Query';
 import { GlobalOverrideActions, GlobalOverrideStore } from 'views/stores/GlobalOverrideStore';
 import GlobalOverride from 'views/logic/search/GlobalOverride';
+import SearchActions from 'views/actions/SearchActions';
 import TimeRangeTypeSelector from './searchbar/TimeRangeTypeSelector';
 import TimeRangeInput from './searchbar/TimeRangeInput';
 import StreamsFilter from './searchbar/StreamsFilter';
@@ -95,10 +96,12 @@ const ResetFilterButton = styled(Button)`
   vertical-align: initial;
 `;
 
+const _resetOverride = () => GlobalOverrideActions.reset().then(SearchActions.executeWithCurrentState);
+
 const ResetOverrideHint = () => (
   <CenteredBox>
     These controls are disabled, because a filter is applied to all widgets.{' '}
-    <ResetFilterButton bsSize="xs" bsStyle="primary" data-testid="reset-filter" onClick={GlobalOverrideActions.reset}>Reset filter</ResetFilterButton>
+    <ResetFilterButton bsSize="xs" bsStyle="primary" data-testid="reset-filter" onClick={_resetOverride}>Reset filter</ResetFilterButton>
   </CenteredBox>
 );
 

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.jsx
@@ -96,7 +96,7 @@ const ResetFilterButton = styled(Button)`
   vertical-align: initial;
 `;
 
-const _resetOverride = () => GlobalOverrideActions.reset().then(SearchActions.executeWithCurrentState);
+const _resetOverride = () => GlobalOverrideActions.reset().then(SearchActions.refresh);
 
 const ResetOverrideHint = () => (
   <CenteredBox>

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.test.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.test.jsx
@@ -1,10 +1,11 @@
 // @flow strict
 import * as React from 'react';
-import { render, waitForElement, cleanup, fireEvent } from 'wrappedTestingLibrary';
+import { render, waitForElement, cleanup, fireEvent, wait } from 'wrappedTestingLibrary';
 import selectEvent from 'react-select-event';
 import '@testing-library/jest-dom/extend-expect';
 
 import { GlobalOverrideActions } from 'views/stores/GlobalOverrideStore';
+import SearchActions from 'views/actions/SearchActions';
 import Widget from 'views/logic/widgets/Widget';
 import WidgetQueryControls from './WidgetQueryControls';
 import { WidgetActions } from '../stores/WidgetStore';
@@ -17,8 +18,11 @@ jest.mock('views/stores/WidgetStore', () => ({
 }));
 jest.mock('views/stores/GlobalOverrideStore', () => ({
   GlobalOverrideActions: {
-    reset: jest.fn(),
+    reset: jest.fn(() => Promise.resolve()),
   },
+}));
+jest.mock('views/actions/SearchActions', () => ({
+  executeWithCurrentState: jest.fn(() => Promise.resolve()),
 }));
 jest.mock('stores/connect', () => x => x);
 
@@ -74,6 +78,13 @@ describe('WidgetQueryControls', () => {
       const resetFilterButton = await waitForElement(() => getByTestId('reset-filter'));
       fireEvent.click(resetFilterButton);
       expect(GlobalOverrideActions.reset).toHaveBeenCalled();
+    });
+
+    it('executes search when reset filter button is clicked', async () => {
+      const { getByTestId } = renderSUT({ globalOverride: globalOverrideWithQuery });
+      const resetFilterButton = await waitForElement(() => getByTestId('reset-filter'));
+      fireEvent.click(resetFilterButton);
+      await wait(() => expect(SearchActions.executeWithCurrentState).toHaveBeenCalled());
     });
 
     it('emptying `globalOverride` prop removes notification', async () => {

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.test.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.test.jsx
@@ -22,7 +22,7 @@ jest.mock('views/stores/GlobalOverrideStore', () => ({
   },
 }));
 jest.mock('views/actions/SearchActions', () => ({
-  executeWithCurrentState: jest.fn(() => Promise.resolve()),
+  refresh: jest.fn(() => Promise.resolve()),
 }));
 jest.mock('stores/connect', () => x => x);
 
@@ -84,7 +84,7 @@ describe('WidgetQueryControls', () => {
       const { getByTestId } = renderSUT({ globalOverride: globalOverrideWithQuery });
       const resetFilterButton = await waitForElement(() => getByTestId('reset-filter'));
       fireEvent.click(resetFilterButton);
-      await wait(() => expect(SearchActions.executeWithCurrentState).toHaveBeenCalled());
+      await wait(() => expect(SearchActions.refresh).toHaveBeenCalled());
     });
 
     it('emptying `globalOverride` prop removes notification', async () => {


### PR DESCRIPTION
This PR fixes #7012.


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

