### PR TITLE
Enforce system wide TLS protocol settings

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsTransport.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsTransport.java
@@ -43,8 +43,9 @@ public class BeatsTransport extends AbstractTcpTransport {
                           EventLoopGroupFactory eventLoopGroupFactory,
                           NettyTransportConfiguration nettyTransportConfiguration,
                           ThroughputCounter throughputCounter,
-                          LocalMetricRegistry localRegistry) {
-        super(configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration);
+                          LocalMetricRegistry localRegistry,
+                          org.graylog2.Configuration graylogConfiguration) {
+        super(configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, graylogConfiguration);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -27,6 +27,7 @@ import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
 import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 import com.github.joschi.jadconfig.validators.PositiveLongValidator;
 import com.github.joschi.jadconfig.validators.StringNotBlankValidator;
+import com.google.common.collect.ImmutableSet;
 import org.graylog2.plugin.BaseConfiguration;
 import org.graylog2.security.realm.RootAccountRealm;
 import org.graylog2.utilities.IPSubnetConverter;
@@ -157,6 +158,11 @@ public class Configuration extends BaseConfiguration {
 
     @Parameter(value = "deactivated_builtin_authentication_providers", converter = StringSetConverter.class)
     private Set<String> deactivatedBuiltinAuthenticationProviders = Collections.emptySet();
+
+    // Defaults to TLS protocols that are currently considered secure
+    @Parameter(value = "enabled_tls_protocols", converter = StringSetConverter.class)
+    private Set<String> enabledTlsProtocols = ImmutableSet.of("TLSv1.2", "TLSv1.3");
+
 
     public boolean isMaster() {
         return isMaster;
@@ -311,6 +317,10 @@ public class Configuration extends BaseConfiguration {
 
     public Set<String> getDeactivatedBuiltinAuthenticationProviders() {
         return deactivatedBuiltinAuthenticationProviders;
+    }
+
+    public Set<String> getEnabledTlsProtocols() {
+        return enabledTlsProtocols;
     }
 
     @ValidatorMethod

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/HttpTransport.java
@@ -65,13 +65,15 @@ public class HttpTransport extends AbstractTcpTransport {
                          EventLoopGroupFactory eventLoopGroupFactory,
                          NettyTransportConfiguration nettyTransportConfiguration,
                          ThroughputCounter throughputCounter,
-                         LocalMetricRegistry localRegistry) {
+                         LocalMetricRegistry localRegistry,
+                         org.graylog2.Configuration graylogConfiguration) {
         super(configuration,
               throughputCounter,
               localRegistry,
               eventLoopGroup,
               eventLoopGroupFactory,
-              nettyTransportConfiguration);
+              nettyTransportConfiguration,
+              graylogConfiguration);
 
         enableCors = configuration.getBoolean(CK_ENABLE_CORS);
 

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/SyslogTcpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/SyslogTcpTransport.java
@@ -40,13 +40,15 @@ public class SyslogTcpTransport extends TcpTransport {
                               EventLoopGroupFactory eventLoopGroupFactory,
                               NettyTransportConfiguration nettyTransportConfiguration,
                               ThroughputCounter throughputCounter,
-                              LocalMetricRegistry localRegistry) {
+                              LocalMetricRegistry localRegistry,
+                              org.graylog2.Configuration graylogConfiguration) {
         super(configuration,
                 eventLoopGroup,
                 eventLoopGroupFactory,
                 nettyTransportConfiguration,
                 throughputCounter,
-                localRegistry);
+                localRegistry,
+                graylogConfiguration);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/TcpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/TcpTransport.java
@@ -56,8 +56,9 @@ public class TcpTransport extends AbstractTcpTransport {
                         EventLoopGroupFactory eventLoopGroupFactory,
                         NettyTransportConfiguration nettyTransportConfiguration,
                         ThroughputCounter throughputCounter,
-                        LocalMetricRegistry localRegistry) {
-        super(configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration);
+                        LocalMetricRegistry localRegistry,
+                        org.graylog2.Configuration graylogConfiguration) {
+        super(configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, graylogConfiguration);
 
         final boolean nulDelimiter = configuration.getBoolean(CK_USE_NULL_DELIMITER);
         this.delimiter = nulDelimiter ? nulDelimiter() : lineDelimiter();

--- a/graylog2-server/src/test/java/org/graylog/plugins/beats/BeatsTransportTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/beats/BeatsTransportTest.java
@@ -25,13 +25,23 @@ import org.graylog2.plugin.inputs.MessageInput;
 import org.graylog2.plugin.inputs.util.ThroughputCounter;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 public class BeatsTransportTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
     private NioEventLoopGroup eventLoopGroup;
+
+    @Mock
+    private org.graylog2.Configuration graylogConfiguration;
 
     @Before
     public void setUp() {
@@ -53,7 +63,8 @@ public class BeatsTransportTest {
                 eventLoopGroupFactory,
                 nettyTransportConfiguration,
                 new ThroughputCounter(eventLoopGroup),
-                new LocalMetricRegistry()
+                new LocalMetricRegistry(),
+                graylogConfiguration
         );
 
         final MessageInput input = mock(MessageInput.class);

--- a/graylog2-server/src/test/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransportTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransportTest.java
@@ -69,6 +69,9 @@ public class AbstractTcpTransportTest {
     @Mock
     private MessageInput input;
 
+    @Mock
+    private org.graylog2.Configuration graylogConfiguration;
+
     private ThroughputCounter throughputCounter;
     private LocalMetricRegistry localRegistry;
     private NioEventLoopGroup eventLoopGroup;
@@ -97,7 +100,7 @@ public class AbstractTcpTransportTest {
         );
 
         final AbstractTcpTransport transport = new AbstractTcpTransport(
-                configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration) {
+                configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, graylogConfiguration) {
         };
         final MessageInput input = mock(MessageInput.class);
         assertThat(transport.getChildChannelHandlers(input)).containsKey("tls");
@@ -116,7 +119,7 @@ public class AbstractTcpTransportTest {
         );
 
         final AbstractTcpTransport transport = new AbstractTcpTransport(
-            configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration) {};
+            configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, graylogConfiguration) {};
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage("Couldn't write to temporary directory: " + tmpDir.getAbsolutePath());
@@ -138,7 +141,7 @@ public class AbstractTcpTransportTest {
         );
 
         final AbstractTcpTransport transport = new AbstractTcpTransport(
-            configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration) {};
+            configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, graylogConfiguration) {};
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage("Couldn't write to temporary directory: " + tmpDir.getAbsolutePath());
@@ -159,7 +162,7 @@ public class AbstractTcpTransportTest {
         );
 
         final AbstractTcpTransport transport = new AbstractTcpTransport(
-            configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration) {};
+            configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, graylogConfiguration) {};
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage("Couldn't write to temporary directory: " + file.getAbsolutePath());
@@ -174,7 +177,7 @@ public class AbstractTcpTransportTest {
                 "bind_address", "127.0.0.1",
                 "port", 0));
         final AbstractTcpTransport transport = new AbstractTcpTransport(
-                configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration) {
+                configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, graylogConfiguration) {
         };
         transport.launch(input);
 
@@ -206,7 +209,7 @@ public class AbstractTcpTransportTest {
                 "bind_address", "127.0.0.1",
                 "port", 0));
         final AbstractTcpTransport transport = new AbstractTcpTransport(
-                configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration) {
+                configuration, throughputCounter, localRegistry, eventLoopGroup, eventLoopGroupFactory, nettyTransportConfiguration, graylogConfiguration) {
         };
         transport.launch(input);
 

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -670,3 +670,8 @@ proxied_requests_thread_pool_size = 32
 # the first start of Graylog.
 # Default: empty
 #content_packs_auto_install = grok-patterns.json
+
+# The allowed TLS protocols for system wide TLS enabled servers. (e.g. message inputs, http interface)
+# Setting this to an empty value, leaves it up to system libraries and the used JDK to chose a default.
+# Default: TLSv1.2,TLSv1.3
+#enabled_tls_protocols= TLSv1.2,TLSv1.3


### PR DESCRIPTION
With the introduction of netty 4 in Graylog 3.0, we changed the default
SslProvider to OpenSSL.
While this gives a better performance, it lacks the ability to disable
TLS protocols that are considered flawed.
Changes to the java security properties are only respected by jdk based
SslProviders (jersey / grizzly in our case).

Introduce a system wide default setting for supported TLS protocols,
with a sane default to TLSv1.2 (and TLSv1.3 if the jdk supports it).
These protocol settings are applied to netty based inputs and
to the webserver.

Changes can be made with a new server setting:
`#enabled_tls_protocols = TLSv1.2,TLSv1.3`

Fixes #6444

PS: This can be tested by using 
`nmap --script ssl-enum-ciphers -p <inputs-port> 127.0.0.1`