### PR TITLE
Use HTTPS for documentation links

### DIFF
--- a/graylog2-web-interface/src/util/DocsHelper.js
+++ b/graylog2-web-interface/src/util/DocsHelper.js
@@ -30,7 +30,7 @@ class DocsHelper {
     WELCOME: '', // Welcome page to the documentation
   };
 
-  DOCS_URL = 'http://docs.graylog.org/en/';
+  DOCS_URL = 'https://docs.graylog.org/en/';
 
   toString(path) {
     const baseUrl = this.DOCS_URL + Version.getMajorAndMinorVersion();

--- a/graylog2-web-interface/src/views/components/__snapshots__/WidgetQueryControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/__snapshots__/WidgetQueryControls.test.jsx.snap
@@ -182,7 +182,7 @@ exports[`WidgetQueryControls should do something 1`] = `
         class="pull-right search-help"
       >
         <a
-          href="http://docs.graylog.org/en/MAJOR_AND_MINOR_VERSION_MOCK/pages/queries.html"
+          href="https://docs.graylog.org/en/MAJOR_AND_MINOR_VERSION_MOCK/pages/queries.html"
           target="_blank"
           title="Search query syntax documentation"
         >


### PR DESCRIPTION
As suggested by @kyleknighted we should use HTTPS for all our documentation links.

E.g. `http://docs.graylog.org/en/3.2/pages/queries.html` will be `https://docs.graylog.org/en/3.2/pages/queries.html`

We should merge https://github.com/Graylog2/graylog2-server/pull/7308 and rebase this branch first.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

