### PR TITLE
Resolve field types correctly for renamed series.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesConfiguration.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { trim } from 'lodash';
 
 import { Button, ControlLabel, FormControl, FormGroup, HelpBlock } from 'components/graylog';
 import Series from 'views/logic/aggregationbuilder/Series';
@@ -8,6 +9,7 @@ export default class SeriesConfiguration extends React.Component {
   static propTypes = {
     series: PropTypes.instanceOf(Series).isRequired,
     onClose: PropTypes.func.isRequired,
+    usedNames: PropTypes.arrayOf(PropTypes.string).isRequired,
   };
 
   constructor(props, context) {
@@ -37,15 +39,18 @@ export default class SeriesConfiguration extends React.Component {
 
   render() {
     const { name } = this.state;
+    const { usedNames = [] } = this.props;
+    const isValid = !usedNames.includes(trim(name));
+    const validationHint = isValid ? null : <strong>Name must be unique.</strong>;
     return (
       <span>
-        <FormGroup>
+        <FormGroup validationState={isValid ? null : 'error'}>
           <ControlLabel>Name</ControlLabel>
           <FormControl type="text" value={name} onChange={this._changeName} />
-          <HelpBlock>The name of the series as it appears in the chart.</HelpBlock>
+          <HelpBlock>The name of the series as it appears in the chart. {validationHint}</HelpBlock>
         </FormGroup>
         <div className="pull-right" style={{ marginBottom: '10px' }}>
-          <Button bsStyle="success" onClick={this._onSubmit}>Done</Button>
+          <Button bsStyle="success" disabled={!isValid} onClick={this._onSubmit}>Done</Button>
         </div>
       </span>
     );

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesConfiguration.jsx
@@ -9,7 +9,11 @@ export default class SeriesConfiguration extends React.Component {
   static propTypes = {
     series: PropTypes.instanceOf(Series).isRequired,
     onClose: PropTypes.func.isRequired,
-    usedNames: PropTypes.arrayOf(PropTypes.string).isRequired,
+    usedNames: PropTypes.arrayOf(PropTypes.string),
+  };
+
+  static defaultProps = {
+    usedNames: [],
   };
 
   constructor(props, context) {
@@ -41,13 +45,13 @@ export default class SeriesConfiguration extends React.Component {
     const { name } = this.state;
     const { usedNames = [] } = this.props;
     const isValid = !usedNames.includes(trim(name));
-    const validationHint = isValid ? null : <strong>Name must be unique.</strong>;
+    const validationHint = isValid ? null : <React.Fragment> <strong>Name must be unique.</strong></React.Fragment>;
     return (
       <span>
         <FormGroup validationState={isValid ? null : 'error'}>
           <ControlLabel>Name</ControlLabel>
           <FormControl type="text" value={name} onChange={this._changeName} />
-          <HelpBlock>The name of the series as it appears in the chart. {validationHint}</HelpBlock>
+          <HelpBlock>The name of the series as it appears in the chart.{validationHint}</HelpBlock>
         </FormGroup>
         <div className="pull-right" style={{ marginBottom: '10px' }}>
           <Button bsStyle="success" disabled={!isValid} onClick={this._onSubmit}>Done</Button>

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesConfiguration.test.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesConfiguration.test.jsx
@@ -61,6 +61,22 @@ describe('SeriesConfiguration', () => {
     expect(onClose).toHaveBeenCalledWith(newSeries);
   });
 
+  it('prevents entering a duplicate series name', () => {
+    const onClose = jest.fn();
+    const series = createNewSeries();
+    const wrapper = mount(<SeriesConfiguration series={series} onClose={onClose} usedNames={['Already Exists']} />);
+    const input = wrapper.find('input');
+
+    expect(input).toHaveProp('value', 'count()');
+
+    input.simulate('change', { target: { value: 'Already Exists' } });
+
+    wrapper.update();
+    const submit = wrapper.find('button');
+    expect(submit).toBeDisabled();
+    expect(wrapper).toIncludeText('Name must be unique');
+  });
+
   it('returns original metric function name upon submit, when no name is defined', () => {
     const onClose = jest.fn();
     const series = createNewSeries(undefined, 'Some other value');

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesSelect.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesSelect.jsx
@@ -1,6 +1,7 @@
 // @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import { trim } from 'lodash';
 
 import Select from 'views/components/Select';
 import Series from 'views/logic/aggregationbuilder/Series';
@@ -33,11 +34,11 @@ const _wrapOption = series => ({ label: series.effectiveName, value: series });
 type Props = {
   onChange: (Array<Series>) => boolean,
   series: Array<Series>,
-  suggester: ((string) => Array<Option>) & { defaults: Array<Option | IncompleteOption | ParameterNeededOption | BackToFunctions >, for: (string | number, ?(string | number)) => Array<Option> },
+  suggester: ((string) => Array<Option>) & { defaults: Array<Option | IncompleteOption | ParameterNeededOption | BackToFunctions>, for: (string | number, ?(string | number)) => Array<Option> },
 };
 
 type State = {
-  options: Array<Option | IncompleteOption | ParameterNeededOption| BackToFunctions>,
+  options: Array<Option | IncompleteOption | ParameterNeededOption | BackToFunctions>,
 };
 
 class SeriesSelect extends React.Component<Props, State> {
@@ -100,10 +101,14 @@ class SeriesSelect extends React.Component<Props, State> {
     const valueComponent = ({ children, innerProps, ...rest }) => {
       const element = rest.data.value;
       const { className } = innerProps;
+      const usedNames = series.filter(s => s !== element)
+        .map(s => (s && s.config && s.config.name ? s.config.name : null))
+        .map(name => trim(name))
+        .filter(name => name !== null && name !== undefined && name !== '');
       return (
         <span className={className}>
           <ConfigurableElement {...rest}
-                               configuration={({ onClose }) => <SeriesConfiguration series={element} onClose={onClose} />}
+                               configuration={({ onClose }) => <SeriesConfiguration series={element} usedNames={usedNames} onClose={onClose} />}
                                onChange={newElement => newSeriesConfigChange(series, element, newElement, onChange)}
                                title="Series Configuration">
             {children}

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/SeriesConfiguration.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/SeriesConfiguration.test.jsx.snap
@@ -11,6 +11,7 @@ exports[`SeriesConfiguration renders the configuration dialog 1`] = `
       "function": "count()",
     }
   }
+  usedNames={Array []}
 >
   <span>
     <Component
@@ -224,14 +225,17 @@ exports[`SeriesConfiguration renders the configuration dialog 1`] = `
     >
       <ForwardRef
         bsStyle="success"
+        disabled={false}
         onClick={[Function]}
       >
         <Button
           bsStyle="success"
+          disabled={false}
           onClick={[Function]}
         >
           <StyledComponent
             bsStyle="success"
+            disabled={false}
             forwardedComponent={
               Object {
                 "$$typeof": Symbol(react.forward_ref),

--- a/graylog2-web-interface/src/views/components/datatable/DataTableEntry.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTableEntry.jsx
@@ -37,6 +37,11 @@ const _column = (field: string, value: *, selectedQuery: string, idx: number, ty
   </td>
 );
 
+const columnNameToField = (column, series = []) => {
+  const currentSeries = series.find(s => s.effectiveName === column);
+  return currentSeries ? currentSeries.function : column;
+};
+
 const DataTableEntry = ({ columnPivots, currentView, fields, series, columnPivotValues, valuePath, item, types }: Props) => {
   const classes = 'message-group';
   const { activeQuery } = currentView;
@@ -57,7 +62,7 @@ const DataTableEntry = ({ columnPivots, currentView, fields, series, columnPivot
   return (
     <tbody className={classes}>
       <tr className="fields-row">
-        {columns.map(({ field, value, path }, idx) => _column(field, value, activeQuery, idx, fieldTypeFor(field, types), path.slice()))}
+        {columns.map(({ field, value, path }, idx) => _column(field, value, activeQuery, idx, fieldTypeFor(columnNameToField(field, series), types), path.slice()))}
       </tr>
     </tbody>
   );

--- a/graylog2-web-interface/src/views/components/datatable/DataTableEntry.test.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTableEntry.test.jsx
@@ -10,6 +10,7 @@ import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import { FieldTypes } from 'views/logic/fieldtypes/FieldType';
 import Series from 'views/logic/aggregationbuilder/Series';
 import DataTableEntry from './DataTableEntry';
+import SeriesConfig from '../../logic/aggregationbuilder/SeriesConfig';
 
 jest.mock('views/components/common/UserTimezoneTimestamp', () => mockComponent('UserTimezoneTimestamp'));
 
@@ -37,6 +38,14 @@ const series = [
 ];
 
 const valuePath = [{ nf_dst_address: '192.168.1.24' }];
+
+const seriesWithName = (fn, name) => Series.forFunction(fn)
+  .toBuilder()
+  .config(SeriesConfig.empty()
+    .toBuilder()
+    .name(name)
+    .build())
+  .build();
 
 describe('DataTableEntry', () => {
   it('does not fail without types', () => {
@@ -99,5 +108,82 @@ describe('DataTableEntry', () => {
     expect(wrapper.find('Provider')
       .map(p => p.props().value))
       .toMatchSnapshot();
+  });
+
+  describe('resolves field types', () => {
+    const timestampTypeMapping = FieldTypeMapping.create('timestamp', FieldTypes.DATE());
+    it('for non-renamed functions', () => {
+      const wrapper = mount((
+        <table>
+          <DataTableEntry columnPivots={columnPivots}
+                          columnPivotValues={columnPivotValues}
+                          currentView={currentView}
+                          fields={fields}
+                          item={item}
+                          series={series}
+                          types={[timestampTypeMapping]}
+                          valuePath={valuePath} />
+        </table>
+      ));
+      const valueFields = wrapper.find('Value[field="max(timestamp)"]');
+      valueFields.forEach(field => expect(field).toHaveProp('type', timestampTypeMapping.type));
+    });
+    it('for simple row with renamed function', () => {
+      const renamedSeries = [seriesWithName('max(timestamp)', 'Last Timestamp')];
+      const itemWithRenamedSeries = {
+        'Last Timestamp': 1554106041841,
+      };
+      const fieldsWithRenamedSeries = Immutable.OrderedSet(['Last Timestamp']);
+
+      const wrapper = mount((
+        <table>
+          <DataTableEntry columnPivots={[]}
+                          columnPivotValues={[]}
+                          currentView={currentView}
+                          fields={fieldsWithRenamedSeries}
+                          item={itemWithRenamedSeries}
+                          series={renamedSeries}
+                          types={[timestampTypeMapping]}
+                          valuePath={[]} />
+        </table>
+      ));
+      const valueFields = wrapper.find('Value[field="Last Timestamp"]');
+      expect(valueFields).toHaveLength(1);
+      valueFields.forEach(field => expect(field).toHaveProp('type', timestampTypeMapping.type));
+    });
+    it('for renamed functions', () => {
+      const renamedSeries = [
+        Series.forFunction('count()'),
+        seriesWithName('max(timestamp)', 'Last Timestamp'),
+        Series.forFunction('card(timestamp)'),
+      ];
+      const itemWithRenamedSeries = {
+        nf_dst_address: '192.168.1.24',
+        nf_proto_name: {
+          TCP: { 'count()': 20, 'Last Timestamp': 1554106041841, 'card(timestamp)': 14 },
+          UDP: { 'count()': 64, 'Last Timestamp': 1554106041841, 'card(timestamp)': 16 },
+        },
+        'count()': 84,
+        'Last Timestamp': 1554106041841,
+        'card(timestamp)': 20,
+      };
+      const fieldsWithRenamedSeries = Immutable.OrderedSet(['nf_dst_address', 'count()', 'Last Timestamp', 'card(timestamp)']);
+
+      const wrapper = mount((
+        <table>
+          <DataTableEntry columnPivots={columnPivots}
+                          columnPivotValues={columnPivotValues}
+                          currentView={currentView}
+                          fields={fieldsWithRenamedSeries}
+                          item={itemWithRenamedSeries}
+                          series={renamedSeries}
+                          types={[timestampTypeMapping]}
+                          valuePath={valuePath} />
+        </table>
+      ));
+      const valueFields = wrapper.find('Value[field="Last Timestamp"]');
+      expect(valueFields).toHaveLength(3);
+      valueFields.forEach(field => expect(field).toHaveProp('type', timestampTypeMapping.type));
+    });
   });
 });

--- a/graylog2-web-interface/src/views/components/datatable/Headers.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/Headers.jsx
@@ -12,9 +12,9 @@ import fieldTypeFor from 'views/logic/fieldtypes/FieldTypeFor';
 
 import styles from './DataTable.css';
 
-const _headerField = (activeQuery: string, fields, field: string, prefix: (string | number) = '', span: number = 1) => (
+const _headerField = (activeQuery: string, fields, field: string, prefix: (string | number) = '', span: number = 1, title: string = field) => (
   <th key={`${prefix}${field}`} colSpan={span} className={styles.leftAligned}>
-    <Field name={field} queryId={activeQuery} type={fieldTypeFor(field, fields)}>{field}</Field>
+    <Field name={field} queryId={activeQuery} type={fieldTypeFor(field, fields)}>{title}</Field>
   </th>
 );
 
@@ -62,11 +62,10 @@ type Props = {
 const Headers = ({ activeQuery, columnPivots, fields, rowPivots, series, rollup, actualColumnPivotFields }: Props) => {
   const rowFieldNames = rowPivots.map(pivot => pivot.field);
   const columnFieldNames = columnPivots.map(pivot => pivot.field);
-  const headerField = (field, prefix = '', span: number = 1) => _headerField(activeQuery, fields, field, prefix, span);
+  const headerField = (field, prefix = '', span: number = 1, title = field) => _headerField(activeQuery, fields, field, prefix, span, title);
   const rowPivotFields = rowFieldNames.map(fieldName => headerField(fieldName));
-  const effectiveSeries: Array<string> = series.map(s => s.effectiveName);
-  const seriesFields = effectiveSeries.map(fieldName => headerField(fieldName));
-  const columnPivotFields = flatten(actualColumnPivotFields.map(key => effectiveSeries.map(s => headerField(s, key.join('-')))));
+  const seriesFields = series.map(s => headerField(s.function, '', 1, s.effectiveName));
+  const columnPivotFields = flatten(actualColumnPivotFields.map(key => series.map(s => headerField(s.function, key.join('-'), 1, s.effectiveName))));
   const offset = rollup ? rowFieldNames.length + series.length : rowFieldNames.length;
 
   return (


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As described in #6664, renaming a series causes field type resolution to fail.

This PR fixes a couple of issues around this:

  - Adding validation to the series configuration dialog, not allowing the user to give a series an already existing name
  - Fixing type resolution in data table headers for renamed series
  - Fixing type resolution in data table cells for the values of renamed series

Fixes #6664.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.