### PR TITLE
Apply `allow_highlighting` config  to views-based search

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/searchtypes/ESMessageList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/searchtypes/ESMessageList.java
@@ -17,6 +17,7 @@
 package org.graylog.plugins.views.search.elasticsearch.searchtypes;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.name.Named;
 import io.searchbox.core.SearchResult;
 import io.searchbox.core.search.aggregation.MetricAggregation;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -32,7 +33,6 @@ import org.graylog.plugins.views.search.elasticsearch.ESQueryDecorators;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.plugins.views.search.searchtypes.Sort;
-import org.graylog2.Configuration;
 import org.graylog2.decorators.Decorator;
 import org.graylog2.decorators.DecoratorProcessor;
 import org.graylog2.indexer.results.ResultMessage;
@@ -55,22 +55,22 @@ public class ESMessageList implements ESSearchTypeHandler<MessageList> {
     private final ESQueryDecorators esQueryDecorators;
     private final DecoratorProcessor decoratorProcessor;
     private final Map<String, SearchResponseDecorator.Factory> searchResponseDecorators;
-    private final Configuration configuration;
+    private final boolean allowHighlighting;
 
     @Inject
     public ESMessageList(ESQueryDecorators esQueryDecorators,
                          DecoratorProcessor decoratorProcessor,
                          Map<String, SearchResponseDecorator.Factory> searchResponseDecorators,
-                         Configuration configuration) {
+                         @Named("allow_highlighting") boolean allowHighlighting) {
         this.esQueryDecorators = esQueryDecorators;
         this.decoratorProcessor = decoratorProcessor;
         this.searchResponseDecorators = searchResponseDecorators;
-        this.configuration = configuration;
+        this.allowHighlighting = allowHighlighting;
     }
 
     @VisibleForTesting
     public ESMessageList(ESQueryDecorators esQueryDecorators) {
-        this(esQueryDecorators, new DecoratorProcessor.Fake(), Collections.emptyMap(), new Configuration());
+        this(esQueryDecorators, new DecoratorProcessor.Fake(), Collections.emptyMap(), false);
     }
 
     @Override
@@ -87,7 +87,7 @@ public class ESMessageList implements ESSearchTypeHandler<MessageList> {
     }
 
     private void applyHighlightingIfActivated(SearchSourceBuilder searchSourceBuilder, SearchJob job, Query query) {
-        if (!configuration.isAllowHighlighting())
+        if (!allowHighlighting)
             return;
 
         final QueryStringQueryBuilder highlightQuery = decoratedHighlightQuery(job, query);

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/searchtypes/ESMessageListTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/searchtypes/ESMessageListTest.java
@@ -30,6 +30,9 @@ import org.graylog.plugins.views.search.elasticsearch.ESQueryDecorator;
 import org.graylog.plugins.views.search.elasticsearch.ESQueryDecorators;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
+import org.graylog2.Configuration;
+import org.graylog2.decorators.DecoratorProcessor;
+import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.junit.Test;
 
@@ -37,64 +40,106 @@ import java.util.Collections;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ESMessageListTest {
-    @Test
-    public void executesQueryDecoratorsOnQueryString() throws Exception {
-        final ESQueryDecorator esQueryDecorator = (String queryString, SearchJob job, Query query, Set<QueryResult> results) -> "Foobar!";
-        final ESMessageList esMessageList = new ESMessageList(new ESQueryDecorators(Collections.singleton(esQueryDecorator)));
-
-        final Query query = Query.builder()
-                .id("deadbeef")
-                .query(ElasticsearchQueryString.builder()
-                        .queryString("Something else")
-                        .build())
-                .timerange(RelativeRange.create(300))
-                .searchTypes(Collections.emptySet())
-                .build();
-        final SearchJob searchJob = mock(SearchJob.class);
-        final MessageList messageList = MessageList.builder()
-                .id("amessagelist")
-                .limit(100)
-                .offset(0)
-                .build();
-        final ESGeneratedQueryContext esGeneratedQueryContext = mock(ESGeneratedQueryContext.class);
-        final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-        when(esGeneratedQueryContext.searchSourceBuilder(eq(messageList))).thenReturn(searchSourceBuilder);
-
-        esMessageList.doGenerateQueryPart(searchJob, query, messageList, esGeneratedQueryContext);
-
-        final DocumentContext doc = JsonPath.parse(searchSourceBuilder.toString());
-        JsonPathAssert.assertThat(doc).jsonPathAsString("$.highlight.highlight_query.query_string.query").isEqualTo("Foobar!");
-    }
 
     @Test
-    public void includesCustomNameinResultIfPresent() throws Exception {
+    public void includesCustomNameInResultIfPresent() {
         final ESMessageList esMessageList = new ESMessageList(new ESQueryDecorators(Collections.emptySet()));
-        final MessageList messageList = MessageList.builder()
-                .id("amessagelist")
-                .name("customResult")
-                .limit(100)
-                .offset(0)
-                .build();
-
-        final Query query = Query.builder()
-                .id("deadbeef")
-                .query(ElasticsearchQueryString.builder()
-                        .queryString("Something else")
-                        .build())
-                .timerange(RelativeRange.create(300))
-                .searchTypes(Collections.emptySet())
-                .build();
-
+        final MessageList messageList = someMessageList().toBuilder().name("customResult").build();
 
         final SearchResult result = new MockSearchResult(Collections.emptyList(), (long)0);
 
-        final SearchType.Result searchTypeResult = esMessageList.doExtractResult(null, query, messageList, result, null, null);
+        final SearchType.Result searchTypeResult = esMessageList.doExtractResult(null, someQuery(), messageList, result, null, null);
 
         assertThat(searchTypeResult.name()).contains("customResult");
+    }
+
+    @Test
+    public void usesHighlightingIfActivatedInConfig() {
+        MessageList messageList = someMessageList();
+
+        ESGeneratedQueryContext context = generateQueryPartFor(messageList, configWithHighlighting(true));
+
+        assertThat(context.searchSourceBuilder(messageList).highlighter()).isNotNull();
+    }
+
+    @Test
+    public void doesNotUseHighlightingIfDeactivatedInConfig() {
+        MessageList messageList = someMessageList();
+
+        ESGeneratedQueryContext context = generateQueryPartFor(messageList, configWithHighlighting(false));
+
+        assertThat(context.searchSourceBuilder(messageList).highlighter())
+                .as("there should be no highlighter configured")
+                .isNull();
+    }
+
+    @Test
+    public void appliesDecoratorsToQueryStringIfHighlightingActivated() {
+        final ESQueryDecorator esQueryDecorator = (String queryString, SearchJob job, Query query, Set<QueryResult> results) -> "Foobar!";
+
+        final MessageList messageList = someMessageList();
+
+        ESGeneratedQueryContext queryContext = generateQueryPartFor(messageList, configWithHighlighting(true), Collections.singleton(esQueryDecorator));
+
+        final DocumentContext doc = JsonPath.parse(queryContext.searchSourceBuilder(messageList).toString());
+        JsonPathAssert.assertThat(doc).jsonPathAsString("$.highlight.highlight_query.query_string.query").isEqualTo("Foobar!");
+    }
+
+    private Query someQuery() {
+        return Query.builder()
+                .id("deadbeef")
+                .query(ElasticsearchQueryString.builder()
+                        .queryString("Something else")
+                        .build())
+                .timerange(someTimeRange())
+                .searchTypes(Collections.emptySet())
+                .build();
+    }
+
+    private RelativeRange someTimeRange() {
+        try {
+            return RelativeRange.create(300);
+        } catch (InvalidRangeParametersException e) {
+            throw new RuntimeException("invalid query time range spec");
+        }
+    }
+
+    private MessageList someMessageList() {
+        return MessageList.builder()
+                .id("amessagelist")
+                .limit(100)
+                .offset(0)
+                .build();
+    }
+
+    private ESGeneratedQueryContext generateQueryPartFor(MessageList messageList, Configuration config) {
+        return generateQueryPartFor(messageList, config, Collections.emptySet());
+    }
+
+    private ESGeneratedQueryContext generateQueryPartFor(MessageList messageList, Configuration config, Set<ESQueryDecorator> decorators) {
+
+        ESMessageList sut = new ESMessageList(
+                new ESQueryDecorators(decorators),
+                new DecoratorProcessor.Fake(),
+                Collections.emptyMap(),
+                config);
+
+        ESGeneratedQueryContext context = mock(ESGeneratedQueryContext.class);
+
+        when(context.searchSourceBuilder(messageList)).thenReturn(new SearchSourceBuilder());
+
+        sut.doGenerateQueryPart(mock(SearchJob.class), someQuery(), messageList, context);
+
+        return context;
+    }
+
+    private Configuration configWithHighlighting(boolean highlightingValue) {
+        Configuration configuration = mock(Configuration.class);
+        when(configuration.isAllowHighlighting()).thenReturn(highlightingValue);
+        return configuration;
     }
 }


### PR DESCRIPTION
## Description
Contrary to the old implementation the new search has not respected the
config file setting for query string highlighting in message list
search results. This pr fixes that.

Fixes #7052 

## How Has This Been Tested?
Added unit tests and manually verified that highlighting is only applied, if activated in config.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

