### PR TITLE
Fix GlobalOverride behavior

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/QueryTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/QueryTest.java
@@ -162,10 +162,7 @@ public class QueryTest {
         );
         Query sut = validQueryBuilder().build();
         Query query = sut.applyExecutionState(objectMapper, objectMapper.convertValue(executionState, JsonNode.class));
-        assertThat(query.globalOverride()).isPresent();
-        final GlobalOverride override = query.globalOverride().get();
-        assertThat(override.timerange()).isEmpty();
-        assertThat(override.query()).isEmpty();
+        assertThat(query.globalOverride()).isEmpty();
     }
     private RelativeRange relativeRange(int range) {
         try {

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/QueryTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/QueryTest.java
@@ -162,7 +162,10 @@ public class QueryTest {
         );
         Query sut = validQueryBuilder().build();
         Query query = sut.applyExecutionState(objectMapper, objectMapper.convertValue(executionState, JsonNode.class));
-        assertThat(query.globalOverride()).isEmpty();
+        assertThat(query.globalOverride()).isPresent();
+        final GlobalOverride override = query.globalOverride().get();
+        assertThat(override.timerange()).isEmpty();
+        assertThat(override.query()).isEmpty();
     }
     private RelativeRange relativeRange(int range) {
         try {

--- a/graylog2-web-interface/src/views/stores/GlobalOverrideStore.js
+++ b/graylog2-web-interface/src/views/stores/GlobalOverrideStore.js
@@ -1,14 +1,13 @@
 // @flow strict
 import Reflux from 'reflux';
 import moment from 'moment';
-import { isEmpty } from 'lodash';
 
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import GlobalOverride from 'views/logic/search/GlobalOverride';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
 import type { TimeRange } from 'views/logic/queries/Query';
 import type { RefluxActions, Store } from 'stores/StoreTypes';
-import { SearchExecutionStateStore, SearchExecutionStateActions } from './SearchExecutionStateStore';
+import { SearchExecutionStateActions, SearchExecutionStateStore } from './SearchExecutionStateStore';
 
 export type GlobalOverrideActionsType = RefluxActions<{
   rangeType: (string) => Promise<?GlobalOverride>,

--- a/graylog2-web-interface/src/views/stores/GlobalOverrideStore.js
+++ b/graylog2-web-interface/src/views/stores/GlobalOverrideStore.js
@@ -59,8 +59,8 @@ export const GlobalOverrideStore: GlobalOverrideStoreType = singletonStore(
     },
     rangeType(newType: string) {
       if (newType === 'disabled') {
-        const { timerange, ...rest } = this.globalOverride || {};
-        const newGlobalOverride: ?GlobalOverride = isEmpty(rest) ? undefined : { ...rest };
+        const currentGlobalOverride = this.globalOverride || GlobalOverride.empty();
+        const newGlobalOverride: ?GlobalOverride = currentGlobalOverride.toBuilder().timerange(undefined).build();
         const promise = this._propagateNewGlobalOverride(newGlobalOverride);
         GlobalOverrideActions.rangeType.promise(promise);
         return promise;


### PR DESCRIPTION
## Description, Motivation and Context
Prior to this change, the globaloverride for timerange was overriden by
the query builder for globaloverride. That way a globaloverride for
query and timerange did not apply the timerange of the override.

Also when disabling the timerange override in the gui the store did
set a plain javascript object instead of a GlobalOverride value class,
with that the Store could not change the timerange of the global
override anymore.

This change will use a common Globaloverride Builder for `hasTimerange`
and `hasQuery` that way the query does not override timerange.

Also when disabling the timerange in the GUI we now only unset the
timerange value of the Globaloverride.

## How Has This Been Tested?
Changed the global override in as many ways as possible.

Fixes #7236 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

