### PR TITLE
Handle orphaned widget positions in migration properly.

### DIFF
--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/sample_dashboard.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/sample_dashboard.json
@@ -83,6 +83,12 @@
           "col": 7,
           "row": 1,
           "height": 3
+        },
+        "f2e76256-0379-483e-8622-8efd661ca939": {
+          "width": 23,
+          "col": 8,
+          "row": 8,
+          "height": 42
         }
       },
       "title": "Sample Dashboard",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When adding a widget to a dashboard, moving it and deleting it
afterwards, a widget position entity is created that references a
missing widget. The dashboard migration PR fails when encountering
these, due to a NPE when looking up the created view widget.

This PR is fixing this and ignores orphaned widget positions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.