### PR TITLE
Handle Request Entity Too Large errors in ElasticSearchOutput (#7071)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
@@ -61,4 +61,7 @@ public class ElasticsearchClientConfiguration {
 
     @Parameter(value = "elasticsearch_compression_enabled")
     boolean compressionEnabled = false;
+
+    @Parameter(value = "elasticsearch_use_expect_continue")
+    boolean useExpectContinue = true;
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/JestUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/JestUtils.java
@@ -62,6 +62,15 @@ public class JestUtils {
         return execute(client, null, request, errorMessage);
     }
 
+    public static <T extends JestResult> T execute(JestClient client, RequestConfig requestConfig,
+                                                   Action<T> request) throws IOException {
+        if (client instanceof JestHttpClient) {
+            return ((JestHttpClient) client).execute(request, requestConfig);
+        } else {
+            return client.execute(request);
+        }
+    }
+
     public static ElasticsearchException specificException(Supplier<String> errorMessage, JsonNode errorNode) {
         final JsonNode rootCauses = errorNode.path("root_cause");
         final List<String> reasons = new ArrayList<>(rootCauses.size());

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -27,6 +27,7 @@ import com.github.rholder.retry.Retryer;
 import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.WaitStrategies;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
 import io.searchbox.core.Bulk;
@@ -35,10 +36,13 @@ import io.searchbox.core.DocumentResult;
 import io.searchbox.core.Get;
 import io.searchbox.core.Index;
 import io.searchbox.indices.Analyze;
+import org.apache.http.client.config.RequestConfig;
+import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.indexer.IndexFailure;
 import org.graylog2.indexer.IndexFailureImpl;
 import org.graylog2.indexer.IndexMapping;
 import org.graylog2.indexer.IndexSet;
+import org.graylog2.indexer.cluster.jest.JestUtils;
 import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.plugin.GlobalMetricNames;
 import org.graylog2.plugin.Message;
@@ -47,11 +51,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
@@ -84,6 +90,7 @@ public class Messages {
     private final Meter invalidTimestampMeter;
     private final JestClient client;
     private final ProcessingStatusRecorder processingStatusRecorder;
+    private final boolean useExpectContinue;
     private final LinkedBlockingQueue<List<IndexFailure>> indexFailureQueue;
     private final Counter outputByteCounter;
     private final Counter systemTrafficCounter;
@@ -91,12 +98,14 @@ public class Messages {
     @Inject
     public Messages(MetricRegistry metricRegistry,
                     JestClient client,
-                    ProcessingStatusRecorder processingStatusRecorder) {
+                    ProcessingStatusRecorder processingStatusRecorder,
+                    @Named("elasticsearch_use_expect_continue") boolean useExpectContinue) {
         invalidTimestampMeter = metricRegistry.meter(name(Messages.class, "invalid-timestamps"));
         outputByteCounter = metricRegistry.counter(GlobalMetricNames.OUTPUT_TRAFFIC);
         systemTrafficCounter = metricRegistry.counter(GlobalMetricNames.SYSTEM_OUTPUT_TRAFFIC);
         this.client = client;
         this.processingStatusRecorder = processingStatusRecorder;
+        this.useExpectContinue = useExpectContinue;
 
         // TODO: Magic number
         this.indexFailureQueue =  new LinkedBlockingQueue<>(1000);
@@ -137,38 +146,91 @@ public class Messages {
             return Collections.emptyList();
         }
 
-        final Bulk.Builder bulk = new Bulk.Builder();
-        for (Map.Entry<IndexSet, Message> entry : messageList) {
-            final Message message = entry.getValue();
-            if (isSystemTraffic) {
-                systemTrafficCounter.inc(message.getSize());
-            } else {
-                outputByteCounter.inc(message.getSize());
+        int chunkSize = messageList.size();
+        int offset = 0;
+        List<BulkResult.BulkResultItem> failedItems = new ArrayList<>();
+        for (;;) {
+            try {
+                failedItems.addAll(bulkIndexChunked(messageList, isSystemTraffic, offset, chunkSize));
+                break; // on success
+            } catch (EntityTooLargeException e) {
+                LOG.warn("Bulk index failed with 'Request Entity Too Large' error. Retrying by splitting up batch size <{}>.", chunkSize);
+                if (chunkSize == messageList.size()) {
+                    LOG.warn("Consider lowering the \"output_batch_size\" setting.");
+                }
+                failedItems.addAll(e.failedItems);
+                offset += e.indexedSuccessfully;
+                chunkSize /= 2;
             }
-
-            bulk.addAction(new Index.Builder(message.toElasticSearchObject(invalidTimestampMeter))
-                .index(entry.getKey().getWriteIndexAlias())
-                .type(IndexMapping.TYPE_MESSAGE)
-                .id(message.getId())
-                .build());
+            if (chunkSize == 0) {
+                throw new ElasticsearchException("Bulk index cannot split output batch any further.");
+            }
         }
 
-        final BulkResult result = runBulkRequest(bulk.build(), messageList.size());
-        final List<BulkResult.BulkResultItem> failedItems = result.getFailedItems();
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Index: Bulk indexed {} messages, took {} ms, failures: {}",
-                    result.getItems().size(), result, failedItems.size());
-        }
 
         if (!failedItems.isEmpty()) {
             final Set<String> failedIds = failedItems.stream().map(item -> item.id).collect(Collectors.toSet());
             recordTimestamp(messageList, failedIds);
-            return propagateFailure(failedItems, messageList, result.getErrorMessage());
+            return propagateFailure(failedItems, messageList);
         } else {
             recordTimestamp(messageList, Collections.emptySet());
             return Collections.emptyList();
         }
+    }
+
+    private List<BulkResult.BulkResultItem> bulkIndexChunked(final List<Map.Entry<IndexSet, Message>> messageList, boolean isSystemTraffic, int offset, int chunkSize) throws EntityTooLargeException {
+        chunkSize = Math.min(messageList.size(), chunkSize);
+
+        final List<BulkResult.BulkResultItem> failedItems = new ArrayList<>();
+        final Iterable<List<Map.Entry<IndexSet, Message>>> partition = Iterables.partition(messageList.subList(offset, messageList.size()), chunkSize);
+        int partitionCount = 1;
+        int indexedSuccessfully = 0;
+        for (List<Map.Entry<IndexSet, Message>> subMessageList: partition) {
+            Bulk.Builder bulk = new Bulk.Builder();
+
+            long messageSizes = 0;
+            for (Map.Entry<IndexSet, Message> entry : subMessageList) {
+                final Message message = entry.getValue();
+                messageSizes += message.getSize();
+
+                bulk.addAction(new Index.Builder(message.toElasticSearchObject(invalidTimestampMeter))
+                        .index(entry.getKey().getWriteIndexAlias())
+                        .type(IndexMapping.TYPE_MESSAGE)
+                        .id(message.getId())
+                        .build());
+            }
+
+            final BulkResult result = runBulkRequest(bulk.build(), subMessageList.size());
+
+            if (result.getResponseCode() == 413) {
+                throw new EntityTooLargeException(indexedSuccessfully, failedItems);
+            }
+
+            // TODO should we check result.isSucceeded()?
+
+            indexedSuccessfully += subMessageList.size();
+            failedItems.addAll(result.getFailedItems());
+            if (isSystemTraffic) {
+                systemTrafficCounter.inc(messageSizes);
+            } else {
+                outputByteCounter.inc(messageSizes);
+            }
+            if (LOG.isDebugEnabled()) {
+                String chunkInfo = "";
+                if (chunkSize != messageList.size()) {
+                    chunkInfo = String.format(Locale.ROOT, " (chunk %d/%d offset %d)", partitionCount,
+                            (int) Math.ceil((double)messageList.size() / chunkSize), offset);
+                }
+                LOG.debug("Index: Bulk indexed {} messages{}, failures: {}",
+                        result.getItems().size(), chunkInfo, failedItems.size());
+            }
+            if (!result.getFailedItems().isEmpty()) {
+                LOG.error("Failed to index [{}] messages. Please check the index error log in your web interface for the reason. Error: {}",
+                        result.getFailedItems().size(), result.getErrorMessage());
+            }
+            partitionCount++;
+        }
+        return failedItems;
     }
 
     private void recordTimestamp(List<Map.Entry<IndexSet, Message>> messageList, Set<String> failedIds) {
@@ -185,7 +247,13 @@ public class Messages {
 
     private BulkResult runBulkRequest(final Bulk request, int count) {
         try {
-            return BULK_REQUEST_RETRYER.call(() -> client.execute(request));
+            if (useExpectContinue) {
+                // Enable Expect-Continue to catch 413 errors before we send the actual data
+                final RequestConfig requestConfig = RequestConfig.custom().setExpectContinueEnabled(true).build();
+                return BULK_REQUEST_RETRYER.call(() -> JestUtils.execute(client, requestConfig, request));
+            } else {
+                return BULK_REQUEST_RETRYER.call(() -> client.execute(request));
+            }
         } catch (ExecutionException | RetryException e) {
             if (e instanceof RetryException) {
                 LOG.error("Could not bulk index {} messages. Giving up after {} attempts.", count, ((RetryException) e).getNumberOfFailedAttempts());
@@ -196,7 +264,7 @@ public class Messages {
         }
     }
 
-    private List<String> propagateFailure(List<BulkResult.BulkResultItem> items, List<Map.Entry<IndexSet, Message>> messageList, String errorMessage) {
+    private List<String> propagateFailure(List<BulkResult.BulkResultItem> items, List<Map.Entry<IndexSet, Message>> messageList) {
         final Map<String, Message> messageMap = messageList.stream()
             .map(Map.Entry::getValue)
             .distinct()
@@ -221,9 +289,6 @@ public class Messages {
             failedMessageIds.add(item.id);
         }
 
-        LOG.error("Failed to index [{}] messages. Please check the index error log in your web interface for the reason. Error: {}",
-                indexFailures.size(), errorMessage);
-
         try {
             // TODO: Magic number
             indexFailureQueue.offer(indexFailures, 25, TimeUnit.MILLISECONDS);
@@ -246,5 +311,15 @@ public class Messages {
 
     public LinkedBlockingQueue<List<IndexFailure>> getIndexFailureQueue() {
         return indexFailureQueue;
+    }
+
+    private class EntityTooLargeException extends Exception {
+        private final int indexedSuccessfully;
+        private final List<BulkResult.BulkResultItem> failedItems;
+
+        public EntityTooLargeException(int indexedSuccessfully, List<BulkResult.BulkResultItem> failedItems)  {
+            this.indexedSuccessfully = indexedSuccessfully;
+            this.failedItems = failedItems;
+        }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
+++ b/graylog2-server/src/main/java/org/graylog2/outputs/ElasticSearchOutput.java
@@ -112,6 +112,7 @@ public class ElasticSearchOutput implements MessageOutput {
         }
         failures.mark(failedMessageIds.size());
 
+        // This does not exclude failedMessageIds, because we don't know if ES is ever gonna accept these messages.
         final Optional<Long> offset = messageList.stream()
             .map(Map.Entry::getValue)
             .map(Message::getJournalOffset)

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
@@ -88,7 +88,7 @@ public class IndexFieldTypePollerIT extends ElasticsearchBase {
         final Indices indices = new Indices(client(),
                 new ObjectMapperProvider().get(),
                 new IndexMappingFactory(new Node(client())),
-                new Messages(new MetricRegistry(), client(), new InMemoryProcessingStatusRecorder()),
+                new Messages(new MetricRegistry(), client(), new InMemoryProcessingStatusRecorder(), true),
                 mock(NodeId.class),
                 new NullAuditEventSender(),
                 new EventBus("index-field-type-poller-it"));

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesGetAllMessageFieldsIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesGetAllMessageFieldsIT.java
@@ -54,7 +54,7 @@ public class IndicesGetAllMessageFieldsIT extends ElasticsearchBase {
         indices = new Indices(client(),
                 new ObjectMapper(),
                 new IndexMappingFactory(node),
-                new Messages(new MetricRegistry(), client(), new InMemoryProcessingStatusRecorder()),
+                new Messages(new MetricRegistry(), client(), new InMemoryProcessingStatusRecorder(), true),
                 mock(NodeId.class),
                 new NullAuditEventSender(),
                 new EventBus());

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
@@ -116,7 +116,7 @@ public class IndicesIT extends ElasticsearchBase {
         indices = new Indices(client(),
                 new ObjectMapperProvider().get(),
                 indexMappingFactory,
-                new Messages(new MetricRegistry(), client(), new InMemoryProcessingStatusRecorder()),
+                new Messages(new MetricRegistry(), client(), new InMemoryProcessingStatusRecorder(), true),
                 mock(NodeId.class),
                 new NullAuditEventSender(),
                 eventBus);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
@@ -38,6 +38,7 @@ import org.graylog2.system.processing.InMemoryProcessingStatusRecorder;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -112,6 +113,8 @@ public class MessagesIT extends ElasticsearchBase {
 
     @Test
     public void testIfTooLargeBatchesGetSplitUp() throws Exception {
+        // We don't have enough memory to run this test within travis
+        Assume.assumeTrue(Strings.isNullOrEmpty(System.getProperty("TRAVIS")));
         // This test assumes that ES is configured with bulk_max_body_size to 100MB
         // Check if we can index about 300MB of messages (once the large batch gets split up)
         final int MESSAGECOUNT = 303;
@@ -129,6 +132,8 @@ public class MessagesIT extends ElasticsearchBase {
 
     @Test
     public void unevenTooLargeBatchesGetSplitUp() throws Exception {
+        // We don't have enough memory to run this test within travis
+        Assume.assumeTrue(Strings.isNullOrEmpty(System.getProperty("TRAVIS")));
         final int MESSAGECOUNT = 100;
         final int LARGE_MESSAGECOUNT = 20;
         final ArrayList<Map.Entry<IndexSet, Message>> messageBatch = createMessageBatch(1024, MESSAGECOUNT);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
@@ -17,17 +17,34 @@
 package org.graylog2.indexer.messages;
 
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.Maps;
 import io.searchbox.client.JestResult;
+import io.searchbox.core.Count;
+import io.searchbox.core.CountResult;
 import io.searchbox.core.DocumentResult;
 import io.searchbox.core.Index;
+import joptsimple.internal.Strings;
 import org.graylog2.ElasticsearchBase;
+import org.graylog2.indexer.IndexSet;
+import org.graylog2.indexer.TestIndexSet;
+import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.results.ResultMessage;
+import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategy;
+import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategyConfig;
+import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
+import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategyConfig;
 import org.graylog2.plugin.Message;
 import org.graylog2.system.processing.InMemoryProcessingStatusRecorder;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -38,8 +55,27 @@ public class MessagesIT extends ElasticsearchBase {
 
     @Before
     public void setUp() throws Exception {
-        messages = new Messages(new MetricRegistry(), client(), new InMemoryProcessingStatusRecorder());
+        messages = new Messages(new MetricRegistry(), client(), new InMemoryProcessingStatusRecorder(), true);
     }
+
+    private static final IndexSetConfig indexSetConfig = IndexSetConfig.builder()
+            .id("index-set-1")
+            .title("Index set 1")
+            .description("For testing")
+            .indexPrefix("graylog")
+            .creationDate(ZonedDateTime.now(ZoneOffset.UTC))
+            .shards(1)
+            .replicas(0)
+            .rotationStrategyClass(MessageCountRotationStrategy.class.getCanonicalName())
+            .rotationStrategy(MessageCountRotationStrategyConfig.createDefault())
+            .retentionStrategyClass(DeletionRetentionStrategy.class.getCanonicalName())
+            .retentionStrategy(DeletionRetentionStrategyConfig.createDefault())
+            .indexAnalyzer("standard")
+            .indexTemplateName("template-1")
+            .indexOptimizationMaxNumSegments(1)
+            .indexOptimizationDisabled(false)
+            .build();
+    private static final IndexSet indexSet = new TestIndexSet(indexSetConfig);
 
     @Test
     public void getResultDoesNotContainJestMetadataFields() throws Exception {
@@ -58,5 +94,50 @@ public class MessagesIT extends ElasticsearchBase {
         assertThat(message).isNotNull();
         assertThat(message.hasField(JestResult.ES_METADATA_ID)).isFalse();
         assertThat(message.hasField(JestResult.ES_METADATA_VERSION)).isFalse();
+    }
+
+    @Test
+    public void testIfTooLargeBatchesGetSplitUp() throws Exception {
+        // This test assumes that ES is configured with bulk_max_body_size to 100MB
+        // Check if we can index about 300MB of messages (once the large batch gets split up)
+        final int MESSAGECOUNT = 303;
+        // Each Message is about 1 MB
+        final ArrayList<Map.Entry<IndexSet, Message>> largeMessageBatch = createMessageBatch(1024 * 1024, MESSAGECOUNT);
+        final List<String> failedItems = this.messages.bulkIndex(largeMessageBatch);
+
+        assertThat(failedItems).isEmpty();
+
+        Thread.sleep(2000); // wait for ES to finish indexing
+        final Count count = new Count.Builder().build();
+        final CountResult result = client().execute(count);
+
+        assertThat(result.getCount()).isEqualTo(MESSAGECOUNT);
+    }
+
+    @Test
+    public void unevenTooLargeBatchesGetSplitUp() throws Exception {
+        final int MESSAGECOUNT = 100;
+        final int LARGE_MESSAGECOUNT = 20;
+        final ArrayList<Map.Entry<IndexSet, Message>> messageBatch = createMessageBatch(1024, MESSAGECOUNT);
+        messageBatch.addAll(createMessageBatch(1024 * 1024 * 5, LARGE_MESSAGECOUNT));
+        final List<String> failedItems = this.messages.bulkIndex(messageBatch);
+
+        assertThat(failedItems).isEmpty();
+
+        Thread.sleep(2000); // wait for ES to finish indexing
+        final Count count = new Count.Builder().build();
+        final CountResult result = client().execute(count);
+
+        assertThat(result.getCount()).isEqualTo(MESSAGECOUNT + LARGE_MESSAGECOUNT);
+    }
+
+    private ArrayList<Map.Entry<IndexSet, Message>> createMessageBatch(int size, int count) {
+        final ArrayList<Map.Entry<IndexSet, Message>> messageList = new ArrayList<>();
+
+        final String message = Strings.repeat('A', size);
+        for (int i = 0; i < count; i++) {
+            messageList.add(Maps.immutableEntry(indexSet, new Message(i + message, "source", DateTime.now(DateTimeZone.UTC))));
+        }
+        return messageList;
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
@@ -114,7 +114,7 @@ public class MessagesIT extends ElasticsearchBase {
     @Test
     public void testIfTooLargeBatchesGetSplitUp() throws Exception {
         // We don't have enough memory to run this test within travis
-        Assume.assumeTrue(Strings.isNullOrEmpty(System.getProperty("TRAVIS")));
+        Assume.assumeTrue(Strings.isNullOrEmpty(System.getenv("TRAVIS")));
         // This test assumes that ES is configured with bulk_max_body_size to 100MB
         // Check if we can index about 300MB of messages (once the large batch gets split up)
         final int MESSAGECOUNT = 303;
@@ -133,7 +133,7 @@ public class MessagesIT extends ElasticsearchBase {
     @Test
     public void unevenTooLargeBatchesGetSplitUp() throws Exception {
         // We don't have enough memory to run this test within travis
-        Assume.assumeTrue(Strings.isNullOrEmpty(System.getProperty("TRAVIS")));
+        Assume.assumeTrue(Strings.isNullOrEmpty(System.getenv("TRAVIS")));
         final int MESSAGECOUNT = 100;
         final int LARGE_MESSAGECOUNT = 20;
         final ArrayList<Map.Entry<IndexSet, Message>> messageBatch = createMessageBatch(1024, MESSAGECOUNT);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
@@ -37,6 +37,7 @@ import org.graylog2.plugin.Message;
 import org.graylog2.system.processing.InMemoryProcessingStatusRecorder;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -51,18 +52,17 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MessagesIT extends ElasticsearchBase {
+    private static final String INDEX_NAME = "messages_it_deflector";
+
     private Messages messages;
 
-    @Before
-    public void setUp() throws Exception {
-        messages = new Messages(new MetricRegistry(), client(), new InMemoryProcessingStatusRecorder(), true);
-    }
+    private Count count;
 
     private static final IndexSetConfig indexSetConfig = IndexSetConfig.builder()
             .id("index-set-1")
             .title("Index set 1")
             .description("For testing")
-            .indexPrefix("graylog")
+            .indexPrefix("messages_it")
             .creationDate(ZonedDateTime.now(ZoneOffset.UTC))
             .shards(1)
             .replicas(0)
@@ -76,6 +76,20 @@ public class MessagesIT extends ElasticsearchBase {
             .indexOptimizationDisabled(false)
             .build();
     private static final IndexSet indexSet = new TestIndexSet(indexSetConfig);
+
+    @Before
+    public void setUp() throws Exception {
+        deleteIndex(INDEX_NAME);
+        createIndex(INDEX_NAME);
+        waitForGreenStatus(INDEX_NAME);
+        count = new Count.Builder().addIndex(INDEX_NAME).build();
+        messages = new Messages(new MetricRegistry(), client(), new InMemoryProcessingStatusRecorder(), true);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        deleteIndex(INDEX_NAME);
+    }
 
     @Test
     public void getResultDoesNotContainJestMetadataFields() throws Exception {
@@ -108,9 +122,8 @@ public class MessagesIT extends ElasticsearchBase {
         assertThat(failedItems).isEmpty();
 
         Thread.sleep(2000); // wait for ES to finish indexing
-        final Count count = new Count.Builder().build();
-        final CountResult result = client().execute(count);
 
+        final CountResult result = client().execute(count);
         assertThat(result.getCount()).isEqualTo(MESSAGECOUNT);
     }
 
@@ -125,7 +138,6 @@ public class MessagesIT extends ElasticsearchBase {
         assertThat(failedItems).isEmpty();
 
         Thread.sleep(2000); // wait for ES to finish indexing
-        final Count count = new Count.Builder().build();
         final CountResult result = client().execute(count);
 
         assertThat(result.getCount()).isEqualTo(MESSAGECOUNT + LARGE_MESSAGECOUNT);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MockedMessagesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MockedMessagesTest.java
@@ -73,7 +73,7 @@ public class MockedMessagesTest {
 
     @Before
     public void setUp() throws Exception {
-        this.messages = new Messages(new MetricRegistry(), jestClient, new InMemoryProcessingStatusRecorder());
+        this.messages = new Messages(new MetricRegistry(), jestClient, new InMemoryProcessingStatusRecorder(), true);
     }
 
     @Test

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -241,6 +241,12 @@ plugin_dir = plugin
 # Default: false
 #elasticsearch_compression_enabled = true
 
+# Enable use of "Expect: 100-continue" Header for Elasticsearch index requests.
+# If this is disabled, Graylog cannot properly handle HTTP 413 Request Entity Too Large errors.
+#
+# Default: true
+#elasticsearch_use_expect_continue = true
+
 # Graylog will use multiple indices to store documents in. You can configured the strategy it uses to determine
 # when to rotate the currently active write index.
 # It supports multiple rotation strategies:


### PR DESCRIPTION
If we try to bulk index a batch of messages that exceeds the
elastic search `http.max_content_length` setting. (default 100MB)
Elastic will respond with an HTTP 413 Entity Too Large error.

In this case we retry the request by splitting the message batch
in half.

When responding with an HTTP 413 error, the server is allowed to close the connection
immediately. This means that our HTTP client (Jest) will simply report
an IOException (Broken pipe) instead of the actual error.
This can be avoided by sending the request with an Expect-Continue
header, which also avoids sending data that will be discarded later on.

Fixes #5091

* Move JestClient execution with RequestConfig into JestUtils
* Please forbiddenapi checker
* Correctly handle batches with unevenly sized messages
  If we have a batch where only the messages at the end will
  exceed the Entity Too Large limit, we could end up duplicating
  messages.
  Thus keep track of the already indexed offset and report it within the
  EntityTooLargeException.
* Make use of Expect: 100-continue header configurable

(cherry picked from commit 085930aa59ff3087d446efbf8f95bb735cae296e)
