### PR TITLE
Implement overlay for select menu

### DIFF
--- a/graylog2-web-interface/src/views/components/Select.jsx
+++ b/graylog2-web-interface/src/views/components/Select.jsx
@@ -17,16 +17,17 @@ const MultiValueRemove = (props) => {
 const OverlayInner = ({ children, style }: {children: Node, style?: Object}) => React.Children.map(children,
   child => React.cloneElement(child, { style: Object.assign({}, style, child.props.style) }));
 
-const menu = (selectRef) => {
+const menu = selectRef => (base) => {
   const defaultMinWidth = 200;
   const containerWidth = get(selectRef, 'current.select.controlRef.offsetWidth') || 0;
   const width = containerWidth > defaultMinWidth ? containerWidth : defaultMinWidth;
-  return base => ({
+  return {
     ...base,
     position: 'relative',
     width: `${width}px`,
-  });
+  };
 };
+
 
 const multiValue = base => ({
   ...base,
@@ -94,6 +95,7 @@ const MenuOverlay = selectRef => (props) => {
 const Select = ({ components, styles, ...rest }: Props) => {
   const selectRef = useRef(null);
   const Menu = useMemo(() => MenuOverlay(selectRef), [selectRef]);
+  const menuStyle = useMemo(() => menu(selectRef), [selectRef]);
   const _components = {
     Menu,
     MultiValueRemove,
@@ -101,7 +103,7 @@ const Select = ({ components, styles, ...rest }: Props) => {
     ...components,
   };
   const _styles = {
-    menu: menu(selectRef),
+    menu: menuStyle,
     multiValue,
     multiValueLabel,
     multiValueRemove,

--- a/graylog2-web-interface/src/views/components/Select.jsx
+++ b/graylog2-web-interface/src/views/components/Select.jsx
@@ -19,12 +19,12 @@ const OverlayInner = ({ children, style }: {children: Node, style?: Object}) => 
 
 const menu = (selectRef) => {
   const defaultMinWidth = 200;
-  const containerWidth = get(selectRef, 'current.select.controlRef.offsetWidth');
+  const containerWidth = get(selectRef, 'current.select.controlRef.offsetWidth') || 0;
   const width = containerWidth > defaultMinWidth ? containerWidth : defaultMinWidth;
   return base => ({
     ...base,
     position: 'relative',
-    width,
+    width: `${width}px`,
   });
 };
 

--- a/graylog2-web-interface/src/views/components/Select.jsx
+++ b/graylog2-web-interface/src/views/components/Select.jsx
@@ -75,9 +75,6 @@ const MenuOverlay = selectRef => (props) => {
   return (
     <Overlay show
              placement="bottom"
-             shouldUpdatePosition
-             onHide={() => {}}
-             rootClose
              target={selectRef.current}>
       <OverlayInner>
         <div style={listStyle}>

--- a/graylog2-web-interface/src/views/components/Select.jsx
+++ b/graylog2-web-interface/src/views/components/Select.jsx
@@ -73,8 +73,9 @@ const MenuOverlay = selectRef => (props) => {
     position: 'absolute',
   };
   return (
-    <Overlay show
-             placement="bottom"
+    <Overlay placement="bottom"
+             shouldUpdatePosition
+             show
              target={selectRef.current}>
       <OverlayInner>
         <div style={listStyle}>

--- a/graylog2-web-interface/src/views/components/Select.jsx
+++ b/graylog2-web-interface/src/views/components/Select.jsx
@@ -28,11 +28,6 @@ const menu = (selectRef) => {
   });
 };
 
-const valueContainer = base => ({
-  ...base,
-  minWidth: '6.5vw',
-});
-
 const multiValue = base => ({
   ...base,
   backgroundColor: '#ebf5ff',
@@ -55,6 +50,16 @@ const multiValueRemove = base => ({
   ':hover': {
     backgroundColor: 'rgba(0,113,230,.08)',
   },
+});
+
+const option = base => ({
+  ...base,
+  wordWrap: 'break-word',
+});
+
+const valueContainer = base => ({
+  ...base,
+  minWidth: '6.5vw',
 });
 
 type Props = {
@@ -96,11 +101,12 @@ const Select = ({ components, styles, ...rest }: Props) => {
     ...components,
   };
   const _styles = {
+    menu: menu(selectRef),
     multiValue,
     multiValueLabel,
     multiValueRemove,
+    option,
     valueContainer,
-    menu: menu(selectRef),
     ...styles,
   };
   return <ReactSelect {...rest} components={_components} styles={_styles} tabSelectsValue={false} ref={selectRef} />;


### PR DESCRIPTION
The current dropdown menu of the `Select` component sometimes gets cut off and some options are no longer selectable. Here is an example of the aggregation builder:

![image](https://user-images.githubusercontent.com/46300478/72260082-4c8f6a80-3612-11ea-9fca-4467616fa6ae.png)

This PR implements the `Overlay` from `react-overlay` to display the menu independently from its parent containers.

![image](https://user-images.githubusercontent.com/46300478/72260151-78125500-3612-11ea-96e9-f3bcac97c939.png)

The new menu wrapper also defines a minimum width of 200px, until now a dropdown could be very small, depending on the parent container.
By default the menu has still the width of the related select input.

With these changes we are also breaking long option names.
Before (master):
![image](https://user-images.githubusercontent.com/46300478/72331717-f1fd1980-36b8-11ea-84ba-300b2bb5ec1d.png)
The user has to scroll horizontally to read the full name, the style is broken, even the list items have a width of 100%. 

After:
![image](https://user-images.githubusercontent.com/46300478/72331756-0214f900-36b9-11ea-8b6c-022aa74086c3.png)

In my opinion the second solution it easier to read. Even when long option names, separated by underscores are not getting perfectly wrapped. What do you think?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

