### PR TITLE
 Add pipeline functions to modify lookup tables

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -78,7 +78,11 @@ import org.graylog.plugins.pipelineprocessor.functions.json.IsJson;
 import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.Lookup;
+import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupAddStringList;
+import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupRemoveStringList;
+import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupSetValue;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupStringList;
+import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupSetStringList;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupValue;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CloneMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CreateMessage;
@@ -255,6 +259,10 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(Lookup.NAME, Lookup.class);
         addMessageProcessorFunction(LookupValue.NAME, LookupValue.class);
         addMessageProcessorFunction(LookupStringList.NAME, LookupStringList.class);
+        addMessageProcessorFunction(LookupSetValue.NAME, LookupSetValue.class);
+        addMessageProcessorFunction(LookupSetStringList.NAME, LookupSetStringList.class);
+        addMessageProcessorFunction(LookupAddStringList.NAME, LookupAddStringList.class);
+        addMessageProcessorFunction(LookupRemoveStringList.NAME, LookupRemoveStringList.class);
 
         // Debug
         addMessageProcessorFunction(Debug.NAME, Debug.class);

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -79,6 +79,7 @@ import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.Lookup;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupAddStringList;
+import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupClearKey;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupRemoveStringList;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupSetValue;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupStringList;
@@ -260,6 +261,7 @@ public class ProcessorFunctionsModule extends PluginModule {
         addMessageProcessorFunction(LookupValue.NAME, LookupValue.class);
         addMessageProcessorFunction(LookupStringList.NAME, LookupStringList.class);
         addMessageProcessorFunction(LookupSetValue.NAME, LookupSetValue.class);
+        addMessageProcessorFunction(LookupClearKey.NAME, LookupClearKey.class);
         addMessageProcessorFunction(LookupSetStringList.NAME, LookupSetStringList.class);
         addMessageProcessorFunction(LookupAddStringList.NAME, LookupAddStringList.class);
         addMessageProcessorFunction(LookupRemoveStringList.NAME, LookupRemoveStringList.class);

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/ProcessorFunctionsModule.java
@@ -78,6 +78,7 @@ import org.graylog.plugins.pipelineprocessor.functions.json.IsJson;
 import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.Lookup;
+import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupStringList;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupValue;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CloneMessage;
 import org.graylog.plugins.pipelineprocessor.functions.messages.CreateMessage;
@@ -253,6 +254,7 @@ public class ProcessorFunctionsModule extends PluginModule {
         // Lookup tables
         addMessageProcessorFunction(Lookup.NAME, Lookup.class);
         addMessageProcessorFunction(LookupValue.NAME, LookupValue.class);
+        addMessageProcessorFunction(LookupStringList.NAME, LookupStringList.class);
 
         // Debug
         addMessageProcessorFunction(Debug.NAME, Debug.class);

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupAddStringList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupAddStringList.java
@@ -38,7 +38,7 @@ public class LookupAddStringList extends AbstractFunction<Object> {
     private final ParameterDescriptor<Object, Object> keyParam;
     @SuppressWarnings("rawtypes")
     private final ParameterDescriptor<List, List> valueParam;
-    private final ParameterDescriptor<Boolean, Boolean> appendOption;
+    private final ParameterDescriptor<Boolean, Boolean> keepDuplicates;
 
     @Inject
     public LookupAddStringList(LookupTableService lookupTableService) {
@@ -49,12 +49,12 @@ public class LookupAddStringList extends AbstractFunction<Object> {
         keyParam = object("key")
                 .description("The key to add in the lookup table")
                 .build();
-        valueParam = ParameterDescriptor.type("list_value", List.class)
+        valueParam = ParameterDescriptor.type("value", List.class)
                 .description("The list value that should be added into the lookup table")
                 .build();
-        appendOption = bool("append_values")
+        keepDuplicates = bool("keep_duplicates")
                 .optional()
-                .description("Append values instead of merging them with existing ones into a set. Defaults to false (merge)")
+                .description("When adding values to an existing list, don't try to omit duplicates. Default is false")
                 .build();
     }
 
@@ -72,9 +72,9 @@ public class LookupAddStringList extends AbstractFunction<Object> {
         if (value == null) {
             return null;
         }
-        final boolean doAppend = appendOption.optional(args, context).orElse(false);
+        final boolean keepDupes = keepDuplicates.optional(args, context).orElse(false);
 
-        return table.addStringList(key, value, doAppend).stringListValue();
+        return table.addStringList(key, value, keepDupes).stringListValue();
     }
 
     @Override
@@ -82,7 +82,7 @@ public class LookupAddStringList extends AbstractFunction<Object> {
         return FunctionDescriptor.builder()
                 .name(NAME)
                 .description("Add a string list in the named lookup table. Returns the updated list on success, null on failure.")
-                .params(lookupTableParam, keyParam, valueParam, appendOption)
+                .params(lookupTableParam, keyParam, valueParam, keepDuplicates)
                 .returnType(List.class)
                 .build();
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupAddStringList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupAddStringList.java
@@ -1,0 +1,89 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.lookup;
+
+import com.google.inject.Inject;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+import org.graylog2.lookup.LookupTableService;
+
+import java.util.List;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.bool;
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.string;
+
+public class LookupAddStringList extends AbstractFunction<Object> {
+
+    public static final String NAME = "lookup_add_string_list";
+
+    private final ParameterDescriptor<String, LookupTableService.Function> lookupTableParam;
+    private final ParameterDescriptor<Object, Object> keyParam;
+    @SuppressWarnings("rawtypes")
+    private final ParameterDescriptor<List, List> valueParam;
+    private final ParameterDescriptor<Boolean, Boolean> appendOption;
+
+    @Inject
+    public LookupAddStringList(LookupTableService lookupTableService) {
+        lookupTableParam = string("lookup_table", LookupTableService.Function.class)
+                .description("The existing lookup table to use to add the given list")
+                .transform(tableName -> lookupTableService.newBuilder().lookupTable(tableName).build())
+                .build();
+        keyParam = object("key")
+                .description("The key to add in the lookup table")
+                .build();
+        valueParam = ParameterDescriptor.type("list_value", List.class)
+                .description("The list value that should be added into the lookup table")
+                .build();
+        appendOption = bool("append_values")
+                .optional()
+                .description("Append values instead of merging them with existing ones into a set. Defaults to false (merge)")
+                .build();
+    }
+
+    @Override
+    public Object evaluate(FunctionArgs args, EvaluationContext context) {
+        Object key = keyParam.required(args, context);
+        if (key == null) {
+            return null;
+        }
+        LookupTableService.Function table = lookupTableParam.required(args, context);
+        if (table == null) {
+            return null;
+        }
+        List<String> value = valueParam.required(args, context);
+        if (value == null) {
+            return null;
+        }
+        final boolean doAppend = appendOption.optional(args, context).orElse(false);
+
+        return table.addStringList(key, value, doAppend).stringListValue();
+    }
+
+    @Override
+    public FunctionDescriptor<Object> descriptor() {
+        return FunctionDescriptor.builder()
+                .name(NAME)
+                .description("Add a string list in the named lookup table. Returns the updated list on success, null on failure.")
+                .params(lookupTableParam, keyParam, valueParam, appendOption)
+                .returnType(List.class)
+                .build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupClearKey.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupClearKey.java
@@ -27,7 +27,7 @@ import org.graylog2.lookup.LookupTableService;
 import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
 import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.string;
 
-public class LookupClearKey extends AbstractFunction<Object> {
+public class LookupClearKey extends AbstractFunction<Void> {
 
     public static final String NAME = "lookup_clear_key";
 
@@ -62,8 +62,8 @@ public class LookupClearKey extends AbstractFunction<Object> {
     }
 
     @Override
-    public FunctionDescriptor<Object> descriptor() {
-        return FunctionDescriptor.builder()
+    public FunctionDescriptor<Void> descriptor() {
+        return FunctionDescriptor.<Void>builder()
                 .name(NAME)
                 .description("Clear (remove) a key in the named lookup table.")
                 .params(lookupTableParam, keyParam)

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupClearKey.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupClearKey.java
@@ -1,0 +1,73 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.lookup;
+
+import com.google.inject.Inject;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+import org.graylog2.lookup.LookupTableService;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.string;
+
+public class LookupClearKey extends AbstractFunction<Object> {
+
+    public static final String NAME = "lookup_clear_key";
+
+    private final ParameterDescriptor<String, LookupTableService.Function> lookupTableParam;
+    private final ParameterDescriptor<Object, Object> keyParam;
+
+    @Inject
+    public LookupClearKey(LookupTableService lookupTableService) {
+        lookupTableParam = string("lookup_table", LookupTableService.Function.class)
+                .description("The existing lookup table to use to clear the given key")
+                .transform(tableName -> lookupTableService.newBuilder().lookupTable(tableName).build())
+                .build();
+        keyParam = object("key")
+                .description("The key to clear in the lookup table")
+                .build();
+    }
+
+    @Override
+    public Void evaluate(FunctionArgs args, EvaluationContext context) {
+        Object key = keyParam.required(args, context);
+        if (key == null) {
+            return null;
+        }
+        LookupTableService.Function table = lookupTableParam.required(args, context);
+        if (table == null) {
+            return null;
+        }
+
+        table.clearKey(key);
+
+        return null;
+    }
+
+    @Override
+    public FunctionDescriptor<Object> descriptor() {
+        return FunctionDescriptor.builder()
+                .name(NAME)
+                .description("Clear (remove) a key in the named lookup table.")
+                .params(lookupTableParam, keyParam)
+                .returnType(Void.class)
+                .build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupRemoveStringList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupRemoveStringList.java
@@ -1,0 +1,82 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.lookup;
+
+import com.google.inject.Inject;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+import org.graylog2.lookup.LookupTableService;
+
+import java.util.List;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.string;
+
+public class LookupRemoveStringList extends AbstractFunction<Object> {
+
+    public static final String NAME = "lookup_remove_string_list";
+
+    private final ParameterDescriptor<String, LookupTableService.Function> lookupTableParam;
+    private final ParameterDescriptor<Object, Object> keyParam;
+    @SuppressWarnings("rawtypes")
+    private final ParameterDescriptor<List, List> valueParam;
+
+    @Inject
+    public LookupRemoveStringList(LookupTableService lookupTableService) {
+        lookupTableParam = string("lookup_table", LookupTableService.Function.class)
+                .description("The existing lookup table to use to remove entries from the given list")
+                .transform(tableName -> lookupTableService.newBuilder().lookupTable(tableName).build())
+                .build();
+        keyParam = object("key")
+                .description("The key to remove the entries in the lookup table")
+                .build();
+        valueParam = ParameterDescriptor.type("list_value", List.class)
+                .description("The list value that should be removed from the lookup table")
+                .build();
+    }
+
+    @Override
+    public Object evaluate(FunctionArgs args, EvaluationContext context) {
+        Object key = keyParam.required(args, context);
+        if (key == null) {
+            return null;
+        }
+        LookupTableService.Function table = lookupTableParam.required(args, context);
+        if (table == null) {
+            return null;
+        }
+        List<String> value = valueParam.required(args, context);
+        if (value == null) {
+            return null;
+        }
+
+        return table.removeStringList(key, value).stringListValue();
+    }
+
+    @Override
+    public FunctionDescriptor<Object> descriptor() {
+        return FunctionDescriptor.builder()
+                .name(NAME)
+                .description("Remove the entries of the given string list from the named lookup table. Returns the updated list on success, null on failure.")
+                .params(lookupTableParam, keyParam, valueParam)
+                .returnType(List.class)
+                .build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupRemoveStringList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupRemoveStringList.java
@@ -47,7 +47,7 @@ public class LookupRemoveStringList extends AbstractFunction<Object> {
         keyParam = object("key")
                 .description("The key to remove the entries in the lookup table")
                 .build();
-        valueParam = ParameterDescriptor.type("list_value", List.class)
+        valueParam = ParameterDescriptor.type("value", List.class)
                 .description("The list value that should be removed from the lookup table")
                 .build();
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupSetStringList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupSetStringList.java
@@ -1,0 +1,81 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.lookup;
+
+import com.google.inject.Inject;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+import org.graylog2.lookup.LookupTableService;
+
+import java.util.List;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.string;
+
+public class LookupSetStringList extends AbstractFunction<Object> {
+
+    public static final String NAME = "lookup_set_string_list";
+
+    private final ParameterDescriptor<String, LookupTableService.Function> lookupTableParam;
+    private final ParameterDescriptor<Object, Object> keyParam;
+    @SuppressWarnings("rawtypes")
+    private final ParameterDescriptor<List, List> valueParam;
+
+    @Inject
+    public LookupSetStringList(LookupTableService lookupTableService) {
+        lookupTableParam = string("lookup_table", LookupTableService.Function.class)
+                .description("The existing lookup table to use to set the given list")
+                .transform(tableName -> lookupTableService.newBuilder().lookupTable(tableName).build())
+                .build();
+        keyParam = object("key")
+                .description("The key to set in the lookup table")
+                .build();
+        valueParam = ParameterDescriptor.type("list_value", List.class)
+                .description("The list value that should be set into the lookup table")
+                .build();
+    }
+
+    @Override
+    public Object evaluate(FunctionArgs args, EvaluationContext context) {
+        Object key = keyParam.required(args, context);
+        if (key == null) {
+            return null;
+        }
+        LookupTableService.Function table = lookupTableParam.required(args, context);
+        if (table == null) {
+            return null;
+        }
+        List<String> value = valueParam.required(args, context);
+        if (value == null) {
+            return null;
+        }
+        return table.setStringList(key, value).stringListValue();
+    }
+
+    @Override
+    public FunctionDescriptor<Object> descriptor() {
+        return FunctionDescriptor.builder()
+                .name(NAME)
+                .description("Set a string list in the named lookup table. Returns the new value on success, null on failure.")
+                .params(lookupTableParam, keyParam, valueParam)
+                .returnType(List.class)
+                .build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupSetStringList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupSetStringList.java
@@ -47,7 +47,7 @@ public class LookupSetStringList extends AbstractFunction<Object> {
         keyParam = object("key")
                 .description("The key to set in the lookup table")
                 .build();
-        valueParam = ParameterDescriptor.type("list_value", List.class)
+        valueParam = ParameterDescriptor.type("value", List.class)
                 .description("The list value that should be set into the lookup table")
                 .build();
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupSetValue.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupSetValue.java
@@ -1,0 +1,78 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.lookup;
+
+import com.google.inject.Inject;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+import org.graylog2.lookup.LookupTableService;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.string;
+
+public class LookupSetValue extends AbstractFunction<Object> {
+
+    public static final String NAME = "lookup_set_value";
+
+    private final ParameterDescriptor<String, LookupTableService.Function> lookupTableParam;
+    private final ParameterDescriptor<Object, Object> keyParam;
+    private final ParameterDescriptor<Object, Object> valueParam;
+
+    @Inject
+    public LookupSetValue(LookupTableService lookupTableService) {
+        lookupTableParam = string("lookup_table", LookupTableService.Function.class)
+                .description("The existing lookup table to use to set the given value")
+                .transform(tableName -> lookupTableService.newBuilder().lookupTable(tableName).build())
+                .build();
+        keyParam = object("key")
+                .description("The key to set in the lookup table")
+                .build();
+        valueParam = object("value")
+                .description("The single value that should be set into the lookup table")
+                .build();
+    }
+
+    @Override
+    public Object evaluate(FunctionArgs args, EvaluationContext context) {
+        Object key = keyParam.required(args, context);
+        if (key == null) {
+            return null;
+        }
+        LookupTableService.Function table = lookupTableParam.required(args, context);
+        if (table == null) {
+            return null;
+        }
+        Object value = valueParam.required(args, context);
+        if (value == null) {
+            return null;
+        }
+        return table.setValue(key, value).singleValue();
+    }
+
+    @Override
+    public FunctionDescriptor<Object> descriptor() {
+        return FunctionDescriptor.builder()
+                .name(NAME)
+                .description("Set a single value in the named lookup table. Returns the new value on success, null on failure.")
+                .params(lookupTableParam, keyParam, valueParam)
+                .returnType(Object.class)
+                .build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupStringList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/functions/lookup/LookupStringList.java
@@ -1,0 +1,89 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.pipelineprocessor.functions.lookup;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import com.google.inject.TypeLiteral;
+import org.graylog.plugins.pipelineprocessor.EvaluationContext;
+import org.graylog.plugins.pipelineprocessor.ast.functions.AbstractFunction;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionArgs;
+import org.graylog.plugins.pipelineprocessor.ast.functions.FunctionDescriptor;
+import org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor;
+import org.graylog2.lookup.LookupTableService;
+import org.graylog2.plugin.lookup.LookupResult;
+
+import java.util.List;
+
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.object;
+import static org.graylog.plugins.pipelineprocessor.ast.functions.ParameterDescriptor.string;
+
+public class LookupStringList extends AbstractFunction<List<String>> {
+
+    public static final String NAME = "lookup_string_list";
+
+    private final ParameterDescriptor<String, LookupTableService.Function> lookupTableParam;
+    private final ParameterDescriptor<Object, Object> keyParam;
+    @SuppressWarnings("rawtypes") // we cannot store class instances of generic types
+    private final ParameterDescriptor<List, List> defaultParam;
+
+    @Inject
+    public LookupStringList(LookupTableService lookupTableService) {
+        lookupTableParam = string("lookup_table", LookupTableService.Function.class)
+                .description("The existing lookup table to use to lookup the given key")
+                .transform(tableName -> lookupTableService.newBuilder().lookupTable(tableName).build())
+                .build();
+        keyParam = object("key")
+                .description("The key to lookup in the table")
+                .build();
+        defaultParam = ParameterDescriptor.type("default", List.class)
+                .description("The default list value that should be used if there is no lookup result")
+                .optional()
+                .build();
+    }
+
+    @Override
+    public List<String> evaluate(FunctionArgs args, EvaluationContext context) {
+        Object key = keyParam.required(args, context);
+        if (key == null) {
+            //noinspection unchecked
+            return defaultParam.optional(args, context).orElse(ImmutableList.of());
+        }
+        LookupTableService.Function table = lookupTableParam.required(args, context);
+        if (table == null) {
+            //noinspection unchecked
+            return defaultParam.optional(args, context).orElse(ImmutableList.of());
+        }
+        LookupResult result = table.lookup(key);
+        if (result == null || result.isEmpty()) {
+            //noinspection unchecked
+            return defaultParam.optional(args, context).orElse(ImmutableList.of());
+        }
+        return result.stringListValue();
+    }
+
+    @Override
+    public FunctionDescriptor<List<String>> descriptor() {
+        //noinspection unchecked
+        return FunctionDescriptor.<List<String>>builder()
+                .name(NAME)
+                .description("Looks up a string list value in the named lookup table.")
+                .params(lookupTableParam, keyParam, defaultParam)
+                .returnType((Class<? extends List<String>>) new TypeLiteral<List<String>>() {}.getRawType())
+                .build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTable.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTable.java
@@ -93,15 +93,22 @@ public abstract class LookupTable {
         cache().purge(LookupCacheKey.create(dataAdapter(), key));
         return result;
     }
+
     public LookupResult addStringList(@Nonnull Object key, @Nonnull List<String> value, boolean keepDuplicates) {
         final LookupResult result = dataAdapter().addStringList(key, value, keepDuplicates);
         cache().purge(LookupCacheKey.create(dataAdapter(), key));
         return result;
     }
+
     public LookupResult removeStringList(@Nonnull Object key, @Nonnull List<String> value) {
         final LookupResult result = dataAdapter().removeStringList(key, value);
         cache().purge(LookupCacheKey.create(dataAdapter(), key));
         return result;
+    }
+
+    public void clearKey(@Nonnull Object key) {
+        dataAdapter().clearKey(key);
+        cache().purge(LookupCacheKey.create(dataAdapter(), key));
     }
 
     @AutoValue.Builder

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTable.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTable.java
@@ -93,8 +93,8 @@ public abstract class LookupTable {
         cache().purge(LookupCacheKey.create(dataAdapter(), key));
         return result;
     }
-    public LookupResult addStringList(@Nonnull Object key, @Nonnull List<String> value, boolean doAppend) {
-        final LookupResult result = dataAdapter().addStringList(key, value, doAppend);
+    public LookupResult addStringList(@Nonnull Object key, @Nonnull List<String> value, boolean keepDuplicates) {
+        final LookupResult result = dataAdapter().addStringList(key, value, keepDuplicates);
         cache().purge(LookupCacheKey.create(dataAdapter(), key));
         return result;
     }

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTable.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTable.java
@@ -26,6 +26,7 @@ import org.graylog2.plugin.lookup.LookupResult;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.Streams.stream;
@@ -78,6 +79,28 @@ public abstract class LookupTable {
         if (result.isEmpty()) {
             return LookupResult.addDefaults(defaultSingleValue(), defaultMultiValue()).hasError(result.hasError()).build();
         }
+        return result;
+    }
+
+    public LookupResult setValue(@Nonnull Object key, @Nonnull Object value) {
+        final LookupResult result = dataAdapter().setValue(key, value);
+        cache().purge(LookupCacheKey.create(dataAdapter(), key));
+        return result;
+    }
+
+    public LookupResult setStringList(@Nonnull Object key, @Nonnull List<String> value) {
+        final LookupResult result = dataAdapter().setStringList(key, value);
+        cache().purge(LookupCacheKey.create(dataAdapter(), key));
+        return result;
+    }
+    public LookupResult addStringList(@Nonnull Object key, @Nonnull List<String> value, boolean doAppend) {
+        final LookupResult result = dataAdapter().addStringList(key, value, doAppend);
+        cache().purge(LookupCacheKey.create(dataAdapter(), key));
+        return result;
+    }
+    public LookupResult removeStringList(@Nonnull Object key, @Nonnull List<String> value) {
+        final LookupResult result = dataAdapter().removeStringList(key, value);
+        cache().purge(LookupCacheKey.create(dataAdapter(), key));
         return result;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
@@ -570,12 +570,12 @@ public class LookupTableService extends AbstractIdleService {
             }
             return lookupTable.setStringList(key, value);
         }
-        public LookupResult addStringList(@Nonnull Object key, @Nonnull List<String> value, boolean doAppend) {
+        public LookupResult addStringList(@Nonnull Object key, @Nonnull List<String> value, boolean keepDuplicates) {
             final LookupTable lookupTable = lookupTableService.getTable(lookupTableName);
             if (lookupTable == null) {
                 return LookupResult.withError();
             }
-            return lookupTable.addStringList(key, value, doAppend);
+            return lookupTable.addStringList(key, value, keepDuplicates);
         }
         public LookupResult removeStringList(@Nonnull Object key, @Nonnull List<String> value) {
             final LookupTable lookupTable = lookupTableService.getTable(lookupTableName);

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
@@ -47,6 +47,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -553,6 +554,35 @@ public class LookupTableService extends AbstractIdleService {
             }
 
             return result;
+        }
+
+        public LookupResult setValue(@Nonnull Object key, @Nonnull Object value) {
+            final LookupTable lookupTable = lookupTableService.getTable(lookupTableName);
+            if (lookupTable == null) {
+                return LookupResult.withError();
+            }
+            return lookupTable.setValue(key, value);
+        }
+        public LookupResult setStringList(@Nonnull Object key, @Nonnull List<String> value) {
+            final LookupTable lookupTable = lookupTableService.getTable(lookupTableName);
+            if (lookupTable == null) {
+                return LookupResult.withError();
+            }
+            return lookupTable.setStringList(key, value);
+        }
+        public LookupResult addStringList(@Nonnull Object key, @Nonnull List<String> value, boolean doAppend) {
+            final LookupTable lookupTable = lookupTableService.getTable(lookupTableName);
+            if (lookupTable == null) {
+                return LookupResult.withError();
+            }
+            return lookupTable.addStringList(key, value, doAppend);
+        }
+        public LookupResult removeStringList(@Nonnull Object key, @Nonnull List<String> value) {
+            final LookupTable lookupTable = lookupTableService.getTable(lookupTableName);
+            if (lookupTable == null) {
+                return LookupResult.withError();
+            }
+            return lookupTable.removeStringList(key, value);
         }
 
         public LookupTable getTable() {

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
@@ -565,6 +565,7 @@ public class LookupTableService extends AbstractIdleService {
             }
             return lookupTable.setValue(key, value);
         }
+
         public LookupResult setStringList(@Nonnull Object key, @Nonnull List<String> value) {
             final LookupTable lookupTable = lookupTableService.getTable(lookupTableName);
             if (lookupTable == null) {
@@ -572,6 +573,7 @@ public class LookupTableService extends AbstractIdleService {
             }
             return lookupTable.setStringList(key, value);
         }
+
         public LookupResult addStringList(@Nonnull Object key, @Nonnull List<String> value, boolean keepDuplicates) {
             final LookupTable lookupTable = lookupTableService.getTable(lookupTableName);
             if (lookupTable == null) {
@@ -579,12 +581,21 @@ public class LookupTableService extends AbstractIdleService {
             }
             return lookupTable.addStringList(key, value, keepDuplicates);
         }
+
         public LookupResult removeStringList(@Nonnull Object key, @Nonnull List<String> value) {
             final LookupTable lookupTable = lookupTableService.getTable(lookupTableName);
             if (lookupTable == null) {
                 return LookupResult.withError();
             }
             return lookupTable.removeStringList(key, value);
+        }
+
+        public void clearKey(@Nonnull Object key) {
+            final LookupTable lookupTable = lookupTableService.getTable(lookupTableName);
+            if (lookupTable == null) {
+                return;
+            }
+            lookupTable.clearKey(key);
         }
 
         public LookupTable getTable() {

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupTableService.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.lookup;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
@@ -459,7 +460,8 @@ public class LookupTableService extends AbstractIdleService {
     }
 
     @Nullable
-    private LookupTable getTable(String name) {
+    @VisibleForTesting
+    public LookupTable getTable(String name) {
         final LookupTable lookupTable = liveTables.get(name);
         if (lookupTable == null) {
             LOG.warn("Lookup table <{}> does not exist", name);

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupDataAdapter.java
@@ -173,12 +173,12 @@ public abstract class LookupDataAdapter extends AbstractIdleService {
     /**
      * Merge / append all list entries for the given key in a DataAdapter.
      * This is a method stub that can be implemented in DataAdapters that support this kind of data modification.
-     * @param key           The key that should be updated.
-     * @param listValue     The list values that should be merged / appended.
-     * @param doAppend      Controls whether new entries should be appended or merged into the list.
+     * @param key             The key that should be updated.
+     * @param listValue       The list values that should be merged / appended.
+     * @param keepDuplicates  Controls whether duplicated entries should be unified.
      * @return A LookupResult containing the updated list or an error
      */
-    public LookupResult addStringList(Object key, List<String> listValue, boolean doAppend) {
+    public LookupResult addStringList(Object key, List<String> listValue, boolean keepDuplicates) {
         return resultWithError;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupDataAdapter.java
@@ -26,6 +26,7 @@ import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -144,7 +145,53 @@ public abstract class LookupDataAdapter extends AbstractIdleService {
     }
     protected abstract LookupResult doGet(Object key);
 
+    @Deprecated
     public abstract void set(Object key, Object value);
+
+    /**
+     * Update a value for the given key in a DataAdapter.
+     * This is a method stub that can be implemented in DataAdapters that support this kind of data modification.
+     * @param key       The key that should be updated.
+     * @param value     The new value.
+     * @return A LookupResult containing the updated value or an error
+     */
+    public LookupResult setValue(Object key, Object value) {
+        return resultWithError;
+    }
+
+    /**
+     * Update all list entries for the given key in a DataAdapter.
+     * This is a method stub that can be implemented in DataAdapters that support this kind of data modification.
+     * @param key           The key that should be updated.
+     * @param listValue     The new list values.
+     * @return A LookupResult containing the updated list or an error
+     */
+    public LookupResult setStringList(Object key, List<String> listValue) {
+        return resultWithError;
+    }
+
+    /**
+     * Merge / append all list entries for the given key in a DataAdapter.
+     * This is a method stub that can be implemented in DataAdapters that support this kind of data modification.
+     * @param key           The key that should be updated.
+     * @param listValue     The list values that should be merged / appended.
+     * @param doAppend      Controls whether new entries should be appended or merged into the list.
+     * @return A LookupResult containing the updated list or an error
+     */
+    public LookupResult addStringList(Object key, List<String> listValue, boolean doAppend) {
+        return resultWithError;
+    }
+
+    /**
+     * Remove all matching list entries for the given key in a DataAdapter.
+     * This is a method stub that can be implemented in DataAdapters that support this kind of data modification.
+     * @param key           The key that should be updated.
+     * @param listValue     The list values that should be removed.
+     * @return A LookupResult containing the updated list or an error
+     */
+    public LookupResult removeStringList(Object key, List<String> listValue) {
+        return resultWithError;
+    }
 
     public LookupDataAdapterConfiguration getConfig() {
         return config;

--- a/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/lookup/LookupDataAdapter.java
@@ -193,6 +193,15 @@ public abstract class LookupDataAdapter extends AbstractIdleService {
         return resultWithError;
     }
 
+    /**
+     * Clear (remove) the given key from the lookup table.
+     *
+     * @param key The key that should be cleared.
+     */
+    public void clearKey(Object key) {
+        // This cannot be abstract due to backwards compatibility with version < 3.2.0
+    }
+
     public LookupDataAdapterConfiguration getConfig() {
         return config;
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/functions/FunctionsSnippetsTest.java
@@ -85,6 +85,7 @@ import org.graylog.plugins.pipelineprocessor.functions.json.IsJson;
 import org.graylog.plugins.pipelineprocessor.functions.json.JsonParse;
 import org.graylog.plugins.pipelineprocessor.functions.json.SelectJsonPath;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupAddStringList;
+import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupClearKey;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupRemoveStringList;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupSetStringList;
 import org.graylog.plugins.pipelineprocessor.functions.lookup.LookupSetValue;
@@ -167,9 +168,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -351,6 +354,7 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         functions.put(MetricCounterIncrement.NAME, new MetricCounterIncrement(metricRegistry));
 
         functions.put(LookupSetValue.NAME, new LookupSetValue(lookupTableService));
+        functions.put(LookupClearKey.NAME, new LookupClearKey(lookupTableService));
         functions.put(LookupSetStringList.NAME, new LookupSetStringList(lookupTableService));
         functions.put(LookupAddStringList.NAME, new LookupAddStringList(lookupTableService));
         functions.put(LookupRemoveStringList.NAME, new LookupRemoveStringList(lookupTableService));
@@ -1065,6 +1069,18 @@ public class FunctionsSnippetsTest extends BaseParserTest {
         verifyNoMoreInteractions(lookupTable);
 
         assertThat(message.getField("new_value")).isEqualTo(123);
+    }
+
+    @Test
+    public void lookupClearKey() {
+        // Stub method call to avoid having verifyNoMoreInteractions() fail
+        doNothing().when(lookupTable).clearKey(any());
+
+        final Rule rule = parser.parseRule(ruleForTest(), true);
+        evaluateRule(rule);
+
+        verify(lookupTable, times(1)).clearKey("key");
+        verifyNoMoreInteractions(lookupTable);
     }
 
     @Test

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lookupAddStringList.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lookupAddStringList.txt
@@ -1,0 +1,7 @@
+rule "lookupAddStringList"
+when
+  true
+then
+  let newValue = lookup_add_string_list("table", "key", ["foo", "bar"]);
+  set_field("new_value", newValue);
+end

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lookupClearKey.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lookupClearKey.txt
@@ -1,0 +1,6 @@
+rule "lookupClearKey"
+when
+  true
+then
+  lookup_clear_key("table", "key");
+end

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lookupRemoveStringList.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lookupRemoveStringList.txt
@@ -1,0 +1,7 @@
+rule "lookupAddStringList"
+when
+  true
+then
+  let newValue = lookup_remove_string_list("table", "key", ["foo", "bar"]);
+  set_field("new_value", newValue);
+end

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lookupSetStringList.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lookupSetStringList.txt
@@ -1,0 +1,7 @@
+rule "lookupSetStringList"
+when
+  true
+then
+  let newValue = lookup_set_string_list("table", "key", ["foo", "bar"]);
+  set_field("new_value", newValue);
+end

--- a/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lookupSetValue.txt
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/pipelineprocessor/functions/lookupSetValue.txt
@@ -1,0 +1,7 @@
+rule "lookupSetValue"
+when
+  true
+then
+  let newValue = lookup_set_value("table", "key", 123);
+  set_field("new_value", newValue);
+end


### PR DESCRIPTION
This adds the following pipeline functions:

- `lookup_set_value("table-name", "key", "value")`
- `lookup_set_string_list("table-name", "key", ["value1", "value2"])`
- `lookup_add_string_list("table-name", "key", ["value1", "value2"])`
- `lookup_remove_string_list("table-name", "key", ["remove1", "remove2"])`
- `lookup_clear_key("table-name", "key")`
