### PR TITLE
Allow PermittedStreams to load empty lists

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.graylog.plugins.views.search.errors.PermissionException;
 import org.graylog.plugins.views.search.views.PluginMetadataSummary;
 import org.graylog2.contentpacks.ContentPackable;
 import org.graylog2.contentpacks.EntityDescriptorIds;
@@ -129,6 +130,10 @@ public abstract class Search implements ContentPackable<SearchEntity> {
         final Set<Query> withoutStreams = Sets.difference(queries(), withStreams);
 
         final ImmutableSet<String> defaultStreams = defaultStreamsSupplier.get();
+
+        if (defaultStreams.isEmpty())
+            throw new PermissionException("User doesn't have access to any streams");
+
         final Set<Query> withDefaultStreams = withoutStreams.stream()
                 .map(q -> q.addStreamsToFilter(defaultStreams))
                 .collect(toSet());

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/PermittedStreams.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/PermittedStreams.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableSet;
 import org.graylog2.streams.StreamService;
 
 import javax.inject.Inject;
-import javax.ws.rs.ForbiddenException;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -45,9 +44,6 @@ public class PermittedStreams {
                 .filter(id -> !DEFAULT_EVENT_STREAM_IDS.contains(id))
                 .filter(isStreamIdPermitted)
                 .collect(toSet());
-
-        if (result.isEmpty())
-            throw new ForbiddenException("There are no streams you are permitted to use.");
 
         return ImmutableSet.copyOf(result);
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import org.graylog.plugins.views.search.engine.BackendQuery;
+import org.graylog.plugins.views.search.errors.PermissionException;
 import org.graylog.plugins.views.search.filter.StreamFilter;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
@@ -36,6 +37,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -65,6 +67,14 @@ public class SearchTest {
         Search after = before.addStreamsToQueriesWithoutStreams(() -> ImmutableSet.of("one", "two", "three"));
 
         assertThat(before).isEqualTo(after);
+    }
+
+    @Test
+    public void throwsExceptionIfQueryHasNoStreamsAndThereAreNoDefaultStreams() {
+        Search search = searchWithQueriesWithStreams("a,b,c", "");
+
+        assertThatExceptionOfType(PermissionException.class)
+                .isThrownBy(() -> search.addStreamsToQueriesWithoutStreams(ImmutableSet::of));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/PermittedStreamsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/PermittedStreamsTest.java
@@ -23,7 +23,6 @@ import org.graylog2.streams.StreamService;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.ws.rs.ForbiddenException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -31,7 +30,6 @@ import java.util.List;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.graylog2.plugin.streams.Stream.DEFAULT_EVENT_STREAM_IDS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -67,11 +65,12 @@ public class PermittedStreamsTest {
     }
 
     @Test
-    public void failsIfNoStreamsFound() {
+    public void returnsEmptyListIfNoStreamsFound() {
         stubStreams("oans", "zwoa", "gsuffa");
 
-        assertThatExceptionOfType(ForbiddenException.class)
-                .isThrownBy(() -> sut.load(id -> false));
+        ImmutableSet<String> result = sut.load(id -> false);
+
+        assertThat(result).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
Before this change a ForbiddenException would be thrown every time streams were loaded for users without access to any streams. This was only appropriate during search execution, but not in other places where `PermittedStreams#load` was reused. This had led to wrong 401s from the backend and  confusing behavior of the frontend where such users were often routed to a 404 error page upon 401s.

Fixes #7165

## Description
- Removed exception from `PermittedStreams#load` to allow reuse of this
  method in places where an exception is not appropriate
- Added exception to `Search#addStreamsToQueriesWithoutStreams` which is
the one place where it's actually needed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
- unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

