### PR TITLE
Use global override time range as reference for offset time ranges.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
@@ -74,11 +74,9 @@ public abstract class Query {
     public abstract Optional<GlobalOverride> globalOverride();
 
     public TimeRange effectiveTimeRange(SearchType searchType) {
-        return this.globalOverride()
-                .flatMap(GlobalOverride::timerange)
-                .orElseGet(() -> searchType.timerange()
-                        .map(range -> range.effectiveTimeRange(this, searchType))
-                        .orElse(this.timerange()));
+        return searchType.timerange()
+                .map(timeRange -> timeRange.effectiveTimeRange(this, searchType))
+                .orElse(this.timerange());
     }
 
     @Nonnull

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/timeranges/DerivedTimeRange.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/timeranges/DerivedTimeRange.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.auto.value.AutoValue;
+import org.graylog.plugins.views.search.GlobalOverride;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
@@ -35,7 +36,7 @@ public abstract class DerivedTimeRange {
             return ((DerivableTimeRange)value()).deriveTimeRange(query, searchType);
         }
 
-        return value();
+        return query.globalOverride().flatMap(GlobalOverride::timerange).orElse(value());
     }
 
     @JsonCreator

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/QueryEffectiveTimeRangeTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/QueryEffectiveTimeRangeTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.views.search;
 
 import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/QueryEffectiveTimeRangeTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/QueryEffectiveTimeRangeTest.java
@@ -1,0 +1,92 @@
+package org.graylog.plugins.views.search;
+
+import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
+import org.graylog.plugins.views.search.timeranges.OffsetRange;
+import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
+import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
+import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+import org.joda.time.DateTimeUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class QueryEffectiveTimeRangeTest {
+    private Query query;
+
+    @Before
+    public void setUp() throws Exception {
+        this.query = Query.emptyRoot();
+    }
+
+    @Test
+    public void returnQueryTimeRangeIfNoSearchTypeTimeRangeAndNoGlobalOverride() throws InvalidRangeParametersException {
+        final SearchType searchType = mock(SearchType.class);
+        when(searchType.timerange()).thenReturn(Optional.empty());
+        final Query queryWithTimeRange = query.toBuilder().timerange(RelativeRange.create(3600)).build();
+
+        final TimeRange result = queryWithTimeRange.effectiveTimeRange(searchType);
+
+        assertThat(result).isEqualTo(RelativeRange.create(3600));
+    }
+
+    @Test
+    public void returnSearchTypeTimeRangeIfPresentAndNoGlobalOverride() throws InvalidRangeParametersException {
+        final SearchType searchType = mock(SearchType.class);
+        when(searchType.timerange())
+                .thenReturn(Optional.of(DerivedTimeRange.of(RelativeRange.create(7200))));
+        final Query queryWithTimeRange = query.toBuilder().timerange(RelativeRange.create(3600)).build();
+
+        final TimeRange result = queryWithTimeRange.effectiveTimeRange(searchType);
+
+        assertThat(result).isEqualTo(RelativeRange.create(7200));
+    }
+
+    @Test
+    public void returnGlobalOverrideTimeRangeIfPresent() throws InvalidRangeParametersException {
+        final SearchType searchType = mock(SearchType.class);
+        when(searchType.timerange())
+                .thenReturn(Optional.of(DerivedTimeRange.of(RelativeRange.create(7200))));
+        final Query queryWithTimeRange = query.toBuilder()
+                .timerange(RelativeRange.create(3600))
+                .globalOverride(GlobalOverride.builder()
+                        .timerange(RelativeRange.create(600))
+                        .build())
+                .build();
+
+        final TimeRange result = queryWithTimeRange.effectiveTimeRange(searchType);
+
+        assertThat(result).isEqualTo(RelativeRange.create(600));
+    }
+
+    @Test
+    public void returnGlobalOverrideTimeRangeWithOffsetIfPresentAndOffsetTimeRange() throws InvalidRangeParametersException {
+        DateTimeUtils.setCurrentMillisFixed(1578590095642L);
+
+        final SearchType searchType = mock(SearchType.class);
+        when(searchType.timerange())
+                .thenReturn(Optional.of(
+                        DerivedTimeRange.of(
+                                OffsetRange.Builder.builder()
+                                        .source("query")
+                                        .build()
+                        )));
+        final Query queryWithTimeRange = query.toBuilder()
+                .timerange(RelativeRange.create(3600))
+                .globalOverride(GlobalOverride.builder()
+                        .timerange(RelativeRange.create(600))
+                        .build())
+                .build();
+
+        final TimeRange result = queryWithTimeRange.effectiveTimeRange(searchType);
+
+        assertThat(result).isEqualTo(AbsoluteRange.create("2020-01-09T16:54:55.642Z", "2020-01-09T17:04:55.642Z"));
+
+        DateTimeUtils.setCurrentMillisSystem();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/timeranges/DerivedTimeRangeTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/timeranges/DerivedTimeRangeTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.plugins.views.search.timeranges;
 
+import org.graylog.plugins.views.search.Query;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.KeywordRange;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
@@ -27,12 +28,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class DerivedTimeRangeTest {
+    private static final Query emptyRootQuery = Query.emptyRoot();
+
     @Test
     public void returnsInitialRangeForRelativeRange() throws Exception {
         final RelativeRange range = RelativeRange.create(300);
         final DerivedTimeRange derivedTimeRange = DerivedTimeRange.of(range);
 
-        assertThat(derivedTimeRange.effectiveTimeRange(null, null)).isEqualTo(range);
+        assertThat(derivedTimeRange.effectiveTimeRange(emptyRootQuery, null)).isEqualTo(range);
     }
 
     @Test
@@ -40,7 +43,7 @@ public class DerivedTimeRangeTest {
         final AbsoluteRange range = AbsoluteRange.create("2019-11-18T10:00:00.000Z", "2019-11-21T12:00:00.000Z");
         final DerivedTimeRange derivedTimeRange = DerivedTimeRange.of(range);
 
-        assertThat(derivedTimeRange.effectiveTimeRange(null, null)).isEqualTo(range);
+        assertThat(derivedTimeRange.effectiveTimeRange(emptyRootQuery, null)).isEqualTo(range);
     }
 
     @Test
@@ -48,7 +51,7 @@ public class DerivedTimeRangeTest {
         final KeywordRange range = KeywordRange.create("yesterday");
         final DerivedTimeRange derivedTimeRange = DerivedTimeRange.of(range);
 
-        assertThat(derivedTimeRange.effectiveTimeRange(null, null)).isEqualTo(range);
+        assertThat(derivedTimeRange.effectiveTimeRange(emptyRootQuery, null)).isEqualTo(range);
     }
 
     @Test
@@ -60,6 +63,6 @@ public class DerivedTimeRangeTest {
         when(range.deriveTimeRange(any(), any())).thenReturn(resultRange);
         final DerivedTimeRange derivedTimeRange = DerivedTimeRange.of(range);
 
-        assertThat(derivedTimeRange.effectiveTimeRange(null, null)).isEqualTo(resultRange);
+        assertThat(derivedTimeRange.effectiveTimeRange(emptyRootQuery, null)).isEqualTo(resultRange);
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, time ranges per search type were either overwritten by the global override time range (if present) or "derived" from the search type/query's time range. This led to offset time ranges being overwritten by the global override time range and therefore breaking trending.

This change is now taking the global override time range into account when "deriving" a time range. That means the offset time range checks if a global override time range is present and uses it as reference. If it is absent, it uses its configured source time range.

Fixes #7134.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.