### PR TITLE
Use effective time range from related search type instead of query in MessageList

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/searchtypes/ESMessageList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/searchtypes/ESMessageList.java
@@ -38,6 +38,7 @@ import org.graylog2.decorators.DecoratorProcessor;
 import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.decorators.SearchResponseDecorator;
+import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.rest.models.messages.responses.ResultMessageSummary;
 import org.graylog2.rest.resources.search.responses.SearchResponse;
 import org.joda.time.DateTime;
@@ -137,6 +138,7 @@ public class ESMessageList implements ESSearchTypeHandler<MessageList> {
 
         final MessageList.Result.Builder resultBuilder = MessageList.Result.result(searchType.id())
                 .messages(decoratedSearchResponse.messages())
+                .effectiveTimerange(AbsoluteRange.create(from, to))
                 .totalResults(decoratedSearchResponse.totalResults());
         return searchType.name().map(resultBuilder::name).orElse(resultBuilder).build();
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/MessageList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/MessageList.java
@@ -26,10 +26,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
-import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
 import org.graylog.plugins.views.search.Filter;
 import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.engine.BackendQuery;
+import org.graylog.plugins.views.search.timeranges.DerivedTimeRange;
+import org.graylog.plugins.views.search.timeranges.OffsetRange;
 import org.graylog2.contentpacks.EntityDescriptorIds;
 import org.graylog2.contentpacks.model.entities.MessageListEntity;
 import org.graylog2.contentpacks.model.entities.SearchTypeEntity;
@@ -37,7 +38,6 @@ import org.graylog2.decorators.Decorator;
 import org.graylog2.decorators.DecoratorImpl;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.KeywordRange;
-import org.graylog.plugins.views.search.timeranges.OffsetRange;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.graylog2.rest.models.messages.responses.DecorationStats;
@@ -49,7 +49,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @AutoValue
 @JsonTypeName(MessageList.NAME)
@@ -192,6 +191,9 @@ public abstract class MessageList implements SearchType {
         public abstract Optional<DecorationStats> decorationStats();
 
         @JsonProperty
+        public abstract AbsoluteRange effectiveTimerange();
+
+        @JsonProperty
         public abstract long totalResults();
 
         public static Builder builder() {
@@ -213,6 +215,8 @@ public abstract class MessageList implements SearchType {
             public abstract Builder totalResults(long totalResults);
 
             public abstract Builder decorationStats(DecorationStats decorationStats);
+
+            public abstract Builder effectiveTimerange(AbsoluteRange effectiveTimerange);
 
             public abstract Result build();
         }

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -46,7 +46,7 @@ type Props = {
   config: MessagesWidgetConfig,
   data: { messages: Array<Object>, total: number, id: string },
   selectedFields?: {},
-  effectiveTimerange: TimeRange,
+  searchTypes: { [searchTypeId: string]: { effectiveTimerange: TimeRange }},
   setLoadingState: (loading: boolean) => void,
   currentView: {
     activeQuery: string,
@@ -66,11 +66,7 @@ class MessageList extends React.Component<Props, State> {
       total: PropTypes.number.isRequired,
       id: PropTypes.string.isRequired,
     }).isRequired,
-    effectiveTimerange: PropTypes.shape({
-      from: PropTypes.string.isRequired,
-      to: PropTypes.string.isRequired,
-      type: PropTypes.string.isRequired,
-    }).isRequired,
+    searchTypes: PropTypes.object.isRequired,
     selectedFields: PropTypes.object,
     setLoadingState: PropTypes.func.isRequired,
     currentView: PropTypes.object.isRequired,
@@ -101,7 +97,8 @@ class MessageList extends React.Component<Props, State> {
 
   _handlePageChange = (pageNo: number) => {
     // execute search with new offset
-    const { pageSize, data: { id: searchTypeId }, effectiveTimerange, setLoadingState } = this.props;
+    const { pageSize, searchTypes, data: { id: searchTypeId }, setLoadingState } = this.props;
+    const { effectiveTimerange } = searchTypes[searchTypeId];
     const searchTypePayload = { [searchTypeId]: { limit: pageSize, offset: pageSize * (pageNo - 1) } };
     RefreshActions.disable();
     setLoadingState(true);
@@ -164,6 +161,6 @@ export default connect(MessageList,
     {},
     props,
     {
-      effectiveTimerange: get(props, ['searches', 'result', 'results', props.currentView.activeQuery, 'effectiveTimerange']),
+      searchTypes: get(props, ['searches', 'result', 'results', props.currentView.activeQuery, 'searchTypes']),
     },
   ));

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
@@ -49,7 +49,19 @@ jest.mock('views/stores/SearchConfigStore', () => ({
 jest.mock('views/stores/SearchStore', () => ({
   SearchStore: MockStore(
     'listen',
-    ['getInitialState', () => ({ result: { results: { somequery: { effectiveTimerange: { from: '2019-11-15T14:40:48.666Z', to: '2019-11-29T14:40:48.666Z', type: 'absolute' } } } } })],
+    ['getInitialState', () => ({
+      result: {
+        results: {
+          somequery: {
+            searchTypes: {
+              'search-type-id': {
+                effectiveTimerange: { from: '2019-11-15T14:40:48.666Z', to: '2019-11-29T14:40:48.666Z', type: 'absolute' },
+              },
+            },
+          },
+        },
+      },
+    })],
   ),
   SearchActions: {
     reexecuteSearchTypes: jest.fn().mockReturnValue(Promise.resolve({ result: { errors: [] } })),
@@ -66,7 +78,7 @@ jest.mock('views/components/messagelist');
 
 describe('MessageList', () => {
   const data = {
-    id: '6ec30961-2519-45f5-80b6-849e3deb1c32',
+    id: 'search-type-id',
     type: 'messages',
     messages: [
       {
@@ -80,7 +92,6 @@ describe('MessageList', () => {
       },
     ],
     total: 1,
-
   };
   beforeEach(() => {
     // eslint-disable-next-line import/namespace

--- a/graylog2-web-interface/src/views/logic/searchtypes/MessageListHandler.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/MessageListHandler.js
@@ -14,6 +14,7 @@ export default {
 
     return {
       id: result.id,
+      effectiveTimerange: result.effective_timerange,
       type: result.type,
       messages: result.messages,
       total: result.total_results,


### PR DESCRIPTION
Prior to these changes using the `MessageList` widget pagination requested messages within a time range which relates to the query. In the context of a dashboard, where each widget has its own time range, this results in a wrong behaviour.

With this PR, the `MessageList` always relates to the effective time range of the related search type.

Fixes #7243

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

