### PR TITLE
Redirect to dashboard route instead of view route after saving new dashboard

### DIFF
--- a/graylog2-web-interface/src/views/logic/views/OnSaveAsViewAction.js
+++ b/graylog2-web-interface/src/views/logic/views/OnSaveAsViewAction.js
@@ -12,7 +12,7 @@ type Router = {
 export default (view: View, router: Router) => {
   return ViewManagementActions.create(view)
     .then(() => ViewActions.load(view))
-    .then(state => router.push(Routes.VIEWS.VIEWID(state.view.id)))
+    .then(state => router.push(Routes.dashboard_show(state.view.id)))
     .then(() => UserNotification.success(`Saving view "${view.title}" was successful!`, 'Success!'))
     .catch(error => UserNotification.error(`Saving view failed: ${error}`, 'Error!'));
 };

--- a/graylog2-web-interface/src/views/logic/views/OnSaveAsViewAction.test.js
+++ b/graylog2-web-interface/src/views/logic/views/OnSaveAsViewAction.test.js
@@ -1,7 +1,5 @@
 import View from './View';
 
-jest.mock('routing/Routes', () => ({ VIEWS: { VIEWID: viewId => `/views/${viewId}` } }));
-
 // eslint-disable-next-line global-require
 const loadSUT = () => require('./OnSaveAsViewAction');
 
@@ -52,7 +50,7 @@ describe('OnSaveAsViewAction', () => {
 
     return onSaveAsView(view, router).then(() => {
       expect(router).toHaveLength(1);
-      expect(router).toEqual(['/views/deadbeef']);
+      expect(router).toEqual(['/dashboards/deadbeef']);
     });
   });
 


### PR DESCRIPTION
As described in #7201, currently the user gets redirected to `/views/[viewID]`, after saving a new dashboard. This PR changes the URL to the correct one `/dashboards/[viewID]`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

