### PR TITLE
Hide Pagination in PaginatedList when context is not interactive

### DIFF
--- a/graylog2-web-interface/src/components/common/PaginatedList.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import * as React from 'react';
 import { Pagination } from 'components/graylog';
 import { Input } from 'components/bootstrap';
+import InteractiveContext from 'views/components/contexts/InteractiveContext';
 
 const defaultPageSizes = [10, 50, 100];
 
@@ -114,23 +115,29 @@ class PaginatedList extends React.Component<Props, State> {
     const numberPages = Math.ceil(totalItems / pageSize);
 
     return (
-      <>
-        {this._pageSizeSelect()}
+      <InteractiveContext.Consumer>
+        {interactive => (
+          <>
+            {this._pageSizeSelect()}
 
-        {children}
+            {children}
 
-        <div className="text-center">
-          <Pagination bsSize="small"
-                      items={numberPages}
-                      maxButtons={10}
-                      activePage={currentPage}
-                      onSelect={this._onChangePage}
-                      prev
-                      next
-                      first
-                      last />
-        </div>
-      </>
+            {interactive && (
+              <div className="text-center">
+                <Pagination bsSize="small"
+                            items={numberPages}
+                            maxButtons={10}
+                            activePage={currentPage}
+                            onSelect={this._onChangePage}
+                            prev
+                            next
+                            first
+                            last />
+              </div>
+            )}
+          </>
+        )}
+      </InteractiveContext.Consumer>
     );
   }
 }

--- a/graylog2-web-interface/src/components/common/PaginatedList.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.jsx
@@ -1,9 +1,10 @@
 // @flow strict
 import PropTypes from 'prop-types';
 import * as React from 'react';
+
 import { Pagination } from 'components/graylog';
 import { Input } from 'components/bootstrap';
-import InteractiveContext from 'views/components/contexts/InteractiveContext';
+import IfInteractive from 'views/components/dashboard/IfInteractive';
 
 const defaultPageSizes = [10, 50, 100];
 
@@ -115,29 +116,25 @@ class PaginatedList extends React.Component<Props, State> {
     const numberPages = Math.ceil(totalItems / pageSize);
 
     return (
-      <InteractiveContext.Consumer>
-        {interactive => (
-          <>
-            {this._pageSizeSelect()}
+      <>
+        {this._pageSizeSelect()}
 
-            {children}
+        {children}
 
-            {interactive && (
-              <div className="text-center">
-                <Pagination bsSize="small"
-                            items={numberPages}
-                            maxButtons={10}
-                            activePage={currentPage}
-                            onSelect={this._onChangePage}
-                            prev
-                            next
-                            first
-                            last />
-              </div>
-            )}
-          </>
-        )}
-      </InteractiveContext.Consumer>
+        <IfInteractive>
+          <div className="text-center">
+            <Pagination bsSize="small"
+                        items={numberPages}
+                        maxButtons={10}
+                        activePage={currentPage}
+                        onSelect={this._onChangePage}
+                        prev
+                        next
+                        first
+                        last />
+          </div>
+        </IfInteractive>
+      </>
     );
   }
 }

--- a/graylog2-web-interface/src/components/common/PaginatedList.test.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.test.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, cleanup } from 'wrappedTestingLibrary';
+
+import InteractiveContext from 'views/components/contexts/InteractiveContext';
+import PaginatedList from './PaginatedList';
+
+describe('PaginatedList', () => {
+  afterEach(cleanup);
+
+  it('should display Pagination', () => {
+    const { getByText } = render(<PaginatedList totalItems={100} onChange={() => {}} pageSize={10}>List</PaginatedList>);
+    expect(getByText('1')).not.toBeNull();
+  });
+  it('should not display Pagination, when context is not interactive', () => {
+    const { queryByText } = render(
+      <InteractiveContext.Provider value={false}>
+        <PaginatedList totalItems={100} onChange={() => {}} pageSize={10}>List</PaginatedList>,
+      </InteractiveContext.Provider>,
+    );
+    expect(queryByText('1')).toBeNull();
+  });
+});

--- a/graylog2-web-interface/src/components/common/PaginatedList.test.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.test.jsx
@@ -1,3 +1,4 @@
+// @flow strict
 import React from 'react';
 import { render, cleanup } from 'wrappedTestingLibrary';
 


### PR DESCRIPTION
As described in #7210, the MessageList pagination does not work in the dashboard full screen mode. This PR hides the pagination inside the PaginatedList, when the `InteractiveContext` defines the context as not interactive. We can safely add this to the shared component because the context is by default interactive.

I would prefer to disable the pagination, but the bootstrap component does not support this functionality and we would have to implement all the styles and logic on our own.

Fixes #7210

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

