### PR TITLE
Remove not needed header from search bookmark list items

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkList.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkList.jsx
@@ -107,9 +107,8 @@ class BookmarkList extends React.Component<Props, State> {
       return (
         <ListGroupItem active={selectedBookmark === bookmark.id}
                        onClick={() => this.setState({ selectedBookmark: bookmark.id })}
-                       header={bookmark.title}
                        key={bookmark.id}>
-          {bookmark.summary}
+          {bookmark.title}
         </ListGroupItem>
       );
     });

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkList.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkList.test.jsx.snap
@@ -348,14 +348,7 @@ exports[`BookmarkList render the BookmarkList should render with views 1`] = `
                 class="ListGroupItem-sc-1ky0joo-0 igGIXt list-group-item"
                 type="button"
               >
-                <h4
-                  class="list-group-item-heading"
-                >
-                  test-0
-                </h4>
-                <p
-                  class="list-group-item-text"
-                />
+                test-0
               </button>
             </div>
             <div


### PR DESCRIPTION
The search bookmark list items are currently displaying the titles as a header element. After merging https://github.com/Graylog2/graylog2-server/pull/7069 (which fixes the active state) these items would have a big font size.

The removed `summary` attribute can no longer be defined for saved searches.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

