### PR TITLE
Do not show `Empty Value` for deduplicated values.

### DIFF
--- a/graylog2-web-interface/src/views/components/EmptyValue.jsx
+++ b/graylog2-web-interface/src/views/components/EmptyValue.jsx
@@ -1,5 +1,11 @@
-import React from 'react';
+// @flow strict
+import * as React from 'react';
+import styled from 'styled-components';
 
-const EmptyValue = () => <i>&lt;Empty Value&gt;</i>;
+const Container: React.ComponentType<{}> = styled.i`
+  color: darkgray;
+`;
+
+const EmptyValue = () => <Container>&lt;Empty Value&gt;</Container>;
 
 export default EmptyValue;

--- a/graylog2-web-interface/src/views/components/datatable/DataTableEntry.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTableEntry.jsx
@@ -32,7 +32,7 @@ const _column = (field: string, value: *, selectedQuery: string, idx: number, ty
   <td key={`${selectedQuery}-${field}=${value}-${idx}`}>
     <AdditionalContext.Provider value={{ valuePath }}>
       <CustomHighlighting field={field} value={value}>
-        {value !== null && value !== undefined ? <Value field={field} type={type} value={value} queryId={selectedQuery} render={DecoratedValue} /> : <EmptyValue />}
+        {value !== null && value !== undefined ? <Value field={field} type={type} value={value} queryId={selectedQuery} render={DecoratedValue} /> : null}
       </CustomHighlighting>
     </AdditionalContext.Provider>
   </td>

--- a/graylog2-web-interface/src/views/components/datatable/DataTableEntry.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTableEntry.jsx
@@ -13,7 +13,6 @@ import fieldTypeFor from 'views/logic/fieldtypes/FieldTypeFor';
 import type { CurrentViewType } from '../CustomPropTypes';
 import CustomHighlighting from '../messagelist/CustomHighlighting';
 import DecoratedValue from '../messagelist/decoration/DecoratedValue';
-import EmptyValue from '../EmptyValue';
 
 type Props = {
   columnPivots: Array<string>,

--- a/graylog2-web-interface/src/views/components/datatable/DataTableEntry.test.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTableEntry.test.jsx
@@ -11,6 +11,7 @@ import { FieldTypes } from 'views/logic/fieldtypes/FieldType';
 import Series from 'views/logic/aggregationbuilder/Series';
 import DataTableEntry from './DataTableEntry';
 import SeriesConfig from '../../logic/aggregationbuilder/SeriesConfig';
+import EmptyValue from '../EmptyValue';
 
 jest.mock('views/components/common/UserTimezoneTimestamp', () => mockComponent('UserTimezoneTimestamp'));
 
@@ -108,6 +109,26 @@ describe('DataTableEntry', () => {
     expect(wrapper.find('Provider')
       .map(p => p.props().value))
       .toMatchSnapshot();
+  });
+
+  it('does not render `Empty Value` for deduplicated values', () => {
+    const fieldsWithDeduplicatedValues = Immutable.OrderedSet(['nf_dst_address', 'nf_dst_port']);
+    const itemWithDeduplicatedValues = {
+      nf_dst_port: 443,
+    };
+    const wrapper = mount((
+      <table>
+        <DataTableEntry columnPivots={columnPivots}
+                        columnPivotValues={columnPivotValues}
+                        currentView={currentView}
+                        fields={fieldsWithDeduplicatedValues}
+                        item={itemWithDeduplicatedValues}
+                        series={series}
+                        types={[]}
+                        valuePath={valuePath} />
+      </table>
+    ));
+    expect(wrapper).not.toContainReact(<EmptyValue/>);
   });
 
   describe('resolves field types', () => {

--- a/graylog2-web-interface/src/views/components/datatable/DataTableEntry.test.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTableEntry.test.jsx
@@ -128,7 +128,7 @@ describe('DataTableEntry', () => {
                         valuePath={valuePath} />
       </table>
     ));
-    expect(wrapper).not.toContainReact(<EmptyValue/>);
+    expect(wrapper).not.toContainReact(<EmptyValue />);
   });
 
   describe('resolves field types', () => {

--- a/graylog2-web-interface/src/views/components/messagelist/CustomHighlighting.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/CustomHighlighting.jsx
@@ -12,7 +12,7 @@ import PossiblyHighlight from './PossiblyHighlight';
 import Highlight from './Highlight';
 
 type Props = {
-  children: React.Node,
+  children: ?React.Node,
   field: string,
   highlightingRules: { [string]: Array<HighlightingRule> },
   value?: any,
@@ -50,12 +50,13 @@ const CustomHighlighting = ({ children, field: fieldName, value: fieldValue, hig
 };
 
 CustomHighlighting.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   field: PropTypes.string.isRequired,
   value: PropTypes.any,
 };
 
 CustomHighlighting.defaultProps = {
+  children: undefined,
   value: undefined,
 };
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #7108, the behavior of `DataTableEntry` is accidentally changed,
returning `EmptyValue` for everything `null` or `undefined`. This
changes the behavior for deduplicated values.

This PR is restoring the original behavior and adds a test case.

Fixes #7181.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.