### PR TITLE
Update StreamSearchPage when current stream id changes

### DIFF
--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.jsx
@@ -46,7 +46,7 @@ const StreamSearchPage = ({ params: { streamId }, route, loadingViewHooks, execu
     ).catch(
       (error) => { UserNotification.error(`Executing search failed with error: ${error}`, 'Could not execute search'); },
     );
-  }, []);
+  }, [streamId]);
 
   const loadView = (viewId: string): Promise<?View> => {
     return ViewLoader(

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.test.jsx
@@ -1,0 +1,43 @@
+// @flow strict
+import * as React from 'react';
+import { mount } from 'wrappedEnzyme';
+
+import mockAction from 'helpers/mocking/MockAction';
+import View from 'views/logic/views/View';
+import { ViewActions } from 'views/stores/ViewStore';
+
+import StreamSearchPage from './StreamSearchPage';
+
+jest.mock('views/stores/SearchStore', () => ({ SearchActions: {} }));
+jest.mock('views/stores/ViewStore', () => ({ ViewActions: {} }));
+jest.mock('views/stores/QueryFiltersStore', () => ({ QueryFiltersStoreActions: {} }));
+
+describe('StreamSearchPage', () => {
+  const SimpleStreamSearchPage = props => (
+    <StreamSearchPage location={{ query: {} }}
+                      params={{ streamId: 'stream-id-1' }}
+                      route={{}}
+                      {...props} />
+  );
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest.resetModules();
+  });
+
+  it('created view with streamId passed from props', () => {
+    ViewActions.create = mockAction(jest.fn(() => Promise.resolve()));
+    mount(<SimpleStreamSearchPage />);
+    expect(ViewActions.create).toHaveBeenCalledWith(View.Type.Search, 'stream-id-1');
+  });
+
+  it('recreated view when streamId passed from props changes', () => {
+    ViewActions.create = mockAction(jest.fn(() => Promise.resolve()));
+    const wrapper = mount(<SimpleStreamSearchPage />);
+    expect(ViewActions.create).toHaveBeenCalledWith(View.Type.Search, 'stream-id-1');
+
+    wrapper.setProps({ params: { streamId: 'stream-id-2' } });
+
+    expect(ViewActions.create).toHaveBeenCalledWith(View.Type.Search, 'stream-id-2');
+  });
+});


### PR DESCRIPTION
This PR fixes #7016

As described in the issue, we are not refreshing the StreamSearchPage view state when selecting a different stream e.g. inside the message list stream overview.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

