### PR TITLE
Add missing leaflet css import for MapVisualization

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/MapVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/MapVisualization.jsx
@@ -6,6 +6,7 @@ import chroma from 'chroma-js';
 import { flatten } from 'lodash';
 import style from 'components/maps/widgets/MapVisualization.css';
 
+// eslint-disable-next-line import/no-webpack-loader-syntax
 import leafletStyles from '!style/useable!css!leaflet/dist/leaflet.css';
 
 const DEFAULT_VIEWPORT = {

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/MapVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/MapVisualization.jsx
@@ -6,7 +6,7 @@ import chroma from 'chroma-js';
 import { flatten } from 'lodash';
 import style from 'components/maps/widgets/MapVisualization.css';
 
-import 'leaflet/dist/leaflet.css';
+import leafletStyles from '!style/useable!css!leaflet/dist/leaflet.css';
 
 const DEFAULT_VIEWPORT = {
   center: [0, 0],
@@ -53,6 +53,7 @@ class MapVisualization extends React.Component {
 
   componentDidMount() {
     this._forceMapUpdate();
+    leafletStyles.use();
   }
 
   componentDidUpdate(prevProps) {
@@ -60,6 +61,10 @@ class MapVisualization extends React.Component {
     if (height !== prevProps.height || width !== prevProps.width) {
       this._forceMapUpdate();
     }
+  }
+
+  componentWillUnmount() {
+    leafletStyles.unuse();
   }
 
   // Workaround to avoid wrong placed markers or empty tiles if the map container size changed.

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/MapVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/MapVisualization.jsx
@@ -6,6 +6,8 @@ import chroma from 'chroma-js';
 import { flatten } from 'lodash';
 import style from 'components/maps/widgets/MapVisualization.css';
 
+import 'leaflet/dist/leaflet.css';
+
 const DEFAULT_VIEWPORT = {
   center: [0, 0],
   zoom: 1,


### PR DESCRIPTION
## Motivation and Context
As described in #7095 the worldmap visualization is currently broken. The reason is the missing and [necessary](https://react-leaflet.js.org/docs/en/setup) leaflet css import.

This error did not appeared before, because webpack was still aware of the `leaflet.css`, due to the import inside the old `MapVisualization.jsx`. But in the meantime the old widget is not getting referenced anymore.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

