### PR TITLE
Remove search message count from sidebar

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -60,5 +60,8 @@ Known Bugs and Limitations
     * Retrieving the full query that is sent to Elasticsearch.
     * Retrieving the list of terms a message field value was indexed with.
     * The list of indices the current search used to generate results.
+    * The count of all received messages displayed next to the search.
+      We will add the count again, once the calculation works as expected.
+      As a workaround a message count widget can be added to the search.
   * The "Show surrounding messages" action is not part of 3.2.0, but will be reimplemented in a next version.
 

--- a/graylog2-web-interface/src/views/components/sidebar/SearchResultOverview.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/SearchResultOverview.jsx
@@ -14,9 +14,7 @@ const SearchResultOverview = ({ results }) => {
   const { timestamp } = results;
   return (
     <span>
-      Found <strong>{numeral(results.documentCount).format('0,0')} messages</strong> in {numeral(results.duration).format('0,0')}ms.
-      <br />
-      Query executed at <UserTimestamp dateTime={timestamp} format={DateTime.Formats.DATETIME} />.
+      Query executed in {numeral(results.duration).format('0,0')}ms at <UserTimestamp dateTime={timestamp} format={DateTime.Formats.DATETIME} />.
     </span>
   );
 };

--- a/graylog2-web-interface/src/views/components/sidebar/SideBar.test.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/SideBar.test.jsx
@@ -102,7 +102,7 @@ describe('<Sidebar />', () => {
 
     wrapper.find('Sidebarstyles__SidebarHeader').simulate('click');
     wrapper.find('div[children="Description"]').simulate('click');
-    expect(wrapper.find('SearchResultOverview').text()).toBe('Found 0 messages in 64ms.Query executed at 2018-08-28 14:39:26.');
+    expect(wrapper.find('SearchResultOverview').text()).toBe('Query executed in 64ms at 2018-08-28 14:39:26.');
   });
 
   it('should render with a specific default title in the context of a new search', () => {


### PR DESCRIPTION
The message count, displayed in the sidebar, is currently not working as expected.
E.g. as described here: #6668

We decided to disable the message count, until we've implemented a working solution. The message count can still be displayed by adding a message count widget.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

