### PR TITLE
Fix reference errors in swagger.js

### DIFF
--- a/graylog2-server/src/main/resources/swagger/lib/swagger.js
+++ b/graylog2-server/src/main/resources/swagger/lib/swagger.js
@@ -59,7 +59,7 @@
             } else if (response.status === 404) {
               return _this.fail('Can\'t read swagger JSON from ' + _this.url);
             } else {
-              return _this.fail(response.status + ' : ' + response.statusText + ' ' + _this.url);
+              return _this.fail('Server return ' + response.status + ' for ' + _this.url);
             }
           },
           response: function(rawResponse) {
@@ -305,7 +305,7 @@
           headers: {},
           on: {
             error: function(response) {
-              return _this.api.fail("Unable to read api '" + _this.name + "' from path " + _this.url + " (server returned " + error.statusText + ")");
+              return _this.api.fail("Unable to read api '" + _this.name + "' from path " + _this.url + " (server returned " + response.status + ")");
             },
             response: function(rawResponse) {
               var response;


### PR DESCRIPTION
Bug: If an API endpoint returns an error the api browser becomes unfunctional with `ReferenceError: error is not defined`

## Description
If one or more API endpoints return error the API browser does not show any documentation for any of the endpoints or that an error occured with said api endpoints. This is because the JavaScript stops processing due to the reference error.

## How Has This Been Tested?
This is untested. However for the change at line 308 was indirectly verfied by breaking to it in a debugger and examining the objects.  As there is no statusText for the object in line 308 I'm making the assumption there's none for the response object in line 62 either.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. 
- [ ] I have added tests to cover my changes.

