### PR TITLE
Implement BootstrapModalForm for ViewPropertiesModal

### DIFF
--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
@@ -61,16 +61,20 @@ const ViewActionsMenu = ({ view, isNewView, metadata, onSaveView, onSaveAsView, 
         </IfDashboard>
       </DropdownButton>
       <DebugOverlay show={debugOpen} onClose={() => setDebugOpen(false)} />
-      <ViewPropertiesModal view={view.toBuilder().newId().build()}
-                           title="Save new dashboard"
-                           onSave={onSaveAsView}
-                           show={saveAsViewOpen}
-                           onClose={() => setSaveAsViewOpen(false)} />
-      <ViewPropertiesModal view={view}
-                           title="Editing dashboard"
-                           onSave={onSaveView}
-                           show={editViewOpen}
-                           onClose={() => setEditViewOpen(false)} />
+      {saveAsViewOpen && (
+        <ViewPropertiesModal view={view.toBuilder().newId().build()}
+                             title="Save new dashboard"
+                             onSave={onSaveAsView}
+                             show
+                             onClose={() => setSaveAsViewOpen(false)} />
+      )}
+      {editViewOpen && (
+        <ViewPropertiesModal view={view}
+                             title="Editing dashboard"
+                             onSave={onSaveView}
+                             show
+                             onClose={() => setEditViewOpen(false)} />
+      )}
       {shareViewOpen && <ShareViewModal view={view} show onClose={() => setShareViewOpen(false)} />}
     </React.Fragment>
   );

--- a/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.jsx
+++ b/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.jsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { isEqual } from 'lodash';
-
-import { Modal, Button } from 'components/graylog';
 import FormsUtils from 'util/FormsUtils';
+
+import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import Input from 'components/bootstrap/Input';
 
 export default class ViewPropertiesModal extends React.Component {
   static propTypes = {
     view: PropTypes.object.isRequired,
-    show: PropTypes.bool,
     title: PropTypes.string.isRequired,
     onSave: PropTypes.func.isRequired,
     onClose: PropTypes.func,
@@ -17,30 +16,32 @@ export default class ViewPropertiesModal extends React.Component {
 
   static defaultProps = {
     onClose: () => {},
-    show: false,
   };
 
   constructor(props) {
     super(props);
     this.state = {
       view: props.view,
-      show: props.show,
       title: props.title,
     };
   }
 
   componentWillReceiveProps(nextProps) {
-    const { show, title } = this.props;
+    const { title } = this.props;
     const { view } = this.state;
-    if (show !== nextProps.show || title !== nextProps.title || !isEqual(view, nextProps.view)) {
-      this.setState({ view: nextProps.view, title: nextProps.title, show: nextProps.show });
+    if (title !== nextProps.title || !isEqual(view, nextProps.view)) {
+      this.setState({ view: nextProps.view, title: nextProps.title });
     }
   }
 
   // eslint-disable-next-line consistent-return
   _onChange = (event) => {
     const { name } = event.target;
-    const value = FormsUtils.getValueFromInput(event.target);
+    let value = FormsUtils.getValueFromInput(event.target);
+    const trimmedValue = value.trim();
+    if (trimmedValue === '') {
+      value = trimmedValue;
+    }
 
     switch (name) {
       case 'title': return this.setState(state => ({ view: state.view.toBuilder().title(value).build() }));
@@ -63,40 +64,37 @@ export default class ViewPropertiesModal extends React.Component {
   };
 
   render() {
-    const { show, view, title } = this.state;
+    const { view: { title = '', summary = '', description = '' }, title: modalTitle } = this.state;
     return (
-      <Modal show={show} bsSize="large" onHide={this.handleClose}>
-        <Modal.Header closeButton>
-          <Modal.Title>{title}</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <Input id="title"
-                 type="text"
-                 name="title"
-                 label="Title"
-                 help="The title of the dashboard."
-                 onChange={this._onChange}
-                 value={view.title} />
-          <Input id="summary"
-                 type="text"
-                 name="summary"
-                 label="Summary"
-                 help="A helpful summary of the dashboard."
-                 onChange={this._onChange}
-                 value={view.summary} />
-          <Input id="description"
-                 type="textarea"
-                 name="description"
-                 label="Description"
-                 help="A longer, helpful description of the dashboard and its functionality."
-                 onChange={this._onChange}
-                 value={view.description} />
-        </Modal.Body>
-        <Modal.Footer>
-          <Button onClick={this._onSave} bsStyle="success">Save</Button>
-          <Button onClick={this._onClose}>Cancel</Button>
-        </Modal.Footer>
-      </Modal>
+      <BootstrapModalForm title={modalTitle}
+                          onSubmitForm={this._onSave}
+                          onModalClose={this._onClose}
+                          submitButtonText="Save"
+                          show
+                          bsSize="large">
+        <Input id="title"
+               type="text"
+               name="title"
+               label="Title"
+               help="The title of the dashboard."
+               required
+               onChange={this._onChange}
+               value={title} />
+        <Input id="summary"
+               type="text"
+               name="summary"
+               label="Summary"
+               help="A helpful summary of the dashboard."
+               onChange={this._onChange}
+               value={summary} />
+        <Input id="description"
+               type="textarea"
+               name="description"
+               label="Description"
+               help="A longer, helpful description of the dashboard and its functionality."
+               onChange={this._onChange}
+               value={description} />
+      </BootstrapModalForm>
     );
   }
 }


### PR DESCRIPTION
As mentioned in https://github.com/Graylog2/graylog2-server/issues/7229 some modal are not using the already existing wrappers.
This PR implements the `BootstrapModalForm` for the `ViewPropertiesModal`, which wraps the inputs in an html form element and allows the usage of html validation.

Before these changes the user was able to submit a form without a title, this results in a backend "error". As described in https://github.com/Graylog2/graylog2-server/issues/7209 the user was also able to submit e.g. empty spaces for the title which results in an backend "error" as well.

Fixes #7209

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

