### PR TITLE
Ignore unknown legacy dashboard widget properties.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/FieldChartConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/FieldChartConfig.java
@@ -39,7 +39,7 @@ import java.util.Set;
 
 @AutoValue
 @JsonAutoDetect
-@JsonIgnoreProperties({"rangeType", "relative", "from", "to", "keyword"})
+@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class FieldChartConfig extends WidgetConfigBase implements WidgetConfigWithQueryAndStreams {
     public abstract String valuetype();
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/QuickValuesConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/QuickValuesConfig.java
@@ -18,6 +18,7 @@ package org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsTo
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Splitter;
@@ -48,6 +49,7 @@ import java.util.stream.Collectors;
 
 @AutoValue
 @JsonAutoDetect
+@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class QuickValuesConfig extends WidgetConfigBase implements WidgetConfigWithQueryAndStreams {
     private static final String VISUALIZATION_PIE = "pie";
     private static final String VISUALIZATION_TABLE = "table";

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/QuickValuesHistogramConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/QuickValuesHistogramConfig.java
@@ -18,6 +18,7 @@ package org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsTo
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Splitter;
@@ -45,6 +46,7 @@ import java.util.stream.Collectors;
 
 @AutoValue
 @JsonAutoDetect
+@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class QuickValuesHistogramConfig extends WidgetConfigBase implements WidgetConfigWithQueryAndStreams {
     private static final String BAR_VISUALIZATION = "bar";
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/SearchResultChartConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/SearchResultChartConfig.java
@@ -18,6 +18,7 @@ package org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsTo
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Strings;
@@ -38,6 +39,7 @@ import java.util.Set;
 
 @AutoValue
 @JsonAutoDetect
+@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class SearchResultChartConfig extends WidgetConfigBase implements WidgetConfigWithQueryAndStreams {
     public abstract String interval();
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/SearchResultCountConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/SearchResultCountConfig.java
@@ -18,6 +18,7 @@ package org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsTo
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Strings;
@@ -36,6 +37,7 @@ import java.util.Set;
 
 @AutoValue
 @JsonAutoDetect
+@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class SearchResultCountConfig extends WidgetConfigBase implements WidgetConfigWithQueryAndStreams {
     private static final String NUMERIC_VISUALIZATION = "numeric";
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/StackedChartConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/StackedChartConfig.java
@@ -18,6 +18,7 @@ package org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsTo
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.AggregationWidget;
@@ -43,6 +44,7 @@ import java.util.stream.Collectors;
 
 @AutoValue
 @JsonAutoDetect
+@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class StackedChartConfig extends WidgetConfigBase implements WidgetConfig {
     private static final Logger LOG = LoggerFactory.getLogger(StackedChartConfig.class);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/StackedSeries.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/StackedSeries.java
@@ -18,12 +18,14 @@ package org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsTo
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Strings;
 
 @AutoValue
 @JsonAutoDetect
+@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class StackedSeries {
     public abstract String query();
     public abstract String field();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/StatsCountConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/StatsCountConfig.java
@@ -18,6 +18,7 @@ package org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsTo
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.RandomUUIDProvider;
@@ -35,6 +36,7 @@ import java.util.Set;
 
 @AutoValue
 @JsonAutoDetect
+@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class StatsCountConfig extends WidgetConfigBase implements WidgetConfigWithQueryAndStreams {
     private static final String NUMERIC_VISUALIZATION = "numeric";
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/WorldMapConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/WorldMapConfig.java
@@ -18,6 +18,7 @@ package org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsTo
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Strings;
@@ -36,6 +37,7 @@ import java.util.Set;
 
 @AutoValue
 @JsonAutoDetect
+@JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class WorldMapConfig extends WidgetConfigBase implements WidgetConfigWithQueryAndStreams {
     private static final String MAP_VISUALIZATION = "map";
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/V20191125144500_MigrateDashboardsToViewsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/V20191125144500_MigrateDashboardsToViewsTest.java
@@ -347,6 +347,19 @@ public class V20191125144500_MigrateDashboardsToViewsTest {
         verify(searchService, times(1)).save(any());
     }
 
+    @Test
+    @MongoDBFixtures("dashboard_with_superfluous_widget_attributes.json")
+    public void migratesADashboardWithSuperfluousWidgetAttributes() {
+        this.migration.upgrade();
+
+        final MigrationCompleted migrationCompleted = captureMigrationCompleted();
+        assertThat(migrationCompleted.migratedDashboardIds()).containsExactly("5ddf8ed5b2d44b2e04472992");
+        assertThat(migrationCompleted.widgetMigrationIds()).hasSize(16);
+
+        verify(viewService, times(1)).save(any());
+        verify(searchService, times(1)).save(any());
+    }
+
     private void assertSearchesWritten(int count, String expectedEntities) throws Exception {
         final ArgumentCaptor<Search> newSearchesCaptor = ArgumentCaptor.forClass(Search.class);
         verify(searchService, times(count)).save(newSearchesCaptor.capture());

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/V20191125144500_MigrateDashboardsToViewsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/V20191125144500_MigrateDashboardsToViewsTest.java
@@ -354,7 +354,7 @@ public class V20191125144500_MigrateDashboardsToViewsTest {
 
         final MigrationCompleted migrationCompleted = captureMigrationCompleted();
         assertThat(migrationCompleted.migratedDashboardIds()).containsExactly("5ddf8ed5b2d44b2e04472992");
-        assertThat(migrationCompleted.widgetMigrationIds()).hasSize(16);
+        assertThat(migrationCompleted.widgetMigrationIds()).hasSize(19);
 
         verify(viewService, times(1)).save(any());
         verify(searchService, times(1)).save(any());

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_superfluous_widget_attributes.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_superfluous_widget_attributes.json
@@ -7,6 +7,24 @@
       "created_at" : { "$date": "2019-11-28T09:09:41.688Z" },
       "title" : "Widgets with superfluous attributes.",
       "positions": {
+        "e444b1fd-71ff-405d-a158-d6a4a6395c24": {
+          "width" : 1,
+          "col" : 1,
+          "row" : 1,
+          "height" : 1
+        },
+        "8a598222-1aef-4684-bb03-c768c29c37fa": {
+          "width" : 3,
+          "col" : 1,
+          "row" : 16,
+          "height" : 4
+        },
+        "f6e9d960-9cc8-4d16-b3c8-770501b2709f": {
+          "width" : 1,
+          "col" : 1,
+          "row" : 1,
+          "height" : 1
+        },
         "5a34d186-2823-4acc-8f1c-f66332865ff4" : {
           "width" : 2,
           "col" : 5,
@@ -106,11 +124,74 @@
       },
       "widgets" : [
         {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Map",
+          "id": "8a598222-1aef-4684-bb03-c768c29c37fa",
+          "type": "org.graylog.plugins.map.widget.strategy.MapWidgetStrategy",
+          "config": {
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "field": "foo_location",
+            "query": "",
+            "unknown_attribute": 42
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Stacked Field graph",
+          "id": "f6e9d960-9cc8-4d16-b3c8-770501b2709f",
+          "type": "STACKED_CHART",
+          "config": {
+            "interval": "minute",
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "renderer": "bar",
+            "interpolation": "linear",
+            "series": [
+              {
+                "query": "",
+                "field": "dns_client",
+                "statistical_function": "count",
+                "unknown_attribute": 42
+              },
+              {
+                "query": "",
+                "field": "nf_bytes",
+                "statistical_function": "count",
+                "unknown_attribute": 42
+              }
+            ],
+            "unknown_attribute": 42
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Histogram",
+          "id": "e444b1fd-71ff-405d-a158-d6a4a6395c24",
+          "type": "SEARCH_RESULT_CHART",
+          "config": {
+            "interval": "minute",
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "query": "",
+            "unknown_attribute": 42
+          }
+        },
+        {
           "creator_user_id" : "admin",
           "cache_time" : 10,
           "description" : "Uncached Requests",
           "id" : "5a34d186-2823-4acc-8f1c-f66332865ff4",
-          "type" : "SEARCH_RESULT_COUNT",
+          "type" : "STREAM_SEARCH_RESULT_COUNT",
           "config" : {
             "timerange" : {
               "type" : "relative",

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_superfluous_widget_attributes.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_superfluous_widget_attributes.json
@@ -1,0 +1,437 @@
+{
+  "dashboards": [
+    {
+      "_id" : { "$oid": "5ddf8ed5b2d44b2e04472992" },
+      "creator_user_id" : "admin",
+      "description" : "This dashboard does have widgets which contain unknown attributes.",
+      "created_at" : { "$date": "2019-11-28T09:09:41.688Z" },
+      "title" : "Widgets with superfluous attributes.",
+      "positions": {
+        "5a34d186-2823-4acc-8f1c-f66332865ff4" : {
+          "width" : 2,
+          "col" : 5,
+          "row" : 1,
+          "height" : 1
+        },
+        "fc9c5600-a771-4e86-974d-2f6e25a7bfa8" : {
+          "width" : 2,
+          "col" : 5,
+          "row" : 5,
+          "height" : 1
+        },
+        "7146f193-a481-4a99-bbea-4a8d74be43d2" : {
+          "width" : 4,
+          "col" : 1,
+          "row" : 6,
+          "height" : 2
+        },
+        "9dfcf2a5-c6b8-480f-b35b-ee2c12126c95" : {
+          "width" : 4,
+          "col" : 1,
+          "row" : 8,
+          "height" : 2
+        },
+        "b898e3e6-5fc4-4bbd-abb2-91237c47d300" : {
+          "width" : 2,
+          "col" : 5,
+          "row" : 2,
+          "height" : 1
+        },
+        "1482035e-4bb7-4064-b313-ba184d8b3cca" : {
+          "width" : 4,
+          "col" : 5,
+          "row" : 8,
+          "height" : 2
+        },
+        "bbd3a980-8547-48fb-b61f-2cb09486120a" : {
+          "width" : 8,
+          "col" : 1,
+          "row" : 3,
+          "height" : 2
+        },
+        "704deed7-07ad-46fd-8b5e-67b041582eb7" : {
+          "width" : 2,
+          "col" : 3,
+          "row" : 1,
+          "height" : 1
+        },
+        "4ce93e89-4771-4ce2-8b59-6dc058cbfd3b" : {
+          "width" : 8,
+          "col" : 1,
+          "row" : 10,
+          "height" : 3
+        },
+        "5f2d78cb-8b5a-43a7-ae60-2f88f1572c50" : {
+          "width" : 2,
+          "col" : 1,
+          "row" : 2,
+          "height" : 1
+        },
+        "e7f07f85-689a-4ef3-8c6f-cd297af3973f" : {
+          "width" : 2,
+          "col" : 3,
+          "row" : 5,
+          "height" : 1
+        },
+        "0f349fbb-04c9-4303-bdc3-137e39d3af8c" : {
+          "width" : 2,
+          "col" : 3,
+          "row" : 2,
+          "height" : 1
+        },
+        "cdf3de92-7c0c-4ef1-a533-67ded72eaf15" : {
+          "width" : 2,
+          "col" : 1,
+          "row" : 5,
+          "height" : 1
+        },
+        "568c005a-11ec-4be9-acd7-b2aa509c07e0" : {
+          "width" : 2,
+          "col" : 7,
+          "row" : 1,
+          "height" : 2
+        },
+        "b959fa46-524c-4009-a493-7db87d8532ba" : {
+          "width" : 4,
+          "col" : 5,
+          "row" : 6,
+          "height" : 2
+        },
+        "eb75eb75-0403-4b2c-ba3a-0772b5c4f99a" : {
+          "width" : 2,
+          "col" : 1,
+          "row" : 1,
+          "height" : 1
+        }
+      },
+      "widgets" : [
+        {
+          "creator_user_id" : "admin",
+          "cache_time" : 10,
+          "description" : "Uncached Requests",
+          "id" : "5a34d186-2823-4acc-8f1c-f66332865ff4",
+          "type" : "SEARCH_RESULT_COUNT",
+          "config" : {
+            "timerange" : {
+              "type" : "relative",
+              "range" : 3600
+            },
+            "lower_is_better" : false,
+            "stream_id" : "5ddf8ed5b2d44b2e0447298c",
+            "trend" : false,
+            "query" : "NOT CacheCacheStatus:hit",
+            "unknown_attribute": 42
+          }
+        },
+        {
+          "creator_user_id" : "admin",
+          "cache_time" : 10,
+          "description" : "Uncached Bandwidth (bytes)",
+          "id" : "fc9c5600-a771-4e86-974d-2f6e25a7bfa8",
+          "type" : "STATS_COUNT",
+          "config" : {
+            "timerange" : {
+              "type" : "relative",
+              "range" : 3600
+            },
+            "field" : "EdgeResponseBytes",
+            "stream_id" : "5ddf8ed5b2d44b2e0447298c",
+            "trend" : false,
+            "query" : "NOT CacheCacheStatus:hit",
+            "stats_function" : "count",
+            "lower_is_better" : false,
+            "unknown_attribute": 42
+          }
+        },
+        {
+          "creator_user_id" : "admin",
+          "cache_time" : 10,
+          "description" : "Cached Requests by Hostname",
+          "id" : "7146f193-a481-4a99-bbea-4a8d74be43d2",
+          "type" : "QUICKVALUES_HISTOGRAM",
+          "config" : {
+            "timerange" : {
+              "type" : "relative",
+              "range" : 3600
+            },
+            "field" : "EdgeRequestHost",
+            "stream_id" : "5ddf8ed5b2d44b2e0447298c",
+            "query" : "CacheCacheStatus:hit",
+            "limit" : 5,
+            "sort_order" : "desc",
+            "stacked_fields" : "",
+            "unknown_attribute": 42
+          }
+        },
+        {
+          "creator_user_id" : "admin",
+          "cache_time" : 10,
+          "description" : "Cached Requests by Protocol",
+          "id" : "9dfcf2a5-c6b8-480f-b35b-ee2c12126c95",
+          "type" : "QUICKVALUES_HISTOGRAM",
+          "config" : {
+            "timerange" : {
+              "type" : "relative",
+              "range" : 3600
+            },
+            "field" : "ClientRequestProtocol",
+            "stream_id" : "5ddf8ed5b2d44b2e0447298c",
+            "query" : "CacheCacheStatus:hit",
+            "limit" : 5,
+            "sort_order" : "desc",
+            "stacked_fields" : "",
+            "unknown_attribute": 42
+          }
+        },
+        {
+          "creator_user_id" : "admin",
+          "cache_time" : 10,
+          "description" : "Response Time - Deviation (ms)",
+          "id" : "b898e3e6-5fc4-4bbd-abb2-91237c47d300",
+          "type" : "STATS_COUNT",
+          "config" : {
+            "timerange" : {
+              "type" : "relative",
+              "range" : 3600
+            },
+            "field" : "OriginResponseTimeMillis",
+            "stream_id" : "5ddf8ed5b2d44b2e0447298c",
+            "trend" : false,
+            "query" : "",
+            "stats_function" : "std_deviation",
+            "lower_is_better" : false,
+            "unknown_attribute": 42
+          }
+        },
+        {
+          "creator_user_id" : "admin",
+          "cache_time" : 10,
+          "description" : "Cached Request by Method",
+          "id" : "1482035e-4bb7-4064-b313-ba184d8b3cca",
+          "type" : "QUICKVALUES_HISTOGRAM",
+          "config" : {
+            "timerange" : {
+              "type" : "relative",
+              "range" : 3600
+            },
+            "field" : "ClientRequestMethod",
+            "stream_id" : "5ddf8ed5b2d44b2e0447298c",
+            "query" : "CacheCacheStatus:hit",
+            "limit" : 5,
+            "sort_order" : "desc",
+            "stacked_fields" : "",
+            "unknown_attribute": 42
+          }
+        },
+        {
+          "creator_user_id" : "admin",
+          "cache_time" : 10,
+          "description" : "Response Time (ms)",
+          "id" : "bbd3a980-8547-48fb-b61f-2cb09486120a",
+          "type" : "FIELD_CHART",
+          "config" : {
+            "valuetype" : "count",
+            "renderer" : "area",
+            "interpolation" : "linear",
+            "timerange" : {
+              "type" : "relative",
+              "range" : 3600
+            },
+            "rangeType" : "relative",
+            "field" : "OriginResponseTimeMillis",
+            "stream_id" : "5ddf8ed5b2d44b2e0447298c",
+            "query" : "",
+            "interval" : "minute",
+            "relative" : 900,
+            "unknown_attribute": 42
+          }
+        },
+        {
+          "creator_user_id" : "admin",
+          "cache_time" : 10,
+          "description" : "Cached Requests",
+          "id" : "704deed7-07ad-46fd-8b5e-67b041582eb7",
+          "type" : "STATS_COUNT",
+          "config" : {
+            "timerange" : {
+              "type" : "relative",
+              "range" : 3600
+            },
+            "field" : "CacheCacheStatus",
+            "stream_id" : "5ddf8ed5b2d44b2e0447298c",
+            "trend" : false,
+            "query" : "CacheCacheStatus:hit",
+            "stats_function" : "cardinality",
+            "lower_is_better" : false,
+            "unknown_attribute": 42
+          }
+        },
+        {
+          "creator_user_id" : "admin",
+          "cache_time" : 10,
+          "description" : "Top Cached URIs",
+          "id" : "4ce93e89-4771-4ce2-8b59-6dc058cbfd3b",
+          "type" : "QUICKVALUES",
+          "config" : {
+            "timerange" : {
+              "type" : "relative",
+              "range" : 3600
+            },
+            "field" : "ClientRequestURI",
+            "stream_id" : "5ddf8ed5b2d44b2e0447298c",
+            "query" : "CacheCacheStatus:hit",
+            "show_data_table" : true,
+            "limit" : 5,
+            "show_pie_chart" : false,
+            "sort_order" : "desc",
+            "stacked_fields" : "",
+            "data_table_limit" : 50,
+            "interval": "minute",
+            "unknown_attribute": 42
+          }
+        },
+        {
+          "creator_user_id" : "admin",
+          "cache_time" : 10,
+          "description" : "Response Time - Average (ms)",
+          "id" : "5f2d78cb-8b5a-43a7-ae60-2f88f1572c50",
+          "type" : "STATS_COUNT",
+          "config" : {
+            "timerange" : {
+              "type" : "relative",
+              "range" : 3600
+            },
+            "field" : "OriginResponseTimeMillis",
+            "stream_id" : "5ddf8ed5b2d44b2e0447298c",
+            "trend" : false,
+            "query" : "",
+            "stats_function" : "mean",
+            "lower_is_better" : false,
+            "unknown_attribute": 42
+          }
+        },
+        {
+          "creator_user_id" : "admin",
+          "cache_time" : 10,
+          "description" : "Cached Bandwidth (bytes)",
+          "id" : "e7f07f85-689a-4ef3-8c6f-cd297af3973f",
+          "type" : "STATS_COUNT",
+          "config" : {
+            "timerange" : {
+              "type" : "relative",
+              "range" : 3600
+            },
+            "field" : "CacheResponseBytes",
+            "stream_id" : "5ddf8ed5b2d44b2e0447298c",
+            "trend" : false,
+            "query" : "CacheCacheStatus:hit",
+            "stats_function" : "count",
+            "lower_is_better" : false,
+            "unknown_attribute": 42
+          }
+        },
+        {
+          "creator_user_id" : "admin",
+          "cache_time" : 10,
+          "description" : "Response Time - Max (ms)",
+          "id" : "0f349fbb-04c9-4303-bdc3-137e39d3af8c",
+          "type" : "STATS_COUNT",
+          "config" : {
+            "timerange" : {
+              "type" : "relative",
+              "range" : 3600
+            },
+            "field" : "OriginResponseTimeMillis",
+            "stream_id" : "5ddf8ed5b2d44b2e0447298c",
+            "trend" : false,
+            "query" : "",
+            "stats_function" : "max",
+            "lower_is_better" : false,
+            "unknown_attribute": 42
+          }
+        },
+        {
+          "creator_user_id" : "admin",
+          "cache_time" : 10,
+          "description" : "Total Request Bandwidth (bytes)",
+          "id" : "cdf3de92-7c0c-4ef1-a533-67ded72eaf15",
+          "type" : "STATS_COUNT",
+          "config" : {
+            "timerange" : {
+              "type" : "relative",
+              "range" : 3600
+            },
+            "field" : "EdgeResponseBytes",
+            "stream_id" : "5ddf8ed5b2d44b2e0447298c",
+            "trend" : false,
+            "query" : "",
+            "stats_function" : "count",
+            "lower_is_better" : false,
+            "unknown_attribute": 42
+          }
+        },
+        {
+          "creator_user_id" : "admin",
+          "cache_time" : 10,
+          "description" : "Cached Status Ratio",
+          "id" : "568c005a-11ec-4be9-acd7-b2aa509c07e0",
+          "type" : "QUICKVALUES",
+          "config" : {
+            "timerange" : {
+              "type" : "relative",
+              "range" : 3600
+            },
+            "field" : "CacheCacheStatus",
+            "stream_id" : "5ddf8ed5b2d44b2e0447298c",
+            "query" : "",
+            "show_data_table" : true,
+            "limit" : 5,
+            "show_pie_chart" : false,
+            "sort_order" : "desc",
+            "stacked_fields" : "",
+            "data_table_limit" : 50,
+            "unknown_attribute": 42
+          }
+        },
+        {
+          "creator_user_id" : "admin",
+          "cache_time" : 10,
+          "description" : "Cached Requests by Content Type",
+          "id" : "b959fa46-524c-4009-a493-7db87d8532ba",
+          "type" : "QUICKVALUES_HISTOGRAM",
+          "config" : {
+            "timerange" : {
+              "type" : "relative",
+              "range" : 3600
+            },
+            "field" : "EdgeResponseContentType",
+            "stream_id" : "5ddf8ed5b2d44b2e0447298c",
+            "query" : "CacheCacheStatus:hit",
+            "limit" : 5
+            "sort_order" : "desc",
+            "stacked_fields" : "",
+            "unknown_attribute": 42
+          }
+        },
+        {
+          "creator_user_id" : "admin",
+          "cache_time" : 10,
+          "description" : "Total Requests",
+          "id" : "eb75eb75-0403-4b2c-ba3a-0772b5c4f99a",
+          "type" : "SEARCH_RESULT_COUNT",
+          "config" : {
+            "timerange" : {
+              "type" : "relative",
+              "range" : 3600
+            },
+            "lower_is_better" : false,
+            "stream_id" : "5ddf8ed5b2d44b2e0447298c",
+            "trend" : false,
+            "query" : "",
+            "unknown_attribute": 42
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, the dashboard migration was very strict concerning
unexpected properties in dashboard widgets. There are users reporting it
to fail because of those (e.g. an `interval` field in a `QUICKVALUES`
widget).

Therefore, this PR is relaving the widget deserialization classes and
ignores unknown properties. A test case containing all known widget
types with superfluous attributes has been added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.