### PR TITLE
Fix blocking issue in DNS lookup data adapter

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/DnsLookupDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/DnsLookupDataAdapter.java
@@ -192,7 +192,7 @@ public class DnsLookupDataAdapter extends LookupDataAdapter {
         } catch (UnknownHostException e) {
             return LookupResult.empty(); // UnknownHostException is a valid case when the DNS record does not exist. Do not log an error.
         } catch (Exception e) {
-            LOG.error("Could not resolve [{}] records for hostname [{}]. Cause [{}]", A_RECORD_LABEL, key, e.toString());
+            LOG.error("Could not resolve [{}] records for hostname [{}]. Cause [{}]", A_RECORD_LABEL, key, ExceptionUtils.getRootCauseOrMessage(e));
             errorCounter.inc();
             return getEmptyResult();
         }
@@ -218,7 +218,7 @@ public class DnsLookupDataAdapter extends LookupDataAdapter {
         } catch (UnknownHostException e) {
             return getEmptyResult(); // UnknownHostException is a valid case when the DNS record does not exist. Do not log an error.
         } catch (Exception e) {
-            LOG.error("Could not resolve [{}] records for hostname [{}]. Cause [{}]", AAAA_RECORD_LABEL, key, ExceptionUtils.getRootCauseMessage(e));
+            LOG.error("Could not resolve [{}] records for hostname [{}]. Cause [{}]", AAAA_RECORD_LABEL, key, ExceptionUtils.getRootCauseOrMessage(e));
             errorCounter.inc();
             return getErrorResult();
         }
@@ -298,7 +298,7 @@ public class DnsLookupDataAdapter extends LookupDataAdapter {
 
             return builder.build();
         } catch (Exception e) {
-            LOG.error("Could not resolve [A/AAAA] records for hostname [{}]. Cause [{}]", key, ExceptionUtils.getRootCauseMessage(e));
+            LOG.error("Could not resolve [A/AAAA] records for hostname [{}]. Cause [{}]", key, ExceptionUtils.getRootCauseOrMessage(e));
             errorCounter.inc();
             return getErrorResult();
         }
@@ -310,7 +310,7 @@ public class DnsLookupDataAdapter extends LookupDataAdapter {
         try {
             dnsResponse = dnsClient.reverseLookup(key.toString());
         } catch (Exception e) {
-            LOG.error("Could not perform reverse DNS lookup for [{}]. Cause [{}]", key, ExceptionUtils.getRootCauseMessage(e));
+            LOG.error("Could not perform reverse DNS lookup for [{}]. Cause [{}]", key, ExceptionUtils.getRootCauseOrMessage(e));
             errorCounter.inc();
             return getErrorResult();
         }
@@ -351,7 +351,7 @@ public class DnsLookupDataAdapter extends LookupDataAdapter {
         try {
             txtDnsAnswers = dnsClient.txtLookup(key.toString());
         } catch (Exception e) {
-            LOG.error("Could not perform TXT DNS lookup for [{}]. Cause [{}]", key, ExceptionUtils.getRootCauseMessage(e));
+            LOG.error("Could not perform TXT DNS lookup for [{}]. Cause [{}]", key, ExceptionUtils.getRootCauseOrMessage(e));
             errorCounter.inc();
             return getErrorResult();
         }

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/DnsLookupDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/DnsLookupDataAdapter.java
@@ -192,7 +192,7 @@ public class DnsLookupDataAdapter extends LookupDataAdapter {
         } catch (UnknownHostException e) {
             return LookupResult.empty(); // UnknownHostException is a valid case when the DNS record does not exist. Do not log an error.
         } catch (Exception e) {
-            LOG.error("Could not resolve [{}] records for hostname [{}]. Cause [{}]", A_RECORD_LABEL, key, ExceptionUtils.getRootCauseMessage(e));
+            LOG.error("Could not resolve [{}] records for hostname [{}]. Cause [{}]", A_RECORD_LABEL, key, e.toString());
             errorCounter.inc();
             return getEmptyResult();
         }

--- a/graylog2-server/src/main/java/org/graylog2/lookup/adapters/DnsLookupDataAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/adapters/DnsLookupDataAdapter.java
@@ -102,8 +102,8 @@ public class DnsLookupDataAdapter extends LookupDataAdapter {
     @Override
     protected void doStart() {
 
-        dnsClient = new DnsClient();
-        dnsClient.start(config.serverIps(), config.requestTimeout());
+        dnsClient = new DnsClient(config.requestTimeout());
+        dnsClient.start(config.serverIps());
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/shared/utilities/ExceptionUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/utilities/ExceptionUtils.java
@@ -60,4 +60,8 @@ public class ExceptionUtils {
     public static String getRootCauseMessage(Throwable t) {
         return formatMessageCause(getRootCause(t));
     }
+    public static String getRootCauseOrMessage(Throwable t) {
+        final Throwable rootCause = getRootCause(t);
+        return formatMessageCause(rootCause != null ? rootCause : t);
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/utilities/ExceptionUtils.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/utilities/ExceptionUtils.java
@@ -16,17 +16,22 @@
  */
 package org.graylog2.shared.utilities;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.net.UnknownHostException;
 
 public class ExceptionUtils {
 
     public static Throwable getRootCause(Throwable t) {
+        return getRootCause(t, false);
+    }
+    public static Throwable getRootCause(Throwable t, boolean causeNeedsMessage) {
         if (t == null) {
             return null;
         }
         Throwable rootCause = t;
         Throwable cause = rootCause.getCause();
-        while (cause != null && cause != rootCause) {
+        while (cause != null && (!causeNeedsMessage || StringUtils.isNotBlank(cause.getMessage())) && cause != rootCause) {
             rootCause = cause;
             cause = cause.getCause();
         }
@@ -61,7 +66,7 @@ public class ExceptionUtils {
         return formatMessageCause(getRootCause(t));
     }
     public static String getRootCauseOrMessage(Throwable t) {
-        final Throwable rootCause = getRootCause(t);
+        final Throwable rootCause = getRootCause(t, true);
         return formatMessageCause(rootCause != null ? rootCause : t);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/lookup/adapters/dnslookup/DnsClientTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/lookup/adapters/dnslookup/DnsClientTest.java
@@ -27,7 +27,7 @@ public class DnsClientTest {
     @Test
     public void testReverseIpFormat() {
 
-        DnsClient dnsClient = new DnsClient();
+        DnsClient dnsClient = new DnsClient(5000);
 
         // Test IPv4 reverse format.
         assertEquals("40.30.20.10.in-addr.arpa.", dnsClient.getInverseAddressFormat("10.20.30.40"));

--- a/graylog2-server/src/test/java/org/graylog2/shared/utilities/ExceptionUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/utilities/ExceptionUtilsTest.java
@@ -25,4 +25,22 @@ public class ExceptionUtilsTest {
     public void formatMessageCause() {
         assertThat(ExceptionUtils.formatMessageCause(new Exception())).isNotBlank();
     }
+    @Test
+    public void getRootCauseMessage() {
+        assertThat(ExceptionUtils.getRootCauseMessage(new Exception("cause1", new Exception("root")))).satisfies(m -> {
+           assertThat(m).isNotBlank();
+           assertThat(m).isEqualTo("root.");
+        });
+    }
+    @Test
+    public void getRootCauseOrMessage() {
+        assertThat(ExceptionUtils.getRootCauseOrMessage(new Exception("cause1", new Exception("root")))).satisfies(m -> {
+            assertThat(m).isNotBlank();
+            assertThat(m).isEqualTo("root.");
+        });
+        assertThat(ExceptionUtils.getRootCauseOrMessage(new Exception("cause1"))).satisfies(m -> {
+            assertThat(m).isNotBlank();
+            assertThat(m).isEqualTo("cause1.");
+        });
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog2/shared/utilities/ExceptionUtilsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/utilities/ExceptionUtilsTest.java
@@ -42,5 +42,9 @@ public class ExceptionUtilsTest {
             assertThat(m).isNotBlank();
             assertThat(m).isEqualTo("cause1.");
         });
+        assertThat(ExceptionUtils.getRootCauseOrMessage(new Exception("cause1", new Exception("")))).satisfies(m -> {
+            assertThat(m).isNotBlank();
+            assertThat(m).isEqualTo("cause1.");
+        });
     }
 }


### PR DESCRIPTION
We cannot use "Future#sync()" to wait for the result of the DNS
resolver. This can block forever (until the server gets restarted)
when the DnsNameResolver and the netty event loop gets shut down while a
DNS request is running.

This happened on busy systems that do a lot of DNS lookups and the DNS
lookup data adapter gets restarted while DNS requests are running. (e.g.
by updating the data adapter's configuration)

It can get even worse when multiple processing threads try to lookup the
same hostname or IP address at the same time, using the same lookup
table. One thread is waiting for a response but never returns.
All other processing threads are blocking on the cache lock, waiting on
the other thread to return.

The solution is to not use "Future#sync()" and use "Future#get()" with a
timeout so the thread doesn't wait for the future completion forever.

By default the timeout for waiting on the future is based on the query
timeout plus 100 ms to avoid canceling the future before a potential
DNS query timeout kicks in.

This change also ensures that the DnsNameResolver will be closed before
shutting down the event loop.

Fixes #5782