### PR TITLE
Show/use view-based dashboards in user/role permissions editor. (3.2)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchDomain.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/SearchDomain.java
@@ -18,6 +18,7 @@ package org.graylog.plugins.views.search;
 
 import org.graylog.plugins.views.search.db.SearchDbService;
 import org.graylog.plugins.views.search.errors.PermissionException;
+import org.graylog.plugins.views.search.views.ViewDTO;
 import org.graylog2.plugin.database.users.User;
 
 import javax.inject.Inject;
@@ -36,7 +37,7 @@ public class SearchDomain {
         this.viewPermissions = viewPermissions;
     }
 
-    public Optional<Search> getForUser(String id, User user, Predicate<String> viewReadPermission) {
+    public Optional<Search> getForUser(String id, User user, Predicate<ViewDTO> viewReadPermission) {
         final Optional<Search> search = dbService.get(id);
 
         search.ifPresent(s -> checkPermission(user, viewReadPermission, s));
@@ -44,22 +45,22 @@ public class SearchDomain {
         return search;
     }
 
-    private void checkPermission(User user, Predicate<String> viewReadPermission, Search s) {
+    private void checkPermission(User user, Predicate<ViewDTO> viewReadPermission, Search s) {
         if (!hasReadPermissionFor(user, viewReadPermission, s))
-            throw new PermissionException("User " + user + " does not have permission to load search " + s.id());
+            throw new PermissionException("User " + user.getName() + " does not have permission to load search " + s.id());
     }
 
-    public List<Search> getAllForUser(User user, Predicate<String> viewReadPermission) {
+    public List<Search> getAllForUser(User user, Predicate<ViewDTO> viewReadPermission) {
         return dbService.streamAll()
                 .filter(s -> hasReadPermissionFor(user, viewReadPermission, s))
                 .collect(Collectors.toList());
     }
 
-    private boolean hasReadPermissionFor(User user, Predicate<String> viewReadPermission, Search search) {
+    private boolean hasReadPermissionFor(User user, Predicate<ViewDTO> viewReadPermission, Search search) {
         return isOwned(search, user) || hasPermissionFromViews(search, user, viewReadPermission);
     }
 
-    private boolean hasPermissionFromViews(Search search, User user, Predicate<String> hasViewReadPermission) {
+    private boolean hasPermissionFromViews(Search search, User user, Predicate<ViewDTO> hasViewReadPermission) {
         return viewPermissions.isSearchPermitted(search.id(), user, hasViewReadPermission);
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/ViewPermissions.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/ViewPermissions.java
@@ -16,12 +16,14 @@
  */
 package org.graylog.plugins.views.search;
 
+import org.graylog.plugins.views.search.views.ViewDTO;
 import org.graylog.plugins.views.search.views.ViewService;
 import org.graylog.plugins.views.search.views.sharing.IsViewSharedForUser;
 import org.graylog.plugins.views.search.views.sharing.ViewSharingService;
 import org.graylog2.plugin.database.users.User;
 
 import javax.inject.Inject;
+import java.util.Collection;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -39,13 +41,14 @@ class ViewPermissions {
         this.isViewSharedForUser = isViewSharedForUser;
     }
 
-    boolean isSearchPermitted(String id, User user, Predicate<String> viewReadPermission) {
-        final Set<String> viewIds = idsFrom(viewService.forSearch(id));
+    boolean isSearchPermitted(String id, User user, Predicate<ViewDTO> viewReadPermission) {
+        final Collection<ViewDTO> views = viewService.forSearch(id);
+        final Set<String> viewIds = idsFrom(views);
 
-        if (viewIds.isEmpty())
+        if (views.isEmpty())
             return false;
 
-        return hasSharedView(user, viewIds) || hasDirectReadPermissionForAny(viewIds, viewReadPermission);
+        return hasSharedView(user, viewIds) || hasDirectReadPermissionForAny(views, viewReadPermission);
     }
 
     private boolean hasSharedView(User user, Set<String> viewIds) {
@@ -53,7 +56,7 @@ class ViewPermissions {
                 .anyMatch(vs -> isViewSharedForUser.isAllowedToSee(user, vs));
     }
 
-    private boolean hasDirectReadPermissionForAny(Set<String> viewIds, Predicate<String> viewReadPermission) {
-        return viewIds.stream().anyMatch(viewReadPermission);
+    private boolean hasDirectReadPermissionForAny(Collection<ViewDTO> views, Predicate<ViewDTO> viewReadPermission) {
+        return views.stream().anyMatch(viewReadPermission);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/DashboardsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/DashboardsResource.java
@@ -32,6 +32,7 @@ import org.graylog2.search.SearchQuery;
 import org.graylog2.search.SearchQueryField;
 import org.graylog2.search.SearchQueryParser;
 import org.graylog2.shared.rest.resources.RestResource;
+import org.graylog2.shared.security.RestPermissions;
 
 import javax.inject.Inject;
 import javax.ws.rs.BadRequestException;
@@ -92,6 +93,7 @@ public class DashboardsResource extends RestResource {
                         final Optional<ViewSharing> viewSharing = viewSharingService.forView(view.id());
 
                         return isPermitted(ViewsRestPermissions.VIEW_READ, view.id())
+                                || isPermitted(RestPermissions.DASHBOARDS_READ, view.id())
                                 || viewSharing.map(sharing -> isViewSharedForUser.isAllowedToSee(getCurrentUser(), sharing)).orElse(false);
                     },
                     order,

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QualifyingViewsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/QualifyingViewsResource.java
@@ -20,6 +20,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog.plugins.views.search.views.QualifyingViewsService;
+import org.graylog.plugins.views.search.views.ViewDTO;
 import org.graylog.plugins.views.search.views.ViewParameterSummaryDTO;
 import org.graylog.plugins.views.search.views.sharing.IsViewSharedForUser;
 import org.graylog.plugins.views.search.views.sharing.ViewSharing;
@@ -27,6 +28,7 @@ import org.graylog.plugins.views.search.views.sharing.ViewSharingService;
 import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.shared.rest.resources.RestResource;
+import org.graylog2.shared.security.RestPermissions;
 
 import javax.inject.Inject;
 import javax.ws.rs.POST;
@@ -65,6 +67,7 @@ public class QualifyingViewsResource extends RestResource implements PluginRestR
                     final Optional<ViewSharing> viewSharing = viewSharingService.forView(view.id());
 
                     return isPermitted(ViewsRestPermissions.VIEW_READ, view.id())
+                            || (view.type().equals(ViewDTO.Type.DASHBOARD) && isPermitted(RestPermissions.DASHBOARDS_READ, view.id()))
                             || viewSharing.map(sharing -> isViewSharedForUser.isAllowedToSee(getCurrentUser(), sharing)).orElse(false);
                 })
                 .collect(Collectors.toSet());

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
@@ -38,6 +38,7 @@ import org.graylog.plugins.views.search.SearchMetadata;
 import org.graylog.plugins.views.search.db.SearchDbService;
 import org.graylog.plugins.views.search.db.SearchJobService;
 import org.graylog.plugins.views.search.engine.QueryEngine;
+import org.graylog.plugins.views.search.views.ViewDTO;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.plugin.rest.PluginRestResource;
@@ -146,8 +147,10 @@ public class SearchResource extends RestResource implements PluginRestResource {
                 .orElseThrow(() -> new NotFoundException("Search with id " + searchId + " does not exist"));
     }
 
-    private boolean hasViewReadPermission(String viewId) {
-        return isPermitted(ViewsRestPermissions.VIEW_READ, viewId);
+    private boolean hasViewReadPermission(ViewDTO view) {
+        final String viewId = view.id();
+        return isPermitted(ViewsRestPermissions.VIEW_READ, viewId)
+                || (view.type().equals(ViewDTO.Type.DASHBOARD) && isPermitted(RestPermissions.DASHBOARDS_READ, viewId));
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewParameterSummaryDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/views/ViewParameterSummaryDTO.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 @JsonAutoDetect
 public abstract class ViewParameterSummaryDTO {
     public static final String FIELD_ID = "id";
+    public static final String FIELD_TYPE = "type";
     public static final String FIELD_TITLE = "title";
     public static final String FIELD_SUMMARY = "summary";
     public static final String FIELD_DESCRIPTION = "description";
@@ -35,6 +36,9 @@ public abstract class ViewParameterSummaryDTO {
 
     @JsonProperty(FIELD_ID)
     public abstract String id();
+
+    @JsonProperty(FIELD_TYPE)
+    public abstract ViewDTO.Type type();
 
     @JsonProperty(FIELD_TITLE)
     public abstract String title();
@@ -49,6 +53,6 @@ public abstract class ViewParameterSummaryDTO {
     public abstract Collection<Parameter> parameters();
 
     public static ViewParameterSummaryDTO create(ViewDTO view, Search search) {
-        return new AutoValue_ViewParameterSummaryDTO(view.id(), view.title(), view.summary(), view.description(), search.parameters());
+        return new AutoValue_ViewParameterSummaryDTO(view.id(), view.type(), view.title(), view.summary(), view.description(), search.parameters());
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/ViewPermissionsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/ViewPermissionsTest.java
@@ -108,7 +108,7 @@ public class ViewPermissionsTest {
 
         mockSomeViewsIncluding(permittedView);
 
-        boolean result = sut.isSearchPermitted("some-id", mock(User.class), id -> id.equals(permittedView.id()));
+        boolean result = sut.isSearchPermitted("some-id", mock(User.class), view -> view.id().equals(permittedView.id()));
 
         assertThat(result).isTrue();
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/QualifyingViewsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/QualifyingViewsResourceTest.java
@@ -19,6 +19,7 @@ package org.graylog.plugins.views.search.rest;
 import com.google.common.collect.ImmutableList;
 import org.apache.shiro.subject.Subject;
 import org.graylog.plugins.views.search.views.QualifyingViewsService;
+import org.graylog.plugins.views.search.views.ViewDTO;
 import org.graylog.plugins.views.search.views.ViewParameterSummaryDTO;
 import org.graylog.plugins.views.search.views.sharing.AllUsersOfInstance;
 import org.graylog.plugins.views.search.views.sharing.IsViewSharedForUser;
@@ -100,9 +101,11 @@ public class QualifyingViewsResourceTest {
     public void returnsNoViewsIfNoneArePermitted() {
         final ViewParameterSummaryDTO view1 = mock(ViewParameterSummaryDTO.class);
         when(view1.id()).thenReturn("view1");
+        when(view1.type()).thenReturn(ViewDTO.Type.SEARCH);
         when(subject.isPermitted(ViewsRestPermissions.VIEW_READ + ":view1")).thenReturn(false);
         final ViewParameterSummaryDTO view2 = mock(ViewParameterSummaryDTO.class);
         when(view2.id()).thenReturn("view2");
+        when(view2.type()).thenReturn(ViewDTO.Type.SEARCH);
         when(subject.isPermitted(ViewsRestPermissions.VIEW_READ + ":view2")).thenReturn(false);
         when(qualifyingViewsService.forValue()).thenReturn(ImmutableList.of(view1, view2));
 
@@ -115,9 +118,11 @@ public class QualifyingViewsResourceTest {
     public void returnsSomeViewsIfSomeArePermitted() {
         final ViewParameterSummaryDTO view1 = mock(ViewParameterSummaryDTO.class);
         when(view1.id()).thenReturn("view1");
+        when(view1.type()).thenReturn(ViewDTO.Type.SEARCH);
         when(subject.isPermitted(ViewsRestPermissions.VIEW_READ + ":view1")).thenReturn(false);
         final ViewParameterSummaryDTO view2 = mock(ViewParameterSummaryDTO.class);
         when(view2.id()).thenReturn("view2");
+        when(view2.type()).thenReturn(ViewDTO.Type.SEARCH);
         when(subject.isPermitted(ViewsRestPermissions.VIEW_READ + ":view2")).thenReturn(true);
         when(qualifyingViewsService.forValue()).thenReturn(ImmutableList.of(view1, view2));
 
@@ -145,9 +150,11 @@ public class QualifyingViewsResourceTest {
     public void returnsViewIfNotPermittedButSharedWithUser() {
         final ViewParameterSummaryDTO view1 = mock(ViewParameterSummaryDTO.class);
         when(view1.id()).thenReturn("view1");
+        when(view1.type()).thenReturn(ViewDTO.Type.SEARCH);
         when(subject.isPermitted(ViewsRestPermissions.VIEW_READ + ":view1")).thenReturn(false);
         final ViewParameterSummaryDTO view2 = mock(ViewParameterSummaryDTO.class);
         when(view2.id()).thenReturn("view2");
+        when(view2.type()).thenReturn(ViewDTO.Type.SEARCH);
         when(subject.isPermitted(ViewsRestPermissions.VIEW_READ + ":view2")).thenReturn(false);
         when(qualifyingViewsService.forValue()).thenReturn(ImmutableList.of(view1, view2));
         final ViewSharing allUsersOfInstance = AllUsersOfInstance.create("view1");

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/views/QualifyingViewsServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/views/QualifyingViewsServiceTest.java
@@ -84,6 +84,7 @@ public class QualifyingViewsServiceTest {
         final Search search = mock(Search.class);
         final String searchId = "streamWithParameter";
         when(view1.id()).thenReturn(viewId);
+        when(view1.type()).thenReturn(ViewDTO.Type.SEARCH);
         when(view1.searchId()).thenReturn(searchId);
         when(view1.title()).thenReturn("My View");
         when(view1.summary()).thenReturn("My Summary");
@@ -112,10 +113,12 @@ public class QualifyingViewsServiceTest {
         final Search search2 = mock(Search.class);
         final String search1Id = "streamWithParameter";
         when(view1.id()).thenReturn(viewId);
+        when(view1.type()).thenReturn(ViewDTO.Type.SEARCH);
         when(view1.searchId()).thenReturn(search1Id);
         when(view1.title()).thenReturn("My View");
         when(view1.summary()).thenReturn("My Summary");
         when(view1.description()).thenReturn("My Description");
+        when(view2.type()).thenReturn(ViewDTO.Type.SEARCH);
         when(search1.id()).thenReturn(search1Id);
         when(search1.parameters()).thenReturn(ImmutableSet.of(ValueParameter.any("foobar")));
         when(search2.parameters()).thenReturn(ImmutableSet.of());

--- a/graylog2-web-interface/src/components/users/RolesComponent.jsx
+++ b/graylog2-web-interface/src/components/users/RolesComponent.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import createReactClass from 'create-react-class';
-import Reflux from 'reflux';
 import Immutable from 'immutable';
 
 import { Button, Col, Row } from 'components/graylog';
@@ -10,47 +8,42 @@ import EditRole from 'components/users/EditRole';
 import PageHeader from 'components/common/PageHeader';
 
 import CombinedProvider from 'injection/CombinedProvider';
+import { DashboardsActions, DashboardsStore } from 'views/stores/DashboardsStore';
+import connect from 'stores/connect';
 
 const { StreamsStore } = CombinedProvider.get('Streams');
-const { DashboardsActions, DashboardsStore } = CombinedProvider.get('Dashboards');
 const { RolesStore } = CombinedProvider.get('Roles');
 
-
-export default createReactClass({
-  displayName: 'RolesComponent',
-  mixins: [Reflux.connect(DashboardsStore, 'dashboards')],
-
-  getInitialState() {
-    return {
-      roles: Immutable.Set(),
-      rolesLoaded: false,
-      editRole: null,
-      streams: Immutable.List(),
-    };
-  },
+class RolesComponent extends React.Component {
+  state = {
+    roles: Immutable.Set(),
+    rolesLoaded: false,
+    editRole: null,
+    streams: Immutable.List(),
+  };
 
   componentDidMount() {
     this.loadRoles();
     StreamsStore.load(streams => this.setState({ streams: Immutable.List(streams) }));
-    DashboardsActions.list();
-  },
+    DashboardsActions.search('', 1, 32768);
+  }
 
-  loadRoles() {
+  loadRoles = () => {
     const promise = RolesStore.loadRoles();
     promise.then((roles) => {
       this.setState({ roles: Immutable.Set(roles), rolesLoaded: true });
     });
-  },
+  };
 
-  _showCreateRole() {
+  _showCreateRole = () => {
     this.setState({ showEditRole: true });
-  },
+  };
 
-  _showEditRole(role) {
+  _showEditRole = (role) => {
     this.setState({ showEditRole: true, editRole: role });
-  },
+  };
 
-  _deleteRole(role) {
+  _deleteRole = (role) => {
     // eslint-disable-next-line no-alert
     if (window.confirm(`Do you really want to delete role ${role.name}?`)) {
       RolesStore.getMembers(role.name).then((membership) => {
@@ -61,42 +54,44 @@ export default createReactClass({
         }
       });
     }
-  },
+  };
 
-  _saveRole(initialName, role) {
+  _saveRole = (initialName, role) => {
     if (initialName === null) {
       RolesStore.createRole(role).then(this._clearEditRole).then(this.loadRoles);
     } else {
       RolesStore.updateRole(initialName, role).then(this._clearEditRole).then(this.loadRoles);
     }
-  },
+  };
 
-  _clearEditRole() {
+  _clearEditRole = () => {
     this.setState({ showEditRole: false, editRole: null });
-  },
+  };
 
   render() {
     let content = null;
-    if (!this.state.rolesLoaded) {
+    const { rolesLoaded, showEditRole, editRole, streams, roles } = this.state;
+    if (!rolesLoaded) {
       content = <span>Loading roles...</span>;
-    } else if (this.state.showEditRole) {
+    } else if (showEditRole) {
+      const { dashboards } = this.props;
       content = (
-        <EditRole initialRole={this.state.editRole}
-                  streams={this.state.streams}
-                  dashboards={this.state.dashboards.dashboards}
+        <EditRole initialRole={editRole}
+                  streams={streams}
+                  dashboards={dashboards.list}
                   onSave={this._saveRole}
                   cancelEdit={this._clearEditRole} />
       );
     } else {
       content = (
-        <RoleList roles={this.state.roles}
+        <RoleList roles={roles}
                   showEditRole={this._showEditRole}
                   deleteRole={this._deleteRole} />
       );
     }
 
     let actionButton;
-    if (!this.state.showEditRole) {
+    if (!showEditRole) {
       actionButton = <Button bsStyle="success" onClick={this._showCreateRole}>Add new role</Button>;
     }
     return (
@@ -116,5 +111,7 @@ export default createReactClass({
         </Col>
       </Row>
     );
-  },
-});
+  }
+}
+
+export default connect(RolesComponent, { dashboards: DashboardsStore });

--- a/graylog2-web-interface/src/components/users/UserForm.jsx
+++ b/graylog2-web-interface/src/components/users/UserForm.jsx
@@ -11,7 +11,6 @@ import FormsUtils from 'util/FormsUtils';
 import ObjectUtils from 'util/ObjectUtils';
 import history from 'util/History';
 
-import CombinedProvider from 'injection/CombinedProvider';
 import StoreProvider from 'injection/StoreProvider';
 
 import { Button, Row, Col, Alert, Panel } from 'components/graylog';
@@ -19,9 +18,9 @@ import { Input } from 'components/bootstrap';
 import TimeoutInput from 'components/users/TimeoutInput';
 import EditRolesForm from 'components/users/EditRolesForm';
 import { IfPermitted, MultiSelect, TimezoneSelect, Spinner } from 'components/common';
+import { DashboardsActions, DashboardsStore } from 'views/stores/DashboardsStore';
 
 const StreamsStore = StoreProvider.getStore('Streams');
-const { DashboardsStore } = CombinedProvider.get('Dashboards');
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 const UsersStore = StoreProvider.getStore('Users');
 
@@ -32,7 +31,7 @@ const UserForm = createReactClass({
     user: PropTypes.object.isRequired,
   },
 
-  mixins: [PermissionsMixin, Reflux.connect(CurrentUserStore), Reflux.connect(DashboardsStore)],
+  mixins: [PermissionsMixin, Reflux.connect(CurrentUserStore), Reflux.connect(DashboardsStore, 'dashboards')],
 
   getInitialState() {
     return {
@@ -47,6 +46,7 @@ const UserForm = createReactClass({
         streams: streams.sort((s1, s2) => s1.title.localeCompare(s2.title)),
       });
     });
+    DashboardsActions.search('', 1, 32768);
   },
 
   componentWillReceiveProps(nextProps) {
@@ -190,13 +190,13 @@ const UserForm = createReactClass({
   },
 
   render() {
-    if (!this.state.streams || !this.state.dashboards) {
+    if (!this.state.streams || !this.state.dashboards || !this.state.dashboards.list) {
       return <Spinner />;
     }
 
     const { user } = this.state;
     const { permissions } = this.state.currentUser;
-    const dashboards = this.state.dashboards.toArray().sort((d1, d2) => d1.title.localeCompare(d2.title));
+    const dashboards = this.state.dashboards.list.sort((d1, d2) => d1.title.localeCompare(d2.title));
 
     let requiresOldPassword = true;
     if (this.isPermitted(permissions, 'users:passwordchange:*')) {

--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
@@ -1,3 +1,4 @@
+
 // @flow strict
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
@@ -28,7 +29,8 @@ import BigDisplayModeConfiguration from './dashboard/BigDisplayModeConfiguration
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 const { isPermitted } = PermissionsMixin;
 
-const _isAllowedToEdit = (view: View, currentUser) => isPermitted(currentUser.permissions, [Permissions.View.Edit(view.id)]);
+const _isAllowedToEdit = (view: View, currentUser) => isPermitted(currentUser.permissions, [Permissions.View.Edit(view.id)])
+  || (view.type === View.Type.Dashboard && isPermitted(currentUser.permissions, [`dashboards:read:${view.id}`]));
 
 const _hasUndeclaredParameters = (searchMetadata: SearchMetadata) => searchMetadata.undeclared.size > 0;
 

--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
@@ -30,7 +30,7 @@ const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 const { isPermitted } = PermissionsMixin;
 
 const _isAllowedToEdit = (view: View, currentUser) => isPermitted(currentUser.permissions, [Permissions.View.Edit(view.id)])
-  || (view.type === View.Type.Dashboard && isPermitted(currentUser.permissions, [`dashboards:read:${view.id}`]));
+  || (view.type === View.Type.Dashboard && isPermitted(currentUser.permissions, [`dashboards:edit:${view.id}`]));
 
 const _hasUndeclaredParameters = (searchMetadata: SearchMetadata) => searchMetadata.undeclared.size > 0;
 

--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
@@ -1,4 +1,3 @@
-
 // @flow strict
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, the user/role permissions editor (`System ->
Authentication -> Users`/`System -> Authentication -> Roles`) did show
legacy dashboards only. This prevented the user from managing
existing/adding new permissions of users for new, views-based
dashboards.

This change is now doing the following:

  * Use the new `DashboardsStore` to list new, views-based dashboards
when managing user/roles permissions
  * Check for `dashboards:read:<id>`/`dashboards:edit:<id>` permissions
when reading/updating dashboards/reading/execution search (and resolving
the views referencing them)

A migration of pre-existing permissions is not required, as the ids of
dashboards stay identical during their migration.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.