### PR TITLE
Allow *Create Extractor* for all types

### DIFF
--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -252,7 +252,7 @@ export default {
     {
       type: 'create-extractor',
       title: 'Create extractor',
-      isEnabled: (({ type, contexts }) => (!!contexts.message && type.type === 'string' && !type.isDecorated()): ActionHandlerCondition),
+      isEnabled: (({ type, contexts }) => (!!contexts.message && !type.isDecorated()): ActionHandlerCondition),
       component: SelectExtractorType,
     },
     {

--- a/graylog2-web-interface/src/views/bindings.valueActions.test.jsx
+++ b/graylog2-web-interface/src/views/bindings.valueActions.test.jsx
@@ -38,9 +38,9 @@ describe('Views bindings value actions', () => {
       expect(isEnabled({ ...defaultArguments, field: 'something', type: FieldTypes.STRING() }))
         .toEqual(true);
     });
-    it('should be disabled for fields with type number', () => {
+    it('should be enabled for fields with type number', () => {
       expect(isEnabled({ ...defaultArguments, field: 'something', type: FieldTypes.INT() }))
-        .toEqual(false);
+        .toEqual(true);
     });
     it('should be enabled for compound fields', () => {
       expect(isEnabled({


### PR DESCRIPTION
## Description, Motivation and Context
Prior to this change, the `create extracotr` field action was only
enabled for string values. This lead to the problem that field
from type `text` and `string` (compound) could not be extracted even
though it would work perfectly fine.

This change will remove the check and allows extrator creation for all
field types.

Tested with: string, number and timestamp.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

