### PR TITLE
Security update to jackson-2.9.10.20200103

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <HdrHistogram.version>2.1.10</HdrHistogram.version>
         <hibernate-validator.version>6.0.13.Final</hibernate-validator.version>
         <hk2.version>2.5.0-b32</hk2.version> <!-- The HK2 version should match the version being used by Jersey -->
-        <jackson.version>2.9.10.20191020</jackson.version>
+        <jackson.version>2.9.10.20200103</jackson.version>
         <jadconfig.version>0.13.0</jadconfig.version>
         <java-semver.version>0.9.0</java-semver.version>
         <javapoet.version>1.11.1</javapoet.version>


### PR DESCRIPTION
This security update blocks two more gadget types (no CVEs yet) and
fixes a NoClassDefFoundError.

For details see:
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9#micro-patches