### PR TITLE
Increasing jest timeout for integration test.

### DIFF
--- a/graylog2-web-interface/src/views/spec/CreateNewDashboard.test.jsx
+++ b/graylog2-web-interface/src/views/spec/CreateNewDashboard.test.jsx
@@ -43,6 +43,10 @@ describe('Create a new dashboard', () => {
     PluginStore.register(new PluginManifest({}, viewsBindings));
   });
 
+  beforeEach(() => {
+    jest.setTimeout(30000);
+  });
+
   afterEach(cleanup);
 
   it('using Dashboards Page', async () => {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The `CreateNewDashboard` integration test has proven to be unreliable
under certain conditions (most probably multiple `jest` runs happening
on CI hardware in parallel), leading to false negatives.

This change is increasing the jest timeout for this specific test suite,
hoping to reduce the number of false negatives when run under load.