### PR TITLE
Improving `CycleQueryTab` test by using fake timers.

### DIFF
--- a/graylog2-web-interface/src/views/components/dashboard/bigdisplay/CycleQueryTab.test.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/bigdisplay/CycleQueryTab.test.jsx
@@ -1,8 +1,7 @@
 // @flow strict
 import * as React from 'react';
-import { mount } from 'wrappedEnzyme';
+import { render, cleanup, wait } from 'wrappedTestingLibrary';
 
-import asMock from 'helpers/mocking/AsMock';
 import View from 'views/logic/views/View';
 import Search from 'views/logic/search/Search';
 import Query from 'views/logic/queries/Query';
@@ -16,88 +15,71 @@ jest.mock('views/stores/ViewStore', () => ({
   },
 }));
 
-const search = Search.create().toBuilder().queries([
-  Query.builder().id('foo').build(),
-  Query.builder().id('bar').build(),
-  Query.builder().id('baz').build(),
-]).build();
-const view = View.create().toBuilder().search(search).build();
+jest.useFakeTimers();
 
 describe('CycleQueryTab', () => {
-  describe('cycles tabs:', () => {
-    let wrapper;
-    afterEach(() => {
-      wrapper.unmount();
-    });
-    it('does not return markup', () => {
-      wrapper = mount(<CycleQueryTab view={view} activeQuery="bar" interval={1} tabs={[1, 2]} />);
-      expect(wrapper).toBeEmptyRender();
-    });
-    it('should switch to next tab after interval', () => {
-      return new Promise((resolve) => {
-        asMock(ViewActions.selectQuery).mockImplementationOnce((queryId) => {
-          expect(queryId).toEqual('baz');
-          resolve();
-        });
+  const search = Search.create().toBuilder().queries([
+    Query.builder().id('foo').build(),
+    Query.builder().id('bar').build(),
+    Query.builder().id('baz').build(),
+  ]).build();
+  const view = View.create().toBuilder().search(search).build();
 
-        wrapper = mount(<CycleQueryTab view={view} activeQuery="bar" interval={1} tabs={[1, 2]} />);
-      });
-    });
-    it('should switch to first tab if current one is the last', () => {
-      return new Promise((resolve) => {
-        asMock(ViewActions.selectQuery).mockImplementationOnce((queryId) => {
-          expect(queryId).toEqual('foo');
-          resolve();
-        });
+  beforeEach(() => { jest.clearAllMocks(); });
+  afterEach(cleanup);
 
-        wrapper = mount(<CycleQueryTab view={view} activeQuery="baz" interval={1} tabs={[0, 1, 2]} />);
-      });
-    });
-    it('should switch to next tab skipping gaps after interval', () => {
-      return new Promise((resolve) => {
-        asMock(ViewActions.selectQuery).mockImplementationOnce((queryId) => {
-          expect(queryId).toEqual('baz');
-          resolve();
-        });
-
-        wrapper = mount(<CycleQueryTab view={view} activeQuery="foo" interval={1} tabs={[0, 2]} />);
-      });
-    });
-    it('should switch to next tab defaulting to all tabs if `tabs` prop` is left out', () => {
-      return new Promise((resolve) => {
-        asMock(ViewActions.selectQuery).mockImplementationOnce((queryId) => {
-          expect(queryId).toEqual('bar');
-          resolve();
-        });
-
-        wrapper = mount(<CycleQueryTab view={view} activeQuery="foo" tabs={[1]} interval={1} />);
-      });
-    });
+  it('does not return markup', () => {
+    const { container } = render(<CycleQueryTab view={view} activeQuery="bar" interval={1} tabs={[1, 2]} />);
+    expect(container.firstChild).toEqual(null);
   });
+  it('should not switch to anything before interval', () => {
+    render(<CycleQueryTab view={view} activeQuery="bar" interval={1} tabs={[1, 2]} />);
 
-  describe('uses setInterval/clearInterval properly', () => {
-    const origSetInterval = window.setInterval;
-    const origClearInterval = window.clearInterval;
-    beforeEach(() => {
-      jest.resetAllMocks();
-      window.setInterval = jest.fn(() => 'deadbeef');
-      window.clearInterval = jest.fn();
-    });
-    afterAll(() => {
-      window.setInterval = origSetInterval;
-      window.clearInterval = origClearInterval;
-    });
-    it('passes the correct interval to setInterval', () => {
-      const wrapper = mount(<CycleQueryTab view={view} activeQuery="foo" interval={42} />);
-      expect(window.setInterval).toHaveBeenCalledTimes(1);
-      expect(window.setInterval).toHaveBeenCalledWith(expect.anything(), 42000);
-      wrapper.unmount();
-      expect(ViewActions.selectQuery).not.toHaveBeenCalled();
-    });
-    it('when unmounting', () => {
-      const wrapper = mount(<CycleQueryTab view={view} activeQuery="foo" interval={1} />);
-      wrapper.unmount();
-      expect(window.clearInterval).toHaveBeenCalledWith('deadbeef');
-    });
+    jest.advanceTimersByTime(900);
+
+    expect(ViewActions.selectQuery).not.toHaveBeenCalled();
+  });
+  it('should switch to next tab after interval', () => {
+    render(<CycleQueryTab view={view} activeQuery="bar" interval={1} tabs={[1, 2]} />);
+
+    jest.advanceTimersByTime(1000);
+
+    expect(ViewActions.selectQuery).toHaveBeenCalledWith('baz');
+  });
+  it('should switch to first tab if current one is the last', () => {
+    render(<CycleQueryTab view={view} activeQuery="baz" interval={1} tabs={[0, 1, 2]} />);
+
+    jest.advanceTimersByTime(1000);
+
+    expect(ViewActions.selectQuery).toHaveBeenCalledWith('foo');
+  });
+  it('should switch to next tab skipping gaps after interval', () => {
+    render(<CycleQueryTab view={view} activeQuery="foo" interval={1} tabs={[0, 2]} />);
+
+    jest.advanceTimersByTime(1000);
+
+    expect(ViewActions.selectQuery).toHaveBeenCalledWith('baz');
+  });
+  it('should switch to next tab defaulting to all tabs if `tabs` prop` is left out', () => {
+    render(<CycleQueryTab view={view} activeQuery="foo" tabs={[1]} interval={1} />);
+
+    jest.advanceTimersByTime(1000);
+
+    expect(ViewActions.selectQuery).toHaveBeenCalledWith('bar');
+  });
+  it('triggers tab change after the correct interval has passed', async () => {
+    render(<CycleQueryTab view={view} activeQuery="foo" interval={42} />);
+
+    jest.advanceTimersByTime(42000);
+
+    expect(ViewActions.selectQuery).toHaveBeenCalledTimes(1);
+  });
+  it('does not trigger after unmounting', () => {
+    const { unmount } = render(<CycleQueryTab view={view} activeQuery="foo" interval={42} />);
+    unmount();
+
+    jest.advanceTimersByTime(42000);
+
+    expect(ViewActions.selectQuery).not.toHaveBeenCalled();
   });
 });

--- a/graylog2-web-interface/src/views/components/dashboard/bigdisplay/CycleQueryTab.test.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/bigdisplay/CycleQueryTab.test.jsx
@@ -1,6 +1,6 @@
 // @flow strict
 import * as React from 'react';
-import { render, cleanup, wait } from 'wrappedTestingLibrary';
+import { render, cleanup } from 'wrappedTestingLibrary';
 
 import View from 'views/logic/views/View';
 import Search from 'views/logic/search/Search';


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, the `CycleQueryTab` test used real timers to wait
for the component to switch tabs. This made the test very slow and also
resulted in false negatives due to race conditions, making the test
unreliable and slowing down overall test execution.

This PR is changing the test to use fake timers and therefore reduces
execution time immensely. In addition, it does not check
`setInterval`/`clearInterval` usage, but tests for their actual
implications, making the test less dependent on the implementation.

Before:

```
 PASS  src/views/components/dashboard/bigdisplay/CycleQueryTab.test.jsx
  CycleQueryTab
    cycles tabs:
      ✓ does not return markup (43ms)
      ✓ should switch to next tab after interval (1009ms)
      ✓ should switch to first tab if current one is the last (1004ms)
      ✓ should switch to next tab skipping gaps after interval (1005ms)
      ✓ should switch to next tab defaulting to all tabs if `tabs` prop` is left out (1003ms)
    uses setInterval/clearInterval properly
      ✓ passes the correct interval to setInterval (5ms)
      ✓ when unmounting (1ms)
```

After:

```
 PASS  src/views/components/dashboard/bigdisplay/CycleQueryTab.test.jsx
  CycleQueryTab
    ✓ does not return markup (20ms)
    ✓ should not switch to anything before interval (2ms)
    ✓ should switch to next tab after interval (2ms)
    ✓ should switch to first tab if current one is the last (1ms)
    ✓ should switch to next tab skipping gaps after interval (1ms)
    ✓ should switch to next tab defaulting to all tabs if `tabs` prop` is left out (1ms)
    ✓ triggers tab change after the correct interval has passed (3ms)
    ✓ does not trigger after unmounting (1ms)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.