### PR TITLE
Increase sidebar field list width

### DIFF
--- a/graylog2-web-interface/src/views/components/sidebar/NavItem.styles.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/NavItem.styles.jsx
@@ -1,3 +1,4 @@
+// @flow strict
 import * as React from 'react';
 import styled, { css } from 'styled-components';
 
@@ -30,7 +31,7 @@ export const Title: React.ComponentType<StyleProps> = styled.div(({ isSelected, 
   `)}
 `);
 
-export const TitleText = styled.div`
+export const TitleText: React.ComponentType<{}> = styled.div`
   font-size: 16px;
   display: inline;
   margin-left: 10px;
@@ -38,7 +39,7 @@ export const TitleText = styled.div`
   white-space: nowrap;
 `;
 
-export const TitleIcon = styled.div`
+export const TitleIcon: React.ComponentType<{}> = styled.div`
   width: 25px;
   text-align: center;
   font-size: 20px;

--- a/graylog2-web-interface/src/views/components/sidebar/NavItem.styles.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/NavItem.styles.jsx
@@ -65,7 +65,7 @@ export const Content: React.ComponentType<StyleProps> = styled.div(({ isSelected
     border: 0;
     bottom: 0;
     padding: 20px;
-    width: 300px;
+    width: 450px;
     overflow-y: hidden;
   `}
 `);


### PR DESCRIPTION
I had a look at #7146 (Context menu for fields is off in search sidebar for long field names) and could not really find a dynamic solution.

We are using `react-window` to render only a part of the probably large field list. The related list component needs to render the list items with `position: absolute`. Which means there is no elegant way to define a dynamic width for the list. There is also no way to have list items with a dynamic height, otherwise wrapping the list items would be a possible solution.

Another possible solution, is setting the Dropdown placement to `bottom`. It would fix the described behaviour, but is not working perfectly for list items near the bottom of the browser window. I also prefer a consistent placement of the field action context menu.

The only workaround I can image right now is setting the list width based on the field with the longest title. but this solution requires some not so dynamic calculation and feels kind of hacky.

Because we plan to implement an overlay solution which opens the context menu near the cursor, increasing the lists width seems to be the most pragmatic solution right now. This works for field names with a length of up to 60 characters.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

