### PR TITLE
Make configuration section layout in AggregationBuilder more responsive

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Col, Row } from 'components/graylog';
 import * as Immutable from 'immutable';
 import { PluginStore } from 'graylog-web-plugin/plugin';
+import styled from 'styled-components';
 
 import CustomPropTypes from 'views/components/CustomPropTypes';
 import { defaultCompare } from 'views/logic/DefaultCompare';
@@ -31,6 +32,12 @@ type Props = {
 type State = {
   config: AggregationWidgetConfig,
 };
+
+const Container: React.ComponentType<{}> = styled.div`
+  display: grid;
+  grid-template-rows: auto minmax(auto, 1fr);
+  height: 100%;
+`;
 
 const _visualizationConfigFor = (type: string) => PluginStore.exports('visualizationConfigTypes')
   .find(visualizationConfigType => visualizationConfigType && visualizationConfigType.type === type);
@@ -120,7 +127,7 @@ export default class AggregationControls extends React.Component<Props, State> {
     const childrenWithCallback = React.Children.map(children, child => React.cloneElement(child, { onVisualizationConfigChange: this._onVisualizationConfigChange }));
     const VisualizationConfigType = _visualizationConfigFor(visualization);
     return (
-      <span>
+      <Container>
         <Row>
           <Col md={2} style={{ paddingRight: '2px', paddingLeft: '10px' }}>
             <DescriptionBox description="Visualization Type">
@@ -152,9 +159,9 @@ export default class AggregationControls extends React.Component<Props, State> {
             </DescriptionBox>
           </Col>
         </Row>
-        <Row style={{ height: 'calc(100% - 110px)' }}>
-          <Col md={2} style={{ paddingRight: '2px', paddingLeft: '10px' }}>
-            <DescriptionBox description="Metrics" help="The unit which is tracked for every row and subcolumn.">
+        <Row style={{ overflowX: 'hidden' }}>
+          <Col md={2} style={{ paddingRight: '2px', paddingLeft: '10px', height: '100%', overflowY: 'auto' }}>
+            <DescriptionBox description="Metrics" help="The unit which is tracked for every row and subcolumn." style={{ marginTop: 0 }}>
               <SeriesSelect onChange={this._onSeriesChange} series={series} suggester={suggester} />
             </DescriptionBox>
             {showEventConfiguration && (
@@ -170,11 +177,11 @@ export default class AggregationControls extends React.Component<Props, State> {
               </DescriptionBox>
             )}
           </Col>
-          <Col md={10} style={{ height: '100%', paddingLeft: '7px', marginTop: '5px' }}>
+          <Col md={10} style={{ height: '100%', paddingLeft: '7px' }}>
             {childrenWithCallback}
           </Col>
         </Row>
-      </span>
+      </Container>
     );
   }
 }

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/DescriptionBox.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/DescriptionBox.jsx
@@ -12,12 +12,16 @@ import HoverForHelp from './HoverForHelp';
 export default class DescriptionBox extends React.Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
-    description: PropTypes.string.isRequired,
     configurableOptions: PropTypes.node,
+    description: PropTypes.string.isRequired,
+    help: PropTypes.string,
+    style: PropTypes.object,
   };
 
   static defaultProps = {
     configurableOptions: undefined,
+    style: undefined,
+    help: undefined,
   };
 
   constructor(props) {
@@ -29,15 +33,19 @@ export default class DescriptionBox extends React.Component {
   }
 
   onToggleConfig = () => {
-    this.setState({ configOpen: !this.state.configOpen });
+    const { configOpen } = this.state;
+    this.setState({ configOpen: !configOpen });
   };
 
   configPopover = () => {
-    if (!this.state.configOpen) {
+    const { configOpen } = this.state;
+    const { configurableOptions } = this.props;
+
+    if (!configOpen) {
       return '';
     }
 
-    const configurableElement = React.cloneElement(this.props.configurableOptions, {
+    const configurableElement = React.cloneElement(configurableOptions, {
       onClose: this.onToggleConfig,
     });
 
@@ -55,7 +63,8 @@ export default class DescriptionBox extends React.Component {
   };
 
   configCaret = () => {
-    if (this.props.configurableOptions) {
+    const { configurableOptions } = this.props;
+    if (configurableOptions) {
       return (
         <Icon ref={(node) => { this.target = node; }}
               role="button"
@@ -68,9 +77,9 @@ export default class DescriptionBox extends React.Component {
   };
 
   render() {
-    const { description, children, help } = this.props;
+    const { description, children, help, style: inlineStyle } = this.props;
     return (
-      <div className={styles.descriptionBox}>
+      <div className={styles.descriptionBox} style={inlineStyle}>
         <div className={styles.description}>{description} {this.configCaret()} {help && <HoverForHelp title={description}>{help}</HoverForHelp>}</div>
         {children}
         {this.configPopover()}

--- a/graylog2-web-interface/src/views/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.jsx
@@ -269,7 +269,6 @@ class Widget extends React.Component<Props, State> {
                              type={widget.type}
                              onChange={newWidgetConfig => this._onWidgetConfigChange(id, newWidgetConfig)}>
                 <WidgetErrorBoundary>
-
                   {visualization}
                 </WidgetErrorBoundary>
               </EditComponent>
@@ -315,7 +314,6 @@ class Widget extends React.Component<Props, State> {
             )}
           </InteractiveContext.Consumer>
           <WidgetErrorBoundary>
-
             {visualization}
           </WidgetErrorBoundary>
         </WidgetFrame>


### PR DESCRIPTION
This PR fixes the horizontal scrolling / overflow problem described in #7109 and also the vertical scrolling problem described in #7105 regarding the AggregationBuilder.

It looks like we could also get rid of `MeasureDimensions`, used in `Widget.jsx`, it is just passing the container height to its children, but I don't see any benefit. I am not doing this refactoring inside this PR, because I want to avoid a bigger layout change at this moment.

## How Has This Been Tested?
Tested in Chrome, Firefox and Safari

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

