### PR TITLE
Introduce MongoDBUpsertRetryer

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/processor/DBEventProcessorStateService.java
+++ b/graylog2-server/src/main/java/org/graylog/events/processor/DBEventProcessorStateService.java
@@ -22,6 +22,7 @@ import com.mongodb.BasicDBObject;
 import org.bson.types.ObjectId;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
+import org.graylog2.database.MongoDBUpsertRetryer;
 import org.joda.time.DateTime;
 import org.mongojack.DBQuery;
 import org.mongojack.DBUpdate;
@@ -138,7 +139,7 @@ public class DBEventProcessorStateService {
                 .addOperation("$min", FIELD_MIN_PROCESSED_TIMESTAMP, updateValue(minProcessedTimestamp))
                 .addOperation("$max", FIELD_MAX_PROCESSED_TIMESTAMP, updateValue(maxProcessedTimestamp));
 
-        return Optional.ofNullable(db.findAndModify(
+        return Optional.ofNullable(MongoDBUpsertRetryer.run(() -> db.findAndModify(
                 // We have a unique index on the eventDefinitionId so this query is enough
                 DBQuery.is(FIELD_EVENT_DEFINITION_ID, eventDefinitionId),
                 null,
@@ -146,7 +147,7 @@ public class DBEventProcessorStateService {
                 false,
                 update,
                 true, // We want to return the updated document to the caller
-                true));
+                true)));
     }
 
     /**

--- a/graylog2-server/src/main/java/org/graylog2/database/MongoDBUpsertRetryer.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/MongoDBUpsertRetryer.java
@@ -17,31 +17,49 @@
 
 package org.graylog2.database;
 
+import com.github.rholder.retry.Attempt;
 import com.github.rholder.retry.RetryException;
+import com.github.rholder.retry.RetryListener;
 import com.github.rholder.retry.Retryer;
 import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.StopStrategies;
 import com.mongodb.DuplicateKeyException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
+/**
+ * MongoDB upsert requests can fail when they are creating a new entry concurrently.
+ * https://jira.mongodb.org/browse/SERVER-14322
+ * This helper can be used to retry upserts if they throw a {@link DuplicateKeyException}
+ */
 public class MongoDBUpsertRetryer {
+    private static final Logger LOG = LoggerFactory.getLogger(MongoDBUpsertRetryer.class);
+
     public static <T> T run(Callable<T> c) {
         final Retryer<T> retryer = RetryerBuilder.<T>newBuilder()
                 .retryIfException(t -> t instanceof DuplicateKeyException && ((DuplicateKeyException) t).getErrorCode() == 11000)
                 .withStopStrategy(StopStrategies.stopAfterAttempt(1))
+                .withRetryListener(new RetryListener() {
+                    @Override
+                    public <V> void onRetry(Attempt<V> attempt) {
+                        if (attempt.hasException()) {
+                            LOG.info("Upsert failed with DuplicateKeyException (E11000). Retrying request");
+                        }
+                    }
+                })
                 .build();
         try {
             return retryer.call(c);
         } catch (ExecutionException e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException(e.getCause());
         } catch (RetryException e) {
             if (e.getCause() instanceof DuplicateKeyException) {
                 throw (DuplicateKeyException) e.getCause();
             }
-            throw new RuntimeException(e);
+            throw new RuntimeException(e.getCause());
         }
-
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/database/MongoDBUpsertRetryer.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/MongoDBUpsertRetryer.java
@@ -48,7 +48,7 @@ public class MongoDBUpsertRetryer {
                     @Override
                     public <V> void onRetry(Attempt<V> attempt) {
                         if (attempt.hasException()) {
-                            LOG.info("Upsert failed with {}. Retrying request", attempt.getExceptionCause().toString());
+                            LOG.debug("Upsert failed with {}. Retrying request", attempt.getExceptionCause().toString());
                         }
                     }
                 })

--- a/graylog2-server/src/main/java/org/graylog2/database/MongoDBUpsertRetryer.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/MongoDBUpsertRetryer.java
@@ -1,0 +1,47 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.graylog2.database;
+
+import com.github.rholder.retry.RetryException;
+import com.github.rholder.retry.Retryer;
+import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.StopStrategies;
+import com.mongodb.DuplicateKeyException;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
+public class MongoDBUpsertRetryer {
+    public static <T> T run(Callable<T> c) {
+        final Retryer<T> retryer = RetryerBuilder.<T>newBuilder()
+                .retryIfException(t -> t instanceof DuplicateKeyException && ((DuplicateKeyException) t).getErrorCode() == 11000)
+                .withStopStrategy(StopStrategies.stopAfterAttempt(1))
+                .build();
+        try {
+            return retryer.call(c);
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e);
+        } catch (RetryException e) {
+            if (e.getCause() instanceof DuplicateKeyException) {
+                throw (DuplicateKeyException) e.getCause();
+            }
+            throw new RuntimeException(e);
+        }
+
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesService.java
@@ -22,6 +22,7 @@ import com.mongodb.BasicDBObject;
 import org.bson.types.ObjectId;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
+import org.graylog2.database.MongoDBUpsertRetryer;
 import org.mongojack.DBQuery;
 import org.mongojack.JacksonDBCollection;
 import org.mongojack.WriteResult;
@@ -70,7 +71,7 @@ public class IndexFieldTypesService {
     }
 
     public Optional<IndexFieldTypesDTO> upsert(IndexFieldTypesDTO dto) {
-        final WriteResult<IndexFieldTypesDTO, ObjectId> update = db.update(
+        final WriteResult<IndexFieldTypesDTO, ObjectId> update = MongoDBUpsertRetryer.run(() -> db.update(
                 DBQuery.and(
                         DBQuery.is(IndexFieldTypesDTO.FIELD_INDEX_NAME, dto.indexName()),
                         DBQuery.is(IndexFieldTypesDTO.FIELD_INDEX_SET_ID, dto.indexSetId())
@@ -78,7 +79,7 @@ public class IndexFieldTypesService {
                 dto,
                 true,
                 false
-        );
+        ));
 
         final Object upsertedId = update.getUpsertedId();
         if (upsertedId instanceof ObjectId) {

--- a/graylog2-server/src/main/java/org/graylog2/system/processing/DBProcessingStatusService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/processing/DBProcessingStatusService.java
@@ -25,6 +25,7 @@ import org.bson.types.ObjectId;
 import org.graylog.scheduler.clock.JobSchedulerClock;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
+import org.graylog2.database.MongoDBUpsertRetryer;
 import org.graylog2.plugin.BaseConfiguration;
 import org.graylog2.plugin.system.NodeId;
 import org.joda.time.DateTime;
@@ -185,13 +186,13 @@ public class DBProcessingStatusService {
         // TODO: Using a timestamp provided by the node for "updated_at" can be bad if the node clock is skewed.
         //       Ideally we would use MongoDB's "$currentDate" but there doesn't seem to be a way to use that
         //       with mongojack.
-        return db.findAndModify(
+        return MongoDBUpsertRetryer.run(() -> db.findAndModify(
                 DBQuery.is(ProcessingStatusDto.FIELD_NODE_ID, nodeId),
                 null,
                 null,
                 false,
                 ProcessingStatusDto.of(nodeId, processingStatusRecorder, updatedAt, baseConfiguration.isMessageJournalEnabled()),
                 true, // We want to return the updated document to the caller
-                true);
+                true));
     }
 }


### PR DESCRIPTION
This allows us to wrap upsert calls, which will
be retried once more if they produce a DuplicateKeyException.

Fixes #7258
