### PR TITLE
Fix default selection for stream output assignment

### DIFF
--- a/graylog2-web-interface/src/components/outputs/AssignOutputDropdown.jsx
+++ b/graylog2-web-interface/src/components/outputs/AssignOutputDropdown.jsx
@@ -4,6 +4,8 @@ import React from 'react';
 import { Button } from 'components/graylog';
 
 class AssignOutputDropdown extends React.Component {
+  PLACEHOLDER = 'placeholder';
+
   static propTypes = {
     outputs: PropTypes.array.isRequired,
     onSubmit: PropTypes.func.isRequired,
@@ -12,8 +14,6 @@ class AssignOutputDropdown extends React.Component {
   state = {
     selectedOutput: this.PLACEHOLDER,
   };
-
-  PLACEHOLDER = 'placeholder';
 
   _formatOutput = (output) => {
     return <option key={output.id} value={output.id}>{output.title}</option>;


### PR DESCRIPTION
When loading the stream output page, the dropdown for "Assign existing
Output" shows the first existing output as selected. When pressing the
button, an error had been generated because there wasn't an actual
selection.

This change is fixing the AssignOutputDropdown to show the placeholder
by default and disable the "Assign existing Output" button until a
selection has been made.