### PR TITLE
Remove widget position from view state, on widget delete

### DIFF
--- a/graylog2-web-interface/src/views/stores/CurrentViewStateStore.js
+++ b/graylog2-web-interface/src/views/stores/CurrentViewStateStore.js
@@ -85,6 +85,14 @@ export const CurrentViewStateStore = singletonStore(
 
     widgets(newWidgets) {
       const positionsMap = Immutable.Map(this._activeState().widgetPositions);
+
+      const positionsMapWithWidget = positionsMap.reduce((clearedPositions, position, positionWidgetId) => {
+        if (newWidgets.find(widget => widget.id === positionWidgetId)) {
+          return clearedPositions.set(positionWidgetId, position);
+        }
+        return clearedPositions;
+      }, Immutable.Map());
+
       const widgetsWithoutPositions = newWidgets.filter((widget) => {
         return !positionsMap.get(widget.id);
       });
@@ -96,7 +104,7 @@ export const CurrentViewStateStore = singletonStore(
           return newPosMap.set(id, pos);
         }, Immutable.Map());
         return result.set(widget.id, new WidgetPosition(1, 1, widgetDef.defaultHeight, widgetDef.defaultWidth));
-      }, positionsMap);
+      }, positionsMapWithWidget);
 
       const newActiveState = this._activeState().toBuilder()
         .widgets(newWidgets)

--- a/graylog2-web-interface/src/views/stores/CurrentViewStateStore.test.js
+++ b/graylog2-web-interface/src/views/stores/CurrentViewStateStore.test.js
@@ -86,13 +86,15 @@ describe('CurrentViewStateStore', () => {
   });
 
   it('should remove widget positions for deleted widgets', async () => {
+    const widgetOne = MessagesWidget.builder().id('widget-one').build();
+    const widgetOnePos = new WidgetPosition(1, 1, 5, 6);
     const existingViewState = viewState.toBuilder()
       .widgetPositions({
-        'widget-one': new WidgetPosition(1, 1, 5, 6),
+        'widget-one': widgetOnePos,
         'widget-two': new WidgetPosition(1, 6, 5, 6),
       })
       .widgets([
-        MessagesWidget.builder().id('widget-one').build(),
+        widgetOne,
         MessagesWidget.builder().id('widget-two').build(),
       ])
       .build();
@@ -100,9 +102,9 @@ describe('CurrentViewStateStore', () => {
     viewStateMap[viewId] = existingViewState;
     const sMap = Immutable.Map(viewStateMap);
 
-    const expectedWidgets = [existingViewState.widgets[0]];
+    const expectedWidgets = [widgetOne];
     const expectedViewState = viewState.toBuilder()
-      .widgetPositions({ 'widget-one': existingViewState.widgetPositions['widget-one'] })
+      .widgetPositions({ 'widget-one': widgetOnePos })
       .widgets(expectedWidgets)
       .build();
     const updateFn = mockAction(jest.fn(() => Promise.resolve(expectedViewState)));

--- a/graylog2-web-interface/src/views/stores/CurrentViewStateStore.test.js
+++ b/graylog2-web-interface/src/views/stores/CurrentViewStateStore.test.js
@@ -20,7 +20,7 @@ describe('CurrentViewStateStore', () => {
     return [{ type: 'MESSAGES', defaultHeight: 5, defaultWidth: 6 }];
   };
 
-  it('should set empty widgets', () => {
+  it('should set empty widgets', async () => {
     const updateFn = mockAction(jest.fn((id, view) => {
       expect(id).toEqual(viewId);
       expect(view).toEqual(viewState);
@@ -29,12 +29,12 @@ describe('CurrentViewStateStore', () => {
     ViewStatesActions.update = updateFn;
     CurrentViewStateStore.onViewStoreChange({ activeQuery: viewId, view: viewState });
     CurrentViewStateStore.onViewStatesStoreChange(statesMap);
-    CurrentViewStateStore.widgets(Immutable.List());
+    await CurrentViewStateStore.widgets(Immutable.List());
 
     expect(asMock(updateFn).mock.calls.length).toBe(1);
   });
 
-  it('should set new widgets', () => {
+  it('should set new widgets', async () => {
     const widgetPos = new WidgetPosition(1, 1, 5, 6);
     const widgetPositionsMap = { dead: widgetPos };
     const widgets = [
@@ -54,11 +54,11 @@ describe('CurrentViewStateStore', () => {
     ViewStatesActions.update = updateFn;
     CurrentViewStateStore.onViewStoreChange({ activeQuery: viewId, view: viewState });
     CurrentViewStateStore.onViewStatesStoreChange(statesMap);
-    CurrentViewStateStore.widgets(widgets);
+    await CurrentViewStateStore.widgets(widgets);
     expect(updateFn).toHaveBeenCalledTimes(1);
   });
 
-  it('should add new widgets', () => {
+  it('should add new widgets', async () => {
     const widgetPos = new WidgetPosition(1, 1, 5, 6);
     const widgetPositionsMap = { dead: widgetPos };
     const oldWidget = MessagesWidget.builder().id('dead').build();
@@ -100,11 +100,11 @@ describe('CurrentViewStateStore', () => {
     ViewStatesActions.update = updateFn;
     CurrentViewStateStore.onViewStoreChange({ activeQuery: viewId, view: oldViewState });
     CurrentViewStateStore.onViewStatesStoreChange(sMap);
-    CurrentViewStateStore.widgets(expectedWidgets);
+    await CurrentViewStateStore.widgets(expectedWidgets);
     expect(updateFn).toHaveBeenCalledTimes(1);
   });
 
-  it('should remove widget positions for deleted widgets', () => {
+  it('should remove widget positions for deleted widgets', async () => {
     const widgetOnePos = new WidgetPosition(1, 1, 5, 6);
     const widgetTwoPos = new WidgetPosition(1, 6, 5, 6);
     const widgetPositionsMap = { 'widget-one': widgetOnePos, 'widget-two': widgetTwoPos };
@@ -135,7 +135,7 @@ describe('CurrentViewStateStore', () => {
     ViewStatesActions.update = updateFn;
     CurrentViewStateStore.onViewStoreChange({ activeQuery: viewId, view: existingViewState });
     CurrentViewStateStore.onViewStatesStoreChange(sMap);
-    CurrentViewStateStore.widgets(expectedWidgets);
+    await CurrentViewStateStore.widgets(expectedWidgets);
     expect(updateFn).toHaveBeenCalledTimes(1);
   });
 });

--- a/graylog2-web-interface/src/views/stores/CurrentViewStateStore.test.js
+++ b/graylog2-web-interface/src/views/stores/CurrentViewStateStore.test.js
@@ -103,4 +103,39 @@ describe('CurrentViewStateStore', () => {
     CurrentViewStateStore.widgets(expectedWidgets);
     expect(updateFn).toHaveBeenCalledTimes(1);
   });
+
+  it('should remove widget positions for deleted widgets', () => {
+    const widgetOnePos = new WidgetPosition(1, 1, 5, 6);
+    const widgetTwoPos = new WidgetPosition(1, 6, 5, 6);
+    const widgetPositionsMap = { 'widget-one': widgetOnePos, 'widget-two': widgetTwoPos };
+    const widgetOne = MessagesWidget.builder().id('widget-one').build();
+    const widgetTwo = MessagesWidget.builder().id('widget-two').build();
+    const existingWidgets = [widgetOne, widgetTwo];
+    const existingViewState = viewState.toBuilder()
+      .widgetPositions(widgetPositionsMap)
+      .widgets(existingWidgets)
+      .build();
+
+    viewStateMap[viewId] = existingViewState;
+    const sMap = Immutable.Map(viewStateMap);
+
+    const expectedWidgets = [widgetOne];
+    const expectedWidgetPosition = { 'widget-one': widgetOnePos };
+    const expectedViewState = viewState.toBuilder()
+      .widgetPositions(expectedWidgetPosition)
+      .widgets(expectedWidgets)
+      .build();
+
+    const updateFn = mockAction(jest.fn((id, newViewState) => {
+      expect(id).toEqual(viewId);
+      expect(newViewState).toEqual(expectedViewState);
+      return Promise.resolve(expectedViewState);
+    }));
+
+    ViewStatesActions.update = updateFn;
+    CurrentViewStateStore.onViewStoreChange({ activeQuery: viewId, view: existingViewState });
+    CurrentViewStateStore.onViewStatesStoreChange(sMap);
+    CurrentViewStateStore.widgets(expectedWidgets);
+    expect(updateFn).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
As described in #6985 the widget position persists in the view state when deleting a widget. When saving a dashboard the widget position still persists in the database as well.

This PR just removes all positions without a related widget, when updating the widgets.

Fixes #6985

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

