### PR TITLE
Save world map widget viewport on widget save

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/WidgetErrorBoundary.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetErrorBoundary.jsx
@@ -22,9 +22,10 @@ export default class WidgetErrorBoundary extends React.Component<Props, State> {
 
   render() {
     const { error } = this.state;
-    const { children } = this.props;
+    const { children, ...rest } = this.props;
+    const childrenWithProps = React.Children.map(children, child => React.cloneElement(child, rest));
     return error
       ? <ErrorWidget title="While rendering this widget, the following error occurred:" errors={[{ description: error.toString() }]} />
-      : children;
+      : childrenWithProps;
   }
 }

--- a/graylog2-web-interface/src/views/components/widgets/WidgetErrorBoundary.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetErrorBoundary.test.jsx
@@ -34,7 +34,7 @@ describe('WidgetErrorBoundary', () => {
     asMock(console.error).mockRestore();
   });
 
-  it('passes own props to child component', () => {
+  it('passes own props to its children', () => {
     const Component = props => <div data-testid="child-component-test-id" {...props} />;
     const { getByTestId } = render((
       <WidgetErrorBoundary extraProp="The extra prop">

--- a/graylog2-web-interface/src/views/components/widgets/WidgetErrorBoundary.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetErrorBoundary.test.jsx
@@ -1,6 +1,7 @@
 // @flow strict
 import * as React from 'react';
 import { render, waitForElement } from 'wrappedTestingLibrary';
+import '@testing-library/jest-dom/extend-expect';
 
 import asMock from 'helpers/mocking/AsMock';
 import WidgetErrorBoundary from './WidgetErrorBoundary';
@@ -14,6 +15,7 @@ describe('WidgetErrorBoundary', () => {
     ));
     await waitForElement(() => getByText('Hello World!'));
   });
+
   it('renders helpful error message if child throws error', async () => {
     jest.spyOn(console, 'error');
     // eslint-disable-next-line no-console
@@ -30,5 +32,15 @@ describe('WidgetErrorBoundary', () => {
 
     // eslint-disable-next-line no-console
     asMock(console.error).mockRestore();
+  });
+
+  it('passes own props to child component', () => {
+    const Component = props => <div data-testid="child-component-test-id" {...props} />;
+    const { getByTestId } = render((
+      <WidgetErrorBoundary extraProp="The extra prop">
+        <Component />
+      </WidgetErrorBoundary>
+    ));
+    expect(getByTestId('child-component-test-id')).toHaveAttribute('extraProp', 'The extra prop');
   });
 });


### PR DESCRIPTION
## Motivation and Context
This PR fixes #7107. The Problem was, we are not passing `onChange` to the `WorldMapVisualization`, due to the new `WidgetErrorBoundary` and the usage of `React.cloneElement` inside the `AggregationControls`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

