### PR TITLE
Clean up naming of views endpoints in api browser

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/DashboardsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/DashboardsResource.java
@@ -69,7 +69,7 @@ public class DashboardsResource extends RestResource {
     }
 
     @GET
-    @ApiOperation("Get a list of all views")
+    @ApiOperation("Get a list of all dashboards")
     public PaginatedResponse<ViewDTO> views(@ApiParam(name = "page") @QueryParam("page") @DefaultValue("1") int page,
                                             @ApiParam(name = "per_page") @QueryParam("per_page") @DefaultValue("50") int perPage,
                                             @ApiParam(name = "sort",

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/FieldTypesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/FieldTypesResource.java
@@ -33,7 +33,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import java.util.Set;
 
-@Api(value = "Enterprise/Field Types", description = "Field Types")
+@Api(value = "Field Types")
 @Path("/views/fields")
 @Produces(MediaType.APPLICATION_JSON)
 @RequiresAuthentication

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/PivotSeriesFunctionsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/PivotSeriesFunctionsResource.java
@@ -28,7 +28,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import java.util.Map;
 
-@Api(value = "Enterprise/Search/Functions", description = "Definitions for aggregation functions")
+@Api(value = "Search/Functions")
 @Path("/views/functions")
 @Produces(MediaType.APPLICATION_JSON)
 @RequiresAuthentication

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QualifyingViewsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QualifyingViewsResource.java
@@ -37,7 +37,7 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-@Api(value = "Enterprise/Views/QualifyingViews", description = "List qualifying views for view interlinking")
+@Api(value = "Views/QualifyingViews")
 @Path("/views/forValue")
 @Produces(MediaType.APPLICATION_JSON)
 @RequiresAuthentication

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SavedSearchesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SavedSearchesResource.java
@@ -46,7 +46,7 @@ import java.util.Optional;
 import static java.util.Locale.ENGLISH;
 
 @RequiresAuthentication
-@Api(value = "SavedSearches")
+@Api(value = "Search/Saved")
 @Produces(MediaType.APPLICATION_JSON)
 @Path("/views/savedSearches")
 public class SavedSearchesResource extends RestResource {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
@@ -72,7 +72,7 @@ import java.util.concurrent.TimeoutException;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
-@Api(value = "Enterprise/Search")
+@Api(value = "Search")
 @Path("/views/search")
 @Produces(MediaType.APPLICATION_JSON)
 @RequiresAuthentication

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewSharingResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewSharingResource.java
@@ -45,7 +45,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Api(value = "Views")
+@Api(value = "Views/Sharing")
 @Path("/views/{id}/share")
 @Produces(MediaType.APPLICATION_JSON)
 @RequiresAuthentication

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewSharingResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewSharingResource.java
@@ -45,7 +45,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Api(value = "Enterprise/Views", description = "View Sharing management")
+@Api(value = "Views")
 @Path("/views/{id}/share")
 @Produces(MediaType.APPLICATION_JSON)
 @RequiresAuthentication

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
@@ -65,7 +65,7 @@ import java.util.Set;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Locale.ENGLISH;
 
-@Api(value = "Enterprise/Views", description = "Views management")
+@Api(value = "Views")
 @Path("/views")
 @Produces(MediaType.APPLICATION_JSON)
 @RequiresAuthentication

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/dashboards/DashboardWidgetsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/dashboards/DashboardWidgetsResource.java
@@ -63,7 +63,7 @@ import java.net.URI;
 import java.util.Map;
 
 @RequiresAuthentication
-@Api(value = "Dashboards/Widgets", description = "Manage widgets of an existing dashboard")
+@Api(value = "Legacy/Dashboards/Widgets", description = "Manage widgets of an existing dashboard")
 @Path("/dashboards/{dashboardId}/widgets")
 public class DashboardWidgetsResource extends RestResource {
     private static final Logger LOG = LoggerFactory.getLogger(DashboardWidgetsResource.class);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/dashboards/DashboardsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/dashboards/DashboardsResource.java
@@ -63,7 +63,7 @@ import java.util.List;
 import java.util.Map;
 
 @RequiresAuthentication
-@Api(value = "Dashboards", description = "Manage dashboards")
+@Api(value = "Legacy/Dashboards", description = "Manage dashboards")
 @Path("/dashboards")
 public class DashboardsResource extends RestResource {
     private static final Logger LOG = LoggerFactory.getLogger(DashboardsResource.class);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/AbsoluteSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/AbsoluteSearchResource.java
@@ -63,7 +63,7 @@ import java.util.Optional;
 import static org.graylog2.utilities.SearchUtils.buildTermsHistogramResult;
 
 @RequiresAuthentication
-@Api(value = "Search/Absolute", description = "Message search")
+@Api(value = "Legacy/Search/Absolute", description = "Message search")
 @Path("/search/universal/absolute")
 public class AbsoluteSearchResource extends SearchResource {
     private static final Logger LOG = LoggerFactory.getLogger(AbsoluteSearchResource.class);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/KeywordSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/KeywordSearchResource.java
@@ -63,7 +63,7 @@ import java.util.Optional;
 import static org.graylog2.utilities.SearchUtils.buildTermsHistogramResult;
 
 @RequiresAuthentication
-@Api(value = "Search/Keyword", description = "Message search")
+@Api(value = "Legacy/Search/Keyword", description = "Message search")
 @Path("/search/universal/keyword")
 public class KeywordSearchResource extends SearchResource {
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
@@ -64,7 +64,7 @@ import java.util.Optional;
 import static org.graylog2.utilities.SearchUtils.buildTermsHistogramResult;
 
 @RequiresAuthentication
-@Api(value = "Search/Relative", description = "Message search")
+@Api(value = "Legacy/Search/Relative", description = "Message search")
 @Path("/search/universal/relative")
 public class RelativeSearchResource extends SearchResource {
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SavedSearchesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/SavedSearchesResource.java
@@ -58,7 +58,7 @@ import java.util.List;
 import java.util.Map;
 
 @RequiresAuthentication
-@Api(value = "Search/Saved", description = "Saved searches")
+@Api(value = "Legacy/Search/Saved", description = "Saved searches")
 @Path("/search/saved")
 public class SavedSearchesResource extends SearchResource {
     private final SavedSearchService savedSearchService;


### PR DESCRIPTION
Removed "Enterprise/" prefix for new views endpoints and added "Legacy/" for old ones.

Fixes #7150

Left `DecoratorResource` untouched: https://github.com/Graylog2/graylog2-server/blob/c02f86de0e283dc53aa4ff2ef9f14a833b5cbe43/graylog2-server/src/main/java/org/graylog2/rest/resources/search/DecoratorResource.java#L52

It technically is an old resource but views depend on it and we should move it to the `views` package imo.

## Motivation and Context
Views is not an Enterprise feature anymore and we want to clearly mark the old endpoints as legacy to discourage users from depending on them.

## How Has This Been Tested?
Manual review in local dev environment

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


