### PR TITLE
Improve API browser for several resources (#6955)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationDto.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationDto.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.events.notifications;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -33,6 +34,7 @@ import org.mongojack.ObjectId;
 import javax.annotation.Nullable;
 
 @AutoValue
+@JsonAutoDetect
 @JsonDeserialize(builder = NotificationDto.Builder.class)
 public abstract class NotificationDto implements ContentPackable {
     public static final String FIELD_ID = "id";

--- a/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionDto.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/EventDefinitionDto.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.events.processor;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -50,6 +51,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @AutoValue
+@JsonAutoDetect
 @JsonDeserialize(builder = EventDefinitionDto.Builder.class)
 @WithBeanGetter
 public abstract class EventDefinitionDto implements EventDefinition, ContentPackable<EventDefinitionEntity> {

--- a/graylog2-server/src/main/java/org/graylog/events/processor/EventProcessorParameters.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/EventProcessorParameters.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.events.processor;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
@@ -25,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         property = EventProcessorParameters.TYPE_FIELD,
         visible = true,
         defaultImpl = EventProcessorParametersWithTimerange.FallbackParameters.class)
+@JsonAutoDetect
 public interface EventProcessorParameters {
     String TYPE_FIELD = "type";
 

--- a/graylog2-server/src/main/java/org/graylog/events/rest/AvailableEntityTypesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/AvailableEntityTypesResource.java
@@ -17,6 +17,7 @@
 package org.graylog.events.rest;
 
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import io.swagger.annotations.Api;
@@ -71,6 +72,7 @@ public class AvailableEntityTypesResource extends RestResource implements Plugin
     }
 
     @AutoValue
+    @JsonAutoDetect
     public static abstract class AvailableEntityTypesSummary {
         @JsonProperty("processor_types")
         public abstract Set<String> processorTypes();

--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventDefinitionsResource.java
@@ -123,7 +123,7 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
     @ApiOperation("Create new event definition")
     @AuditEvent(type = EventsAuditEventTypes.EVENT_DEFINITION_CREATE)
     @RequiresPermissions(RestPermissions.EVENT_DEFINITIONS_CREATE)
-    public Response create(EventDefinitionDto dto) {
+    public Response create(@ApiParam(name = "JSON Body") EventDefinitionDto dto) {
         checkEventDefinitionPermissions(dto, "create");
 
         final ValidationResult result = dto.validate();
@@ -138,7 +138,7 @@ public class EventDefinitionsResource extends RestResource implements PluginRest
     @ApiOperation("Update existing event definition")
     @AuditEvent(type = EventsAuditEventTypes.EVENT_DEFINITION_UPDATE)
     public Response update(@ApiParam(name = "definitionId") @PathParam("definitionId") @NotBlank String definitionId,
-                           EventDefinitionDto dto) {
+                           @ApiParam(name = "JSON Body") EventDefinitionDto dto) {
         checkPermission(RestPermissions.EVENT_DEFINITIONS_EDIT, definitionId);
         checkEventDefinitionPermissions(dto, "update");
         dbService.get(definitionId)

--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventNotificationsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventNotificationsResource.java
@@ -117,7 +117,7 @@ public class EventNotificationsResource extends RestResource implements PluginRe
     @ApiOperation("Create new notification definition")
     @AuditEvent(type = EventsAuditEventTypes.EVENT_NOTIFICATION_CREATE)
     @RequiresPermissions(RestPermissions.EVENT_NOTIFICATIONS_CREATE)
-    public Response create(NotificationDto dto) {
+    public Response create(@ApiParam(name = "JSON Body") NotificationDto dto) {
         final ValidationResult validationResult = dto.validate();
         if (validationResult.failed()) {
             return Response.status(Response.Status.BAD_REQUEST).entity(validationResult).build();
@@ -130,7 +130,7 @@ public class EventNotificationsResource extends RestResource implements PluginRe
     @ApiOperation("Update existing notification")
     @AuditEvent(type = EventsAuditEventTypes.EVENT_NOTIFICATION_UPDATE)
     public Response update(@ApiParam(name = "notificationId") @PathParam("notificationId") @NotBlank String notificationId,
-                                  NotificationDto dto) {
+                                  @ApiParam(name = "JSON Body") NotificationDto dto) {
         checkPermission(RestPermissions.EVENT_NOTIFICATIONS_EDIT, notificationId);
         dbNotificationService.get(notificationId)
                 .orElseThrow(() -> new NotFoundException("Notification " + notificationId + " doesn't exist"));
@@ -186,7 +186,7 @@ public class EventNotificationsResource extends RestResource implements PluginRe
             @ApiResponse(code = 500, message = "Error while testing event notification")
     })
     @NoAuditEvent("only used to test event notifications")
-    public Response test(NotificationDto dto) {
+    public Response test(@ApiParam(name = "JSON Body") NotificationDto dto) {
         checkPermission(RestPermissions.EVENT_NOTIFICATIONS_CREATE);
         final ValidationResult validationResult = dto.validate();
         if (validationResult.failed()) {

--- a/graylog2-server/src/main/java/org/graylog/events/rest/EventsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/events/rest/EventsResource.java
@@ -18,6 +18,7 @@ package org.graylog.events.rest;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog.events.search.EventsSearchParameters;
 import org.graylog.events.search.EventsSearchResult;
@@ -50,7 +51,7 @@ public class EventsResource extends RestResource implements PluginRestResource {
     @Path("/search")
     @ApiOperation("Search events")
     @NoAuditEvent("Doesn't change any data, only searches for events")
-    public EventsSearchResult search(EventsSearchParameters request) {
+    public EventsSearchResult search(@ApiParam(name = "JSON body") EventsSearchParameters request) {
         return searchService.search(request, getSubject());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/events/search/EventsSearchParameters.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/EventsSearchParameters.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.events.search;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -26,6 +27,7 @@ import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
 @AutoValue
+@JsonAutoDetect
 @JsonDeserialize(builder = EventsSearchParameters.Builder.class)
 public abstract class EventsSearchParameters {
     private static final String FIELD_PAGE = "page";

--- a/graylog2-server/src/main/java/org/graylog/events/search/EventsSearchResult.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/EventsSearchResult.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.events.search;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
@@ -26,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 
 @AutoValue
+@JsonAutoDetect
 public abstract class EventsSearchResult {
     @JsonProperty("events")
     public abstract List<Event> events();

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/processing/ProcessingStatusSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/processing/ProcessingStatusSummary.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.rest.models.system.processing;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -25,6 +26,7 @@ import org.graylog2.system.processing.ProcessingStatusRecorder;
 import org.joda.time.DateTime;
 
 @AutoValue
+@JsonAutoDetect
 @JsonDeserialize(builder = ProcessingStatusSummary.Builder.class)
 public abstract class ProcessingStatusSummary {
     public static final String FIELD_RECEIVE_TIMES = "receive_times";

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/alarmcallbacks/AlarmCallbackHistoryResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/alarmcallbacks/AlarmCallbackHistoryResource.java
@@ -39,7 +39,7 @@ import javax.ws.rs.core.MediaType;
 import java.util.List;
 
 @RequiresAuthentication
-@Api(value = "AlarmCallbackHistories", description = "Manage stream alarm callback histories")
+@Api(value = "AlarmCallbackHistories", description = "Manage stream legacy alarm callback histories")
 @Path("/streams/{streamid}/alerts/{alertId}/history")
 public class AlarmCallbackHistoryResource extends RestResource {
     private final AlarmCallbackHistoryService alarmCallbackHistoryService;

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/alarmcallbacks/AlarmCallbacksResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/alarmcallbacks/AlarmCallbacksResource.java
@@ -65,7 +65,7 @@ import static org.graylog2.shared.security.RestPermissions.STREAMS_READ;
 import static org.graylog2.shared.security.RestPermissions.USERS_LIST;
 
 @RequiresAuthentication
-@Api(value = "AlarmCallbacks", description = "Manage alarm callbacks (aka alert notifications)")
+@Api(value = "AlarmCallbacks", description = "Manage legacy alarm callbacks (aka alert notifications)")
 @Path("/alerts/callbacks")
 @Produces(MediaType.APPLICATION_JSON)
 public class AlarmCallbacksResource extends RestResource {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/alarmcallbacks/StreamAlarmCallbackResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/alarmcallbacks/StreamAlarmCallbackResource.java
@@ -67,7 +67,7 @@ import java.util.List;
 import java.util.Map;
 
 @RequiresAuthentication
-@Api(value = "Stream/AlarmCallbacks", description = "Manage stream alarm callbacks")
+@Api(value = "Stream/AlarmCallbacks", description = "Manage stream legacy alarm callbacks")
 @Path("/streams/{streamid}/alarmcallbacks")
 public class StreamAlarmCallbackResource extends RestResource {
     private static final Logger LOG = LoggerFactory.getLogger(StreamAlarmCallbackResource.class);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/alerts/AlertResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/alerts/AlertResource.java
@@ -51,7 +51,7 @@ import java.util.stream.Stream;
 import static org.graylog2.shared.security.RestPermissions.STREAMS_READ;
 
 @RequiresAuthentication
-@Api(value = "Alerts", description = "Manage stream alerts for all streams")
+@Api(value = "Alerts", description = "Manage stream legacy alerts for all streams")
 @Path("/streams/alerts")
 @Produces(MediaType.APPLICATION_JSON)
 public class AlertResource extends RestResource {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/AlertConditionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/AlertConditionsResource.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 import static org.graylog2.shared.security.RestPermissions.STREAMS_READ;
 
 @RequiresAuthentication
-@Api(value = "AlertConditions", description = "Manage stream alert conditions")
+@Api(value = "AlertConditions", description = "Manage stream legacy alert conditions")
 @Path("/alerts/conditions")
 @Produces(MediaType.APPLICATION_JSON)
 public class AlertConditionsResource extends RestResource {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertConditionResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertConditionResource.java
@@ -63,7 +63,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @RequiresAuthentication
-@Api(value = "Stream/AlertConditions", description = "Manage stream alert conditions")
+@Api(value = "Stream/AlertConditions", description = "Manage stream legacy alert conditions")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
 @Path("/streams/{streamId}/alerts/conditions")

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/streams/alerts/StreamAlertResource.java
@@ -85,7 +85,7 @@ import java.util.stream.Collectors;
 import static com.google.common.base.Preconditions.checkArgument;
 
 @RequiresAuthentication
-@Api(value = "Stream/Alerts", description = "Manage stream alerts for a given stream")
+@Api(value = "Stream/Alerts", description = "Manage stream legacy alerts for a given stream")
 @Path("/streams/{streamId}/alerts")
 public class StreamAlertResource extends RestResource {
     private static final int REST_CHECK_CACHE_SECONDS = 30;


### PR DESCRIPTION
Most event resources were either missing `@ApiParam` annotations
or their models were not annotated with `@JsonAutoDetect`.

Both are needed to show meaningful model data in swagger.

Fixes #6742

(cherry picked from commit 4fe82c2833d2523fdcb363dbbe0fb75677564032)
