### PR TITLE
Disabling field actions if not applicable to current field/function.

### DIFF
--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -193,12 +193,12 @@ export default {
       type: 'aggregate',
       title: 'Aggregate',
       handler: AggregateActionHandler,
-      isEnabled: (({ type }) => (!type.isCompound() && !type.isDecorated()): ActionHandlerCondition),
+      isEnabled: (({ field, type }) => (!isFunction(field) && !type.isCompound() && !type.isDecorated()): ActionHandlerCondition),
     },
     {
       type: 'statistics',
       title: 'Statistics',
-      isEnabled: (({ type }) => !type.isDecorated(): ActionHandlerCondition),
+      isEnabled: (({ field, type }) => (!isFunction(field) && !type.isDecorated()): ActionHandlerCondition),
       handler: FieldStatisticsHandler,
     },
     {
@@ -209,7 +209,7 @@ export default {
       isHidden: AddToTableActionHandler.isHidden,
     },
     {
-      type: 'remove-to-table',
+      type: 'remove-from-table',
       title: 'Remove from table',
       handler: RemoveFromTableActionHandler,
       isEnabled: RemoveFromTableActionHandler.isEnabled,
@@ -219,13 +219,13 @@ export default {
       type: 'add-to-all-tables',
       title: 'Add to all tables',
       handler: AddToAllTablesActionHandler,
-      isEnabled: (({ type }) => !type.isDecorated(): ActionHandlerCondition),
+      isEnabled: (({ field, type }) => (!isFunction(field) && !type.isDecorated()): ActionHandlerCondition),
     },
     {
       type: 'remove-from-all-tables',
       title: 'Remove from all tables',
       handler: RemoveFromAllTablesActionHandler,
-      isEnabled: (({ type }) => !type.isDecorated(): ActionHandlerCondition),
+      isEnabled: (({ field, type }) => (!isFunction(field) && !type.isDecorated()): ActionHandlerCondition),
     },
   ],
   valueActions: [

--- a/graylog2-web-interface/src/views/bindings.test.jsx
+++ b/graylog2-web-interface/src/views/bindings.test.jsx
@@ -1,0 +1,159 @@
+// @flow strict
+import FieldType, { FieldTypes, Properties } from 'views/logic/fieldtypes/FieldType';
+import bindings from './bindings';
+import type { ActionHandlerCondition } from './components/actions/ActionHandler';
+
+describe('Views bindings', () => {
+  describe('field actions', () => {
+    const { fieldActions } = bindings;
+    type FieldAction = {
+      isEnabled: ActionHandlerCondition,
+    };
+    const defaultArguments = {
+      queryId: 'query1',
+      contexts: {},
+      type: FieldType.Unknown,
+    };
+    const findAction = type => fieldActions.find(binding => binding.type === type);
+    describe('Aggregate', () => {
+      // $FlowFixMe: We are assuming here it is generally present
+      const action: FieldAction = findAction('aggregate');
+      const { isEnabled } = action;
+      it('is present', () => {
+        expect(action).toBeDefined();
+      });
+      it('has `isEnabled` condition', () => {
+        expect(isEnabled).toBeDefined();
+      });
+      it('should be disabled for functions', () => {
+        expect(isEnabled({ ...defaultArguments, field: 'avg(something)' }))
+          .toEqual(false);
+      });
+      it('should be enabled for fields', () => {
+        expect(isEnabled({ ...defaultArguments, field: 'something', type: FieldTypes.STRING() }))
+          .toEqual(true);
+      });
+      it('should be disabled for compound fields', () => {
+        expect(isEnabled({
+          ...defaultArguments,
+          field: 'something',
+          type: FieldType.create('string', [Properties.Compound]),
+        }))
+          .toEqual(false);
+      });
+      it('should be disabled for decorated fields', () => {
+        expect(isEnabled({
+          ...defaultArguments,
+          field: 'something',
+          type: FieldType.create('string', [Properties.Decorated]),
+        }))
+          .toEqual(false);
+      });
+    });
+    describe('Statistics', () => {
+      // $FlowFixMe: We are assuming here it is generally present
+      const action: FieldAction = findAction('statistics');
+      const { isEnabled } = action;
+      it('is present', () => {
+        expect(action).toBeDefined();
+      });
+      it('has `isEnabled` condition', () => {
+        expect(isEnabled).toBeDefined();
+      });
+      it('should be disabled for functions', () => {
+        expect(isEnabled({ ...defaultArguments, field: 'avg(something)' }))
+          .toEqual(false);
+      });
+      it('should be enabled for fields', () => {
+        expect(isEnabled({ ...defaultArguments, field: 'something', type: FieldTypes.STRING() }))
+          .toEqual(true);
+      });
+      it('should be enabled for compound fields', () => {
+        expect(isEnabled({
+          ...defaultArguments,
+          field: 'something',
+          type: FieldType.create('string', [Properties.Compound]),
+        }))
+          .toEqual(true);
+      });
+      it('should be disabled for decorated fields', () => {
+        expect(isEnabled({
+          ...defaultArguments,
+          field: 'something',
+          type: FieldType.create('string', [Properties.Decorated]),
+        }))
+          .toEqual(false);
+      });
+    });
+    describe('AddToAllTables', () => {
+      // $FlowFixMe: We are assuming here it is generally present
+      const action: FieldAction = findAction('add-to-all-tables');
+      const { isEnabled } = action;
+      it('is present', () => {
+        expect(action).toBeDefined();
+      });
+      it('has `isEnabled` condition', () => {
+        expect(isEnabled).toBeDefined();
+      });
+      it('should be disabled for functions', () => {
+        expect(isEnabled({ ...defaultArguments, field: 'avg(something)' }))
+          .toEqual(false);
+      });
+      it('should be enabled for fields', () => {
+        expect(isEnabled({ ...defaultArguments, field: 'something', type: FieldTypes.STRING() }))
+          .toEqual(true);
+      });
+      it('should be enabled for compound fields', () => {
+        expect(isEnabled({
+          ...defaultArguments,
+          field: 'something',
+          type: FieldType.create('string', [Properties.Compound]),
+        }))
+          .toEqual(true);
+      });
+      it('should be disabled for decorated fields', () => {
+        expect(isEnabled({
+          ...defaultArguments,
+          field: 'something',
+          type: FieldType.create('string', [Properties.Decorated]),
+        }))
+          .toEqual(false);
+      });
+    });
+    describe('RemoveFromAllTables', () => {
+      // $FlowFixMe: We are assuming here it is generally present
+      const action: FieldAction = findAction('remove-from-all-tables');
+      const { isEnabled } = action;
+      it('is present', () => {
+        expect(action).toBeDefined();
+      });
+      it('has `isEnabled` condition', () => {
+        expect(isEnabled).toBeDefined();
+      });
+      it('should be disabled for functions', () => {
+        expect(isEnabled({ ...defaultArguments, field: 'avg(something)' }))
+          .toEqual(false);
+      });
+      it('should be enabled for fields', () => {
+        expect(isEnabled({ ...defaultArguments, field: 'something', type: FieldTypes.STRING() }))
+          .toEqual(true);
+      });
+      it('should be enabled for compound fields', () => {
+        expect(isEnabled({
+          ...defaultArguments,
+          field: 'something',
+          type: FieldType.create('string', [Properties.Compound]),
+        }))
+          .toEqual(true);
+      });
+      it('should be disabled for decorated fields', () => {
+        expect(isEnabled({
+          ...defaultArguments,
+          field: 'something',
+          type: FieldType.create('string', [Properties.Decorated]),
+        }))
+          .toEqual(false);
+      });
+    });
+  });
+});

--- a/graylog2-web-interface/src/views/logic/fieldactions/ChartActionHandler.js
+++ b/graylog2-web-interface/src/views/logic/fieldactions/ChartActionHandler.js
@@ -6,7 +6,7 @@ import { WidgetActions } from 'views/stores/WidgetStore';
 import pivotForField from 'views/logic/searchtypes/aggregation/PivotGenerator';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import AggregationWidget from 'views/logic/aggregationbuilder/AggregationWidget';
-import Series from 'views/logic/aggregationbuilder/Series';
+import Series, { isFunction } from 'views/logic/aggregationbuilder/Series';
 import { FieldTypesStore } from 'views/stores/FieldTypesStore';
 import type { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
 import type { FieldActionHandler } from './FieldActionHandler';
@@ -35,9 +35,10 @@ const fieldTypeFor = (fieldName: string, queryId: string): FieldType => {
 };
 
 const ChartActionHandler: FieldActionHandler = ({ queryId, field, contexts: { widget: origWidget = Widget.empty() } }) => {
+  const series = isFunction(field) ? Series.forFunction(field) : Series.forFunction(`avg(${field})`);
   const config = AggregationWidgetConfig.builder()
     .rowPivots([pivotForField(TIMESTAMP_FIELD, fieldTypeFor(TIMESTAMP_FIELD, queryId))])
-    .series([Series.forFunction(`avg(${field})`)])
+    .series([series])
     .visualization('line')
     .rollup(true)
     .build();

--- a/graylog2-web-interface/src/views/logic/fieldactions/ChartActionHandler.test.js
+++ b/graylog2-web-interface/src/views/logic/fieldactions/ChartActionHandler.test.js
@@ -7,6 +7,7 @@ import Widget from 'views/logic/widgets/Widget';
 import { WidgetActions } from 'views/stores/WidgetStore';
 import { FieldTypesStore } from 'views/stores/FieldTypesStore';
 import pivotForField from 'views/logic/searchtypes/aggregation/PivotGenerator';
+import Series from 'views/logic/aggregationbuilder/Series';
 import FieldTypeMapping from '../fieldtypes/FieldTypeMapping';
 import FieldType from '../fieldtypes/FieldType';
 import ChartActionHandler from './ChartActionHandler';
@@ -21,6 +22,26 @@ jest.mock('views/logic/searchtypes/aggregation/PivotGenerator', () => jest.fn())
 
 describe('ChartActionHandler', () => {
   const emptyFieldType = new FieldType('empty', [], []);
+
+  it('uses average function if triggered on field', async () => {
+    await ChartActionHandler({ queryId: 'queryId', field: 'somefield', type: emptyFieldType, contexts: {} });
+
+    expect(WidgetActions.create).toHaveBeenCalledWith(expect.objectContaining({
+      config: expect.objectContaining({
+        series: [Series.forFunction('avg(somefield)')],
+      }),
+    }));
+  });
+
+  it('uses the function itself if it was triggered on one', async () => {
+    await ChartActionHandler({ queryId: 'queryId', field: 'max(somefield)', type: emptyFieldType, contexts: {} });
+
+    expect(WidgetActions.create).toHaveBeenCalledWith(expect.objectContaining({
+      config: expect.objectContaining({
+        series: [Series.forFunction('max(somefield)')],
+      }),
+    }));
+  });
 
   describe('retrieves field type for `timestamp` field', () => {
     beforeEach(() => {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is correcting the conditions for enabling `Aggregate`, `Statistics`, `Add to all tables` & `Remove from all tables` if the current field is a function.

In addition, it changes the `Chart` action to use the function itself as the series for the newly created widget if it was triggered by clicking on a function instead of a field.

Fixes #7089.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.