### PR TITLE
Fix placeholder overflow for SortDirectionSelect

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationbuilder/SortDirectionSelect.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/SortDirectionSelect.jsx
@@ -11,6 +11,11 @@ type Props = {
   onChange: (Direction) => any,
 };
 
+const valueContainer = base => ({
+  ...base,
+  minHeight: '35px',
+});
+
 const SortDirectionSelect = ({ direction, disabled, onChange }: Props): Select => (
   <Select isDisabled={disabled}
           isClearable={false}
@@ -21,6 +26,7 @@ const SortDirectionSelect = ({ direction, disabled, onChange }: Props): Select =
           ]}
           onChange={({ value }) => onChange(Direction.fromString(value))}
           placeholder={disabled ? 'No sorting selected' : 'Click to select direction'}
+          styles={{ valueContainer }}
           value={direction && { label: direction, value: direction }} />
 );
 


### PR DESCRIPTION
Before this change, the `SortDirectionSelect` placeholder looked like
![image](https://user-images.githubusercontent.com/46300478/72334997-86b64600-36be-11ea-948d-9ecba4c17286.png)
depending on the resolution.

This only happens for the `SortDirectionSelect`, because we are using `Select` from `react-select` directly instead of our own `Select` component.

Ideally we should use our own `Select` component for the `SortDirectionSelect` as well.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

