### PR TITLE
Convert week/month bucket interval to days if value is bigger than 1.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/TimeUnitInterval.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/TimeUnitInterval.java
@@ -42,6 +42,11 @@ public abstract class TimeUnitInterval implements Interval {
     @JsonProperty
     public abstract String timeunit();
 
+    @Override
+    public DateHistogramInterval toDateHistogramInterval(TimeRange timerange) {
+        return new DateHistogramInterval(adjustUnitsLongerThanDays(timeunit()));
+    }
+
     private String adjustUnitsLongerThanDays(String timeunit) {
         final Matcher matcher = TIMEUNIT_PATTERN.matcher(timeunit());
         checkArgument(matcher.matches(),
@@ -58,11 +63,6 @@ public abstract class TimeUnitInterval implements Interval {
             case "M": return quantity == 1 ? timeunit : (30 * quantity) + "d";
             default: throw new RuntimeException("Invalid time unit: " + timeunit);
         }
-    }
-
-    @Override
-    public DateHistogramInterval toDateHistogramInterval(TimeRange timerange) {
-        return new DateHistogramInterval(adjustUnitsLongerThanDays(timeunit()));
     }
 
     @AutoValue.Builder

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/TimeUnitInterval.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/TimeUnitInterval.java
@@ -51,7 +51,7 @@ public abstract class TimeUnitInterval implements Interval {
         final Matcher matcher = TIMEUNIT_PATTERN.matcher(timeunit());
         checkArgument(matcher.matches(),
                 "Time unit must be {quantity}{unit}, where quantity is a positive number and unit [smhdwM].");
-        final int quantity = Integer.parseInt(matcher.group("quantity"), 10);
+        final int quantity = Integer.parseInt(matcher.group("quantity"));
         final String unit = matcher.group("unit");
 
         switch (unit) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/TimeUnitInterval.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/TimeUnitInterval.java
@@ -24,11 +24,17 @@ import com.google.auto.value.AutoValue;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
 @AutoValue
 @JsonTypeName(TimeUnitInterval.type)
 @JsonDeserialize(builder = TimeUnitInterval.Builder.class)
 public abstract class TimeUnitInterval implements Interval {
     public static final String type = "timeunit";
+    public static final Pattern TIMEUNIT_PATTERN = Pattern.compile("(?<quantity>\\d+)(?<unit>[smhdwM])");
 
     @JsonProperty
     public abstract String type();
@@ -36,9 +42,27 @@ public abstract class TimeUnitInterval implements Interval {
     @JsonProperty
     public abstract String timeunit();
 
+    private String adjustUnitsLongerThanDays(String timeunit) {
+        final Matcher matcher = TIMEUNIT_PATTERN.matcher(timeunit());
+        checkArgument(matcher.matches(),
+                "Time unit must be {quantity}{unit}, where quantity is a positive number and unit [smhdwM].");
+        final int quantity = Integer.parseInt(matcher.group("quantity"), 10);
+        final String unit = matcher.group("unit");
+
+        switch (unit) {
+            case "s":
+            case "m":
+            case "h":
+            case "d": return timeunit;
+            case "w": return quantity == 1 ? timeunit : (7 * quantity) + "d";
+            case "M": return quantity == 1 ? timeunit : (30 * quantity) + "d";
+            default: throw new RuntimeException("Invalid time unit: " + timeunit);
+        }
+    }
+
     @Override
     public DateHistogramInterval toDateHistogramInterval(TimeRange timerange) {
-        return new DateHistogramInterval(timeunit());
+        return new DateHistogramInterval(adjustUnitsLongerThanDays(timeunit()));
     }
 
     @AutoValue.Builder
@@ -49,7 +73,19 @@ public abstract class TimeUnitInterval implements Interval {
         @JsonProperty("timeunit")
         public abstract Builder timeunit(String timeunit);
 
-        public abstract TimeUnitInterval build();
+        abstract TimeUnitInterval autoBuild();
+        public TimeUnitInterval build() {
+            final TimeUnitInterval interval = autoBuild();
+            final Matcher matcher = TIMEUNIT_PATTERN.matcher(interval.timeunit());
+            checkArgument(matcher.matches(),
+                    "Time unit must be {quantity}{unit}, where quantity is a positive number and unit [smhdwM].");
+
+            final int quantity = Integer.parseInt(matcher.group("quantity"), 10);
+            checkArgument(quantity > 0,
+                    "Time unit's value must be a positive number, greater than zero.");
+
+            return interval;
+        }
 
         @JsonCreator
         public static Builder builder() {

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/TimeUnitIntervalTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/TimeUnitIntervalTest.java
@@ -1,16 +1,16 @@
 /**
  * This file is part of Graylog.
- * <p>
+ *
  * Graylog is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * <p>
+ *
  * Graylog is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * <p>
+ *
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/TimeUnitIntervalTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/TimeUnitIntervalTest.java
@@ -1,0 +1,67 @@
+package org.graylog.plugins.views.search.searchtypes.pivot.buckets;
+
+import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
+import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
+import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class TimeUnitIntervalTest {
+    private TimeUnitInterval.Builder builder() {
+        return TimeUnitInterval.Builder.builder();
+    }
+
+    @Test
+    public void doesNotAllowInvalidTimeUnit() {
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> builder().timeunit("foobar").build())
+                .withMessage("Time unit must be {quantity}{unit}, where quantity is a positive number and unit [smhdwM].");
+    }
+
+    @Test
+    public void doesNotAllowNegativeQuantity() {
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> builder().timeunit("-1s").build())
+                .withMessage("Time unit must be {quantity}{unit}, where quantity is a positive number and unit [smhdwM].");
+    }
+
+    @Test
+    public void doesNotAllowZeroQuantity() {
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> builder().timeunit("0d").build())
+                .withMessage("Time unit's value must be a positive number, greater than zero.");
+    }
+
+    @Test
+    public void doesNotAllowUnknownUnit() {
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> builder().timeunit("1x").build())
+                .withMessage("Time unit must be {quantity}{unit}, where quantity is a positive number and unit [smhdwM].");
+    }
+
+    @Test
+    public void allowsPositiveQuantityAndKnownUnit() throws InvalidRangeParametersException {
+        final TimeUnitInterval timeunit = builder().timeunit("1m").build();
+
+        assertThat(timeunit.toDateHistogramInterval(RelativeRange.create(300)))
+                .isEqualTo(new DateHistogramInterval("1m"));
+    }
+
+    @Test
+    public void adjustsIfMoreThanOneWeek() throws InvalidRangeParametersException {
+        final TimeUnitInterval timeunit = builder().timeunit("2w").build();
+
+        assertThat(timeunit.toDateHistogramInterval(RelativeRange.create(30 * 24 * 60 * 60)))
+                .isEqualTo(new DateHistogramInterval("14d"));
+    }
+
+    @Test
+    public void adjustsIfMoreThanOneMonth() throws InvalidRangeParametersException {
+        final TimeUnitInterval timeunit = builder().timeunit("2M").build();
+
+        assertThat(timeunit.toDateHistogramInterval(RelativeRange.create(365 * 24 * 60 * 60)))
+                .isEqualTo(new DateHistogramInterval("60d"));
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/TimeUnitIntervalTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/TimeUnitIntervalTest.java
@@ -1,16 +1,16 @@
 /**
  * This file is part of Graylog.
- *
+ * <p>
  * Graylog is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * <p>
  * Graylog is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * <p>
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -20,64 +20,90 @@ import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInter
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+@RunWith(Enclosed.class)
 public class TimeUnitIntervalTest {
-    private TimeUnitInterval.Builder builder() {
+    private static TimeUnitInterval.Builder builder() {
         return TimeUnitInterval.Builder.builder();
     }
 
-    @Test
-    public void doesNotAllowInvalidTimeUnit() {
-        assertThatExceptionOfType(RuntimeException.class)
-                .isThrownBy(() -> builder().timeunit("foobar").build())
-                .withMessage("Time unit must be {quantity}{unit}, where quantity is a positive number and unit [smhdwM].");
+    public static class InvalidTimeUnits {
+        public static final String INVALID_TIME_UNIT_MESSAGE = "Time unit must be {quantity}{unit}, where quantity is a positive number and unit [smhdwM].";
+
+        @Test
+        public void doesNotAllowInvalidTimeUnit() {
+            assertThatExceptionOfType(RuntimeException.class)
+                    .isThrownBy(() -> builder().timeunit("foobar").build())
+                    .withMessage(INVALID_TIME_UNIT_MESSAGE);
+        }
+
+        @Test
+        public void doesNotAllowNegativeQuantity() {
+            assertThatExceptionOfType(RuntimeException.class)
+                    .isThrownBy(() -> builder().timeunit("-1s").build())
+                    .withMessage(INVALID_TIME_UNIT_MESSAGE);
+        }
+
+        @Test
+        public void doesNotAllowZeroQuantity() {
+            assertThatExceptionOfType(RuntimeException.class)
+                    .isThrownBy(() -> builder().timeunit("0d").build())
+                    .withMessage("Time unit's value must be a positive number, greater than zero.");
+        }
+
+        @Test
+        public void doesNotAllowUnknownUnit() {
+            assertThatExceptionOfType(RuntimeException.class)
+                    .isThrownBy(() -> builder().timeunit("1x").build())
+                    .withMessage(INVALID_TIME_UNIT_MESSAGE);
+        }
     }
 
-    @Test
-    public void doesNotAllowNegativeQuantity() {
-        assertThatExceptionOfType(RuntimeException.class)
-                .isThrownBy(() -> builder().timeunit("-1s").build())
-                .withMessage("Time unit must be {quantity}{unit}, where quantity is a positive number and unit [smhdwM].");
-    }
+    @RunWith(Parameterized.class)
+    public static class ValidTimeUnitIntervalsTest {
+        @Parameterized.Parameters
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][]{
+                    {"1s", "1s"},
+                    {"2s", "2s"},
+                    {"1m", "1m"},
+                    {"4m", "4m"},
+                    {"1h", "1h"},
+                    {"2h", "2h"},
+                    {"1d", "1d"},
+                    {"4d", "4d"},
+                    {"1w", "1w"},
+                    {"2w", "14d"},
+                    {"4w", "28d"},
+                    {"1M", "1M"},
+                    {"2M", "60d"},
+                    {"4M", "120d"}
+            });
+        }
 
-    @Test
-    public void doesNotAllowZeroQuantity() {
-        assertThatExceptionOfType(RuntimeException.class)
-                .isThrownBy(() -> builder().timeunit("0d").build())
-                .withMessage("Time unit's value must be a positive number, greater than zero.");
-    }
+        private final String timeunit;
+        private final String expectedTimeunit;
 
-    @Test
-    public void doesNotAllowUnknownUnit() {
-        assertThatExceptionOfType(RuntimeException.class)
-                .isThrownBy(() -> builder().timeunit("1x").build())
-                .withMessage("Time unit must be {quantity}{unit}, where quantity is a positive number and unit [smhdwM].");
-    }
+        public ValidTimeUnitIntervalsTest(String timeunit, String expectedTimeunit) {
+            this.timeunit = timeunit;
+            this.expectedTimeunit = expectedTimeunit;
+        }
 
-    @Test
-    public void allowsPositiveQuantityAndKnownUnit() throws InvalidRangeParametersException {
-        final TimeUnitInterval timeunit = builder().timeunit("1m").build();
+        @Test
+        public void allowsPositiveQuantityAndKnownUnit() throws InvalidRangeParametersException {
+            final TimeUnitInterval interval = builder().timeunit(timeunit).build();
 
-        assertThat(timeunit.toDateHistogramInterval(RelativeRange.create(300)))
-                .isEqualTo(new DateHistogramInterval("1m"));
-    }
-
-    @Test
-    public void adjustsIfMoreThanOneWeek() throws InvalidRangeParametersException {
-        final TimeUnitInterval timeunit = builder().timeunit("2w").build();
-
-        assertThat(timeunit.toDateHistogramInterval(RelativeRange.create(30 * 24 * 60 * 60)))
-                .isEqualTo(new DateHistogramInterval("14d"));
-    }
-
-    @Test
-    public void adjustsIfMoreThanOneMonth() throws InvalidRangeParametersException {
-        final TimeUnitInterval timeunit = builder().timeunit("2M").build();
-
-        assertThat(timeunit.toDateHistogramInterval(RelativeRange.create(365 * 24 * 60 * 60)))
-                .isEqualTo(new DateHistogramInterval("60d"));
+            assertThat(interval.toDateHistogramInterval(RelativeRange.create(300)))
+                    .isEqualTo(new DateHistogramInterval(expectedTimeunit));
+        }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/TimeUnitIntervalTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/searchtypes/pivot/buckets/TimeUnitIntervalTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.views.search.searchtypes.pivot.buckets;
 
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Due to limitations in Elasticsearch, it does not support time unit
bucket intervals with values bigger than 1 for units bigger than days.
Therefore, this PR transparently converts these to days (with multiples
of 7 resp. 30) if the value is bigger than 1, leaving the original unit
otherwise.

In contrast to the initial attempt in #7055, this PR is performing the
change in the backend, transparent to the caller and relieving the
caller from having to do the conversion before.

Fixes #7022.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.