### PR TITLE
Only set data adapters / cache form focus, when related type changes

### DIFF
--- a/graylog2-web-interface/src/components/lookup-tables/CacheForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CacheForm.jsx
@@ -58,9 +58,11 @@ class CacheForm extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    this._input.getInputDOMNode().focus();
+    const { type: currentType } = this.props;
+    if (prevProps.type !== currentType) {
+      this._input.getInputDOMNode().focus();
+    }
     const { cache } = this.props;
-
     if (_.isEqual(cache, prevProps.cache)) {
       // props haven't change, don't update our state from them
       return;

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterForm.jsx
@@ -60,7 +60,10 @@ class DataAdapterForm extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    this._input.getInputDOMNode().focus();
+    const { type: currentType } = this.props;
+    if (prevProps.type !== currentType) {
+      this._input.getInputDOMNode().focus();
+    }
     const { dataAdapter } = this.props;
     if (_.isEqual(dataAdapter, prevProps.dataAdapter)) {
       // props haven't changed, don't update our state from them


### PR DESCRIPTION
This PR fixes the form focus problem described in #7294 

I tried to solve this issue by only using autoFocus, but in the end saw the need for the current workaround. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

