### PR TITLE
Resize plotly visualizations correctly when changing their width

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.jsx
@@ -143,7 +143,7 @@ class GenericPlot extends React.Component<Props, State> {
 
     const style = { height: 'calc(100% - 10px)', width: '100%' };
 
-    const config = { displayModeBar: false, doubleClick: false };
+    const config = { displayModeBar: false, doubleClick: false, responsive: true };
 
     const { legendConfig } = this.state;
 


### PR DESCRIPTION
This PR fixes: #7049

The reason for the static width, was in in the end the changed widget layout (`display: grid`). While searching for a solution I found the plotly config setting `responsive: true` and it allows these type of flexible containers. We still need the layout setting `autosize: true`, otherwise the charts would have a fixed size.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

