### PR TITLE
Destructure result from `SystemStore` properly in `Footer`.

### DIFF
--- a/graylog2-web-interface/src/components/layout/Footer.jsx
+++ b/graylog2-web-interface/src/components/layout/Footer.jsx
@@ -56,4 +56,4 @@ Footer.defaultProps = {
   system: undefined,
 };
 
-export default connect(Footer, { system: SystemStore });
+export default connect(Footer, { system: SystemStore }, ({ system: { system } = {} }) => ({ system }));

--- a/graylog2-web-interface/src/components/layout/Footer.test.jsx
+++ b/graylog2-web-interface/src/components/layout/Footer.test.jsx
@@ -1,0 +1,31 @@
+// @flow strict
+import * as React from 'react';
+import { cleanup, render, waitForElement } from '@testing-library/react';
+
+import Footer from './Footer';
+
+jest.mock('injection/StoreProvider', () => ({
+  getStore: () => ({
+    getInitialState: () => ({
+      system: { version: '23.42.0-SNAPSHOT+SPECIALFEATURE', hostname: 'hopper.local' },
+    }),
+    jvm: jest.fn(() => Promise.resolve({ info: 'SomeJDK v12.0.0' })),
+    listen: jest.fn(() => () => {}),
+  }),
+}));
+
+describe('Footer', () => {
+  afterEach(cleanup);
+  it('includes Graylog version', async () => {
+    const { getByText } = render(<Footer />);
+    await waitForElement(() => getByText('Graylog 23.42.0-SNAPSHOT+SPECIALFEATURE', { exact: false }));
+  });
+  it('includes hostname', async () => {
+    const { getByText } = render(<Footer />);
+    await waitForElement(() => getByText('on hopper.local', { exact: false }));
+  });
+  it('includes JRE version', async () => {
+    const { getByText } = render(<Footer />);
+    await waitForElement(() => getByText('SomeJDK v12.0.0', { exact: false }));
+  });
+});


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When refactoring the `Footer` component, it was overlooked that the
state of the `SystemStore` is wrapped in an object with another `system`
key and tried to access its contents directly. Thus the footer did not
show the Graylog version and the current hostname.

This change is now adding a props mapper function to the `connect` call
which destructures the store's state properly and adds tests.

Fixes #7076.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.