### PR TITLE
Fix server startup

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/dashboardV1/EntityConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/dashboardV1/EntityConverter.java
@@ -35,6 +35,7 @@ import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
+import javax.inject.Inject;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -51,6 +52,7 @@ public class EntityConverter {
     private Map<String, ValueReference> parameters;
     private DashboardWidgetConverter dashboardWidgetConverter;
 
+    @Inject
     public EntityConverter(DashboardWidgetConverter dashboardWidgetConverter) {
        this.dashboardWidgetConverter = dashboardWidgetConverter;
     }


### PR DESCRIPTION
While working on https://github.com/Graylog2/graylog2-server/pull/7186

we forgot to include an important fix. Otherwise the server startup will fail with:

```
2020-01-24 16:49:24,408 ERROR: org.graylog2.bootstrap.CmdLineTool - Guice error (more detail on log level debug): Could not find a suitable constructor in org.graylog2.contentpacks.facades.dashboardV1.EntityConverter. Classes must have either one (and only one) constructor annotated with @Inject or a zero-argument constructor that is not private.
Exception in thread "main" com.google.inject.CreationException: Unable to create injector, see the following errors:

1) Could not find a suitable constructor in org.graylog2.contentpacks.facades.dashboardV1.EntityConverter. Classes must have either one (and only one) constructor annotated with @Inject or a zero-argument constructor that is not private.
  at org.graylog2.contentpacks.facades.dashboardV1.EntityConverter.class(EntityConverter.java:54)
  while locating org.graylog2.contentpacks.facades.dashboardV1.EntityConverter
    for the 3rd parameter of org.graylog2.contentpacks.facades.dashboardV1.DashboardV1Facade.<init>(DashboardV1Facade.java:51)
  at org.graylog2.plugin.PluginModule.addEntityFacade(PluginModule.java:215)
```