### PR TITLE
Fix horizontal scrolling for datatable widget

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationbuilder/FullSizeContainer.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/FullSizeContainer.jsx
@@ -45,7 +45,7 @@ class FullSizeContainer extends React.Component<Props, State> {
     const { children } = this.props;
     const { height, width } = this.state;
     return (
-      <div ref={(elem) => { this.wrapper = elem; }} style={{ height: '100%', width: '100%' }}>
+      <div ref={(elem) => { this.wrapper = elem; }} style={{ height: '100%', width: '100%', overflow: 'hidden' }}>
         {children({ height, width })}
       </div>
     );


### PR DESCRIPTION
## Motivation and Context
As described in #7091, the horizontal scrolling for a datatable with many columns is currently broken. This PR fixes this issue by adding `overflow: hidden;` to the widget container. The datatable already has a `overflow: auto;` and will show the scrollbar dynamically.

While having a look at these changes I identified another problem. In the aggregation builder the scrollbar exists and the user could scroll horizontal in theory, but the scrollbar is not visible, due to some height calculation. I will create another issue for this case, because we need to adjust the aggregation builder layout, I did not fixed this issue with this PR.

## How Has This Been Tested?
I had a look at all other widget types, to make sure this has no side effects.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

