### PR TITLE
Update current view title, summary and description on view edit

### DIFF
--- a/graylog2-web-interface/src/views/logic/views/OnSaveViewAction.js
+++ b/graylog2-web-interface/src/views/logic/views/OnSaveViewAction.js
@@ -1,8 +1,11 @@
 import UserNotification from 'util/UserNotification';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
+import { ViewActions } from 'views/stores/ViewStore';
 
-export default (view) => {
-  return ViewManagementActions.update(view)
-    .then(() => UserNotification.success(`Saving view "${view.title}" was successful!`, 'Success!'))
-    .catch(error => UserNotification.error(`Saving view failed: ${error}`, 'Error!'));
+export default (newView) => {
+  return ViewActions.update(newView).then(({ view }) => {
+    return ViewManagementActions.update(view);
+  }).then(({ title }) => {
+    return UserNotification.success(`Saving view "${title}" was successful!`, 'Success!');
+  }).catch(error => UserNotification.error(`Saving view failed: ${error}`, 'Error!'));
 };

--- a/graylog2-web-interface/src/views/stores/ViewStore.js
+++ b/graylog2-web-interface/src/views/stores/ViewStore.js
@@ -27,14 +27,12 @@ export type ViewStoreState = {
 
 type ViewActionsType = RefluxActions<{
   create: (ViewType, ?string) => Promise<ViewStoreState>,
-  description: (string) => Promise<ViewStoreState>,
   load: (View, ?boolean) => Promise<ViewStoreState>,
   properties: (Properties) => Promise<void>,
   search: (Search) => Promise<View>,
   selectQuery: (string) => Promise<string>,
   state: (ViewState) => Promise<View>,
-  summary: (string) => Promise<void>,
-  title: (string) => Promise<void>,
+  update: (View) => Promise<ViewStoreState>,
 }>;
 
 export const ViewActions: ViewActionsType = singletonActions(
@@ -42,15 +40,13 @@ export const ViewActions: ViewActionsType = singletonActions(
   () => Reflux.createActions({
     create: { asyncResult: true },
     dashboardState: { asyncResult: true },
-    description: { asyncResult: true },
     load: { asyncResult: true },
     properties: { asyncResult: true },
     search: { asyncResult: true },
     selectQuery: { asyncResult: true },
     state: { asyncResult: true },
-    summary: { asyncResult: true },
-    title: { asyncResult: true },
     setNew: { asyncResult: true },
+    update: { asyncResult: true },
   }),
 );
 
@@ -120,12 +116,12 @@ export const ViewStore: ViewStoreType = singletonStore(
 
       QueriesActions.create.promise(promise);
     },
-    description(newDescription: string) {
-      this.dirty = true;
-      this.view = this.view.toBuilder().description(newDescription).build();
+    update(view: View) {
+      this.dirty = false;
+      this.view = view;
       this._trigger();
       const promise = Promise.resolve(this._state());
-      ViewActions.description.promise(promise);
+      ViewActions.update.promise(promise);
       return promise;
     },
     load(view: View, isNew: ?boolean = false): Promise<ViewStoreState> {
@@ -173,16 +169,6 @@ export const ViewStore: ViewStoreType = singletonStore(
       const promise = (isModified ? ViewActions.search(view.search) : Promise.resolve(view)).then(() => this._trigger());
       ViewActions.state.promise(promise);
       return promise;
-    },
-    summary(newSummary) {
-      this.dirty = true;
-      this.view = this.view.toBuilder().summary(newSummary).build();
-      this._trigger();
-    },
-    title(newTitle) {
-      this.dirty = true;
-      this.view = this.view.toBuilder().title(newTitle).build();
-      this._trigger();
     },
     _updateSearch(view: View): [View, boolean] {
       if (!view.search) {

--- a/graylog2-web-interface/src/views/stores/ViewStore.test.js
+++ b/graylog2-web-interface/src/views/stores/ViewStore.test.js
@@ -47,7 +47,6 @@ describe('ViewStore', () => {
     .then(() => ViewActions.load(dummyView, true))
     .then(state => expect(state.isNew).toBe(true)));
 
-
   it('.update should update existing view state', () => {
     // const search = Search.create();
     const newView = View.builder()

--- a/graylog2-web-interface/src/views/stores/ViewStore.test.js
+++ b/graylog2-web-interface/src/views/stores/ViewStore.test.js
@@ -10,7 +10,6 @@ import mockAction from 'helpers/mocking/MockAction';
 import AggregationWidget from '../logic/aggregationbuilder/AggregationWidget';
 import { ViewActions, ViewStore } from './ViewStore';
 
-
 jest.mock('views/actions/SearchActions');
 jest.mock('views/logic/Widgets', () => ({
   widgetDefinition: () => ({


### PR DESCRIPTION
As described in #7244 editing a dashboards title, description and summary updated the database entry, but not the frontend view state. This PR implements a new `ViewAction` named `updated`. It gets called in `OnSaveViewAction`, before calling the api to update the database entry. It also removes some not needed `ViewActions`

I had a look at other cases where we are using `ViewManagementActions.update`, to check if implementing the new `ViewActions.update` method would make sense, but could not find one.

Fixes #7244

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

