### PR TITLE
Register search type generator for default widget.

### DIFF
--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -159,6 +159,7 @@ export default {
       type: 'default',
       visualizationComponent: UnknownWidget,
       editComponent: UnknownWidget,
+      searchTypes: () => [],
     },
   ],
   searchTypes: [


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is registering a search type generator for default widgets
(which are also used for migrated unknown 3rd party widgets), which just
returns an empty list.

This is necessary, because otherwise regenerating a search for a
search/dashboard containing an unknown widget fails, as no function
generating search types for this widget can be resolved.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.