### PR TITLE
Handle Request Entity Too Large errors in ElasticSearchOutput

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
@@ -61,4 +61,7 @@ public class ElasticsearchClientConfiguration {
 
     @Parameter(value = "elasticsearch_compression_enabled")
     boolean compressionEnabled = false;
+
+    @Parameter(value = "elasticsearch_use_expect_continue")
+    boolean useExpectContinue = true;
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/JestUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/JestUtils.java
@@ -63,6 +63,15 @@ public class JestUtils {
         return execute(client, null, request, errorMessage);
     }
 
+    public static <T extends JestResult> T execute(JestClient client, RequestConfig requestConfig,
+                                                   Action<T> request) throws IOException {
+        if (client instanceof JestHttpClient) {
+            return ((JestHttpClient) client).execute(request, requestConfig);
+        } else {
+            return client.execute(request);
+        }
+    }
+
     public static ElasticsearchException specificException(Supplier<String> errorMessage, JsonNode errorNode) {
         final JsonNode rootCauses = errorNode.path("root_cause");
         final List<String> reasons = new ArrayList<>(rootCauses.size());

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
-import io.searchbox.client.http.JestHttpClient;
 import io.searchbox.core.Bulk;
 import io.searchbox.core.BulkResult;
 import io.searchbox.core.DocumentResult;
@@ -43,6 +42,7 @@ import org.graylog2.indexer.IndexFailure;
 import org.graylog2.indexer.IndexFailureImpl;
 import org.graylog2.indexer.IndexMapping;
 import org.graylog2.indexer.IndexSet;
+import org.graylog2.indexer.cluster.jest.JestUtils;
 import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.plugin.GlobalMetricNames;
 import org.graylog2.plugin.Message;
@@ -240,7 +240,7 @@ public class Messages {
         try {
             // Enable Expect-Continue to catch 413 errors before we send the actual data
             final RequestConfig requestConfig = RequestConfig.custom().setExpectContinueEnabled(true).build();
-            return BULK_REQUEST_RETRYER.call(() -> ((JestHttpClient)client).execute(request, requestConfig));
+            return BULK_REQUEST_RETRYER.call(() -> JestUtils.execute(client, requestConfig, request));
         } catch (ExecutionException | RetryException e) {
             if (e instanceof RetryException) {
                 LOG.error("Could not bulk index {} messages. Giving up after {} attempts.", count, ((RetryException) e).getNumberOfFailedAttempts());

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -158,7 +158,7 @@ public class Messages {
                 if (chunkSize == messageList.size()) {
                     LOG.warn("Consider lowering the \"output_batch_size\" setting.");
                 }
-                failedItems = e.failedItems;
+                failedItems.addAll(e.failedItems);
                 offset += e.indexedSuccessfully;
                 chunkSize /= 2;
             }

--- a/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
@@ -112,6 +112,7 @@ public class ElasticSearchOutput implements MessageOutput {
         }
         failures.mark(failedMessageIds.size());
 
+        // TODO why doesn't this exclude the failedMessageIds?
         final Optional<Long> offset = messageList.stream()
             .map(Map.Entry::getValue)
             .map(Message::getJournalOffset)

--- a/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
@@ -112,7 +112,7 @@ public class ElasticSearchOutput implements MessageOutput {
         }
         failures.mark(failedMessageIds.size());
 
-        // TODO why doesn't this exclude the failedMessageIds?
+        // This does not exclude failedMessageIds, because we don't know if ES is ever gonna accept these messages.
         final Optional<Long> offset = messageList.stream()
             .map(Map.Entry::getValue)
             .map(Message::getJournalOffset)

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
@@ -77,7 +77,7 @@ public class IndexFieldTypePollerIT extends ElasticsearchBaseTest {
         final Indices indices = new Indices(jestClient(),
                 new ObjectMapperProvider().get(),
                 new IndexMappingFactory(new Node(jestClient())),
-                new Messages(new MetricRegistry(), jestClient(), new InMemoryProcessingStatusRecorder()),
+                new Messages(new MetricRegistry(), jestClient(), new InMemoryProcessingStatusRecorder(), true),
                 mock(NodeId.class),
                 new NullAuditEventSender(),
                 new EventBus("index-field-type-poller-it"));

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesGetAllMessageFieldsIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesGetAllMessageFieldsIT.java
@@ -52,7 +52,7 @@ public class IndicesGetAllMessageFieldsIT extends ElasticsearchBaseTest {
         indices = new Indices(jestClient(),
                 new ObjectMapper(),
                 new IndexMappingFactory(node),
-                new Messages(new MetricRegistry(), jestClient(), new InMemoryProcessingStatusRecorder()),
+                new Messages(new MetricRegistry(), jestClient(), new InMemoryProcessingStatusRecorder(), true),
                 mock(NodeId.class),
                 new NullAuditEventSender(),
                 new EventBus());

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
@@ -105,7 +105,7 @@ public class IndicesIT extends ElasticsearchBaseTest {
         indices = new Indices(jestClient(),
                 new ObjectMapperProvider().get(),
                 indexMappingFactory,
-                new Messages(new MetricRegistry(), jestClient(), new InMemoryProcessingStatusRecorder()),
+                new Messages(new MetricRegistry(), jestClient(), new InMemoryProcessingStatusRecorder(), true),
                 mock(NodeId.class),
                 new NullAuditEventSender(),
                 eventBus);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
@@ -55,7 +55,7 @@ public class MessagesIT extends ElasticsearchBaseTest {
 
     @Before
     public void setUp() throws Exception {
-        messages = new Messages(new MetricRegistry(), jestClient(), new InMemoryProcessingStatusRecorder());
+        messages = new Messages(new MetricRegistry(), jestClient(), new InMemoryProcessingStatusRecorder(), true);
     }
 
     private static final IndexSetConfig indexSetConfig = IndexSetConfig.builder()

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
@@ -36,6 +36,7 @@ import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategyConf
 import org.graylog2.plugin.Message;
 import org.graylog2.system.processing.InMemoryProcessingStatusRecorder;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -118,7 +119,7 @@ public class MessagesIT extends ElasticsearchBaseTest {
         // Each Message is about 1 MB
         final String message = Strings.repeat('A', 1024 * 1024);
         for (int i = 0; i < size; i++) {
-            messageList.add(Maps.immutableEntry(indexSet, new Message(i + message, "source", DateTime.now())));
+            messageList.add(Maps.immutableEntry(indexSet, new Message(i + message, "source", DateTime.now(DateTimeZone.UTC))));
         }
         return messageList;
     }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
@@ -39,6 +39,7 @@ import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -61,7 +62,7 @@ public class MessagesIT extends ElasticsearchBaseTest {
             .title("Index set 1")
             .description("For testing")
             .indexPrefix("graylog")
-            .creationDate(ZonedDateTime.now())
+            .creationDate(ZonedDateTime.now(ZoneOffset.UTC))
             .shards(1)
             .replicas(0)
             .rotationStrategyClass(MessageCountRotationStrategy.class.getCanonicalName())

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
@@ -17,17 +17,32 @@
 package org.graylog2.indexer.messages;
 
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.Maps;
 import io.searchbox.client.JestResult;
+import io.searchbox.core.Count;
+import io.searchbox.core.CountResult;
 import io.searchbox.core.DocumentResult;
 import io.searchbox.core.Index;
+import joptsimple.internal.Strings;
 import org.graylog.testing.elasticsearch.ElasticsearchBaseTest;
+import org.graylog2.indexer.IndexSet;
+import org.graylog2.indexer.TestIndexSet;
+import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.results.ResultMessage;
+import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategy;
+import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategyConfig;
+import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
+import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategyConfig;
 import org.graylog2.plugin.Message;
 import org.graylog2.system.processing.InMemoryProcessingStatusRecorder;
+import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -40,6 +55,25 @@ public class MessagesIT extends ElasticsearchBaseTest {
     public void setUp() throws Exception {
         messages = new Messages(new MetricRegistry(), jestClient(), new InMemoryProcessingStatusRecorder());
     }
+
+    private static final IndexSetConfig indexSetConfig = IndexSetConfig.builder()
+            .id("index-set-1")
+            .title("Index set 1")
+            .description("For testing")
+            .indexPrefix("graylog")
+            .creationDate(ZonedDateTime.now())
+            .shards(1)
+            .replicas(0)
+            .rotationStrategyClass(MessageCountRotationStrategy.class.getCanonicalName())
+            .rotationStrategy(MessageCountRotationStrategyConfig.createDefault())
+            .retentionStrategyClass(DeletionRetentionStrategy.class.getCanonicalName())
+            .retentionStrategy(DeletionRetentionStrategyConfig.createDefault())
+            .indexAnalyzer("standard")
+            .indexTemplateName("template-1")
+            .indexOptimizationMaxNumSegments(1)
+            .indexOptimizationDisabled(false)
+            .build();
+    private static final IndexSet indexSet = new TestIndexSet(indexSetConfig);
 
     @Test
     public void getResultDoesNotContainJestMetadataFields() throws Exception {
@@ -58,5 +92,33 @@ public class MessagesIT extends ElasticsearchBaseTest {
         assertThat(message).isNotNull();
         assertThat(message.hasField(JestResult.ES_METADATA_ID)).isFalse();
         assertThat(message.hasField(JestResult.ES_METADATA_VERSION)).isFalse();
+    }
+
+    @Test
+    public void testIfTooLargeBatchesGetSplitUp() throws Exception {
+        // This test assumes that ES is configured with bulk_max_body_size to 100MB
+        // Check if we can index about 300MB of messages (once the large batch gets split up)
+        final int MESSAGECOUNT = 303;
+        final ArrayList<Map.Entry<IndexSet, Message>> largeMessageBatch = createMessageBatch(MESSAGECOUNT);
+        final List<String> failedItems = this.messages.bulkIndex(largeMessageBatch);
+
+        assertThat(failedItems).isEmpty();
+
+        Thread.sleep(2000); // wait for ES to finish indexing
+        final Count count = new Count.Builder().build();
+        final CountResult result = jestClient().execute(count);
+
+        assertThat(result.getCount()).isEqualTo(MESSAGECOUNT);
+    }
+
+    private ArrayList<Map.Entry<IndexSet, Message>> createMessageBatch(int size) {
+        final ArrayList<Map.Entry<IndexSet, Message>> messageList = new ArrayList<>();
+
+        // Each Message is about 1 MB
+        final String message = Strings.repeat('A', 1024 * 1024);
+        for (int i = 0; i < size; i++) {
+            messageList.add(Maps.immutableEntry(indexSet, new Message(i + message, "source", DateTime.now())));
+        }
+        return messageList;
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MockedMessagesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MockedMessagesTest.java
@@ -73,7 +73,7 @@ public class MockedMessagesTest {
 
     @Before
     public void setUp() throws Exception {
-        this.messages = new Messages(new MetricRegistry(), jestClient, new InMemoryProcessingStatusRecorder());
+        this.messages = new Messages(new MetricRegistry(), jestClient, new InMemoryProcessingStatusRecorder(), true);
     }
 
     @Test

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -241,6 +241,12 @@ plugin_dir = plugin
 # Default: false
 #elasticsearch_compression_enabled = true
 
+# Enable use of "Expect: 100-continue" Header for Elasticsearch index requests.
+# If this is disabled, Graylog cannot properly handle HTTP 413 Request Entity Too Large errors.
+#
+# Default: true
+#elasticsearch_use_expect_continue = true
+
 # Graylog will use multiple indices to store documents in. You can configured the strategy it uses to determine
 # when to rotate the currently active write index.
 # It supports multiple rotation strategies:


### PR DESCRIPTION
If we try to bulk index a batch of messages that exceeds the
elastic search `http.max_content_length` setting. (default 100MB)
Elastic will respond with an HTTP 413 Entity Too Large error.

In this case we retry the request by splitting the message batch
in half.

When responding with an HTTP 413 error, the server is allowed to close the connection
immediately. This means that our HTTP client (Jest) will simply report
an IOException (Broken pipe) instead of the actual error.
This can be avoided by sending the request with an Expect-Continue
header, which also avoids sending data that will be discarded later on.

Fixes #5091
Fixes #6965