### PR TITLE
 Unify search and dashboard sidebar

### DIFF
--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
@@ -50,7 +50,7 @@ const DashboardSearchBar = ({ config, currentQuery, disableSearch = false, onExe
         <Col md={12}>
           <form method="GET" onSubmit={submitForm}>
             <Row className="no-bm extended-search-query-metadata">
-              <Col md={4}>
+              <Col lg={4} md={6} xs={8}>
                 <TimeRangeOverrideTypeSelector onSelect={newRangeType => GlobalOverrideActions.rangeType(newRangeType).then(performSearch)}
                                                value={rangeType} />
                 <TimeRangeOverrideInput onChange={(key, value) => GlobalOverrideActions.rangeParams(key, value).then(performSearch)}
@@ -58,12 +58,7 @@ const DashboardSearchBar = ({ config, currentQuery, disableSearch = false, onExe
                                         rangeParams={rangeParams}
                                         config={config} />
               </Col>
-              <Col mdHidden lgHidden>
-                <HorizontalSpacer />
-              </Col>
-              <Col md={5} xs={8} />
-
-              <Col md={3} xs={4}>
+              <Col lg={8} md={6} xs={4}>
                 <RefreshControls />
               </Col>
             </Row>

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
@@ -8,7 +8,6 @@ import connect from 'stores/connect';
 import DocumentationLink from 'components/support/DocumentationLink';
 import DocsHelper from 'util/DocsHelper';
 import RefreshControls from 'views/components/searchbar/RefreshControls';
-import HorizontalSpacer from 'views/components/horizontalspacer/HorizontalSpacer';
 import { Icon, Spinner } from 'components/common';
 import ScrollToHint from 'views/components/common/ScrollToHint';
 import TimeRangeOverrideTypeSelector from 'views/components/searchbar/TimeRangeOverrideTypeSelector';

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
@@ -15,6 +15,7 @@ import TimeRangeOverrideTypeSelector from 'views/components/searchbar/TimeRangeO
 import TimeRangeOverrideInput from 'views/components/searchbar/TimeRangeOverrideInput';
 import SearchButton from 'views/components/searchbar/SearchButton';
 import QueryInput from 'views/components/searchbar/AsyncQueryInput';
+import ViewActionsMenu from 'views/components/ViewActionsMenu';
 import { GlobalOverrideActions, GlobalOverrideStore } from '../stores/GlobalOverrideStore';
 
 type Props = {
@@ -48,8 +49,27 @@ const DashboardSearchBar = ({ config, currentQuery, disableSearch = false, onExe
       <Row className="content">
         <Col md={12}>
           <form method="GET" onSubmit={submitForm}>
+            <Row className="no-bm extended-search-query-metadata">
+              <Col md={4}>
+                <TimeRangeOverrideTypeSelector onSelect={newRangeType => GlobalOverrideActions.rangeType(newRangeType).then(performSearch)}
+                                               value={rangeType} />
+                <TimeRangeOverrideInput onChange={(key, value) => GlobalOverrideActions.rangeParams(key, value).then(performSearch)}
+                                        rangeType={rangeType}
+                                        rangeParams={rangeParams}
+                                        config={config} />
+              </Col>
+              <Col mdHidden lgHidden>
+                <HorizontalSpacer />
+              </Col>
+              <Col md={5} xs={8} />
+
+              <Col md={3} xs={4}>
+                <RefreshControls />
+              </Col>
+            </Row>
+
             <Row className="no-bm">
-              <Col lg={8} md={7} xs={6}>
+              <Col md={9} xs={8}>
                 <div className="pull-right search-help">
                   <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
                                      title="Search query syntax documentation"
@@ -62,23 +82,10 @@ const DashboardSearchBar = ({ config, currentQuery, disableSearch = false, onExe
                             onChange={value => GlobalOverrideActions.query(value).then(performSearch).then(() => value)}
                             onExecute={performSearch} />
               </Col>
-              <Col lg={4} md={5} xs={6}>
-                <TimeRangeOverrideTypeSelector onSelect={newRangeType => GlobalOverrideActions.rangeType(newRangeType).then(performSearch)}
-                                               value={rangeType} />
-                <TimeRangeOverrideInput onChange={(key, value) => GlobalOverrideActions.rangeParams(key, value).then(performSearch)}
-                                        rangeType={rangeType}
-                                        rangeParams={rangeParams}
-                                        config={config} />
-              </Col>
-            </Row>
-            <Row className="no-bm">
-              <Col>
-                <HorizontalSpacer />
-              </Col>
-            </Row>
-            <Row className="no-bm">
-              <Col md={12}>
-                <RefreshControls />
+              <Col md={3} xs={4}>
+                <div className="pull-right">
+                  <ViewActionsMenu />
+                </div>
               </Col>
             </Row>
           </form>

--- a/graylog2-web-interface/src/views/components/QueryBar.jsx
+++ b/graylog2-web-interface/src/views/components/QueryBar.jsx
@@ -1,14 +1,11 @@
 // @flow strict
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withRouter } from 'react-router';
 
 import connect from 'stores/connect';
 import { TitlesActions } from 'views/stores/TitlesStore';
 import { ViewActions } from 'views/stores/ViewStore';
 import NewQueryActionHandler from 'views/logic/NewQueryActionHandler';
-import onSaveView from 'views/logic/views/OnSaveViewAction';
-import onSaveAsView from 'views/logic/views/OnSaveAsViewAction';
 import { QueriesActions } from 'views/stores/QueriesStore';
 import { QueryIdsStore } from 'views/stores/QueryIdsStore';
 import { QueryTitlesStore } from 'views/stores/QueryTitlesStore';
@@ -37,7 +34,7 @@ const onCloseTab = (queryId, currentQuery, queries) => {
   return promise.then(() => QueriesActions.remove(queryId)).then(() => ViewStatesActions.remove(queryId));
 };
 
-const QueryBar = ({ children, queries, queryTitles, router, viewMetadata }) => {
+const QueryBar = ({ children, queries, queryTitles, viewMetadata }) => {
   const { activeQuery } = viewMetadata;
   const childrenWithQueryId = React.Children.map(children, child => React.cloneElement(child, { queryId: activeQuery }));
   const selectQueryAndExecute = queryId => onSelectQuery(queryId);
@@ -47,8 +44,6 @@ const QueryBar = ({ children, queries, queryTitles, router, viewMetadata }) => {
                titles={queryTitles}
                onSelect={selectQueryAndExecute}
                onTitleChange={onTitleChange}
-               onSaveView={view => onSaveView(view, router)}
-               onSaveAsView={view => onSaveAsView(view, router)}
                onRemove={queryId => onCloseTab(queryId, activeQuery, queries)}>
       {childrenWithQueryId}
     </QueryTabs>
@@ -59,7 +54,6 @@ QueryBar.propTypes = {
   children: CustomPropTypes.node,
   queries: PropTypes.object.isRequired,
   queryTitles: PropTypes.object.isRequired,
-  router: PropTypes.any.isRequired,
   viewMetadata: PropTypes.shape({
     activeQuery: PropTypes.string.isRequired,
   }).isRequired,
@@ -69,4 +63,4 @@ QueryBar.defaultProps = {
   children: null,
 };
 
-export default withRouter(connect(QueryBar, { queries: QueryIdsStore, queryTitles: QueryTitlesStore, viewMetadata: ViewMetadataStore }));
+export default connect(QueryBar, { queries: QueryIdsStore, queryTitles: QueryTitlesStore, viewMetadata: ViewMetadataStore });

--- a/graylog2-web-interface/src/views/components/QueryTabs.jsx
+++ b/graylog2-web-interface/src/views/components/QueryTabs.jsx
@@ -4,21 +4,17 @@ import * as Immutable from 'immutable';
 import PropTypes from 'prop-types';
 
 import { Tab, Tabs, Col, Row } from 'components/graylog';
-import ViewActionsMenu from 'views/components/ViewActionsMenu';
 import QueryTitle from 'views/components/queries/QueryTitle';
 import QueryTitleEditModal from 'views/components/queries/QueryTitleEditModal';
 
 import { QueryIdsStore } from 'views/stores/QueryIdsStore';
 import Query from 'views/logic/queries/Query';
 import type { TitlesMap } from 'views/stores/TitleTypes';
-import View from 'views/logic/views/View';
 import ViewState from 'views/logic/views/ViewState';
 
 type Props = {
   children: React.Node,
   onRemove: (queryId: string) => Promise<void> | Promise<ViewState>,
-  onSaveAsView: (view: View) => Promise<View>,
-  onSaveView: (View) => void,
   onSelect: (queryId: string) => Promise<Query> | Promise<string>,
   onTitleChange: (queryId: string, newTitle: string) => Promise<TitlesMap>,
   queries: Array<QueryIdsStore>,
@@ -32,8 +28,6 @@ class QueryTabs extends React.Component<Props> {
   static propTypes = {
     children: PropTypes.node,
     onRemove: PropTypes.func.isRequired,
-    onSaveAsView: PropTypes.func.isRequired,
-    onSaveView: PropTypes.func.isRequired,
     onSelect: PropTypes.func.isRequired,
     onTitleChange: PropTypes.func.isRequired,
     queries: PropTypes.object.isRequired,
@@ -55,8 +49,6 @@ class QueryTabs extends React.Component<Props> {
     const {
       children,
       onRemove,
-      onSaveAsView,
-      onSaveView,
       onSelect,
       onTitleChange,
       queries,
@@ -89,9 +81,6 @@ class QueryTabs extends React.Component<Props> {
     return (
       <Row style={{ marginBottom: 0 }}>
         <Col>
-          <span className="pull-right">
-            <ViewActionsMenu onSaveView={onSaveView} onSaveAsView={onSaveAsView} />
-          </span>
           <Tabs activeKey={selectedQueryId}
                 animation={false}
                 id="QueryTabs"

--- a/graylog2-web-interface/src/views/components/SearchBar.jsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.jsx
@@ -59,56 +59,52 @@ const SearchBar = ({ availableStreams, config, currentQuery, disableSearch = fal
     <ScrollToHint value={query.query_string}>
       <Row className="content">
         <Col md={12}>
-          <Row className="no-bm">
-            <Col md={12}>
-              <form method="GET" onSubmit={submitForm}>
+          <form method="GET" onSubmit={submitForm}>
+            <Row className="no-bm extended-search-query-metadata">
+              <Col md={4}>
+                <TimeRangeTypeSelector onSelect={newRangeType => QueriesActions.rangeType(id, newRangeType).then(performSearch)}
+                                       value={rangeType} />
+                <TimeRangeInput onChange={(key, value) => QueriesActions.rangeParams(id, key, value).then(performSearch)}
+                                rangeType={rangeType}
+                                rangeParams={rangeParams}
+                                config={config} />
+              </Col>
 
-                <Row className="no-bm extended-search-query-metadata">
-                  <Col md={4}>
-                    <TimeRangeTypeSelector onSelect={newRangeType => QueriesActions.rangeType(id, newRangeType).then(performSearch)}
-                                           value={rangeType} />
-                    <TimeRangeInput onChange={(key, value) => QueriesActions.rangeParams(id, key, value).then(performSearch)}
-                                    rangeType={rangeType}
-                                    rangeParams={rangeParams}
-                                    config={config} />
-                  </Col>
+              <Col mdHidden lgHidden>
+                <HorizontalSpacer />
+              </Col>
 
-                  <Col mdHidden lgHidden>
-                    <HorizontalSpacer />
-                  </Col>
+              <Col md={5} xs={8}>
+                <StreamsFilter value={streams}
+                               streams={availableStreams}
+                               onChange={value => QueryFiltersActions.streams(id, value)} />
+              </Col>
 
-                  <Col md={5} xs={8}>
-                    <StreamsFilter value={streams}
-                                   streams={availableStreams}
-                                   onChange={value => QueryFiltersActions.streams(id, value)} />
-                  </Col>
+              <Col md={3} xs={4}>
+                <RefreshControls />
+              </Col>
+            </Row>
 
-                  <Col md={3} xs={4}>
-                    <RefreshControls />
-                  </Col>
-                </Row>
+            <Row className="no-bm">
+              <Col md={9} xs={8}>
+                <div className="pull-right search-help">
+                  <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
+                                     title="Search query syntax documentation"
+                                     text={<Icon name="lightbulb-o" />} />
+                </div>
+                <SearchButton disabled={disableSearch} />
 
-                <Row className="no-bm">
-                  <Col md={9} xs={8}>
-                    <div className="pull-right search-help">
-                      <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
-                                         title="Search query syntax documentation"
-                                         text={<Icon name="lightbulb-o" />} />
-                    </div>
-                    <SearchButton disabled={disableSearch} />
+                <QueryInput value={query.query_string}
+                            placeholder={'Type your search query here and press enter. E.g.: ("not found" AND http) OR http_response_code:[400 TO 404]'}
+                            onChange={value => QueriesActions.query(id, value).then(performSearch).then(() => value)}
+                            onExecute={performSearch} />
+              </Col>
+              <Col md={3} xs={4} className="pull-right">
+                <BookmarkControls />
+              </Col>
+            </Row>
+          </form>
 
-                    <QueryInput value={query.query_string}
-                                placeholder={'Type your search query here and press enter. E.g.: ("not found" AND http) OR http_response_code:[400 TO 404]'}
-                                onChange={value => QueriesActions.query(id, value).then(performSearch).then(() => value)}
-                                onExecute={performSearch} />
-                  </Col>
-                  <Col md={3} xs={4}>
-                    <BookmarkControls />
-                  </Col>
-                </Row>
-              </form>
-            </Col>
-          </Row>
         </Col>
       </Row>
     </ScrollToHint>


### PR DESCRIPTION
As described in https://github.com/Graylog2/graylog2-server/issues/7248 the white space visible at the bottom of the dashboard searchbar can be confusing:
![image](https://user-images.githubusercontent.com/46300478/73171204-76f82200-4100-11ea-8b25-773e9951f89a.png)

Having a look at the search searchbar:
![image](https://user-images.githubusercontent.com/46300478/73171268-aa3ab100-4100-11ea-8b0e-b110e3a160ec.png)
we've decided to unify the searchbars. This helps with the white space and the user does not have to get used to the different layout. One part of the restructuring is moving the dashboard actions into the searchbar.
In the last weeks we've already improved the searchbar actions, by implementing related icons. I tried to adopt this for the dashboard searchbar as well.

Dashboard searchbar after the changes:
![image](https://user-images.githubusercontent.com/46300478/73171667-90e63480-4101-11ea-9b3d-b45dbe6a15e8.png)

Fixes https://github.com/Graylog2/graylog2-server/issues/7248

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

