### PR TITLE
Zoom global override when zooming in timeline chart on dashboard.

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/OnZoom.js
+++ b/graylog2-web-interface/src/views/components/visualizations/OnZoom.js
@@ -7,6 +7,7 @@ import Query from 'views/logic/queries/Query';
 import type { ViewType } from 'views/logic/views/View';
 import View from 'views/logic/views/View';
 import { GlobalOverrideActions } from 'views/stores/GlobalOverrideStore';
+import SearchActions from 'views/actions/SearchActions';
 
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
@@ -20,7 +21,7 @@ const onZoom = (currentQuery: Query, from: string, to: string, viewType: ?ViewTy
   };
 
   const action = viewType === View.Type.Dashboard
-    ? GlobalOverrideActions.timerange
+    ? timerange => GlobalOverrideActions.timerange(timerange).then(SearchActions.refresh)
     : timerange => QueriesActions.timerange(currentQuery.id, timerange);
 
   action(newTimerange);

--- a/graylog2-web-interface/src/views/components/visualizations/OnZoom.js
+++ b/graylog2-web-interface/src/views/components/visualizations/OnZoom.js
@@ -1,12 +1,16 @@
 // @flow strict
 import moment from 'moment-timezone';
-import { QueriesActions } from 'views/stores/QueriesStore';
 import CombinedProvider from 'injection/CombinedProvider';
+
+import { QueriesActions } from 'views/stores/QueriesStore';
 import Query from 'views/logic/queries/Query';
+import type { ViewType } from 'views/logic/views/View';
+import View from 'views/logic/views/View';
+import { GlobalOverrideActions } from 'views/stores/GlobalOverrideStore';
 
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
-const onZoom = (currentQuery: Query, from: string, to: string) => {
+const onZoom = (currentQuery: Query, from: string, to: string, viewType: ?ViewType) => {
   const { timezone } = CurrentUserStore.get();
 
   const newTimerange = {
@@ -15,7 +19,11 @@ const onZoom = (currentQuery: Query, from: string, to: string) => {
     to: moment.tz(to, timezone).toISOString(),
   };
 
-  QueriesActions.timerange(currentQuery.id, newTimerange);
+  const action = viewType === View.Type.Dashboard
+    ? GlobalOverrideActions.timerange
+    : timerange => QueriesActions.timerange(currentQuery.id, timerange);
+
+  action(newTimerange);
   return false;
 };
 

--- a/graylog2-web-interface/src/views/components/visualizations/OnZoom.test.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/OnZoom.test.jsx
@@ -1,0 +1,58 @@
+// @flow strict
+import View from 'views/logic/views/View';
+import Query from 'views/logic/queries/Query';
+import { QueriesActions } from 'views/stores/QueriesStore';
+import { GlobalOverrideActions } from 'views/stores/GlobalOverrideStore';
+
+import OnZoom from './OnZoom';
+
+const mockGetTimezone = jest.fn(() => ({ timezone: 'UTC'}));
+
+jest.mock('injection/CombinedProvider', () => ({
+  get: () => ({ CurrentUserStore: { get: () => mockGetTimezone() } }),
+}));
+
+jest.mock('views/stores/QueriesStore', () => ({
+  QueriesActions: {
+    query: jest.fn(() => Promise.resolve()),
+    timerange: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+jest.mock('views/stores/GlobalOverrideStore', () => ({
+  GlobalOverrideActions: {
+    timerange: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+describe('OnZoom', () => {
+  it('sets the global override timerange if called from a dashboard ', async () => {
+    const query = Query.builder().build();
+    await OnZoom(query, '2020-01-10 13:23:42.000', '2020-01-10 14:23:42.000', View.Type.Dashboard);
+    expect(GlobalOverrideActions.timerange).toHaveBeenCalledWith({
+      from: '2020-01-10T13:23:42.000Z',
+      to: '2020-01-10T14:23:42.000Z',
+      type: 'absolute',
+    });
+  });
+  it('sets the query timerange if called from a dashboard ', async () => {
+    const query = Query.builder().id('query1').build();
+    await OnZoom(query, '2020-01-10 13:23:42.000', '2020-01-10 14:23:42.000', View.Type.Search);
+    expect(QueriesActions.timerange).toHaveBeenCalledWith('query1', {
+      from: '2020-01-10T13:23:42.000Z',
+      to: '2020-01-10T14:23:42.000Z',
+      type: 'absolute',
+    });
+  });
+
+  it('converts the passed time stamps from the user\'s time range to UTC', async () => {
+    mockGetTimezone.mockReturnValue({ timezone: 'CET' });
+    const query = Query.builder().id('query1').build();
+    await OnZoom(query, '2020-01-10 13:23:42.000', '2020-01-10 14:23:42.000', View.Type.Search);
+    expect(QueriesActions.timerange).toHaveBeenCalledWith('query1', {
+      from: '2020-01-10T12:23:42.000Z',
+      to: '2020-01-10T13:23:42.000Z',
+      type: 'absolute',
+    });
+  });
+});

--- a/graylog2-web-interface/src/views/components/visualizations/OnZoom.test.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/OnZoom.test.jsx
@@ -6,7 +6,7 @@ import { GlobalOverrideActions } from 'views/stores/GlobalOverrideStore';
 
 import OnZoom from './OnZoom';
 
-const mockGetTimezone = jest.fn(() => ({ timezone: 'UTC'}));
+const mockGetTimezone = jest.fn(() => ({ timezone: 'UTC' }));
 
 jest.mock('injection/CombinedProvider', () => ({
   get: () => ({ CurrentUserStore: { get: () => mockGetTimezone() } }),

--- a/graylog2-web-interface/src/views/components/visualizations/XYPlot.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/XYPlot.jsx
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { useCallback } from 'react';
+import React, { useCallback, useContext } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment-timezone';
 import { get, merge } from 'lodash';
@@ -10,11 +10,13 @@ import CombinedProvider from 'injection/CombinedProvider';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import { CurrentQueryStore } from 'views/stores/CurrentQueryStore';
 import Query from 'views/logic/queries/Query';
+import type { ViewType } from 'views/logic/views/View';
 
 import GenericPlot from './GenericPlot';
 import OnZoom from './OnZoom';
 import CustomPropTypes from '../CustomPropTypes';
 import type { ChartColor, ChartConfig, ColorMap } from './GenericPlot';
+import ViewTypeContext from '../contexts/ViewTypeContext';
 
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
 
@@ -30,7 +32,7 @@ type Props = {
   getChartColor?: (Array<ChartConfig>, string) => ?string,
   setChartColor?: (ChartConfig, ColorMap) => ChartColor,
   plotLayout?: any,
-  onZoom: (Query, string, string) => boolean,
+  onZoom: (Query, string, string, ?ViewType) => boolean,
 };
 
 const XYPlot = ({
@@ -48,7 +50,10 @@ const XYPlot = ({
 
   const layout = merge({}, { yaxis }, plotLayout);
 
-  const _onZoom = useCallback(config.isTimeline ? (from, to) => onZoom(currentQuery, from, to) : () => true, [config.isTimeline, onZoom]);
+  const viewType = useContext(ViewTypeContext);
+  const _onZoom = useCallback(config.isTimeline
+    ? (from, to) => onZoom(currentQuery, from, to, viewType)
+    : () => true, [config.isTimeline, onZoom]);
 
   if (config.isTimeline && effectiveTimerange) {
     const normalizedFrom = moment.tz(effectiveTimerange.from, timezone).format();

--- a/graylog2-web-interface/src/views/stores/GlobalOverrideStore.js
+++ b/graylog2-web-interface/src/views/stores/GlobalOverrideStore.js
@@ -15,6 +15,7 @@ export type GlobalOverrideActionsType = RefluxActions<{
   rangeParams: (string, string | number) => Promise<?GlobalOverride>,
   query: (string) => Promise<?GlobalOverride>,
   reset: () => Promise<?GlobalOverride>,
+  timerange: (TimeRange) => Promise<?GlobalOverride>,
 }>;
 
 export const GlobalOverrideActions: GlobalOverrideActionsType = singletonActions(
@@ -24,6 +25,7 @@ export const GlobalOverrideActions: GlobalOverrideActionsType = singletonActions
     rangeParams: { asyncResult: true },
     query: { asyncResult: true },
     reset: { asyncResult: true },
+    timerange: { asyncResult: true },
   }),
 );
 
@@ -46,6 +48,14 @@ export const GlobalOverrideStore: GlobalOverrideStoreType = singletonStore(
     },
     getInitialState() {
       return this.globalOverride;
+    },
+    timerange(newTimerange: TimeRange) {
+      const currentGlobalOverride = this.globalOverride || GlobalOverride.empty();
+      const newGlobalOverride = currentGlobalOverride.toBuilder().timerange(newTimerange).build();
+
+      const promise = this._propagateNewGlobalOverride(newGlobalOverride);
+      GlobalOverrideActions.timerange.promise(promise);
+      return promise;
     },
     rangeType(newType: string) {
       if (newType === 'disabled') {
@@ -81,8 +91,8 @@ export const GlobalOverrideStore: GlobalOverrideStoreType = singletonStore(
             };
             break;
         }
-        const newGlobalOverride: GlobalOverride = this.globalOverride ? new GlobalOverride(newTimerange, this.globalOverride.query) : new GlobalOverride(newTimerange);
-        const promise = this._propagateNewGlobalOverride(newGlobalOverride);
+
+        const promise = this.timerange(newTimerange);
         GlobalOverrideActions.rangeType.promise(promise);
         return promise;
       }
@@ -95,8 +105,8 @@ export const GlobalOverrideStore: GlobalOverrideStoreType = singletonStore(
         ? { ...this.globalOverride.timerange, [key]: value }
         // $FlowFixMe: Flow is unable to validate that timerange is complete
         : { [key]: value };
-      const newGlobalOverride: GlobalOverride = this.globalOverride ? new GlobalOverride(newTimerange, this.globalOverride.query) : new GlobalOverride(newTimerange);
-      const promise = this._propagateNewGlobalOverride(newGlobalOverride);
+
+      const promise = this.timerange(newTimerange);
       GlobalOverrideActions.rangeParams.promise(promise);
       return promise;
     },


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, zooming (dragging a range) on a timeline chart on
a dashboard did nothing, because it set the query's time range which is
not considered on dashboards.

This change is now conditionally setting the global override's time
range if on a dashboard and the query's time range if not. It does this
by checking the view's type in the zoom handler.

Ideally we should instead provide a `DrilldownContext` for all actions,
that provides commonly used actions/states (setting/getting current time
range, query, stream selection), so actions do not determine on their
own which one to pick.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.