### PR TITLE
Reload search/dashboard again if id props changes.

### DIFF
--- a/graylog2-web-interface/src/views/pages/ShowViewPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ShowViewPage.jsx
@@ -73,9 +73,16 @@ class ShowViewPage extends React.Component<Props, State> {
     return this.loadView(viewId);
   };
 
+  componentWillReceiveProps({ params: { viewId: nextViewId } }) {
+    const { params: { viewId } } = this.props;
+    if (viewId !== nextViewId) {
+      this.loadView(nextViewId);
+    }
+  }
+
   loadNewView = () => {
     return history.push('/search');
-  }
+  };
 
   loadView = (viewId: string): Promise<?View> => {
     const { location, loadingViewHooks, executingViewHooks, viewLoader } = this.props;

--- a/graylog2-web-interface/src/views/pages/ShowViewPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ShowViewPage.jsx
@@ -73,10 +73,10 @@ class ShowViewPage extends React.Component<Props, State> {
     return this.loadView(viewId);
   };
 
-  componentWillReceiveProps({ params: { viewId: nextViewId } }) {
+  componentDidUpdate({ params: { viewId: lastViewId } }) {
     const { params: { viewId } } = this.props;
-    if (viewId !== nextViewId) {
-      this.loadView(nextViewId);
+    if (viewId !== lastViewId) {
+      this.loadView(viewId);
     }
   }
 

--- a/graylog2-web-interface/src/views/pages/ShowViewPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/ShowViewPage.test.jsx
@@ -111,4 +111,14 @@ describe('ShowViewPage', () => {
 
     expect(viewLoader).toHaveBeenCalled();
   });
+  it('calls ViewLoader again if view id prop changes', () => {
+    const viewLoader = jest.fn(() => Promise.resolve());
+    const wrapper = mount(<SimpleShowViewPage viewLoader={viewLoader} />);
+
+    expect(viewLoader).toHaveBeenCalledWith('foo', [], [], {}, expect.anything(), expect.anything());
+
+    wrapper.setProps({ params: { viewId: 'bar' } });
+
+    expect(viewLoader).toHaveBeenCalledWith('bar', [], [], {}, expect.anything(), expect.anything());
+  });
 });

--- a/graylog2-web-interface/src/views/pages/ShowViewPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/ShowViewPage.test.jsx
@@ -121,4 +121,16 @@ describe('ShowViewPage', () => {
 
     expect(viewLoader).toHaveBeenCalledWith('bar', [], [], {}, expect.anything(), expect.anything());
   });
+  it('does not call ViewLoader again if view id prop does not change', () => {
+    const viewLoader = jest.fn(() => Promise.resolve());
+    const wrapper = mount(<SimpleShowViewPage viewLoader={viewLoader} />);
+
+    expect(viewLoader).toHaveBeenCalledWith('foo', [], [], {}, expect.anything(), expect.anything());
+
+    viewLoader.mockClear();
+
+    wrapper.setProps({ params: { viewId: 'foo' } });
+
+    expect(viewLoader).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, loading multiple searches consecutively, exporting a
search to a dashboard or saving a dashboard as a new one and navigating
back and forth in the browser history would not trigger reloading the
corresponding searches/dashboards.

This change is now implementing the required check which triggers
reloading a search/dashboard if the id of the current search/dashboard
in the URL changes.

Fixes #7298.
Fixes #7299.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.