### PR TITLE
Start retention from the oldest index, not the newest

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexCountBasedRetentionStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/retention/strategies/AbstractIndexCountBasedRetentionStrategy.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -92,7 +93,9 @@ public abstract class AbstractIndexCountBasedRetentionStrategy implements Retent
         orderedIndices
             .stream()
             .skip(orderedIndices.size() - removeCount)
-            .forEach(indexName -> {
+             // reverse order to archive oldest index first
+            .collect(Collectors.toCollection(LinkedList::new)).descendingIterator()
+            .forEachRemaining(indexName -> {
                 final String strategyName = this.getClass().getCanonicalName();
                 final String msg = "Running retention strategy [" + strategyName + "] for index <" + indexName + ">";
                 LOG.info(msg);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/retention/strategies/AbstractIndexCountBasedRetentionStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/retention/strategies/AbstractIndexCountBasedRetentionStrategyTest.java
@@ -119,7 +119,8 @@ public class AbstractIndexCountBasedRetentionStrategyTest {
 
         final ArgumentCaptor<String> retainedIndexName = ArgumentCaptor.forClass(String.class);
         verify(retentionStrategy, times(2)).retain(retainedIndexName.capture(), eq(indexSet));
-        assertThat(retainedIndexName.getAllValues()).contains("index1", "index2");
+        // Ensure that the oldest indices come first
+        assertThat(retainedIndexName.getAllValues()).containsExactly("index1", "index2");
 
         verify(activityWriter, times(3)).write(any(Activity.class));
     }


### PR DESCRIPTION
While testing another archiving change, I noticed that we start archiving from the newest to the oldest index, which isn't the best way to handle things.
