### PR TITLE
Update to netty 4.1.45

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <mongodb-driver.version>3.6.4</mongodb-driver.version>
         <mongojack.version>2.10.0</mongojack.version>
         <natty.version>0.13</natty.version>
-        <netty.version>4.1.44.Final</netty.version>
+        <netty.version>4.1.45.Final</netty.version>
         <netty-tcnative-boringssl-static.version>2.0.28.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>3.14.2</okhttp.version>
         <opencsv.version>2.3</opencsv.version>


### PR DESCRIPTION
This includes fixes for regressions that have been introduced in 4.1.44.

See full changelog: https://netty.io/news/2020/01/13/4-1-45-Final.html