### PR TITLE
Duplicate query/timerange/streams/filter for specific field/value actions.

### DIFF
--- a/graylog2-web-interface/src/views/logic/fieldactions/AggregateActionHandler.js
+++ b/graylog2-web-interface/src/views/logic/fieldactions/AggregateActionHandler.js
@@ -7,8 +7,9 @@ import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationW
 import Series from 'views/logic/aggregationbuilder/Series';
 import DataTable from 'views/components/datatable/DataTable';
 import type { FieldActionHandler } from './FieldActionHandler';
+import duplicateCommonWidgetSettings from './DuplicateCommonWidgetSettings';
 
-const AggregateActionHandler: FieldActionHandler = ({ field, type, contexts: { widget: origWidget = Widget.empty() } }) => {
+const AggregateActionHandler: FieldActionHandler = ({ field, type, contexts: { widget = Widget.empty() } }) => {
   const newWidgetBuilder = AggregationWidget.builder()
     .newId()
     .config(AggregationWidgetConfig.builder()
@@ -16,10 +17,9 @@ const AggregateActionHandler: FieldActionHandler = ({ field, type, contexts: { w
       .series([Series.forFunction('count()')])
       .visualization(DataTable.type)
       .build());
-  if (origWidget.filter) {
-    newWidgetBuilder.filter(origWidget.filter);
-  }
-  return WidgetActions.create(newWidgetBuilder.build());
+  const newWidget = duplicateCommonWidgetSettings(newWidgetBuilder, widget).build();
+
+  return WidgetActions.create(newWidget);
 };
 
 export default AggregateActionHandler;

--- a/graylog2-web-interface/src/views/logic/fieldactions/AggregateActionHandler.test.jsx
+++ b/graylog2-web-interface/src/views/logic/fieldactions/AggregateActionHandler.test.jsx
@@ -8,6 +8,7 @@ import FieldType from '../fieldtypes/FieldType';
 import AggregationWidget from '../aggregationbuilder/AggregationWidget';
 import Pivot from '../aggregationbuilder/Pivot';
 import Widget from '../widgets/Widget';
+import { createElasticsearchQueryString } from '../queries/Query';
 
 jest.mock('views/stores/WidgetStore', () => ({ WidgetActions: {} }));
 jest.mock('views/components/datatable/DataTable', () => ({ type: 'table' }));
@@ -28,12 +29,36 @@ describe('AggregateActionHandler', () => {
 
   it('uses field type when generating widget', () => {
     WidgetActions.create = mockAction(jest.fn((widget: Widget) => Promise.resolve(widget)));
-    const filter = "author: 'Vanth'";
+    const filter = 'author: "Vanth"';
     const origWidget = Widget.builder().filter(filter).build();
     AggregateActionHandler({ queryId: 'queryId', field: 'foo', type: new FieldType('keyword', [], []), contexts: { widget: origWidget } });
 
     expect(WidgetActions.create).toHaveBeenCalled();
     const widget: AggregationWidget = asMock(WidgetActions.create).mock.calls[0][0];
     expect(widget.filter).toEqual(filter);
+  });
+
+  it('duplicates query/timerange/streams/filter of original widget', () => {
+    WidgetActions.create = mockAction(jest.fn((widget: Widget) => Promise.resolve(widget)));
+    const origWidget = Widget.builder()
+      .filter('author: "Vanth"')
+      .query(createElasticsearchQueryString('foo:42'))
+      .streams(['stream1', 'stream23'])
+      .timerange({ type: 'relative', range: 3600 })
+      .build();
+
+    AggregateActionHandler({
+      queryId: 'queryId',
+      field: 'foo',
+      type: new FieldType('keyword', [], []),
+      contexts: { widget: origWidget },
+    });
+
+    expect(WidgetActions.create).toHaveBeenCalled();
+    const { filter, query, streams, timerange }: AggregationWidget = asMock(WidgetActions.create).mock.calls[0][0];
+    expect(filter).toEqual('author: "Vanth"');
+    expect(query).toEqual(createElasticsearchQueryString('foo:42'));
+    expect(streams).toEqual(['stream1', 'stream23']);
+    expect(timerange).toEqual({ type: 'relative', range: 3600 });
   });
 });

--- a/graylog2-web-interface/src/views/logic/fieldactions/ChartActionHandler.js
+++ b/graylog2-web-interface/src/views/logic/fieldactions/ChartActionHandler.js
@@ -12,6 +12,7 @@ import type { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
 import type { FieldActionHandler } from './FieldActionHandler';
 import FieldType from '../fieldtypes/FieldType';
 import FieldTypeMapping from '../fieldtypes/FieldTypeMapping';
+import duplicateCommonWidgetSettings from './DuplicateCommonWidgetSettings';
 
 const TIMESTAMP_FIELD = 'timestamp';
 
@@ -46,10 +47,7 @@ const ChartActionHandler: FieldActionHandler = ({ queryId, field, contexts: { wi
     .newId()
     .config(config);
 
-  if (origWidget.filter) {
-    widgetBuilder.filter(origWidget.filter);
-  }
-  const widget = widgetBuilder.build();
+  const widget = duplicateCommonWidgetSettings(widgetBuilder, origWidget).build();
   return WidgetActions.create(widget);
 };
 

--- a/graylog2-web-interface/src/views/logic/fieldactions/ChartActionHandler.test.js
+++ b/graylog2-web-interface/src/views/logic/fieldactions/ChartActionHandler.test.js
@@ -11,6 +11,8 @@ import Series from 'views/logic/aggregationbuilder/Series';
 import FieldTypeMapping from '../fieldtypes/FieldTypeMapping';
 import FieldType from '../fieldtypes/FieldType';
 import ChartActionHandler from './ChartActionHandler';
+import { createElasticsearchQueryString } from '../queries/Query';
+import AggregationWidget from '../aggregationbuilder/AggregationWidget';
 
 jest.mock('views/stores/FieldTypesStore', () => ({ FieldTypesStore: { getInitialState: jest.fn() } }));
 jest.mock('views/stores/WidgetStore', () => ({
@@ -151,6 +153,28 @@ describe('ChartActionHandler', () => {
 
       expect(widget.filter).toEqual(filter);
       expect(pivotForField).toHaveBeenCalledWith('timestamp', timestampFieldType);
+    });
+    it('duplicates query/timerange/streams/filter of original widget', () => {
+      const origWidget = Widget.builder()
+        .filter('author: "Vanth"')
+        .query(createElasticsearchQueryString('foo:42'))
+        .streams(['stream1', 'stream23'])
+        .timerange({ type: 'relative', range: 3600 })
+        .build();
+
+      ChartActionHandler({
+        queryId: 'queryId',
+        field: 'foo',
+        type: new FieldType('keyword', [], []),
+        contexts: { widget: origWidget },
+      });
+
+      expect(WidgetActions.create).toHaveBeenCalled();
+      const { filter, query, streams, timerange }: AggregationWidget = asMock(WidgetActions.create).mock.calls[0][0];
+      expect(filter).toEqual('author: "Vanth"');
+      expect(query).toEqual(createElasticsearchQueryString('foo:42'));
+      expect(streams).toEqual(['stream1', 'stream23']);
+      expect(timerange).toEqual({ type: 'relative', range: 3600 });
     });
   });
 });

--- a/graylog2-web-interface/src/views/logic/fieldactions/DuplicateCommonWidgetSettings.js
+++ b/graylog2-web-interface/src/views/logic/fieldactions/DuplicateCommonWidgetSettings.js
@@ -1,0 +1,22 @@
+// @flow strict
+import Widget from '../widgets/Widget';
+
+const duplicateCommonWidgetSettings = (widgetBuilder: Widget.Builder, originalWidget: Widget) => {
+  let result = widgetBuilder;
+  const { filter, query, streams, timerange } = originalWidget;
+  if (filter) {
+    result = result.filter(filter);
+  }
+  if (query) {
+    result = result.query(query)
+  }
+  if (streams) {
+    result = result.streams(streams);
+  }
+  if (timerange) {
+    result = result.timerange(timerange);
+  }
+  return result;
+};
+
+export default duplicateCommonWidgetSettings;

--- a/graylog2-web-interface/src/views/logic/fieldactions/DuplicateCommonWidgetSettings.js
+++ b/graylog2-web-interface/src/views/logic/fieldactions/DuplicateCommonWidgetSettings.js
@@ -8,7 +8,7 @@ const duplicateCommonWidgetSettings = (widgetBuilder: Widget.Builder, originalWi
     result = result.filter(filter);
   }
   if (query) {
-    result = result.query(query)
+    result = result.query(query);
   }
   if (streams) {
     result = result.streams(streams);

--- a/graylog2-web-interface/src/views/logic/fieldactions/DuplicateCommonWidgetSettings.test.jsx
+++ b/graylog2-web-interface/src/views/logic/fieldactions/DuplicateCommonWidgetSettings.test.jsx
@@ -1,0 +1,55 @@
+// @flow strict
+import Widget from '../widgets/Widget';
+import DuplicateCommonWidgetSettings from './DuplicateCommonWidgetSettings';
+import { createElasticsearchQueryString } from '../queries/Query';
+
+describe('DuplicateCommonWidgetSettings', () => {
+  it('does not do anything if no query/filter/timerange/streams are defined', () => {
+    const widget = Widget.builder().build();
+    const widgetBuilder = Widget.builder();
+
+    const result = DuplicateCommonWidgetSettings(widgetBuilder, widget);
+
+    expect(result).toEqual(widgetBuilder);
+  });
+  it('duplicates query if present', () => {
+    const widget = Widget.builder()
+      .query(createElasticsearchQueryString('hello:world'))
+      .build();
+    const widgetBuilder = Widget.builder();
+
+    const result = DuplicateCommonWidgetSettings(widgetBuilder, widget);
+
+    expect(result.build().query).toEqual(createElasticsearchQueryString('hello:world'));
+  });
+  it('duplicates filter if present', () => {
+    const widget = Widget.builder()
+      .filter('hello:world')
+      .build();
+    const widgetBuilder = Widget.builder();
+
+    const result = DuplicateCommonWidgetSettings(widgetBuilder, widget);
+
+    expect(result.build().filter).toEqual('hello:world');
+  });
+  it('duplicates timerange if present', () => {
+    const widget = Widget.builder()
+      .timerange({ type: 'relative', range: 3600 })
+      .build();
+    const widgetBuilder = Widget.builder();
+
+    const result = DuplicateCommonWidgetSettings(widgetBuilder, widget);
+
+    expect(result.build().timerange).toEqual({ type: 'relative', range: 3600 });
+  });
+  it('duplicates streams if present', () => {
+    const widget = Widget.builder()
+      .streams(['stream1', 'stream23', 'stream42'])
+      .build();
+    const widgetBuilder = Widget.builder();
+
+    const result = DuplicateCommonWidgetSettings(widgetBuilder, widget);
+
+    expect(result.build().streams).toEqual(['stream1', 'stream23', 'stream42']);
+  });
+});

--- a/graylog2-web-interface/src/views/logic/fieldactions/FieldStatisticsHandler.js
+++ b/graylog2-web-interface/src/views/logic/fieldactions/FieldStatisticsHandler.js
@@ -6,6 +6,7 @@ import AggregationWidget from 'views/logic/aggregationbuilder/AggregationWidget'
 import Series from 'views/logic/aggregationbuilder/Series';
 import { TitlesActions, TitleTypes } from 'views/stores/TitlesStore';
 import type { FieldActionHandler } from './FieldActionHandler';
+import duplicateCommonWidgetSettings from './DuplicateCommonWidgetSettings';
 
 const NUMERIC_FIELD_SERIES = ['count', 'sum', 'avg', 'min', 'max', 'stddev', 'variance', 'card', 'percentile'];
 const NONNUMERIC_FIELD_SERIES = ['count', 'card'];
@@ -28,10 +29,7 @@ const handler: FieldActionHandler = ({ field, type, contexts: { widget: origWidg
     .newId()
     .config(config);
 
-  if (origWidget.filter) {
-    widgetBuilder.filter(origWidget.filter);
-  }
-  const widget = widgetBuilder.build();
+  const widget = duplicateCommonWidgetSettings(widgetBuilder, origWidget).build();
 
   return WidgetActions.create(widget).then(newWidget => TitlesActions.set(TitleTypes.Widget, newWidget.id, `Field Statistics for ${field}`));
 };

--- a/graylog2-web-interface/src/views/logic/fieldactions/FieldStatisticsHandler.test.js
+++ b/graylog2-web-interface/src/views/logic/fieldactions/FieldStatisticsHandler.test.js
@@ -6,6 +6,9 @@ import Widget from 'views/logic/widgets/Widget';
 import { TitlesActions, TitleTypes } from 'views/stores/TitlesStore';
 import handler from './FieldStatisticsHandler';
 import FieldType from '../fieldtypes/FieldType';
+import { createElasticsearchQueryString } from '../queries/Query';
+import ChartActionHandler from './ChartActionHandler';
+import AggregationWidget from '../aggregationbuilder/AggregationWidget';
 
 jest.mock('views/stores/WidgetStore', () => ({
   WidgetActions: {
@@ -76,6 +79,28 @@ describe('FieldStatisticsHandler', () => {
       const widget = asMock(WidgetActions.create).mock.calls[0][0];
 
       expect(TitlesActions.set).toHaveBeenCalledWith(TitleTypes.Widget, widget.id, `Field Statistics for ${fieldName}`);
+    });
+  });
+  it('duplicates query/timerange/streams/filter of original widget', () => {
+    const origWidget = Widget.builder()
+      .filter('author: "Vanth"')
+      .query(createElasticsearchQueryString('foo:42'))
+      .streams(['stream1', 'stream23'])
+      .timerange({ type: 'relative', range: 3600 })
+      .build();
+
+    return handler({
+      queryId,
+      field: fieldName,
+      type: nonNumericFieldType,
+      contexts: { widget: origWidget },
+    }).then(() => {
+      expect(WidgetActions.create).toHaveBeenCalled();
+      const { filter, query, streams, timerange }: AggregationWidget = asMock(WidgetActions.create).mock.calls[0][0];
+      expect(filter).toEqual('author: "Vanth"');
+      expect(query).toEqual(createElasticsearchQueryString('foo:42'));
+      expect(streams).toEqual(['stream1', 'stream23']);
+      expect(timerange).toEqual({ type: 'relative', range: 3600 });
     });
   });
 });

--- a/graylog2-web-interface/src/views/logic/fieldactions/FieldStatisticsHandler.test.js
+++ b/graylog2-web-interface/src/views/logic/fieldactions/FieldStatisticsHandler.test.js
@@ -7,7 +7,6 @@ import { TitlesActions, TitleTypes } from 'views/stores/TitlesStore';
 import handler from './FieldStatisticsHandler';
 import FieldType from '../fieldtypes/FieldType';
 import { createElasticsearchQueryString } from '../queries/Query';
-import ChartActionHandler from './ChartActionHandler';
 import AggregationWidget from '../aggregationbuilder/AggregationWidget';
 
 jest.mock('views/stores/WidgetStore', () => ({

--- a/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.js
+++ b/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.js
@@ -49,9 +49,6 @@ const ShowDocumentsHandler: ValueActionHandler = ({ contexts: { valuePath, widge
       .showMessageRow(true).build())
     .build();
 
-  const newWidget = (view && view.type === View.Type.Dashboard)
-    ? newWidgetBuilder.timerange(widget.timerange).streams(widget.streams).build()
-    : newWidgetBuilder.build();
   const title = `Messages for ${valuePathQuery}`;
   return WidgetActions.create(newWidget).then(() => TitlesActions.set(TitleTypes.Widget, newWidget.id, title));
 };

--- a/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.js
+++ b/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.js
@@ -11,6 +11,7 @@ import View from '../views/View';
 import Widget from '../widgets/Widget';
 import { createElasticsearchQueryString } from '../queries/Query';
 import { TitlesActions } from '../../stores/TitlesStore';
+import duplicateCommonWidgetSettings from '../fieldactions/DuplicateCommonWidgetSettings';
 
 type Contexts = {
   valuePath: ValuePath,
@@ -31,7 +32,7 @@ const extractFieldsFromValuePath = (valuePath: ValuePath): Array<string> => {
     .reduce((prev, cur) => (prev.includes(cur) ? prev : [...prev, cur]), []);
 };
 
-const ShowDocumentsHandler: ValueActionHandler = ({ contexts: { valuePath, widget, view } }: Arguments) => {
+const ShowDocumentsHandler: ValueActionHandler = ({ contexts: { valuePath, widget } }: Arguments) => {
   const mergedObject = valuePath.reduce((elem, acc) => ({ ...acc, ...elem }), {});
   const widgetQuery = widget && widget.query ? widget.query.query_string : '';
   const valuePathQuery = Object.entries(mergedObject)
@@ -40,12 +41,13 @@ const ShowDocumentsHandler: ValueActionHandler = ({ contexts: { valuePath, widge
   const query = addToQuery(widgetQuery, valuePathQuery);
   const valuePathFields = extractFieldsFromValuePath(valuePath);
   const messageListFields = new Set([...DEFAULT_MESSAGE_FIELDS, ...valuePathFields]);
-  const newWidgetBuilder = MessagesWidget.builder()
+  const newWidget = duplicateCommonWidgetSettings(MessagesWidget.builder(), widget)
     .query(createElasticsearchQueryString(query))
     .newId()
     .config(new MessagesWidgetConfig.builder()
       .fields([...messageListFields])
-      .showMessageRow(true).build());
+      .showMessageRow(true).build())
+    .build();
 
   const newWidget = (view && view.type === View.Type.Dashboard)
     ? newWidgetBuilder.timerange(widget.timerange).streams(widget.streams).build()

--- a/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.test.js
+++ b/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.test.js
@@ -11,6 +11,7 @@ import AggregationWidget from '../aggregationbuilder/AggregationWidget';
 import AggregationWidgetConfig from '../aggregationbuilder/AggregationWidgetConfig';
 import PivotGenerator from '../searchtypes/aggregation/PivotGenerator';
 import { createElasticsearchQueryString } from '../queries/Query';
+import Widget from '../widgets/Widget';
 
 jest.mock('views/stores/WidgetStore', () => ({
   WidgetActions: {
@@ -93,40 +94,31 @@ describe('ShowDocumentsHandler', () => {
       });
   });
   describe('on dashboard', () => {
-    const view = View.builder().type(View.Type.Dashboard).build();
-    it('copies timerange of original widget', () => {
-      const widgetWithFilter = widget.toBuilder()
-        .timerange({ type: 'relative', range: 1800 })
-        .query(createElasticsearchQueryString())
+    it('duplicates query/timerange/streams/filter of original widget', () => {
+      const origWidget = Widget.builder()
+        .filter('author: "Vanth"')
+        .query(createElasticsearchQueryString('foo:42'))
+        .streams(['stream1', 'stream23'])
+        .timerange({ type: 'relative', range: 3600 })
         .build();
+
       return ShowDocumentsHandler({
         queryId,
         field: 'hello',
         value: 'world',
         type: FieldType.Unknown,
-        contexts: { widget: widgetWithFilter, valuePath: [{ bar: 42 }, { hello: 'world' }], view },
-      })
-        .then(() => {
-          const newWidget = asMock(WidgetActions.create).mock.calls[0][0];
-          expect(newWidget.timerange).toEqual({ type: 'relative', range: 1800 });
-        });
-    });
-    it('copies timerange of original widget', () => {
-      const widgetWithFilter = widget.toBuilder()
-        .streams(['deadbeef', 'cafecafe'])
-        .query(createElasticsearchQueryString())
-        .build();
-      return ShowDocumentsHandler({
-        queryId,
-        field: 'hello',
-        value: 'world',
-        type: FieldType.Unknown,
-        contexts: { widget: widgetWithFilter, valuePath: [{ bar: 42 }, { hello: 'world' }], view },
-      })
-        .then(() => {
-          const newWidget = asMock(WidgetActions.create).mock.calls[0][0];
-          expect(newWidget.streams).toEqual(['deadbeef', 'cafecafe']);
-        });
+        contexts: {
+          widget: origWidget,
+          valuePath: [{ bar: 42 }, { hello: 'world' }],
+        },
+      }).then(() => {
+        expect(WidgetActions.create).toHaveBeenCalled();
+        const { filter, query, streams, timerange }: AggregationWidget = asMock(WidgetActions.create).mock.calls[0][0];
+        expect(filter).toEqual('author: "Vanth"');
+        expect(query).toEqual(createElasticsearchQueryString('foo:42 AND hello:world AND bar:42'));
+        expect(streams).toEqual(['stream1', 'stream23']);
+        expect(timerange).toEqual({ type: 'relative', range: 3600 });
+      });
     });
   });
 });

--- a/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.test.js
+++ b/graylog2-web-interface/src/views/logic/valueactions/ShowDocumentsHandler.test.js
@@ -4,7 +4,6 @@ import FieldType from 'views/logic/fieldtypes/FieldType';
 import asMock from 'helpers/mocking/AsMock';
 import { TitlesActions } from 'views/stores/TitlesStore';
 import TitleTypes from 'views/stores/TitleTypes';
-import View from 'views/logic/views/View';
 import { WidgetActions } from 'views/stores/WidgetStore';
 import ShowDocumentsHandler from './ShowDocumentsHandler';
 import AggregationWidget from '../aggregationbuilder/AggregationWidget';


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, several field actions ("Chart", "Aggregate", "Statistics") and the "Show documents for value" value action did not duplicate the context of the widget they were triggered from, although the user most certainly expects that. This led to differing results.

When a user e.g. clicks on the "Show documents for value" action on a value of a filtered down (or extended through a bigger time range) result, the widget created from the action did not contain the same query/timerange/streams/filter settings but the default ones, and therefore referred to a different set of documents.

This change is creating a shared function which duplicates these settings from a given widget and is supposed to be used by any action that creates a new widget that is supposed to work in the same context as the widget it was triggered from. This shared function is used in the aforementioned actions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.