### PR TITLE
Fix version check of content packs in development

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/constraints/GraylogVersionConstraintChecker.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/constraints/GraylogVersionConstraintChecker.java
@@ -52,7 +52,7 @@ public class GraylogVersionConstraintChecker implements ConstraintChecker {
             if (constraint instanceof GraylogVersionConstraint) {
                 final GraylogVersionConstraint versionConstraint = (GraylogVersionConstraint) constraint;
                 final Requirement requiredVersion = versionConstraint.version();
-                if (requiredVersion.isSatisfiedBy(graylogVersion.toString())) {
+                if (requiredVersion.isSatisfiedBy(graylogVersion.withClearedSuffixAndBuild())) {
                     fulfilledConstraints.add(constraint);
                 }
             }
@@ -68,7 +68,7 @@ public class GraylogVersionConstraintChecker implements ConstraintChecker {
                 final GraylogVersionConstraint versionConstraint = (GraylogVersionConstraint) constraint;
                 final Requirement requiredVersion = versionConstraint.version();
                 final ConstraintCheckResult constraintCheckResult = ConstraintCheckResult.create(versionConstraint,
-                        requiredVersion.isSatisfiedBy(graylogVersion.toString()));
+                        requiredVersion.isSatisfiedBy(graylogVersion.withClearedSuffix()));
                 fulfilledConstraints.add(constraintCheckResult);
             }
         }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/constraints/GraylogVersionConstraintChecker.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/constraints/GraylogVersionConstraintChecker.java
@@ -68,7 +68,7 @@ public class GraylogVersionConstraintChecker implements ConstraintChecker {
                 final GraylogVersionConstraint versionConstraint = (GraylogVersionConstraint) constraint;
                 final Requirement requiredVersion = versionConstraint.version();
                 final ConstraintCheckResult constraintCheckResult = ConstraintCheckResult.create(versionConstraint,
-                        requiredVersion.isSatisfiedBy(graylogVersion.withClearedSuffix()));
+                        requiredVersion.isSatisfiedBy(graylogVersion.withClearedSuffixAndBuild()));
                 fulfilledConstraints.add(constraintCheckResult);
             }
         }


### PR DESCRIPTION
## Motivation
Prior to this change, the version check for content packs in development
failed, since the graylog version had a suffix (like SNAPSHOT or beta-1)
which prevented the check to succeed.

## Description
This change will clear the suffix before testing the requirement
(version check).


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

