### PR TITLE
Display view type specific default sidebar title

### DIFF
--- a/graylog2-web-interface/src/views/components/sidebar/SideBar.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/SideBar.jsx
@@ -1,19 +1,19 @@
 // @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import { capitalize } from 'lodash';
 
+import type { ViewMetaData } from 'views/stores/ViewMetadataStore';
+import type { ViewType } from 'views/logic/views/View';
+import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
 
 import { AddWidgetButton } from 'views/components/sidebar';
 import { Icon, Spinner } from 'components/common';
-import type { ViewMetaData } from 'views/stores/ViewMetadataStore';
-
 import { Container, ContentOverlay, SidebarHeader, Headline, ToggleIcon, HorizontalRuler } from './Sidebar.styles';
 import CustomPropTypes from '../CustomPropTypes';
 import HighlightingRules from './highlighting/HighlightingRules';
 import NavItem from './NavItem';
 import ViewDescription from './ViewDescription';
-
-const defaultNewViewTitle = 'Untitled Search';
 
 type Props = {
   children: React.Element<any>,
@@ -103,51 +103,64 @@ class SideBar extends React.Component<Props, State> {
     return navItemChildren;
   }
 
+  sidebarTitle = (viewType: ?ViewType) => {
+    const { viewMetadata } = this.props;
+    const defaultTitle = `Untitled ${capitalize(viewType)}`;
+    return viewMetadata.title || defaultTitle;
+  }
+
   render() {
     const { results, viewMetadata, children, queryId } = this.props;
     const { open, selectedKey } = this.state;
-    const title = viewMetadata.title || defaultNewViewTitle;
+
     const toggleIcon = open
       ? 'times'
       : 'chevron-right';
     return (
-      <Container ref={(node) => { this.wrapperRef = node; }} open={open}>
-        {open && <ContentOverlay onClick={this.toggleOpen} />}
-        <SidebarHeader role="presentation" onClick={this.toggleOpen} hasTitle={!!title} open={open}>
-          {open && title && <Headline title={title}>{title}</Headline>}
-          <ToggleIcon><Icon name={toggleIcon} /></ToggleIcon>
-        </SidebarHeader>
-        <HorizontalRuler />
-        <NavItem isSelected={open && selectedKey === 'viewDescription'}
-                 text="Description"
-                 icon="info"
-                 onClick={this.setSelectedKey('viewDescription')}
-                 isOpen={open}>
-          {this.navItemChildren(<ViewDescription viewMetadata={viewMetadata} results={results} />)}
-        </NavItem>
-        <NavItem isSelected={open && selectedKey === 'createWidget'}
-                 text="Create"
-                 icon="plus"
-                 onClick={this.setSelectedKey('createWidget')}
-                 isOpen={open}>
-          {this.navItemChildren(<AddWidgetButton onClick={this.toggleOpen} toggleAutoClose={this.toggleAutoClose} queryId={queryId} />)}
-        </NavItem>
-        <NavItem isSelected={open && selectedKey === 'highlighting'}
-                 text="Formatting & Highlighting"
-                 icon="paragraph"
-                 onClick={this.setSelectedKey('highlighting')}
-                 isOpen={open}>
-          {this.navItemChildren(<HighlightingRules />)}
-        </NavItem>
-        <NavItem isSelected={open && selectedKey === 'fields'}
-                 text="Fields"
-                 icon="subscript"
-                 onClick={this.setSelectedKey('fields')}
-                 expandRight
-                 isOpen={open}>
-          {this.navItemChildren(children)}
-        </NavItem>
-      </Container>
+      <ViewTypeContext.Consumer>
+        {(viewType) => {
+          const title = this.sidebarTitle(viewType);
+          return (
+            <Container ref={(node) => { this.wrapperRef = node; }} open={open}>
+              {open && <ContentOverlay onClick={this.toggleOpen} />}
+              <SidebarHeader role="presentation" onClick={this.toggleOpen} hasTitle={!!title} open={open}>
+                {open && title && <Headline title={title}>{title}</Headline>}
+                <ToggleIcon><Icon name={toggleIcon} /></ToggleIcon>
+              </SidebarHeader>
+              <HorizontalRuler />
+              <NavItem isSelected={open && selectedKey === 'viewDescription'}
+                       text="Description"
+                       icon="info"
+                       onClick={this.setSelectedKey('viewDescription')}
+                       isOpen={open}>
+                {this.navItemChildren(<ViewDescription viewMetadata={viewMetadata} results={results} />)}
+              </NavItem>
+              <NavItem isSelected={open && selectedKey === 'createWidget'}
+                       text="Create"
+                       icon="plus"
+                       onClick={this.setSelectedKey('createWidget')}
+                       isOpen={open}>
+                {this.navItemChildren(<AddWidgetButton onClick={this.toggleOpen} toggleAutoClose={this.toggleAutoClose} queryId={queryId} />)}
+              </NavItem>
+              <NavItem isSelected={open && selectedKey === 'highlighting'}
+                       text="Formatting & Highlighting"
+                       icon="paragraph"
+                       onClick={this.setSelectedKey('highlighting')}
+                       isOpen={open}>
+                {this.navItemChildren(<HighlightingRules />)}
+              </NavItem>
+              <NavItem isSelected={open && selectedKey === 'fields'}
+                       text="Fields"
+                       icon="subscript"
+                       onClick={this.setSelectedKey('fields')}
+                       expandRight
+                       isOpen={open}>
+                {this.navItemChildren(children)}
+              </NavItem>
+            </Container>
+          );
+        }}
+      </ViewTypeContext.Consumer>
     );
   }
 }

--- a/graylog2-web-interface/src/views/components/sidebar/SideBar.test.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/SideBar.test.jsx
@@ -84,7 +84,7 @@ describe('<Sidebar />', () => {
     expect(wrapper.find('h3').text()).toBe(viewMetaData.title);
   });
 
-  it('should render with a default title and a description', () => {
+  it('should render with a description', () => {
     const emptyViewMetaData = {
       activeQuery: '34efae1e-e78e-48ab-ab3f-e83c8611a683',
       id: '5b34f4c44880a54df9616380',
@@ -102,8 +102,51 @@ describe('<Sidebar />', () => {
 
     wrapper.find('Sidebarstyles__SidebarHeader').simulate('click');
     wrapper.find('div[children="Description"]').simulate('click');
-    expect(wrapper.find('h3').text()).toBe('Untitled Search');
     expect(wrapper.find('SearchResultOverview').text()).toBe('Found 0 messages in 64ms.Query executed at 2018-08-28 14:39:26.');
+  });
+
+  it('should render with a specific default title in the context of a new search', () => {
+    const emptyViewMetaData = {
+      activeQuery: '34efae1e-e78e-48ab-ab3f-e83c8611a683',
+      id: '5b34f4c44880a54df9616380',
+    };
+
+    const SideBar = loadSUT();
+    const wrapper = mount(
+      <ViewTypeContext.Provider value={View.Type.Search}>
+        <SideBar viewMetadata={emptyViewMetaData}
+                 toggleOpen={jest.fn}
+                 queryId={query.id}
+                 results={queryResult}>
+          <TestComponent />
+        </SideBar>,
+      </ViewTypeContext.Provider>,
+    );
+
+    wrapper.find('Sidebarstyles__SidebarHeader').simulate('click');
+    expect(wrapper.find('h3').text()).toBe('Untitled Search');
+  });
+
+  it('should render with a specific default title in the context of a new dashboard', () => {
+    const emptyViewMetaData = {
+      activeQuery: '34efae1e-e78e-48ab-ab3f-e83c8611a683',
+      id: '5b34f4c44880a54df9616380',
+    };
+
+    const SideBar = loadSUT();
+    const wrapper = mount(
+      <ViewTypeContext.Provider value={View.Type.Dashboard}>
+        <SideBar viewMetadata={emptyViewMetaData}
+                 toggleOpen={jest.fn}
+                 queryId={query.id}
+                 results={queryResult}>
+          <TestComponent />
+        </SideBar>
+      </ViewTypeContext.Provider>,
+    );
+
+    wrapper.find('Sidebarstyles__SidebarHeader').simulate('click');
+    expect(wrapper.find('h3').text()).toBe('Untitled Dashboard');
   });
 
   it('should render a summary and descirption, for dashboard view', () => {


### PR DESCRIPTION
Follow up PR for https://github.com/Graylog2/graylog2-server/pull/7171

A view type specific default title should improve the user experience even more. Thanks @dennisoelkers for the suggestion.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

