### PR TITLE
Fix active / selected list group item styling

### DIFF
--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPacksList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPacksList.test.jsx.snap
@@ -1051,7 +1051,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "xqpkX",
+                          "lastClassName": "dpulNM",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -1063,10 +1063,14 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{&:not(.active){background-color:",
+                            ";}}&.list-group-item{background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
+                            ";&.active{color:",
+                            "#FFF",
+                            ";background-color:",
+                            "#9E1F63",
                             ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
@@ -1089,11 +1093,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX"
+                      className="listGroupHeader ListGroupItem-sc-1ky0joo-0 dpulNM"
                       listItem={false}
                     >
                       <span
-                        className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                        className="listGroupHeader ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                       >
                         <div
                           className="headerWrapper"
@@ -1123,7 +1127,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "xqpkX",
+                          "lastClassName": "dpulNM",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -1135,10 +1139,14 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{&:not(.active){background-color:",
+                            ";}}&.list-group-item{background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
+                            ";&.active{color:",
+                            "#FFF",
+                            ";background-color:",
+                            "#9E1F63",
                             ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
@@ -1161,11 +1169,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                      className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                       listItem={false}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                       >
                         <Row
                           bsClass="row"
@@ -1995,7 +2003,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "xqpkX",
+                          "lastClassName": "dpulNM",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -2007,10 +2015,14 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{&:not(.active){background-color:",
+                            ";}}&.list-group-item{background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
+                            ";&.active{color:",
+                            "#FFF",
+                            ";background-color:",
+                            "#9E1F63",
                             ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
@@ -2033,11 +2045,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                      className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                       listItem={false}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                       >
                         <Row
                           bsClass="row"
@@ -2867,7 +2879,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "xqpkX",
+                          "lastClassName": "dpulNM",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -2879,10 +2891,14 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{&:not(.active){background-color:",
+                            ";}}&.list-group-item{background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
+                            ";&.active{color:",
+                            "#FFF",
+                            ";background-color:",
+                            "#9E1F63",
                             ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
@@ -2905,11 +2921,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                      className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                       listItem={false}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                       >
                         <Row
                           bsClass="row"
@@ -3670,7 +3686,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "xqpkX",
+                          "lastClassName": "dpulNM",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -3682,10 +3698,14 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{&:not(.active){background-color:",
+                            ";}}&.list-group-item{background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
+                            ";&.active{color:",
+                            "#FFF",
+                            ";background-color:",
+                            "#9E1F63",
                             ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
@@ -3708,11 +3728,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                      className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                       listItem={false}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                       >
                         <Row
                           bsClass="row"
@@ -4474,7 +4494,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "xqpkX",
+                          "lastClassName": "dpulNM",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -4486,10 +4506,14 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{&:not(.active){background-color:",
+                            ";}}&.list-group-item{background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
+                            ";&.active{color:",
+                            "#FFF",
+                            ";background-color:",
+                            "#9E1F63",
                             ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
@@ -4512,11 +4536,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                      className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                       listItem={false}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                       >
                         <Row
                           bsClass="row"
@@ -5278,7 +5302,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "xqpkX",
+                          "lastClassName": "dpulNM",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -5290,10 +5314,14 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{&:not(.active){background-color:",
+                            ";}}&.list-group-item{background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
+                            ";&.active{color:",
+                            "#FFF",
+                            ";background-color:",
+                            "#9E1F63",
                             ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
@@ -5316,11 +5344,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                      className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                       listItem={false}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                       >
                         <Row
                           bsClass="row"
@@ -6082,7 +6110,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "xqpkX",
+                          "lastClassName": "dpulNM",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -6094,10 +6122,14 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{&:not(.active){background-color:",
+                            ";}}&.list-group-item{background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
+                            ";&.active{color:",
+                            "#FFF",
+                            ";background-color:",
+                            "#9E1F63",
                             ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
@@ -6120,11 +6152,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                      className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                       listItem={false}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                       >
                         <Row
                           bsClass="row"
@@ -6886,7 +6918,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "xqpkX",
+                          "lastClassName": "dpulNM",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -6898,10 +6930,14 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{&:not(.active){background-color:",
+                            ";}}&.list-group-item{background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
+                            ";&.active{color:",
+                            "#FFF",
+                            ";background-color:",
+                            "#9E1F63",
                             ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
@@ -6924,11 +6960,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                      className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                       listItem={false}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                       >
                         <Row
                           bsClass="row"
@@ -7689,7 +7725,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "xqpkX",
+                          "lastClassName": "dpulNM",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -7701,10 +7737,14 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{&:not(.active){background-color:",
+                            ";}}&.list-group-item{background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
+                            ";&.active{color:",
+                            "#FFF",
+                            ";background-color:",
+                            "#9E1F63",
                             ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
@@ -7727,11 +7767,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                      className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                       listItem={false}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                       >
                         <Row
                           bsClass="row"
@@ -8493,7 +8533,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "xqpkX",
+                          "lastClassName": "dpulNM",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -8505,10 +8545,14 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{&:not(.active){background-color:",
+                            ";}}&.list-group-item{background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
+                            ";&.active{color:",
+                            "#FFF",
+                            ";background-color:",
+                            "#9E1F63",
                             ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
@@ -8531,11 +8575,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                      className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                       listItem={false}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                       >
                         <Row
                           bsClass="row"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPacksList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPacksList.test.jsx.snap
@@ -1051,7 +1051,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "igGIXt",
+                          "lastClassName": "xqpkX",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -1063,11 +1063,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{background-color:",
+                            ";}}&.list-group-item{&:not(.active){background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
-                            ";&.disabled,&:disabled{color:",
+                            ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
                             "#FFF",
@@ -1089,11 +1089,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="listGroupHeader ListGroupItem-sc-1ky0joo-0 igGIXt"
+                      className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX"
                       listItem={false}
                     >
                       <span
-                        className="listGroupHeader ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                        className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                       >
                         <div
                           className="headerWrapper"
@@ -1123,7 +1123,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "igGIXt",
+                          "lastClassName": "xqpkX",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -1135,11 +1135,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{background-color:",
+                            ";}}&.list-group-item{&:not(.active){background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
-                            ";&.disabled,&:disabled{color:",
+                            ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
                             "#FFF",
@@ -1161,11 +1161,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                       listItem={false}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                       >
                         <Row
                           bsClass="row"
@@ -1995,7 +1995,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "igGIXt",
+                          "lastClassName": "xqpkX",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -2007,11 +2007,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{background-color:",
+                            ";}}&.list-group-item{&:not(.active){background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
-                            ";&.disabled,&:disabled{color:",
+                            ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
                             "#FFF",
@@ -2033,11 +2033,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                       listItem={false}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                       >
                         <Row
                           bsClass="row"
@@ -2867,7 +2867,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "igGIXt",
+                          "lastClassName": "xqpkX",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -2879,11 +2879,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{background-color:",
+                            ";}}&.list-group-item{&:not(.active){background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
-                            ";&.disabled,&:disabled{color:",
+                            ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
                             "#FFF",
@@ -2905,11 +2905,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                       listItem={false}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                       >
                         <Row
                           bsClass="row"
@@ -3670,7 +3670,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "igGIXt",
+                          "lastClassName": "xqpkX",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -3682,11 +3682,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{background-color:",
+                            ";}}&.list-group-item{&:not(.active){background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
-                            ";&.disabled,&:disabled{color:",
+                            ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
                             "#FFF",
@@ -3708,11 +3708,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                       listItem={false}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                       >
                         <Row
                           bsClass="row"
@@ -4474,7 +4474,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "igGIXt",
+                          "lastClassName": "xqpkX",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -4486,11 +4486,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{background-color:",
+                            ";}}&.list-group-item{&:not(.active){background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
-                            ";&.disabled,&:disabled{color:",
+                            ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
                             "#FFF",
@@ -4512,11 +4512,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                       listItem={false}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                       >
                         <Row
                           bsClass="row"
@@ -5278,7 +5278,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "igGIXt",
+                          "lastClassName": "xqpkX",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -5290,11 +5290,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{background-color:",
+                            ";}}&.list-group-item{&:not(.active){background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
-                            ";&.disabled,&:disabled{color:",
+                            ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
                             "#FFF",
@@ -5316,11 +5316,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                       listItem={false}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                       >
                         <Row
                           bsClass="row"
@@ -6082,7 +6082,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "igGIXt",
+                          "lastClassName": "xqpkX",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -6094,11 +6094,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{background-color:",
+                            ";}}&.list-group-item{&:not(.active){background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
-                            ";&.disabled,&:disabled{color:",
+                            ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
                             "#FFF",
@@ -6120,11 +6120,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                       listItem={false}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                       >
                         <Row
                           bsClass="row"
@@ -6886,7 +6886,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "igGIXt",
+                          "lastClassName": "xqpkX",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -6898,11 +6898,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{background-color:",
+                            ";}}&.list-group-item{&:not(.active){background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
-                            ";&.disabled,&:disabled{color:",
+                            ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
                             "#FFF",
@@ -6924,11 +6924,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                       listItem={false}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                       >
                         <Row
                           bsClass="row"
@@ -7689,7 +7689,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "igGIXt",
+                          "lastClassName": "xqpkX",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -7701,11 +7701,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{background-color:",
+                            ";}}&.list-group-item{&:not(.active){background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
-                            ";&.disabled,&:disabled{color:",
+                            ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
                             "#FFF",
@@ -7727,11 +7727,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                       listItem={false}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                       >
                         <Row
                           bsClass="row"
@@ -8493,7 +8493,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "igGIXt",
+                          "lastClassName": "xqpkX",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -8505,11 +8505,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{background-color:",
+                            ";}}&.list-group-item{&:not(.active){background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
-                            ";&.disabled,&:disabled{color:",
+                            ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
                             "#FFF",
@@ -8531,11 +8531,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                       listItem={false}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                       >
                         <Row
                           bsClass="row"

--- a/graylog2-web-interface/src/components/graylog/ListGroupItem.jsx
+++ b/graylog2-web-interface/src/components/graylog/ListGroupItem.jsx
@@ -77,7 +77,7 @@ const ListGroupItem = forwardRef(({ bsStyle, ...props }, ref) => {
           &:disabled {
             color: ${colors.primary.tre};
             background-color: ${colors.primary.due};
-          }          
+          }
         }
 
         ${bsStyleThemeVariant(listGroupItemStyles)}

--- a/graylog2-web-interface/src/components/graylog/ListGroupItem.jsx
+++ b/graylog2-web-interface/src/components/graylog/ListGroupItem.jsx
@@ -64,14 +64,16 @@ const ListGroupItem = forwardRef(({ bsStyle, ...props }, ref) => {
         }
 
         &.list-group-item {
-          background-color: ${colors.primary.due};
-          border-color: ${colors.secondary.tre};
+          &:not(.active) {
+            background-color: ${colors.primary.due};
+            border-color: ${colors.secondary.tre};
+          }
 
           &.disabled,
           &:disabled {
             color: ${colors.primary.tre};
             background-color: ${colors.primary.due};
-          }
+          }          
         }
 
         ${bsStyleThemeVariant(listGroupItemStyles)}

--- a/graylog2-web-interface/src/components/graylog/ListGroupItem.jsx
+++ b/graylog2-web-interface/src/components/graylog/ListGroupItem.jsx
@@ -4,6 +4,7 @@ import styled, { css } from 'styled-components';
 // eslint-disable-next-line no-restricted-imports
 import { ListGroupItem as BootstrapListGroupItem } from 'react-bootstrap';
 import { darken } from 'polished';
+import teinte from 'theme/teinte';
 
 import { useTheme } from 'theme/GraylogThemeContext';
 import { util } from 'theme';
@@ -64,9 +65,12 @@ const ListGroupItem = forwardRef(({ bsStyle, ...props }, ref) => {
         }
 
         &.list-group-item {
-          &:not(.active) {
-            background-color: ${colors.primary.due};
-            border-color: ${colors.secondary.tre};
+          background-color: ${colors.primary.due};
+          border-color: ${colors.secondary.tre};
+
+          &.active {
+            color: ${teinte.primary.due};
+            background-color: ${teinte.tertiary.quattro};
           }
 
           &.disabled,

--- a/graylog2-web-interface/src/components/grok-patterns/__snapshots__/GrokPatternInput.test.jsx.snap
+++ b/graylog2-web-interface/src/components/grok-patterns/__snapshots__/GrokPatternInput.test.jsx.snap
@@ -545,7 +545,7 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "xqpkX",
+                          "lastClassName": "dpulNM",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -557,10 +557,14 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{&:not(.active){background-color:",
+                            ";}}&.list-group-item{background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
+                            ";&.active{color:",
+                            "#FFF",
+                            ";background-color:",
+                            "#9E1F63",
                             ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
@@ -586,14 +590,14 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                      className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                       header="COMMONMAC"
                       id="list-item-0"
                       listItem={false}
                       onKeyDown={[Function]}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                         id="list-item-0"
                         onKeyDown={[Function]}
                       >
@@ -719,7 +723,7 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "xqpkX",
+                          "lastClassName": "dpulNM",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -731,10 +735,14 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{&:not(.active){background-color:",
+                            ";}}&.list-group-item{background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
+                            ";&.active{color:",
+                            "#FFF",
+                            ";background-color:",
+                            "#9E1F63",
                             ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
@@ -760,14 +768,14 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                      className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                       header="DATA"
                       id="list-item-1"
                       listItem={false}
                       onKeyDown={[Function]}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                         id="list-item-1"
                         onKeyDown={[Function]}
                       >
@@ -893,7 +901,7 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "xqpkX",
+                          "lastClassName": "dpulNM",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -905,10 +913,14 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{&:not(.active){background-color:",
+                            ";}}&.list-group-item{background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
+                            ";&.active{color:",
+                            "#FFF",
+                            ";background-color:",
+                            "#9E1F63",
                             ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
@@ -934,14 +946,14 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                      className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                       header="DATE"
                       id="list-item-2"
                       listItem={false}
                       onKeyDown={[Function]}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                         id="list-item-2"
                         onKeyDown={[Function]}
                       >

--- a/graylog2-web-interface/src/components/grok-patterns/__snapshots__/GrokPatternInput.test.jsx.snap
+++ b/graylog2-web-interface/src/components/grok-patterns/__snapshots__/GrokPatternInput.test.jsx.snap
@@ -545,7 +545,7 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "igGIXt",
+                          "lastClassName": "xqpkX",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -557,11 +557,11 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{background-color:",
+                            ";}}&.list-group-item{&:not(.active){background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
-                            ";&.disabled,&:disabled{color:",
+                            ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
                             "#FFF",
@@ -586,14 +586,14 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                       header="COMMONMAC"
                       id="list-item-0"
                       listItem={false}
                       onKeyDown={[Function]}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                         id="list-item-0"
                         onKeyDown={[Function]}
                       >
@@ -719,7 +719,7 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "igGIXt",
+                          "lastClassName": "xqpkX",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -731,11 +731,11 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{background-color:",
+                            ";}}&.list-group-item{&:not(.active){background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
-                            ";&.disabled,&:disabled{color:",
+                            ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
                             "#FFF",
@@ -760,14 +760,14 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                       header="DATA"
                       id="list-item-1"
                       listItem={false}
                       onKeyDown={[Function]}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                         id="list-item-1"
                         onKeyDown={[Function]}
                       >
@@ -893,7 +893,7 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
                         "componentStyle": ComponentStyle {
                           "componentId": "ListGroupItem-sc-1ky0joo-0",
                           "isStatic": false,
-                          "lastClassName": "igGIXt",
+                          "lastClassName": "xqpkX",
                           "rules": Array [
                             "&.list-group-item-action{color:",
                             "#1F1F1F",
@@ -905,11 +905,11 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
                             "#424344",
                             ";background-color:",
                             "#DCE1E5",
-                            ";}}&.list-group-item{background-color:",
+                            ";}}&.list-group-item{&:not(.active){background-color:",
                             "#FFF",
                             ";border-color:",
                             "#DCE1E5",
-                            ";&.disabled,&:disabled{color:",
+                            ";}&.disabled,&:disabled{color:",
                             "#1F1F1F",
                             ";background-color:",
                             "#FFF",
@@ -934,14 +934,14 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
                   >
                     <ListGroupItem
                       bsClass="list-group-item"
-                      className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                      className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                       header="DATE"
                       id="list-item-2"
                       listItem={false}
                       onKeyDown={[Function]}
                     >
                       <span
-                        className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                        className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                         id="list-item-2"
                         onKeyDown={[Function]}
                       >

--- a/graylog2-web-interface/src/components/users/__snapshots__/PermissionSelector.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/PermissionSelector.test.jsx.snap
@@ -771,7 +771,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "xqpkX",
+                                                      "lastClassName": "dpulNM",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -783,10 +783,14 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{&:not(.active){background-color:",
+                                                        ";}}&.list-group-item{background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
+                                                        ";&.active{color:",
+                                                        "#FFF",
+                                                        ";background-color:",
+                                                        "#9E1F63",
                                                         ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
@@ -809,11 +813,11 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX"
+                                                  className="listGroupHeader ListGroupItem-sc-1ky0joo-0 dpulNM"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                                                    className="listGroupHeader ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                                                   >
                                                     <Input
                                                       addonAfter={null}
@@ -949,7 +953,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "xqpkX",
+                                                      "lastClassName": "dpulNM",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -961,10 +965,14 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{&:not(.active){background-color:",
+                                                        ";}}&.list-group-item{background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
+                                                        ";&.active{color:",
+                                                        "#FFF",
+                                                        ";background-color:",
+                                                        "#9E1F63",
                                                         ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
@@ -987,11 +995,11 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                                                  className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                                                    className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                                                   >
                                                     <div
                                                       className="itemWrapper "
@@ -1296,7 +1304,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "xqpkX",
+                                                      "lastClassName": "dpulNM",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -1308,10 +1316,14 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{&:not(.active){background-color:",
+                                                        ";}}&.list-group-item{background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
+                                                        ";&.active{color:",
+                                                        "#FFF",
+                                                        ";background-color:",
+                                                        "#9E1F63",
                                                         ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
@@ -1334,11 +1346,11 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                                                  className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                                                    className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                                                   >
                                                     <div
                                                       className="itemWrapper "
@@ -2180,7 +2192,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "xqpkX",
+                                                      "lastClassName": "dpulNM",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -2192,10 +2204,14 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{&:not(.active){background-color:",
+                                                        ";}}&.list-group-item{background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
+                                                        ";&.active{color:",
+                                                        "#FFF",
+                                                        ";background-color:",
+                                                        "#9E1F63",
                                                         ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
@@ -2218,11 +2234,11 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX"
+                                                  className="listGroupHeader ListGroupItem-sc-1ky0joo-0 dpulNM"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                                                    className="listGroupHeader ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                                                   >
                                                     <Input
                                                       addonAfter={null}
@@ -2358,7 +2374,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "xqpkX",
+                                                      "lastClassName": "dpulNM",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -2370,10 +2386,14 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{&:not(.active){background-color:",
+                                                        ";}}&.list-group-item{background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
+                                                        ";&.active{color:",
+                                                        "#FFF",
+                                                        ";background-color:",
+                                                        "#9E1F63",
                                                         ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
@@ -2396,11 +2416,11 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                                                  className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                                                    className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                                                   >
                                                     <div
                                                       className="itemWrapper "
@@ -2705,7 +2725,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "xqpkX",
+                                                      "lastClassName": "dpulNM",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -2717,10 +2737,14 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{&:not(.active){background-color:",
+                                                        ";}}&.list-group-item{background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
+                                                        ";&.active{color:",
+                                                        "#FFF",
+                                                        ";background-color:",
+                                                        "#9E1F63",
                                                         ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
@@ -2743,11 +2767,11 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                                                  className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                                                    className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                                                   >
                                                     <div
                                                       className="itemWrapper "
@@ -3832,7 +3856,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "xqpkX",
+                                                      "lastClassName": "dpulNM",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -3844,10 +3868,14 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{&:not(.active){background-color:",
+                                                        ";}}&.list-group-item{background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
+                                                        ";&.active{color:",
+                                                        "#FFF",
+                                                        ";background-color:",
+                                                        "#9E1F63",
                                                         ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
@@ -3870,11 +3898,11 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX"
+                                                  className="listGroupHeader ListGroupItem-sc-1ky0joo-0 dpulNM"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                                                    className="listGroupHeader ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                                                   >
                                                     <Input
                                                       addonAfter={null}
@@ -4010,7 +4038,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "xqpkX",
+                                                      "lastClassName": "dpulNM",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -4022,10 +4050,14 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{&:not(.active){background-color:",
+                                                        ";}}&.list-group-item{background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
+                                                        ";&.active{color:",
+                                                        "#FFF",
+                                                        ";background-color:",
+                                                        "#9E1F63",
                                                         ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
@@ -4048,11 +4080,11 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                                                  className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                                                    className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                                                   >
                                                     <div
                                                       className="itemWrapper "
@@ -4357,7 +4389,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "xqpkX",
+                                                      "lastClassName": "dpulNM",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -4369,10 +4401,14 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{&:not(.active){background-color:",
+                                                        ";}}&.list-group-item{background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
+                                                        ";&.active{color:",
+                                                        "#FFF",
+                                                        ";background-color:",
+                                                        "#9E1F63",
                                                         ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
@@ -4395,11 +4431,11 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                                                  className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                                                    className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                                                   >
                                                     <div
                                                       className="itemWrapper "
@@ -5241,7 +5277,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "xqpkX",
+                                                      "lastClassName": "dpulNM",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -5253,10 +5289,14 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{&:not(.active){background-color:",
+                                                        ";}}&.list-group-item{background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
+                                                        ";&.active{color:",
+                                                        "#FFF",
+                                                        ";background-color:",
+                                                        "#9E1F63",
                                                         ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
@@ -5279,11 +5319,11 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX"
+                                                  className="listGroupHeader ListGroupItem-sc-1ky0joo-0 dpulNM"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                                                    className="listGroupHeader ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                                                   >
                                                     <Input
                                                       addonAfter={null}
@@ -5419,7 +5459,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "xqpkX",
+                                                      "lastClassName": "dpulNM",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -5431,10 +5471,14 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{&:not(.active){background-color:",
+                                                        ";}}&.list-group-item{background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
+                                                        ";&.active{color:",
+                                                        "#FFF",
+                                                        ";background-color:",
+                                                        "#9E1F63",
                                                         ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
@@ -5457,11 +5501,11 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                                                  className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                                                    className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                                                   >
                                                     <div
                                                       className="itemWrapper "
@@ -5766,7 +5810,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "xqpkX",
+                                                      "lastClassName": "dpulNM",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -5778,10 +5822,14 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{&:not(.active){background-color:",
+                                                        ";}}&.list-group-item{background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
+                                                        ";&.active{color:",
+                                                        "#FFF",
+                                                        ";background-color:",
+                                                        "#9E1F63",
                                                         ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
@@ -5804,11 +5852,11 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                                                  className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                                                    className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                                                   >
                                                     <div
                                                       className="itemWrapper "

--- a/graylog2-web-interface/src/components/users/__snapshots__/PermissionSelector.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/PermissionSelector.test.jsx.snap
@@ -771,7 +771,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "igGIXt",
+                                                      "lastClassName": "xqpkX",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -783,11 +783,11 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{background-color:",
+                                                        ";}}&.list-group-item{&:not(.active){background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
-                                                        ";&.disabled,&:disabled{color:",
+                                                        ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
                                                         "#FFF",
@@ -809,11 +809,11 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="listGroupHeader ListGroupItem-sc-1ky0joo-0 igGIXt"
+                                                  className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="listGroupHeader ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                                                    className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                                                   >
                                                     <Input
                                                       addonAfter={null}
@@ -949,7 +949,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "igGIXt",
+                                                      "lastClassName": "xqpkX",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -961,11 +961,11 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{background-color:",
+                                                        ";}}&.list-group-item{&:not(.active){background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
-                                                        ";&.disabled,&:disabled{color:",
+                                                        ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
                                                         "#FFF",
@@ -987,11 +987,11 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                                                  className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                                                    className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                                                   >
                                                     <div
                                                       className="itemWrapper "
@@ -1296,7 +1296,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "igGIXt",
+                                                      "lastClassName": "xqpkX",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -1308,11 +1308,11 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{background-color:",
+                                                        ";}}&.list-group-item{&:not(.active){background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
-                                                        ";&.disabled,&:disabled{color:",
+                                                        ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
                                                         "#FFF",
@@ -1334,11 +1334,11 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                                                  className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                                                    className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                                                   >
                                                     <div
                                                       className="itemWrapper "
@@ -2180,7 +2180,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "igGIXt",
+                                                      "lastClassName": "xqpkX",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -2192,11 +2192,11 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{background-color:",
+                                                        ";}}&.list-group-item{&:not(.active){background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
-                                                        ";&.disabled,&:disabled{color:",
+                                                        ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
                                                         "#FFF",
@@ -2218,11 +2218,11 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="listGroupHeader ListGroupItem-sc-1ky0joo-0 igGIXt"
+                                                  className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="listGroupHeader ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                                                    className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                                                   >
                                                     <Input
                                                       addonAfter={null}
@@ -2358,7 +2358,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "igGIXt",
+                                                      "lastClassName": "xqpkX",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -2370,11 +2370,11 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{background-color:",
+                                                        ";}}&.list-group-item{&:not(.active){background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
-                                                        ";&.disabled,&:disabled{color:",
+                                                        ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
                                                         "#FFF",
@@ -2396,11 +2396,11 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                                                  className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                                                    className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                                                   >
                                                     <div
                                                       className="itemWrapper "
@@ -2705,7 +2705,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "igGIXt",
+                                                      "lastClassName": "xqpkX",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -2717,11 +2717,11 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{background-color:",
+                                                        ";}}&.list-group-item{&:not(.active){background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
-                                                        ";&.disabled,&:disabled{color:",
+                                                        ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
                                                         "#FFF",
@@ -2743,11 +2743,11 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                                                  className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                                                    className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                                                   >
                                                     <div
                                                       className="itemWrapper "
@@ -3832,7 +3832,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "igGIXt",
+                                                      "lastClassName": "xqpkX",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -3844,11 +3844,11 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{background-color:",
+                                                        ";}}&.list-group-item{&:not(.active){background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
-                                                        ";&.disabled,&:disabled{color:",
+                                                        ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
                                                         "#FFF",
@@ -3870,11 +3870,11 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="listGroupHeader ListGroupItem-sc-1ky0joo-0 igGIXt"
+                                                  className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="listGroupHeader ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                                                    className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                                                   >
                                                     <Input
                                                       addonAfter={null}
@@ -4010,7 +4010,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "igGIXt",
+                                                      "lastClassName": "xqpkX",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -4022,11 +4022,11 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{background-color:",
+                                                        ";}}&.list-group-item{&:not(.active){background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
-                                                        ";&.disabled,&:disabled{color:",
+                                                        ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
                                                         "#FFF",
@@ -4048,11 +4048,11 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                                                  className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                                                    className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                                                   >
                                                     <div
                                                       className="itemWrapper "
@@ -4357,7 +4357,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "igGIXt",
+                                                      "lastClassName": "xqpkX",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -4369,11 +4369,11 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{background-color:",
+                                                        ";}}&.list-group-item{&:not(.active){background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
-                                                        ";&.disabled,&:disabled{color:",
+                                                        ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
                                                         "#FFF",
@@ -4395,11 +4395,11 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                                                  className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                                                    className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                                                   >
                                                     <div
                                                       className="itemWrapper "
@@ -5241,7 +5241,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "igGIXt",
+                                                      "lastClassName": "xqpkX",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -5253,11 +5253,11 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{background-color:",
+                                                        ";}}&.list-group-item{&:not(.active){background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
-                                                        ";&.disabled,&:disabled{color:",
+                                                        ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
                                                         "#FFF",
@@ -5279,11 +5279,11 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="listGroupHeader ListGroupItem-sc-1ky0joo-0 igGIXt"
+                                                  className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="listGroupHeader ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                                                    className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                                                   >
                                                     <Input
                                                       addonAfter={null}
@@ -5419,7 +5419,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "igGIXt",
+                                                      "lastClassName": "xqpkX",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -5431,11 +5431,11 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{background-color:",
+                                                        ";}}&.list-group-item{&:not(.active){background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
-                                                        ";&.disabled,&:disabled{color:",
+                                                        ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
                                                         "#FFF",
@@ -5457,11 +5457,11 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                                                  className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                                                    className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                                                   >
                                                     <div
                                                       className="itemWrapper "
@@ -5766,7 +5766,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                     "componentStyle": ComponentStyle {
                                                       "componentId": "ListGroupItem-sc-1ky0joo-0",
                                                       "isStatic": false,
-                                                      "lastClassName": "igGIXt",
+                                                      "lastClassName": "xqpkX",
                                                       "rules": Array [
                                                         "&.list-group-item-action{color:",
                                                         "#1F1F1F",
@@ -5778,11 +5778,11 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                         "#424344",
                                                         ";background-color:",
                                                         "#DCE1E5",
-                                                        ";}}&.list-group-item{background-color:",
+                                                        ";}}&.list-group-item{&:not(.active){background-color:",
                                                         "#FFF",
                                                         ";border-color:",
                                                         "#DCE1E5",
-                                                        ";&.disabled,&:disabled{color:",
+                                                        ";}&.disabled,&:disabled{color:",
                                                         "#1F1F1F",
                                                         ";background-color:",
                                                         "#FFF",
@@ -5804,11 +5804,11 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                               >
                                                 <ListGroupItem
                                                   bsClass="list-group-item"
-                                                  className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                                                  className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                                                   listItem={false}
                                                 >
                                                   <span
-                                                    className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                                                    className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                                                   >
                                                     <div
                                                       className="itemWrapper "

--- a/graylog2-web-interface/src/components/users/__snapshots__/TokenList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/TokenList.test.jsx.snap
@@ -760,7 +760,7 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
                             "componentStyle": ComponentStyle {
                               "componentId": "ListGroupItem-sc-1ky0joo-0",
                               "isStatic": false,
-                              "lastClassName": "xqpkX",
+                              "lastClassName": "dpulNM",
                               "rules": Array [
                                 "&.list-group-item-action{color:",
                                 "#1F1F1F",
@@ -772,10 +772,14 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
                                 "#424344",
                                 ";background-color:",
                                 "#DCE1E5",
-                                ";}}&.list-group-item{&:not(.active){background-color:",
+                                ";}}&.list-group-item{background-color:",
                                 "#FFF",
                                 ";border-color:",
                                 "#DCE1E5",
+                                ";&.active{color:",
+                                "#FFF",
+                                ";background-color:",
+                                "#9E1F63",
                                 ";}&.disabled,&:disabled{color:",
                                 "#1F1F1F",
                                 ";background-color:",
@@ -798,11 +802,11 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
                       >
                         <ListGroupItem
                           bsClass="list-group-item"
-                          className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX"
+                          className="listGroupHeader ListGroupItem-sc-1ky0joo-0 dpulNM"
                           listItem={false}
                         >
                           <span
-                            className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                            className="listGroupHeader ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                           >
                             <div
                               className="headerWrapper"
@@ -830,7 +834,7 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
                             "componentStyle": ComponentStyle {
                               "componentId": "ListGroupItem-sc-1ky0joo-0",
                               "isStatic": false,
-                              "lastClassName": "xqpkX",
+                              "lastClassName": "dpulNM",
                               "rules": Array [
                                 "&.list-group-item-action{color:",
                                 "#1F1F1F",
@@ -842,10 +846,14 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
                                 "#424344",
                                 ";background-color:",
                                 "#DCE1E5",
-                                ";}}&.list-group-item{&:not(.active){background-color:",
+                                ";}}&.list-group-item{background-color:",
                                 "#FFF",
                                 ";border-color:",
                                 "#DCE1E5",
+                                ";&.active{color:",
+                                "#FFF",
+                                ";background-color:",
+                                "#9E1F63",
                                 ";}&.disabled,&:disabled{color:",
                                 "#1F1F1F",
                                 ";background-color:",
@@ -868,11 +876,11 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
                       >
                         <ListGroupItem
                           bsClass="list-group-item"
-                          className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                          className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                           listItem={false}
                         >
                           <span
-                            className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                            className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                           >
                             No items to display
                           </span>
@@ -1710,7 +1718,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
                             "componentStyle": ComponentStyle {
                               "componentId": "ListGroupItem-sc-1ky0joo-0",
                               "isStatic": false,
-                              "lastClassName": "xqpkX",
+                              "lastClassName": "dpulNM",
                               "rules": Array [
                                 "&.list-group-item-action{color:",
                                 "#1F1F1F",
@@ -1722,10 +1730,14 @@ exports[`<TokenList /> should render with tokens 1`] = `
                                 "#424344",
                                 ";background-color:",
                                 "#DCE1E5",
-                                ";}}&.list-group-item{&:not(.active){background-color:",
+                                ";}}&.list-group-item{background-color:",
                                 "#FFF",
                                 ";border-color:",
                                 "#DCE1E5",
+                                ";&.active{color:",
+                                "#FFF",
+                                ";background-color:",
+                                "#9E1F63",
                                 ";}&.disabled,&:disabled{color:",
                                 "#1F1F1F",
                                 ";background-color:",
@@ -1748,11 +1760,11 @@ exports[`<TokenList /> should render with tokens 1`] = `
                       >
                         <ListGroupItem
                           bsClass="list-group-item"
-                          className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX"
+                          className="listGroupHeader ListGroupItem-sc-1ky0joo-0 dpulNM"
                           listItem={false}
                         >
                           <span
-                            className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                            className="listGroupHeader ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                           >
                             <div
                               className="headerWrapper"
@@ -1782,7 +1794,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
                             "componentStyle": ComponentStyle {
                               "componentId": "ListGroupItem-sc-1ky0joo-0",
                               "isStatic": false,
-                              "lastClassName": "xqpkX",
+                              "lastClassName": "dpulNM",
                               "rules": Array [
                                 "&.list-group-item-action{color:",
                                 "#1F1F1F",
@@ -1794,10 +1806,14 @@ exports[`<TokenList /> should render with tokens 1`] = `
                                 "#424344",
                                 ";background-color:",
                                 "#DCE1E5",
-                                ";}}&.list-group-item{&:not(.active){background-color:",
+                                ";}}&.list-group-item{background-color:",
                                 "#FFF",
                                 ";border-color:",
                                 "#DCE1E5",
+                                ";&.active{color:",
+                                "#FFF",
+                                ";background-color:",
+                                "#9E1F63",
                                 ";}&.disabled,&:disabled{color:",
                                 "#1F1F1F",
                                 ";background-color:",
@@ -1820,11 +1836,11 @@ exports[`<TokenList /> should render with tokens 1`] = `
                       >
                         <ListGroupItem
                           bsClass="list-group-item"
-                          className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                          className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                           listItem={false}
                         >
                           <span
-                            className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                            className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                           >
                             <div
                               className="itemWrapper itemWrapperStatic"
@@ -1958,7 +1974,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
                             "componentStyle": ComponentStyle {
                               "componentId": "ListGroupItem-sc-1ky0joo-0",
                               "isStatic": false,
-                              "lastClassName": "xqpkX",
+                              "lastClassName": "dpulNM",
                               "rules": Array [
                                 "&.list-group-item-action{color:",
                                 "#1F1F1F",
@@ -1970,10 +1986,14 @@ exports[`<TokenList /> should render with tokens 1`] = `
                                 "#424344",
                                 ";background-color:",
                                 "#DCE1E5",
-                                ";}}&.list-group-item{&:not(.active){background-color:",
+                                ";}}&.list-group-item{background-color:",
                                 "#FFF",
                                 ";border-color:",
                                 "#DCE1E5",
+                                ";&.active{color:",
+                                "#FFF",
+                                ";background-color:",
+                                "#9E1F63",
                                 ";}&.disabled,&:disabled{color:",
                                 "#1F1F1F",
                                 ";background-color:",
@@ -1996,11 +2016,11 @@ exports[`<TokenList /> should render with tokens 1`] = `
                       >
                         <ListGroupItem
                           bsClass="list-group-item"
-                          className="ListGroupItem-sc-1ky0joo-0 xqpkX"
+                          className="ListGroupItem-sc-1ky0joo-0 dpulNM"
                           listItem={false}
                         >
                           <span
-                            className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                            className="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                           >
                             <div
                               className="itemWrapper itemWrapperStatic"

--- a/graylog2-web-interface/src/components/users/__snapshots__/TokenList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/TokenList.test.jsx.snap
@@ -760,7 +760,7 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
                             "componentStyle": ComponentStyle {
                               "componentId": "ListGroupItem-sc-1ky0joo-0",
                               "isStatic": false,
-                              "lastClassName": "igGIXt",
+                              "lastClassName": "xqpkX",
                               "rules": Array [
                                 "&.list-group-item-action{color:",
                                 "#1F1F1F",
@@ -772,11 +772,11 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
                                 "#424344",
                                 ";background-color:",
                                 "#DCE1E5",
-                                ";}}&.list-group-item{background-color:",
+                                ";}}&.list-group-item{&:not(.active){background-color:",
                                 "#FFF",
                                 ";border-color:",
                                 "#DCE1E5",
-                                ";&.disabled,&:disabled{color:",
+                                ";}&.disabled,&:disabled{color:",
                                 "#1F1F1F",
                                 ";background-color:",
                                 "#FFF",
@@ -798,11 +798,11 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
                       >
                         <ListGroupItem
                           bsClass="list-group-item"
-                          className="listGroupHeader ListGroupItem-sc-1ky0joo-0 igGIXt"
+                          className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX"
                           listItem={false}
                         >
                           <span
-                            className="listGroupHeader ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                            className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                           >
                             <div
                               className="headerWrapper"
@@ -830,7 +830,7 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
                             "componentStyle": ComponentStyle {
                               "componentId": "ListGroupItem-sc-1ky0joo-0",
                               "isStatic": false,
-                              "lastClassName": "igGIXt",
+                              "lastClassName": "xqpkX",
                               "rules": Array [
                                 "&.list-group-item-action{color:",
                                 "#1F1F1F",
@@ -842,11 +842,11 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
                                 "#424344",
                                 ";background-color:",
                                 "#DCE1E5",
-                                ";}}&.list-group-item{background-color:",
+                                ";}}&.list-group-item{&:not(.active){background-color:",
                                 "#FFF",
                                 ";border-color:",
                                 "#DCE1E5",
-                                ";&.disabled,&:disabled{color:",
+                                ";}&.disabled,&:disabled{color:",
                                 "#1F1F1F",
                                 ";background-color:",
                                 "#FFF",
@@ -868,11 +868,11 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
                       >
                         <ListGroupItem
                           bsClass="list-group-item"
-                          className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                          className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                           listItem={false}
                         >
                           <span
-                            className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                            className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                           >
                             No items to display
                           </span>
@@ -1710,7 +1710,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
                             "componentStyle": ComponentStyle {
                               "componentId": "ListGroupItem-sc-1ky0joo-0",
                               "isStatic": false,
-                              "lastClassName": "igGIXt",
+                              "lastClassName": "xqpkX",
                               "rules": Array [
                                 "&.list-group-item-action{color:",
                                 "#1F1F1F",
@@ -1722,11 +1722,11 @@ exports[`<TokenList /> should render with tokens 1`] = `
                                 "#424344",
                                 ";background-color:",
                                 "#DCE1E5",
-                                ";}}&.list-group-item{background-color:",
+                                ";}}&.list-group-item{&:not(.active){background-color:",
                                 "#FFF",
                                 ";border-color:",
                                 "#DCE1E5",
-                                ";&.disabled,&:disabled{color:",
+                                ";}&.disabled,&:disabled{color:",
                                 "#1F1F1F",
                                 ";background-color:",
                                 "#FFF",
@@ -1748,11 +1748,11 @@ exports[`<TokenList /> should render with tokens 1`] = `
                       >
                         <ListGroupItem
                           bsClass="list-group-item"
-                          className="listGroupHeader ListGroupItem-sc-1ky0joo-0 igGIXt"
+                          className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX"
                           listItem={false}
                         >
                           <span
-                            className="listGroupHeader ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                            className="listGroupHeader ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                           >
                             <div
                               className="headerWrapper"
@@ -1782,7 +1782,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
                             "componentStyle": ComponentStyle {
                               "componentId": "ListGroupItem-sc-1ky0joo-0",
                               "isStatic": false,
-                              "lastClassName": "igGIXt",
+                              "lastClassName": "xqpkX",
                               "rules": Array [
                                 "&.list-group-item-action{color:",
                                 "#1F1F1F",
@@ -1794,11 +1794,11 @@ exports[`<TokenList /> should render with tokens 1`] = `
                                 "#424344",
                                 ";background-color:",
                                 "#DCE1E5",
-                                ";}}&.list-group-item{background-color:",
+                                ";}}&.list-group-item{&:not(.active){background-color:",
                                 "#FFF",
                                 ";border-color:",
                                 "#DCE1E5",
-                                ";&.disabled,&:disabled{color:",
+                                ";}&.disabled,&:disabled{color:",
                                 "#1F1F1F",
                                 ";background-color:",
                                 "#FFF",
@@ -1820,11 +1820,11 @@ exports[`<TokenList /> should render with tokens 1`] = `
                       >
                         <ListGroupItem
                           bsClass="list-group-item"
-                          className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                          className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                           listItem={false}
                         >
                           <span
-                            className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                            className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                           >
                             <div
                               className="itemWrapper itemWrapperStatic"
@@ -1958,7 +1958,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
                             "componentStyle": ComponentStyle {
                               "componentId": "ListGroupItem-sc-1ky0joo-0",
                               "isStatic": false,
-                              "lastClassName": "igGIXt",
+                              "lastClassName": "xqpkX",
                               "rules": Array [
                                 "&.list-group-item-action{color:",
                                 "#1F1F1F",
@@ -1970,11 +1970,11 @@ exports[`<TokenList /> should render with tokens 1`] = `
                                 "#424344",
                                 ";background-color:",
                                 "#DCE1E5",
-                                ";}}&.list-group-item{background-color:",
+                                ";}}&.list-group-item{&:not(.active){background-color:",
                                 "#FFF",
                                 ";border-color:",
                                 "#DCE1E5",
-                                ";&.disabled,&:disabled{color:",
+                                ";}&.disabled,&:disabled{color:",
                                 "#1F1F1F",
                                 ";background-color:",
                                 "#FFF",
@@ -1996,11 +1996,11 @@ exports[`<TokenList /> should render with tokens 1`] = `
                       >
                         <ListGroupItem
                           bsClass="list-group-item"
-                          className="ListGroupItem-sc-1ky0joo-0 igGIXt"
+                          className="ListGroupItem-sc-1ky0joo-0 xqpkX"
                           listItem={false}
                         >
                           <span
-                            className="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                            className="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                           >
                             <div
                               className="itemWrapper itemWrapperStatic"

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkList.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkList.test.jsx.snap
@@ -345,7 +345,7 @@ exports[`BookmarkList render the BookmarkList should render with views 1`] = `
               class="list-group"
             >
               <button
-                class="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                class="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                 type="button"
               >
                 <h4

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkList.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkList.test.jsx.snap
@@ -345,7 +345,7 @@ exports[`BookmarkList render the BookmarkList should render with views 1`] = `
               class="list-group"
             >
               <button
-                class="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                class="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                 type="button"
               >
                 <h4

--- a/graylog2-web-interface/src/views/components/widgets/__snapshots__/CopyToDashboardForm.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/widgets/__snapshots__/CopyToDashboardForm.test.jsx.snap
@@ -338,7 +338,7 @@ exports[`CopyToDashboardForm should render the modal with entries 1`] = `
               class="list-group"
             >
               <button
-                class="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                class="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                 type="button"
               >
                 <h4
@@ -351,7 +351,7 @@ exports[`CopyToDashboardForm should render the modal with entries 1`] = `
                 />
               </button>
               <button
-                class="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
+                class="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
                 type="button"
               >
                 <h4

--- a/graylog2-web-interface/src/views/components/widgets/__snapshots__/CopyToDashboardForm.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/widgets/__snapshots__/CopyToDashboardForm.test.jsx.snap
@@ -338,7 +338,7 @@ exports[`CopyToDashboardForm should render the modal with entries 1`] = `
               class="list-group"
             >
               <button
-                class="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                class="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                 type="button"
               >
                 <h4
@@ -351,7 +351,7 @@ exports[`CopyToDashboardForm should render the modal with entries 1`] = `
                 />
               </button>
               <button
-                class="ListGroupItem-sc-1ky0joo-0 xqpkX list-group-item"
+                class="ListGroupItem-sc-1ky0joo-0 dpulNM list-group-item"
                 type="button"
               >
                 <h4


### PR DESCRIPTION
As described in #7193 the "active" (not in the context of a css selector) styling of a list group item is currently broken.

Fixes #7193

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

