### PR TITLE
Add validation to multiple aggregation condition

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.jsx
@@ -127,7 +127,9 @@ class EventDefinitionFormContainer extends React.Component {
         return;
       }
       if (body.type && body.type === 'ApiError') {
-        if (body.message.includes('org.graylog.events.conditions.Expression')) {
+        if (body.message.includes('org.graylog.events.conditions.Expression')
+        || body.message.includes('org.graylog.events.conditions.Expr')
+        || body.message.includes('org.graylog.events.processor.aggregation.AggregationSeries')) {
           this.setState({
             validation: {
               errors: { conditions: ['Aggregation condition is not valid'] },

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.jsx
@@ -115,6 +115,29 @@ class EventDefinitionFormContainer extends React.Component {
     return { isValid: true };
   };
 
+  handleSubmitSuccessResponse = () => {
+    this.setState({ isDirty: false }, () => history.push(Routes.ALERTS.DEFINITIONS.LIST));
+  };
+
+  handleSubmitFailureResponse = (errorResponse) => {
+    const { body } = errorResponse.additional;
+    if (errorResponse.status === 400) {
+      if (body && body.failed) {
+        this.setState({ validation: body });
+        return;
+      }
+      if (body.type && body.type === 'ApiError') {
+        if (body.message.includes('org.graylog.events.conditions.Expression')) {
+          this.setState({
+            validation: {
+              errors: { conditions: ['Aggregation condition is not valid'] },
+            },
+          });
+        }
+      }
+    }
+  };
+
   handleSubmit = () => {
     const { action } = this.props;
     const { eventDefinition } = this.state;
@@ -126,26 +149,10 @@ class EventDefinitionFormContainer extends React.Component {
 
     if (action === 'create') {
       EventDefinitionsActions.create(eventDefinition)
-        .then(
-          () => this.setState({ isDirty: false }, () => history.push(Routes.ALERTS.DEFINITIONS.LIST)),
-          (errorResponse) => {
-            const { body } = errorResponse.additional;
-            if (errorResponse.status === 400 && body && body.failed) {
-              this.setState({ validation: body });
-            }
-          },
-        );
+        .then(this.handleSubmitSuccessResponse, this.handleSubmitFailureResponse);
     } else {
       EventDefinitionsActions.update(eventDefinition.id, eventDefinition)
-        .then(
-          () => this.setState({ isDirty: false }, () => history.push(Routes.ALERTS.DEFINITIONS.LIST)),
-          (errorResponse) => {
-            const { body } = errorResponse.additional;
-            if (errorResponse.status === 400 && body && body.failed) {
-              this.setState({ validation: body });
-            }
-          },
-        );
+        .then(this.handleSubmitSuccessResponse, this.handleSubmitFailureResponse);
     }
   };
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpression.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpression.jsx
@@ -25,7 +25,7 @@ import styles from './AggregationConditionExpression.css';
 class AggregationConditionExpression extends React.Component {
   static propTypes = {
     eventDefinition: PropTypes.object.isRequired,
-    validation: PropTypes.object.isRequired,
+    validation: PropTypes.object,
     formattedFields: PropTypes.array.isRequired,
     aggregationFunctions: PropTypes.array.isRequired,
     onChange: PropTypes.func.isRequired,
@@ -39,6 +39,7 @@ class AggregationConditionExpression extends React.Component {
     level: 0,
     parent: undefined,
     renderLabel: true,
+    validation: {},
   };
 
   state = {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/BooleanExpression.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/BooleanExpression.jsx
@@ -9,18 +9,20 @@ import { internalNodePropType } from 'logic/alerts/AggregationExpressionTypes';
 import AggregationConditionExpression from '../AggregationConditionExpression';
 
 const BooleanExpression = (props) => {
-  const { expression, level, onChildChange } = props;
+  const { expression, level, onChildChange, validation } = props;
 
   return (
     <>
       <AggregationConditionExpression {...props}
                                       expression={expression.left}
+                                      validation={validation.left}
                                       parent={expression}
                                       onChange={onChildChange('left')}
                                       level={level + 1} />
       <Clearfix />
       <AggregationConditionExpression {...props}
                                       expression={expression.right}
+                                      validation={validation.right}
                                       parent={expression}
                                       onChange={onChildChange('right')}
                                       level={level + 1}
@@ -35,10 +37,12 @@ BooleanExpression.propTypes = {
   level: PropTypes.number.isRequired,
   onChange: PropTypes.func.isRequired,
   onChildChange: PropTypes.func.isRequired,
+  validation: PropTypes.object,
 };
 
 BooleanExpression.defaultProps = {
   parent: undefined,
+  validation: {},
 };
 
 export default BooleanExpression;

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/ComparisonExpression.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/ComparisonExpression.jsx
@@ -24,12 +24,13 @@ const ComparisonExpression = (props) => {
       <Row className="row-sm">
         <AggregationConditionExpression {...props}
                                         expression={expression.left}
+                                        validation={validation.left}
                                         parent={expression}
                                         onChange={onChildChange('left')}
                                         level={level + 1} />
 
         <Col md={3}>
-          <FormGroup controlId="aggregation-condition" validationState={validation.errors.conditions ? 'error' : null}>
+          <FormGroup controlId="aggregation-condition" validationState={validation.message ? 'error' : null}>
             {renderLabel && <ControlLabel>Is</ControlLabel>}
             <Select id="aggregation-condition"
                     matchProp="label"
@@ -44,13 +45,12 @@ const ComparisonExpression = (props) => {
                     ]}
                     value={expression.expr}
                     clearable={false} />
-            {validation.errors.conditions && (
-              <HelpBlock>{lodash.get(validation, 'errors.conditions[0]')}</HelpBlock>
-            )}
+            {validation.message && <HelpBlock>{validation.message}</HelpBlock>}
           </FormGroup>
         </Col>
         <AggregationConditionExpression {...props}
                                         expression={expression.right}
+                                        validation={validation.right}
                                         parent={expression}
                                         onChange={onChildChange('right')}
                                         level={level + 1} />
@@ -65,7 +65,11 @@ ComparisonExpression.propTypes = {
   onChange: PropTypes.func.isRequired,
   onChildChange: PropTypes.func.isRequired,
   renderLabel: PropTypes.bool.isRequired,
-  validation: PropTypes.object.isRequired,
+  validation: PropTypes.object,
+};
+
+ComparisonExpression.defaultProps = {
+  validation: {},
 };
 
 export default ComparisonExpression;

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/GroupExpression.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/GroupExpression.jsx
@@ -16,7 +16,7 @@ const Group = styled.div`
 `;
 
 const GroupExpression = (props) => {
-  const { expression, level, onChange, onChildChange } = props;
+  const { expression, level, onChange, onChildChange, validation } = props;
 
   const handleOperatorChange = (nextOperator) => {
     const nextExpression = cloneDeep(expression);
@@ -32,6 +32,7 @@ const GroupExpression = (props) => {
       <Group>
         <AggregationConditionExpression {...props}
                                         expression={expression.child}
+                                        validation={validation.child}
                                         parent={expression}
                                         onChange={onChildChange('child')}
                                         level={level + 1} />
@@ -45,7 +46,11 @@ GroupExpression.propTypes = {
   level: PropTypes.number.isRequired,
   onChange: PropTypes.func.isRequired,
   onChildChange: PropTypes.func.isRequired,
-  validation: PropTypes.object.isRequired,
+  validation: PropTypes.object,
+};
+
+GroupExpression.defaultProps = {
+  validation: {},
 };
 
 export default GroupExpression;

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/NumberExpression.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/NumberExpression.jsx
@@ -23,8 +23,8 @@ const NumberExpression = ({ expression, onChange, renderLabel, validation }) => 
              label={renderLabel ? 'Threshold' : ''}
              type="number"
              value={lodash.get(expression, 'value')}
-             bsStyle={validation.errors.conditions ? 'error' : null}
-             help={lodash.get(validation, 'errors.conditions[0]', null)}
+             bsStyle={validation.message ? 'error' : null}
+             help={validation.message}
              onChange={handleChange} />
     </Col>
   );
@@ -34,7 +34,11 @@ NumberExpression.propTypes = {
   expression: numberExpressionNodePropType.isRequired,
   onChange: PropTypes.func.isRequired,
   renderLabel: PropTypes.bool.isRequired,
-  validation: PropTypes.object.isRequired,
+  validation: PropTypes.object,
+};
+
+NumberExpression.defaultProps = {
+  validation: {},
 };
 
 export default NumberExpression;

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/NumberRefExpression.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionExpressions/NumberRefExpression.jsx
@@ -79,7 +79,7 @@ const NumberRefExpression = ({
 
   return (
     <Col md={6}>
-      <FormGroup controlId="aggregation-function" validationState={validation.errors.series ? 'error' : null}>
+      <FormGroup controlId="aggregation-function" validationState={validation.message ? 'error' : null}>
         {renderLabel && <ControlLabel>If</ControlLabel>}
         <Row className="row-sm">
           <Col md={6}>
@@ -101,9 +101,7 @@ const NumberRefExpression = ({
                     allowCreate />
           </Col>
         </Row>
-        {validation.errors.series && (
-          <HelpBlock>{lodash.get(validation, 'errors.series[0]')}</HelpBlock>
-        )}
+        {validation.message && <HelpBlock>{validation.message}</HelpBlock>}
       </FormGroup>
     </Col>
   );
@@ -116,7 +114,11 @@ NumberRefExpression.propTypes = {
   formattedFields: PropTypes.array.isRequired,
   onChange: PropTypes.func.isRequired,
   renderLabel: PropTypes.bool.isRequired,
-  validation: PropTypes.object.isRequired,
+  validation: PropTypes.object,
+};
+
+NumberRefExpression.defaultProps = {
+  validation: {},
 };
 
 export default NumberRefExpression;

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionSummary.jsx
@@ -3,6 +3,10 @@ import PropTypes from 'prop-types';
 
 const AggregationConditionSummary = ({ conditions, series }) => {
   const renderExpression = (expression) => {
+    if (!expression) {
+      return 'No condition configured';
+    }
+
     switch (expression.expr) {
       case 'number':
         return expression.value;

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionsForm.jsx
@@ -56,12 +56,16 @@ class AggregationConditionsForm extends React.Component {
       return;
     }
 
-    // Propagate empty comparison expression, if the last expression was removed
-    const nextConditions = changes.conditions || emptyComparisonExpressionConfig();
+    const nextConditions = changes.conditions;
 
-    // Keep series up-to-date with changes in conditions
-    const seriesReferences = extractSeriesReferences(nextConditions);
-    const nextSeries = (changes.series || eventDefinition.config.series).filter(s => seriesReferences.includes(s.id));
+    let nextSeries;
+    if (nextConditions) {
+      // Keep series up-to-date with changes in conditions
+      const seriesReferences = extractSeriesReferences(nextConditions);
+      nextSeries = (changes.series || eventDefinition.config.series).filter(s => seriesReferences.includes(s.id));
+    } else {
+      nextSeries = [];
+    }
 
     onChange(Object.assign({}, changes, {
       conditions: { expression: nextConditions },

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionsForm.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { get } from 'lodash';
 
-import { Button, Row, Well } from 'components/graylog';
+import { Alert, Button, Row, Well } from 'components/graylog';
 import { Icon } from 'components/common';
 import { emptyComparisonExpressionConfig } from 'logic/alerts/AggregationExpressionConfig';
 
@@ -28,6 +29,14 @@ const extractSeriesReferences = (expression, acc = []) => {
 
 const StyledWell = styled(Well)`
   margin-top: 10px;
+`;
+
+const StyledPanel = styled(Panel)`
+  margin-top: 10px;
+`;
+
+const StyledAlert = styled(Alert)`
+  margin-bottom: 10px !important;
 `;
 
 class AggregationConditionsForm extends React.Component {
@@ -75,16 +84,23 @@ class AggregationConditionsForm extends React.Component {
 
   render() {
     const { showConditionSummary } = this.state;
-    const { eventDefinition } = this.props;
+    const { eventDefinition, validation } = this.props;
     const expression = eventDefinition.config.conditions.expression || initialEmptyConditionConfig;
 
     return (
       <React.Fragment>
         <h3 className={commonStyles.title}>Create Events for Definition</h3>
+        {validation.errors.conditions && (
+          <StyledAlert bsStyle="danger">
+            <h4><Icon name="warning" />&nbsp;Errors found</h4>
+            <p>{get(validation, 'errors.conditions[0]')}</p>
+          </StyledAlert>
+        )}
 
         <Row>
           <AggregationConditionExpression expression={expression}
                                           {...this.props}
+                                          validation={{}}
                                           onChange={this.handleChange} />
         </Row>
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionsForm.jsx
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { get } from 'lodash';
 
-import { Alert, Button, Row, Well } from 'components/graylog';
+import { Alert, Row } from 'components/graylog';
 import { Icon } from 'components/common';
 import { emptyComparisonExpressionConfig } from 'logic/alerts/AggregationExpressionConfig';
+import validateExpression from 'logic/alerts/AggregationExpressionValidation';
 
 import AggregationConditionExpression from './AggregationConditionExpression';
-import AggregationConditionSummary from './AggregationConditionSummary';
+import AggregationConditionsFormSummary from './AggregationConditionsFormSummary';
 
 import commonStyles from '../common/commonStyles.css';
 
@@ -27,14 +28,6 @@ const extractSeriesReferences = (expression, acc = []) => {
   return acc;
 };
 
-const StyledWell = styled(Well)`
-  margin-top: 10px;
-`;
-
-const StyledPanel = styled(Panel)`
-  margin-top: 10px;
-`;
-
 const StyledAlert = styled(Alert)`
   margin-bottom: 10px !important;
 `;
@@ -49,12 +42,12 @@ class AggregationConditionsForm extends React.Component {
   };
 
   state = {
-    showConditionSummary: false,
+    showInlineValidation: false,
   };
 
-  toggleShowConditionSummary = () => {
-    const { showConditionSummary } = this.state;
-    this.setState({ showConditionSummary: !showConditionSummary });
+  toggleShowInlineValidation = () => {
+    const { showInlineValidation } = this.state;
+    this.setState({ showInlineValidation: !showInlineValidation });
   };
 
   handleChange = (changes) => {
@@ -83,9 +76,10 @@ class AggregationConditionsForm extends React.Component {
   };
 
   render() {
-    const { showConditionSummary } = this.state;
+    const { showInlineValidation } = this.state;
     const { eventDefinition, validation } = this.props;
     const expression = eventDefinition.config.conditions.expression || initialEmptyConditionConfig;
+    const expressionValidation = validateExpression(expression, eventDefinition.config.series);
 
     return (
       <React.Fragment>
@@ -100,20 +94,15 @@ class AggregationConditionsForm extends React.Component {
         <Row>
           <AggregationConditionExpression expression={expression}
                                           {...this.props}
-                                          validation={{}}
+                                          validation={showInlineValidation ? expressionValidation.validationTree : {}}
                                           onChange={this.handleChange} />
         </Row>
 
-
-        <Button bsSize="small" bsStyle="link" className="btn-text" onClick={this.toggleShowConditionSummary}>
-          <Icon name={showConditionSummary ? 'caret-down' : 'caret-right'} />
-          &nbsp;{showConditionSummary ? 'Hide' : 'Show'} condition preview
-        </Button>
-        {showConditionSummary && (
-          <StyledWell bsSize="small">
-            <AggregationConditionSummary series={eventDefinition.config.series} conditions={eventDefinition.config.conditions} />
-          </StyledWell>
-        )}
+        <AggregationConditionsFormSummary conditions={eventDefinition.config.conditions}
+                                          series={eventDefinition.config.series}
+                                          expressionValidation={expressionValidation}
+                                          showInlineValidation={showInlineValidation}
+                                          toggleShowValidation={this.toggleShowInlineValidation} />
       </React.Fragment>
     );
   }

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionsFormSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionsFormSummary.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+import { Button, Panel } from 'components/graylog';
+import { Icon } from 'components/common';
+import AggregationConditionSummary from './AggregationConditionSummary';
+
+const StyledPanel = styled(Panel)`
+  margin-top: 10px;
+`;
+
+const StyledButton = styled(Button)`
+  margin-left: 15px;
+  vertical-align: baseline;
+`;
+
+const AggregationConditionsFormSummary = (props) => {
+  const { conditions, series, expressionValidation, showInlineValidation, toggleShowValidation } = props;
+
+  return (
+    <div>
+      <StyledPanel header="Condition summary">
+        {expressionValidation.isValid
+          ? <p className="text-success"><Icon name="check-square" />&nbsp;Condition is valid</p>
+          : (
+            <p className="text-danger">
+              <Icon name="exclamation-triangle" />&nbsp;Condition is not valid
+              <StyledButton bsSize="xsmall" onClick={toggleShowValidation}>
+                {showInlineValidation ? 'Hide errors' : 'Show errors'}
+              </StyledButton>
+            </p>
+          )
+          }
+        <b>Preview:</b> <AggregationConditionSummary series={series} conditions={conditions} />
+      </StyledPanel>
+    </div>
+  );
+};
+
+AggregationConditionsFormSummary.propTypes = {
+  conditions: PropTypes.object.isRequired,
+  series: PropTypes.array.isRequired,
+  expressionValidation: PropTypes.object,
+  showInlineValidation: PropTypes.bool,
+  toggleShowValidation: PropTypes.func.isRequired,
+};
+
+AggregationConditionsFormSummary.defaultProps = {
+  expressionValidation: { isValid: true },
+  showInlineValidation: false,
+};
+
+export default AggregationConditionsFormSummary;

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.jsx
@@ -4,11 +4,13 @@ import lodash from 'lodash';
 import { Link } from 'react-router';
 
 import { Alert } from 'components/graylog';
-import { Icon } from 'components/common';
 import { extractDurationAndUnit } from 'components/common/TimeUnitInput';
+import { Icon } from 'components/common';
 import PermissionsMixin from 'util/PermissionsMixin';
 import { naturalSortIgnoreCase } from 'util/SortUtils';
 import Routes from 'routing/Routes';
+import validateExpression from 'logic/alerts/AggregationExpressionValidation';
+
 
 import AggregationConditionSummary from './AggregationConditionSummary';
 import withStreams from './withStreams';
@@ -92,6 +94,8 @@ class FilterAggregationSummary extends React.Component {
     const effectiveStreamIds = PermissionsMixin.isPermitted(currentUser.permissions, 'streams:read')
       ? streams : [];
 
+    const validationResults = validateExpression(conditions.expression, series);
+
     return (
       <dl>
         <dt>Type</dt>
@@ -111,7 +115,14 @@ class FilterAggregationSummary extends React.Component {
             <dd>{groupBy && groupBy.length > 0 ? groupBy.join(', ') : 'No Group by configured'}</dd>
             <dt>Create Events if</dt>
             <dd>
-              <AggregationConditionSummary series={series} conditions={conditions} />
+              {validationResults.isValid
+                ? <AggregationConditionSummary series={series} conditions={conditions} />
+                : (
+                  <Alert bsSize="small" bsStyle="danger"><Icon name="exclamation-triangle" />&nbsp;
+                    Condition is not valid: {validationResults.errors.join(', ')}
+                  </Alert>
+                )
+              }
             </dd>
           </React.Fragment>
         )}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/__snapshots__/AggregationConditionExpression.test.jsx.snap
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/__snapshots__/AggregationConditionExpression.test.jsx.snap
@@ -1900,11 +1900,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
         }
       }
       renderLabel={true}
-      validation={
-        Object {
-          "errors": Object {},
-        }
-      }
+      validation={Object {}}
     >
       <ComparisonExpression
         aggregationFunctions={Array []}
@@ -1966,11 +1962,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
           }
         }
         renderLabel={true}
-        validation={
-          Object {
-            "errors": Object {},
-          }
-        }
+        validation={Object {}}
       >
         <Col
           bsClass="col"
@@ -2027,11 +2019,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                     }
                   }
                   renderLabel={true}
-                  validation={
-                    Object {
-                      "errors": Object {},
-                    }
-                  }
+                  validation={Object {}}
                 >
                   <NumberRefExpression
                     aggregationFunctions={Array []}
@@ -2072,11 +2060,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                       }
                     }
                     renderLabel={true}
-                    validation={
-                      Object {
-                        "errors": Object {},
-                      }
-                    }
+                    validation={Object {}}
                   >
                     <Col
                       bsClass="col"
@@ -6799,11 +6783,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                     }
                   }
                   renderLabel={true}
-                  validation={
-                    Object {
-                      "errors": Object {},
-                    }
-                  }
+                  validation={Object {}}
                 >
                   <NumberExpression
                     aggregationFunctions={Array []}
@@ -6844,11 +6824,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                       }
                     }
                     renderLabel={true}
-                    validation={
-                      Object {
-                        "errors": Object {},
-                      }
-                    }
+                    validation={Object {}}
                   >
                     <Col
                       bsClass="col"
@@ -6862,7 +6838,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                           addonAfter={null}
                           bsStyle={null}
                           buttonAfter={null}
-                          help={null}
+                          help=""
                           id="aggregation-threshold"
                           label="Threshold"
                           name="threshold"
@@ -7453,11 +7429,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
         }
       }
       renderLabel={false}
-      validation={
-        Object {
-          "errors": Object {},
-        }
-      }
+      validation={Object {}}
     >
       <ComparisonExpression
         aggregationFunctions={Array []}
@@ -7519,11 +7491,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
           }
         }
         renderLabel={false}
-        validation={
-          Object {
-            "errors": Object {},
-          }
-        }
+        validation={Object {}}
       >
         <Col
           bsClass="col"
@@ -7580,11 +7548,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                     }
                   }
                   renderLabel={false}
-                  validation={
-                    Object {
-                      "errors": Object {},
-                    }
-                  }
+                  validation={Object {}}
                 >
                   <NumberRefExpression
                     aggregationFunctions={Array []}
@@ -7625,11 +7589,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                       }
                     }
                     renderLabel={false}
-                    validation={
-                      Object {
-                        "errors": Object {},
-                      }
-                    }
+                    validation={Object {}}
                   >
                     <Col
                       bsClass="col"
@@ -12268,11 +12228,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                     }
                   }
                   renderLabel={false}
-                  validation={
-                    Object {
-                      "errors": Object {},
-                    }
-                  }
+                  validation={Object {}}
                 >
                   <NumberExpression
                     aggregationFunctions={Array []}
@@ -12313,11 +12269,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                       }
                     }
                     renderLabel={false}
-                    validation={
-                      Object {
-                        "errors": Object {},
-                      }
-                    }
+                    validation={Object {}}
                   >
                     <Col
                       bsClass="col"
@@ -12331,7 +12283,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                           addonAfter={null}
                           bsStyle={null}
                           buttonAfter={null}
-                          help={null}
+                          help=""
                           id="aggregation-threshold"
                           label=""
                           name="threshold"
@@ -14726,11 +14678,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
         }
       }
       renderLabel={true}
-      validation={
-        Object {
-          "errors": Object {},
-        }
-      }
+      validation={Object {}}
     >
       <ComparisonExpression
         aggregationFunctions={Array []}
@@ -14796,11 +14744,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
           }
         }
         renderLabel={true}
-        validation={
-          Object {
-            "errors": Object {},
-          }
-        }
+        validation={Object {}}
       >
         <Col
           bsClass="col"
@@ -14857,11 +14801,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                     }
                   }
                   renderLabel={true}
-                  validation={
-                    Object {
-                      "errors": Object {},
-                    }
-                  }
+                  validation={Object {}}
                 >
                   <NumberRefExpression
                     aggregationFunctions={Array []}
@@ -14902,11 +14842,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                       }
                     }
                     renderLabel={true}
-                    validation={
-                      Object {
-                        "errors": Object {},
-                      }
-                    }
+                    validation={Object {}}
                   >
                     <Col
                       bsClass="col"
@@ -19629,11 +19565,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                     }
                   }
                   renderLabel={true}
-                  validation={
-                    Object {
-                      "errors": Object {},
-                    }
-                  }
+                  validation={Object {}}
                 >
                   <NumberExpression
                     aggregationFunctions={Array []}
@@ -19674,11 +19606,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                       }
                     }
                     renderLabel={true}
-                    validation={
-                      Object {
-                        "errors": Object {},
-                      }
-                    }
+                    validation={Object {}}
                   >
                     <Col
                       bsClass="col"
@@ -19692,7 +19620,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                           addonAfter={null}
                           bsStyle={null}
                           buttonAfter={null}
-                          help={null}
+                          help=""
                           id="aggregation-threshold"
                           label="Threshold"
                           name="threshold"
@@ -20291,11 +20219,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
         }
       }
       renderLabel={false}
-      validation={
-        Object {
-          "errors": Object {},
-        }
-      }
+      validation={Object {}}
     >
       <GroupExpression
         aggregationFunctions={Array []}
@@ -20365,11 +20289,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
           }
         }
         renderLabel={false}
-        validation={
-          Object {
-            "errors": Object {},
-          }
-        }
+        validation={Object {}}
       >
         <BooleanOperatorSelector
           initialText=""
@@ -22123,11 +22043,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                   }
                 }
                 renderLabel={false}
-                validation={
-                  Object {
-                    "errors": Object {},
-                  }
-                }
+                validation={Object {}}
               >
                 <ComparisonExpression
                   aggregationFunctions={Array []}
@@ -22179,11 +22095,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                     }
                   }
                   renderLabel={false}
-                  validation={
-                    Object {
-                      "errors": Object {},
-                    }
-                  }
+                  validation={Object {}}
                 >
                   <Col
                     bsClass="col"
@@ -22240,11 +22152,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                               }
                             }
                             renderLabel={false}
-                            validation={
-                              Object {
-                                "errors": Object {},
-                              }
-                            }
+                            validation={Object {}}
                           >
                             <NumberRefExpression
                               aggregationFunctions={Array []}
@@ -22285,11 +22193,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                 }
                               }
                               renderLabel={false}
-                              validation={
-                                Object {
-                                  "errors": Object {},
-                                }
-                              }
+                              validation={Object {}}
                             >
                               <Col
                                 bsClass="col"
@@ -26928,11 +26832,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                               }
                             }
                             renderLabel={false}
-                            validation={
-                              Object {
-                                "errors": Object {},
-                              }
-                            }
+                            validation={Object {}}
                           >
                             <NumberExpression
                               aggregationFunctions={Array []}
@@ -26973,11 +26873,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                 }
                               }
                               renderLabel={false}
-                              validation={
-                                Object {
-                                  "errors": Object {},
-                                }
-                              }
+                              validation={Object {}}
                             >
                               <Col
                                 bsClass="col"
@@ -26991,7 +26887,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                     addonAfter={null}
                                     bsStyle={null}
                                     buttonAfter={null}
-                                    help={null}
+                                    help=""
                                     id="aggregation-threshold"
                                     label=""
                                     name="threshold"
@@ -29317,11 +29213,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
               }
             }
             renderLabel={true}
-            validation={
-              Object {
-                "errors": Object {},
-              }
-            }
+            validation={Object {}}
           >
             <ComparisonExpression
               aggregationFunctions={Array []}
@@ -29373,11 +29265,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                 }
               }
               renderLabel={true}
-              validation={
-                Object {
-                  "errors": Object {},
-                }
-              }
+              validation={Object {}}
             >
               <Col
                 bsClass="col"
@@ -29434,11 +29322,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                           }
                         }
                         renderLabel={true}
-                        validation={
-                          Object {
-                            "errors": Object {},
-                          }
-                        }
+                        validation={Object {}}
                       >
                         <NumberRefExpression
                           aggregationFunctions={Array []}
@@ -29479,11 +29363,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                             }
                           }
                           renderLabel={true}
-                          validation={
-                            Object {
-                              "errors": Object {},
-                            }
-                          }
+                          validation={Object {}}
                         >
                           <Col
                             bsClass="col"
@@ -34206,11 +34086,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                           }
                         }
                         renderLabel={true}
-                        validation={
-                          Object {
-                            "errors": Object {},
-                          }
-                        }
+                        validation={Object {}}
                       >
                         <NumberExpression
                           aggregationFunctions={Array []}
@@ -34251,11 +34127,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                             }
                           }
                           renderLabel={true}
-                          validation={
-                            Object {
-                              "errors": Object {},
-                            }
-                          }
+                          validation={Object {}}
                         >
                           <Col
                             bsClass="col"
@@ -34269,7 +34141,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                 addonAfter={null}
                                 bsStyle={null}
                                 buttonAfter={null}
-                                help={null}
+                                help=""
                                 id="aggregation-threshold"
                                 label="Threshold"
                                 name="threshold"
@@ -36648,11 +36520,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                 }
               }
               renderLabel={true}
-              validation={
-                Object {
-                  "errors": Object {},
-                }
-              }
+              validation={Object {}}
             >
               <NumberRefExpression
                 aggregationFunctions={Array []}
@@ -36687,11 +36555,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                   }
                 }
                 renderLabel={true}
-                validation={
-                  Object {
-                    "errors": Object {},
-                  }
-                }
+                validation={Object {}}
               >
                 <Col
                   bsClass="col"
@@ -41213,11 +41077,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                 }
               }
               renderLabel={true}
-              validation={
-                Object {
-                  "errors": Object {},
-                }
-              }
+              validation={Object {}}
             >
               <NumberExpression
                 aggregationFunctions={Array []}
@@ -41252,11 +41112,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                   }
                 }
                 renderLabel={true}
-                validation={
-                  Object {
-                    "errors": Object {},
-                  }
-                }
+                validation={Object {}}
               >
                 <Col
                   bsClass="col"
@@ -41270,7 +41126,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                       addonAfter={null}
                       bsStyle={null}
                       buttonAfter={null}
-                      help={null}
+                      help=""
                       id="aggregation-threshold"
                       label="Threshold"
                       name="threshold"
@@ -43662,11 +43518,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                 }
               }
               renderLabel={true}
-              validation={
-                Object {
-                  "errors": Object {},
-                }
-              }
+              validation={Object {}}
             >
               <NumberRefExpression
                 aggregationFunctions={Array []}
@@ -43707,11 +43559,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                   }
                 }
                 renderLabel={true}
-                validation={
-                  Object {
-                    "errors": Object {},
-                  }
-                }
+                validation={Object {}}
               >
                 <Col
                   bsClass="col"
@@ -48469,11 +48317,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                 }
               }
               renderLabel={true}
-              validation={
-                Object {
-                  "errors": Object {},
-                }
-              }
+              validation={Object {}}
             >
               <NumberExpression
                 aggregationFunctions={Array []}
@@ -48514,11 +48358,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                   }
                 }
                 renderLabel={true}
-                validation={
-                  Object {
-                    "errors": Object {},
-                  }
-                }
+                validation={Object {}}
               >
                 <Col
                   bsClass="col"
@@ -48532,7 +48372,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                       addonAfter={null}
                       bsStyle={null}
                       buttonAfter={null}
-                      help={null}
+                      help=""
                       id="aggregation-threshold"
                       label="Threshold"
                       name="threshold"

--- a/graylog2-web-interface/src/logic/alerts/AggregationExpressionValidation.js
+++ b/graylog2-web-interface/src/logic/alerts/AggregationExpressionValidation.js
@@ -1,0 +1,54 @@
+import { union } from 'lodash';
+
+const flattenValidationTree = (validationTree, errors = []) => {
+  if (validationTree.message) {
+    return union(errors, [validationTree.message]);
+  }
+  if (validationTree.left) {
+    return union(errors, flattenValidationTree(validationTree.left), flattenValidationTree(validationTree.right));
+  }
+  if (validationTree.child) {
+    return union(errors, flattenValidationTree(validationTree.child));
+  }
+  return errors;
+};
+
+const validateExpressionTree = (expression, series, validationTree = {}) => {
+  switch (expression.expr) {
+    case 'number':
+      return (Number.isSafeInteger(expression.value) ? {} : { message: 'Threshold must be a valid number' });
+    case 'number-ref':
+      return (expression.ref && series.find(s => s.id === expression.ref) ? {} : { message: 'Function must be set' });
+    case '&&':
+    case '||':
+    case '<':
+    case '<=':
+    case '>':
+    case '>=':
+    case '==':
+      return Object.assign({},
+        { left: validateExpressionTree(expression.left, series, validationTree) },
+        { right: validateExpressionTree(expression.right, series, validationTree) });
+    case 'group':
+      return { child: validateExpressionTree(expression.child, series, validationTree) };
+    default:
+      return { message: 'Condition must be set' };
+  }
+};
+
+const validateExpression = (expression, series) => {
+  const validationResults = {};
+
+  if (!expression) {
+    validationResults.isValid = true;
+    return validationResults;
+  }
+
+  validationResults.validationTree = validateExpressionTree(expression, series);
+  validationResults.errors = flattenValidationTree(validationResults.validationTree);
+  validationResults.isValid = validationResults.errors.length === 0;
+
+  return validationResults;
+};
+
+export default validateExpression;

--- a/graylog2-web-interface/src/logic/alerts/AggregationExpressionValidation.js
+++ b/graylog2-web-interface/src/logic/alerts/AggregationExpressionValidation.js
@@ -18,7 +18,14 @@ const validateExpressionTree = (expression, series, validationTree = {}) => {
     case 'number':
       return (Number.isSafeInteger(expression.value) ? {} : { message: 'Threshold must be a valid number' });
     case 'number-ref':
-      return (expression.ref && series.find(s => s.id === expression.ref) ? {} : { message: 'Function must be set' });
+      /* eslint-disable no-case-declarations */
+      const error = { message: 'Function must be set' };
+      if (!expression.ref) {
+        return error;
+      }
+      const selectedSeries = series.find(s => s.id === expression.ref);
+      return (selectedSeries && selectedSeries.function ? {} : error);
+      /* eslint-enable no-case-declarations */
     case '&&':
     case '||':
     case '<':


### PR DESCRIPTION
Adds frontend validation to multiple aggregation condition. Doing the validation in the backend didn't really work, since a non-valid expression tree won't be parsed by Jackson and can't be validated in a custom way in the same way other configuration is.

This is how it looks like while editing the form:

<img width="1658" alt="Screenshot 2020-01-17 at 13 58 38" src="https://user-images.githubusercontent.com/716185/72614596-f46aa800-3932-11ea-8006-e8e87ad403ea.png">
<img width="1658" alt="Screenshot 2020-01-17 at 13 58 54" src="https://user-images.githubusercontent.com/716185/72614597-f46aa800-3932-11ea-8bfe-a126d2094382.png">

And this is after the server answers with a 400 error:

<img width="1654" alt="Screenshot 2020-01-17 at 14 02 58" src="https://user-images.githubusercontent.com/716185/72614616-064c4b00-3933-11ea-803b-5533c37952ef.png">
<img width="1654" alt="Screenshot 2020-01-17 at 14 07 53" src="https://user-images.githubusercontent.com/716185/72614618-06e4e180-3933-11ea-8adc-643619a8faf6.png">


Fixes #7149