### PR TITLE
Clear MessageList error on search execution

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -95,7 +95,7 @@ class MessageList extends React.Component<Props, State> {
   _resetPagination = () => {
     const { currentPage } = this.state;
     if (currentPage !== 1) {
-      this.setState({ currentPage: 1 });
+      this.setState({ currentPage: 1, errors: [] });
     }
   }
 

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
@@ -61,7 +61,7 @@ jest.mock('views/stores/RefreshStore', () => ({
     disable: jest.fn(),
   },
 }));
-jest.mock('legacy/result-histogram', () => 'Histograrem');
+jest.mock('legacy/result-histogram', () => 'Histogram');
 jest.mock('views/components/messagelist');
 
 describe('MessageList', () => {


### PR DESCRIPTION
As described in #7204 the `MessageList` can display errors, but they don't get cleared after executing a new search.

This PR just resets the error state and adds a test, to check if errors are getting displayed correctly.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

