### PR TITLE
Fix Swagger annotations in Views resources

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewSharingResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewSharingResource.java
@@ -63,7 +63,7 @@ public class ViewSharingResource extends RestResource implements PluginRestResou
 
     @GET
     @ApiOperation("Get the sharing configuration for this view")
-    public ViewSharing get(@ApiParam @PathParam("id") @NotEmpty String id) {
+    public ViewSharing get(@ApiParam(name="id") @PathParam("id") @NotEmpty String id) {
         ensureUserIsPermittedForView(id);
         return viewSharingService.forView(id).orElseThrow(NotFoundException::new);
     }
@@ -71,7 +71,7 @@ public class ViewSharingResource extends RestResource implements PluginRestResou
     @POST
     @ApiOperation("Configure sharing for a view")
     @AuditEvent(type = ViewsAuditEventTypes.VIEW_SHARING_CREATE)
-    public ViewSharing create(@ApiParam @PathParam("id") @NotEmpty String id, ViewSharing viewSharing) {
+    public ViewSharing create(@ApiParam(name="id") @PathParam("id") @NotEmpty String id, ViewSharing viewSharing) {
         ensureUserIsPermittedForView(id);
         checkPermission(ViewsRestPermissions.VIEW_EDIT, id);
         return viewSharingService.create(viewSharing);
@@ -80,7 +80,7 @@ public class ViewSharingResource extends RestResource implements PluginRestResou
     @DELETE
     @ApiOperation("Delete sharing of a view")
     @AuditEvent(type = ViewsAuditEventTypes.VIEW_SHARING_DELETE)
-    public ViewSharing delete(@ApiParam @PathParam("id") @NotEmpty String id) {
+    public ViewSharing delete(@ApiParam(name="id") @PathParam("id") @NotEmpty String id) {
         ensureUserIsPermittedForView(id);
         checkPermission(ViewsRestPermissions.VIEW_EDIT, id);
         return viewSharingService.remove(id).orElse(null);
@@ -89,7 +89,7 @@ public class ViewSharingResource extends RestResource implements PluginRestResou
     @GET
     @Path("/users")
     @ApiOperation("Get a list of summaries of available users for sharing")
-    public Set<UserShortSummary> summarizeUsers(@ApiParam @PathParam("id") @NotEmpty String id) {
+    public Set<UserShortSummary> summarizeUsers(@ApiParam(name="id") @PathParam("id") @NotEmpty String id) {
         final List<User> users = userService.loadAll();
         final String currentUser = getCurrentUser() != null ? getCurrentUser().getName() : null;
         return users.stream()

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
@@ -131,7 +131,7 @@ public class ViewsResource extends RestResource implements PluginRestResource {
     @GET
     @Path("{id}")
     @ApiOperation("Get a single view")
-    public ViewDTO get(@ApiParam @PathParam("id") @NotEmpty String id) {
+    public ViewDTO get(@ApiParam(name="id") @PathParam("id") @NotEmpty String id) {
         if ("default".equals(id)) {
             // If the user is not permitted to access the default view, return a 404
             return dbService.getDefault()
@@ -162,7 +162,7 @@ public class ViewsResource extends RestResource implements PluginRestResource {
     @Path("{id}")
     @ApiOperation("Update view")
     @AuditEvent(type = ViewsAuditEventTypes.VIEW_UPDATE)
-    public ViewDTO update(@ApiParam @PathParam("id") @NotEmpty String id,
+    public ViewDTO update(@ApiParam(name="id") @PathParam("id") @NotEmpty String id,
                           @ApiParam @Valid ViewDTO dto) {
         checkPermission(ViewsRestPermissions.VIEW_EDIT, id);
         loadView(id);
@@ -173,7 +173,7 @@ public class ViewsResource extends RestResource implements PluginRestResource {
     @Path("{id}/default")
     @ApiOperation("Configures the view as default view")
     @AuditEvent(type = ViewsAuditEventTypes.DEFAULT_VIEW_SET)
-    public void setDefault(@ApiParam @PathParam("id") @NotEmpty String id) {
+    public void setDefault(@ApiParam(name="id") @PathParam("id") @NotEmpty String id) {
         checkPermission(ViewsRestPermissions.VIEW_READ, id);
         checkPermission(ViewsRestPermissions.DEFAULT_VIEW_SET);
         dbService.saveDefault(loadView(id));
@@ -183,7 +183,7 @@ public class ViewsResource extends RestResource implements PluginRestResource {
     @Path("{id}")
     @ApiOperation("Delete view")
     @AuditEvent(type = ViewsAuditEventTypes.VIEW_DELETE)
-    public ViewDTO delete(@ApiParam @PathParam("id") @NotEmpty String id) {
+    public ViewDTO delete(@ApiParam(name="id") @PathParam("id") @NotEmpty String id) {
         checkPermission(ViewsRestPermissions.VIEW_DELETE, id);
         final ViewDTO dto = loadView(id);
         dbService.delete(id);


### PR DESCRIPTION
Before this commit none of the endpoints of the affected resources that
included a path parameter worked from the API browser, because the path
parameters weren't properly processed.

Fixes #6860

## Description
Swagger annotations for path parameters need to include the parameter name to be preoperly processed in the API browser.

## How Has This Been Tested?
Manual tests from local API browser

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


