### PR TITLE
Avoid global override time range reset on dashboard search execution

### DIFF
--- a/graylog2-web-interface/src/views/stores/GlobalOverrideStore.js
+++ b/graylog2-web-interface/src/views/stores/GlobalOverrideStore.js
@@ -119,7 +119,7 @@ export const GlobalOverrideStore: GlobalOverrideStoreType = singletonStore(
         type: 'elasticsearch',
         query_string: newQueryString,
       };
-      const newGlobalOverride: GlobalOverride = this.globalOverride ? new GlobalOverride(this.globalOverride.newTimerange, newQuery) : new GlobalOverride(undefined, newQuery);
+      const newGlobalOverride: GlobalOverride = this.globalOverride ? new GlobalOverride(this.globalOverride.timerange, newQuery) : new GlobalOverride(undefined, newQuery);
       const promise = this._propagateNewGlobalOverride(newGlobalOverride);
       GlobalOverrideActions.query.promise(promise);
       return promise;


### PR DESCRIPTION
As described in #7269 the global time range configured for a dashboard, gets lost when executing the search with a query. This PR fixes the described behaviour, by using the right object key inside the `GlobalOverrideStore`

Fixes #7269

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

