### PR TITLE
Add "gl2_accounted_message_size" field to indexed messages

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -43,6 +43,10 @@ For each of the index names returned by the previous command, the following comm
 
   curl -s -X PUT --data '{"properties":{"gl2_accounted_message_size":{"type": "long"}}}' -H Content-Type:application/json localhost:9200/<active-write-index-name>/_mapping/message
 
+The two steps could also be combined::
+
+  for index in `curl -s localhost:9200/_cat/aliases/*_deflector?h=index`; do curl -s -X PUT --data '{"properties":{"gl2_accounted_message_size":{"type": "long"}}}' -H Content-Type:application/json localhost:9200/$index/_mapping/message ; done'
+
 The Graylog servers can now be restarted with the 3.2.0 version.
 
 Known Bugs and Limitations

--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -26,6 +26,25 @@ Indexing Requests use HTTP Expect: 100-Continue Header
 Messages indexing requests to Elasticsearch are now executed with a HTTP Expect-Continue header.
 For the unlikely case that this is creating problems, it can be disabled using the newly introduced ``elasticsearch_use_expect_continue`` setting.
 
+Accounted Message Size Field
+============================
+
+Every message now includes the ``gl2_accounted_message_size`` field. To make sure this field will be created with the correct data type in all active write indices, the mapping of these indices needs to be updated. New indices created by index rotation will automatically have the correct mapping because the index template got updated automatically.
+
+.. warning:: The following steps need to be executed **before** starting the server with the 3.2.0 version!
+
+All of the following commands need to be executed against one of the Elasticsearch servers in the cluster.
+
+First, a list of all active write indices is needed::
+
+  curl -s localhost:9200/_cat/aliases/*_deflector?h=index
+
+For each of the index names returned by the previous command, the following command needs to be executed (``<active-write-index-name>`` in the URL needs to be replaced with the actual index name)::
+
+  curl -s -X PUT --data '{"properties":{"gl2_accounted_message_size":{"type": "long"}}}' -H Content-Type:application/json localhost:9200/<active-write-index-name>/_mapping/message
+
+The Graylog servers can now be restarted with the 3.2.0 version.
+
 Known Bugs and Limitations
 ==========================
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
@@ -90,6 +90,10 @@ public abstract class IndexMapping implements IndexMappingTemplate {
                 "format", Tools.ES_DATE_FORMAT);
     }
 
+    protected Map<String, Object> typeLong() {
+        return ImmutableMap.of("type", "long");
+    }
+
     protected Map<String, Boolean> enabled() {
         return ImmutableMap.of("enabled", true);
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping5.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping5.java
@@ -36,6 +36,7 @@ public class IndexMapping5 extends IndexMapping {
                 // http://joda-time.sourceforge.net/api-release/org/joda/time/format/DateTimeFormat.html
                 // http://www.elasticsearch.org/guide/reference/mapping/date-format.html
                 .put("timestamp", typeTimeWithMillis())
+                .put(Message.FIELD_GL2_ACCOUNTED_MESSAGE_SIZE, typeLong())
                 .put(Message.FIELD_GL2_RECEIVE_TIMESTAMP, typeTimeWithMillis())
                 .put(Message.FIELD_GL2_PROCESSING_TIMESTAMP, typeTimeWithMillis())
                 // to support wildcard searches in source we need to lowercase the content (wildcard search lowercases search term)

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping6.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping6.java
@@ -68,6 +68,7 @@ public class IndexMapping6 extends IndexMapping {
                 // http://joda-time.sourceforge.net/api-release/org/joda/time/format/DateTimeFormat.html
                 // http://www.elasticsearch.org/guide/reference/mapping/date-format.html
                 .put("timestamp", typeTimeWithMillis())
+                .put(Message.FIELD_GL2_ACCOUNTED_MESSAGE_SIZE, typeLong())
                 .put(Message.FIELD_GL2_RECEIVE_TIMESTAMP, typeTimeWithMillis())
                 .put(Message.FIELD_GL2_PROCESSING_TIMESTAMP, typeTimeWithMillis())
                 // to support wildcard searches in source we need to lowercase the content (wildcard search lowercases search term)

--- a/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/Message.java
@@ -91,6 +91,11 @@ public class Message implements Messages {
     public static final String INTERNAL_FIELD_PREFIX = "gl2_";
 
     /**
+     * Will be set to the accounted message size in bytes.
+     */
+    public static final String FIELD_GL2_ACCOUNTED_MESSAGE_SIZE = "gl2_accounted_message_size";
+
+    /**
      * This is the message ID. It will be set to a {@link de.huxhorn.sulky.ulid.ULID} during processing.
      * <p></p>
      * <b>Attention:</b> This is currently NOT the "_id" field which is used as ID for the document in Elasticsearch!
@@ -182,6 +187,7 @@ public class Message implements Messages {
     private static final char KEY_REPLACEMENT_CHAR = '_';
 
     private static final ImmutableSet<String> GRAYLOG_FIELDS = ImmutableSet.of(
+        FIELD_GL2_ACCOUNTED_MESSAGE_SIZE,
         FIELD_GL2_ORIGINAL_TIMESTAMP,
         FIELD_GL2_PROCESSING_ERROR,
         FIELD_GL2_PROCESSING_TIMESTAMP,
@@ -384,6 +390,7 @@ public class Message implements Messages {
         obj.put(FIELD_MESSAGE, getMessage());
         obj.put(FIELD_SOURCE, getSource());
         obj.put(FIELD_STREAMS, getStreamIds());
+        obj.put(FIELD_GL2_ACCOUNTED_MESSAGE_SIZE, getSize());
 
         final Object timestampValue = getField(FIELD_TIMESTAMP);
         DateTime dateTime;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
@@ -117,6 +117,7 @@ public class IndexFieldTypePollerIT extends ElasticsearchBaseTest {
                 FieldTypeDTO.create("timestamp", "date"),
                 FieldTypeDTO.create("gl2_receive_timestamp", "date"),
                 FieldTypeDTO.create("gl2_processing_timestamp", "date"),
+                FieldTypeDTO.create("gl2_accounted_message_size", "long"),
                 FieldTypeDTO.create("streams", "keyword")
         );
     }
@@ -140,6 +141,7 @@ public class IndexFieldTypePollerIT extends ElasticsearchBaseTest {
                 FieldTypeDTO.create("timestamp", "date"),
                 FieldTypeDTO.create("gl2_receive_timestamp", "date"),
                 FieldTypeDTO.create("gl2_processing_timestamp", "date"),
+                FieldTypeDTO.create("gl2_accounted_message_size", "long"),
                 FieldTypeDTO.create("streams", "keyword")
         );
     }

--- a/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/MessageTest.java
@@ -449,6 +449,14 @@ public class MessageTest {
     }
 
     @Test
+    public void testToElasticsearchObjectAddsAccountedMessageSize() {
+        final Message message = new Message("message", "source", Tools.nowUTC());
+
+        assertThat(message.toElasticSearchObject(invalidTimestampMeter).get("gl2_accounted_message_size"))
+                .isEqualTo(43L);
+    }
+
+    @Test
     public void messageSizes() {
         final Meter invalidTimestampMeter = new Meter();
 

--- a/graylog2-web-interface/src/logic/message/MessageFieldsFilter.js
+++ b/graylog2-web-interface/src/logic/message/MessageFieldsFilter.js
@@ -10,6 +10,7 @@ const MessageFieldsFilter = {
     '_score',
 
     // Our reserved fields.
+    'gl2_accounted_message_size',
     'gl2_message_id',
     'gl2_source_node',
     'gl2_source_input',


### PR DESCRIPTION
That field contains the message size that will be accouted for
Enterprise license checks. It can be used to analyze traffic per stream
or similar use cases.

This change adds the new field to all message index templates and writes
the field to indexed messages.

Closes #6838