### PR TITLE
Bugfix proper Event Notification creation using Content Pack

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/contentpack/facade/NotificationFacade.java
+++ b/graylog2-server/src/main/java/org/graylog/events/contentpack/facade/NotificationFacade.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.graylog.events.contentpack.entities.NotificationEntity;
 import org.graylog.events.notifications.DBNotificationService;
 import org.graylog.events.notifications.NotificationDto;
+import org.graylog.events.notifications.NotificationResourceHandler;
 import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.contentpacks.facades.EntityFacade;
 import org.graylog2.contentpacks.model.ModelId;
@@ -47,12 +48,15 @@ public class NotificationFacade implements EntityFacade<NotificationDto> {
 
     private final ObjectMapper objectMapper;
     private final DBNotificationService notificationService;
+    private final NotificationResourceHandler notificationResourceHandler;
 
     @Inject
     public NotificationFacade(ObjectMapper objectMapper,
+                              NotificationResourceHandler notificationResourceHandler,
                               DBNotificationService notificationService) {
         this.objectMapper = objectMapper;
         this.notificationService = notificationService;
+        this.notificationResourceHandler = notificationResourceHandler;
     }
 
     @Override
@@ -88,7 +92,7 @@ public class NotificationFacade implements EntityFacade<NotificationDto> {
                                                  Map<EntityDescriptor, Object> nativeEntities) {
         final NotificationEntity entity = objectMapper.convertValue(entityV1.data(), NotificationEntity.class);
         final NotificationDto notificationDto = entity.toNativeEntity(parameters, nativeEntities);
-        final NotificationDto savedDto = notificationService.save(notificationDto);
+        final NotificationDto savedDto = notificationResourceHandler.create(notificationDto);
         return NativeEntity.create(entityV1.id(), savedDto.id(), ModelTypes.NOTIFICATION_V1, savedDto.title(), savedDto);
     }
 
@@ -100,7 +104,7 @@ public class NotificationFacade implements EntityFacade<NotificationDto> {
 
     @Override
     public void delete(NotificationDto nativeEntity) {
-        notificationService.delete(nativeEntity.id());
+        notificationResourceHandler.delete(nativeEntity.id());
     }
 
     @Override


### PR DESCRIPTION
## Description

Fixes issues:
- it's not possible to update Event Notification installed from Content
Pack on fresh GrayLog instance
- notifications doesn't work, server logs show:
ERROR: org.graylog.events.notifications.EventNotificationHandler - Couldnt find job definition for notification <5dfa2847b6730e001230c323>
- properly delete Event Notification with related resources 

## Motivation and Context

#7044

## How Has This Been Tested?
- isolated unit test (`mvn -Dtest=NotificationFacadeTest test`)
- manually tested Content Pack installation on built image

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

Tests are far from perfect, but I was following pattens from `EventDefinitionFacade` and `EventDefinitionFacadeTest`, so hopefully they are acceptable. 
Closes #7044.