### PR TITLE
 Rename view to dashboard for all dashboard related info text

### DIFF
--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
@@ -62,12 +62,12 @@ const ViewActionsMenu = ({ view, isNewView, metadata, onSaveView, onSaveAsView, 
       </DropdownButton>
       <DebugOverlay show={debugOpen} onClose={() => setDebugOpen(false)} />
       <ViewPropertiesModal view={view.toBuilder().newId().build()}
-                           title="Save new view"
+                           title="Save new dashboard"
                            onSave={onSaveAsView}
                            show={saveAsViewOpen}
                            onClose={() => setSaveAsViewOpen(false)} />
       <ViewPropertiesModal view={view}
-                           title="Editing view"
+                           title="Editing dashboard"
                            onSave={onSaveView}
                            show={editViewOpen}
                            onClose={() => setEditViewOpen(false)} />

--- a/graylog2-web-interface/src/views/components/views/ShareViewModal.jsx
+++ b/graylog2-web-interface/src/views/components/views/ShareViewModal.jsx
@@ -135,7 +135,7 @@ class ShareViewModal extends React.Component<Props, State> {
           Any user of this Graylog
         </Radio>{' '}
         <Additional>
-          <HelpBlock>Anyone with an account can access the view.</HelpBlock>
+          <HelpBlock>Anyone with an account can access the dashboard.</HelpBlock>
         </Additional>
 
         <Radio name={SpecificRoles.Type} checked={type === SpecificRoles.Type} onChange={this._onChange}>
@@ -148,7 +148,7 @@ class ShareViewModal extends React.Component<Props, State> {
                   placeholder="Select roles"
                   onChange={this._onRolesChange}
                   options={rolesOptions} />
-          <HelpBlock>Only users with these roles can access the view.</HelpBlock>
+          <HelpBlock>Only users with these roles can access the dashboard.</HelpBlock>
         </Additional>
 
         <Radio name={SpecificUsers.Type} checked={type === SpecificUsers.Type} onChange={this._onChange}>
@@ -161,21 +161,21 @@ class ShareViewModal extends React.Component<Props, State> {
                   placeholder="Select users"
                   onChange={this._onUsersChange}
                   options={userOptions || []} />
-          <HelpBlock>Only these users can access the view.</HelpBlock>
+          <HelpBlock>Only these users can access the dashboard.</HelpBlock>
         </Additional>
 
         <Radio name="none" checked={type === 'none'} onChange={this._onChange}>
           Only me
         </Radio>
         <Additional>
-          <HelpBlock>Noone but you can access the view.</HelpBlock>
+          <HelpBlock>Noone but you can access the dashboard.</HelpBlock>
         </Additional>
       </FormGroup>
     );
     return (
       <Modal show={show} onHide={this._onClose}>
         <Modal.Body>
-          <h3>Who is supposed to access the view {view.title}?</h3>
+          <h3>Who is supposed to access the dashboard {view.title}?</h3>
           {content}
         </Modal.Body>
         <Modal.Footer>

--- a/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.jsx
+++ b/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.jsx
@@ -30,7 +30,9 @@ export default class ViewPropertiesModal extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.show !== nextProps.show || this.props.title !== nextProps.title || !isEqual(this.state.view, nextProps.view)) {
+    const { show, title } = this.props;
+    const { view } = this.state;
+    if (show !== nextProps.show || title !== nextProps.title || !isEqual(view, nextProps.view)) {
       this.setState({ view: nextProps.view, title: nextProps.title, show: nextProps.show });
     }
   }
@@ -48,11 +50,16 @@ export default class ViewPropertiesModal extends React.Component {
     }
   };
 
-  _onClose = () => this.props.onClose();
+  _onClose = () => {
+    const { onClose } = this.props;
+    onClose();
+  };
 
   _onSave = () => {
-    this.props.onSave(this.state.view);
-    this.props.onClose();
+    const { onSave, onClose } = this.props;
+    const { view } = this.state;
+    onSave(view);
+    onClose();
   };
 
   render() {

--- a/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.jsx
+++ b/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.jsx
@@ -67,21 +67,21 @@ export default class ViewPropertiesModal extends React.Component {
                  type="text"
                  name="title"
                  label="Title"
-                 help="The title of the view."
+                 help="The title of the dashboard."
                  onChange={this._onChange}
                  value={view.title} />
           <Input id="summary"
                  type="text"
                  name="summary"
                  label="Summary"
-                 help="A helpful summary of the view."
+                 help="A helpful summary of the dashboard."
                  onChange={this._onChange}
                  value={view.summary} />
           <Input id="description"
                  type="textarea"
                  name="description"
                  label="Description"
-                 help="A longer, helpful description of the view and its functionality."
+                 help="A longer, helpful description of the dashboard and its functionality."
                  onChange={this._onChange}
                  value={view.description} />
         </Modal.Body>


### PR DESCRIPTION
As described in #7018 the word "view" still exists in some dashboard info tests. This PR renames them to "dashboard".

Fixes #7018

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

