### PR TITLE
Fix Alerting Lookup Table Parameters UI

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EditQueryParameterModal.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EditQueryParameterModal.jsx
@@ -116,7 +116,7 @@ class EditQueryParameterModal extends React.Component {
         <Button bsSize="small"
                 bsStyle={queryParameter.embryonic ? 'primary' : 'info'}
                 onClick={() => this.openModal()}>
-          {queryParameter.name}
+          {queryParameter.name}{queryParameter.embryonic && ': undeclared'}
         </Button>
 
         <BootstrapModalForm ref={(ref) => { this.modal = ref; }}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EditQueryParameterModal.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EditQueryParameterModal.jsx
@@ -139,6 +139,7 @@ class EditQueryParameterModal extends React.Component {
                     onChange={this.handleSelectChange('lookup_table')}
                     options={this.formatLookupTables(lookupTables)}
                     value={queryParameter.lookup_table}
+                    autoFocus
                     required />
             <HelpBlock>
               {validation.lookup_table || 'Select the Lookup Table Graylog should use to get the values.'}
@@ -152,7 +153,6 @@ class EditQueryParameterModal extends React.Component {
                  onChange={this.handleChange}
                  bsStyle={validation.key ? 'error' : null}
                  help={validation.key ? validation.key : 'Select the Lookup Table Key'}
-                 autoFocus
                  spellCheck={false}
                  required />
           <Input id={`default-value-${queryParameter.name}`}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EditQueryParameterModal.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EditQueryParameterModal.jsx
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
 import React from 'react';
-import { Button, Panel } from 'components/graylog';
+import { Button, Panel, ControlLabel, FormGroup, HelpBlock } from 'components/graylog';
 import { BootstrapModalForm, Input } from 'components/bootstrap';
-import { ControlLabel, FormGroup, HelpBlock } from 'components/graylog';
+
 import { Select } from 'components/common';
 import FormsUtils from 'util/FormsUtils';
 import { naturalSortIgnoreCase } from 'util/SortUtils';
@@ -120,7 +120,7 @@ class EditQueryParameterModal extends React.Component {
     return (
       <React.Fragment>
         <Button bsSize="small"
-                bsStyle={queryParameter.embryonic ? 'warning' : 'info'}
+                bsStyle={queryParameter.embryonic ? 'primary' : 'info'}
                 onClick={() => this.openModal()}>
           {queryParameter.name}
         </Button>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EditQueryParameterModal.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EditQueryParameterModal.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
 import React from 'react';
+import styled from 'styled-components';
+
 import { Button, Panel, ControlLabel, FormGroup, HelpBlock } from 'components/graylog';
 import { BootstrapModalForm, Input } from 'components/bootstrap';
 
@@ -8,6 +10,14 @@ import { Select } from 'components/common';
 import FormsUtils from 'util/FormsUtils';
 import { naturalSortIgnoreCase } from 'util/SortUtils';
 
+const StyledPanel = styled(Panel)`
+  margin-top: 20px;
+`;
+
+const StyledInlineCode = styled('code')`
+  margin: 0 0.25em;
+  white-space: nowrap;
+`;
 
 class EditQueryParameterModal extends React.Component {
   static propTypes = {
@@ -163,34 +173,30 @@ class EditQueryParameterModal extends React.Component {
                  defaultValue={queryParameter.default_value}
                  spellCheck={false}
                  onChange={this.handleChange} />
-          <Panel header="How to use" style={{ marginTop: 20 }}>
+          <StyledPanel header="How to use">
+            <h5>General Usage</h5>
             <p>
-              <h5>General Usage</h5>
-              After declaring it, the parameter {' '}
-              <span style={{ whiteSpace: 'nowrap' }}>
-                <code>{parameterSyntax}</code>
-              </span>{' '}
+              After declaring it, the parameter
+              <StyledInlineCode>{parameterSyntax}</StyledInlineCode>
               in your query, will be replaced with the list of results from the lookup table.
               The list of results will be presented in the form of a Lucene BooleanQuery. E.g.:
-              <span style={{ whiteSpace: 'nowrap' }}>
-                <code>(&quot;foo&quot; OR &quot;bar&quot; OR &quot;baz&quot;)</code>
-              </span>
+              <StyledInlineCode>(&quot;foo&quot; OR &quot;bar&quot; OR &quot;baz&quot;)</StyledInlineCode>
             </p>
+            <h5>Behaviour on empty lookup result list</h5>
             <p>
-              <h5>Behaviour on empty lookup result list</h5>
               The event definition query is only executed if a value for the parameter is present.
               If the lookup result is empty, the execution will be skipped and treated as if the <i>Search Query</i> found
-              no messages. If an execution is desired a <i>Default Value</i> that yields the desired search result needs to be provided.
-              For example, (depending on the use case) a wildcard like <span style={{ whiteSpace: 'nowrap' }}><code>*</code></span>
+              no messages. If an execution is desired a <i>Default Value</i> that yields the desired search result
+              needs to be provided. For example, (depending on the use case) a wildcard like
+              <StyledInlineCode>*</StyledInlineCode>
               can be a meaningful Default Value.
             </p>
+            <h5>Limitations</h5>
             <p>
-              <h5>Limitations</h5>
               Please note that maximum number of supported results is 1024. If the lookup table returns
               more results, the event definition is not executed.
             </p>
-
-          </Panel>
+          </StyledPanel>
         </BootstrapModalForm>
       </React.Fragment>
     );

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionFormContainer.jsx
@@ -94,9 +94,35 @@ class EventDefinitionFormContainer extends React.Component {
     history.push(Routes.ALERTS.DEFINITIONS.LIST);
   };
 
+  _validate = (eventDefinition) => {
+    const validation = {
+      isValid: false,
+    };
+
+    const { query_parameters: queryParameters } = eventDefinition.config;
+    if (queryParameters.length > 0 && queryParameters.some(p => p.embryonic)) {
+      const undeclaredParameters = queryParameters.filter(p => p.embryonic)
+        .map(p => p.name)
+        .join(', ');
+      validation.results = {
+        errors: {
+          query_parameters: [`Undeclared parameters: ${undeclaredParameters}.`],
+        },
+      };
+      return validation;
+    }
+
+    return { isValid: true };
+  };
+
   handleSubmit = () => {
     const { action } = this.props;
     const { eventDefinition } = this.state;
+    const validation = this._validate(eventDefinition);
+    if (!validation.isValid) {
+      this.setState({ validation: validation.results });
+      return;
+    }
 
     if (action === 'create') {
       EventDefinitionsActions.create(eventDefinition)

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import lodash from 'lodash';
 import { Link } from 'react-router';
 
+import { Alert } from 'components/graylog';
+import { Icon } from 'components/common';
 import { extractDurationAndUnit } from 'components/common/TimeUnitInput';
 import PermissionsMixin from 'util/PermissionsMixin';
 import { naturalSortIgnoreCase } from 'util/SortUtils';
@@ -54,10 +56,26 @@ class FilterAggregationSummary extends React.Component {
       .map(this.formatStreamOrId);
   };
 
+  renderQueryParameters = (queryParameters) => {
+    if (queryParameters.some(p => p.embryonic)) {
+      const undeclaredParameters = queryParameters.filter(p => p.embryonic)
+        .map(p => p.name)
+        .join(', ');
+      return (
+        <Alert bsStyle="danger">
+          <Icon name="exclamation-triangle" />&nbsp;There are undeclared query parameters: {undeclaredParameters}
+        </Alert>
+      );
+    }
+
+    return <dd>{queryParameters.map(p => p.name).join(', ')}</dd>;
+  }
+
   render() {
     const { config, currentUser } = this.props;
     const {
       query,
+      query_parameters: queryParameters,
       streams,
       search_within_ms: searchWithinMs,
       execute_every_ms: executeEveryMs,
@@ -80,6 +98,7 @@ class FilterAggregationSummary extends React.Component {
         <dd>{lodash.upperFirst(conditionType)}</dd>
         <dt>Search Query</dt>
         <dd>{query || '*'}</dd>
+        {queryParameters.length > 0 && this.renderQueryParameters(queryParameters)}
         <dt>Streams</dt>
         <dd className={styles.streamList}>{this.renderStreams(effectiveStreamIds)}</dd>
         <dt>Search within</dt>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
 import uuid from 'uuid/v4';
-import { ButtonToolbar, ControlLabel, FormGroup, HelpBlock, Well } from 'components/graylog';
+import { Alert, ButtonToolbar, ControlLabel, FormGroup, HelpBlock } from 'components/graylog';
 import moment from 'moment';
 
 import connect from 'stores/connect';
@@ -216,13 +216,13 @@ class FilterForm extends React.Component {
     const hasEmbryonicParameters = !lodash.isEmpty(queryParameters.filter(param => (param.embryonic)));
     return (
       <FormGroup validationState={hasEmbryonicParameters && 'error'}>
-        <ControlLabel>Query Parameters</ControlLabel>
-        <Well>
+        <ControlLabel>{hasEmbryonicParameters ? 'Undeclared ' : ''}Query Parameters</ControlLabel>
+        <Alert bsStyle="danger">
           <ButtonToolbar>
             {parameterButtons}
           </ButtonToolbar>
-        </Well>
-        { hasEmbryonicParameters && <HelpBlock>Please define the missing query parameters by clicking on the buttons above.</HelpBlock> }
+        </Alert>
+        { hasEmbryonicParameters && <HelpBlock>Please declare missing query parameters by clicking on the buttons above.</HelpBlock> }
       </FormGroup>
     );
   };

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
@@ -243,7 +243,12 @@ class FilterForm extends React.Component {
                name="query"
                label="Search Query"
                type="text"
-               help="Search query that Messages should match. You can use the same syntax as in the Search page."
+               help={(
+                 <span>
+                  Search query that Messages should match. You can use the same syntax as in the Search page,
+                  including declaring Query Parameters from Lookup Tables by using the <code>$newParameter$</code> syntax.
+                 </span>
+               )}
                value={lodash.defaultTo(eventDefinition.config.query, '')}
                onChange={this.handleQueryChange} />
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
@@ -165,7 +165,7 @@ class FilterForm extends React.Component {
       type: 'lut-parameter-v1',
       data_type: 'any',
       title: 'new title',
-      // has no binding!
+      // has no binding, no need to set binding property
     });
   };
 
@@ -216,7 +216,7 @@ class FilterForm extends React.Component {
     const hasEmbryonicParameters = !lodash.isEmpty(queryParameters.filter(param => (param.embryonic)));
     return (
       <FormGroup>
-        <ControlLabel>{hasEmbryonicParameters ? 'Undeclared ' : ''}Query Parameters</ControlLabel>
+        <ControlLabel>Query Parameters</ControlLabel>
         <Alert bsStyle={hasEmbryonicParameters ? 'danger' : 'info'}>
           <ButtonToolbar>
             {parameterButtons}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
@@ -215,14 +215,14 @@ class FilterForm extends React.Component {
     }
     const hasEmbryonicParameters = !lodash.isEmpty(queryParameters.filter(param => (param.embryonic)));
     return (
-      <FormGroup validationState={hasEmbryonicParameters && 'error'}>
+      <FormGroup>
         <ControlLabel>{hasEmbryonicParameters ? 'Undeclared ' : ''}Query Parameters</ControlLabel>
-        <Alert bsStyle="danger">
+        <Alert bsStyle={hasEmbryonicParameters ? 'danger' : 'info'}>
           <ButtonToolbar>
             {parameterButtons}
           </ButtonToolbar>
         </Alert>
-        { hasEmbryonicParameters && <HelpBlock>Please declare missing query parameters by clicking on the buttons above.</HelpBlock> }
+        {hasEmbryonicParameters && <HelpBlock>Please declare missing query parameters by clicking on the buttons above.</HelpBlock> }
       </FormGroup>
     );
   };

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
@@ -247,10 +247,7 @@ class FilterForm extends React.Component {
                value={lodash.defaultTo(eventDefinition.config.query, '')}
                onChange={this.handleQueryChange} />
 
-        <FormGroup controlId="filter-query-parameters">
-
-          {this.renderQueryParameters()}
-        </FormGroup>
+        {this.renderQueryParameters()}
 
         <FormGroup controlId="filter-streams">
           <ControlLabel>Streams <small className="text-muted">(Optional)</small></ControlLabel>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterForm.jsx
@@ -215,14 +215,21 @@ class FilterForm extends React.Component {
     }
     const hasEmbryonicParameters = !lodash.isEmpty(queryParameters.filter(param => (param.embryonic)));
     return (
-      <FormGroup>
+      <FormGroup validationState={validation.errors.query_parameters ? 'error' : null}>
         <ControlLabel>Query Parameters</ControlLabel>
         <Alert bsStyle={hasEmbryonicParameters ? 'danger' : 'info'}>
           <ButtonToolbar>
             {parameterButtons}
           </ButtonToolbar>
         </Alert>
-        {hasEmbryonicParameters && <HelpBlock>Please declare missing query parameters by clicking on the buttons above.</HelpBlock> }
+        {hasEmbryonicParameters && (
+          <HelpBlock>
+            {validation.errors.query_parameters
+              ? lodash.get(validation, 'errors.query_parameters[0]')
+              : 'Please declare missing query parameters by clicking on the buttons above.'
+            }
+          </HelpBlock>
+        )}
       </FormGroup>
     );
   };


### PR DESCRIPTION
This PR makes some improvements in the UI around support for Lookup Table Parameters in Filter & Aggregation Alerts, and also removes two warnings from the developer console:
- `Warning: Failed prop type: The prop `children` is marked as required in `<<anonymous>>`, but its value is ``null``.`
- `Warning: validateDOMNesting(...): <h5> cannot appear as a descendant of <p>.`

Before:
<img width="851" alt="Screenshot 2020-01-17 at 15 11 05" src="https://user-images.githubusercontent.com/716185/72618678-e8cfaf00-393b-11ea-834a-c114a9c546c5.png">

After:
<img width="859" alt="Screenshot 2020-01-20 at 12 26 10" src="https://user-images.githubusercontent.com/716185/72723923-33426d00-3b82-11ea-9aab-7165bd4fc4d6.png">
<img width="1677" alt="Screenshot 2020-01-20 at 12 36 41" src="https://user-images.githubusercontent.com/716185/72723925-33426d00-3b82-11ea-9ddc-010e825ca40b.png">

