### PR TITLE
Complete migration to React Select v2

### DIFF
--- a/graylog2-web-interface/src/components/common/Select.jsx
+++ b/graylog2-web-interface/src/components/common/Select.jsx
@@ -156,7 +156,7 @@ type Option = { [string]: any };
 type Props = {
   onChange: (string) => void,
   placeholder: string,
-  clearable: boolean,
+  clearable?: boolean,
   displayKey?: string,
   valueKey?: string,
   delimiter?: string,
@@ -214,6 +214,7 @@ class Select extends React.Component<Props, State> {
      */
     components: PropTypes.arrayOf(PropTypes.node),
     disabled: PropTypes.bool,
+    clearable: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -230,6 +231,7 @@ class Select extends React.Component<Props, State> {
     addLabelText: undefined,
     onReactSelectChange: undefined,
     components: null,
+    clearable: true,
   };
 
   constructor(props: Props) {
@@ -313,6 +315,7 @@ class Select extends React.Component<Props, State> {
     const {
       multi: isMulti = false,
       disabled: isDisabled = false,
+      clearable: isClearable,
       ...rest
     } = this.props;
 
@@ -321,6 +324,7 @@ class Select extends React.Component<Props, State> {
                        onChange={onReactSelectChange || this._onChange}
                        isMulti={isMulti}
                        isDisabled={isDisabled}
+                       isClearable={isClearable}
                        getOptionLabel={option => option[displayKey]}
                        getOptionValue={option => option[valueKey]}
                        components={{

--- a/graylog2-web-interface/src/components/common/Select.jsx
+++ b/graylog2-web-interface/src/components/common/Select.jsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import lodash from 'lodash';
 import PropTypes from 'prop-types';
-import ReactSelect, { components as Components, Creatable } from 'react-select';
+import ReactSelect, { components as Components, Creatable, createFilter } from 'react-select';
 
 import Icon from './Icon';
 
@@ -162,7 +162,7 @@ type Props = {
   delimiter?: string,
   options: Array<Option>,
   components: ?{string: React.Node},
-  matchProp?: string,
+  matchProp?: 'any' | 'label' | 'value',
   value?: string,
   autoFocus?: boolean,
   size?: 'normal' | 'small',
@@ -215,6 +215,7 @@ class Select extends React.Component<Props, State> {
     components: PropTypes.arrayOf(PropTypes.node),
     disabled: PropTypes.bool,
     clearable: PropTypes.bool,
+    matchProp: PropTypes.oneOf(['any', 'label', 'value']),
   };
 
   static defaultProps = {
@@ -225,7 +226,7 @@ class Select extends React.Component<Props, State> {
     delimiter: ',',
     allowCreate: false,
     value: undefined,
-    matchProp: undefined,
+    matchProp: 'any',
     autoFocus: false,
     disabled: false,
     addLabelText: undefined,
@@ -316,8 +317,12 @@ class Select extends React.Component<Props, State> {
       multi: isMulti,
       disabled: isDisabled,
       clearable: isClearable,
+      matchProp,
       ...rest
     } = this.props;
+
+    const stringify = option => option[matchProp];
+    const customFilter = matchProp === 'any' ? createFilter() : createFilter({ stringify });
 
     return (
       <SelectComponent {...rest}
@@ -327,6 +332,7 @@ class Select extends React.Component<Props, State> {
                        isClearable={isClearable}
                        getOptionLabel={option => option[displayKey]}
                        getOptionValue={option => option[valueKey]}
+                       filterOption={customFilter}
                        components={{
                          ..._components,
                          ...components,

--- a/graylog2-web-interface/src/components/common/Select.jsx
+++ b/graylog2-web-interface/src/components/common/Select.jsx
@@ -179,26 +179,26 @@ const _styles = props => ({
 });
 
 type Props = {
-  onChange: (string) => void,
-  placeholder: string,
-  clearable?: boolean,
-  displayKey?: string,
-  valueKey?: string,
-  delimiter?: string,
-  options: Array<Option>,
-  components: ?{string: React.Node},
-  matchProp?: 'any' | 'label' | 'value',
-  value?: string,
-  autoFocus?: boolean,
-  size?: 'normal' | 'small',
-  disabled?: boolean,
   addLabelText?: string,
   allowCreate?: boolean,
+  autoFocus?: boolean,
+  clearable?: boolean,
+  components: ?{string: React.Node},
+  delimiter?: string,
+  disabled?: boolean,
+  displayKey?: string,
+  inputProps?: { [string]: any },
+  matchProp?: 'any' | 'label' | 'value',
   multi?: boolean,
+  onChange: (string) => void,
   onReactSelectChange?: (Option | Array<Option>) => void,
   optionRenderer?: (Option) => React.Node,
+  options: Array<Option>,
+  placeholder: string,
+  size?: 'normal' | 'small',
+  value?: string,
+  valueKey?: string,
   valueRenderer?: (Option) => React.Node,
-  inputProps?: { [string]: any },
 };
 
 type State = {
@@ -208,6 +208,29 @@ type State = {
 
 class Select extends React.Component<Props, State> {
   static propTypes = {
+    /** Specifies if the user can create new entries in `multi` Selects. */
+    allowCreate: PropTypes.bool,
+    /** Indicates if the Select value is clearable or not. */
+    clearable: PropTypes.bool,
+    /**
+     * A collection of custom `react-select` components from https://react-select.com/components
+     */
+    components: PropTypes.objectOf(PropTypes.elementType),
+    /** Delimiter to use as value separator in `multi` Selects. */
+    delimiter: PropTypes.string,
+    /** Indicates whether the Select component is disabled or not. */
+    disabled: PropTypes.bool,
+    /** Indicates which option object key contains the text to display in the select input. Same as react-select's `labelKey` prop. */
+    displayKey: PropTypes.string,
+    /**
+     * @deprecated Use `inputId` or custom components with the `components` prop instead.
+     * Custom attributes for the input (inside the Select).
+     */
+    inputProps: PropTypes.object,
+    /** Indicates which option property to filter on. */
+    matchProp: PropTypes.oneOf(['any', 'label', 'value']),
+    /** Specifies if multiple values can be selected or not. */
+    multi: PropTypes.bool,
     /**
      * Callback when selected option changes. It receives the value of the
      * selected option as an argument. If `multi` is enabled, the passed
@@ -215,23 +238,6 @@ class Select extends React.Component<Props, State> {
      * options.
      */
     onChange: PropTypes.func.isRequired,
-    /** Size of the select input. */
-    size: PropTypes.oneOf(['normal', 'small']),
-    /**
-     * String containing the selected value. If `multi` is enabled, it must
-     * be a string containing all values separated by the `delimiter`.
-     */
-    value: PropTypes.string,
-    /** Specifies if multiple values can be selected or not. */
-    multi: PropTypes.bool,
-    /** Indicates which option object key contains the text to display in the select input. Same as react-select's `labelKey` prop. */
-    displayKey: PropTypes.string,
-    /** Indicates which option object key contains the value of the option. */
-    valueKey: PropTypes.string,
-    /** Delimiter to use as value separator in `multi` Selects. */
-    delimiter: PropTypes.string,
-    /** Specifies if the user can create new entries in `multi` Selects. */
-    allowCreate: PropTypes.bool,
     /**
      * Available options shown in the select field. It should be an array of objects,
      * each one with a display key (specified in `displayKey`), and a value key
@@ -239,36 +245,39 @@ class Select extends React.Component<Props, State> {
      * Options including an optional `disabled: true` key-value pair, will be disabled in the Select component.
      */
     options: PropTypes.array.isRequired,
-    /**
-     * A collection of custom `react-select` components from https://react-select.com/components
-     */
-    components: PropTypes.objectOf(PropTypes.elementType),
-    disabled: PropTypes.bool,
-    clearable: PropTypes.bool,
-    matchProp: PropTypes.oneOf(['any', 'label', 'value']),
+    /** Custom function to render the options in the menu. */
     optionRenderer: PropTypes.func,
+    /** Size of the select input. */
+    size: PropTypes.oneOf(['normal', 'small']),
+    /**
+     * String containing the selected value. If `multi` is enabled, it must
+     * be a string containing all values separated by the `delimiter`.
+     */
+    value: PropTypes.string,
+    /** Indicates which option object key contains the value of the option. */
+    valueKey: PropTypes.string,
+    /** Custom function to render the selected option in the Select. */
     valueRenderer: PropTypes.func,
-    inputProps: PropTypes.object,
   };
 
   static defaultProps = {
-    multi: false,
-    size: 'normal',
-    displayKey: 'label',
-    valueKey: 'value',
-    delimiter: ',',
-    allowCreate: false,
-    value: undefined,
-    matchProp: 'any',
-    autoFocus: false,
-    disabled: false,
     addLabelText: undefined,
-    onReactSelectChange: undefined,
-    components: null,
+    allowCreate: false,
+    autoFocus: false,
     clearable: true,
-    optionRenderer: undefined,
-    valueRenderer: undefined,
+    components: null,
+    delimiter: ',',
+    disabled: false,
+    displayKey: 'label',
     inputProps: undefined,
+    matchProp: 'any',
+    multi: false,
+    onReactSelectChange: undefined,
+    optionRenderer: undefined,
+    size: 'normal',
+    value: undefined,
+    valueKey: 'value',
+    valueRenderer: undefined,
   };
 
   constructor(props: Props) {

--- a/graylog2-web-interface/src/components/common/Select.jsx
+++ b/graylog2-web-interface/src/components/common/Select.jsx
@@ -213,6 +213,7 @@ class Select extends React.Component<Props, State> {
      * A collection of custom `react-select` components from https://react-select.com/components
      */
     components: PropTypes.arrayOf(PropTypes.node),
+    disabled: PropTypes.bool,
   };
 
   static defaultProps = {

--- a/graylog2-web-interface/src/components/common/Select.jsx
+++ b/graylog2-web-interface/src/components/common/Select.jsx
@@ -313,8 +313,8 @@ class Select extends React.Component<Props, State> {
     }
 
     const {
-      multi: isMulti = false,
-      disabled: isDisabled = false,
+      multi: isMulti,
+      disabled: isDisabled,
       clearable: isClearable,
       ...rest
     } = this.props;

--- a/graylog2-web-interface/src/components/common/Select.jsx
+++ b/graylog2-web-interface/src/components/common/Select.jsx
@@ -226,6 +226,7 @@ class Select extends React.Component<Props, State> {
      * Available options shown in the select field. It should be an array of objects,
      * each one with a display key (specified in `displayKey`), and a value key
      * (specified in `valueKey`).
+     * Options including an optional `disabled: true` key-value pair, will be disabled in the Select component.
      */
     options: PropTypes.array.isRequired,
     /**
@@ -368,6 +369,7 @@ class Select extends React.Component<Props, State> {
                          ...components,
                          ...optionComponent,
                        }}
+                       isOptionDisabled={option => !!option.disabled}
                        styles={{
                          ..._styles(this.props),
                        }}

--- a/graylog2-web-interface/src/components/common/Select.jsx
+++ b/graylog2-web-interface/src/components/common/Select.jsx
@@ -53,6 +53,10 @@ const CustomSingleValue = (valueRenderer: (Option) => React.Node) => (
   ({ data, ...rest }) => <Components.SingleValue {...rest}>{valueRenderer(data)}</Components.SingleValue>
 );
 
+const CustomInput = (inputProps: { [string]: any }) => (
+  props => <Components.Input {...props} {...inputProps} />
+);
+
 const dropdownIndicator = (base, state) => ({
   ...base,
   padding: '0px',
@@ -194,6 +198,7 @@ type Props = {
   onReactSelectChange?: (Option | Array<Option>) => void,
   optionRenderer?: (Option) => React.Node,
   valueRenderer?: (Option) => React.Node,
+  inputProps?: { [string]: any },
 };
 
 type State = {
@@ -243,6 +248,7 @@ class Select extends React.Component<Props, State> {
     matchProp: PropTypes.oneOf(['any', 'label', 'value']),
     optionRenderer: PropTypes.func,
     valueRenderer: PropTypes.func,
+    inputProps: PropTypes.object,
   };
 
   static defaultProps = {
@@ -262,29 +268,36 @@ class Select extends React.Component<Props, State> {
     clearable: true,
     optionRenderer: undefined,
     valueRenderer: undefined,
+    inputProps: undefined,
   };
 
   constructor(props: Props) {
     super(props);
-    const { optionRenderer, value, valueRenderer } = props;
+    const { inputProps, optionRenderer, value, valueRenderer } = props;
     this.state = {
-      customComponents: this.getCustomComponents(optionRenderer, valueRenderer),
+      customComponents: this.getCustomComponents(inputProps, optionRenderer, valueRenderer),
       value,
     };
   }
 
   componentWillReceiveProps = (nextProps: Props) => {
-    const { optionRenderer, value, valueRenderer } = this.props;
+    const { inputProps, optionRenderer, value, valueRenderer } = this.props;
     if (value !== nextProps.value) {
       this.setState({ value: nextProps.value });
     }
-    if (optionRenderer !== nextProps.optionRenderer || valueRenderer !== nextProps.valueRenderer) {
-      this.setState({ customComponents: this.getCustomComponents(optionRenderer, valueRenderer) });
+    if (inputProps !== nextProps.inputProps
+      || optionRenderer !== nextProps.optionRenderer
+      || valueRenderer !== nextProps.valueRenderer) {
+      this.setState({ customComponents: this.getCustomComponents(inputProps, optionRenderer, valueRenderer) });
     }
   };
 
-  getCustomComponents = (optionRenderer?: (Option) => React.Node, valueRenderer?: (Option) => React.Node): any => {
+  getCustomComponents = (inputProps?: { [string]: any }, optionRenderer?: (Option) => React.Node,
+    valueRenderer?: (Option) => React.Node): any => {
     const customComponents = {};
+    if (inputProps) {
+      customComponents.Input = CustomInput(inputProps);
+    }
     if (optionRenderer) {
       customComponents.Option = CustomOption(optionRenderer);
     }
@@ -361,6 +374,7 @@ class Select extends React.Component<Props, State> {
       multi: isMulti,
       disabled: isDisabled,
       clearable: isClearable,
+      inputProps, // Do not pass down prop
       matchProp,
       optionRenderer, // Do not pass down prop
       valueRenderer, // Do not pass down prop

--- a/graylog2-web-interface/src/components/common/Select.test.jsx
+++ b/graylog2-web-interface/src/components/common/Select.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
+import SelectComponent, { components as Components } from 'react-select';
 import Select from './Select';
 
 describe('Select', () => {
@@ -21,6 +22,18 @@ describe('Select', () => {
     it('should convert clearable to isClearable', () => {
       const wrapper = shallow(<Select clearable options={options} onChange={onChange} />);
       expect(wrapper.props().isClearable).toBeTruthy();
+    });
+
+    it('should use displayKey to select the option label', () => {
+      const customOptions = [{ customLabel: 'my great label', value: 'value' }];
+      const wrapper = mount(<Select options={customOptions} onChange={onChange} displayKey="customLabel" menuIsOpen />);
+      expect(wrapper.find(Components.Option).props().label).toBe('my great label');
+    });
+
+    it('should use valueKey to select the option value', () => {
+      const customOptions = [{ label: 'label', customValue: 42 }];
+      const wrapper = mount(<Select options={customOptions} onChange={onChange} valueKey="customValue" menuIsOpen />);
+      expect(wrapper.find(Components.Option).props().value).toBe(42);
     });
   });
 });

--- a/graylog2-web-interface/src/components/common/Select.test.jsx
+++ b/graylog2-web-interface/src/components/common/Select.test.jsx
@@ -10,18 +10,27 @@ describe('Select', () => {
     const onChange = () => { };
 
     it('should convert multi to isMulti', () => {
-      const wrapper = shallow(<Select multi options={options} onChange={onChange} />);
-      expect(wrapper.props().isMulti).toBeTruthy();
+      const multiWrapper = shallow(<Select multi options={options} onChange={onChange} />);
+      expect(multiWrapper.props().isMulti).toBeTruthy();
+
+      const nonMultiWrapper = shallow(<Select options={options} onChange={onChange} />);
+      expect(nonMultiWrapper.props().isMulti).toBeFalsy();
     });
 
     it('should convert disabled to isDisabled', () => {
-      const wrapper = shallow(<Select disabled options={options} onChange={onChange} />);
-      expect(wrapper.props().isDisabled).toBeTruthy();
+      const disabledWrapper = shallow(<Select disabled options={options} onChange={onChange} />);
+      expect(disabledWrapper.props().isDisabled).toBeTruthy();
+
+      const enabledWrapper = shallow(<Select options={options} onChange={onChange} />);
+      expect(enabledWrapper.props().isDisabled).toBeFalsy();
     });
 
     it('should convert clearable to isClearable', () => {
-      const wrapper = shallow(<Select clearable options={options} onChange={onChange} />);
-      expect(wrapper.props().isClearable).toBeTruthy();
+      const clearableWrapper = shallow(<Select options={options} onChange={onChange} />);
+      expect(clearableWrapper.props().isClearable).toBeTruthy();
+
+      const nonClearableWrapper = shallow(<Select clearable={false} options={options} onChange={onChange} />);
+      expect(nonClearableWrapper.props().isClearable).toBeFalsy();
     });
 
     it('should use displayKey to select the option label', () => {

--- a/graylog2-web-interface/src/components/common/Select.test.jsx
+++ b/graylog2-web-interface/src/components/common/Select.test.jsx
@@ -68,6 +68,12 @@ describe('Select', () => {
       expect(wrapper.find(Components.Option).props().children).toBe('Custom label');
     });
 
+    it('should use valueRenderer to customize selected value\'s appearance', () => {
+      const valueRenderer = option => `Custom ${option.value}`;
+      const wrapper = mount(<Select options={options} onChange={onChange} valueRenderer={valueRenderer} value={options[0].value} />);
+      expect(wrapper.find(Components.SingleValue).props().children).toBe('Custom value');
+    });
+
     it('should disable options that include a disabled property', () => {
       const customOptions = [
         { label: 'enabled', value: 'enabled' },

--- a/graylog2-web-interface/src/components/common/Select.test.jsx
+++ b/graylog2-web-interface/src/components/common/Select.test.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Select from './Select';
+
+describe('Select', () => {
+  describe('Upgrade to react-select v2', () => {
+    const options = [{ label: 'label', value: 'value' }];
+    const onChange = () => { };
+
+    it('should convert multi to isMulti', () => {
+      const wrapper = shallow(<Select multi options={options} onChange={onChange} />);
+      expect(wrapper.props().isMulti).toBeTruthy();
+    });
+
+    it('should convert disabled to isDisabled', () => {
+      const wrapper = shallow(<Select disabled options={options} onChange={onChange} />);
+      expect(wrapper.props().isDisabled).toBeTruthy();
+    });
+
+    it('should convert clearable to isClearable', () => {
+      const wrapper = shallow(<Select clearable options={options} onChange={onChange} />);
+      expect(wrapper.props().isClearable).toBeTruthy();
+    });
+  });
+});

--- a/graylog2-web-interface/src/components/common/Select.test.jsx
+++ b/graylog2-web-interface/src/components/common/Select.test.jsx
@@ -85,5 +85,11 @@ describe('Select', () => {
       expect(renderedOptions.at(0).props().isDisabled).toBeFalsy();
       expect(renderedOptions.at(1).props().isDisabled).toBeTruthy();
     });
+
+    it('should add custom props to input using inputProps', () => {
+      const inputProps = { id: 'myId' };
+      const wrapper = mount(<Select options={options} onChange={onChange} menuIsOpen inputProps={inputProps} />);
+      expect(wrapper.find(Components.Input).props().id).toBe(inputProps.id);
+    });
   });
 });

--- a/graylog2-web-interface/src/components/common/Select.test.jsx
+++ b/graylog2-web-interface/src/components/common/Select.test.jsx
@@ -67,5 +67,17 @@ describe('Select', () => {
       const wrapper = mount(<Select options={options} onChange={onChange} optionRenderer={optionRenderer} menuIsOpen />);
       expect(wrapper.find(Components.Option).props().children).toBe('Custom label');
     });
+
+    it('should disable options that include a disabled property', () => {
+      const customOptions = [
+        { label: 'enabled', value: 'enabled' },
+        { label: 'disabled', value: 'disabled', disabled: true },
+      ];
+      const wrapper = mount(<Select options={customOptions} onChange={onChange} menuIsOpen />);
+      const renderedOptions = wrapper.find(Components.Option);
+      expect(renderedOptions).toHaveLength(2);
+      expect(renderedOptions.at(0).props().isDisabled).toBeFalsy();
+      expect(renderedOptions.at(1).props().isDisabled).toBeTruthy();
+    });
   });
 });

--- a/graylog2-web-interface/src/components/common/Select.test.jsx
+++ b/graylog2-web-interface/src/components/common/Select.test.jsx
@@ -35,5 +35,22 @@ describe('Select', () => {
       const wrapper = mount(<Select options={customOptions} onChange={onChange} valueKey="customValue" menuIsOpen />);
       expect(wrapper.find(Components.Option).props().value).toBe(42);
     });
+
+    it('should use matchProp to configure how options are filtered', () => {
+      const matchAnyWrapper = shallow(<Select options={options} onChange={onChange} />);
+      const matchAnyFilter = matchAnyWrapper.find(SelectComponent).props().filterOption;
+      expect(matchAnyFilter(options[0], 'label')).toBeTruthy();
+      expect(matchAnyFilter(options[0], 'value')).toBeTruthy();
+
+      const matchLabelWrapper = shallow(<Select options={options} onChange={onChange} matchProp="label" />);
+      const matchLabelFilter = matchLabelWrapper.find(SelectComponent).props().filterOption;
+      expect(matchLabelFilter(options[0], 'label')).toBeTruthy();
+      expect(matchLabelFilter(options[0], 'value')).toBeFalsy();
+
+      const matchValueWrapper = shallow(<Select options={options} onChange={onChange} matchProp="value" />);
+      const matchValueFilter = matchValueWrapper.find(SelectComponent).props().filterOption;
+      expect(matchValueFilter(options[0], 'label')).toBeFalsy();
+      expect(matchValueFilter(options[0], 'value')).toBeTruthy();
+    });
   });
 });

--- a/graylog2-web-interface/src/components/common/Select.test.jsx
+++ b/graylog2-web-interface/src/components/common/Select.test.jsx
@@ -36,7 +36,7 @@ describe('Select', () => {
     it('should use displayKey to select the option label', () => {
       const customOptions = [{ customLabel: 'my great label', value: 'value' }];
       const wrapper = mount(<Select options={customOptions} onChange={onChange} displayKey="customLabel" menuIsOpen />);
-      expect(wrapper.find(Components.Option).props().label).toBe('my great label');
+      expect(wrapper.find(Components.Option).props().children).toBe('my great label');
     });
 
     it('should use valueKey to select the option value', () => {
@@ -60,6 +60,12 @@ describe('Select', () => {
       const matchValueFilter = matchValueWrapper.find(SelectComponent).props().filterOption;
       expect(matchValueFilter(options[0], 'label')).toBeFalsy();
       expect(matchValueFilter(options[0], 'value')).toBeTruthy();
+    });
+
+    it('should use optionRenderer to customize options\' appearance', () => {
+      const optionRenderer = option => `Custom ${option.label}`;
+      const wrapper = mount(<Select options={options} onChange={onChange} optionRenderer={optionRenderer} menuIsOpen />);
+      expect(wrapper.find(Components.Option).props().children).toBe('Custom label');
     });
   });
 });

--- a/graylog2-web-interface/src/components/configurations/decorators/StreamSelect.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/StreamSelect.jsx
@@ -30,7 +30,6 @@ const StreamSelect = ({ onChange, value, streams }: Props) => {
               onChange={onChange}
               options={options}
               clearable={false}
-              style={{ width: '100%' }}
               placeholder="There are no decorators configured for any stream."
               value={value} />
     </SelectContainer>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/BooleanOperatorSelector.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/BooleanOperatorSelector.jsx
@@ -34,7 +34,8 @@ const BooleanOperatorSelector = ({ initialText, operator, onOperatorChange }) =>
                     { label: 'all', value: '&&' },
                     { label: 'any', value: '||' },
                   ]}
-                  value={operator} />
+                  value={operator}
+                  clearable={false} />
         </BooleanOperatorSelect>
         <FormGroup>
           <FormControl.Static> of the following rules:</FormControl.Static>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/ComparisonExpression.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/ComparisonExpression.jsx
@@ -42,7 +42,8 @@ const ComparisonExpression = (props) => {
                       { label: '>=', value: '>=' },
                       { label: '=', value: '==' },
                     ]}
-                    value={expression.expr} />
+                    value={expression.expr}
+                    clearable={false} />
             {validation.errors.conditions && (
               <HelpBlock>{lodash.get(validation, 'errors.conditions[0]')}</HelpBlock>
             )}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/NumberRefExpression.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/NumberRefExpression.jsx
@@ -88,6 +88,7 @@ const NumberRefExpression = ({
                     placeholder="Select Function"
                     onChange={handleAggregationFunctionChange}
                     options={formatFunctions(aggregationFunctions)}
+                    clearable={false}
                     value={series.function} />
           </Col>
           <Col md={6}>
@@ -97,8 +98,7 @@ const NumberRefExpression = ({
                     onChange={handleAggregationFieldChange}
                     options={formattedFields}
                     value={series.field}
-                    allowCreate
-                    isClearable />
+                    allowCreate />
           </Col>
         </Row>
         {validation.errors.series && (

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/__snapshots__/AggregationConditionExpression.test.jsx.snap
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/__snapshots__/AggregationConditionExpression.test.jsx.snap
@@ -286,12 +286,12 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                   defaultValue={null}
                                   delimiter=","
                                   displayKey="label"
+                                  filterOption={[Function]}
                                   getOptionLabel={[Function]}
                                   getOptionValue={[Function]}
                                   isClearable={false}
                                   isDisabled={false}
                                   isMulti={false}
-                                  matchProp="label"
                                   onChange={[Function]}
                                   options={
                                     Array [
@@ -363,7 +363,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                     isRtl={false}
                                     isSearchable={true}
                                     loadingMessage={[Function]}
-                                    matchProp="label"
                                     maxMenuHeight={300}
                                     menuIsOpen={false}
                                     menuPlacement="bottom"
@@ -483,7 +482,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                           "isRtl": false,
                                           "isSearchable": true,
                                           "loadingMessage": [Function],
-                                          "matchProp": "label",
                                           "maxMenuHeight": 300,
                                           "menuIsOpen": false,
                                           "menuPlacement": "bottom",
@@ -635,7 +633,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                               "isRtl": false,
                                               "isSearchable": true,
                                               "loadingMessage": [Function],
-                                              "matchProp": "label",
                                               "maxMenuHeight": 300,
                                               "menuIsOpen": false,
                                               "menuPlacement": "bottom",
@@ -779,7 +776,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -927,7 +923,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -1064,7 +1059,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -1296,7 +1290,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -1439,7 +1432,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -1586,7 +1578,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -2235,12 +2226,12 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                               defaultValue={null}
                                               delimiter=","
                                               displayKey="label"
+                                              filterOption={[Function]}
                                               getOptionLabel={[Function]}
                                               getOptionValue={[Function]}
                                               isClearable={false}
                                               isDisabled={false}
                                               isMulti={false}
-                                              matchProp="label"
                                               onChange={[Function]}
                                               options={Array []}
                                               placeholder="Select Function"
@@ -2299,7 +2290,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                 isRtl={false}
                                                 isSearchable={true}
                                                 loadingMessage={[Function]}
-                                                matchProp="label"
                                                 maxMenuHeight={300}
                                                 menuIsOpen={false}
                                                 menuPlacement="bottom"
@@ -2394,7 +2384,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -2523,7 +2512,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                           "isRtl": false,
                                                           "isSearchable": true,
                                                           "loadingMessage": [Function],
-                                                          "matchProp": "label",
                                                           "maxMenuHeight": 300,
                                                           "menuIsOpen": false,
                                                           "menuPlacement": "bottom",
@@ -2644,7 +2632,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                               "isRtl": false,
                                                               "isSearchable": true,
                                                               "loadingMessage": [Function],
-                                                              "matchProp": "label",
                                                               "maxMenuHeight": 300,
                                                               "menuIsOpen": false,
                                                               "menuPlacement": "bottom",
@@ -2765,7 +2752,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                   "isRtl": false,
                                                                   "isSearchable": true,
                                                                   "loadingMessage": [Function],
-                                                                  "matchProp": "label",
                                                                   "maxMenuHeight": 300,
                                                                   "menuIsOpen": false,
                                                                   "menuPlacement": "bottom",
@@ -2890,7 +2876,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                   "isRtl": false,
                                                                   "isSearchable": true,
                                                                   "loadingMessage": [Function],
-                                                                  "matchProp": "label",
                                                                   "maxMenuHeight": 300,
                                                                   "menuIsOpen": false,
                                                                   "menuPlacement": "bottom",
@@ -3099,7 +3084,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                               "isRtl": false,
                                                               "isSearchable": true,
                                                               "loadingMessage": [Function],
-                                                              "matchProp": "label",
                                                               "maxMenuHeight": 300,
                                                               "menuIsOpen": false,
                                                               "menuPlacement": "bottom",
@@ -3219,7 +3203,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                   "isRtl": false,
                                                                   "isSearchable": true,
                                                                   "loadingMessage": [Function],
-                                                                  "matchProp": "label",
                                                                   "maxMenuHeight": 300,
                                                                   "menuIsOpen": false,
                                                                   "menuPlacement": "bottom",
@@ -3343,7 +3326,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                   "isRtl": false,
                                                                   "isSearchable": true,
                                                                   "loadingMessage": [Function],
-                                                                  "matchProp": "label",
                                                                   "maxMenuHeight": 300,
                                                                   "menuIsOpen": false,
                                                                   "menuPlacement": "bottom",
@@ -3502,12 +3484,12 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                               defaultValue={null}
                                               delimiter=","
                                               displayKey="label"
+                                              filterOption={[Function]}
                                               getOptionLabel={[Function]}
                                               getOptionValue={[Function]}
                                               isClearable={true}
                                               isDisabled={false}
                                               isMulti={false}
-                                              matchProp="label"
                                               onChange={[Function]}
                                               options={Array []}
                                               placeholder="Select Field (Optional)"
@@ -3551,6 +3533,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                 createOptionPosition="last"
                                                 delimiter=","
                                                 displayKey="label"
+                                                filterOption={[Function]}
                                                 formatCreateLabel={[Function]}
                                                 getNewOptionData={[Function]}
                                                 getOptionLabel={[Function]}
@@ -3560,7 +3543,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                 isDisabled={false}
                                                 isMulti={false}
                                                 isValidNewOption={[Function]}
-                                                matchProp="label"
                                                 menuIsOpen={false}
                                                 onChange={[Function]}
                                                 onInputChange={[Function]}
@@ -3631,7 +3613,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                   isSearchable={true}
                                                   isValidNewOption={[Function]}
                                                   loadingMessage={[Function]}
-                                                  matchProp="label"
                                                   maxMenuHeight={300}
                                                   menuIsOpen={false}
                                                   menuPlacement="bottom"
@@ -3734,7 +3715,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                         "isSearchable": true,
                                                         "isValidNewOption": [Function],
                                                         "loadingMessage": [Function],
-                                                        "matchProp": "label",
                                                         "maxMenuHeight": 300,
                                                         "menuIsOpen": false,
                                                         "menuPlacement": "bottom",
@@ -3871,7 +3851,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                             "isSearchable": true,
                                                             "isValidNewOption": [Function],
                                                             "loadingMessage": [Function],
-                                                            "matchProp": "label",
                                                             "maxMenuHeight": 300,
                                                             "menuIsOpen": false,
                                                             "menuPlacement": "bottom",
@@ -4000,7 +3979,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                 "isSearchable": true,
                                                                 "isValidNewOption": [Function],
                                                                 "loadingMessage": [Function],
-                                                                "matchProp": "label",
                                                                 "maxMenuHeight": 300,
                                                                 "menuIsOpen": false,
                                                                 "menuPlacement": "bottom",
@@ -4133,7 +4111,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                     "isSearchable": true,
                                                                     "isValidNewOption": [Function],
                                                                     "loadingMessage": [Function],
-                                                                    "matchProp": "label",
                                                                     "maxMenuHeight": 300,
                                                                     "menuIsOpen": false,
                                                                     "menuPlacement": "bottom",
@@ -4266,7 +4243,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                     "isSearchable": true,
                                                                     "isValidNewOption": [Function],
                                                                     "loadingMessage": [Function],
-                                                                    "matchProp": "label",
                                                                     "maxMenuHeight": 300,
                                                                     "menuIsOpen": false,
                                                                     "menuPlacement": "bottom",
@@ -4483,7 +4459,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                 "isSearchable": true,
                                                                 "isValidNewOption": [Function],
                                                                 "loadingMessage": [Function],
-                                                                "matchProp": "label",
                                                                 "maxMenuHeight": 300,
                                                                 "menuIsOpen": false,
                                                                 "menuPlacement": "bottom",
@@ -4617,7 +4592,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                     "isSearchable": true,
                                                                     "isValidNewOption": [Function],
                                                                     "loadingMessage": [Function],
-                                                                    "matchProp": "label",
                                                                     "maxMenuHeight": 300,
                                                                     "menuIsOpen": false,
                                                                     "menuPlacement": "bottom",
@@ -4768,7 +4742,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                     "isSearchable": true,
                                                                     "isValidNewOption": [Function],
                                                                     "loadingMessage": [Function],
-                                                                    "matchProp": "label",
                                                                     "maxMenuHeight": 300,
                                                                     "menuIsOpen": false,
                                                                     "menuPlacement": "bottom",
@@ -4900,7 +4873,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                     "isSearchable": true,
                                                                     "isValidNewOption": [Function],
                                                                     "loadingMessage": [Function],
-                                                                    "matchProp": "label",
                                                                     "maxMenuHeight": 300,
                                                                     "menuIsOpen": false,
                                                                     "menuPlacement": "bottom",
@@ -5186,13 +5158,13 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                   defaultValue={null}
                                   delimiter=","
                                   displayKey="label"
+                                  filterOption={[Function]}
                                   getOptionLabel={[Function]}
                                   getOptionValue={[Function]}
                                   id="aggregation-condition"
                                   isClearable={false}
                                   isDisabled={false}
                                   isMulti={false}
-                                  matchProp="label"
                                   onChange={[Function]}
                                   options={
                                     Array [
@@ -5274,7 +5246,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                     isRtl={false}
                                     isSearchable={true}
                                     loadingMessage={[Function]}
-                                    matchProp="label"
                                     maxMenuHeight={300}
                                     menuIsOpen={false}
                                     menuPlacement="bottom"
@@ -5414,7 +5385,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                           "isRtl": false,
                                           "isSearchable": true,
                                           "loadingMessage": [Function],
-                                          "matchProp": "label",
                                           "maxMenuHeight": 300,
                                           "menuIsOpen": false,
                                           "menuPlacement": "bottom",
@@ -5588,7 +5558,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                               "isRtl": false,
                                               "isSearchable": true,
                                               "loadingMessage": [Function],
-                                              "matchProp": "label",
                                               "maxMenuHeight": 300,
                                               "menuIsOpen": false,
                                               "menuPlacement": "bottom",
@@ -5753,7 +5722,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -5918,7 +5886,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -6064,7 +6031,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -6317,7 +6283,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -6481,7 +6446,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -6649,7 +6613,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -7770,12 +7733,12 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                               defaultValue={null}
                                               delimiter=","
                                               displayKey="label"
+                                              filterOption={[Function]}
                                               getOptionLabel={[Function]}
                                               getOptionValue={[Function]}
                                               isClearable={false}
                                               isDisabled={false}
                                               isMulti={false}
-                                              matchProp="label"
                                               onChange={[Function]}
                                               options={Array []}
                                               placeholder="Select Function"
@@ -7834,7 +7797,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                 isRtl={false}
                                                 isSearchable={true}
                                                 loadingMessage={[Function]}
-                                                matchProp="label"
                                                 maxMenuHeight={300}
                                                 menuIsOpen={false}
                                                 menuPlacement="bottom"
@@ -7929,7 +7891,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -8058,7 +8019,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                           "isRtl": false,
                                                           "isSearchable": true,
                                                           "loadingMessage": [Function],
-                                                          "matchProp": "label",
                                                           "maxMenuHeight": 300,
                                                           "menuIsOpen": false,
                                                           "menuPlacement": "bottom",
@@ -8179,7 +8139,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                               "isRtl": false,
                                                               "isSearchable": true,
                                                               "loadingMessage": [Function],
-                                                              "matchProp": "label",
                                                               "maxMenuHeight": 300,
                                                               "menuIsOpen": false,
                                                               "menuPlacement": "bottom",
@@ -8300,7 +8259,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                   "isRtl": false,
                                                                   "isSearchable": true,
                                                                   "loadingMessage": [Function],
-                                                                  "matchProp": "label",
                                                                   "maxMenuHeight": 300,
                                                                   "menuIsOpen": false,
                                                                   "menuPlacement": "bottom",
@@ -8425,7 +8383,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                   "isRtl": false,
                                                                   "isSearchable": true,
                                                                   "loadingMessage": [Function],
-                                                                  "matchProp": "label",
                                                                   "maxMenuHeight": 300,
                                                                   "menuIsOpen": false,
                                                                   "menuPlacement": "bottom",
@@ -8634,7 +8591,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                               "isRtl": false,
                                                               "isSearchable": true,
                                                               "loadingMessage": [Function],
-                                                              "matchProp": "label",
                                                               "maxMenuHeight": 300,
                                                               "menuIsOpen": false,
                                                               "menuPlacement": "bottom",
@@ -8754,7 +8710,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                   "isRtl": false,
                                                                   "isSearchable": true,
                                                                   "loadingMessage": [Function],
-                                                                  "matchProp": "label",
                                                                   "maxMenuHeight": 300,
                                                                   "menuIsOpen": false,
                                                                   "menuPlacement": "bottom",
@@ -8878,7 +8833,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                   "isRtl": false,
                                                                   "isSearchable": true,
                                                                   "loadingMessage": [Function],
-                                                                  "matchProp": "label",
                                                                   "maxMenuHeight": 300,
                                                                   "menuIsOpen": false,
                                                                   "menuPlacement": "bottom",
@@ -9037,12 +8991,12 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                               defaultValue={null}
                                               delimiter=","
                                               displayKey="label"
+                                              filterOption={[Function]}
                                               getOptionLabel={[Function]}
                                               getOptionValue={[Function]}
                                               isClearable={true}
                                               isDisabled={false}
                                               isMulti={false}
-                                              matchProp="label"
                                               onChange={[Function]}
                                               options={Array []}
                                               placeholder="Select Field (Optional)"
@@ -9086,6 +9040,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                 createOptionPosition="last"
                                                 delimiter=","
                                                 displayKey="label"
+                                                filterOption={[Function]}
                                                 formatCreateLabel={[Function]}
                                                 getNewOptionData={[Function]}
                                                 getOptionLabel={[Function]}
@@ -9095,7 +9050,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                 isDisabled={false}
                                                 isMulti={false}
                                                 isValidNewOption={[Function]}
-                                                matchProp="label"
                                                 menuIsOpen={false}
                                                 onChange={[Function]}
                                                 onInputChange={[Function]}
@@ -9166,7 +9120,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                   isSearchable={true}
                                                   isValidNewOption={[Function]}
                                                   loadingMessage={[Function]}
-                                                  matchProp="label"
                                                   maxMenuHeight={300}
                                                   menuIsOpen={false}
                                                   menuPlacement="bottom"
@@ -9269,7 +9222,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                         "isSearchable": true,
                                                         "isValidNewOption": [Function],
                                                         "loadingMessage": [Function],
-                                                        "matchProp": "label",
                                                         "maxMenuHeight": 300,
                                                         "menuIsOpen": false,
                                                         "menuPlacement": "bottom",
@@ -9406,7 +9358,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                             "isSearchable": true,
                                                             "isValidNewOption": [Function],
                                                             "loadingMessage": [Function],
-                                                            "matchProp": "label",
                                                             "maxMenuHeight": 300,
                                                             "menuIsOpen": false,
                                                             "menuPlacement": "bottom",
@@ -9535,7 +9486,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                 "isSearchable": true,
                                                                 "isValidNewOption": [Function],
                                                                 "loadingMessage": [Function],
-                                                                "matchProp": "label",
                                                                 "maxMenuHeight": 300,
                                                                 "menuIsOpen": false,
                                                                 "menuPlacement": "bottom",
@@ -9668,7 +9618,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                     "isSearchable": true,
                                                                     "isValidNewOption": [Function],
                                                                     "loadingMessage": [Function],
-                                                                    "matchProp": "label",
                                                                     "maxMenuHeight": 300,
                                                                     "menuIsOpen": false,
                                                                     "menuPlacement": "bottom",
@@ -9801,7 +9750,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                     "isSearchable": true,
                                                                     "isValidNewOption": [Function],
                                                                     "loadingMessage": [Function],
-                                                                    "matchProp": "label",
                                                                     "maxMenuHeight": 300,
                                                                     "menuIsOpen": false,
                                                                     "menuPlacement": "bottom",
@@ -10018,7 +9966,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                 "isSearchable": true,
                                                                 "isValidNewOption": [Function],
                                                                 "loadingMessage": [Function],
-                                                                "matchProp": "label",
                                                                 "maxMenuHeight": 300,
                                                                 "menuIsOpen": false,
                                                                 "menuPlacement": "bottom",
@@ -10152,7 +10099,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                     "isSearchable": true,
                                                                     "isValidNewOption": [Function],
                                                                     "loadingMessage": [Function],
-                                                                    "matchProp": "label",
                                                                     "maxMenuHeight": 300,
                                                                     "menuIsOpen": false,
                                                                     "menuPlacement": "bottom",
@@ -10303,7 +10249,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                     "isSearchable": true,
                                                                     "isValidNewOption": [Function],
                                                                     "loadingMessage": [Function],
-                                                                    "matchProp": "label",
                                                                     "maxMenuHeight": 300,
                                                                     "menuIsOpen": false,
                                                                     "menuPlacement": "bottom",
@@ -10435,7 +10380,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                     "isSearchable": true,
                                                                     "isValidNewOption": [Function],
                                                                     "loadingMessage": [Function],
-                                                                    "matchProp": "label",
                                                                     "maxMenuHeight": 300,
                                                                     "menuIsOpen": false,
                                                                     "menuPlacement": "bottom",
@@ -10679,13 +10623,13 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                   defaultValue={null}
                                   delimiter=","
                                   displayKey="label"
+                                  filterOption={[Function]}
                                   getOptionLabel={[Function]}
                                   getOptionValue={[Function]}
                                   id="aggregation-condition"
                                   isClearable={false}
                                   isDisabled={false}
                                   isMulti={false}
-                                  matchProp="label"
                                   onChange={[Function]}
                                   options={
                                     Array [
@@ -10767,7 +10711,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                     isRtl={false}
                                     isSearchable={true}
                                     loadingMessage={[Function]}
-                                    matchProp="label"
                                     maxMenuHeight={300}
                                     menuIsOpen={false}
                                     menuPlacement="bottom"
@@ -10907,7 +10850,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                           "isRtl": false,
                                           "isSearchable": true,
                                           "loadingMessage": [Function],
-                                          "matchProp": "label",
                                           "maxMenuHeight": 300,
                                           "menuIsOpen": false,
                                           "menuPlacement": "bottom",
@@ -11081,7 +11023,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                               "isRtl": false,
                                               "isSearchable": true,
                                               "loadingMessage": [Function],
-                                              "matchProp": "label",
                                               "maxMenuHeight": 300,
                                               "menuIsOpen": false,
                                               "menuPlacement": "bottom",
@@ -11246,7 +11187,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -11411,7 +11351,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -11557,7 +11496,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -11810,7 +11748,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -11974,7 +11911,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -12142,7 +12078,6 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -13160,12 +13095,12 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                   defaultValue={null}
                                   delimiter=","
                                   displayKey="label"
+                                  filterOption={[Function]}
                                   getOptionLabel={[Function]}
                                   getOptionValue={[Function]}
                                   isClearable={false}
                                   isDisabled={false}
                                   isMulti={false}
-                                  matchProp="label"
                                   onChange={[Function]}
                                   options={
                                     Array [
@@ -13237,7 +13172,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                     isRtl={false}
                                     isSearchable={true}
                                     loadingMessage={[Function]}
-                                    matchProp="label"
                                     maxMenuHeight={300}
                                     menuIsOpen={false}
                                     menuPlacement="bottom"
@@ -13357,7 +13291,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                           "isRtl": false,
                                           "isSearchable": true,
                                           "loadingMessage": [Function],
-                                          "matchProp": "label",
                                           "maxMenuHeight": 300,
                                           "menuIsOpen": false,
                                           "menuPlacement": "bottom",
@@ -13509,7 +13442,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                               "isRtl": false,
                                               "isSearchable": true,
                                               "loadingMessage": [Function],
-                                              "matchProp": "label",
                                               "maxMenuHeight": 300,
                                               "menuIsOpen": false,
                                               "menuPlacement": "bottom",
@@ -13653,7 +13585,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -13801,7 +13732,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -13938,7 +13868,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -14170,7 +14099,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -14313,7 +14241,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -14460,7 +14387,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -15121,12 +15047,12 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                               defaultValue={null}
                                               delimiter=","
                                               displayKey="label"
+                                              filterOption={[Function]}
                                               getOptionLabel={[Function]}
                                               getOptionValue={[Function]}
                                               isClearable={false}
                                               isDisabled={false}
                                               isMulti={false}
-                                              matchProp="label"
                                               onChange={[Function]}
                                               options={Array []}
                                               placeholder="Select Function"
@@ -15185,7 +15111,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                 isRtl={false}
                                                 isSearchable={true}
                                                 loadingMessage={[Function]}
-                                                matchProp="label"
                                                 maxMenuHeight={300}
                                                 menuIsOpen={false}
                                                 menuPlacement="bottom"
@@ -15280,7 +15205,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -15409,7 +15333,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                           "isRtl": false,
                                                           "isSearchable": true,
                                                           "loadingMessage": [Function],
-                                                          "matchProp": "label",
                                                           "maxMenuHeight": 300,
                                                           "menuIsOpen": false,
                                                           "menuPlacement": "bottom",
@@ -15530,7 +15453,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                               "isRtl": false,
                                                               "isSearchable": true,
                                                               "loadingMessage": [Function],
-                                                              "matchProp": "label",
                                                               "maxMenuHeight": 300,
                                                               "menuIsOpen": false,
                                                               "menuPlacement": "bottom",
@@ -15651,7 +15573,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                   "isRtl": false,
                                                                   "isSearchable": true,
                                                                   "loadingMessage": [Function],
-                                                                  "matchProp": "label",
                                                                   "maxMenuHeight": 300,
                                                                   "menuIsOpen": false,
                                                                   "menuPlacement": "bottom",
@@ -15776,7 +15697,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                   "isRtl": false,
                                                                   "isSearchable": true,
                                                                   "loadingMessage": [Function],
-                                                                  "matchProp": "label",
                                                                   "maxMenuHeight": 300,
                                                                   "menuIsOpen": false,
                                                                   "menuPlacement": "bottom",
@@ -15985,7 +15905,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                               "isRtl": false,
                                                               "isSearchable": true,
                                                               "loadingMessage": [Function],
-                                                              "matchProp": "label",
                                                               "maxMenuHeight": 300,
                                                               "menuIsOpen": false,
                                                               "menuPlacement": "bottom",
@@ -16105,7 +16024,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                   "isRtl": false,
                                                                   "isSearchable": true,
                                                                   "loadingMessage": [Function],
-                                                                  "matchProp": "label",
                                                                   "maxMenuHeight": 300,
                                                                   "menuIsOpen": false,
                                                                   "menuPlacement": "bottom",
@@ -16229,7 +16147,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                   "isRtl": false,
                                                                   "isSearchable": true,
                                                                   "loadingMessage": [Function],
-                                                                  "matchProp": "label",
                                                                   "maxMenuHeight": 300,
                                                                   "menuIsOpen": false,
                                                                   "menuPlacement": "bottom",
@@ -16388,12 +16305,12 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                               defaultValue={null}
                                               delimiter=","
                                               displayKey="label"
+                                              filterOption={[Function]}
                                               getOptionLabel={[Function]}
                                               getOptionValue={[Function]}
                                               isClearable={true}
                                               isDisabled={false}
                                               isMulti={false}
-                                              matchProp="label"
                                               onChange={[Function]}
                                               options={Array []}
                                               placeholder="Select Field (Optional)"
@@ -16437,6 +16354,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                 createOptionPosition="last"
                                                 delimiter=","
                                                 displayKey="label"
+                                                filterOption={[Function]}
                                                 formatCreateLabel={[Function]}
                                                 getNewOptionData={[Function]}
                                                 getOptionLabel={[Function]}
@@ -16446,7 +16364,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                 isDisabled={false}
                                                 isMulti={false}
                                                 isValidNewOption={[Function]}
-                                                matchProp="label"
                                                 menuIsOpen={false}
                                                 onChange={[Function]}
                                                 onInputChange={[Function]}
@@ -16517,7 +16434,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                   isSearchable={true}
                                                   isValidNewOption={[Function]}
                                                   loadingMessage={[Function]}
-                                                  matchProp="label"
                                                   maxMenuHeight={300}
                                                   menuIsOpen={false}
                                                   menuPlacement="bottom"
@@ -16620,7 +16536,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         "isSearchable": true,
                                                         "isValidNewOption": [Function],
                                                         "loadingMessage": [Function],
-                                                        "matchProp": "label",
                                                         "maxMenuHeight": 300,
                                                         "menuIsOpen": false,
                                                         "menuPlacement": "bottom",
@@ -16757,7 +16672,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "isSearchable": true,
                                                             "isValidNewOption": [Function],
                                                             "loadingMessage": [Function],
-                                                            "matchProp": "label",
                                                             "maxMenuHeight": 300,
                                                             "menuIsOpen": false,
                                                             "menuPlacement": "bottom",
@@ -16886,7 +16800,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                 "isSearchable": true,
                                                                 "isValidNewOption": [Function],
                                                                 "loadingMessage": [Function],
-                                                                "matchProp": "label",
                                                                 "maxMenuHeight": 300,
                                                                 "menuIsOpen": false,
                                                                 "menuPlacement": "bottom",
@@ -17019,7 +16932,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                     "isSearchable": true,
                                                                     "isValidNewOption": [Function],
                                                                     "loadingMessage": [Function],
-                                                                    "matchProp": "label",
                                                                     "maxMenuHeight": 300,
                                                                     "menuIsOpen": false,
                                                                     "menuPlacement": "bottom",
@@ -17152,7 +17064,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                     "isSearchable": true,
                                                                     "isValidNewOption": [Function],
                                                                     "loadingMessage": [Function],
-                                                                    "matchProp": "label",
                                                                     "maxMenuHeight": 300,
                                                                     "menuIsOpen": false,
                                                                     "menuPlacement": "bottom",
@@ -17369,7 +17280,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                 "isSearchable": true,
                                                                 "isValidNewOption": [Function],
                                                                 "loadingMessage": [Function],
-                                                                "matchProp": "label",
                                                                 "maxMenuHeight": 300,
                                                                 "menuIsOpen": false,
                                                                 "menuPlacement": "bottom",
@@ -17503,7 +17413,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                     "isSearchable": true,
                                                                     "isValidNewOption": [Function],
                                                                     "loadingMessage": [Function],
-                                                                    "matchProp": "label",
                                                                     "maxMenuHeight": 300,
                                                                     "menuIsOpen": false,
                                                                     "menuPlacement": "bottom",
@@ -17654,7 +17563,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                     "isSearchable": true,
                                                                     "isValidNewOption": [Function],
                                                                     "loadingMessage": [Function],
-                                                                    "matchProp": "label",
                                                                     "maxMenuHeight": 300,
                                                                     "menuIsOpen": false,
                                                                     "menuPlacement": "bottom",
@@ -17786,7 +17694,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                     "isSearchable": true,
                                                                     "isValidNewOption": [Function],
                                                                     "loadingMessage": [Function],
-                                                                    "matchProp": "label",
                                                                     "maxMenuHeight": 300,
                                                                     "menuIsOpen": false,
                                                                     "menuPlacement": "bottom",
@@ -18072,13 +17979,13 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                   defaultValue={null}
                                   delimiter=","
                                   displayKey="label"
+                                  filterOption={[Function]}
                                   getOptionLabel={[Function]}
                                   getOptionValue={[Function]}
                                   id="aggregation-condition"
                                   isClearable={false}
                                   isDisabled={false}
                                   isMulti={false}
-                                  matchProp="label"
                                   onChange={[Function]}
                                   options={
                                     Array [
@@ -18160,7 +18067,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                     isRtl={false}
                                     isSearchable={true}
                                     loadingMessage={[Function]}
-                                    matchProp="label"
                                     maxMenuHeight={300}
                                     menuIsOpen={false}
                                     menuPlacement="bottom"
@@ -18300,7 +18206,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                           "isRtl": false,
                                           "isSearchable": true,
                                           "loadingMessage": [Function],
-                                          "matchProp": "label",
                                           "maxMenuHeight": 300,
                                           "menuIsOpen": false,
                                           "menuPlacement": "bottom",
@@ -18474,7 +18379,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                               "isRtl": false,
                                               "isSearchable": true,
                                               "loadingMessage": [Function],
-                                              "matchProp": "label",
                                               "maxMenuHeight": 300,
                                               "menuIsOpen": false,
                                               "menuPlacement": "bottom",
@@ -18639,7 +18543,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -18804,7 +18707,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -18950,7 +18852,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -19203,7 +19104,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -19367,7 +19267,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -19535,7 +19434,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -20631,12 +20529,12 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                         defaultValue={null}
                                         delimiter=","
                                         displayKey="label"
+                                        filterOption={[Function]}
                                         getOptionLabel={[Function]}
                                         getOptionValue={[Function]}
                                         isClearable={false}
                                         isDisabled={false}
                                         isMulti={false}
-                                        matchProp="label"
                                         onChange={[Function]}
                                         options={
                                           Array [
@@ -20708,7 +20606,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                           isRtl={false}
                                           isSearchable={true}
                                           loadingMessage={[Function]}
-                                          matchProp="label"
                                           maxMenuHeight={300}
                                           menuIsOpen={false}
                                           menuPlacement="bottom"
@@ -20828,7 +20725,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                 "isRtl": false,
                                                 "isSearchable": true,
                                                 "loadingMessage": [Function],
-                                                "matchProp": "label",
                                                 "maxMenuHeight": 300,
                                                 "menuIsOpen": false,
                                                 "menuPlacement": "bottom",
@@ -20980,7 +20876,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                     "isRtl": false,
                                                     "isSearchable": true,
                                                     "loadingMessage": [Function],
-                                                    "matchProp": "label",
                                                     "maxMenuHeight": 300,
                                                     "menuIsOpen": false,
                                                     "menuPlacement": "bottom",
@@ -21124,7 +21019,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         "isRtl": false,
                                                         "isSearchable": true,
                                                         "loadingMessage": [Function],
-                                                        "matchProp": "label",
                                                         "maxMenuHeight": 300,
                                                         "menuIsOpen": false,
                                                         "menuPlacement": "bottom",
@@ -21272,7 +21166,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "isRtl": false,
                                                             "isSearchable": true,
                                                             "loadingMessage": [Function],
-                                                            "matchProp": "label",
                                                             "maxMenuHeight": 300,
                                                             "menuIsOpen": false,
                                                             "menuPlacement": "bottom",
@@ -21409,7 +21302,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "isRtl": false,
                                                             "isSearchable": true,
                                                             "loadingMessage": [Function],
-                                                            "matchProp": "label",
                                                             "maxMenuHeight": 300,
                                                             "menuIsOpen": false,
                                                             "menuPlacement": "bottom",
@@ -21641,7 +21533,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         "isRtl": false,
                                                         "isSearchable": true,
                                                         "loadingMessage": [Function],
-                                                        "matchProp": "label",
                                                         "maxMenuHeight": 300,
                                                         "menuIsOpen": false,
                                                         "menuPlacement": "bottom",
@@ -21784,7 +21675,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "isRtl": false,
                                                             "isSearchable": true,
                                                             "loadingMessage": [Function],
-                                                            "matchProp": "label",
                                                             "maxMenuHeight": 300,
                                                             "menuIsOpen": false,
                                                             "menuPlacement": "bottom",
@@ -21931,7 +21821,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "isRtl": false,
                                                             "isSearchable": true,
                                                             "loadingMessage": [Function],
-                                                            "matchProp": "label",
                                                             "maxMenuHeight": 300,
                                                             "menuIsOpen": false,
                                                             "menuPlacement": "bottom",
@@ -22494,12 +22383,12 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         defaultValue={null}
                                                         delimiter=","
                                                         displayKey="label"
+                                                        filterOption={[Function]}
                                                         getOptionLabel={[Function]}
                                                         getOptionValue={[Function]}
                                                         isClearable={false}
                                                         isDisabled={false}
                                                         isMulti={false}
-                                                        matchProp="label"
                                                         onChange={[Function]}
                                                         options={Array []}
                                                         placeholder="Select Function"
@@ -22558,7 +22447,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                           isRtl={false}
                                                           isSearchable={true}
                                                           loadingMessage={[Function]}
-                                                          matchProp="label"
                                                           maxMenuHeight={300}
                                                           menuIsOpen={false}
                                                           menuPlacement="bottom"
@@ -22653,7 +22541,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                 "isRtl": false,
                                                                 "isSearchable": true,
                                                                 "loadingMessage": [Function],
-                                                                "matchProp": "label",
                                                                 "maxMenuHeight": 300,
                                                                 "menuIsOpen": false,
                                                                 "menuPlacement": "bottom",
@@ -22782,7 +22669,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                     "isRtl": false,
                                                                     "isSearchable": true,
                                                                     "loadingMessage": [Function],
-                                                                    "matchProp": "label",
                                                                     "maxMenuHeight": 300,
                                                                     "menuIsOpen": false,
                                                                     "menuPlacement": "bottom",
@@ -22903,7 +22789,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                         "isRtl": false,
                                                                         "isSearchable": true,
                                                                         "loadingMessage": [Function],
-                                                                        "matchProp": "label",
                                                                         "maxMenuHeight": 300,
                                                                         "menuIsOpen": false,
                                                                         "menuPlacement": "bottom",
@@ -23024,7 +22909,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                             "isRtl": false,
                                                                             "isSearchable": true,
                                                                             "loadingMessage": [Function],
-                                                                            "matchProp": "label",
                                                                             "maxMenuHeight": 300,
                                                                             "menuIsOpen": false,
                                                                             "menuPlacement": "bottom",
@@ -23149,7 +23033,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                             "isRtl": false,
                                                                             "isSearchable": true,
                                                                             "loadingMessage": [Function],
-                                                                            "matchProp": "label",
                                                                             "maxMenuHeight": 300,
                                                                             "menuIsOpen": false,
                                                                             "menuPlacement": "bottom",
@@ -23358,7 +23241,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                         "isRtl": false,
                                                                         "isSearchable": true,
                                                                         "loadingMessage": [Function],
-                                                                        "matchProp": "label",
                                                                         "maxMenuHeight": 300,
                                                                         "menuIsOpen": false,
                                                                         "menuPlacement": "bottom",
@@ -23478,7 +23360,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                             "isRtl": false,
                                                                             "isSearchable": true,
                                                                             "loadingMessage": [Function],
-                                                                            "matchProp": "label",
                                                                             "maxMenuHeight": 300,
                                                                             "menuIsOpen": false,
                                                                             "menuPlacement": "bottom",
@@ -23602,7 +23483,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                             "isRtl": false,
                                                                             "isSearchable": true,
                                                                             "loadingMessage": [Function],
-                                                                            "matchProp": "label",
                                                                             "maxMenuHeight": 300,
                                                                             "menuIsOpen": false,
                                                                             "menuPlacement": "bottom",
@@ -23761,12 +23641,12 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         defaultValue={null}
                                                         delimiter=","
                                                         displayKey="label"
+                                                        filterOption={[Function]}
                                                         getOptionLabel={[Function]}
                                                         getOptionValue={[Function]}
                                                         isClearable={true}
                                                         isDisabled={false}
                                                         isMulti={false}
-                                                        matchProp="label"
                                                         onChange={[Function]}
                                                         options={Array []}
                                                         placeholder="Select Field (Optional)"
@@ -23810,6 +23690,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                           createOptionPosition="last"
                                                           delimiter=","
                                                           displayKey="label"
+                                                          filterOption={[Function]}
                                                           formatCreateLabel={[Function]}
                                                           getNewOptionData={[Function]}
                                                           getOptionLabel={[Function]}
@@ -23819,7 +23700,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                           isDisabled={false}
                                                           isMulti={false}
                                                           isValidNewOption={[Function]}
-                                                          matchProp="label"
                                                           menuIsOpen={false}
                                                           onChange={[Function]}
                                                           onInputChange={[Function]}
@@ -23890,7 +23770,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             isSearchable={true}
                                                             isValidNewOption={[Function]}
                                                             loadingMessage={[Function]}
-                                                            matchProp="label"
                                                             maxMenuHeight={300}
                                                             menuIsOpen={false}
                                                             menuPlacement="bottom"
@@ -23993,7 +23872,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                   "isSearchable": true,
                                                                   "isValidNewOption": [Function],
                                                                   "loadingMessage": [Function],
-                                                                  "matchProp": "label",
                                                                   "maxMenuHeight": 300,
                                                                   "menuIsOpen": false,
                                                                   "menuPlacement": "bottom",
@@ -24130,7 +24008,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                       "isSearchable": true,
                                                                       "isValidNewOption": [Function],
                                                                       "loadingMessage": [Function],
-                                                                      "matchProp": "label",
                                                                       "maxMenuHeight": 300,
                                                                       "menuIsOpen": false,
                                                                       "menuPlacement": "bottom",
@@ -24259,7 +24136,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                           "isSearchable": true,
                                                                           "isValidNewOption": [Function],
                                                                           "loadingMessage": [Function],
-                                                                          "matchProp": "label",
                                                                           "maxMenuHeight": 300,
                                                                           "menuIsOpen": false,
                                                                           "menuPlacement": "bottom",
@@ -24392,7 +24268,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                               "isSearchable": true,
                                                                               "isValidNewOption": [Function],
                                                                               "loadingMessage": [Function],
-                                                                              "matchProp": "label",
                                                                               "maxMenuHeight": 300,
                                                                               "menuIsOpen": false,
                                                                               "menuPlacement": "bottom",
@@ -24525,7 +24400,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                               "isSearchable": true,
                                                                               "isValidNewOption": [Function],
                                                                               "loadingMessage": [Function],
-                                                                              "matchProp": "label",
                                                                               "maxMenuHeight": 300,
                                                                               "menuIsOpen": false,
                                                                               "menuPlacement": "bottom",
@@ -24742,7 +24616,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                           "isSearchable": true,
                                                                           "isValidNewOption": [Function],
                                                                           "loadingMessage": [Function],
-                                                                          "matchProp": "label",
                                                                           "maxMenuHeight": 300,
                                                                           "menuIsOpen": false,
                                                                           "menuPlacement": "bottom",
@@ -24876,7 +24749,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                               "isSearchable": true,
                                                                               "isValidNewOption": [Function],
                                                                               "loadingMessage": [Function],
-                                                                              "matchProp": "label",
                                                                               "maxMenuHeight": 300,
                                                                               "menuIsOpen": false,
                                                                               "menuPlacement": "bottom",
@@ -25027,7 +24899,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                               "isSearchable": true,
                                                                               "isValidNewOption": [Function],
                                                                               "loadingMessage": [Function],
-                                                                              "matchProp": "label",
                                                                               "maxMenuHeight": 300,
                                                                               "menuIsOpen": false,
                                                                               "menuPlacement": "bottom",
@@ -25159,7 +25030,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                               "isSearchable": true,
                                                                               "isValidNewOption": [Function],
                                                                               "loadingMessage": [Function],
-                                                                              "matchProp": "label",
                                                                               "maxMenuHeight": 300,
                                                                               "menuIsOpen": false,
                                                                               "menuPlacement": "bottom",
@@ -25403,13 +25273,13 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                             defaultValue={null}
                                             delimiter=","
                                             displayKey="label"
+                                            filterOption={[Function]}
                                             getOptionLabel={[Function]}
                                             getOptionValue={[Function]}
                                             id="aggregation-condition"
                                             isClearable={false}
                                             isDisabled={false}
                                             isMulti={false}
-                                            matchProp="label"
                                             onChange={[Function]}
                                             options={
                                               Array [
@@ -25491,7 +25361,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                               isRtl={false}
                                               isSearchable={true}
                                               loadingMessage={[Function]}
-                                              matchProp="label"
                                               maxMenuHeight={300}
                                               menuIsOpen={false}
                                               menuPlacement="bottom"
@@ -25631,7 +25500,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                     "isRtl": false,
                                                     "isSearchable": true,
                                                     "loadingMessage": [Function],
-                                                    "matchProp": "label",
                                                     "maxMenuHeight": 300,
                                                     "menuIsOpen": false,
                                                     "menuPlacement": "bottom",
@@ -25805,7 +25673,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         "isRtl": false,
                                                         "isSearchable": true,
                                                         "loadingMessage": [Function],
-                                                        "matchProp": "label",
                                                         "maxMenuHeight": 300,
                                                         "menuIsOpen": false,
                                                         "menuPlacement": "bottom",
@@ -25970,7 +25837,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "isRtl": false,
                                                             "isSearchable": true,
                                                             "loadingMessage": [Function],
-                                                            "matchProp": "label",
                                                             "maxMenuHeight": 300,
                                                             "menuIsOpen": false,
                                                             "menuPlacement": "bottom",
@@ -26135,7 +26001,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                 "isRtl": false,
                                                                 "isSearchable": true,
                                                                 "loadingMessage": [Function],
-                                                                "matchProp": "label",
                                                                 "maxMenuHeight": 300,
                                                                 "menuIsOpen": false,
                                                                 "menuPlacement": "bottom",
@@ -26281,7 +26146,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                 "isRtl": false,
                                                                 "isSearchable": true,
                                                                 "loadingMessage": [Function],
-                                                                "matchProp": "label",
                                                                 "maxMenuHeight": 300,
                                                                 "menuIsOpen": false,
                                                                 "menuPlacement": "bottom",
@@ -26534,7 +26398,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "isRtl": false,
                                                             "isSearchable": true,
                                                             "loadingMessage": [Function],
-                                                            "matchProp": "label",
                                                             "maxMenuHeight": 300,
                                                             "menuIsOpen": false,
                                                             "menuPlacement": "bottom",
@@ -26698,7 +26561,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                 "isRtl": false,
                                                                 "isSearchable": true,
                                                                 "loadingMessage": [Function],
-                                                                "matchProp": "label",
                                                                 "maxMenuHeight": 300,
                                                                 "menuIsOpen": false,
                                                                 "menuPlacement": "bottom",
@@ -26866,7 +26728,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                 "isRtl": false,
                                                                 "isSearchable": true,
                                                                 "loadingMessage": [Function],
-                                                                "matchProp": "label",
                                                                 "maxMenuHeight": 300,
                                                                 "menuIsOpen": false,
                                                                 "menuPlacement": "bottom",
@@ -27857,12 +27718,12 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                     defaultValue={null}
                                     delimiter=","
                                     displayKey="label"
+                                    filterOption={[Function]}
                                     getOptionLabel={[Function]}
                                     getOptionValue={[Function]}
                                     isClearable={false}
                                     isDisabled={false}
                                     isMulti={false}
-                                    matchProp="label"
                                     onChange={[Function]}
                                     options={
                                       Array [
@@ -27934,7 +27795,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                       isRtl={false}
                                       isSearchable={true}
                                       loadingMessage={[Function]}
-                                      matchProp="label"
                                       maxMenuHeight={300}
                                       menuIsOpen={false}
                                       menuPlacement="bottom"
@@ -28054,7 +27914,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                             "isRtl": false,
                                             "isSearchable": true,
                                             "loadingMessage": [Function],
-                                            "matchProp": "label",
                                             "maxMenuHeight": 300,
                                             "menuIsOpen": false,
                                             "menuPlacement": "bottom",
@@ -28206,7 +28065,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                 "isRtl": false,
                                                 "isSearchable": true,
                                                 "loadingMessage": [Function],
-                                                "matchProp": "label",
                                                 "maxMenuHeight": 300,
                                                 "menuIsOpen": false,
                                                 "menuPlacement": "bottom",
@@ -28350,7 +28208,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                     "isRtl": false,
                                                     "isSearchable": true,
                                                     "loadingMessage": [Function],
-                                                    "matchProp": "label",
                                                     "maxMenuHeight": 300,
                                                     "menuIsOpen": false,
                                                     "menuPlacement": "bottom",
@@ -28498,7 +28355,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         "isRtl": false,
                                                         "isSearchable": true,
                                                         "loadingMessage": [Function],
-                                                        "matchProp": "label",
                                                         "maxMenuHeight": 300,
                                                         "menuIsOpen": false,
                                                         "menuPlacement": "bottom",
@@ -28635,7 +28491,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         "isRtl": false,
                                                         "isSearchable": true,
                                                         "loadingMessage": [Function],
-                                                        "matchProp": "label",
                                                         "maxMenuHeight": 300,
                                                         "menuIsOpen": false,
                                                         "menuPlacement": "bottom",
@@ -28867,7 +28722,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                     "isRtl": false,
                                                     "isSearchable": true,
                                                     "loadingMessage": [Function],
-                                                    "matchProp": "label",
                                                     "maxMenuHeight": 300,
                                                     "menuIsOpen": false,
                                                     "menuPlacement": "bottom",
@@ -29010,7 +28864,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         "isRtl": false,
                                                         "isSearchable": true,
                                                         "loadingMessage": [Function],
-                                                        "matchProp": "label",
                                                         "maxMenuHeight": 300,
                                                         "menuIsOpen": false,
                                                         "menuPlacement": "bottom",
@@ -29157,7 +29010,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         "isRtl": false,
                                                         "isSearchable": true,
                                                         "loadingMessage": [Function],
-                                                        "matchProp": "label",
                                                         "maxMenuHeight": 300,
                                                         "menuIsOpen": false,
                                                         "menuPlacement": "bottom",
@@ -29762,12 +29614,12 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                     defaultValue={null}
                                                     delimiter=","
                                                     displayKey="label"
+                                                    filterOption={[Function]}
                                                     getOptionLabel={[Function]}
                                                     getOptionValue={[Function]}
                                                     isClearable={false}
                                                     isDisabled={false}
                                                     isMulti={false}
-                                                    matchProp="label"
                                                     onChange={[Function]}
                                                     options={Array []}
                                                     placeholder="Select Function"
@@ -29826,7 +29678,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       isRtl={false}
                                                       isSearchable={true}
                                                       loadingMessage={[Function]}
-                                                      matchProp="label"
                                                       maxMenuHeight={300}
                                                       menuIsOpen={false}
                                                       menuPlacement="bottom"
@@ -29921,7 +29772,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "isRtl": false,
                                                             "isSearchable": true,
                                                             "loadingMessage": [Function],
-                                                            "matchProp": "label",
                                                             "maxMenuHeight": 300,
                                                             "menuIsOpen": false,
                                                             "menuPlacement": "bottom",
@@ -30050,7 +29900,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                 "isRtl": false,
                                                                 "isSearchable": true,
                                                                 "loadingMessage": [Function],
-                                                                "matchProp": "label",
                                                                 "maxMenuHeight": 300,
                                                                 "menuIsOpen": false,
                                                                 "menuPlacement": "bottom",
@@ -30171,7 +30020,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                     "isRtl": false,
                                                                     "isSearchable": true,
                                                                     "loadingMessage": [Function],
-                                                                    "matchProp": "label",
                                                                     "maxMenuHeight": 300,
                                                                     "menuIsOpen": false,
                                                                     "menuPlacement": "bottom",
@@ -30292,7 +30140,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                         "isRtl": false,
                                                                         "isSearchable": true,
                                                                         "loadingMessage": [Function],
-                                                                        "matchProp": "label",
                                                                         "maxMenuHeight": 300,
                                                                         "menuIsOpen": false,
                                                                         "menuPlacement": "bottom",
@@ -30417,7 +30264,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                         "isRtl": false,
                                                                         "isSearchable": true,
                                                                         "loadingMessage": [Function],
-                                                                        "matchProp": "label",
                                                                         "maxMenuHeight": 300,
                                                                         "menuIsOpen": false,
                                                                         "menuPlacement": "bottom",
@@ -30626,7 +30472,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                     "isRtl": false,
                                                                     "isSearchable": true,
                                                                     "loadingMessage": [Function],
-                                                                    "matchProp": "label",
                                                                     "maxMenuHeight": 300,
                                                                     "menuIsOpen": false,
                                                                     "menuPlacement": "bottom",
@@ -30746,7 +30591,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                         "isRtl": false,
                                                                         "isSearchable": true,
                                                                         "loadingMessage": [Function],
-                                                                        "matchProp": "label",
                                                                         "maxMenuHeight": 300,
                                                                         "menuIsOpen": false,
                                                                         "menuPlacement": "bottom",
@@ -30870,7 +30714,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                         "isRtl": false,
                                                                         "isSearchable": true,
                                                                         "loadingMessage": [Function],
-                                                                        "matchProp": "label",
                                                                         "maxMenuHeight": 300,
                                                                         "menuIsOpen": false,
                                                                         "menuPlacement": "bottom",
@@ -31029,12 +30872,12 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                     defaultValue={null}
                                                     delimiter=","
                                                     displayKey="label"
+                                                    filterOption={[Function]}
                                                     getOptionLabel={[Function]}
                                                     getOptionValue={[Function]}
                                                     isClearable={true}
                                                     isDisabled={false}
                                                     isMulti={false}
-                                                    matchProp="label"
                                                     onChange={[Function]}
                                                     options={Array []}
                                                     placeholder="Select Field (Optional)"
@@ -31078,6 +30921,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       createOptionPosition="last"
                                                       delimiter=","
                                                       displayKey="label"
+                                                      filterOption={[Function]}
                                                       formatCreateLabel={[Function]}
                                                       getNewOptionData={[Function]}
                                                       getOptionLabel={[Function]}
@@ -31087,7 +30931,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       isDisabled={false}
                                                       isMulti={false}
                                                       isValidNewOption={[Function]}
-                                                      matchProp="label"
                                                       menuIsOpen={false}
                                                       onChange={[Function]}
                                                       onInputChange={[Function]}
@@ -31158,7 +31001,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         isSearchable={true}
                                                         isValidNewOption={[Function]}
                                                         loadingMessage={[Function]}
-                                                        matchProp="label"
                                                         maxMenuHeight={300}
                                                         menuIsOpen={false}
                                                         menuPlacement="bottom"
@@ -31261,7 +31103,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                               "isSearchable": true,
                                                               "isValidNewOption": [Function],
                                                               "loadingMessage": [Function],
-                                                              "matchProp": "label",
                                                               "maxMenuHeight": 300,
                                                               "menuIsOpen": false,
                                                               "menuPlacement": "bottom",
@@ -31398,7 +31239,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                   "isSearchable": true,
                                                                   "isValidNewOption": [Function],
                                                                   "loadingMessage": [Function],
-                                                                  "matchProp": "label",
                                                                   "maxMenuHeight": 300,
                                                                   "menuIsOpen": false,
                                                                   "menuPlacement": "bottom",
@@ -31527,7 +31367,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                       "isSearchable": true,
                                                                       "isValidNewOption": [Function],
                                                                       "loadingMessage": [Function],
-                                                                      "matchProp": "label",
                                                                       "maxMenuHeight": 300,
                                                                       "menuIsOpen": false,
                                                                       "menuPlacement": "bottom",
@@ -31660,7 +31499,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                           "isSearchable": true,
                                                                           "isValidNewOption": [Function],
                                                                           "loadingMessage": [Function],
-                                                                          "matchProp": "label",
                                                                           "maxMenuHeight": 300,
                                                                           "menuIsOpen": false,
                                                                           "menuPlacement": "bottom",
@@ -31793,7 +31631,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                           "isSearchable": true,
                                                                           "isValidNewOption": [Function],
                                                                           "loadingMessage": [Function],
-                                                                          "matchProp": "label",
                                                                           "maxMenuHeight": 300,
                                                                           "menuIsOpen": false,
                                                                           "menuPlacement": "bottom",
@@ -32010,7 +31847,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                       "isSearchable": true,
                                                                       "isValidNewOption": [Function],
                                                                       "loadingMessage": [Function],
-                                                                      "matchProp": "label",
                                                                       "maxMenuHeight": 300,
                                                                       "menuIsOpen": false,
                                                                       "menuPlacement": "bottom",
@@ -32144,7 +31980,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                           "isSearchable": true,
                                                                           "isValidNewOption": [Function],
                                                                           "loadingMessage": [Function],
-                                                                          "matchProp": "label",
                                                                           "maxMenuHeight": 300,
                                                                           "menuIsOpen": false,
                                                                           "menuPlacement": "bottom",
@@ -32295,7 +32130,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                           "isSearchable": true,
                                                                           "isValidNewOption": [Function],
                                                                           "loadingMessage": [Function],
-                                                                          "matchProp": "label",
                                                                           "maxMenuHeight": 300,
                                                                           "menuIsOpen": false,
                                                                           "menuPlacement": "bottom",
@@ -32427,7 +32261,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                           "isSearchable": true,
                                                                           "isValidNewOption": [Function],
                                                                           "loadingMessage": [Function],
-                                                                          "matchProp": "label",
                                                                           "maxMenuHeight": 300,
                                                                           "menuIsOpen": false,
                                                                           "menuPlacement": "bottom",
@@ -32713,13 +32546,13 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                         defaultValue={null}
                                         delimiter=","
                                         displayKey="label"
+                                        filterOption={[Function]}
                                         getOptionLabel={[Function]}
                                         getOptionValue={[Function]}
                                         id="aggregation-condition"
                                         isClearable={false}
                                         isDisabled={false}
                                         isMulti={false}
-                                        matchProp="label"
                                         onChange={[Function]}
                                         options={
                                           Array [
@@ -32801,7 +32634,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                           isRtl={false}
                                           isSearchable={true}
                                           loadingMessage={[Function]}
-                                          matchProp="label"
                                           maxMenuHeight={300}
                                           menuIsOpen={false}
                                           menuPlacement="bottom"
@@ -32941,7 +32773,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                 "isRtl": false,
                                                 "isSearchable": true,
                                                 "loadingMessage": [Function],
-                                                "matchProp": "label",
                                                 "maxMenuHeight": 300,
                                                 "menuIsOpen": false,
                                                 "menuPlacement": "bottom",
@@ -33115,7 +32946,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                     "isRtl": false,
                                                     "isSearchable": true,
                                                     "loadingMessage": [Function],
-                                                    "matchProp": "label",
                                                     "maxMenuHeight": 300,
                                                     "menuIsOpen": false,
                                                     "menuPlacement": "bottom",
@@ -33280,7 +33110,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         "isRtl": false,
                                                         "isSearchable": true,
                                                         "loadingMessage": [Function],
-                                                        "matchProp": "label",
                                                         "maxMenuHeight": 300,
                                                         "menuIsOpen": false,
                                                         "menuPlacement": "bottom",
@@ -33445,7 +33274,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "isRtl": false,
                                                             "isSearchable": true,
                                                             "loadingMessage": [Function],
-                                                            "matchProp": "label",
                                                             "maxMenuHeight": 300,
                                                             "menuIsOpen": false,
                                                             "menuPlacement": "bottom",
@@ -33591,7 +33419,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "isRtl": false,
                                                             "isSearchable": true,
                                                             "loadingMessage": [Function],
-                                                            "matchProp": "label",
                                                             "maxMenuHeight": 300,
                                                             "menuIsOpen": false,
                                                             "menuPlacement": "bottom",
@@ -33844,7 +33671,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         "isRtl": false,
                                                         "isSearchable": true,
                                                         "loadingMessage": [Function],
-                                                        "matchProp": "label",
                                                         "maxMenuHeight": 300,
                                                         "menuIsOpen": false,
                                                         "menuPlacement": "bottom",
@@ -34008,7 +33834,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "isRtl": false,
                                                             "isSearchable": true,
                                                             "loadingMessage": [Function],
-                                                            "matchProp": "label",
                                                             "maxMenuHeight": 300,
                                                             "menuIsOpen": false,
                                                             "menuPlacement": "bottom",
@@ -34176,7 +34001,6 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "isRtl": false,
                                                             "isSearchable": true,
                                                             "loadingMessage": [Function],
-                                                            "matchProp": "label",
                                                             "maxMenuHeight": 300,
                                                             "menuIsOpen": false,
                                                             "menuPlacement": "bottom",
@@ -35217,12 +35041,12 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                   defaultValue={null}
                                   delimiter=","
                                   displayKey="label"
+                                  filterOption={[Function]}
                                   getOptionLabel={[Function]}
                                   getOptionValue={[Function]}
                                   isClearable={false}
                                   isDisabled={false}
                                   isMulti={false}
-                                  matchProp="label"
                                   onChange={[Function]}
                                   options={
                                     Array [
@@ -35294,7 +35118,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                     isRtl={false}
                                     isSearchable={true}
                                     loadingMessage={[Function]}
-                                    matchProp="label"
                                     maxMenuHeight={300}
                                     menuIsOpen={false}
                                     menuPlacement="bottom"
@@ -35414,7 +35237,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                           "isRtl": false,
                                           "isSearchable": true,
                                           "loadingMessage": [Function],
-                                          "matchProp": "label",
                                           "maxMenuHeight": 300,
                                           "menuIsOpen": false,
                                           "menuPlacement": "bottom",
@@ -35566,7 +35388,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                               "isRtl": false,
                                               "isSearchable": true,
                                               "loadingMessage": [Function],
-                                              "matchProp": "label",
                                               "maxMenuHeight": 300,
                                               "menuIsOpen": false,
                                               "menuPlacement": "bottom",
@@ -35710,7 +35531,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -35858,7 +35678,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -35995,7 +35814,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -36227,7 +36045,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -36370,7 +36187,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -36517,7 +36333,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -37001,12 +36816,12 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                           defaultValue={null}
                                           delimiter=","
                                           displayKey="label"
+                                          filterOption={[Function]}
                                           getOptionLabel={[Function]}
                                           getOptionValue={[Function]}
                                           isClearable={false}
                                           isDisabled={false}
                                           isMulti={false}
-                                          matchProp="label"
                                           onChange={[Function]}
                                           options={Array []}
                                           placeholder="Select Function"
@@ -37065,7 +36880,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                             isRtl={false}
                                             isSearchable={true}
                                             loadingMessage={[Function]}
-                                            matchProp="label"
                                             maxMenuHeight={300}
                                             menuIsOpen={false}
                                             menuPlacement="bottom"
@@ -37160,7 +36974,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -37289,7 +37102,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -37410,7 +37222,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                           "isRtl": false,
                                                           "isSearchable": true,
                                                           "loadingMessage": [Function],
-                                                          "matchProp": "label",
                                                           "maxMenuHeight": 300,
                                                           "menuIsOpen": false,
                                                           "menuPlacement": "bottom",
@@ -37531,7 +37342,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                               "isRtl": false,
                                                               "isSearchable": true,
                                                               "loadingMessage": [Function],
-                                                              "matchProp": "label",
                                                               "maxMenuHeight": 300,
                                                               "menuIsOpen": false,
                                                               "menuPlacement": "bottom",
@@ -37656,7 +37466,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                               "isRtl": false,
                                                               "isSearchable": true,
                                                               "loadingMessage": [Function],
-                                                              "matchProp": "label",
                                                               "maxMenuHeight": 300,
                                                               "menuIsOpen": false,
                                                               "menuPlacement": "bottom",
@@ -37865,7 +37674,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                           "isRtl": false,
                                                           "isSearchable": true,
                                                           "loadingMessage": [Function],
-                                                          "matchProp": "label",
                                                           "maxMenuHeight": 300,
                                                           "menuIsOpen": false,
                                                           "menuPlacement": "bottom",
@@ -37985,7 +37793,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                               "isRtl": false,
                                                               "isSearchable": true,
                                                               "loadingMessage": [Function],
-                                                              "matchProp": "label",
                                                               "maxMenuHeight": 300,
                                                               "menuIsOpen": false,
                                                               "menuPlacement": "bottom",
@@ -38109,7 +37916,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                               "isRtl": false,
                                                               "isSearchable": true,
                                                               "loadingMessage": [Function],
-                                                              "matchProp": "label",
                                                               "maxMenuHeight": 300,
                                                               "menuIsOpen": false,
                                                               "menuPlacement": "bottom",
@@ -38267,12 +38073,12 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                           defaultValue={null}
                                           delimiter=","
                                           displayKey="label"
+                                          filterOption={[Function]}
                                           getOptionLabel={[Function]}
                                           getOptionValue={[Function]}
                                           isClearable={true}
                                           isDisabled={false}
                                           isMulti={false}
-                                          matchProp="label"
                                           onChange={[Function]}
                                           options={Array []}
                                           placeholder="Select Field (Optional)"
@@ -38313,6 +38119,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                             createOptionPosition="last"
                                             delimiter=","
                                             displayKey="label"
+                                            filterOption={[Function]}
                                             formatCreateLabel={[Function]}
                                             getNewOptionData={[Function]}
                                             getOptionLabel={[Function]}
@@ -38322,7 +38129,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                             isDisabled={false}
                                             isMulti={false}
                                             isValidNewOption={[Function]}
-                                            matchProp="label"
                                             menuIsOpen={false}
                                             onChange={[Function]}
                                             onInputChange={[Function]}
@@ -38390,7 +38196,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                               isSearchable={true}
                                               isValidNewOption={[Function]}
                                               loadingMessage={[Function]}
-                                              matchProp="label"
                                               maxMenuHeight={300}
                                               menuIsOpen={false}
                                               menuPlacement="bottom"
@@ -38490,7 +38295,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                     "isSearchable": true,
                                                     "isValidNewOption": [Function],
                                                     "loadingMessage": [Function],
-                                                    "matchProp": "label",
                                                     "maxMenuHeight": 300,
                                                     "menuIsOpen": false,
                                                     "menuPlacement": "bottom",
@@ -38624,7 +38428,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                         "isSearchable": true,
                                                         "isValidNewOption": [Function],
                                                         "loadingMessage": [Function],
-                                                        "matchProp": "label",
                                                         "maxMenuHeight": 300,
                                                         "menuIsOpen": false,
                                                         "menuPlacement": "bottom",
@@ -38750,7 +38553,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                             "isSearchable": true,
                                                             "isValidNewOption": [Function],
                                                             "loadingMessage": [Function],
-                                                            "matchProp": "label",
                                                             "maxMenuHeight": 300,
                                                             "menuIsOpen": false,
                                                             "menuPlacement": "bottom",
@@ -38876,7 +38678,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                                 "isSearchable": true,
                                                                 "isValidNewOption": [Function],
                                                                 "loadingMessage": [Function],
-                                                                "matchProp": "label",
                                                                 "maxMenuHeight": 300,
                                                                 "menuIsOpen": false,
                                                                 "menuPlacement": "bottom",
@@ -39006,7 +38807,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                                 "isSearchable": true,
                                                                 "isValidNewOption": [Function],
                                                                 "loadingMessage": [Function],
-                                                                "matchProp": "label",
                                                                 "maxMenuHeight": 300,
                                                                 "menuIsOpen": false,
                                                                 "menuPlacement": "bottom",
@@ -39220,7 +39020,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                             "isSearchable": true,
                                                             "isValidNewOption": [Function],
                                                             "loadingMessage": [Function],
-                                                            "matchProp": "label",
                                                             "maxMenuHeight": 300,
                                                             "menuIsOpen": false,
                                                             "menuPlacement": "bottom",
@@ -39345,7 +39144,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                                 "isSearchable": true,
                                                                 "isValidNewOption": [Function],
                                                                 "loadingMessage": [Function],
-                                                                "matchProp": "label",
                                                                 "maxMenuHeight": 300,
                                                                 "menuIsOpen": false,
                                                                 "menuPlacement": "bottom",
@@ -39474,7 +39272,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                                 "isSearchable": true,
                                                                 "isValidNewOption": [Function],
                                                                 "loadingMessage": [Function],
-                                                                "matchProp": "label",
                                                                 "maxMenuHeight": 300,
                                                                 "menuIsOpen": false,
                                                                 "menuPlacement": "bottom",
@@ -39757,13 +39554,13 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                               defaultValue={null}
                               delimiter=","
                               displayKey="label"
+                              filterOption={[Function]}
                               getOptionLabel={[Function]}
                               getOptionValue={[Function]}
                               id="aggregation-condition"
                               isClearable={false}
                               isDisabled={false}
                               isMulti={false}
-                              matchProp="label"
                               onChange={[Function]}
                               options={
                                 Array [
@@ -39845,7 +39642,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                 isRtl={false}
                                 isSearchable={true}
                                 loadingMessage={[Function]}
-                                matchProp="label"
                                 maxMenuHeight={300}
                                 menuIsOpen={false}
                                 menuPlacement="bottom"
@@ -39985,7 +39781,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                       "isRtl": false,
                                       "isSearchable": true,
                                       "loadingMessage": [Function],
-                                      "matchProp": "label",
                                       "maxMenuHeight": 300,
                                       "menuIsOpen": false,
                                       "menuPlacement": "bottom",
@@ -40159,7 +39954,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                           "isRtl": false,
                                           "isSearchable": true,
                                           "loadingMessage": [Function],
-                                          "matchProp": "label",
                                           "maxMenuHeight": 300,
                                           "menuIsOpen": false,
                                           "menuPlacement": "bottom",
@@ -40324,7 +40118,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                               "isRtl": false,
                                               "isSearchable": true,
                                               "loadingMessage": [Function],
-                                              "matchProp": "label",
                                               "maxMenuHeight": 300,
                                               "menuIsOpen": false,
                                               "menuPlacement": "bottom",
@@ -40489,7 +40282,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -40635,7 +40427,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -40888,7 +40679,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                               "isRtl": false,
                                               "isSearchable": true,
                                               "loadingMessage": [Function],
-                                              "matchProp": "label",
                                               "maxMenuHeight": 300,
                                               "menuIsOpen": false,
                                               "menuPlacement": "bottom",
@@ -41052,7 +40842,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -41220,7 +41009,6 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -42250,12 +42038,12 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                   defaultValue={null}
                                   delimiter=","
                                   displayKey="label"
+                                  filterOption={[Function]}
                                   getOptionLabel={[Function]}
                                   getOptionValue={[Function]}
                                   isClearable={false}
                                   isDisabled={false}
                                   isMulti={false}
-                                  matchProp="label"
                                   onChange={[Function]}
                                   options={
                                     Array [
@@ -42327,7 +42115,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                     isRtl={false}
                                     isSearchable={true}
                                     loadingMessage={[Function]}
-                                    matchProp="label"
                                     maxMenuHeight={300}
                                     menuIsOpen={false}
                                     menuPlacement="bottom"
@@ -42447,7 +42234,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                           "isRtl": false,
                                           "isSearchable": true,
                                           "loadingMessage": [Function],
-                                          "matchProp": "label",
                                           "maxMenuHeight": 300,
                                           "menuIsOpen": false,
                                           "menuPlacement": "bottom",
@@ -42599,7 +42385,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                               "isRtl": false,
                                               "isSearchable": true,
                                               "loadingMessage": [Function],
-                                              "matchProp": "label",
                                               "maxMenuHeight": 300,
                                               "menuIsOpen": false,
                                               "menuPlacement": "bottom",
@@ -42743,7 +42528,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -42891,7 +42675,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -43028,7 +42811,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -43260,7 +43042,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -43403,7 +43184,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -43550,7 +43330,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -44053,12 +43832,12 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                           defaultValue={null}
                                           delimiter=","
                                           displayKey="label"
+                                          filterOption={[Function]}
                                           getOptionLabel={[Function]}
                                           getOptionValue={[Function]}
                                           isClearable={false}
                                           isDisabled={false}
                                           isMulti={false}
-                                          matchProp="label"
                                           onChange={[Function]}
                                           options={Array []}
                                           placeholder="Select Function"
@@ -44117,7 +43896,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                             isRtl={false}
                                             isSearchable={true}
                                             loadingMessage={[Function]}
-                                            matchProp="label"
                                             maxMenuHeight={300}
                                             menuIsOpen={false}
                                             menuPlacement="bottom"
@@ -44212,7 +43990,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -44341,7 +44118,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                       "isRtl": false,
                                                       "isSearchable": true,
                                                       "loadingMessage": [Function],
-                                                      "matchProp": "label",
                                                       "maxMenuHeight": 300,
                                                       "menuIsOpen": false,
                                                       "menuPlacement": "bottom",
@@ -44462,7 +44238,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                           "isRtl": false,
                                                           "isSearchable": true,
                                                           "loadingMessage": [Function],
-                                                          "matchProp": "label",
                                                           "maxMenuHeight": 300,
                                                           "menuIsOpen": false,
                                                           "menuPlacement": "bottom",
@@ -44583,7 +44358,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                               "isRtl": false,
                                                               "isSearchable": true,
                                                               "loadingMessage": [Function],
-                                                              "matchProp": "label",
                                                               "maxMenuHeight": 300,
                                                               "menuIsOpen": false,
                                                               "menuPlacement": "bottom",
@@ -44708,7 +44482,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                               "isRtl": false,
                                                               "isSearchable": true,
                                                               "loadingMessage": [Function],
-                                                              "matchProp": "label",
                                                               "maxMenuHeight": 300,
                                                               "menuIsOpen": false,
                                                               "menuPlacement": "bottom",
@@ -44917,7 +44690,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                           "isRtl": false,
                                                           "isSearchable": true,
                                                           "loadingMessage": [Function],
-                                                          "matchProp": "label",
                                                           "maxMenuHeight": 300,
                                                           "menuIsOpen": false,
                                                           "menuPlacement": "bottom",
@@ -45037,7 +44809,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                               "isRtl": false,
                                                               "isSearchable": true,
                                                               "loadingMessage": [Function],
-                                                              "matchProp": "label",
                                                               "maxMenuHeight": 300,
                                                               "menuIsOpen": false,
                                                               "menuPlacement": "bottom",
@@ -45161,7 +44932,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                               "isRtl": false,
                                                               "isSearchable": true,
                                                               "loadingMessage": [Function],
-                                                              "matchProp": "label",
                                                               "maxMenuHeight": 300,
                                                               "menuIsOpen": false,
                                                               "menuPlacement": "bottom",
@@ -45320,12 +45090,12 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                           defaultValue={null}
                                           delimiter=","
                                           displayKey="label"
+                                          filterOption={[Function]}
                                           getOptionLabel={[Function]}
                                           getOptionValue={[Function]}
                                           isClearable={true}
                                           isDisabled={false}
                                           isMulti={false}
-                                          matchProp="label"
                                           onChange={[Function]}
                                           options={Array []}
                                           placeholder="Select Field (Optional)"
@@ -45369,6 +45139,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                             createOptionPosition="last"
                                             delimiter=","
                                             displayKey="label"
+                                            filterOption={[Function]}
                                             formatCreateLabel={[Function]}
                                             getNewOptionData={[Function]}
                                             getOptionLabel={[Function]}
@@ -45378,7 +45149,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                             isDisabled={false}
                                             isMulti={false}
                                             isValidNewOption={[Function]}
-                                            matchProp="label"
                                             menuIsOpen={false}
                                             onChange={[Function]}
                                             onInputChange={[Function]}
@@ -45449,7 +45219,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                               isSearchable={true}
                                               isValidNewOption={[Function]}
                                               loadingMessage={[Function]}
-                                              matchProp="label"
                                               maxMenuHeight={300}
                                               menuIsOpen={false}
                                               menuPlacement="bottom"
@@ -45552,7 +45321,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                     "isSearchable": true,
                                                     "isValidNewOption": [Function],
                                                     "loadingMessage": [Function],
-                                                    "matchProp": "label",
                                                     "maxMenuHeight": 300,
                                                     "menuIsOpen": false,
                                                     "menuPlacement": "bottom",
@@ -45689,7 +45457,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                         "isSearchable": true,
                                                         "isValidNewOption": [Function],
                                                         "loadingMessage": [Function],
-                                                        "matchProp": "label",
                                                         "maxMenuHeight": 300,
                                                         "menuIsOpen": false,
                                                         "menuPlacement": "bottom",
@@ -45818,7 +45585,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                             "isSearchable": true,
                                                             "isValidNewOption": [Function],
                                                             "loadingMessage": [Function],
-                                                            "matchProp": "label",
                                                             "maxMenuHeight": 300,
                                                             "menuIsOpen": false,
                                                             "menuPlacement": "bottom",
@@ -45951,7 +45717,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                                 "isSearchable": true,
                                                                 "isValidNewOption": [Function],
                                                                 "loadingMessage": [Function],
-                                                                "matchProp": "label",
                                                                 "maxMenuHeight": 300,
                                                                 "menuIsOpen": false,
                                                                 "menuPlacement": "bottom",
@@ -46084,7 +45849,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                                 "isSearchable": true,
                                                                 "isValidNewOption": [Function],
                                                                 "loadingMessage": [Function],
-                                                                "matchProp": "label",
                                                                 "maxMenuHeight": 300,
                                                                 "menuIsOpen": false,
                                                                 "menuPlacement": "bottom",
@@ -46301,7 +46065,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                             "isSearchable": true,
                                                             "isValidNewOption": [Function],
                                                             "loadingMessage": [Function],
-                                                            "matchProp": "label",
                                                             "maxMenuHeight": 300,
                                                             "menuIsOpen": false,
                                                             "menuPlacement": "bottom",
@@ -46435,7 +46198,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                                 "isSearchable": true,
                                                                 "isValidNewOption": [Function],
                                                                 "loadingMessage": [Function],
-                                                                "matchProp": "label",
                                                                 "maxMenuHeight": 300,
                                                                 "menuIsOpen": false,
                                                                 "menuPlacement": "bottom",
@@ -46586,7 +46348,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                                 "isSearchable": true,
                                                                 "isValidNewOption": [Function],
                                                                 "loadingMessage": [Function],
-                                                                "matchProp": "label",
                                                                 "maxMenuHeight": 300,
                                                                 "menuIsOpen": false,
                                                                 "menuPlacement": "bottom",
@@ -46718,7 +46479,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                                 "isSearchable": true,
                                                                 "isValidNewOption": [Function],
                                                                 "loadingMessage": [Function],
-                                                                "matchProp": "label",
                                                                 "maxMenuHeight": 300,
                                                                 "menuIsOpen": false,
                                                                 "menuPlacement": "bottom",
@@ -47005,13 +46765,13 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                               defaultValue={null}
                               delimiter=","
                               displayKey="label"
+                              filterOption={[Function]}
                               getOptionLabel={[Function]}
                               getOptionValue={[Function]}
                               id="aggregation-condition"
                               isClearable={false}
                               isDisabled={false}
                               isMulti={false}
-                              matchProp="label"
                               onChange={[Function]}
                               options={
                                 Array [
@@ -47096,7 +46856,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                 isRtl={false}
                                 isSearchable={true}
                                 loadingMessage={[Function]}
-                                matchProp="label"
                                 maxMenuHeight={300}
                                 menuIsOpen={false}
                                 menuPlacement="bottom"
@@ -47239,7 +46998,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                       "isRtl": false,
                                       "isSearchable": true,
                                       "loadingMessage": [Function],
-                                      "matchProp": "label",
                                       "maxMenuHeight": 300,
                                       "menuIsOpen": false,
                                       "menuPlacement": "bottom",
@@ -47416,7 +47174,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                           "isRtl": false,
                                           "isSearchable": true,
                                           "loadingMessage": [Function],
-                                          "matchProp": "label",
                                           "maxMenuHeight": 300,
                                           "menuIsOpen": false,
                                           "menuPlacement": "bottom",
@@ -47584,7 +47341,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                               "isRtl": false,
                                               "isSearchable": true,
                                               "loadingMessage": [Function],
-                                              "matchProp": "label",
                                               "maxMenuHeight": 300,
                                               "menuIsOpen": false,
                                               "menuPlacement": "bottom",
@@ -47756,7 +47512,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -47905,7 +47660,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -48161,7 +47915,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                               "isRtl": false,
                                               "isSearchable": true,
                                               "loadingMessage": [Function],
-                                              "matchProp": "label",
                                               "maxMenuHeight": 300,
                                               "menuIsOpen": false,
                                               "menuPlacement": "bottom",
@@ -48328,7 +48081,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",
@@ -48499,7 +48251,6 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                   "isRtl": false,
                                                   "isSearchable": true,
                                                   "loadingMessage": [Function],
-                                                  "matchProp": "label",
                                                   "maxMenuHeight": 300,
                                                   "menuIsOpen": false,
                                                   "menuPlacement": "bottom",

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/__snapshots__/AggregationConditionExpression.test.jsx.snap
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/__snapshots__/AggregationConditionExpression.test.jsx.snap
@@ -292,6 +292,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                   isClearable={false}
                                   isDisabled={false}
                                   isMulti={false}
+                                  isOptionDisabled={[Function]}
                                   onChange={[Function]}
                                   options={
                                     Array [
@@ -2232,6 +2233,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                               isClearable={false}
                                               isDisabled={false}
                                               isMulti={false}
+                                              isOptionDisabled={[Function]}
                                               onChange={[Function]}
                                               options={Array []}
                                               placeholder="Select Function"
@@ -3490,6 +3492,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                               isClearable={true}
                                               isDisabled={false}
                                               isMulti={false}
+                                              isOptionDisabled={[Function]}
                                               onChange={[Function]}
                                               options={Array []}
                                               placeholder="Select Field (Optional)"
@@ -3542,6 +3545,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                 isClearable={true}
                                                 isDisabled={false}
                                                 isMulti={false}
+                                                isOptionDisabled={[Function]}
                                                 isValidNewOption={[Function]}
                                                 menuIsOpen={false}
                                                 onChange={[Function]}
@@ -5165,6 +5169,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                   isClearable={false}
                                   isDisabled={false}
                                   isMulti={false}
+                                  isOptionDisabled={[Function]}
                                   onChange={[Function]}
                                   options={
                                     Array [
@@ -7739,6 +7744,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                               isClearable={false}
                                               isDisabled={false}
                                               isMulti={false}
+                                              isOptionDisabled={[Function]}
                                               onChange={[Function]}
                                               options={Array []}
                                               placeholder="Select Function"
@@ -8997,6 +9003,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                               isClearable={true}
                                               isDisabled={false}
                                               isMulti={false}
+                                              isOptionDisabled={[Function]}
                                               onChange={[Function]}
                                               options={Array []}
                                               placeholder="Select Field (Optional)"
@@ -9049,6 +9056,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                 isClearable={true}
                                                 isDisabled={false}
                                                 isMulti={false}
+                                                isOptionDisabled={[Function]}
                                                 isValidNewOption={[Function]}
                                                 menuIsOpen={false}
                                                 onChange={[Function]}
@@ -10630,6 +10638,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                   isClearable={false}
                                   isDisabled={false}
                                   isMulti={false}
+                                  isOptionDisabled={[Function]}
                                   onChange={[Function]}
                                   options={
                                     Array [
@@ -13101,6 +13110,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                   isClearable={false}
                                   isDisabled={false}
                                   isMulti={false}
+                                  isOptionDisabled={[Function]}
                                   onChange={[Function]}
                                   options={
                                     Array [
@@ -15053,6 +15063,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                               isClearable={false}
                                               isDisabled={false}
                                               isMulti={false}
+                                              isOptionDisabled={[Function]}
                                               onChange={[Function]}
                                               options={Array []}
                                               placeholder="Select Function"
@@ -16311,6 +16322,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                               isClearable={true}
                                               isDisabled={false}
                                               isMulti={false}
+                                              isOptionDisabled={[Function]}
                                               onChange={[Function]}
                                               options={Array []}
                                               placeholder="Select Field (Optional)"
@@ -16363,6 +16375,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                 isClearable={true}
                                                 isDisabled={false}
                                                 isMulti={false}
+                                                isOptionDisabled={[Function]}
                                                 isValidNewOption={[Function]}
                                                 menuIsOpen={false}
                                                 onChange={[Function]}
@@ -17986,6 +17999,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                   isClearable={false}
                                   isDisabled={false}
                                   isMulti={false}
+                                  isOptionDisabled={[Function]}
                                   onChange={[Function]}
                                   options={
                                     Array [
@@ -20535,6 +20549,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                         isClearable={false}
                                         isDisabled={false}
                                         isMulti={false}
+                                        isOptionDisabled={[Function]}
                                         onChange={[Function]}
                                         options={
                                           Array [
@@ -22389,6 +22404,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         isClearable={false}
                                                         isDisabled={false}
                                                         isMulti={false}
+                                                        isOptionDisabled={[Function]}
                                                         onChange={[Function]}
                                                         options={Array []}
                                                         placeholder="Select Function"
@@ -23647,6 +23663,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         isClearable={true}
                                                         isDisabled={false}
                                                         isMulti={false}
+                                                        isOptionDisabled={[Function]}
                                                         onChange={[Function]}
                                                         options={Array []}
                                                         placeholder="Select Field (Optional)"
@@ -23699,6 +23716,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                           isClearable={true}
                                                           isDisabled={false}
                                                           isMulti={false}
+                                                          isOptionDisabled={[Function]}
                                                           isValidNewOption={[Function]}
                                                           menuIsOpen={false}
                                                           onChange={[Function]}
@@ -25280,6 +25298,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                             isClearable={false}
                                             isDisabled={false}
                                             isMulti={false}
+                                            isOptionDisabled={[Function]}
                                             onChange={[Function]}
                                             options={
                                               Array [
@@ -27724,6 +27743,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                     isClearable={false}
                                     isDisabled={false}
                                     isMulti={false}
+                                    isOptionDisabled={[Function]}
                                     onChange={[Function]}
                                     options={
                                       Array [
@@ -29620,6 +29640,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                     isClearable={false}
                                                     isDisabled={false}
                                                     isMulti={false}
+                                                    isOptionDisabled={[Function]}
                                                     onChange={[Function]}
                                                     options={Array []}
                                                     placeholder="Select Function"
@@ -30878,6 +30899,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                     isClearable={true}
                                                     isDisabled={false}
                                                     isMulti={false}
+                                                    isOptionDisabled={[Function]}
                                                     onChange={[Function]}
                                                     options={Array []}
                                                     placeholder="Select Field (Optional)"
@@ -30930,6 +30952,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       isClearable={true}
                                                       isDisabled={false}
                                                       isMulti={false}
+                                                      isOptionDisabled={[Function]}
                                                       isValidNewOption={[Function]}
                                                       menuIsOpen={false}
                                                       onChange={[Function]}
@@ -32553,6 +32576,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                         isClearable={false}
                                         isDisabled={false}
                                         isMulti={false}
+                                        isOptionDisabled={[Function]}
                                         onChange={[Function]}
                                         options={
                                           Array [
@@ -35047,6 +35071,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                   isClearable={false}
                                   isDisabled={false}
                                   isMulti={false}
+                                  isOptionDisabled={[Function]}
                                   onChange={[Function]}
                                   options={
                                     Array [
@@ -36822,6 +36847,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                           isClearable={false}
                                           isDisabled={false}
                                           isMulti={false}
+                                          isOptionDisabled={[Function]}
                                           onChange={[Function]}
                                           options={Array []}
                                           placeholder="Select Function"
@@ -38079,6 +38105,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                           isClearable={true}
                                           isDisabled={false}
                                           isMulti={false}
+                                          isOptionDisabled={[Function]}
                                           onChange={[Function]}
                                           options={Array []}
                                           placeholder="Select Field (Optional)"
@@ -38128,6 +38155,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                             isClearable={true}
                                             isDisabled={false}
                                             isMulti={false}
+                                            isOptionDisabled={[Function]}
                                             isValidNewOption={[Function]}
                                             menuIsOpen={false}
                                             onChange={[Function]}
@@ -39561,6 +39589,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                               isClearable={false}
                               isDisabled={false}
                               isMulti={false}
+                              isOptionDisabled={[Function]}
                               onChange={[Function]}
                               options={
                                 Array [
@@ -42044,6 +42073,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                   isClearable={false}
                                   isDisabled={false}
                                   isMulti={false}
+                                  isOptionDisabled={[Function]}
                                   onChange={[Function]}
                                   options={
                                     Array [
@@ -43838,6 +43868,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                           isClearable={false}
                                           isDisabled={false}
                                           isMulti={false}
+                                          isOptionDisabled={[Function]}
                                           onChange={[Function]}
                                           options={Array []}
                                           placeholder="Select Function"
@@ -45096,6 +45127,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                           isClearable={true}
                                           isDisabled={false}
                                           isMulti={false}
+                                          isOptionDisabled={[Function]}
                                           onChange={[Function]}
                                           options={Array []}
                                           placeholder="Select Field (Optional)"
@@ -45148,6 +45180,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                             isClearable={true}
                                             isDisabled={false}
                                             isMulti={false}
+                                            isOptionDisabled={[Function]}
                                             isValidNewOption={[Function]}
                                             menuIsOpen={false}
                                             onChange={[Function]}
@@ -46772,6 +46805,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                               isClearable={false}
                               isDisabled={false}
                               isMulti={false}
+                              isOptionDisabled={[Function]}
                               onChange={[Function]}
                               options={
                                 Array [

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/__snapshots__/AggregationConditionExpression.test.jsx.snap
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/__snapshots__/AggregationConditionExpression.test.jsx.snap
@@ -246,6 +246,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                 allowCreate={false}
                                 autoFocus={false}
                                 className="boolean-operator"
+                                clearable={false}
                                 components={null}
                                 delimiter=","
                                 disabled={false}
@@ -287,6 +288,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                   displayKey="label"
                                   getOptionLabel={[Function]}
                                   getOptionValue={[Function]}
+                                  isClearable={false}
                                   isDisabled={false}
                                   isMulti={false}
                                   matchProp="label"
@@ -353,6 +355,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                     getOptionLabel={[Function]}
                                     getOptionValue={[Function]}
                                     inputValue=""
+                                    isClearable={false}
                                     isDisabled={false}
                                     isLoading={false}
                                     isMulti={false}
@@ -472,6 +475,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                           "getOptionLabel": [Function],
                                           "getOptionValue": [Function],
                                           "inputValue": "",
+                                          "isClearable": false,
                                           "isDisabled": false,
                                           "isLoading": false,
                                           "isMulti": false,
@@ -623,6 +627,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                               "getOptionLabel": [Function],
                                               "getOptionValue": [Function],
                                               "inputValue": "",
+                                              "isClearable": false,
                                               "isDisabled": false,
                                               "isLoading": false,
                                               "isMulti": false,
@@ -766,6 +771,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                   "getOptionLabel": [Function],
                                                   "getOptionValue": [Function],
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -913,6 +919,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "getOptionLabel": [Function],
                                                       "getOptionValue": [Function],
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -1049,6 +1056,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "getOptionLabel": [Function],
                                                       "getOptionValue": [Function],
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -1280,6 +1288,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                   "getOptionLabel": [Function],
                                                   "getOptionValue": [Function],
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -1422,6 +1431,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "getOptionLabel": [Function],
                                                       "getOptionValue": [Function],
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -1568,6 +1578,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "getOptionLabel": [Function],
                                                       "getOptionValue": [Function],
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -2194,6 +2205,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                             allowCreate={false}
                                             autoFocus={false}
                                             className="aggregation-function"
+                                            clearable={false}
                                             components={null}
                                             delimiter=","
                                             disabled={false}
@@ -2225,6 +2237,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                               displayKey="label"
                                               getOptionLabel={[Function]}
                                               getOptionValue={[Function]}
+                                              isClearable={false}
                                               isDisabled={false}
                                               isMulti={false}
                                               matchProp="label"
@@ -2278,6 +2291,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                 getOptionLabel={[Function]}
                                                 getOptionValue={[Function]}
                                                 inputValue=""
+                                                isClearable={false}
                                                 isDisabled={false}
                                                 isLoading={false}
                                                 isMulti={false}
@@ -2372,6 +2386,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "getOptionLabel": [Function],
                                                       "getOptionValue": [Function],
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -2500,6 +2515,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                           "getOptionLabel": [Function],
                                                           "getOptionValue": [Function],
                                                           "inputValue": "",
+                                                          "isClearable": false,
                                                           "isDisabled": false,
                                                           "isLoading": false,
                                                           "isMulti": false,
@@ -2620,6 +2636,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                               "getOptionLabel": [Function],
                                                               "getOptionValue": [Function],
                                                               "inputValue": "",
+                                                              "isClearable": false,
                                                               "isDisabled": false,
                                                               "isLoading": false,
                                                               "isMulti": false,
@@ -2740,6 +2757,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                   "getOptionLabel": [Function],
                                                                   "getOptionValue": [Function],
                                                                   "inputValue": "",
+                                                                  "isClearable": false,
                                                                   "isDisabled": false,
                                                                   "isLoading": false,
                                                                   "isMulti": false,
@@ -2864,6 +2882,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                   "getOptionLabel": [Function],
                                                                   "getOptionValue": [Function],
                                                                   "inputValue": "",
+                                                                  "isClearable": false,
                                                                   "isDisabled": false,
                                                                   "isLoading": false,
                                                                   "isMulti": false,
@@ -3072,6 +3091,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                               "getOptionLabel": [Function],
                                                               "getOptionValue": [Function],
                                                               "inputValue": "",
+                                                              "isClearable": false,
                                                               "isDisabled": false,
                                                               "isLoading": false,
                                                               "isMulti": false,
@@ -3191,6 +3211,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                   "getOptionLabel": [Function],
                                                                   "getOptionValue": [Function],
                                                                   "inputValue": "",
+                                                                  "isClearable": false,
                                                                   "isDisabled": false,
                                                                   "isLoading": false,
                                                                   "isMulti": false,
@@ -3314,6 +3335,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                   "getOptionLabel": [Function],
                                                                   "getOptionValue": [Function],
                                                                   "inputValue": "",
+                                                                  "isClearable": false,
                                                                   "isDisabled": false,
                                                                   "isLoading": false,
                                                                   "isMulti": false,
@@ -3450,11 +3472,11 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                             allowCreate={true}
                                             autoFocus={false}
                                             className="aggregation-function-field"
+                                            clearable={true}
                                             components={null}
                                             delimiter=","
                                             disabled={false}
                                             displayKey="label"
-                                            isClearable={true}
                                             matchProp="label"
                                             multi={false}
                                             onChange={[Function]}
@@ -5112,6 +5134,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                               <Select
                                 allowCreate={false}
                                 autoFocus={false}
+                                clearable={false}
                                 components={null}
                                 delimiter=","
                                 disabled={false}
@@ -5166,6 +5189,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                   getOptionLabel={[Function]}
                                   getOptionValue={[Function]}
                                   id="aggregation-condition"
+                                  isClearable={false}
                                   isDisabled={false}
                                   isMulti={false}
                                   matchProp="label"
@@ -5242,6 +5266,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                     getOptionValue={[Function]}
                                     id="aggregation-condition"
                                     inputValue=""
+                                    isClearable={false}
                                     isDisabled={false}
                                     isLoading={false}
                                     isMulti={false}
@@ -5381,6 +5406,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                           "getOptionValue": [Function],
                                           "id": "aggregation-condition",
                                           "inputValue": "",
+                                          "isClearable": false,
                                           "isDisabled": false,
                                           "isLoading": false,
                                           "isMulti": false,
@@ -5554,6 +5580,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                               "getOptionValue": [Function],
                                               "id": "aggregation-condition",
                                               "inputValue": "",
+                                              "isClearable": false,
                                               "isDisabled": false,
                                               "isLoading": false,
                                               "isMulti": false,
@@ -5718,6 +5745,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                   "getOptionValue": [Function],
                                                   "id": "aggregation-condition",
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -5882,6 +5910,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "getOptionValue": [Function],
                                                       "id": "aggregation-condition",
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -6027,6 +6056,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "getOptionValue": [Function],
                                                       "id": "aggregation-condition",
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -6279,6 +6309,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                   "getOptionValue": [Function],
                                                   "id": "aggregation-condition",
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -6442,6 +6473,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "getOptionValue": [Function],
                                                       "id": "aggregation-condition",
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -6609,6 +6641,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "getOptionValue": [Function],
                                                       "id": "aggregation-condition",
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -7707,6 +7740,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                             allowCreate={false}
                                             autoFocus={false}
                                             className="aggregation-function"
+                                            clearable={false}
                                             components={null}
                                             delimiter=","
                                             disabled={false}
@@ -7738,6 +7772,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                               displayKey="label"
                                               getOptionLabel={[Function]}
                                               getOptionValue={[Function]}
+                                              isClearable={false}
                                               isDisabled={false}
                                               isMulti={false}
                                               matchProp="label"
@@ -7791,6 +7826,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                 getOptionLabel={[Function]}
                                                 getOptionValue={[Function]}
                                                 inputValue=""
+                                                isClearable={false}
                                                 isDisabled={false}
                                                 isLoading={false}
                                                 isMulti={false}
@@ -7885,6 +7921,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "getOptionLabel": [Function],
                                                       "getOptionValue": [Function],
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -8013,6 +8050,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                           "getOptionLabel": [Function],
                                                           "getOptionValue": [Function],
                                                           "inputValue": "",
+                                                          "isClearable": false,
                                                           "isDisabled": false,
                                                           "isLoading": false,
                                                           "isMulti": false,
@@ -8133,6 +8171,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                               "getOptionLabel": [Function],
                                                               "getOptionValue": [Function],
                                                               "inputValue": "",
+                                                              "isClearable": false,
                                                               "isDisabled": false,
                                                               "isLoading": false,
                                                               "isMulti": false,
@@ -8253,6 +8292,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                   "getOptionLabel": [Function],
                                                                   "getOptionValue": [Function],
                                                                   "inputValue": "",
+                                                                  "isClearable": false,
                                                                   "isDisabled": false,
                                                                   "isLoading": false,
                                                                   "isMulti": false,
@@ -8377,6 +8417,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                   "getOptionLabel": [Function],
                                                                   "getOptionValue": [Function],
                                                                   "inputValue": "",
+                                                                  "isClearable": false,
                                                                   "isDisabled": false,
                                                                   "isLoading": false,
                                                                   "isMulti": false,
@@ -8585,6 +8626,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                               "getOptionLabel": [Function],
                                                               "getOptionValue": [Function],
                                                               "inputValue": "",
+                                                              "isClearable": false,
                                                               "isDisabled": false,
                                                               "isLoading": false,
                                                               "isMulti": false,
@@ -8704,6 +8746,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                   "getOptionLabel": [Function],
                                                                   "getOptionValue": [Function],
                                                                   "inputValue": "",
+                                                                  "isClearable": false,
                                                                   "isDisabled": false,
                                                                   "isLoading": false,
                                                                   "isMulti": false,
@@ -8827,6 +8870,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                   "getOptionLabel": [Function],
                                                                   "getOptionValue": [Function],
                                                                   "inputValue": "",
+                                                                  "isClearable": false,
                                                                   "isDisabled": false,
                                                                   "isLoading": false,
                                                                   "isMulti": false,
@@ -8963,11 +9007,11 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                             allowCreate={true}
                                             autoFocus={false}
                                             className="aggregation-function-field"
+                                            clearable={true}
                                             components={null}
                                             delimiter=","
                                             disabled={false}
                                             displayKey="label"
-                                            isClearable={true}
                                             matchProp="label"
                                             multi={false}
                                             onChange={[Function]}
@@ -10583,6 +10627,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                               <Select
                                 allowCreate={false}
                                 autoFocus={false}
+                                clearable={false}
                                 components={null}
                                 delimiter=","
                                 disabled={false}
@@ -10637,6 +10682,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                   getOptionLabel={[Function]}
                                   getOptionValue={[Function]}
                                   id="aggregation-condition"
+                                  isClearable={false}
                                   isDisabled={false}
                                   isMulti={false}
                                   matchProp="label"
@@ -10713,6 +10759,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                     getOptionValue={[Function]}
                                     id="aggregation-condition"
                                     inputValue=""
+                                    isClearable={false}
                                     isDisabled={false}
                                     isLoading={false}
                                     isMulti={false}
@@ -10852,6 +10899,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                           "getOptionValue": [Function],
                                           "id": "aggregation-condition",
                                           "inputValue": "",
+                                          "isClearable": false,
                                           "isDisabled": false,
                                           "isLoading": false,
                                           "isMulti": false,
@@ -11025,6 +11073,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                               "getOptionValue": [Function],
                                               "id": "aggregation-condition",
                                               "inputValue": "",
+                                              "isClearable": false,
                                               "isDisabled": false,
                                               "isLoading": false,
                                               "isMulti": false,
@@ -11189,6 +11238,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                   "getOptionValue": [Function],
                                                   "id": "aggregation-condition",
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -11353,6 +11403,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "getOptionValue": [Function],
                                                       "id": "aggregation-condition",
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -11498,6 +11549,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "getOptionValue": [Function],
                                                       "id": "aggregation-condition",
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -11750,6 +11802,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                   "getOptionValue": [Function],
                                                   "id": "aggregation-condition",
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -11913,6 +11966,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "getOptionValue": [Function],
                                                       "id": "aggregation-condition",
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -12080,6 +12134,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                       "getOptionValue": [Function],
                                                       "id": "aggregation-condition",
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -13065,6 +13120,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                 allowCreate={false}
                                 autoFocus={false}
                                 className="boolean-operator"
+                                clearable={false}
                                 components={null}
                                 delimiter=","
                                 disabled={false}
@@ -13106,6 +13162,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                   displayKey="label"
                                   getOptionLabel={[Function]}
                                   getOptionValue={[Function]}
+                                  isClearable={false}
                                   isDisabled={false}
                                   isMulti={false}
                                   matchProp="label"
@@ -13172,6 +13229,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                     getOptionLabel={[Function]}
                                     getOptionValue={[Function]}
                                     inputValue=""
+                                    isClearable={false}
                                     isDisabled={false}
                                     isLoading={false}
                                     isMulti={false}
@@ -13291,6 +13349,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                           "getOptionLabel": [Function],
                                           "getOptionValue": [Function],
                                           "inputValue": "",
+                                          "isClearable": false,
                                           "isDisabled": false,
                                           "isLoading": false,
                                           "isMulti": false,
@@ -13442,6 +13501,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                               "getOptionLabel": [Function],
                                               "getOptionValue": [Function],
                                               "inputValue": "",
+                                              "isClearable": false,
                                               "isDisabled": false,
                                               "isLoading": false,
                                               "isMulti": false,
@@ -13585,6 +13645,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                   "getOptionLabel": [Function],
                                                   "getOptionValue": [Function],
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -13732,6 +13793,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       "getOptionLabel": [Function],
                                                       "getOptionValue": [Function],
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -13868,6 +13930,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       "getOptionLabel": [Function],
                                                       "getOptionValue": [Function],
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -14099,6 +14162,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                   "getOptionLabel": [Function],
                                                   "getOptionValue": [Function],
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -14241,6 +14305,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       "getOptionLabel": [Function],
                                                       "getOptionValue": [Function],
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -14387,6 +14452,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       "getOptionLabel": [Function],
                                                       "getOptionValue": [Function],
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -15025,6 +15091,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                             allowCreate={false}
                                             autoFocus={false}
                                             className="aggregation-function"
+                                            clearable={false}
                                             components={null}
                                             delimiter=","
                                             disabled={false}
@@ -15056,6 +15123,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                               displayKey="label"
                                               getOptionLabel={[Function]}
                                               getOptionValue={[Function]}
+                                              isClearable={false}
                                               isDisabled={false}
                                               isMulti={false}
                                               matchProp="label"
@@ -15109,6 +15177,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                 getOptionLabel={[Function]}
                                                 getOptionValue={[Function]}
                                                 inputValue=""
+                                                isClearable={false}
                                                 isDisabled={false}
                                                 isLoading={false}
                                                 isMulti={false}
@@ -15203,6 +15272,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       "getOptionLabel": [Function],
                                                       "getOptionValue": [Function],
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -15331,6 +15401,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                           "getOptionLabel": [Function],
                                                           "getOptionValue": [Function],
                                                           "inputValue": "",
+                                                          "isClearable": false,
                                                           "isDisabled": false,
                                                           "isLoading": false,
                                                           "isMulti": false,
@@ -15451,6 +15522,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                               "getOptionLabel": [Function],
                                                               "getOptionValue": [Function],
                                                               "inputValue": "",
+                                                              "isClearable": false,
                                                               "isDisabled": false,
                                                               "isLoading": false,
                                                               "isMulti": false,
@@ -15571,6 +15643,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                   "getOptionLabel": [Function],
                                                                   "getOptionValue": [Function],
                                                                   "inputValue": "",
+                                                                  "isClearable": false,
                                                                   "isDisabled": false,
                                                                   "isLoading": false,
                                                                   "isMulti": false,
@@ -15695,6 +15768,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                   "getOptionLabel": [Function],
                                                                   "getOptionValue": [Function],
                                                                   "inputValue": "",
+                                                                  "isClearable": false,
                                                                   "isDisabled": false,
                                                                   "isLoading": false,
                                                                   "isMulti": false,
@@ -15903,6 +15977,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                               "getOptionLabel": [Function],
                                                               "getOptionValue": [Function],
                                                               "inputValue": "",
+                                                              "isClearable": false,
                                                               "isDisabled": false,
                                                               "isLoading": false,
                                                               "isMulti": false,
@@ -16022,6 +16097,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                   "getOptionLabel": [Function],
                                                                   "getOptionValue": [Function],
                                                                   "inputValue": "",
+                                                                  "isClearable": false,
                                                                   "isDisabled": false,
                                                                   "isLoading": false,
                                                                   "isMulti": false,
@@ -16145,6 +16221,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                   "getOptionLabel": [Function],
                                                                   "getOptionValue": [Function],
                                                                   "inputValue": "",
+                                                                  "isClearable": false,
                                                                   "isDisabled": false,
                                                                   "isLoading": false,
                                                                   "isMulti": false,
@@ -16281,11 +16358,11 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                             allowCreate={true}
                                             autoFocus={false}
                                             className="aggregation-function-field"
+                                            clearable={true}
                                             components={null}
                                             delimiter=","
                                             disabled={false}
                                             displayKey="label"
-                                            isClearable={true}
                                             matchProp="label"
                                             multi={false}
                                             onChange={[Function]}
@@ -17943,6 +18020,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                               <Select
                                 allowCreate={false}
                                 autoFocus={false}
+                                clearable={false}
                                 components={null}
                                 delimiter=","
                                 disabled={false}
@@ -17997,6 +18075,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                   getOptionLabel={[Function]}
                                   getOptionValue={[Function]}
                                   id="aggregation-condition"
+                                  isClearable={false}
                                   isDisabled={false}
                                   isMulti={false}
                                   matchProp="label"
@@ -18073,6 +18152,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                     getOptionValue={[Function]}
                                     id="aggregation-condition"
                                     inputValue=""
+                                    isClearable={false}
                                     isDisabled={false}
                                     isLoading={false}
                                     isMulti={false}
@@ -18212,6 +18292,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                           "getOptionValue": [Function],
                                           "id": "aggregation-condition",
                                           "inputValue": "",
+                                          "isClearable": false,
                                           "isDisabled": false,
                                           "isLoading": false,
                                           "isMulti": false,
@@ -18385,6 +18466,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                               "getOptionValue": [Function],
                                               "id": "aggregation-condition",
                                               "inputValue": "",
+                                              "isClearable": false,
                                               "isDisabled": false,
                                               "isLoading": false,
                                               "isMulti": false,
@@ -18549,6 +18631,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                   "getOptionValue": [Function],
                                                   "id": "aggregation-condition",
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -18713,6 +18796,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       "getOptionValue": [Function],
                                                       "id": "aggregation-condition",
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -18858,6 +18942,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       "getOptionValue": [Function],
                                                       "id": "aggregation-condition",
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -19110,6 +19195,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                   "getOptionValue": [Function],
                                                   "id": "aggregation-condition",
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -19273,6 +19359,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       "getOptionValue": [Function],
                                                       "id": "aggregation-condition",
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -19440,6 +19527,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       "getOptionValue": [Function],
                                                       "id": "aggregation-condition",
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -20503,6 +20591,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                       allowCreate={false}
                                       autoFocus={false}
                                       className="boolean-operator"
+                                      clearable={false}
                                       components={null}
                                       delimiter=","
                                       disabled={false}
@@ -20544,6 +20633,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                         displayKey="label"
                                         getOptionLabel={[Function]}
                                         getOptionValue={[Function]}
+                                        isClearable={false}
                                         isDisabled={false}
                                         isMulti={false}
                                         matchProp="label"
@@ -20610,6 +20700,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                           getOptionLabel={[Function]}
                                           getOptionValue={[Function]}
                                           inputValue=""
+                                          isClearable={false}
                                           isDisabled={false}
                                           isLoading={false}
                                           isMulti={false}
@@ -20729,6 +20820,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                 "getOptionLabel": [Function],
                                                 "getOptionValue": [Function],
                                                 "inputValue": "",
+                                                "isClearable": false,
                                                 "isDisabled": false,
                                                 "isLoading": false,
                                                 "isMulti": false,
@@ -20880,6 +20972,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                     "getOptionLabel": [Function],
                                                     "getOptionValue": [Function],
                                                     "inputValue": "",
+                                                    "isClearable": false,
                                                     "isDisabled": false,
                                                     "isLoading": false,
                                                     "isMulti": false,
@@ -21023,6 +21116,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         "getOptionLabel": [Function],
                                                         "getOptionValue": [Function],
                                                         "inputValue": "",
+                                                        "isClearable": false,
                                                         "isDisabled": false,
                                                         "isLoading": false,
                                                         "isMulti": false,
@@ -21170,6 +21264,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "getOptionLabel": [Function],
                                                             "getOptionValue": [Function],
                                                             "inputValue": "",
+                                                            "isClearable": false,
                                                             "isDisabled": false,
                                                             "isLoading": false,
                                                             "isMulti": false,
@@ -21306,6 +21401,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "getOptionLabel": [Function],
                                                             "getOptionValue": [Function],
                                                             "inputValue": "",
+                                                            "isClearable": false,
                                                             "isDisabled": false,
                                                             "isLoading": false,
                                                             "isMulti": false,
@@ -21537,6 +21633,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         "getOptionLabel": [Function],
                                                         "getOptionValue": [Function],
                                                         "inputValue": "",
+                                                        "isClearable": false,
                                                         "isDisabled": false,
                                                         "isLoading": false,
                                                         "isMulti": false,
@@ -21679,6 +21776,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "getOptionLabel": [Function],
                                                             "getOptionValue": [Function],
                                                             "inputValue": "",
+                                                            "isClearable": false,
                                                             "isDisabled": false,
                                                             "isLoading": false,
                                                             "isMulti": false,
@@ -21825,6 +21923,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "getOptionLabel": [Function],
                                                             "getOptionValue": [Function],
                                                             "inputValue": "",
+                                                            "isClearable": false,
                                                             "isDisabled": false,
                                                             "isLoading": false,
                                                             "isMulti": false,
@@ -22365,6 +22464,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       allowCreate={false}
                                                       autoFocus={false}
                                                       className="aggregation-function"
+                                                      clearable={false}
                                                       components={null}
                                                       delimiter=","
                                                       disabled={false}
@@ -22396,6 +22496,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         displayKey="label"
                                                         getOptionLabel={[Function]}
                                                         getOptionValue={[Function]}
+                                                        isClearable={false}
                                                         isDisabled={false}
                                                         isMulti={false}
                                                         matchProp="label"
@@ -22449,6 +22550,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                           getOptionLabel={[Function]}
                                                           getOptionValue={[Function]}
                                                           inputValue=""
+                                                          isClearable={false}
                                                           isDisabled={false}
                                                           isLoading={false}
                                                           isMulti={false}
@@ -22543,6 +22645,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                 "getOptionLabel": [Function],
                                                                 "getOptionValue": [Function],
                                                                 "inputValue": "",
+                                                                "isClearable": false,
                                                                 "isDisabled": false,
                                                                 "isLoading": false,
                                                                 "isMulti": false,
@@ -22671,6 +22774,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                     "getOptionLabel": [Function],
                                                                     "getOptionValue": [Function],
                                                                     "inputValue": "",
+                                                                    "isClearable": false,
                                                                     "isDisabled": false,
                                                                     "isLoading": false,
                                                                     "isMulti": false,
@@ -22791,6 +22895,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                         "getOptionLabel": [Function],
                                                                         "getOptionValue": [Function],
                                                                         "inputValue": "",
+                                                                        "isClearable": false,
                                                                         "isDisabled": false,
                                                                         "isLoading": false,
                                                                         "isMulti": false,
@@ -22911,6 +23016,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                             "getOptionLabel": [Function],
                                                                             "getOptionValue": [Function],
                                                                             "inputValue": "",
+                                                                            "isClearable": false,
                                                                             "isDisabled": false,
                                                                             "isLoading": false,
                                                                             "isMulti": false,
@@ -23035,6 +23141,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                             "getOptionLabel": [Function],
                                                                             "getOptionValue": [Function],
                                                                             "inputValue": "",
+                                                                            "isClearable": false,
                                                                             "isDisabled": false,
                                                                             "isLoading": false,
                                                                             "isMulti": false,
@@ -23243,6 +23350,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                         "getOptionLabel": [Function],
                                                                         "getOptionValue": [Function],
                                                                         "inputValue": "",
+                                                                        "isClearable": false,
                                                                         "isDisabled": false,
                                                                         "isLoading": false,
                                                                         "isMulti": false,
@@ -23362,6 +23470,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                             "getOptionLabel": [Function],
                                                                             "getOptionValue": [Function],
                                                                             "inputValue": "",
+                                                                            "isClearable": false,
                                                                             "isDisabled": false,
                                                                             "isLoading": false,
                                                                             "isMulti": false,
@@ -23485,6 +23594,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                             "getOptionLabel": [Function],
                                                                             "getOptionValue": [Function],
                                                                             "inputValue": "",
+                                                                            "isClearable": false,
                                                                             "isDisabled": false,
                                                                             "isLoading": false,
                                                                             "isMulti": false,
@@ -23621,11 +23731,11 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       allowCreate={true}
                                                       autoFocus={false}
                                                       className="aggregation-function-field"
+                                                      clearable={true}
                                                       components={null}
                                                       delimiter=","
                                                       disabled={false}
                                                       displayKey="label"
-                                                      isClearable={true}
                                                       matchProp="label"
                                                       multi={false}
                                                       onChange={[Function]}
@@ -25241,6 +25351,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                         <Select
                                           allowCreate={false}
                                           autoFocus={false}
+                                          clearable={false}
                                           components={null}
                                           delimiter=","
                                           disabled={false}
@@ -25295,6 +25406,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                             getOptionLabel={[Function]}
                                             getOptionValue={[Function]}
                                             id="aggregation-condition"
+                                            isClearable={false}
                                             isDisabled={false}
                                             isMulti={false}
                                             matchProp="label"
@@ -25371,6 +25483,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                               getOptionValue={[Function]}
                                               id="aggregation-condition"
                                               inputValue=""
+                                              isClearable={false}
                                               isDisabled={false}
                                               isLoading={false}
                                               isMulti={false}
@@ -25510,6 +25623,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                     "getOptionValue": [Function],
                                                     "id": "aggregation-condition",
                                                     "inputValue": "",
+                                                    "isClearable": false,
                                                     "isDisabled": false,
                                                     "isLoading": false,
                                                     "isMulti": false,
@@ -25683,6 +25797,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         "getOptionValue": [Function],
                                                         "id": "aggregation-condition",
                                                         "inputValue": "",
+                                                        "isClearable": false,
                                                         "isDisabled": false,
                                                         "isLoading": false,
                                                         "isMulti": false,
@@ -25847,6 +25962,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "getOptionValue": [Function],
                                                             "id": "aggregation-condition",
                                                             "inputValue": "",
+                                                            "isClearable": false,
                                                             "isDisabled": false,
                                                             "isLoading": false,
                                                             "isMulti": false,
@@ -26011,6 +26127,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                 "getOptionValue": [Function],
                                                                 "id": "aggregation-condition",
                                                                 "inputValue": "",
+                                                                "isClearable": false,
                                                                 "isDisabled": false,
                                                                 "isLoading": false,
                                                                 "isMulti": false,
@@ -26156,6 +26273,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                 "getOptionValue": [Function],
                                                                 "id": "aggregation-condition",
                                                                 "inputValue": "",
+                                                                "isClearable": false,
                                                                 "isDisabled": false,
                                                                 "isLoading": false,
                                                                 "isMulti": false,
@@ -26408,6 +26526,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "getOptionValue": [Function],
                                                             "id": "aggregation-condition",
                                                             "inputValue": "",
+                                                            "isClearable": false,
                                                             "isDisabled": false,
                                                             "isLoading": false,
                                                             "isMulti": false,
@@ -26571,6 +26690,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                 "getOptionValue": [Function],
                                                                 "id": "aggregation-condition",
                                                                 "inputValue": "",
+                                                                "isClearable": false,
                                                                 "isDisabled": false,
                                                                 "isLoading": false,
                                                                 "isMulti": false,
@@ -26738,6 +26858,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                 "getOptionValue": [Function],
                                                                 "id": "aggregation-condition",
                                                                 "inputValue": "",
+                                                                "isClearable": false,
                                                                 "isDisabled": false,
                                                                 "isLoading": false,
                                                                 "isMulti": false,
@@ -27696,6 +27817,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                   allowCreate={false}
                                   autoFocus={false}
                                   className="boolean-operator"
+                                  clearable={false}
                                   components={null}
                                   delimiter=","
                                   disabled={false}
@@ -27737,6 +27859,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                     displayKey="label"
                                     getOptionLabel={[Function]}
                                     getOptionValue={[Function]}
+                                    isClearable={false}
                                     isDisabled={false}
                                     isMulti={false}
                                     matchProp="label"
@@ -27803,6 +27926,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                       getOptionLabel={[Function]}
                                       getOptionValue={[Function]}
                                       inputValue=""
+                                      isClearable={false}
                                       isDisabled={false}
                                       isLoading={false}
                                       isMulti={false}
@@ -27922,6 +28046,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                             "getOptionLabel": [Function],
                                             "getOptionValue": [Function],
                                             "inputValue": "",
+                                            "isClearable": false,
                                             "isDisabled": false,
                                             "isLoading": false,
                                             "isMulti": false,
@@ -28073,6 +28198,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                 "getOptionLabel": [Function],
                                                 "getOptionValue": [Function],
                                                 "inputValue": "",
+                                                "isClearable": false,
                                                 "isDisabled": false,
                                                 "isLoading": false,
                                                 "isMulti": false,
@@ -28216,6 +28342,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                     "getOptionLabel": [Function],
                                                     "getOptionValue": [Function],
                                                     "inputValue": "",
+                                                    "isClearable": false,
                                                     "isDisabled": false,
                                                     "isLoading": false,
                                                     "isMulti": false,
@@ -28363,6 +28490,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         "getOptionLabel": [Function],
                                                         "getOptionValue": [Function],
                                                         "inputValue": "",
+                                                        "isClearable": false,
                                                         "isDisabled": false,
                                                         "isLoading": false,
                                                         "isMulti": false,
@@ -28499,6 +28627,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         "getOptionLabel": [Function],
                                                         "getOptionValue": [Function],
                                                         "inputValue": "",
+                                                        "isClearable": false,
                                                         "isDisabled": false,
                                                         "isLoading": false,
                                                         "isMulti": false,
@@ -28730,6 +28859,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                     "getOptionLabel": [Function],
                                                     "getOptionValue": [Function],
                                                     "inputValue": "",
+                                                    "isClearable": false,
                                                     "isDisabled": false,
                                                     "isLoading": false,
                                                     "isMulti": false,
@@ -28872,6 +29002,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         "getOptionLabel": [Function],
                                                         "getOptionValue": [Function],
                                                         "inputValue": "",
+                                                        "isClearable": false,
                                                         "isDisabled": false,
                                                         "isLoading": false,
                                                         "isMulti": false,
@@ -29018,6 +29149,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         "getOptionLabel": [Function],
                                                         "getOptionValue": [Function],
                                                         "inputValue": "",
+                                                        "isClearable": false,
                                                         "isDisabled": false,
                                                         "isLoading": false,
                                                         "isMulti": false,
@@ -29600,6 +29732,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                   allowCreate={false}
                                                   autoFocus={false}
                                                   className="aggregation-function"
+                                                  clearable={false}
                                                   components={null}
                                                   delimiter=","
                                                   disabled={false}
@@ -29631,6 +29764,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                     displayKey="label"
                                                     getOptionLabel={[Function]}
                                                     getOptionValue={[Function]}
+                                                    isClearable={false}
                                                     isDisabled={false}
                                                     isMulti={false}
                                                     matchProp="label"
@@ -29684,6 +29818,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                       getOptionLabel={[Function]}
                                                       getOptionValue={[Function]}
                                                       inputValue=""
+                                                      isClearable={false}
                                                       isDisabled={false}
                                                       isLoading={false}
                                                       isMulti={false}
@@ -29778,6 +29913,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "getOptionLabel": [Function],
                                                             "getOptionValue": [Function],
                                                             "inputValue": "",
+                                                            "isClearable": false,
                                                             "isDisabled": false,
                                                             "isLoading": false,
                                                             "isMulti": false,
@@ -29906,6 +30042,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                 "getOptionLabel": [Function],
                                                                 "getOptionValue": [Function],
                                                                 "inputValue": "",
+                                                                "isClearable": false,
                                                                 "isDisabled": false,
                                                                 "isLoading": false,
                                                                 "isMulti": false,
@@ -30026,6 +30163,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                     "getOptionLabel": [Function],
                                                                     "getOptionValue": [Function],
                                                                     "inputValue": "",
+                                                                    "isClearable": false,
                                                                     "isDisabled": false,
                                                                     "isLoading": false,
                                                                     "isMulti": false,
@@ -30146,6 +30284,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                         "getOptionLabel": [Function],
                                                                         "getOptionValue": [Function],
                                                                         "inputValue": "",
+                                                                        "isClearable": false,
                                                                         "isDisabled": false,
                                                                         "isLoading": false,
                                                                         "isMulti": false,
@@ -30270,6 +30409,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                         "getOptionLabel": [Function],
                                                                         "getOptionValue": [Function],
                                                                         "inputValue": "",
+                                                                        "isClearable": false,
                                                                         "isDisabled": false,
                                                                         "isLoading": false,
                                                                         "isMulti": false,
@@ -30478,6 +30618,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                     "getOptionLabel": [Function],
                                                                     "getOptionValue": [Function],
                                                                     "inputValue": "",
+                                                                    "isClearable": false,
                                                                     "isDisabled": false,
                                                                     "isLoading": false,
                                                                     "isMulti": false,
@@ -30597,6 +30738,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                         "getOptionLabel": [Function],
                                                                         "getOptionValue": [Function],
                                                                         "inputValue": "",
+                                                                        "isClearable": false,
                                                                         "isDisabled": false,
                                                                         "isLoading": false,
                                                                         "isMulti": false,
@@ -30720,6 +30862,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                         "getOptionLabel": [Function],
                                                                         "getOptionValue": [Function],
                                                                         "inputValue": "",
+                                                                        "isClearable": false,
                                                                         "isDisabled": false,
                                                                         "isLoading": false,
                                                                         "isMulti": false,
@@ -30856,11 +30999,11 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                   allowCreate={true}
                                                   autoFocus={false}
                                                   className="aggregation-function-field"
+                                                  clearable={true}
                                                   components={null}
                                                   delimiter=","
                                                   disabled={false}
                                                   displayKey="label"
-                                                  isClearable={true}
                                                   matchProp="label"
                                                   multi={false}
                                                   onChange={[Function]}
@@ -32518,6 +32661,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                     <Select
                                       allowCreate={false}
                                       autoFocus={false}
+                                      clearable={false}
                                       components={null}
                                       delimiter=","
                                       disabled={false}
@@ -32572,6 +32716,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                         getOptionLabel={[Function]}
                                         getOptionValue={[Function]}
                                         id="aggregation-condition"
+                                        isClearable={false}
                                         isDisabled={false}
                                         isMulti={false}
                                         matchProp="label"
@@ -32648,6 +32793,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                           getOptionValue={[Function]}
                                           id="aggregation-condition"
                                           inputValue=""
+                                          isClearable={false}
                                           isDisabled={false}
                                           isLoading={false}
                                           isMulti={false}
@@ -32787,6 +32933,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                 "getOptionValue": [Function],
                                                 "id": "aggregation-condition",
                                                 "inputValue": "",
+                                                "isClearable": false,
                                                 "isDisabled": false,
                                                 "isLoading": false,
                                                 "isMulti": false,
@@ -32960,6 +33107,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                     "getOptionValue": [Function],
                                                     "id": "aggregation-condition",
                                                     "inputValue": "",
+                                                    "isClearable": false,
                                                     "isDisabled": false,
                                                     "isLoading": false,
                                                     "isMulti": false,
@@ -33124,6 +33272,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         "getOptionValue": [Function],
                                                         "id": "aggregation-condition",
                                                         "inputValue": "",
+                                                        "isClearable": false,
                                                         "isDisabled": false,
                                                         "isLoading": false,
                                                         "isMulti": false,
@@ -33288,6 +33437,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "getOptionValue": [Function],
                                                             "id": "aggregation-condition",
                                                             "inputValue": "",
+                                                            "isClearable": false,
                                                             "isDisabled": false,
                                                             "isLoading": false,
                                                             "isMulti": false,
@@ -33433,6 +33583,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "getOptionValue": [Function],
                                                             "id": "aggregation-condition",
                                                             "inputValue": "",
+                                                            "isClearable": false,
                                                             "isDisabled": false,
                                                             "isLoading": false,
                                                             "isMulti": false,
@@ -33685,6 +33836,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         "getOptionValue": [Function],
                                                         "id": "aggregation-condition",
                                                         "inputValue": "",
+                                                        "isClearable": false,
                                                         "isDisabled": false,
                                                         "isLoading": false,
                                                         "isMulti": false,
@@ -33848,6 +34000,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "getOptionValue": [Function],
                                                             "id": "aggregation-condition",
                                                             "inputValue": "",
+                                                            "isClearable": false,
                                                             "isDisabled": false,
                                                             "isLoading": false,
                                                             "isMulti": false,
@@ -34015,6 +34168,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             "getOptionValue": [Function],
                                                             "id": "aggregation-condition",
                                                             "inputValue": "",
+                                                            "isClearable": false,
                                                             "isDisabled": false,
                                                             "isLoading": false,
                                                             "isMulti": false,
@@ -35023,6 +35177,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                 allowCreate={false}
                                 autoFocus={false}
                                 className="boolean-operator"
+                                clearable={false}
                                 components={null}
                                 delimiter=","
                                 disabled={false}
@@ -35064,6 +35219,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                   displayKey="label"
                                   getOptionLabel={[Function]}
                                   getOptionValue={[Function]}
+                                  isClearable={false}
                                   isDisabled={false}
                                   isMulti={false}
                                   matchProp="label"
@@ -35130,6 +35286,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                     getOptionLabel={[Function]}
                                     getOptionValue={[Function]}
                                     inputValue=""
+                                    isClearable={false}
                                     isDisabled={false}
                                     isLoading={false}
                                     isMulti={false}
@@ -35249,6 +35406,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                           "getOptionLabel": [Function],
                                           "getOptionValue": [Function],
                                           "inputValue": "",
+                                          "isClearable": false,
                                           "isDisabled": false,
                                           "isLoading": false,
                                           "isMulti": false,
@@ -35400,6 +35558,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                               "getOptionLabel": [Function],
                                               "getOptionValue": [Function],
                                               "inputValue": "",
+                                              "isClearable": false,
                                               "isDisabled": false,
                                               "isLoading": false,
                                               "isMulti": false,
@@ -35543,6 +35702,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                   "getOptionLabel": [Function],
                                                   "getOptionValue": [Function],
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -35690,6 +35850,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                       "getOptionLabel": [Function],
                                                       "getOptionValue": [Function],
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -35826,6 +35987,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                       "getOptionLabel": [Function],
                                                       "getOptionValue": [Function],
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -36057,6 +36219,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                   "getOptionLabel": [Function],
                                                   "getOptionValue": [Function],
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -36199,6 +36362,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                       "getOptionLabel": [Function],
                                                       "getOptionValue": [Function],
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -36345,6 +36509,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                       "getOptionLabel": [Function],
                                                       "getOptionValue": [Function],
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -36807,6 +36972,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                         allowCreate={false}
                                         autoFocus={false}
                                         className="aggregation-function"
+                                        clearable={false}
                                         components={null}
                                         delimiter=","
                                         disabled={false}
@@ -36837,6 +37003,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                           displayKey="label"
                                           getOptionLabel={[Function]}
                                           getOptionValue={[Function]}
+                                          isClearable={false}
                                           isDisabled={false}
                                           isMulti={false}
                                           matchProp="label"
@@ -36890,6 +37057,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                             getOptionLabel={[Function]}
                                             getOptionValue={[Function]}
                                             inputValue=""
+                                            isClearable={false}
                                             isDisabled={false}
                                             isLoading={false}
                                             isMulti={false}
@@ -36984,6 +37152,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                   "getOptionLabel": [Function],
                                                   "getOptionValue": [Function],
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -37112,6 +37281,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                       "getOptionLabel": [Function],
                                                       "getOptionValue": [Function],
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -37232,6 +37402,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                           "getOptionLabel": [Function],
                                                           "getOptionValue": [Function],
                                                           "inputValue": "",
+                                                          "isClearable": false,
                                                           "isDisabled": false,
                                                           "isLoading": false,
                                                           "isMulti": false,
@@ -37352,6 +37523,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                               "getOptionLabel": [Function],
                                                               "getOptionValue": [Function],
                                                               "inputValue": "",
+                                                              "isClearable": false,
                                                               "isDisabled": false,
                                                               "isLoading": false,
                                                               "isMulti": false,
@@ -37476,6 +37648,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                               "getOptionLabel": [Function],
                                                               "getOptionValue": [Function],
                                                               "inputValue": "",
+                                                              "isClearable": false,
                                                               "isDisabled": false,
                                                               "isLoading": false,
                                                               "isMulti": false,
@@ -37684,6 +37857,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                           "getOptionLabel": [Function],
                                                           "getOptionValue": [Function],
                                                           "inputValue": "",
+                                                          "isClearable": false,
                                                           "isDisabled": false,
                                                           "isLoading": false,
                                                           "isMulti": false,
@@ -37803,6 +37977,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                               "getOptionLabel": [Function],
                                                               "getOptionValue": [Function],
                                                               "inputValue": "",
+                                                              "isClearable": false,
                                                               "isDisabled": false,
                                                               "isLoading": false,
                                                               "isMulti": false,
@@ -37926,6 +38101,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                               "getOptionLabel": [Function],
                                                               "getOptionValue": [Function],
                                                               "inputValue": "",
+                                                              "isClearable": false,
                                                               "isDisabled": false,
                                                               "isLoading": false,
                                                               "isMulti": false,
@@ -38062,11 +38238,11 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                         allowCreate={true}
                                         autoFocus={false}
                                         className="aggregation-function-field"
+                                        clearable={true}
                                         components={null}
                                         delimiter=","
                                         disabled={false}
                                         displayKey="label"
-                                        isClearable={true}
                                         matchProp="label"
                                         multi={false}
                                         onChange={[Function]}
@@ -39529,6 +39705,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                           <Select
                             allowCreate={false}
                             autoFocus={false}
+                            clearable={false}
                             components={null}
                             delimiter=","
                             disabled={false}
@@ -39583,6 +39760,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                               getOptionLabel={[Function]}
                               getOptionValue={[Function]}
                               id="aggregation-condition"
+                              isClearable={false}
                               isDisabled={false}
                               isMulti={false}
                               matchProp="label"
@@ -39659,6 +39837,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                 getOptionValue={[Function]}
                                 id="aggregation-condition"
                                 inputValue=""
+                                isClearable={false}
                                 isDisabled={false}
                                 isLoading={false}
                                 isMulti={false}
@@ -39798,6 +39977,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                       "getOptionValue": [Function],
                                       "id": "aggregation-condition",
                                       "inputValue": "",
+                                      "isClearable": false,
                                       "isDisabled": false,
                                       "isLoading": false,
                                       "isMulti": false,
@@ -39971,6 +40151,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                           "getOptionValue": [Function],
                                           "id": "aggregation-condition",
                                           "inputValue": "",
+                                          "isClearable": false,
                                           "isDisabled": false,
                                           "isLoading": false,
                                           "isMulti": false,
@@ -40135,6 +40316,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                               "getOptionValue": [Function],
                                               "id": "aggregation-condition",
                                               "inputValue": "",
+                                              "isClearable": false,
                                               "isDisabled": false,
                                               "isLoading": false,
                                               "isMulti": false,
@@ -40299,6 +40481,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                   "getOptionValue": [Function],
                                                   "id": "aggregation-condition",
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -40444,6 +40627,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                   "getOptionValue": [Function],
                                                   "id": "aggregation-condition",
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -40696,6 +40880,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                               "getOptionValue": [Function],
                                               "id": "aggregation-condition",
                                               "inputValue": "",
+                                              "isClearable": false,
                                               "isDisabled": false,
                                               "isLoading": false,
                                               "isMulti": false,
@@ -40859,6 +41044,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                   "getOptionValue": [Function],
                                                   "id": "aggregation-condition",
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -41026,6 +41212,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                   "getOptionValue": [Function],
                                                   "id": "aggregation-condition",
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -42023,6 +42210,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                 allowCreate={false}
                                 autoFocus={false}
                                 className="boolean-operator"
+                                clearable={false}
                                 components={null}
                                 delimiter=","
                                 disabled={false}
@@ -42064,6 +42252,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                   displayKey="label"
                                   getOptionLabel={[Function]}
                                   getOptionValue={[Function]}
+                                  isClearable={false}
                                   isDisabled={false}
                                   isMulti={false}
                                   matchProp="label"
@@ -42130,6 +42319,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                     getOptionLabel={[Function]}
                                     getOptionValue={[Function]}
                                     inputValue=""
+                                    isClearable={false}
                                     isDisabled={false}
                                     isLoading={false}
                                     isMulti={false}
@@ -42249,6 +42439,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                           "getOptionLabel": [Function],
                                           "getOptionValue": [Function],
                                           "inputValue": "",
+                                          "isClearable": false,
                                           "isDisabled": false,
                                           "isLoading": false,
                                           "isMulti": false,
@@ -42400,6 +42591,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                               "getOptionLabel": [Function],
                                               "getOptionValue": [Function],
                                               "inputValue": "",
+                                              "isClearable": false,
                                               "isDisabled": false,
                                               "isLoading": false,
                                               "isMulti": false,
@@ -42543,6 +42735,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                   "getOptionLabel": [Function],
                                                   "getOptionValue": [Function],
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -42690,6 +42883,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                       "getOptionLabel": [Function],
                                                       "getOptionValue": [Function],
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -42826,6 +43020,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                       "getOptionLabel": [Function],
                                                       "getOptionValue": [Function],
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -43057,6 +43252,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                   "getOptionLabel": [Function],
                                                   "getOptionValue": [Function],
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -43199,6 +43395,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                       "getOptionLabel": [Function],
                                                       "getOptionValue": [Function],
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -43345,6 +43542,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                       "getOptionLabel": [Function],
                                                       "getOptionValue": [Function],
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -43825,6 +44023,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                         allowCreate={false}
                                         autoFocus={false}
                                         className="aggregation-function"
+                                        clearable={false}
                                         components={null}
                                         delimiter=","
                                         disabled={false}
@@ -43856,6 +44055,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                           displayKey="label"
                                           getOptionLabel={[Function]}
                                           getOptionValue={[Function]}
+                                          isClearable={false}
                                           isDisabled={false}
                                           isMulti={false}
                                           matchProp="label"
@@ -43909,6 +44109,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                             getOptionLabel={[Function]}
                                             getOptionValue={[Function]}
                                             inputValue=""
+                                            isClearable={false}
                                             isDisabled={false}
                                             isLoading={false}
                                             isMulti={false}
@@ -44003,6 +44204,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                   "getOptionLabel": [Function],
                                                   "getOptionValue": [Function],
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -44131,6 +44333,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                       "getOptionLabel": [Function],
                                                       "getOptionValue": [Function],
                                                       "inputValue": "",
+                                                      "isClearable": false,
                                                       "isDisabled": false,
                                                       "isLoading": false,
                                                       "isMulti": false,
@@ -44251,6 +44454,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                           "getOptionLabel": [Function],
                                                           "getOptionValue": [Function],
                                                           "inputValue": "",
+                                                          "isClearable": false,
                                                           "isDisabled": false,
                                                           "isLoading": false,
                                                           "isMulti": false,
@@ -44371,6 +44575,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                               "getOptionLabel": [Function],
                                                               "getOptionValue": [Function],
                                                               "inputValue": "",
+                                                              "isClearable": false,
                                                               "isDisabled": false,
                                                               "isLoading": false,
                                                               "isMulti": false,
@@ -44495,6 +44700,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                               "getOptionLabel": [Function],
                                                               "getOptionValue": [Function],
                                                               "inputValue": "",
+                                                              "isClearable": false,
                                                               "isDisabled": false,
                                                               "isLoading": false,
                                                               "isMulti": false,
@@ -44703,6 +44909,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                           "getOptionLabel": [Function],
                                                           "getOptionValue": [Function],
                                                           "inputValue": "",
+                                                          "isClearable": false,
                                                           "isDisabled": false,
                                                           "isLoading": false,
                                                           "isMulti": false,
@@ -44822,6 +45029,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                               "getOptionLabel": [Function],
                                                               "getOptionValue": [Function],
                                                               "inputValue": "",
+                                                              "isClearable": false,
                                                               "isDisabled": false,
                                                               "isLoading": false,
                                                               "isMulti": false,
@@ -44945,6 +45153,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                               "getOptionLabel": [Function],
                                                               "getOptionValue": [Function],
                                                               "inputValue": "",
+                                                              "isClearable": false,
                                                               "isDisabled": false,
                                                               "isLoading": false,
                                                               "isMulti": false,
@@ -45081,11 +45290,11 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                         allowCreate={true}
                                         autoFocus={false}
                                         className="aggregation-function-field"
+                                        clearable={true}
                                         components={null}
                                         delimiter=","
                                         disabled={false}
                                         displayKey="label"
-                                        isClearable={true}
                                         matchProp="label"
                                         multi={false}
                                         onChange={[Function]}
@@ -46743,6 +46952,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                           <Select
                             allowCreate={false}
                             autoFocus={false}
+                            clearable={false}
                             components={null}
                             delimiter=","
                             disabled={false}
@@ -46798,6 +47008,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                               getOptionLabel={[Function]}
                               getOptionValue={[Function]}
                               id="aggregation-condition"
+                              isClearable={false}
                               isDisabled={false}
                               isMulti={false}
                               matchProp="label"
@@ -46877,6 +47088,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                 getOptionValue={[Function]}
                                 id="aggregation-condition"
                                 inputValue=""
+                                isClearable={false}
                                 isDisabled={false}
                                 isLoading={false}
                                 isMulti={false}
@@ -47019,6 +47231,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                       "getOptionValue": [Function],
                                       "id": "aggregation-condition",
                                       "inputValue": "",
+                                      "isClearable": false,
                                       "isDisabled": false,
                                       "isLoading": false,
                                       "isMulti": false,
@@ -47195,6 +47408,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                           "getOptionValue": [Function],
                                           "id": "aggregation-condition",
                                           "inputValue": "",
+                                          "isClearable": false,
                                           "isDisabled": false,
                                           "isLoading": false,
                                           "isMulti": false,
@@ -47362,6 +47576,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                               "getOptionValue": [Function],
                                               "id": "aggregation-condition",
                                               "inputValue": "",
+                                              "isClearable": false,
                                               "isDisabled": false,
                                               "isLoading": false,
                                               "isMulti": false,
@@ -47533,6 +47748,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                   "getOptionValue": [Function],
                                                   "id": "aggregation-condition",
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -47681,6 +47897,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                   "getOptionValue": [Function],
                                                   "id": "aggregation-condition",
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -47936,6 +48153,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                               "getOptionValue": [Function],
                                               "id": "aggregation-condition",
                                               "inputValue": "",
+                                              "isClearable": false,
                                               "isDisabled": false,
                                               "isLoading": false,
                                               "isMulti": false,
@@ -48102,6 +48320,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                   "getOptionValue": [Function],
                                                   "id": "aggregation-condition",
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,
@@ -48272,6 +48491,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                   "getOptionValue": [Function],
                                                   "id": "aggregation-condition",
                                                   "inputValue": "",
+                                                  "isClearable": false,
                                                   "isDisabled": false,
                                                   "isLoading": false,
                                                   "isMulti": false,

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/CollectorForm.jsx
@@ -187,7 +187,7 @@ const CollectorForm = createReactClass({
             <FormGroup controlId="service_type"
                        validationState={this._validationState('service_type')}>
               <ControlLabel>Process management</ControlLabel>
-              <Select inputProps={{ id: 'service_type' }}
+              <Select inputId="service_type"
                       options={this._formatServiceTypes()}
                       value={formData.service_type}
                       onChange={this._formDataUpdate('service_type')}
@@ -196,10 +196,10 @@ const CollectorForm = createReactClass({
               <HelpBlock>{this._formatValidationMessage('service_type', 'Choose the service type this collector is meant for.')}</HelpBlock>
             </FormGroup>
 
-            <FormGroup controlId="operating_system"
+            <FormGroup controlId="node_operating_system"
                        validationState={this._validationState('node_operating_system')}>
               <ControlLabel>Operating System</ControlLabel>
-              <Select inputProps={{ id: 'node_operating_system' }}
+              <Select inputId="node_operating_system"
                       options={this._formatOperatingSystems()}
                       value={formData.node_operating_system}
                       onChange={this._formDataUpdate('node_operating_system')}

--- a/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configuration-forms/ConfigurationForm.jsx
@@ -251,7 +251,7 @@ const ConfigurationForm = createReactClass({
 
     return (
       <span>
-        <Select inputProps={{ id: 'collector_id' }}
+        <Select inputId="collector_id"
                 options={this._formatCollectorOptions()}
                 value={collectorId}
                 onChange={this._onCollectorChange}

--- a/graylog2-web-interface/src/components/streams/StreamForm.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamForm.jsx
@@ -95,7 +95,7 @@ class StreamForm extends React.Component {
         <Input id="index-set-selector"
                label="Index Set"
                help="Messages that match this stream will be written to the configured index set.">
-          <Select inputProps={{ id: 'index-set-selector' }}
+          <Select inputId="index-set-selector"
                   placeholder="Select index set"
                   options={this._formatSelectOptions()}
                   matchProp="label"

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesSelect.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesSelect.jsx
@@ -33,11 +33,11 @@ const _wrapOption = series => ({ label: series.effectiveName, value: series });
 type Props = {
   onChange: (Array<Series>) => boolean,
   series: Array<Series>,
-  suggester: ((string) => Array<Option>) & { defaults: Array<Option | IncompleteOption | ParameterNeededOption | BackToFunctions >, for: (string | number, ?(string | number)) => Array<Option> },
+  suggester: ((string) => Array<Option>) & { defaults: Array<Option | IncompleteOption | ParameterNeededOption | BackToFunctions>, for: (string | number, ?(string | number)) => Array<Option> },
 };
 
 type State = {
-  options: Array<Option | IncompleteOption | ParameterNeededOption| BackToFunctions>,
+  options: Array<Option | IncompleteOption | ParameterNeededOption | BackToFunctions>,
 };
 
 class SeriesSelect extends React.Component<Props, State> {
@@ -122,8 +122,6 @@ class SeriesSelect extends React.Component<Props, State> {
               components={_components}
               onClose={this._onClose}
               closeMenuOnSelect={false}
-              onBlurResetsInput
-              onCloseResetsInput
               menuShouldScrollIntoView
               tabSelectsValue
               escapeClearsValue

--- a/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/decorators/AddDecoratorButton.jsx
@@ -106,7 +106,6 @@ class AddDecoratorButton extends React.Component {
                     onChange={this._onTypeChange}
                     options={decoratorTypeOptions}
                     matchProp="label"
-                    isClearable
                     disabled={disabled}
                     value={typeName} />
           </div>

--- a/graylog2-web-interface/src/views/components/searchbar/StreamsFilter.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/StreamsFilter.jsx
@@ -17,7 +17,6 @@ const StreamsFilter = ({ disabled, value, streams, onChange }) => {
               onChange={selected => onChange(selected === '' ? [] : selected.split(','))}
               options={options}
               multi
-              style={{ width: '100%' }}
               value={selectedStreams} />
     </div>
   );


### PR DESCRIPTION
During the React Select migration to v2 we missed to replicate the functionality of some props that got removed or renamed, so some features of selects we and plugins relied on were not working as expected in some cases.

This PR fixes all missing functionality I found, and adds some tests to ensure that is currently working. Here is some information on the props adapted in this PR:

- `clearable` was renamed to ` isClearable`. Since the default value for this property in v1 was `true`, I used the same as default
- `disabled` inside the `options` object is no longer supported, we now use `isOptionDisabled` to check if that property is set and disable the `option`
- `inputProps` was removed, we use a custom component to achieve that. All usages of `inputProps` were replaced by `inputId`, since setting the inner input ID is all what we were using that for
- `optionRenderer` was removed, we use a custom component to achieve that functionality
- `valueRenderer` was removed, we use a custom component to achieve that functionality
- `matchProp` was removed, we use `createFilter` to create a custom filter
- `required` was removed but may be implemented later. I don't see an easy way to replicate that behaviour, so I vote for leaving the props as they are and adding an issue that targets that specifically
- `style` was removed and I don't see an easy way to adapt that in a generic way, since the API for that changed dramatically. We only used that `prop` in two components and as far as I could see was not really necessary, so I removed it from them
- `onBlurResetsInput` and `onCloseResetsInput` were also removed. They were only used in `SeriesSelect` as far as I could see, and after asking the Search team we decided to remove them

For reference, here are the [v2 upgrade guide](https://react-select.com/upgrade-guide#prop-update-guide) and the [v1 props](https://github.com/JedWatson/react-select/tree/v1.x#select-props).

Fixes #6946
