### PR TITLE
Use Urlwhitelist API instead of clusterConfig API

### DIFF
--- a/graylog2-web-interface/src/actions/configurations/ConfigurationActions.js
+++ b/graylog2-web-interface/src/actions/configurations/ConfigurationActions.js
@@ -7,6 +7,7 @@ const ConfigurationActions = Reflux.createActions({
   listEventsClusterConfig: { asyncResult: true },
   listWhiteListConfig: { asyncResult: true },
   update: { asyncResult: true },
+  updateWhitelist: { asyncResult: true },
   updateMessageProcessorsConfig: { asyncResult: true },
 });
 

--- a/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
+++ b/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
@@ -60,6 +60,8 @@ class ConfigurationsPage extends React.Component {
       switch (configType) {
         case MESSAGE_PROCESSORS_CONFIG:
           return ConfigurationsActions.updateMessageProcessorsConfig(configType, config);
+        case URL_WHITELIST_CONFIG:
+          return ConfigurationsActions.updateWhitelist(configType, config);
         default:
           return ConfigurationsActions.update(configType, config);
       }

--- a/graylog2-web-interface/src/stores/configurations/ConfigurationsStore.js
+++ b/graylog2-web-interface/src/stores/configurations/ConfigurationsStore.js
@@ -122,11 +122,11 @@ const ConfigurationsStore = Reflux.createStore({
       () => {
         this.configuration[configType] = config;
         this.propagateChanges();
-        UserNotification.success('Configuration updated successfully');
+        UserNotification.success('Url Whitelist Configuration updated successfully');
         return config;
       },
       (error) => {
-        UserNotification.error(`Search config update failed: ${error}`, `Could not update search config: ${configType}`);
+        UserNotification.error(`Url Whitelist config update failed: ${error}`, `Could not update search config: ${configType}`);
       },
     );
 

--- a/graylog2-web-interface/src/stores/configurations/ConfigurationsStore.js
+++ b/graylog2-web-interface/src/stores/configurations/ConfigurationsStore.js
@@ -115,6 +115,24 @@ const ConfigurationsStore = Reflux.createStore({
     ConfigurationActions.update.promise(promise);
   },
 
+  updateWhitelist(configType, config) {
+    const promise = fetch('PUT', URLUtils.qualifyUrl('/system/urlwhitelist'), config);
+
+    promise.then(
+      () => {
+        this.configuration[configType] = config;
+        this.propagateChanges();
+        UserNotification.success('Configuration updated successfully');
+        return config;
+      },
+      (error) => {
+        UserNotification.error(`Search config update failed: ${error}`, `Could not update search config: ${configType}`);
+      },
+    );
+
+    ConfigurationActions.updateWhitelist.promise(promise);
+  },
+
   updateMessageProcessorsConfig(configType, config) {
     const promise = fetch('PUT', URLUtils.qualifyUrl('/system/messageprocessors/config'), config);
 


### PR DESCRIPTION
Before this change we were using ClusterConfig API to update
Urlwhitelist, result of that audit log shows cluster config event
instead of Urlwhitelist event.

* Add updateWhitelist method to store
* Update ConfigurationsPage to use updateWhitelist when updating
urlwhitelist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

