### PR TITLE
Improve form validation for dashboard full screen config modal

### DIFF
--- a/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.jsx
@@ -47,50 +47,56 @@ const ConfigurationModal = ({ onSave, onCancel, view }: ConfigurationModalProps)
 
   return (
     <Modal show bsSize="large" onHide={onCancel}>
-      <Modal.Header closeButton>
-        <Modal.Title>Configuring Full Screen</Modal.Title>
-      </Modal.Header>
-      <Modal.Body>
-        <Input id="refresh-interval"
-               type="number"
-               name="refresh-interval"
-               label="Refresh Interval"
-               help="After how many seconds should the dashboard refresh?"
-               onChange={({ target: { value } }) => setRefreshInterval(Number.parseInt(value, 10))}
-               required
-               value={refreshInterval} />
+      <form onSubmit={_onSave}>
+        <Modal.Header closeButton>
+          <Modal.Title>Configuring Full Screen</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Input id="refresh-interval"
+                 type="number"
+                 min="1"
+                 name="refresh-interval"
+                 label="Refresh Interval"
+                 help="After how many seconds should the dashboard refresh?"
+                 onChange={({ target: { value } }) => setRefreshInterval(value ? Number.parseInt(value, 10) : value)}
+                 required
+                 step="1"
+                 value={refreshInterval} />
 
-        <FormGroup>
-          <ControlLabel>Tabs</ControlLabel>
-          <ul>
-            {availableTabs.map(([idx, title]) => (
-              <li key={`${idx}-${title}`}>
-                <Checkbox inline
-                          checked={queryTabs.includes(idx)}
-                          onChange={event => (event.target.checked ? addQueryTab(idx) : removeQueryTab(idx))}>
-                  {title}
-                </Checkbox>
-              </li>
-            ))}
-          </ul>
-          <HelpBlock>
+          <FormGroup>
+            <ControlLabel>Tabs</ControlLabel>
+            <ul>
+              {availableTabs.map(([idx, title]) => (
+                <li key={`${idx}-${title}`}>
+                  <Checkbox inline
+                            checked={queryTabs.includes(idx)}
+                            onChange={event => (event.target.checked ? addQueryTab(idx) : removeQueryTab(idx))}>
+                    {title}
+                  </Checkbox>
+                </li>
+              ))}
+            </ul>
+            <HelpBlock>
             Select the query tabs to include in rotation.
-          </HelpBlock>
-        </FormGroup>
+            </HelpBlock>
+          </FormGroup>
 
-        <Input id="query-cycle-interval"
-               type="number"
-               name="query-cycle-interval"
-               label="Tab cycle interval"
-               help="After how many seconds should the next tab be shown?"
-               onChange={({ target: { value } }) => setQueryCycleInterval(value)}
-               required
-               value={queryCycleInterval} />
-      </Modal.Body>
-      <Modal.Footer>
-        <Button onClick={_onSave} bsStyle="success">Save</Button>
-        <Button onClick={onCancel}>Cancel</Button>
-      </Modal.Footer>
+          <Input id="query-cycle-interval"
+                 type="number"
+                 min="1"
+                 name="query-cycle-interval"
+                 label="Tab cycle interval"
+                 help="After how many seconds should the next tab be shown?"
+                 onChange={({ target: { value } }) => setQueryCycleInterval(value ? Number.parseInt(value, 10) : value)}
+                 required
+                 step="1"
+                 value={queryCycleInterval} />
+        </Modal.Body>
+        <Modal.Footer>
+          <Button bsStyle="success" type="submit">Save</Button>
+          <Button onClick={onCancel}>Cancel</Button>
+        </Modal.Footer>
+      </form>
     </Modal>
   );
 };

--- a/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.jsx
@@ -47,7 +47,7 @@ const ConfigurationModal = ({ onSave, onCancel, view }: ConfigurationModalProps)
 
   return (
     <Modal show bsSize="large" onHide={onCancel}>
-      <form onSubmit={_onSave}>
+      <form onSubmit={_onSave} data-testid="display-mode-config-form">
         <Modal.Header closeButton>
           <Modal.Title>Configuring Full Screen</Modal.Title>
         </Modal.Header>

--- a/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.test.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.test.jsx
@@ -56,7 +56,7 @@ describe('BigDisplayModeConfiguration', () => {
   it('disables menu item if `disabled` prop is `true`', () => {
     const { getByText, queryByText } = render(<BigDisplayModeConfiguration view={view} disabled />);
     const menuItem = getByText('Full Screen');
-    fireEvent.click(menuItem);
+    fireEvent.submit(menuItem);
 
     expect(queryByText('Configuring Full Screen')).toBeNull();
   });
@@ -90,39 +90,39 @@ describe('BigDisplayModeConfiguration', () => {
       Routes.pluginRoute = jest.fn(() => viewId => `/dashboards/tv/${viewId}`);
     });
 
-    it('when "Save" is clicked', () => {
-      const { getByText } = render(<BigDisplayModeConfiguration view={view} show />);
-      const saveButton = getByText('Save');
-      expect(saveButton).not.toBeNull();
+    it('on form submit', () => {
+      const { getByTestId } = render(<BigDisplayModeConfiguration view={view} show />);
+      const form = getByTestId('display-mode-config-form');
+      expect(form).not.toBeNull();
 
-      fireEvent.click(saveButton);
+      fireEvent.submit(form);
 
       expect(Routes.pluginRoute).toHaveBeenCalledWith('DASHBOARDS_TV_VIEWID');
       expect(history.push).toHaveBeenCalledWith('/dashboards/tv/deadbeef?interval=30&refresh=10');
     });
 
     it('including changed refresh interval', () => {
-      const { getByLabelText, getByText } = render(<BigDisplayModeConfiguration view={view} show />);
+      const { getByLabelText, getByTestId } = render(<BigDisplayModeConfiguration view={view} show />);
 
       const refreshInterval = getByLabelText('Refresh Interval');
 
       fireEvent.change(refreshInterval, { target: { value: 42 } });
 
-      const saveButton = getByText('Save');
-      fireEvent.click(saveButton);
+      const form = getByTestId('display-mode-config-form');
+      fireEvent.submit(form);
 
       expect(Routes.pluginRoute).toHaveBeenCalledWith('DASHBOARDS_TV_VIEWID');
       expect(history.push).toHaveBeenCalledWith('/dashboards/tv/deadbeef?interval=30&refresh=42');
     });
 
     it('including tab cycle interval setting', () => {
-      const { getByLabelText, getByText } = render(<BigDisplayModeConfiguration view={view} show />);
+      const { getByLabelText, getByTestId } = render(<BigDisplayModeConfiguration view={view} show />);
 
       const cycleInterval = getByLabelText('Tab cycle interval');
       fireEvent.change(cycleInterval, { target: { value: 4242 } });
 
-      const saveButton = getByText('Save');
-      fireEvent.click(saveButton);
+      const form = getByTestId('display-mode-config-form');
+      fireEvent.submit(form);
 
       expect(Routes.pluginRoute).toHaveBeenCalledWith('DASHBOARDS_TV_VIEWID');
       expect(history.push).toHaveBeenCalledWith('/dashboards/tv/deadbeef?interval=4242&refresh=10');
@@ -130,13 +130,13 @@ describe('BigDisplayModeConfiguration', () => {
 
     it('including selected tabs', () => {
       const viewWithQueries = createViewWithQueries();
-      const { getByLabelText, getByText } = render(<BigDisplayModeConfiguration view={viewWithQueries} show />);
+      const { getByLabelText, getByTestId } = render(<BigDisplayModeConfiguration view={viewWithQueries} show />);
 
       const query1 = getByLabelText('Query#1');
       fireEvent.click(query1);
 
-      const saveButton = getByText('Save');
-      fireEvent.click(saveButton);
+      const form = getByTestId('display-mode-config-form');
+      fireEvent.submit(form);
 
       expect(Routes.pluginRoute).toHaveBeenCalledWith('DASHBOARDS_TV_VIEWID');
       expect(history.push).toHaveBeenCalledWith('/dashboards/tv/deadbeef?interval=30&refresh=10&tabs=1%2C2');

--- a/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.test.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.test.jsx
@@ -84,6 +84,24 @@ describe('BigDisplayModeConfiguration', () => {
     expect(getByText('Query#3')).not.toBeNull();
   });
 
+  it('should not allow strings for the refresh interval', () => {
+    const { getByLabelText } = render(<BigDisplayModeConfiguration view={view} show />);
+
+    const refreshInterval = getByLabelText('Refresh Interval');
+
+    fireEvent.change(refreshInterval, { target: { value: 'a string' } });
+    expect(refreshInterval.value).toBe('');
+  });
+
+  it('should not allow strings for the cycle interval', () => {
+    const { getByLabelText } = render(<BigDisplayModeConfiguration view={view} show />);
+
+    const cycleInterval = getByLabelText('Tab cycle interval');
+
+    fireEvent.change(cycleInterval, { target: { value: 'a string' } });
+    expect(cycleInterval.value).toBe('');
+  });
+
   describe('redirects to tv mode page', () => {
     beforeEach(() => {
       history.push = jest.fn();


### PR DESCRIPTION
This PR fixes the behaviour described in #7211 (allowing negative numbers for refresh and cycle interval) regarding the full screen dashboard config modal, mainly by adding a HTML form element.

I had to adjust the form submit inside the related tests, because submitting the form by triggering a click on the save button results in the following error:
`Not implemented: HTMLFormElement.prototype.submit`.

Fixes #7211

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

