### PR TITLE
Allow queries with empty search types.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackend.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackend.java
@@ -40,8 +40,6 @@ import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.elasticsearch.searchtypes.ESSearchTypeHandler;
 import org.graylog.plugins.views.search.engine.QueryBackend;
-import org.graylog.plugins.views.search.errors.QueryError;
-import org.graylog.plugins.views.search.errors.SearchException;
 import org.graylog.plugins.views.search.errors.SearchTypeError;
 import org.graylog.plugins.views.search.errors.SearchTypeErrorParser;
 import org.graylog.plugins.views.search.filter.AndFilter;
@@ -117,9 +115,6 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
         final ElasticsearchQueryString backendQuery = (ElasticsearchQueryString) query.query();
 
         final Set<SearchType> searchTypes = query.searchTypes();
-        if (searchTypes.isEmpty()) {
-            throw new SearchException(new QueryError(query, "Cannot generate query without any search types"));
-        }
 
         final String queryString = this.esQueryDecorators.decorate(backendQuery.queryString(), job, query, results);
         final QueryBuilder normalizedRootQuery = normalizeQueryString(queryString);
@@ -215,6 +210,13 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
 
     @Override
     public QueryResult doRun(SearchJob job, Query query, ESGeneratedQueryContext queryContext, Set<QueryResult> predecessorResults) {
+        if (query.searchTypes().isEmpty()) {
+            return QueryResult.builder()
+                    .query(query)
+                    .searchTypes(Collections.emptyMap())
+                    .errors(new HashSet<>(queryContext.errors()))
+                    .build();
+        }
         LOG.debug("Running query {} for job {}", query.id(), job.getId());
         final HashMap<String, SearchType.Result> resultsMap = Maps.newHashMap();
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change lifts a restriction where the backend raises an exception
when a search contains a query with an empty set of search types.
Searches like this can be generated for:

1.) new dashboards containing no widgets
2.) dashboards containing only widgets which do not generate search
types (e.g. unknown 3rd party widgets migrated over)

In the first case the resulting error message is only briefly shown to
the user, in the second case all widgets contain this error instead of
showing the "Unknown widget" help text.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.