### PR TITLE
Add mapping of stream ids in view content packs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Filter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Filter.java
@@ -41,6 +41,14 @@ public interface Filter {
     @JsonProperty("filters")
     Set<Filter> filters();
 
+    Builder toGenericBuilder();
+
+    interface Builder {
+        public abstract Builder filters(Set<Filter> filters);
+
+        public abstract Filter build();
+    }
+
     @JsonAutoDetect
     class Fallback implements Filter {
         @JsonProperty
@@ -76,6 +84,11 @@ public interface Filter {
         @Override
         public int hashCode() {
             return Objects.hash(type);
+        }
+
+        @Override
+        public Builder toGenericBuilder() {
+            return null;
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
@@ -32,6 +32,10 @@ import org.graylog.plugins.views.search.engine.BackendQuery;
 import org.graylog.plugins.views.search.engine.EmptyTimeRange;
 import org.graylog.plugins.views.search.filter.AndFilter;
 import org.graylog.plugins.views.search.filter.StreamFilter;
+import org.graylog2.contentpacks.ContentPackable;
+import org.graylog2.contentpacks.EntityDescriptorIds;
+import org.graylog2.contentpacks.model.ModelTypes;
+import org.graylog2.contentpacks.model.entities.QueryEntity;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +47,7 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
@@ -53,7 +58,7 @@ import static java.util.stream.Collectors.toSet;
 @JsonAutoDetect
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonDeserialize(builder = Query.Builder.class)
-public abstract class Query {
+public abstract class Query implements ContentPackable<QueryEntity> {
     private static final Logger LOG = LoggerFactory.getLogger(Query.class);
 
     @JsonProperty
@@ -241,5 +246,36 @@ public abstract class Query {
         public Query build() {
             return autoBuild();
         }
+    }
+
+    private Filter mappedFilter(EntityDescriptorIds entityDescriptorIds) {
+        return Optional.ofNullable(filter())
+                .map(optFilter -> {
+                    Set<Filter> newFilters = optFilter.filters().stream()
+                            .map(filter -> {
+                                if (filter.type().matches(StreamFilter.NAME)) {
+                                    final StreamFilter streamFilter = (StreamFilter) filter;
+                                    final String streamId = entityDescriptorIds.
+                                            getOrThrow(streamFilter.streamId(), ModelTypes.STREAM_V1);
+                                    return streamFilter.toBuilder().streamId(streamId).build();
+                                }
+                                return filter;
+                            }).collect(toSet());
+                    return optFilter.toGenericBuilder().filters(newFilters).build();
+                })
+                .orElse(null);
+    }
+
+    @Override
+    public QueryEntity toContentPackEntity(EntityDescriptorIds entityDescriptorIds) {
+        return QueryEntity.builder()
+                .searchTypes(searchTypes().stream().map(s -> s.toContentPackEntity(entityDescriptorIds))
+                        .collect(Collectors.toSet()))
+                .filter(mappedFilter(entityDescriptorIds))
+                .query(query())
+                .id(id())
+                .globalOverride(globalOverride().orElse(null))
+                .timerange(timerange())
+                .build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
@@ -248,7 +248,8 @@ public abstract class Query implements ContentPackable<QueryEntity> {
         }
     }
 
-    private Filter mappedFilter(EntityDescriptorIds entityDescriptorIds) {
+    // This code assumes that we only add streams via gui shallow.
+    private Filter shallowMappedFilter(EntityDescriptorIds entityDescriptorIds) {
         return Optional.ofNullable(filter())
                 .map(optFilter -> {
                     Set<Filter> newFilters = optFilter.filters().stream()
@@ -271,7 +272,7 @@ public abstract class Query implements ContentPackable<QueryEntity> {
         return QueryEntity.builder()
                 .searchTypes(searchTypes().stream().map(s -> s.toContentPackEntity(entityDescriptorIds))
                         .collect(Collectors.toSet()))
-                .filter(mappedFilter(entityDescriptorIds))
+                .filter(shallowMappedFilter(entityDescriptorIds))
                 .query(query())
                 .id(id())
                 .globalOverride(globalOverride().orElse(null))

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
@@ -248,13 +248,14 @@ public abstract class Query implements ContentPackable<QueryEntity> {
         }
     }
 
-    // This code assumes that we only add streams via gui shallow.
+    // TODO: This code assumes that we only use shallow filters for streams.
+    //       If this ever changes, we need to implement a mapper that can handle filter trees.
     private Filter shallowMappedFilter(EntityDescriptorIds entityDescriptorIds) {
         return Optional.ofNullable(filter())
                 .map(optFilter -> {
                     Set<Filter> newFilters = optFilter.filters().stream()
                             .map(filter -> {
-                                if (filter.type().matches(StreamFilter.NAME)) {
+                                if (filter.type().equals(StreamFilter.NAME)) {
                                     final StreamFilter streamFilter = (StreamFilter) filter;
                                     final String streamId = entityDescriptorIds.
                                             getOrThrow(streamFilter.streamId(), ModelTypes.STREAM_V1);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
@@ -154,7 +154,7 @@ public abstract class Search implements ContentPackable<SearchEntity> {
         return Builder.create().parameters(of()).queries(ImmutableSet.<Query>builder().build());
     }
 
-    Set<String> usedStreamIds() {
+    public Set<String> usedStreamIds() {
         final Set<String> queryStreamIds = queries().stream()
                 .map(Query::usedStreamIds)
                 .reduce(Collections.emptySet(), Sets::union);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableSet.of;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
@@ -208,7 +209,9 @@ public abstract class Search implements ContentPackable<SearchEntity> {
     @Override
     public SearchEntity toContentPackEntity(EntityDescriptorIds entityDescriptorIds) {
         final SearchEntity.Builder searchEntityBuilder = SearchEntity.builder()
-                .queries(this.queries())
+                .queries(ImmutableSet.copyOf(this.queries().stream()
+                        .map(query -> query.toContentPackEntity(entityDescriptorIds))
+                        .collect(Collectors.toSet())))
                 .parameters(this.parameters())
                 .requires(this.requires())
                 .createdAt(this.createdAt());

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchType.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchType.java
@@ -28,6 +28,7 @@ import org.graylog.plugins.views.search.engine.BackendQuery;
 import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
 import org.graylog2.contentpacks.ContentPackable;
 import org.graylog2.contentpacks.EntityDescriptorIds;
+import org.graylog2.contentpacks.exceptions.ContentPackException;
 import org.graylog2.contentpacks.model.ModelTypes;
 import org.graylog2.contentpacks.model.entities.EntityDescriptor;
 import org.graylog2.contentpacks.model.entities.SearchTypeEntity;
@@ -209,9 +210,9 @@ public interface SearchType extends ContentPackable<SearchTypeEntity> {
 
     default Set<String> mappedStreams(EntityDescriptorIds entityDescriptorIds) {
         return streams().stream()
-                .map(s -> entityDescriptorIds.get(EntityDescriptor.create(s, ModelTypes.STREAM_V1)))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
+                .map(streamId -> entityDescriptorIds.get(EntityDescriptor.create(streamId, ModelTypes.STREAM_V1)))
+                .map(optionalStreamId -> optionalStreamId.orElseThrow(() ->
+                        new ContentPackException("Did not find matching stream id")))
                 .collect(Collectors.toSet());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/filter/AndFilter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/filter/AndFilter.java
@@ -50,8 +50,15 @@ public abstract class AndFilter implements Filter {
                 .build();
     }
 
+    public abstract Builder toBuilder();
+
+    @Override
+    public Filter.Builder toGenericBuilder() {
+        return toBuilder();
+    }
+
     @AutoValue.Builder
-    public abstract static class Builder {
+    public abstract static class Builder implements Filter.Builder {
         @JsonProperty
         public abstract Builder type(String type);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/filter/OrFilter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/filter/OrFilter.java
@@ -50,8 +50,15 @@ public abstract class OrFilter implements Filter {
                 .build();
     }
 
+    public abstract Builder toBuilder();
+
+    @Override
+    public Filter.Builder toGenericBuilder() {
+        return toBuilder();
+    }
+
     @AutoValue.Builder
-    public abstract static class Builder {
+    public abstract static class Builder implements Filter.Builder {
         @JsonProperty
         public abstract Builder type(String type);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/filter/QueryStringFilter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/filter/QueryStringFilter.java
@@ -48,8 +48,15 @@ public abstract class QueryStringFilter implements Filter {
     @JsonProperty("query")
     public abstract String query();
 
+    public abstract Builder toBuilder();
+
+    @Override
+    public Filter.Builder toGenericBuilder() {
+        return toBuilder();
+    }
+
     @AutoValue.Builder
-    public abstract static class Builder {
+    public abstract static class Builder implements Filter.Builder {
 
         @JsonCreator
         public static Builder create() {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/filter/StreamFilter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/filter/StreamFilter.java
@@ -56,6 +56,8 @@ public abstract class StreamFilter implements Filter {
         return Builder.create();
     }
 
+    public abstract Builder toBuilder();
+
     public static StreamFilter ofId(String id) {
         return builder().streamId(id).build();
     }
@@ -69,8 +71,13 @@ public abstract class StreamFilter implements Filter {
                 .build();
     }
 
+    @Override
+    public Filter.Builder toGenericBuilder() {
+        return toBuilder();
+    }
+
     @AutoValue.Builder
-    public abstract static class Builder {
+    public abstract static class Builder implements Filter.Builder {
         @JsonProperty
         public abstract Builder type(String type);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/MessageList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/MessageList.java
@@ -30,6 +30,9 @@ import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
 import org.graylog.plugins.views.search.Filter;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.engine.BackendQuery;
+import org.graylog2.contentpacks.EntityDescriptorIds;
+import org.graylog2.contentpacks.model.entities.MessageListEntity;
+import org.graylog2.contentpacks.model.entities.SearchTypeEntity;
 import org.graylog2.decorators.Decorator;
 import org.graylog2.decorators.DecoratorImpl;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
@@ -213,5 +216,22 @@ public abstract class MessageList implements SearchType {
 
             public abstract Result build();
         }
+    }
+
+    @Override
+    public SearchTypeEntity toContentPackEntity(EntityDescriptorIds entityDescriptorIds) {
+        return MessageListEntity.builder()
+                .decorators(decorators())
+                .streams(mappedStreams(entityDescriptorIds))
+                .timerange(timerange().orElse(null))
+                .limit(limit())
+                .offset(offset())
+                .filter(filter())
+                .id(id())
+                .name(name().orElse(null))
+                .query(query().orElse(null))
+                .type(type())
+                .sort(sort())
+                .build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/events/EventList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/events/EventList.java
@@ -28,6 +28,9 @@ import org.graylog.plugins.views.search.Filter;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.engine.BackendQuery;
 import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
+import org.graylog2.contentpacks.EntityDescriptorIds;
+import org.graylog2.contentpacks.model.entities.EventListEntity;
+import org.graylog2.contentpacks.model.entities.SearchTypeEntity;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -139,5 +142,18 @@ public abstract class EventList implements SearchType {
 
             public abstract Result build();
         }
+    }
+
+    @Override
+    public SearchTypeEntity toContentPackEntity(EntityDescriptorIds entityDescriptorIds) {
+        return EventListEntity.builder()
+                .streams(mappedStreams(entityDescriptorIds))
+                .filter(filter())
+                .id(id())
+                .name(name().orElse(null))
+                .query(query().orElse(null))
+                .type(type())
+                .timerange(timerange().orElse(null))
+                .build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/WidgetDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/WidgetDTO.java
@@ -25,6 +25,8 @@ import org.graylog.autovalue.WithBeanGetter;
 import org.graylog.plugins.views.search.engine.BackendQuery;
 import org.graylog2.contentpacks.ContentPackable;
 import org.graylog2.contentpacks.EntityDescriptorIds;
+import org.graylog2.contentpacks.model.ModelTypes;
+import org.graylog2.contentpacks.model.entities.EntityDescriptor;
 import org.graylog2.contentpacks.model.entities.WidgetEntity;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
@@ -32,6 +34,7 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @AutoValue
 @JsonDeserialize(builder = WidgetDTO.Builder.class)
@@ -110,11 +113,16 @@ public abstract class WidgetDTO implements ContentPackable<WidgetEntity> {
 
     @Override
     public WidgetEntity toContentPackEntity(EntityDescriptorIds entityDescriptorIds) {
+        Set<String> mappedStreams = streams().stream().map(streamId ->
+                entityDescriptorIds.get(EntityDescriptor.create(streamId, ModelTypes.STREAM_V1)))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toSet());
         final WidgetEntity.Builder builder = WidgetEntity.builder()
                 .id(this.id())
                 .config(this.config())
                 .filter(this.filter())
-                .streams(this.streams())
+                .streams(mappedStreams)
                 .type(this.type());
         if (this.query().isPresent()) {
             builder.query(this.query().get());

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPacksModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/ContentPacksModule.java
@@ -34,6 +34,9 @@ import org.graylog2.contentpacks.facades.SidecarCollectorFacade;
 import org.graylog2.contentpacks.facades.StreamFacade;
 import org.graylog2.contentpacks.facades.UrlWhitelistFacade;
 import org.graylog2.contentpacks.jersey.ModelIdParamConverter;
+import org.graylog2.contentpacks.model.entities.EventListEntity;
+import org.graylog2.contentpacks.model.entities.MessageListEntity;
+import org.graylog2.contentpacks.model.entities.PivotEntity;
 import org.graylog2.plugin.PluginModule;
 
 public class ContentPacksModule extends PluginModule {
@@ -63,5 +66,9 @@ public class ContentPacksModule extends PluginModule {
 
         addConstraintChecker(GraylogVersionConstraintChecker.class);
         addConstraintChecker(PluginVersionConstraintChecker.class);
+
+        registerJacksonSubtype(MessageListEntity.class);
+        registerJacksonSubtype(PivotEntity.class);
+        registerJacksonSubtype(EventListEntity.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/ViewFacade.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/ViewFacade.java
@@ -174,10 +174,7 @@ public Stream<ViewDTO> getNativeViews() {
                 orElseThrow(() -> new NoSuchElementException("Could not find view with id " + modelId.id()));
         final Search search = searchDbService.get(viewDTO.searchId()).
                 orElseThrow(() -> new NoSuchElementException("Could not find search with id " + viewDTO.searchId()));
-        final Stream<String> usedStreamIds = search.queries().stream().flatMap(q -> q.usedStreamIds().stream());
-        final Stream<String> effectiveStreams = search.queries().stream()
-                .flatMap(q -> q.searchTypes().stream().flatMap(s -> s.effectiveStreams().stream()));
-        Stream.concat(usedStreamIds, effectiveStreams).map(s -> EntityDescriptor.create(s, ModelTypes.STREAM_V1))
+        search.usedStreamIds().stream().map(s -> EntityDescriptor.create(s, ModelTypes.STREAM_V1))
                 .forEach(streamDescriptor -> mutableGraph.putEdge(entityDescriptor, streamDescriptor));
         return ImmutableGraph.copyOf(mutableGraph);
     }
@@ -201,12 +198,7 @@ public Stream<ViewDTO> getNativeViews() {
         mutableGraph.addNode(entity);
 
         final ViewEntity viewEntity = objectMapper.convertValue(entity.data(), ViewEntity.class);
-        final Stream<String> usedStreams = viewEntity.search().queries().stream()
-                .flatMap(q -> q.usedStreamIds().stream());
-        final Stream<String> effectiveStreams = viewEntity.search().queries().stream()
-                .flatMap(q -> q.searchTypes().stream().flatMap(s -> s.effectiveStreams().stream()));
-        Stream.concat(usedStreams, effectiveStreams)
-                .distinct()
+        viewEntity.search().usedStreamIds().stream()
                 .map(s -> EntityDescriptor.create(s, ModelTypes.STREAM_V1))
                 .map(entities::get)
                 .filter(Objects::nonNull)

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/EventListEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/EventListEntity.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.contentpacks.model.entities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/EventListEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/EventListEntity.java
@@ -1,0 +1,96 @@
+package org.graylog2.contentpacks.model.entities;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import org.graylog.plugins.views.search.Filter;
+import org.graylog.plugins.views.search.SearchType;
+import org.graylog.plugins.views.search.engine.BackendQuery;
+import org.graylog.plugins.views.search.searchtypes.events.EventList;
+import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
+import org.graylog2.contentpacks.model.entities.references.ValueReference;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+@AutoValue
+@JsonTypeName(EventListEntity.NAME)
+@JsonDeserialize(builder = EventListEntity.Builder.class)
+public abstract class EventListEntity implements SearchTypeEntity {
+    public static final String NAME = "events";
+
+    @Override
+    public abstract String type();
+
+    @Override
+    @Nullable
+    @JsonProperty
+    public abstract String id();
+
+    @Nullable
+    @Override
+    public abstract Filter filter();
+
+    @JsonCreator
+    public static Builder builder() {
+        return new AutoValue_EventListEntity.Builder()
+                .type(NAME)
+                .streams(Collections.emptySet());
+    }
+
+    public abstract EventListEntity.Builder toBuilder();
+
+    @Override
+    public SearchTypeEntity.Builder toGenericBuilder() {
+        return toBuilder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder implements SearchTypeEntity.Builder{
+        @JsonCreator
+        public static Builder createDefault() {
+            return builder()
+                    .streams(Collections.emptySet());
+        }
+
+        @JsonProperty
+        public abstract Builder type(String type);
+
+        @JsonProperty
+        public abstract Builder id(String id);
+
+        @JsonProperty
+        public abstract Builder name(@Nullable String name);
+
+        @JsonProperty
+        public abstract Builder filter(@Nullable Filter filter);
+
+        @JsonProperty
+        public abstract Builder query(@Nullable BackendQuery query);
+
+        @JsonProperty
+        public abstract Builder timerange(@Nullable DerivedTimeRange timeRange);
+
+        @JsonProperty
+        public abstract Builder streams(Set<String> streams);
+
+        public abstract EventListEntity build();
+    }
+
+    @Override
+    public SearchType toNativeEntity(Map<String, ValueReference> parameters, Map<EntityDescriptor, Object> nativeEntities) {
+        return EventList.builder()
+                .type(type())
+                .streams(mappedStreams(nativeEntities))
+                .id(id())
+                .filter(filter())
+                .query(query().orElse(null))
+                .timerange(timerange().orElse(null))
+                .name(name().orElse(null))
+                .build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/MessageListEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/MessageListEntity.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.contentpacks.model.entities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/MessageListEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/MessageListEntity.java
@@ -1,0 +1,157 @@
+package org.graylog2.contentpacks.model.entities;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import org.graylog.plugins.views.search.Filter;
+import org.graylog.plugins.views.search.SearchType;
+import org.graylog.plugins.views.search.engine.BackendQuery;
+import org.graylog.plugins.views.search.searchtypes.MessageList;
+import org.graylog.plugins.views.search.searchtypes.Sort;
+import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
+import org.graylog.plugins.views.search.timeranges.OffsetRange;
+import org.graylog2.contentpacks.model.entities.references.ValueReference;
+import org.graylog2.decorators.Decorator;
+import org.graylog2.decorators.DecoratorImpl;
+import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
+import org.graylog2.plugin.indexer.searches.timeranges.KeywordRange;
+import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+@AutoValue
+@JsonTypeName(MessageListEntity.NAME)
+@JsonDeserialize(builder = MessageListEntity.Builder.class)
+public abstract class MessageListEntity implements SearchTypeEntity {
+    public static final String NAME = "messages";
+
+    @Override
+    public abstract String type();
+
+    @Override
+    @Nullable
+    @JsonProperty
+    public abstract String id();
+
+    @JsonProperty
+    public abstract Optional<String> name();
+
+    @Nullable
+    @Override
+    public abstract Filter filter();
+
+    @JsonProperty
+    public abstract int limit();
+
+    @JsonProperty
+    public abstract int offset();
+
+    @Nullable
+    public abstract List<Sort> sort();
+
+    @JsonProperty
+    public abstract List<Decorator> decorators();
+
+    @JsonCreator
+    public static Builder builder() {
+        return new AutoValue_MessageListEntity.Builder()
+                .type(NAME)
+                .limit(150)
+                .offset(0)
+                .streams(Collections.emptySet())
+                .decorators(Collections.emptyList());
+    }
+
+    public abstract Builder toBuilder();
+
+    @Override
+    public Builder toGenericBuilder() {
+        return toBuilder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder implements SearchTypeEntity.Builder {
+        @JsonCreator
+        public static Builder createDefault() {
+            return builder()
+                    .streams(Collections.emptySet());
+        }
+
+        @JsonProperty
+        public abstract Builder type(String type);
+
+        @JsonProperty
+        public abstract Builder id(@Nullable String id);
+
+        @JsonProperty
+        public abstract Builder name(@Nullable String name);
+
+        @JsonProperty
+        public abstract Builder filter(@Nullable Filter filter);
+
+        @JsonProperty
+        @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "type", visible = true)
+        @JsonSubTypes({
+                @JsonSubTypes.Type(name = AbsoluteRange.ABSOLUTE, value = AbsoluteRange.class),
+                @JsonSubTypes.Type(name = RelativeRange.RELATIVE, value = RelativeRange.class),
+                @JsonSubTypes.Type(name = KeywordRange.KEYWORD, value = KeywordRange.class),
+                @JsonSubTypes.Type(name = OffsetRange.OFFSET, value = OffsetRange.class)
+        })
+        public Builder timerange(@Nullable TimeRange timerange) {
+            return timerange(timerange == null ? null : DerivedTimeRange.of(timerange));
+        }
+        public abstract Builder timerange(@Nullable DerivedTimeRange timerange);
+
+        @JsonProperty
+        public abstract Builder query(@Nullable BackendQuery query);
+
+        @JsonProperty
+        public abstract Builder streams(Set<String> streams);
+
+        @JsonProperty
+        public abstract Builder limit(int limit);
+
+        @JsonProperty
+        public abstract Builder offset(int offset);
+
+        @JsonProperty
+        public abstract Builder sort(@Nullable List<Sort> sort);
+
+        @JsonProperty("decorators")
+        public Builder _decorators(List<DecoratorImpl> decorators) {
+            return decorators(new ArrayList<>(decorators));
+        }
+
+        public abstract Builder decorators(List<Decorator> decorators);
+
+        public abstract MessageListEntity build();
+    }
+
+    @Override
+    public SearchType toNativeEntity(Map<String, ValueReference> parameters, Map<EntityDescriptor, Object> nativeEntities) {
+       return MessageList.builder()
+       .limit(limit())
+       .streams(mappedStreams(nativeEntities))
+       .id(id())
+       .offset(offset())
+       .decorators(decorators())
+       .timerange(timerange().orElse(null))
+       .filter(filter())
+       .name(name().orElse(null))
+       .type(type())
+       .query(query().orElse(null))
+       .sort(sort())
+       .build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/PivotEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/PivotEntity.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.contentpacks.model.entities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/PivotEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/PivotEntity.java
@@ -1,55 +1,40 @@
-/**
- * This file is part of Graylog.
- *
- * Graylog is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * Graylog is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
- */
-package org.graylog.plugins.views.search.searchtypes.pivot;
+package org.graylog2.contentpacks.model.entities;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
-import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
 import org.graylog.plugins.views.search.Filter;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.engine.BackendQuery;
-import org.graylog2.contentpacks.EntityDescriptorIds;
-import org.graylog2.contentpacks.model.entities.PivotEntity;
-import org.graylog2.contentpacks.model.entities.SearchTypeEntity;
+import org.graylog.plugins.views.search.searchtypes.pivot.BucketSpec;
+import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
+import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
+import org.graylog.plugins.views.search.searchtypes.pivot.SortSpec;
+import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
+import org.graylog.plugins.views.search.timeranges.OffsetRange;
+import org.graylog2.contentpacks.model.entities.references.ValueReference;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.KeywordRange;
-import org.graylog.plugins.views.search.timeranges.OffsetRange;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableList.of;
 
 @AutoValue
-@JsonTypeName(Pivot.NAME)
-@JsonDeserialize(builder = Pivot.Builder.class)
-public abstract class Pivot implements SearchType {
+@JsonTypeName(PivotEntity.NAME)
+@JsonDeserialize(builder = PivotEntity.Builder.class)
+public abstract class PivotEntity implements SearchTypeEntity {
     public static final String NAME = "pivot";
 
     @Override
@@ -85,12 +70,12 @@ public abstract class Pivot implements SearchType {
     public abstract Builder toBuilder();
 
     @Override
-    public SearchType applyExecutionContext(ObjectMapper objectMapper, JsonNode state) {
-        return this;
+    public Builder toGenericBuilder() {
+        return toBuilder();
     }
 
     public static Builder builder() {
-        return new AutoValue_Pivot.Builder()
+        return new AutoValue_PivotEntity.Builder()
                 .type(NAME)
                 .rowGroups(of())
                 .columnGroups(of())
@@ -99,7 +84,7 @@ public abstract class Pivot implements SearchType {
     }
 
     @AutoValue.Builder
-    public static abstract class Builder {
+    public static abstract class Builder implements SearchTypeEntity.Builder {
         @JsonCreator
         public static Builder createDefault() {
             return builder()
@@ -153,24 +138,24 @@ public abstract class Pivot implements SearchType {
         @JsonProperty
         public abstract Builder streams(Set<String> streams);
 
-        public abstract Pivot build();
+        public abstract PivotEntity build();
     }
 
     @Override
-    public SearchTypeEntity toContentPackEntity(EntityDescriptorIds entityDescriptorIds) {
-        return PivotEntity.builder()
-                .sort(sort())
-                .streams(mappedStreams(entityDescriptorIds))
-                .timerange(timerange().orElse(null))
-                .columnGroups(columnGroups())
-                .rowGroups(rowGroups())
-                .filter(filter())
-                .query(query().orElse(null))
-                .id(id())
+    public SearchType toNativeEntity(Map<String, ValueReference> parameters, Map<EntityDescriptor, Object> nativeEntities) {
+        return Pivot.builder()
+                .streams(mappedStreams(nativeEntities))
                 .name(name().orElse(null))
-                .rollup(rollup())
+                .sort(sort())
+                .timerange(timerange().orElse(null))
+                .rowGroups(rowGroups())
+                .columnGroups(columnGroups())
                 .series(series())
+                .rollup(rollup())
+                .query(query().orElse(null))
+                .filter(filter())
                 .type(type())
+                .id(id())
                 .build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/QueryEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/QueryEntity.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.contentpacks.model.entities;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/QueryEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/QueryEntity.java
@@ -130,7 +130,8 @@ public abstract class QueryEntity implements NativeEntityConverter<Query> {
         }
     }
 
-    private Filter mappedFilter(Map<EntityDescriptor, Object> nativeEntities) {
+    // This code assumes that we only add streams via gui shallow.
+    private Filter shallowMappedFilter(Map<EntityDescriptor, Object> nativeEntities) {
        return Optional.ofNullable(filter())
                .map(optFilter -> {
                   Set<Filter> newFilters = optFilter.filters().stream()
@@ -159,7 +160,7 @@ public abstract class QueryEntity implements NativeEntityConverter<Query> {
                 .searchTypes(searchTypes().stream().map(s -> s.toNativeEntity(parameters, nativeEntities))
                         .collect(Collectors.toSet()))
                 .query(query())
-                .filter(mappedFilter(nativeEntities))
+                .filter(shallowMappedFilter(nativeEntities))
                 .timerange(timerange())
                 .globalOverride(globalOverride().orElse(null))
                 .build();

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/QueryEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/QueryEntity.java
@@ -1,0 +1,151 @@
+package org.graylog2.contentpacks.model.entities;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.graph.Traverser;
+import org.graylog.plugins.views.search.Filter;
+import org.graylog.plugins.views.search.GlobalOverride;
+import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.engine.BackendQuery;
+import org.graylog.plugins.views.search.filter.StreamFilter;
+import org.graylog2.contentpacks.NativeEntityConverter;
+import org.graylog2.contentpacks.exceptions.ContentPackException;
+import org.graylog2.contentpacks.model.ModelTypes;
+import org.graylog2.contentpacks.model.entities.references.ValueReference;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+import org.graylog2.plugin.streams.Stream;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.collect.ImmutableSortedSet.of;
+import static java.util.stream.Collectors.toSet;
+
+@AutoValue
+@JsonAutoDetect
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonDeserialize(builder = QueryEntity.Builder.class)
+public abstract class QueryEntity implements NativeEntityConverter<Query> {
+
+    @JsonProperty
+    public abstract String id();
+
+    @JsonProperty
+    public abstract TimeRange timerange();
+
+    @Nullable
+    @JsonProperty
+    public abstract Filter filter();
+
+    @Nonnull
+    @JsonProperty
+    public abstract BackendQuery query();
+
+    @JsonIgnore
+    public abstract Optional<GlobalOverride> globalOverride();
+
+    @Nonnull
+    @JsonProperty("search_types")
+    public abstract ImmutableSet<SearchTypeEntity> searchTypes();
+
+    public Set<String> usedStreamIds() {
+        return Optional.ofNullable(filter())
+                .map(optFilter -> {
+                    @SuppressWarnings("UnstableApiUsage") final Traverser<Filter> filterTraverser = Traverser.forTree(filter -> firstNonNull(filter.filters(), Collections.emptySet()));
+                    return StreamSupport.stream(filterTraverser.breadthFirst(optFilter).spliterator(), false)
+                            .filter(filter -> filter instanceof StreamFilter)
+                            .map(streamFilter -> ((StreamFilter) streamFilter).streamId())
+                            .filter(Objects::nonNull)
+                            .collect(toSet());
+                })
+                .orElse(Collections.emptySet());
+    }
+
+    public abstract Builder toBuilder();
+
+    public static Builder builder() {
+        return Builder.createWithDefaults();
+    }
+
+    @AutoValue.Builder
+    @JsonPOJOBuilder(withPrefix = "")
+    public abstract static class Builder {
+        @JsonProperty
+        public abstract Builder id(String id);
+
+        @JsonProperty
+        public abstract Builder timerange(TimeRange timerange);
+
+        @JsonProperty
+        public abstract Builder filter(Filter filter);
+
+        @JsonProperty
+        public abstract Builder query(BackendQuery query);
+
+        public abstract Builder globalOverride(@Nullable GlobalOverride globalOverride);
+
+        @JsonProperty("search_types")
+        public abstract Builder searchTypes(@Nullable Set<SearchTypeEntity> searchTypes);
+
+        abstract QueryEntity autoBuild();
+
+        @JsonCreator
+        static Builder createWithDefaults() {
+            return new AutoValue_QueryEntity.Builder().searchTypes(of());
+        }
+
+        public QueryEntity build() {
+            return autoBuild();
+        }
+    }
+
+    private Filter mappedFilter(Map<EntityDescriptor, Object> nativeEntities) {
+       return Optional.ofNullable(filter())
+               .map(optFilter -> {
+                  Set<Filter> newFilters = optFilter.filters().stream()
+                          .map(filter -> {
+                              if (filter.type().matches(StreamFilter.NAME)) {
+                                  final StreamFilter streamFilter = (StreamFilter) filter;
+                                  final Stream stream = (Stream) nativeEntities.get(
+                                          EntityDescriptor.create(streamFilter.streamId(), ModelTypes.STREAM_V1));
+                                  if (Objects.isNull(stream)) {
+                                      throw new ContentPackException("Could not find matching stream id: " +
+                                              streamFilter.streamId());
+                                  }
+                                  return streamFilter.toBuilder().streamId(stream.getId()).build();
+                              }
+                              return filter;
+                          }).collect(Collectors.toSet());
+                  return optFilter.toGenericBuilder().filters(newFilters).build();
+               })
+               .orElse(null);
+    }
+
+    @Override
+    public Query toNativeEntity(Map<String, ValueReference> parameters, Map<EntityDescriptor, Object> nativeEntities) {
+        return Query.builder()
+                .id(id())
+                .searchTypes(searchTypes().stream().map(s -> s.toNativeEntity(parameters, nativeEntities))
+                        .collect(Collectors.toSet()))
+                .query(query())
+                .filter(mappedFilter(nativeEntities))
+                .timerange(timerange())
+                .globalOverride(globalOverride().orElse(null))
+                .build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/QueryEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/QueryEntity.java
@@ -130,7 +130,8 @@ public abstract class QueryEntity implements NativeEntityConverter<Query> {
         }
     }
 
-    // This code assumes that we only add streams via gui shallow.
+    // TODO: This code assumes that we only use shallow filters for streams.
+    //       If this ever changes, we need to implement a mapper that can handle filter trees.
     private Filter shallowMappedFilter(Map<EntityDescriptor, Object> nativeEntities) {
        return Optional.ofNullable(filter())
                .map(optFilter -> {

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/SearchEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/SearchEntity.java
@@ -23,9 +23,11 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import org.graylog.plugins.views.search.Parameter;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.Search;
+import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.views.PluginMetadataSummary;
 import org.graylog2.contentpacks.NativeEntityConverter;
 import org.graylog2.contentpacks.exceptions.ContentPackException;
@@ -39,6 +41,7 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableSet.of;
@@ -100,6 +103,18 @@ public abstract class SearchEntity implements NativeEntityConverter<Search> {
                     .parameters(of());
         }
 
+    }
+
+    public Set<String> usedStreamIds() {
+        final Set<String> queryStreamIds = queries().stream()
+                .map(QueryEntity::usedStreamIds)
+                .reduce(Collections.emptySet(), Sets::union);
+        final Set<String> searchTypeStreamIds = queries().stream()
+                .flatMap(q -> q.searchTypes().stream())
+                .map(SearchTypeEntity::effectiveStreams)
+                .reduce(Collections.emptySet(), Sets::union);
+
+        return Sets.union(queryStreamIds, searchTypeStreamIds);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/SearchEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/SearchEntity.java
@@ -28,7 +28,10 @@ import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.views.PluginMetadataSummary;
 import org.graylog2.contentpacks.NativeEntityConverter;
+import org.graylog2.contentpacks.exceptions.ContentPackException;
+import org.graylog2.contentpacks.model.ModelTypes;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
+import org.graylog2.plugin.streams.Stream;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
@@ -36,6 +39,7 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableSet.of;
 
@@ -48,7 +52,7 @@ public abstract class SearchEntity implements NativeEntityConverter<Search> {
     public static final String FIELD_OWNER = "owner";
 
     @JsonProperty
-    public abstract ImmutableSet<Query> queries();
+    public abstract ImmutableSet<QueryEntity> queries();
 
     @JsonProperty
     public abstract ImmutableSet<Parameter> parameters();
@@ -65,14 +69,14 @@ public abstract class SearchEntity implements NativeEntityConverter<Search> {
     public abstract Builder toBuilder();
 
     public static Builder builder() {
-        return Builder.create().parameters(of()).queries(ImmutableSet.<Query>builder().build());
+        return Builder.create().parameters(of()).queries(ImmutableSet.<QueryEntity>builder().build());
     }
 
     @AutoValue.Builder
     @JsonPOJOBuilder(withPrefix = "")
     public abstract static class Builder {
         @JsonProperty
-        public abstract Builder queries(ImmutableSet<Query> queries);
+        public abstract Builder queries(ImmutableSet<QueryEntity> queries);
 
         @JsonProperty
         public abstract Builder parameters(ImmutableSet<Parameter> parameters);
@@ -99,9 +103,13 @@ public abstract class SearchEntity implements NativeEntityConverter<Search> {
     }
 
     @Override
-    public Search toNativeEntity(Map<String, ValueReference> parameters, Map<EntityDescriptor, Object> nativeEntities) {
+    public Search toNativeEntity(Map<String, ValueReference> parameters,
+                                 Map<EntityDescriptor, Object> nativeEntities) {
         final Search.Builder searchBuilder = Search.builder()
-                .queries(this.queries())
+                .queries(ImmutableSet.copyOf(
+                        queries().stream()
+                                .map(q -> q.toNativeEntity(parameters, nativeEntities))
+                                .collect(Collectors.toSet())))
                 .parameters(this.parameters())
                 .requires(this.requires())
                 .createdAt(this.createdAt());

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/SearchTypeEntity.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/SearchTypeEntity.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.contentpacks.model.entities;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/ViewFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/ViewFacadeTest.java
@@ -78,14 +78,12 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-import javax.swing.text.html.Option;
 import javax.ws.rs.NotFoundException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb.InMemoryMongoRuleBuilder.newInMemoryMongoDbRule;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/ViewFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/ViewFacadeTest.java
@@ -27,12 +27,16 @@ import com.lordofthejars.nosqlunit.annotation.UsingDataSet;
 import com.lordofthejars.nosqlunit.core.LoadStrategyEnum;
 import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
 import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchRequirements;
 import org.graylog.plugins.views.search.db.SearchDbService;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.filter.OrFilter;
 import org.graylog.plugins.views.search.filter.QueryStringFilter;
 import org.graylog.plugins.views.search.filter.StreamFilter;
+import org.graylog.plugins.views.search.searchtypes.MessageList;
+import org.graylog.plugins.views.search.searchtypes.events.EventList;
+import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.views.DisplayModeSettings;
 import org.graylog.plugins.views.search.views.FormattingSettings;
 import org.graylog.plugins.views.search.views.Titles;
@@ -51,7 +55,10 @@ import org.graylog2.contentpacks.model.entities.Entity;
 import org.graylog2.contentpacks.model.entities.EntityDescriptor;
 import org.graylog2.contentpacks.model.entities.EntityExcerpt;
 import org.graylog2.contentpacks.model.entities.EntityV1;
+import org.graylog2.contentpacks.model.entities.EventListEntity;
+import org.graylog2.contentpacks.model.entities.MessageListEntity;
 import org.graylog2.contentpacks.model.entities.NativeEntity;
+import org.graylog2.contentpacks.model.entities.PivotEntity;
 import org.graylog2.contentpacks.model.entities.QueryEntity;
 import org.graylog2.contentpacks.model.entities.SearchEntity;
 import org.graylog2.contentpacks.model.entities.StreamEntity;
@@ -63,6 +70,7 @@ import org.graylog2.database.MongoConnectionRule;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.indexer.searches.timeranges.KeywordRange;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.graylog2.streams.StreamImpl;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Before;
@@ -70,8 +78,10 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import javax.swing.text.html.Option;
 import javax.ws.rs.NotFoundException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -122,6 +132,12 @@ public class ViewFacadeTest {
         objectMapper.registerSubtypes(new NamedType(StreamFilter.class, StreamFilter.NAME));
         objectMapper.registerSubtypes(new NamedType(QueryStringFilter.class, QueryStringFilter.NAME));
         objectMapper.registerSubtypes(new NamedType(AutoIntervalDTO.class, AutoIntervalDTO.type));
+        objectMapper.registerSubtypes(MessageListEntity.class);
+        objectMapper.registerSubtypes(PivotEntity.class);
+        objectMapper.registerSubtypes(EventListEntity.class);
+        objectMapper.registerSubtypes(MessageList.class);
+        objectMapper.registerSubtypes(Pivot.class);
+        objectMapper.registerSubtypes(EventList.class);
         searchDbService = new TestSearchDBService(mongoRule.getMongoConnection(),
                 new MongoJackObjectMapperProvider(objectMapper));
         viewService = new TestViewService(mongoRule.getMongoConnection(),
@@ -134,21 +150,28 @@ public class ViewFacadeTest {
     public void itShouldCreateAViewEntity() {
         final ViewDTO viewDTO = viewService.get(viewId)
                 .orElseThrow(() -> new NotFoundException("Missing view with id: " + viewId));
-        final EntityDescriptor descriptor = EntityDescriptor.create(viewDTO.id(), ModelTypes.SEARCH_V1);
-        final EntityDescriptorIds entityDescriptorIds = EntityDescriptorIds.of(descriptor);
-        final Optional<Entity> optionalEntity = facade.exportEntity(descriptor, entityDescriptorIds);
+        final EntityDescriptor searchDescriptor = EntityDescriptor.create(viewDTO.id(), ModelTypes.SEARCH_V1);
+        final EntityDescriptor streamDescriptor = EntityDescriptor.create(streamId, ModelTypes.STREAM_V1);
+        final EntityDescriptorIds entityDescriptorIds = EntityDescriptorIds.of(searchDescriptor, streamDescriptor);
+        final Optional<Entity> optionalEntity = facade.exportEntity(searchDescriptor, entityDescriptorIds);
 
         assertThat(optionalEntity).isPresent();
         final Entity entity = optionalEntity.get();
 
         assertThat(entity).isInstanceOf(EntityV1.class);
         final EntityV1 entityV1 = (EntityV1) entity;
-        assertThat(entityV1.id()).isEqualTo(ModelId.of(entityDescriptorIds.get(descriptor).orElse(null)));
+        assertThat(entityV1.id()).isEqualTo(ModelId.of(entityDescriptorIds.get(searchDescriptor).orElse(null)));
         assertThat(entityV1.type()).isEqualTo(ModelTypes.SEARCH_V1);
 
         final ViewEntity viewEntity = objectMapper.convertValue(entityV1.data(), ViewEntity.class);
         assertThat(viewEntity.title().asString()).isEqualTo(viewDTO.title());
         assertThat(viewEntity.type().toString()).isEqualTo(ViewDTO.Type.SEARCH.toString());
+
+        assertThat(viewEntity.search().queries().size()).isEqualTo(1);
+        final QueryEntity queryEntity = viewEntity.search().queries().iterator().next();
+        assertThat(queryEntity.filter().filters().size()).isEqualTo(1);
+        final StreamFilter filter = (StreamFilter) queryEntity.filter().filters().iterator().next();
+        assertThat(filter.streamId()).doesNotMatch(streamId);
     }
 
     @Test
@@ -194,15 +217,25 @@ public class ViewFacadeTest {
     @Test
     @UsingDataSet(loadStrategy = LoadStrategyEnum.CLEAN_INSERT)
     public void itShouldCreateADTOFromAnEntity() throws Exception {
+        final StreamImpl stream = new StreamImpl(Collections.emptyMap());
         final Entity viewEntity = createViewEntity();
+        final Map<EntityDescriptor, Object> nativeEntities = new HashMap<>(1);
+        nativeEntities.put(EntityDescriptor.create(newStreamId, ModelTypes.STREAM_V1), stream);
         final NativeEntity<ViewDTO> nativeEntity = facade.createNativeEntity(viewEntity,
-                Collections.emptyMap(), Collections.emptyMap(), "admin");
+                Collections.emptyMap(), nativeEntities, "admin");
 
         assertThat(nativeEntity.descriptor().title()).isEqualTo("title");
         assertThat(nativeEntity.descriptor().type()).isEqualTo(ModelTypes.SEARCH_V1);
 
-        assertThat(viewService.get(nativeEntity.descriptor().id().id())).isPresent();
-        assertThat(searchDbService.streamAll().collect(Collectors.toSet())).hasSize(2);
+        Optional<ViewDTO> resultedView = viewService.get(nativeEntity.descriptor().id().id());
+        assertThat(resultedView).isPresent();
+        Optional<Search> search = searchDbService.get(resultedView.get().searchId());
+        assertThat(search).isPresent();
+        final Query query = search.get().queries().iterator().next();
+        assertThat(query.filter()).isNotNull();
+        assertThat(query.filter().filters()).isNotEmpty();
+        final StreamFilter streamFilter = (StreamFilter) query.filter().filters().iterator().next();
+        assertThat(streamFilter.streamId()).doesNotMatch(newStreamId);
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/ViewFacadeTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/facades/ViewFacadeTest.java
@@ -52,6 +52,7 @@ import org.graylog2.contentpacks.model.entities.EntityDescriptor;
 import org.graylog2.contentpacks.model.entities.EntityExcerpt;
 import org.graylog2.contentpacks.model.entities.EntityV1;
 import org.graylog2.contentpacks.model.entities.NativeEntity;
+import org.graylog2.contentpacks.model.entities.QueryEntity;
 import org.graylog2.contentpacks.model.entities.SearchEntity;
 import org.graylog2.contentpacks.model.entities.StreamEntity;
 import org.graylog2.contentpacks.model.entities.ViewEntity;
@@ -248,7 +249,7 @@ public class ViewFacadeTest {
     }
 
     private EntityV1 createViewEntity() throws Exception {
-        final Query query = Query.builder()
+        final QueryEntity query = QueryEntity.builder()
                 .id("dead-beef")
                 .timerange(KeywordRange.create("last 5 minutes"))
                 .filter(OrFilter.or(StreamFilter.ofId(newStreamId)))


### PR DESCRIPTION
## Description
    This change adds this mapping to the Widget and WidgetEntit
    for the DashboardWidget.
    For the search types there are now Entities so we can easily
    map the streams during creation and installation of the
    content pack.
    For the query we needed to add a generic Builder access
    for the Filter so we could change the Stream id for
    a StreamFilter and rebuild the Filter refered in the
    QueryEntity and Query.

## Motivation and Context
    Prior this change, when creating a content pack containing
    views with streams the stream was collected as an dependency
    into the content pack but the StreamEntity got a new id.
    This id needs to be used in all references of the stream.
    Therefore also in the ViewEntity where a streamid is persisted.
    Also when installing this content pack the installed
    stream has a new ID yet again and the view needs to know
    this as well.

Fixes #7180 

## How Has This Been Tested?
- Created a search and dashboard view with refering streams content pack.
- Removed Stream and View.
- Installed Content Pack

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

