### PR TITLE
Trigger changing widget title on blur.

### DIFF
--- a/graylog2-web-interface/src/views/components/common/EditableTitle.jsx
+++ b/graylog2-web-interface/src/views/components/common/EditableTitle.jsx
@@ -17,7 +17,6 @@ export default class EditableTitle extends React.Component {
 
   state = {
     editing: false,
-    onChange: () => {},
     value: this.props.value,
   };
 
@@ -26,7 +25,8 @@ export default class EditableTitle extends React.Component {
   }
 
   _toggleEditing = () => {
-    if (!this.props.disabled) {
+    const { disabled } = this.props;
+    if (!disabled) {
       this.setState(state => ({ editing: !state.editing }));
     }
   };
@@ -42,10 +42,12 @@ export default class EditableTitle extends React.Component {
   };
 
   _onSubmit = () => {
-    if (this.state.value !== '') {
-      this.props.onChange(this.state.value);
+    const { value } = this.state;
+    const { onChange, value: propsValue } = this.props;
+    if (value !== '') {
+      onChange(value);
     } else {
-      this.setState({ value: this.props.value });
+      this.setState({ value: propsValue });
     }
     this.setState({ editing: false });
   };
@@ -55,6 +57,7 @@ export default class EditableTitle extends React.Component {
     return editing ? (
       <span>
         <form onSubmit={this._onSubmit} className={styles.inlineForm}>
+          {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
           <input autoFocus
                  type="text"
                  value={value}

--- a/graylog2-web-interface/src/views/components/common/EditableTitle.jsx
+++ b/graylog2-web-interface/src/views/components/common/EditableTitle.jsx
@@ -31,6 +31,11 @@ export default class EditableTitle extends React.Component {
     }
   };
 
+  _onBlur = () => {
+    this._toggleEditing();
+    this._onSubmit();
+  };
+
   _onChange = (evt) => {
     evt.preventDefault();
     this.setState({ value: evt.target.value });
@@ -53,7 +58,7 @@ export default class EditableTitle extends React.Component {
           <input autoFocus
                  type="text"
                  value={value}
-                 onBlur={this._toggleEditing}
+                 onBlur={this._onBlur}
                  onChange={this._onChange} />
         </form>
       </span>

--- a/graylog2-web-interface/src/views/components/common/EditableTitle.jsx
+++ b/graylog2-web-interface/src/views/components/common/EditableTitle.jsx
@@ -17,6 +17,7 @@ export default class EditableTitle extends React.Component {
 
   state = {
     editing: false,
+    // eslint-disable-next-line react/destructuring-assignment
     value: this.props.value,
   };
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, when editing a widget title, updating it was only
triggered upon a form submit event (when pressing enter inside the
widget title input). This lead to confusing behavior as described in
#7266.

This change is now also triggering a change event when the input is
blurred.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.