### PR TITLE
Do not parse empty value of from/to field as date for absolute ranges.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/AbsoluteTimeRangeSelector.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/AbsoluteTimeRangeSelector.jsx
@@ -60,7 +60,11 @@ export default class AbsoluteTimeRangeSelector extends React.Component {
 
   onBlur = (key, onChange) => {
     // eslint-disable-next-line react/destructuring-assignment
-    onChange(key, _formattedDateStringInUserTZ(this.state[key]).toISOString());
+    const value = this.state[key];
+
+    if (_isValidDateString(value)) {
+      onChange(key, _formattedDateStringInUserTZ(value).toISOString());
+    }
   };
 
   onChange = (key, value) => {
@@ -92,7 +96,7 @@ export default class AbsoluteTimeRangeSelector extends React.Component {
                      <Button disabled={disabled} onClick={() => _setDateTimeToNow('from', onChange)}>
                        <Icon name="magic" />
                      </Button>
-)}
+                   )}
                    bsStyle={_isValidDateString(from) ? null : 'error'}
                    required />
           </DatePicker>
@@ -120,7 +124,7 @@ export default class AbsoluteTimeRangeSelector extends React.Component {
                      <Button disabled={disabled} onClick={() => _setDateTimeToNow('to', onChange)}>
                        <Icon name="magic" />
                      </Button>
-)}
+                   )}
                    bsStyle={_isValidDateString(to) ? null : 'error'}
                    required />
           </DatePicker>

--- a/graylog2-web-interface/src/views/components/searchbar/AbsoluteTimeRangeSelector.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/AbsoluteTimeRangeSelector.test.jsx
@@ -1,0 +1,32 @@
+// @flow strict
+import * as React from 'react';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import * as Immutable from 'immutable';
+
+import AbsoluteTimeRangeSelector from './AbsoluteTimeRangeSelector';
+
+describe('AbsoluteTimeRangeSelector', () => {
+  afterEach(cleanup);
+  it('does not try to parse an empty date in from field', () => {
+    const value = Immutable.Map({ from: '2020-01-16 10:04:30.329', to: '2020-01-16 12:04:30.329' });
+    const onChange = jest.fn();
+    const { getByDisplayValue } = render(<AbsoluteTimeRangeSelector value={value} onChange={onChange} />);
+    const fromDate = getByDisplayValue('2020-01-16 10:04:30.329');
+
+    fireEvent.change(fromDate, { target: { value: '' } });
+    fireEvent.blur(fromDate);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+  it('does not try to parse an empty date in to field', () => {
+    const value = Immutable.Map({ from: '2020-01-16 10:04:30.329', to: '2020-01-16 12:04:30.329' });
+    const onChange = jest.fn();
+    const { getByDisplayValue } = render(<AbsoluteTimeRangeSelector value={value} onChange={onChange} />);
+    const toDate = getByDisplayValue('2020-01-16 12:04:30.329');
+
+    fireEvent.change(toDate, { target: { value: '' } });
+    fireEvent.blur(toDate);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, emptying one of the date fields of the absolute time
range inputs resulted in an error being logged to the browser console,
because it was tried to parse as date.

This PR is checking if the supplied new value is a valid date string
before parsing it.

Fixes #7190.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.