### PR TITLE
Convert week/month bucket interval to days if value is bigger than 1.

### DIFF
--- a/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotConfigGenerator.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotConfigGenerator.js
@@ -48,7 +48,7 @@ const adjustUnitsLongerThanDays = (interval: UnitValueInterval) => {
 
 const mapToTimeUnitInterval = (interval: UnitValueInterval) => {
   const { unit, value } = adjustUnitsLongerThanDays(interval);
-  return { type: 'timeunit', timeunit: `${value}${mapTimeunit(unit)}` }
+  return { type: 'timeunit', timeunit: `${value}${mapTimeunit(unit)}` };
 };
 
 const formatPivot = (pivot: Pivot) => {

--- a/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotConfigGenerator.test.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotConfigGenerator.test.js
@@ -58,11 +58,11 @@ describe('PivotConfigGenerator', () => {
       .columnPivots([])
       .series([Series.forFunction('count')])
       .build();
-    const generateConfigForPivotWithTimeUnit = ({ timeUnit, expectedMappedTimeUnit }) => {
+    const generateConfigForPivotWithTimeUnit = ({ timeUnit, expectedMappedTimeUnit, value = 1 }) => {
       const config = createWidgetConfigWithPivot(Pivot.create(
         'foo',
         'time',
-        { interval: { type: 'timeunit', unit: timeUnit, value: 1 } },
+        { interval: { type: 'timeunit', unit: timeUnit, value } },
       ));
       const result = PivotConfigGenerator({ config });
       const [{ config: { row_groups: [pivot] } }] = result;
@@ -78,5 +78,19 @@ describe('PivotConfigGenerator', () => {
     ${'weeks'}    | ${'1w'}
     ${'months'}   | ${'1M'}
   `('maps time unit $timeUnit to short name $expectedMappedTimeUnit', generateConfigForPivotWithTimeUnit);
+    it.each`
+    timeUnit      | value | expectedMappedTimeUnit
+    ${'seconds'}  | ${2}  | ${'2s'}
+    ${'minutes'}  | ${2}  | ${'2m'}
+    ${'hours'}    | ${2}  | ${'2h'}
+    ${'days'}     | ${2}  | ${'2d'}
+    ${'weeks'}    | ${1}  | ${'1w'}
+    ${'weeks'}    | ${2}  | ${'14d'}
+    ${'weeks'}    | ${3}  | ${'21d'}
+    ${'weeks'}    | ${4}  | ${'28d'}
+    ${'months'}   | ${1}  | ${'1M'}
+    ${'months'}   | ${2}  | ${'60d'}
+    ${'months'}   | ${3}  | ${'90d'}
+  `('maps time unit $value$timeUnit to $expectedMappedTimeUnit', generateConfigForPivotWithTimeUnit);
   });
 });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Due to limitations in Elasticsearch, it does not support time unit
bucket intervals with values bigger than 1 for units bigger than days.
Therefore, this PR transparently converts these to days (with multiples
of 7 resp. 30) if the value is bigger than 1, leaving the original unit
otherwise.

Fixes #7022.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.