### PR TITLE
Avoid using PathConfiguration#getDataDir() for default path configs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -144,7 +144,7 @@ public class Configuration extends BaseConfiguration {
     private boolean contentPacksLoaderEnabled = false;
 
     @Parameter(value = "content_packs_dir")
-    private Path contentPacksDir = getDataDir().resolve("contentpacks");
+    private Path contentPacksDir = DEFAULT_DATA_DIR.resolve("contentpacks");
 
     @Parameter(value = "content_packs_auto_install", converter = TrimmedStringSetConverter.class)
     private Set<String> contentPacksAutoInstall = Collections.emptySet();

--- a/graylog2-server/src/main/java/org/graylog2/configuration/PathConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/PathConfiguration.java
@@ -22,14 +22,18 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public abstract class PathConfiguration {
+    protected static final Path DEFAULT_BIN_DIR = Paths.get("bin");
+    protected static final Path DEFAULT_DATA_DIR = Paths.get("data");
+    protected static final Path DEFAULT_PLUGIN_DIR = Paths.get("plugin");
+
     @Parameter(value = "bin_dir", required = true)
-    private Path binDir = Paths.get("bin");
+    private Path binDir = DEFAULT_BIN_DIR;
 
     @Parameter(value = "data_dir", required = true)
-    private Path dataDir = Paths.get("data");
+    private Path dataDir = DEFAULT_DATA_DIR;
 
     @Parameter(value = "plugin_dir", required = true)
-    private Path pluginDir = Paths.get("plugin");
+    private Path pluginDir = DEFAULT_PLUGIN_DIR;
 
     public Path getBinDir() {
         return binDir;

--- a/graylog2-server/src/main/java/org/graylog2/plugin/KafkaJournalConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/KafkaJournalConfiguration.java
@@ -25,7 +25,6 @@ import org.graylog2.configuration.PathConfiguration;
 import org.joda.time.Duration;
 
 import javax.validation.constraints.NotNull;
-import java.io.File;
 import java.nio.file.Path;
 import java.util.Objects;
 
@@ -52,7 +51,7 @@ public class KafkaJournalConfiguration extends PathConfiguration {
 
     @Parameter(value = "message_journal_dir", required = true)
     @JsonProperty("directory")
-    private Path messageJournalDir = getDataDir().resolve("journal");
+    private Path messageJournalDir = DEFAULT_DATA_DIR.resolve("journal");
 
     @Parameter("message_journal_segment_size")
     @JsonProperty("segment_size")


### PR DESCRIPTION
Using "#getDataDir()" to initialize the default dir values for the
contentpack and message journal works, but it implies that they
will automatically use the user configured "data_dir" setting. This is
not true because "#getDataDir()" to set the default value will be called
before the configuration is parsed.

Introduce constants for the bin, data and plugin dir and use those as
default values to make it explicit that the default will not change
automatically by setting a custom "data_dir".