### PR TITLE
Synchronize timerange & query with URL on search page.

### DIFF
--- a/graylog2-web-interface/src/views/actions/QueriesActions.js
+++ b/graylog2-web-interface/src/views/actions/QueriesActions.js
@@ -8,7 +8,7 @@ import Query from 'views/logic/queries/Query';
 import ViewState from 'views/logic/views/ViewState';
 import { singletonActions } from 'views/logic/singleton';
 
-type QueriesList = Immutable.OrderedMap<QueryId, Query>;
+export type QueriesList = Immutable.OrderedMap<QueryId, Query>;
 
 type QueriesActionsType = RefluxActions<{
   create: (Query, ViewState) => Promise<QueriesList>,

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
@@ -47,7 +47,7 @@ const bindSearchParamsFromQuery: ViewHook = ({ query, view }) => {
   if (queryString !== undefined) {
     queryBuilder = queryBuilder.query(createElasticsearchQueryString(queryString));
   }
-  if(timerange) {
+  if (timerange) {
     queryBuilder = queryBuilder.timerange(timerange);
   }
 

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
@@ -11,7 +11,7 @@ const _getTimerange = (query = {}) => {
 
   switch (type) {
     case 'relative':
-      return query.relative ? { type, range: query.relative } : undefined;
+      return query.relative ? { type, range: parseInt(query.relative, 10) } : undefined;
     case 'absolute':
       return (query.from || query.to)
         ? {

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
@@ -4,65 +4,54 @@ import { DEFAULT_RANGE_TYPE } from 'views/Constants';
 import { QueriesActions } from 'views/stores/QueriesStore';
 import type { ViewHook } from 'views/logic/hooks/ViewHook';
 import View from 'views/logic/views/View';
+import { createElasticsearchQueryString } from '../logic/queries/Query';
 
 const _getTimerange = (query = {}) => {
   const type = query.rangetype || DEFAULT_RANGE_TYPE;
-  const _setRange = (condition, newRange) => {
-    if (condition) {
-      return newRange;
-    }
-    return undefined;
-  };
 
   switch (type) {
     case 'relative':
-      return _setRange(query.relative, { type, range: query.relative });
+      return query.relative ? { type, range: query.relative } : undefined;
     case 'absolute':
-      return _setRange((query.from || query.to), {
-        type: type,
-        from: query.from,
-        to: query.to,
-      });
+      return (query.from || query.to)
+        ? {
+          type: type,
+          from: query.from,
+          to: query.to,
+        }
+        : undefined;
     case 'keyword':
-      return _setRange(query.keyword, { type, keyword: query.keyword });
+      return query.keyword ? { type, keyword: query.keyword } : undefined;
     default:
       throw new Error(`Unsupported range type ${type}`);
   }
-};
-
-const _getQueryIdFromView = (view: View) => {
-  if (!view.search || !view.search.queries) {
-    throw new Error('Unable to extract queries from search!');
-  }
-  const { queries } = view.search;
-  if (queries.size !== 1) {
-    throw new Error('Searches must only have a single query!');
-  }
-  return queries.map(({ id }) => id).first();
-};
-
-const _setQueryString = (queryId, query) => {
-  const queryString = query.q;
-  if (!queryString) {
-    return Promise.resolve();
-  }
-  return QueriesActions.query(queryId, queryString);
-};
-
-const _setQueryTimerange = (queryId, query) => {
-  const timerange = _getTimerange(query);
-  if (!timerange) {
-    return Promise.resolve();
-  }
-  return QueriesActions.timerange(queryId, timerange);
 };
 
 const bindSearchParamsFromQuery: ViewHook = ({ query, view }) => {
   if (view.type !== View.Type.Search) {
     return Promise.resolve(true);
   }
-  const queryId = _getQueryIdFromView(view);
-  return _setQueryString(queryId, query).then(() => _setQueryTimerange(queryId, query)).then(() => true);
+  const { q: queryString } = query;
+  const timerange = _getTimerange(query);
+
+  if (!queryString && !timerange) {
+    return Promise.resolve(true);
+  }
+
+  const { queries } = view.search;
+  if (queries.size !== 1) {
+    throw new Error('Searches must only have a single query!');
+  }
+  const firstQuery = queries.first();
+  let queryBuilder = firstQuery.toBuilder();
+  if (queryString !== undefined) {
+    queryBuilder = queryBuilder.query(createElasticsearchQueryString(queryString));
+  }
+  if(timerange) {
+    queryBuilder = queryBuilder.timerange(timerange);
+  }
+
+  return QueriesActions.update(firstQuery.id, queryBuilder.build());
 };
 
 export default bindSearchParamsFromQuery;

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.js
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.js
@@ -9,8 +9,7 @@ const MOCK_VIEW_QUERY_ID = 'query-id';
 
 jest.mock('views/stores/QueriesStore', () => ({
   QueriesActions: {
-    query: jest.fn(() => Promise.resolve()),
-    timerange: jest.fn(() => Promise.resolve()),
+    update: jest.fn(() => Promise.resolve()),
   },
 }));
 
@@ -41,7 +40,7 @@ describe('BindSearchParamsFromQuery should', () => {
       view: view.toBuilder().type(View.Type.Dashboard).build(),
     };
     await bindSearchParamsFromQuery(input);
-    expect(QueriesActions.query).not.toHaveBeenCalled();
+    expect(QueriesActions.update).not.toHaveBeenCalled();
   });
 
   it('update query string with provided query param', async () => {
@@ -50,12 +49,16 @@ describe('BindSearchParamsFromQuery should', () => {
       query: { q: 'gl2_source_input:source-input-id' },
     };
     await bindSearchParamsFromQuery(input);
-    expect(QueriesActions.query).toHaveBeenCalledWith(MOCK_VIEW_QUERY_ID, input.query.q);
+    expect(QueriesActions.update)
+      .toHaveBeenCalledWith(
+        MOCK_VIEW_QUERY_ID,
+        expect.objectContaining({ query: { query_string: 'gl2_source_input:source-input-id', type: 'elasticsearch' } }),
+      );
   });
 
   it('not update query string when no query param is provided', async () => {
     await bindSearchParamsFromQuery(defaultInput);
-    expect(QueriesActions.query).not.toHaveBeenCalled();
+    expect(QueriesActions.update).not.toHaveBeenCalled();
   });
 
   it('update query timerange when relative range value param is povided', async () => {
@@ -68,7 +71,11 @@ describe('BindSearchParamsFromQuery should', () => {
       range: input.query.relative,
     };
     await bindSearchParamsFromQuery(input);
-    expect(QueriesActions.timerange).toHaveBeenCalledWith(MOCK_VIEW_QUERY_ID, expectedTimerange);
+    expect(QueriesActions.update)
+      .toHaveBeenCalledWith(
+        MOCK_VIEW_QUERY_ID,
+        expect.objectContaining({ timerange: expectedTimerange }),
+    );
   });
 
   it('update query timerange when provided query range param is absolute', async () => {
@@ -82,7 +89,11 @@ describe('BindSearchParamsFromQuery should', () => {
       to: input.query.to,
     };
     await bindSearchParamsFromQuery(input);
-    expect(QueriesActions.timerange).toHaveBeenCalledWith(MOCK_VIEW_QUERY_ID, expectedTimerange);
+    expect(QueriesActions.update)
+      .toHaveBeenCalledWith(
+        MOCK_VIEW_QUERY_ID,
+        expect.objectContaining({ timerange: expectedTimerange }),
+      );
   });
 
   it('update query timerange when provided query range is keyword', async () => {
@@ -94,6 +105,10 @@ describe('BindSearchParamsFromQuery should', () => {
       type: input.query.rangetype, keyword: input.query.keyword,
     };
     await bindSearchParamsFromQuery(input);
-    expect(QueriesActions.timerange).toHaveBeenCalledWith(MOCK_VIEW_QUERY_ID, expectedTimerange);
+    expect(QueriesActions.update)
+      .toHaveBeenCalledWith(
+        MOCK_VIEW_QUERY_ID,
+        expect.objectContaining({ timerange: expectedTimerange }),
+      );
   });
 });

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.js
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.js
@@ -68,7 +68,7 @@ describe('BindSearchParamsFromQuery should', () => {
     };
     const expectedTimerange = {
       type: 'relative',
-      range: input.query.relative,
+      range: 0,
     };
     await bindSearchParamsFromQuery(input);
     expect(QueriesActions.update)

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.js
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.js
@@ -75,7 +75,7 @@ describe('BindSearchParamsFromQuery should', () => {
       .toHaveBeenCalledWith(
         MOCK_VIEW_QUERY_ID,
         expect.objectContaining({ timerange: expectedTimerange }),
-    );
+      );
   });
 
   it('update query timerange when provided query range param is absolute', async () => {

--- a/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.js
+++ b/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.js
@@ -29,7 +29,11 @@ const extractTimerangeParams = (timerange) => {
 export const syncWithQueryParameters = (query: string) => {
   const { view } = ViewStore.getInitialState() || {};
   if (view && view.type === View.Type.Search) {
-    const firstQuery = view.search.queries.first();
+    const { queries } = view.search;
+    if (queries.size !== 1) {
+      throw new Error('Searches must only have a single query!');
+    }
+    const firstQuery = queries.first();
     if (firstQuery) {
       const { query: { query_string: queryString }, timerange } = firstQuery;
       const baseUri = new URI(query).setSearch('q', queryString)

--- a/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.js
+++ b/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.js
@@ -27,8 +27,8 @@ const extractTimerangeParams = (timerange) => {
 };
 
 export const syncWithQueryParameters = (query: string) => {
-  const { view } = ViewStore.getInitialState();
-  if (view.type === View.Type.Search) {
+  const { view } = ViewStore.getInitialState() || {};
+  if (view && view.type === View.Type.Search) {
     const firstQuery = view.search.queries.first();
     if (firstQuery) {
       const { query: { query_string: queryString }, timerange } = firstQuery;

--- a/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.js
+++ b/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.js
@@ -1,0 +1,53 @@
+// @flow strict
+import { useEffect } from 'react';
+import URI from 'urijs';
+import history from 'util/History';
+
+import { ViewStore } from 'views/stores/ViewStore';
+import View from 'views/logic/views/View';
+import { QueriesActions } from 'views/actions/QueriesActions';
+
+const useActionListeners = (actions, callback, dependencies) => {
+  useEffect(() => {
+    const unsubscribes = actions.map(action => action.listen(callback));
+    return () => unsubscribes.forEach(unsubscribe => unsubscribe());
+  }, dependencies);
+};
+
+const extractTimerangeParams = (timerange) => {
+  const { type } = timerange;
+  const result = { rangetype: type };
+
+  switch (type) {
+    case 'relative': return Object.entries({ ...result, relative: timerange.range });
+    case 'keyword': return Object.entries({ ...result, keyword: timerange.keyword });
+    case 'absolute': return Object.entries({ ...result, from: timerange.from, to: timerange.to });
+    default: return Object.entries(result);
+  }
+};
+
+export const syncWithQueryParameters = (query: string) => {
+  const { view } = ViewStore.getInitialState();
+  if (view.type === View.Type.Search) {
+    const firstQuery = view.search.queries.first();
+    if (firstQuery) {
+      const { query: { query_string: queryString }, timerange } = firstQuery;
+      const baseUri = new URI(query).setSearch('q', queryString)
+        .removeQuery('from')
+        .removeQuery('to')
+        .removeQuery('keyword')
+        .removeQuery('relative');
+      const uri = extractTimerangeParams(timerange)
+        .reduce((prev, [key, value]) => prev.setSearch(key, value), baseUri);
+      history.push(uri.toString());
+    }
+  }
+};
+
+export const useSyncWithQueryParameters = (query: string) => {
+  useActionListeners(
+    [QueriesActions.query.completed, QueriesActions.timerange.completed],
+    () => syncWithQueryParameters(query),
+    [query],
+  );
+};

--- a/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.js
+++ b/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.js
@@ -45,6 +45,7 @@ export const syncWithQueryParameters = (query: string) => {
 };
 
 export const useSyncWithQueryParameters = (query: string) => {
+  useEffect(() => syncWithQueryParameters(query), []);
   useActionListeners(
     [QueriesActions.query.completed, QueriesActions.timerange.completed],
     () => syncWithQueryParameters(query),

--- a/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.js
+++ b/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.js
@@ -42,8 +42,11 @@ export const syncWithQueryParameters = (query: string) => {
         .removeQuery('keyword')
         .removeQuery('relative');
       const uri = extractTimerangeParams(timerange)
-        .reduce((prev, [key, value]) => prev.setSearch(key, value), baseUri);
-      history.push(uri.toString());
+        .reduce((prev, [key, value]) => prev.setSearch(key, value), baseUri)
+        .toString();
+      if (query !== uri) {
+        history.push(uri);
+      }
     }
   }
 };

--- a/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.test.jsx
+++ b/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.test.jsx
@@ -1,0 +1,108 @@
+// @flow strict
+import history from 'util/History';
+
+import asMock from 'helpers/mocking/AsMock';
+import { ViewStore } from 'views/stores/ViewStore';
+import View from 'views/logic/views/View';
+import { syncWithQueryParameters } from './SyncWithQueryParameters';
+import Query, { createElasticsearchQueryString } from '../logic/queries/Query';
+import Search from '../logic/search/Search';
+
+jest.mock('views/stores/ViewStore', () => ({
+  ViewStore: {
+    getInitialState: jest.fn(),
+  },
+}));
+jest.mock('util/History', () => ({ push: jest.fn() }));
+
+describe('SyncWithQueryParameters', () => {
+  it('does not do anything if no view is loaded', () => {
+    syncWithQueryParameters('');
+    expect(history.push).not.toHaveBeenCalled();
+  });
+  it('does not do anything if current view is not a search', () => {
+    asMock(ViewStore.getInitialState).mockReturnValueOnce({
+      view: View.builder().type(View.Type.Dashboard).build(),
+    });
+    syncWithQueryParameters('');
+    expect(history.push).not.toHaveBeenCalled();
+  });
+  describe('if current view is search, adds state to history', () => {
+    const view = View.builder()
+      .type(View.Type.Search)
+      .search(
+        Search.builder()
+          .queries([
+            Query.builder()
+              .timerange({ type: 'relative', range: 600 })
+              .query(createElasticsearchQueryString('foo:42'))
+              .build(),
+          ])
+          .build(),
+      )
+      .build();
+    it('with current time range and query', () => {
+      asMock(ViewStore.getInitialState).mockReturnValueOnce({ view });
+
+      syncWithQueryParameters('/search');
+
+      expect(history.push).toHaveBeenCalledWith('/search?q=foo%3A42&rangetype=relative&relative=600');
+    });
+    it('preserving query parameters present before', () => {
+      asMock(ViewStore.getInitialState).mockReturnValueOnce({ view });
+
+      syncWithQueryParameters('/search?somevalue=23&somethingelse=foo');
+
+      expect(history.push).toHaveBeenCalledWith('/search?somevalue=23&somethingelse=foo&q=foo%3A42&rangetype=relative&relative=600');
+    });
+    it('if time range is absolute', () => {
+      const viewWithAbsoluteTimerange = View.builder()
+        .type(View.Type.Search)
+        .search(
+          Search.builder()
+            .queries([
+              Query.builder()
+                .timerange({
+                  type: 'absolute',
+                  from: '2019-01-12T13:42:23.000Z',
+                  to: '2020-01-12T13:42:23.000Z',
+                })
+                .query(createElasticsearchQueryString('foo:42'))
+                .build(),
+            ])
+            .build(),
+        )
+        .build();
+      asMock(ViewStore.getInitialState).mockReturnValueOnce({ view: viewWithAbsoluteTimerange });
+
+      syncWithQueryParameters('/search');
+
+      expect(history.push)
+        .toHaveBeenCalledWith('/search?q=foo%3A42&rangetype=absolute&from=2019-01-12T13%3A42%3A23.000Z&to=2020-01-12T13%3A42%3A23.000Z');
+    });
+    it('if time range is keyword time range', () => {
+      const viewWithAbsoluteTimerange = View.builder()
+        .type(View.Type.Search)
+        .search(
+          Search.builder()
+            .queries([
+              Query.builder()
+                .timerange({
+                  type: 'keyword',
+                  keyword: 'Last five minutes',
+                })
+                .query(createElasticsearchQueryString('foo:42'))
+                .build(),
+            ])
+            .build(),
+        )
+        .build();
+      asMock(ViewStore.getInitialState).mockReturnValueOnce({ view: viewWithAbsoluteTimerange });
+
+      syncWithQueryParameters('/search');
+
+      expect(history.push)
+        .toHaveBeenCalledWith('/search?q=foo%3A42&rangetype=keyword&keyword=Last+five+minutes');
+    });
+  });
+});

--- a/graylog2-web-interface/src/views/logic/queries/Query.js
+++ b/graylog2-web-interface/src/views/logic/queries/Query.js
@@ -1,6 +1,7 @@
 // @flow strict
 import Immutable, { is } from 'immutable';
 import uuid from 'uuid/v4';
+import { isEqual } from 'lodash';
 
 export type QueryId = string;
 
@@ -97,7 +98,7 @@ export default class Query {
       return false;
     }
 
-    if (this.id !== other.id || !is(this.query, other.query) || !is(this.timerange, other.timerange) || !is(this.filter, other.filter) || !is(this.searchTypes, other.searchTypes)) {
+    if (this.id !== other.id || !isEqual(this.query, other.query) || !isEqual(this.timerange, other.timerange) || !is(this.filter, other.filter) || !is(this.searchTypes, other.searchTypes)) {
       return false;
     }
 

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -4,8 +4,11 @@ import type { ComponentType } from 'react';
 import PropTypes from 'prop-types';
 import * as Immutable from 'immutable';
 import styled, { css } from 'styled-components';
+import { withRouter } from 'react-router';
 
 import connect from 'stores/connect';
+import Footer from 'components/layout/Footer';
+
 import SideBar from 'views/components/sidebar/SideBar';
 import WithSearchStatus from 'views/components/WithSearchStatus';
 import SearchResult from 'views/components/SearchResult';
@@ -13,7 +16,6 @@ import type {
   SearchRefreshCondition,
   SearchRefreshConditionArguments,
 } from 'views/logic/hooks/SearchRefreshCondition';
-import Footer from 'components/layout/Footer';
 
 import { Grid } from 'components/graylog';
 import { FieldTypesStore, FieldTypesActions } from 'views/stores/FieldTypesStore';
@@ -37,11 +39,13 @@ import SearchBar from 'views/components/SearchBar';
 import CurrentViewTypeProvider from 'views/components/views/CurrentViewTypeProvider';
 import IfSearch from 'views/components/search/IfSearch';
 import { AdditionalContext } from 'views/logic/ActionContext';
+import IfInteractive from 'views/components/dashboard/IfInteractive';
+import InteractiveContext from 'views/components/contexts/InteractiveContext';
+import bindSearchParamsFromQuery from 'views/hooks/BindSearchParamsFromQuery';
+import { useSyncWithQueryParameters } from 'views/hooks/SyncWithQueryParameters';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import style from '!style/useable!css!./ExtendedSearchPage.css';
-import IfInteractive from '../components/dashboard/IfInteractive';
-import InteractiveContext from '../components/contexts/InteractiveContext';
 
 const GridContainer: ComponentType<{ interactive: boolean }> = styled.div`
   ${({ interactive }) => (interactive ? css`
@@ -87,6 +91,12 @@ const ConnectedFieldList = connect(FieldList, { fieldTypes: FieldTypesStore, vie
 type Props = {
   route: any,
   searchRefreshHooks: Array<SearchRefreshCondition>,
+  router: {
+    getCurrentLocation: () => ({ pathname: string, search: string }),
+  },
+  location?: {
+    query: { [string]: string },
+  },
 };
 
 const _searchRefreshConditionChain = (searchRefreshHooks, state: SearchRefreshConditionArguments) => {
@@ -112,14 +122,30 @@ const DashboardSearchBarWithStatus = WithSearchStatus(DashboardSearchBar);
 
 const ViewAdditionalContextProvider = connect(AdditionalContext.Provider, { view: ViewStore }, ({ view }) => ({ value: { view: view.view } }));
 
-const ExtendedSearchPage = ({ route, searchRefreshHooks }: Props) => {
+const useStyle = () => {
+  useEffect(() => {
+    style.use();
+    return () => style.unuse();
+  }, []);
+};
+
+const ExtendedSearchPage = ({ route, location = { query: {} }, router, searchRefreshHooks }: Props) => {
+  const { pathname, search } = router.getCurrentLocation();
+  const query = `${pathname}${search}`;
   const refreshIfNotUndeclared = () => _refreshIfNotUndeclared(searchRefreshHooks, SearchExecutionStateStore.getInitialState());
 
   useEffect(() => {
-    style.use();
+    const { view } = ViewStore.getInitialState();
 
+    bindSearchParamsFromQuery({ view, query: location.query, retry: () => Promise.resolve() });
+  }, [query]);
+
+  useStyle();
+
+  useEffect(() => {
     SearchConfigActions.refresh();
     FieldTypesActions.all();
+    StreamsActions.refresh();
 
     let storeListenersUnsubscribes = Immutable.List();
     refreshIfNotUndeclared().then(() => {
@@ -129,14 +155,11 @@ const ExtendedSearchPage = ({ route, searchRefreshHooks }: Props) => {
       return null;
     }, () => { });
 
-    StreamsActions.refresh();
-
     // Returning cleanup function used when unmounting
-    return () => {
-      style.unuse();
-      storeListenersUnsubscribes.forEach(unsubscribeFunc => unsubscribeFunc());
-    };
+    return () => storeListenersUnsubscribes.forEach(unsubscribeFunc => unsubscribeFunc());
   }, []);
+
+  useSyncWithQueryParameters(query);
 
   return (
     <CurrentViewTypeProvider>
@@ -186,11 +209,18 @@ const ExtendedSearchPage = ({ route, searchRefreshHooks }: Props) => {
 
 ExtendedSearchPage.propTypes = {
   route: PropTypes.object.isRequired,
+  location: PropTypes.shape({
+    query: PropTypes.object.isRequired,
+  }),
   searchRefreshHooks: PropTypes.arrayOf(PropTypes.func).isRequired,
+};
+
+ExtendedSearchPage.defaultProps = {
+  location: { query: {} },
 };
 
 const mapping = {
   searchRefreshHooks: 'views.hooks.searchRefresh',
 };
 
-export default withPluginEntities<Props, typeof mapping>(ExtendedSearchPage, mapping);
+export default withPluginEntities<$Rest<Props, {| router: any |}>, typeof mapping>(withRouter(ExtendedSearchPage), mapping);

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -212,11 +212,22 @@ ExtendedSearchPage.propTypes = {
   location: PropTypes.shape({
     query: PropTypes.object.isRequired,
   }),
+  router: PropTypes.object,
   searchRefreshHooks: PropTypes.arrayOf(PropTypes.func).isRequired,
 };
 
 ExtendedSearchPage.defaultProps = {
   location: { query: {} },
+  router: {
+    getCurrentLocation: () => ({ pathname: '', search: '' }),
+    push: () => {},
+    replace: () => {},
+    go: () => {},
+    goBack: () => {},
+    goForward: () => {},
+    setRouteLeaveHook: () => {},
+    isActive: () => {},
+  },
 };
 
 const mapping = {

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.test.jsx
@@ -15,7 +15,6 @@ import { SearchConfigActions } from 'views/stores/SearchConfigStore';
 import { ViewActions, ViewStore } from 'views/stores/ViewStore';
 import { FieldTypesActions } from 'views/stores/FieldTypesStore';
 import { SearchMetadataActions, SearchMetadataStore } from 'views/stores/SearchMetadataStore';
-import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import View from 'views/logic/views/View';
 import SearchMetadata from 'views/logic/search/SearchMetadata';
 import CurrentViewTypeProvider from 'views/components/views/CurrentViewTypeProvider';
@@ -23,6 +22,7 @@ import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
 
 import ExtendedSearchPage from './ExtendedSearchPage';
 
+jest.mock('react-router', () => ({ withRouter: x => x }));
 jest.mock('components/layout/Footer', () => <div />);
 jest.mock('views/stores/ViewMetadataStore', () => ({
   ViewMetadataStore: MockStore(
@@ -108,12 +108,21 @@ describe('ExtendedSearchPage', () => {
     CurrentViewTypeProvider.mockImplementation(({ children }) => <ViewTypeContext.Provider value={View.Type.Dashboard}>{children}</ViewTypeContext.Provider>);
   });
 
+  const mockRouter = {
+    getCurrentLocation: jest.fn(() => ({ pathname: '', search: '' })),
+    push: () => {},
+    replace: () => {},
+    go: () => {},
+    goBack: () => {},
+    goForward: () => {},
+    setRouteLeaveHook: () => {},
+    isActive: () => {},
+  };
   const SimpleExtendedSearchPage = props => (
     <ExtendedSearchPage route={{}}
-                        executionState={SearchExecutionState.empty()}
-                        headerElements={[]}
+                        router={mockRouter}
+                        location={{ query: {} }}
                         searchRefreshHooks={[]}
-                        queryBarElements={[]}
                         {...props} />
   );
 

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.test.jsx
@@ -108,19 +108,8 @@ describe('ExtendedSearchPage', () => {
     CurrentViewTypeProvider.mockImplementation(({ children }) => <ViewTypeContext.Provider value={View.Type.Dashboard}>{children}</ViewTypeContext.Provider>);
   });
 
-  const mockRouter = {
-    getCurrentLocation: jest.fn(() => ({ pathname: '', search: '' })),
-    push: () => {},
-    replace: () => {},
-    go: () => {},
-    goBack: () => {},
-    goForward: () => {},
-    setRouteLeaveHook: () => {},
-    isActive: () => {},
-  };
   const SimpleExtendedSearchPage = props => (
     <ExtendedSearchPage route={{}}
-                        router={mockRouter}
                         location={{ query: {} }}
                         searchRefreshHooks={[]}
                         {...props} />

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
@@ -97,7 +97,7 @@ class NewSearchPage extends React.Component<Props, State> {
       const { route } = this.props;
       return (
         <ViewLoaderContext.Provider value={this.loadView}>
-          <ExtendedSearchPage route={route} />
+          <ExtendedSearchPage route={route} location={location} />
         </ViewLoaderContext.Provider>
       );
     }

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
@@ -94,7 +94,7 @@ class NewSearchPage extends React.Component<Props, State> {
     }
 
     if (loaded) {
-      const { route } = this.props;
+      const { location, route } = this.props;
       return (
         <ViewLoaderContext.Provider value={this.loadView}>
           <ExtendedSearchPage route={route} location={location} />

--- a/graylog2-web-interface/src/views/stores/QueriesStore.js
+++ b/graylog2-web-interface/src/views/stores/QueriesStore.js
@@ -103,15 +103,14 @@ export const QueriesStore: QueriesStoreType = singletonStore(
       return promise;
     },
     rangeType(queryId: QueryId, type: TimeRangeTypes) {
-      return new Promise(() => {
+      const promise = new Promise((resolve) => {
         const oldQuery = this.queries.get(queryId);
         const oldTimerange = oldQuery.timerange;
         const oldType = oldTimerange.type;
 
         if (type === oldType) {
-          const promise: Promise<QueriesList> = Promise.resolve(this.queries);
-          QueriesActions.rangeType.promise(promise);
-          return promise;
+          resolve(this.queries);
+          return;
         }
 
         let newTimerange: TimeRange;
@@ -139,10 +138,10 @@ export const QueriesStore: QueriesStoreType = singletonStore(
             break;
           default: throw new Error(`Invalid time range type: ${type}`);
         }
-        const promise: Promise<QueriesList> = QueriesActions.timerange(queryId, newTimerange);
-        QueriesActions.rangeType.promise(promise);
-        return promise;
+        resolve(QueriesActions.timerange(queryId, newTimerange));
       });
+      QueriesActions.rangeType.promise(promise);
+      return promise;
     },
 
     _propagateQueryChange(newQueries: QueriesList) {

--- a/graylog2-web-interface/src/views/stores/QueriesStore.js
+++ b/graylog2-web-interface/src/views/stores/QueriesStore.js
@@ -69,7 +69,9 @@ export const QueriesStore: QueriesStoreType = singletonStore(
     },
     update(queryId: QueryId, query: Query) {
       const newQueries = this.queries.set(queryId, query);
-      const promise: Promise<QueriesList> = this._propagateQueryChange(newQueries).then(() => newQueries);
+      const promise: Promise<QueriesList> = this.queries.get(queryId).equals(query)
+        ? Promise.resolve(this.queries)
+        : this._propagateQueryChange(newQueries).then(() => newQueries);
       QueriesActions.update.promise(promise);
       return promise;
     },
@@ -83,8 +85,11 @@ export const QueriesStore: QueriesStoreType = singletonStore(
       return promise;
     },
     timerange(queryId: QueryId, timerange: TimeRange) {
-      const newQueries = this.queries.update(queryId, query => query.toBuilder().timerange(timerange).build());
-      const promise: Promise<QueriesList> = this._propagateQueryChange(newQueries).then(() => newQueries);
+      const query = this.queries.get(queryId);
+      const newQueries = this.queries.update(queryId, q => q.toBuilder().timerange(timerange).build());
+      const promise: Promise<QueriesList> = query.timerange === timerange
+        ? Promise.resolve(this.queries)
+        : this._propagateQueryChange(newQueries).then(() => newQueries);
       QueriesActions.timerange.promise(promise);
       return promise;
     },

--- a/graylog2-web-interface/src/views/stores/QueriesStore.test.jsx
+++ b/graylog2-web-interface/src/views/stores/QueriesStore.test.jsx
@@ -1,0 +1,107 @@
+// @flow strict
+import moment from 'moment';
+import * as Immutable from 'immutable';
+
+import asMock from 'helpers/mocking/AsMock';
+import { QueriesActions, QueriesStore } from './QueriesStore';
+import type { QueryId } from '../logic/queries/Query';
+import Query from '../logic/queries/Query';
+import { ViewStore } from './ViewStore';
+import Search from '../logic/search/Search';
+
+jest.mock('./ViewStore', () => ({
+  ViewStore: {
+    listen: jest.fn(() => {}),
+  },
+  ViewActions: {
+    search: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+jest.mock('./ViewStatesStore', () => ({
+  ViewStatesActions: {},
+}));
+
+describe('QueriesStore', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('initializes with an empty map', () => {
+    expect(QueriesStore.getInitialState()).toEqual(new Immutable.OrderedMap<QueryId, Query>());
+  });
+  it('subscribes to ViewStore upon initialization', () => {
+    expect(ViewStore.listen).toHaveBeenCalled();
+  });
+
+  it('retrieves and propagates queries from ViewStore upon updates', (done) => {
+    const query1 = Query.builder().id('query1').build();
+    const queries = [query1];
+    const callback = asMock(ViewStore).listen.mock.calls[0][0];
+    const unsubscribe = QueriesStore.listen((newQueries) => {
+      expect(newQueries).toEqual(new Immutable.OrderedMap<QueryId, Query>({ query1 }));
+      done();
+    });
+    callback({
+      view: {
+        search: {
+          queries,
+        },
+      },
+    });
+    unsubscribe();
+  });
+
+  describe('rangeType', () => {
+    const query1 = Query.builder()
+      .id('query1')
+      .timerange({ type: 'relative', range: 300 })
+      .build();
+    const queries = [query1];
+    beforeEach(() => {
+      const callback = asMock(ViewStore).listen.mock.calls[0][0];
+
+      callback({
+        view: {
+          search: Search.builder().queries(queries).build(),
+        },
+      });
+    });
+    it('throws error if no type is given', () => {
+      expect(
+        // $FlowFixMe: Passing no second argument on purpose
+        QueriesActions.rangeType('query1', undefined),
+      ).rejects.toEqual(new Error('Invalid time range type: undefined'));
+    });
+    it('throws error if invalid type is given', () => {
+      expect(
+        // $FlowFixMe: Passing invalid second argument on purpose
+        QueriesActions.rangeType('query1', 'invalid'),
+      ).rejects.toEqual(new Error('Invalid time range type: invalid'));
+    });
+    it('does not do anything if type stays the same', () => {
+      expect(QueriesActions.rangeType('query1', 'relative')).resolves.toEqual(new Immutable.OrderedMap<QueryId, Query>({ query1 }));
+    });
+    it('translates current relative time range parameters to absolute ones when switching to absolute', () => {
+      expect(QueriesActions.rangeType('query1', 'absolute')).resolves.toEqual(new Immutable.OrderedMap<QueryId, Query>({
+        query1: query1.toBuilder()
+          .timerange({
+            type: 'absolute',
+            from: moment().subtract(300, 'seconds').toISOString(),
+            to: moment().toISOString(),
+          })
+          .build(),
+      }));
+    });
+    it('translates current relative time range parameters to keyword when switching to keyword', () => {
+      expect(QueriesActions.rangeType('query1', 'keyword')).resolves.toEqual(new Immutable.OrderedMap<QueryId, Query>({
+        query1: query1.toBuilder()
+          .timerange({
+            type: 'keyword',
+            keyword: 'Last five minutes',
+          })
+          .build(),
+      }));
+    });
+  });
+});


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The current search has a feature, where the current time range and query
string is synchronized with the URL in the browser. This means that:

  - current time range and query string are part of the URL and copying
and replaying the URL allows restoring the state for these
  - a change to time range or query string creates a new state in the
history stack, allowing the user to go back and forward between
different states
  - going back or forward in the browser history restores the time range
& query string of this specific state

This PR is recreating this functionality for the new search.

Fixes #7144.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.