### PR TITLE
Reducing remounting/-rendering of `MessageDetail` component.

### DIFF
--- a/graylog2-web-interface/src/pages/ShowMessagePage.jsx
+++ b/graylog2-web-interface/src/pages/ShowMessagePage.jsx
@@ -7,7 +7,6 @@ import ActionsProvider from 'injection/ActionsProvider';
 import StoreProvider from 'injection/StoreProvider';
 import DocumentTitle from 'components/common/DocumentTitle';
 import Spinner from 'components/common/Spinner';
-import connect from 'stores/connect';
 import { Col, Row } from 'components/graylog';
 import InteractiveContext from 'views/components/contexts/InteractiveContext';
 import MessageDetail from 'views/components/messagelist/MessageDetail';
@@ -15,12 +14,15 @@ import MessageDetail from 'views/components/messagelist/MessageDetail';
 const NodesActions = ActionsProvider.getActions('Nodes');
 const InputsActions = ActionsProvider.getActions('Inputs');
 const MessagesActions = ActionsProvider.getActions('Messages');
-const NodesStore = StoreProvider.getStore('Nodes');
 const StreamsStore = StoreProvider.getStore('Streams');
 
-const ConnectedMessageDetail = connect(MessageDetail, { nodes: NodesStore }, ({ nodes }) => ({ nodes: Immutable.Map(nodes.nodes) }));
-
-const ShowMessagePage = ({ params: { index, messageId }, params }) => {
+type Props = {
+  params: {
+    index: string,
+    messageId: string,
+  },
+};
+const ShowMessagePage = ({ params: { index, messageId }, params }: Props) => {
   const [message, setMessage] = useState();
   const [inputs, setInputs] = useState(Immutable.Map);
   const [streams, setStreams] = useState();
@@ -59,13 +61,13 @@ const ShowMessagePage = ({ params: { index, messageId }, params }) => {
         <Row className="content">
           <Col md={12}>
             <InteractiveContext.Provider value={false}>
-              <ConnectedMessageDetail fields={Immutable.Map()}
-                                      streams={streams}
-                                      allStreams={allStreams}
-                                      disableSurroundingSearch
-                                      disableFieldActions
-                                      inputs={inputs}
-                                      message={message} />
+              <MessageDetail fields={Immutable.Map()}
+                             streams={streams}
+                             allStreams={allStreams}
+                             disableSurroundingSearch
+                             disableFieldActions
+                             inputs={inputs}
+                             message={message} />
             </InteractiveContext.Provider>
           </Col>
         </Row>
@@ -82,4 +84,4 @@ ShowMessagePage.propTypes = {
   }).isRequired,
 };
 
-export default connect(ShowMessagePage, { nodes: NodesStore });
+export default ShowMessagePage;

--- a/graylog2-web-interface/src/pages/__snapshots__/ShowMessagePage.test.jsx.snap
+++ b/graylog2-web-interface/src/pages/__snapshots__/ShowMessagePage.test.jsx.snap
@@ -10,7 +10,6 @@ exports[`ShowMessagePage renders for generic event 1`] = `
     >
       <span>
         {
-  "nodes": {},
   "fields": {},
   "streams": {},
   "allStreams": [],
@@ -93,7 +92,6 @@ exports[`ShowMessagePage renders for generic message 1`] = `
     >
       <span>
         {
-  "nodes": {},
   "fields": {},
   "streams": {},
   "allStreams": [],

--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.jsx
@@ -21,27 +21,23 @@ import CustomHighlighting from './CustomHighlighting';
 import style from './MessageTableEntry.css';
 import type { Message } from './Types';
 
-const { NodesStore } = CombinedProvider.get('Nodes');
 const { InputsStore } = CombinedProvider.get('Inputs');
 
 const ConnectedMessageDetail = connect(
   MessageDetail,
   {
     availableInputs: InputsStore,
-    availableNodes: NodesStore,
     availableStreams: StreamsStore,
     configurations: SearchConfigStore,
   },
-  ({ availableStreams = {}, availableNodes = {}, availableInputs = {}, configurations = {}, ...rest }) => {
+  ({ availableStreams = {}, availableInputs = {}, configurations = {}, ...rest }) => {
     const { streams = [] } = availableStreams;
-    const { nodes } = availableNodes;
     const { inputs = [] } = availableInputs;
     const { searchesClusterConfig } = configurations;
     return ({
       ...rest,
       allStreams: Immutable.List(streams),
       streams: Immutable.Map(streams.map(stream => [stream.id, stream])),
-      nodes: Immutable.Map(nodes),
       inputs: Immutable.Map(inputs.map(input => [input.id, input])),
       searchConfig: searchesClusterConfig,
     });

--- a/graylog2-web-interface/src/views/components/messagelist/NodeName.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/NodeName.jsx
@@ -1,0 +1,45 @@
+// @flow strict
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import Routes from 'routing/Routes';
+import { Icon } from 'components/common';
+import CombinedProvider from 'injection/CombinedProvider';
+import connect from 'stores/connect';
+
+const { NodesStore } = CombinedProvider.get('Nodes');
+
+type NodeId = string;
+type NodeInfo = {
+  short_node_id: string,
+  hostname: string,
+}
+type Props = {
+  nodeId: NodeId,
+  nodes: { [NodeId]: NodeInfo },
+};
+
+const NodeName = ({ nodeId, nodes }: Props) => {
+  const node = nodes[nodeId];
+  if (node) {
+    const nodeURL = Routes.node(nodeId);
+    return (
+      <a href={nodeURL}>
+        <Icon name="code-fork" />
+        &nbsp;
+        <span style={{ wordBreak: 'break-word' }}>
+          {node.short_node_id}
+        </span>&nbsp;/&nbsp;
+        <span style={{ wordBreak: 'break-word' }}>
+          {node.hostname}
+        </span>
+      </a>
+    );
+  }
+  return <span style={{ wordBreak: 'break-word' }}>stopped node</span>;
+};
+
+NodeName.propTypes = {
+  nodeId: PropTypes.string.isRequired,
+};
+
+export default connect(NodeName, { nodes: NodesStore }, ({ nodes: { nodes = {} } = {} }) => ({ nodes }));


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, the `NodesStore` triggered a periodic rerendering
of the `MessageDetail` component. This caused a remounting of the
`FieldActions`/`ValueActions` component, resetting the state of
potentially opened drop downs.

This change is decoupling the consumption of the `NodesStore` by
reusing the `LinkToNode` component, keeping the store consumption as
local to rendering as possible.

Fixes #7059.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.