### PR TITLE
Rename default search sidebar title from 'New Search' to 'Untitled Search'

### DIFF
--- a/graylog2-web-interface/src/views/components/sidebar/SideBar.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/SideBar.jsx
@@ -13,7 +13,7 @@ import HighlightingRules from './highlighting/HighlightingRules';
 import NavItem from './NavItem';
 import ViewDescription from './ViewDescription';
 
-const defaultNewViewTitle = 'New Search';
+const defaultNewViewTitle = 'Untitled Search';
 
 type Props = {
   children: React.Element<any>,

--- a/graylog2-web-interface/src/views/components/sidebar/SideBar.test.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/SideBar.test.jsx
@@ -102,7 +102,7 @@ describe('<Sidebar />', () => {
 
     wrapper.find('Sidebarstyles__SidebarHeader').simulate('click');
     wrapper.find('div[children="Description"]').simulate('click');
-    expect(wrapper.find('h3').text()).toBe('New Search');
+    expect(wrapper.find('h3').text()).toBe('Untitled Search');
     expect(wrapper.find('SearchResultOverview').text()).toBe('Found 0 messages in 64ms.Query executed at 2018-08-28 14:39:26.');
   });
 


### PR DESCRIPTION
Because the previous search sidebar title "New Search" is sometimes misleading, we are changing it to "Untitled Search"

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

