### PR TITLE
Mock Version.js to avoid failing snaphot tests after version change

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -30,7 +30,8 @@
     "setupFiles": [
       "jest-localstorage-mock",
       "<rootDir>/test/setup-jest.jsx",
-      "<rootDir>/test/mock-FetchProvider.js"
+      "<rootDir>/test/mock-FetchProvider.js",
+      "<rootDir>/test/mock-Version.js"
     ],
     "setupFilesAfterEnv": [
       "jest-enzyme"

--- a/graylog2-web-interface/src/util/DocsHelper.js
+++ b/graylog2-web-interface/src/util/DocsHelper.js
@@ -1,4 +1,4 @@
-import Version from './Version';
+import Version from 'util/Version';
 
 class DocsHelper {
   PAGES = {

--- a/graylog2-web-interface/src/views/components/__snapshots__/WidgetQueryControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/__snapshots__/WidgetQueryControls.test.jsx.snap
@@ -182,7 +182,7 @@ exports[`WidgetQueryControls should do something 1`] = `
         class="pull-right search-help"
       >
         <a
-          href="http://docs.graylog.org/en/1.0/pages/queries.html"
+          href="http://docs.graylog.org/en/MAJOR_AND_MINOR_VERSION_MOCK/pages/queries.html"
           target="_blank"
           title="Search query syntax documentation"
         >

--- a/graylog2-web-interface/src/views/components/__snapshots__/WidgetQueryControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/__snapshots__/WidgetQueryControls.test.jsx.snap
@@ -182,7 +182,7 @@ exports[`WidgetQueryControls should do something 1`] = `
         class="pull-right search-help"
       >
         <a
-          href="http://docs.graylog.org/en/3.3/pages/queries.html"
+          href="http://docs.graylog.org/en/1.0/pages/queries.html"
           target="_blank"
           title="Search query syntax documentation"
         >

--- a/graylog2-web-interface/src/views/components/__snapshots__/WidgetQueryControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/__snapshots__/WidgetQueryControls.test.jsx.snap
@@ -182,7 +182,7 @@ exports[`WidgetQueryControls should do something 1`] = `
         class="pull-right search-help"
       >
         <a
-          href="http://docs.graylog.org/en/3.2/pages/queries.html"
+          href="http://docs.graylog.org/en/3.3/pages/queries.html"
           target="_blank"
           title="Search query syntax documentation"
         >

--- a/graylog2-web-interface/test/mock-Version.js
+++ b/graylog2-web-interface/test/mock-Version.js
@@ -1,0 +1,8 @@
+// We are mocking the application version, to avoid failing snapshot tests after a version change.
+
+const mockDefaultExport = {
+  getMajorAndMinorVersion: jest.fn(() => '1.0'),
+  getFullVersion: jest.fn(() => '1.0.0-SNAPSHOT'),
+};
+
+jest.mock('util/Version', () => mockDefaultExport);

--- a/graylog2-web-interface/test/mock-Version.js
+++ b/graylog2-web-interface/test/mock-Version.js
@@ -1,8 +1,8 @@
 // We are mocking the application version, to avoid failing snapshot tests after a version change.
 
 const mockDefaultExport = {
-  getMajorAndMinorVersion: jest.fn(() => '1.0'),
-  getFullVersion: jest.fn(() => '1.0.0-SNAPSHOT'),
+  getMajorAndMinorVersion: jest.fn(() => 'MAJOR_AND_MINOR_VERSION_MOCK'),
+  getFullVersion: jest.fn(() => 'FULL_VERSION_MOCK'),
 };
 
 jest.mock('util/Version', () => mockDefaultExport);


### PR DESCRIPTION
Due to the new version in the `package.json`, the docs url has changed and the `WidgetQueryControls` test failed.

We've decided to mock the functionality which causes the failing snapshot test/s.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

