### PR TITLE
Reset time in SearchesCleanUpJobWithDBServicesTest teardown method

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/QueryEffectiveTimeRangeTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/QueryEffectiveTimeRangeTest.java
@@ -23,6 +23,7 @@ import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersExc
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.joda.time.DateTimeUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -38,6 +39,12 @@ public class QueryEffectiveTimeRangeTest {
     @Before
     public void setUp() throws Exception {
         this.query = Query.emptyRoot();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        // Some tests modify the time so we make sure to reset it after each test even if assertions fail
+        DateTimeUtils.setCurrentMillisSystem();
     }
 
     @Test
@@ -102,7 +109,5 @@ public class QueryEffectiveTimeRangeTest {
         final TimeRange result = queryWithTimeRange.effectiveTimeRange(searchType);
 
         assertThat(result).isEqualTo(AbsoluteRange.create("2020-01-09T16:54:55.642Z", "2020-01-09T17:04:55.642Z"));
-
-        DateTimeUtils.setCurrentMillisSystem();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/db/SearchesCleanUpJobWithDBServicesTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/db/SearchesCleanUpJobWithDBServicesTest.java
@@ -35,6 +35,7 @@ import org.joda.time.DateTimeUtils;
 import org.joda.time.Duration;
 import org.jukito.JukitoRunner;
 import org.jukito.UseModules;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -92,6 +93,11 @@ public class SearchesCleanUpJobWithDBServicesTest {
                 )
         );
         this.searchesCleanUpJob = new SearchesCleanUpJob(viewService, searchDbService, Duration.standardDays(4));
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        DateTimeUtils.setCurrentMillisSystem();
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendUsingCorrectIndicesTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendUsingCorrectIndicesTest.java
@@ -38,6 +38,7 @@ import org.graylog2.streams.StreamService;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -110,6 +111,12 @@ public class ElasticsearchBackendUsingCorrectIndicesTest extends ElasticsearchBa
         this.job = new SearchJob("job1", search, "admin");
     }
 
+    @After
+    public void tearDown() throws Exception {
+        // Some tests modify the time so we make sure to reset it after each test even if assertions fail
+        DateTimeUtils.setCurrentMillisSystem();
+    }
+
     @Test
     public void queryDoesNotFallBackToUsingAllIndicesWhenNoIndexRangesAreReturned() throws Exception {
         when(indexRangeService.find(any(DateTime.class), any(DateTime.class))).thenReturn(new TreeSet<>());
@@ -140,8 +147,6 @@ public class ElasticsearchBackendUsingCorrectIndicesTest extends ElasticsearchBa
 
         assertThat(fromCapture.getValue()).isEqualTo(new DateTime(datetimeFixture, DateTimeZone.UTC).minusSeconds(600));
         assertThat(toCapture.getValue()).isEqualTo(new DateTime(datetimeFixture, DateTimeZone.UTC));
-
-        DateTimeUtils.setCurrentMillisSystem();
     }
 
     private Query dummyQuery(TimeRange timeRange) {

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/searchtypes/pivot/ESPivotTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/searchtypes/pivot/ESPivotTest.java
@@ -49,6 +49,7 @@ import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersExc
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -97,6 +98,12 @@ public class ESPivotTest {
         seriesHandlers = new HashMap<>();
         this.esPivot = new ESPivot(bucketHandlers, seriesHandlers);
         when(pivot.id()).thenReturn("dummypivot");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        // Some tests modify the time so we make sure to reset it after each test even if assertions fail
+        DateTimeUtils.setCurrentMillisSystem();
     }
 
     private MetricAggregation createTimestampRangeAggregations(Double min, Double max) {
@@ -339,7 +346,6 @@ public class ESPivotTest {
                 DateTime.parse("2020-01-09T15:39:25.408Z"),
                 DateTime.parse("2020-01-09T15:44:25.408Z")
         ));
-        DateTimeUtils.setCurrentMillisSystem();
     }
 
     @Test
@@ -382,6 +388,5 @@ public class ESPivotTest {
                 DateTime.parse("1970-01-01T00:00:00.000Z"),
                 DateTime.parse("2020-01-09T15:44:25.408Z")
         ));
-        DateTimeUtils.setCurrentMillisSystem();
     }
 }


### PR DESCRIPTION
This adds a missing `DateTimeUtils.setCurrentMillisSystem()` to avoid
a sporadic test failure in `DBJobTriggerServiceTest`.

The `SearchesCleanUpJobWithDBServicesTest` is using
`DateTimeUtils.setCurrentMillisFixed()` to set the time to a specific
value. This requires the usage of `DateTimeUtils.setCurrentMillisSystem()`
to reset the time to the current time. Otherwise tests running in the
same JVM using the current time might fail.

I noticed that the `DBJobTriggerServiceTest#deleteCompleted` test method
failed from time to time on a new Jenkins worker machine. This is
probably due to a changed execution order because the machine is faster
than the older worker machine. Still, strange that it didn't show up
earlier.