### PR TITLE
Update to netty-4.1.44

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <mongodb-driver.version>3.6.4</mongodb-driver.version>
         <mongojack.version>2.10.0</mongojack.version>
         <natty.version>0.13</natty.version>
-        <netty.version>4.1.43.Final</netty.version>
+        <netty.version>4.1.44.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.28.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>3.14.2</okhttp.version>
         <opencsv.version>2.3</opencsv.version>


### PR DESCRIPTION
This is a bug-fix release. One of the important fixes is, that it
removes the dependency on a newer glibc version:

- Remove dependency on GLIBC 2.12 by using syscalls directly
  (netty/netty#9797)

For more details see the changelog:
https://netty.io/news/2019/12/18/4-1-44-Final.html