### PR TITLE
Remove not needed CSV export info from upgrading doc

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -56,7 +56,6 @@ Known Bugs and Limitations
 
   * Content Packs containing old Dashbords can not be installed in Graylog 3.2.
   * Some functionality of the search has been removed, namely:
-    * Exporting a result set to CSV from the UI.
     * Retrieving the full query that is sent to Elasticsearch.
     * Retrieving the list of terms a message field value was indexed with.
     * The list of indices the current search used to generate results.


### PR DESCRIPTION
We reimplemented the CSV export in the user interface, but in the `UPGRADING.rst` is still an entry regarding the removal. This PR removes the related entry.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

