### PR TITLE
Change color chart from Map to List of Value Class 

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -21,6 +21,7 @@ import com.google.inject.Scopes;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import org.graylog.plugins.views.audit.ViewsAuditEventTypes;
 import org.graylog.plugins.views.migrations.V20181220133700_AddViewsAdminRole;
+import org.graylog.plugins.views.migrations.V20190127111728_MigrateWidgetFormatSettings;
 import org.graylog.plugins.views.migrations.V20190304102700_MigrateMessageListStructure;
 import org.graylog.plugins.views.migrations.V20190805115800_RemoveDashboardStateFromViews;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.V20191125144500_MigrateDashboardsToViews;
@@ -143,6 +144,7 @@ public class ViewsBindings extends ViewsModule {
         addMigration(V20191204000000_RemoveLegacyViewsPermissions.class);
         addMigration(V20191125144500_MigrateDashboardsToViews.class);
         addMigration(V20191203120602_MigrateSavedSearchesToViews.class);
+        addMigration(V20190127111728_MigrateWidgetFormatSettings.class);
 
         addAuditEventTypes(ViewsAuditEventTypes.class);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20190127111728_MigrateWidgetFormatSettings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20190127111728_MigrateWidgetFormatSettings.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.views.migrations;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20190127111728_MigrateWidgetFormatSettings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20190127111728_MigrateWidgetFormatSettings.java
@@ -1,0 +1,124 @@
+package org.graylog.plugins.views.migrations;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.google.inject.Inject;
+import com.google.protobuf.MapEntry;
+import com.mongodb.BasicDBObject;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import org.graylog.autovalue.WithBeanGetter;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.migrations.Migration;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.slf4j.Logger;
+import org.bson.Document;
+import org.slf4j.LoggerFactory;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class V20190127111728_MigrateWidgetFormatSettings extends Migration {
+    private static final Logger LOG = LoggerFactory.getLogger(V20190127111728_MigrateWidgetFormatSettings.class);
+
+    private final ClusterConfigService clusterConfigService;
+    private final MongoCollection<Document> viewsCollection;
+
+    @Inject
+    public V20190127111728_MigrateWidgetFormatSettings(MongoConnection mongoConnection,
+                                                       ClusterConfigService clusterConfigService) {
+        this.clusterConfigService = clusterConfigService;
+        this.viewsCollection = mongoConnection.getMongoDatabase().getCollection("views");
+    }
+
+    @Override
+    public ZonedDateTime createdAt() {
+        return ZonedDateTime.parse("2019-01-27T11:17:28Z");
+    }
+
+    @Override
+    public void upgrade() {
+        if (clusterConfigService.get(MigrationCompleted.class) != null) {
+            LOG.debug("Migration already completed.");
+            return;
+        }
+
+        final Set<String> viewIds = new HashSet<>();
+        final FindIterable<Document> documents = viewsCollection.find();
+        boolean viewMigrated;
+        for (final Document view : documents) {
+            viewMigrated = false;
+            final Document states = view.get("state", Document.class);
+            for(Map.Entry<String, Object> obj : states.entrySet()) {
+                final Document state = (Document) obj.getValue();
+                if (state.get("widgets") instanceof List) {
+                    @SuppressWarnings("unchecked") final List<Document> widgets = (List) state.get("widgets");
+                    for (final Document widget : widgets) {
+                        final String type = widget.getString("type");
+                        if (type.equals("aggregation")) {
+                            final Document config = widget.get("config", Document.class);
+                            final Document formatSettings = config.get("formatting_settings", Document.class);
+                            if (formatSettings == null) {
+                                continue;
+                            }
+                            final Object charColorsObj = formatSettings.get("chart_colors");
+                            if (charColorsObj == null) {
+                                continue;
+                            }
+                            viewMigrated = true;
+                            @SuppressWarnings({"unchecked", "rawtypes"}) final Map<String, String> chartColors =
+                                    (Map) charColorsObj;
+                            List<Document> chartColorSettings = chartColors.entrySet().stream().map(entry -> {
+                                final Document chartColorFieldSetting = new Document();
+                                chartColorFieldSetting.put("field_name", entry.getKey());
+                                chartColorFieldSetting.put("chart_color", entry.getValue());
+                                return chartColorFieldSetting;
+                            }).collect(Collectors.toList());
+                            formatSettings.put("chart_colors", chartColorSettings);
+                            config.put("formatting_settings", formatSettings);
+                            widget.put("config", config);
+                        }
+                    }
+                    if (viewMigrated) {
+                        state.put("widgets", widgets);
+                    }
+                }
+            }
+
+            if (viewMigrated) {
+                viewsCollection.updateOne(new BasicDBObject("_id", view.getObjectId("_id")), new Document("$set", view));
+                final String viewId = view.getObjectId("_id").toString();
+                viewIds.add(viewId);
+            }
+        }
+        LOG.info("Migration completed. {} views where migrated.", viewIds.size());
+        clusterConfigService.write(V20190127111728_MigrateWidgetFormatSettings.MigrationCompleted.create(
+                viewIds.size(), viewIds));
+    }
+
+    @JsonAutoDetect
+    @AutoValue
+    @WithBeanGetter
+    public static abstract class MigrationCompleted {
+        @JsonProperty("modified_views_count")
+        public abstract long modifiedViewsCount();
+
+        @JsonProperty("modified_view_ids")
+        public abstract Set<String> modifiedViewIds();
+
+        @JsonCreator
+        public static V20190127111728_MigrateWidgetFormatSettings.MigrationCompleted create(
+                @JsonProperty("modified_views_count") final long modifiedViews,
+                @JsonProperty("modified_view_ids") final Set<String> modifiedViewIds) {
+            return new AutoValue_V20190127111728_MigrateWidgetFormatSettings_MigrationCompleted(
+                    modifiedViews, modifiedViewIds);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/ChartColorMapping.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/ChartColorMapping.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 
 @AutoValue
-@JsonDeserialize(builder = ChartColorSetting.Builder.class)
-public abstract class ChartColorSetting {
+@JsonDeserialize(builder = ChartColorMapping.Builder.class)
+public abstract class ChartColorMapping {
    private static final String FIELD_NAME = "field_name";
     private static final String FIELD_CHART_COLOR = "chart_color";
 
@@ -41,11 +41,11 @@ public abstract class ChartColorSetting {
         @JsonProperty(FIELD_CHART_COLOR)
         public abstract Builder chartColor(ChartColor chartColor);
 
-        public abstract ChartColorSetting build();
+        public abstract ChartColorMapping build();
 
         @JsonCreator
         static Builder builder() {
-            return new AutoValue_ChartColorSetting.Builder();
+            return new AutoValue_ChartColorMapping.Builder();
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/ChartColorSetting.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/ChartColorSetting.java
@@ -1,0 +1,35 @@
+package org.graylog.plugins.views.search.views.widgets.aggregation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+@JsonDeserialize(builder = ChartColorSetting.Builder.class)
+public abstract class ChartColorSetting {
+   private static final String FIELD_NAME = "field_name";
+    private static final String FIELD_CHART_COLOR = "chart_color";
+
+    @JsonProperty(FIELD_NAME)
+    public abstract String fieldName();
+
+    @JsonProperty(FIELD_CHART_COLOR)
+    public abstract ChartColor chartColor();
+
+    @AutoValue.Builder
+    public static abstract class Builder {
+        @JsonProperty(FIELD_NAME)
+        public abstract Builder fieldName(String widgetId);
+
+        @JsonProperty(FIELD_CHART_COLOR)
+        public abstract Builder chartColor(ChartColor chartColor);
+
+        public abstract ChartColorSetting build();
+
+        @JsonCreator
+        static Builder builder() {
+            return new AutoValue_ChartColorSetting.Builder();
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/ChartColorSetting.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/ChartColorSetting.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.views.search.views.widgets.aggregation;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/WidgetFormattingSettings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/WidgetFormattingSettings.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 
 import java.util.Collections;
-import java.util.Map;
+import java.util.List;
 
 @AutoValue
 @JsonDeserialize(builder = WidgetFormattingSettings.Builder.class)
@@ -30,19 +30,19 @@ public abstract class WidgetFormattingSettings {
     private static final String FIELD_CHART_COLORS = "chart_colors";
 
     @JsonProperty(FIELD_CHART_COLORS)
-    public abstract Map<String, ChartColor> chartColors();
+    public abstract List<ChartColorSetting> chartColorSettings();
 
     @AutoValue.Builder
     public static abstract class Builder {
         @JsonProperty(FIELD_CHART_COLORS)
-        public abstract Builder chartColors(Map<String, ChartColor> chartColors);
+        public abstract Builder chartColorSettings(List<ChartColorSetting> chartColorSettings);
 
         public abstract WidgetFormattingSettings build();
 
         @JsonCreator
         static Builder builder() {
             return new AutoValue_WidgetFormattingSettings.Builder()
-                    .chartColors(Collections.emptyMap());
+                    .chartColorSettings(Collections.emptyList());
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/WidgetFormattingSettings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/widgets/aggregation/WidgetFormattingSettings.java
@@ -30,19 +30,19 @@ public abstract class WidgetFormattingSettings {
     private static final String FIELD_CHART_COLORS = "chart_colors";
 
     @JsonProperty(FIELD_CHART_COLORS)
-    public abstract List<ChartColorSetting> chartColorSettings();
+    public abstract List<ChartColorMapping> chartColors();
 
     @AutoValue.Builder
     public static abstract class Builder {
         @JsonProperty(FIELD_CHART_COLORS)
-        public abstract Builder chartColorSettings(List<ChartColorSetting> chartColorSettings);
+        public abstract Builder chartColors(List<ChartColorMapping> chartColors);
 
         public abstract WidgetFormattingSettings build();
 
         @JsonCreator
         static Builder builder() {
             return new AutoValue_WidgetFormattingSettings.Builder()
-                    .chartColorSettings(Collections.emptyList());
+                    .chartColors(Collections.emptyList());
         }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20190127111728_MigrateWidgetFormatSettingsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20190127111728_MigrateWidgetFormatSettingsTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.views.migrations;
 
 import com.mongodb.BasicDBObject;

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20190127111728_MigrateWidgetFormatSettingsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20190127111728_MigrateWidgetFormatSettingsTest.java
@@ -1,0 +1,69 @@
+package org.graylog.plugins.views.migrations;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.graylog.testing.mongodb.MongoDBFixtures;
+import org.graylog.testing.mongodb.MongoDBInstance;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class V20190127111728_MigrateWidgetFormatSettingsTest {
+    @Rule
+    public final MongoDBInstance mongoDB = MongoDBInstance.createForClass();
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    private V20190127111728_MigrateWidgetFormatSettings migration;
+
+    @Mock
+    private ClusterConfigService clusterConfigService;
+
+    @Before
+    public void setUp() {
+        migration = new V20190127111728_MigrateWidgetFormatSettings(mongoDB.mongoConnection(), clusterConfigService);
+    }
+
+    @Test
+    @MongoDBFixtures("V20190127111728_MigrateWidgetFormatSettings.json")
+    public void testMigration() {
+        final BasicDBObject dbQuery1 = new BasicDBObject();
+        dbQuery1.put("_id", new ObjectId("5e2ee372b22d7970576b2eb3"));
+        final MongoCollection<Document> collection = mongoDB.mongoConnection()
+                .getMongoDatabase()
+                .getCollection("views");
+        migration.upgrade();
+        final FindIterable<Document> views = collection.find(dbQuery1);
+        final Document view1 = views.first();
+
+        @SuppressWarnings("unchecked")
+        final List<Document> widgets1 = (List) view1.get("state", Document.class).get("2c67cc0f-c62e-47c1-8b70-e3198925e6bc", Document.class).get("widgets");
+        assertThat(widgets1.size()).isEqualTo(2);
+        Set<Document> aggregationWidgets =widgets1.stream().filter(w -> w.getString("type")
+                .equals("aggregation")).collect(Collectors.toSet());
+        assertThat(aggregationWidgets.size()).isEqualTo(1);
+        final Document aggregationWidget = aggregationWidgets.iterator().next();
+        final Document config = aggregationWidget.get("config", Document.class);
+        final Document formattingSettings = config.get("formatting_settings", Document.class);
+
+        @SuppressWarnings("unchecked")
+        final List<Document> chartColors = (List) formattingSettings.get("chart_colors", List.class);
+        assertThat(chartColors.size()).isEqualTo(1);
+        final Document chartColor = chartColors.get(0);
+        assertThat(chartColor.getString("field_name")).isEqualTo("count()");
+        assertThat(chartColor.getString("chart_color")).isEqualTo("#e91e63");
+    }
+}

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20190127111728_MigrateWidgetFormatSettings.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20190127111728_MigrateWidgetFormatSettings.json
@@ -1,0 +1,105 @@
+{
+  "views": [
+    {
+      "_id" : { "$oid": "5e2ee372b22d7970576b2eb3" },
+      "type" : "SEARCH",
+      "title" : "mig test",
+      "summary" : "",
+      "description" : "",
+      "search_id" : "5e2ee360b22d7970576b2eb2",
+      "properties" : [],
+      "requires" : {},
+      "state" : {
+        "2c67cc0f-c62e-47c1-8b70-e3198925e6bc" : {
+          "titles" : {
+            "widget" : {
+              "3cdaa286-e1c9-44bf-9467-b91f8fe146a4" : "Message Count",
+              "414d294b-cc94-47c8-8b9c-56a42b53748b" : "All Messages"
+            }
+          },
+          "widgets" : [
+            {
+              "id" : "414d294b-cc94-47c8-8b9c-56a42b53748b",
+              "type" : "messages",
+              "timerange" : null,
+              "query" : null,
+              "streams" : [],
+              "config" : {
+                "fields" : [
+                  "timestamp",
+                  "source"
+                ],
+                "show_message_row" : true,
+                "decorators" : []
+              }
+            },
+            {
+              "id" : "3cdaa286-e1c9-44bf-9467-b91f8fe146a4",
+              "type" : "aggregation",
+              "timerange" : null,
+              "query" : null,
+              "streams" : [],
+              "config" : {
+                "row_pivots" : [
+                  {
+                    "field" : "timestamp",
+                    "type" : "time",
+                    "config" : {
+                      "interval" : {
+                        "type" : "auto",
+                        "scaling" : null
+                      }
+                    }
+                  }
+                ],
+                "column_pivots" : [],
+                "series" : [
+                  {
+                    "config" : {},
+                    "function" : "count()"
+                  }
+                ],
+                "sort" : [],
+                "visualization" : "bar",
+                "formatting_settings" : {
+                  "chart_colors" : {
+                    "count()" : "#e91e63"
+                  }
+                },
+                "rollup" : true,
+                "event_annotation" : false
+              }
+            }
+          ],
+          "widget_mapping" : {
+            "3cdaa286-e1c9-44bf-9467-b91f8fe146a4" : [
+              "cca70fb5-b19a-4142-b500-51f9973ba917"
+            ],
+            "414d294b-cc94-47c8-8b9c-56a42b53748b" : [
+              "6a3754dd-113d-4dcd-b4b4-c2825b9d5c47"
+            ]
+          },
+          "positions" : {
+            "3cdaa286-e1c9-44bf-9467-b91f8fe146a4" : {
+              "col" : 1,
+              "row" : 1,
+              "height" : 2,
+              "width" : 8,
+            },
+            "414d294b-cc94-47c8-8b9c-56a42b53748b" : {
+              "col" : 1,
+              "row" : 3,
+              "height" : 6,
+              "width" : 8,
+            }
+          },
+          "display_mode_settings" : {
+            "positions" : {}
+          }
+        }
+      },
+      "owner" : "admin",
+      "created_at" : "2020-01-27T13:19:12.465Z"
+    }
+  ]
+}

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20190127111728_MigrateWidgetFormatSettings_withMultipleColorMappings.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20190127111728_MigrateWidgetFormatSettings_withMultipleColorMappings.json
@@ -1,0 +1,108 @@
+{
+  "views": [
+    {
+      "_id" : { "$oid": "5e2ee372b22d7970576b2eb3" },
+      "type" : "SEARCH",
+      "title" : "mig test",
+      "summary" : "",
+      "description" : "",
+      "search_id" : "5e2ee360b22d7970576b2eb2",
+      "properties" : [],
+      "requires" : {},
+      "state" : {
+        "2c67cc0f-c62e-47c1-8b70-e3198925e6bc" : {
+          "titles" : {
+            "widget" : {
+              "3cdaa286-e1c9-44bf-9467-b91f8fe146a4" : "Message Count",
+              "414d294b-cc94-47c8-8b9c-56a42b53748b" : "All Messages"
+            }
+          },
+          "widgets" : [
+            {
+              "id" : "414d294b-cc94-47c8-8b9c-56a42b53748b",
+              "type" : "messages",
+              "timerange" : null,
+              "query" : null,
+              "streams" : [],
+              "config" : {
+                "fields" : [
+                  "timestamp",
+                  "source"
+                ],
+                "show_message_row" : true,
+                "decorators" : []
+              }
+            },
+            {
+              "id" : "3cdaa286-e1c9-44bf-9467-b91f8fe146a4",
+              "type" : "aggregation",
+              "timerange" : null,
+              "query" : null,
+              "streams" : [],
+              "config" : {
+                "row_pivots" : [
+                  {
+                    "field" : "timestamp",
+                    "type" : "time",
+                    "config" : {
+                      "interval" : {
+                        "type" : "auto",
+                        "scaling" : null
+                      }
+                    }
+                  }
+                ],
+                "column_pivots" : [],
+                "series" : [
+                  {
+                    "config" : {},
+                    "function" : "count()"
+                  }
+                ],
+                "sort" : [],
+                "visualization" : "bar",
+                "formatting_settings" : {
+                  "chart_colors" : {
+                    "count()" : "#e91e63",
+                    "avg(fields)" : "#e81e63",
+                    "mean(man)" : "#e91f63",
+                    "total(win)" : "#e91fff"
+                  }
+                },
+                "rollup" : true,
+                "event_annotation" : false
+              }
+            }
+          ],
+          "widget_mapping" : {
+            "3cdaa286-e1c9-44bf-9467-b91f8fe146a4" : [
+              "cca70fb5-b19a-4142-b500-51f9973ba917"
+            ],
+            "414d294b-cc94-47c8-8b9c-56a42b53748b" : [
+              "6a3754dd-113d-4dcd-b4b4-c2825b9d5c47"
+            ]
+          },
+          "positions" : {
+            "3cdaa286-e1c9-44bf-9467-b91f8fe146a4" : {
+              "col" : 1,
+              "row" : 1,
+              "height" : 2,
+              "width" : 8,
+            },
+            "414d294b-cc94-47c8-8b9c-56a42b53748b" : {
+              "col" : 1,
+              "row" : 3,
+              "height" : 6,
+              "width" : 8,
+            }
+          },
+          "display_mode_settings" : {
+            "positions" : {}
+          }
+        }
+      },
+      "owner" : "admin",
+      "created_at" : "2020-01-27T13:19:12.465Z"
+    }
+  ]
+}

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20190127111728_MigrateWidgetFormatSettings_without_color_mapping.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20190127111728_MigrateWidgetFormatSettings_without_color_mapping.json
@@ -1,0 +1,101 @@
+{
+  "views": [
+    {
+      "_id" : { "$oid": "5e2ee372b22d7970576b2eb3" },
+      "type" : "SEARCH",
+      "title" : "mig test",
+      "summary" : "",
+      "description" : "",
+      "search_id" : "5e2ee360b22d7970576b2eb2",
+      "properties" : [],
+      "requires" : {},
+      "state" : {
+        "2c67cc0f-c62e-47c1-8b70-e3198925e6bc" : {
+          "titles" : {
+            "widget" : {
+              "3cdaa286-e1c9-44bf-9467-b91f8fe146a4" : "Message Count",
+              "414d294b-cc94-47c8-8b9c-56a42b53748b" : "All Messages"
+            }
+          },
+          "widgets" : [
+            {
+              "id" : "414d294b-cc94-47c8-8b9c-56a42b53748b",
+              "type" : "messages",
+              "timerange" : null,
+              "query" : null,
+              "streams" : [],
+              "config" : {
+                "fields" : [
+                  "timestamp",
+                  "source"
+                ],
+                "show_message_row" : true,
+                "decorators" : []
+              }
+            },
+            {
+              "id" : "3cdaa286-e1c9-44bf-9467-b91f8fe146a4",
+              "type" : "aggregation",
+              "timerange" : null,
+              "query" : null,
+              "streams" : [],
+              "config" : {
+                "row_pivots" : [
+                  {
+                    "field" : "timestamp",
+                    "type" : "time",
+                    "config" : {
+                      "interval" : {
+                        "type" : "auto",
+                        "scaling" : null
+                      }
+                    }
+                  }
+                ],
+                "column_pivots" : [],
+                "series" : [
+                  {
+                    "config" : {},
+                    "function" : "count()"
+                  }
+                ],
+                "sort" : [],
+                "visualization" : "bar",
+                "formatting_settings" : { },
+                "rollup" : true,
+                "event_annotation" : false
+              }
+            }
+          ],
+          "widget_mapping" : {
+            "3cdaa286-e1c9-44bf-9467-b91f8fe146a4" : [
+              "cca70fb5-b19a-4142-b500-51f9973ba917"
+            ],
+            "414d294b-cc94-47c8-8b9c-56a42b53748b" : [
+              "6a3754dd-113d-4dcd-b4b4-c2825b9d5c47"
+            ]
+          },
+          "positions" : {
+            "3cdaa286-e1c9-44bf-9467-b91f8fe146a4" : {
+              "col" : 1,
+              "row" : 1,
+              "height" : 2,
+              "width" : 8,
+            },
+            "414d294b-cc94-47c8-8b9c-56a42b53748b" : {
+              "col" : 1,
+              "row" : 3,
+              "height" : 6,
+              "width" : 8,
+            }
+          },
+          "display_mode_settings" : {
+            "positions" : {}
+          }
+        }
+      },
+      "owner" : "admin",
+      "created_at" : "2020-01-27T13:19:12.465Z"
+    }
+  ]
+}

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/WidgetFormattingSettings.js
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/WidgetFormattingSettings.js
@@ -3,12 +3,19 @@ import * as Immutable from 'immutable';
 
 import type { Color } from 'views/logic/views/formatting/highlighting/HighlightingRule';
 
+type ChartColors = { [string]: Color };
+
 type InternalState = {
-  chartColors: { [string]: Color },
+  chartColors: ChartColors,
+};
+
+type ChartColorSettingJson = {
+  field_name: string,
+  chart_color: Color,
 };
 
 export type WidgetFormattingSettingsJSON = {
-  chart_colors: { [string]: Color },
+  chart_colors: Array<ChartColorSettingJson>,
 };
 
 export default class WidgetFormattingSettings {
@@ -45,14 +52,18 @@ export default class WidgetFormattingSettings {
 
   toJSON() {
     const { chartColors } = this._value;
-
-    return {
-      chart_colors: chartColors,
-    };
+    // $FlowFixMe flow cannot handle Object.keys
+    const chartColorJson = Object.keys(chartColors)
+      .map(fieldName => ({ field_name: fieldName, chart_color: chartColors[fieldName] }));
+    return { chart_colors: chartColorJson };
   }
 
   static fromJSON(value: WidgetFormattingSettingsJSON) {
-    const { chart_colors: chartColors } = value;
+    const { chart_colors: chartColorJson } = value;
+    const chartColors: ChartColors = chartColorJson.reduce((acc, { field_name: fieldName, chart_color: chartColor }) => {
+      acc[fieldName] = chartColor;
+      return acc;
+    }, {});
     return WidgetFormattingSettings.create(chartColors);
   }
 }


### PR DESCRIPTION
## Description, Motivation and Context
Prior to this change, the data structure to store
WidgetFormattingSettings did use the "user input" for storing a map.
But mongodb does not allow to store keys with dot in the map.

This change will change the data structure from a map to a list
of objects. That way mongodb does not need to store the keys.

Also add migration to fix existing color charts in mongodbs.

Fixes #7235 

## How Has This Been Tested?
1. Add dashboard with color chart containing a non IP keyname with dots and see that it
does not get saved. 
1. Remove dots from name
1. Run migration
1. Check that chart color still exists and add the dots back to the name which should now successfully be saved.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

