### PR TITLE
Handling `null` attributes when migrating quickvalues widgets.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/QuickValuesConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/QuickValuesConfig.java
@@ -47,6 +47,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 @AutoValue
 @JsonAutoDetect
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -173,8 +175,8 @@ public abstract class QuickValuesConfig extends WidgetConfigBase implements Widg
             @JsonProperty("query") String query,
             @JsonProperty("timerange") TimeRange timerange,
             @JsonProperty("field") String field,
-            @JsonProperty("show_data_table") Boolean showDataTable,
-            @JsonProperty("show_pie_chart") Boolean showPieChart,
+            @JsonProperty("show_data_table") @Nullable Boolean showDataTable,
+            @JsonProperty("show_pie_chart") @Nullable Boolean showPieChart,
             @JsonProperty("limit") Integer limit,
             @JsonProperty("data_table_limit") Integer dataTableLimit,
             @JsonProperty("sort_order") String sortOrder,
@@ -186,8 +188,10 @@ public abstract class QuickValuesConfig extends WidgetConfigBase implements Widg
                 query,
                 Optional.ofNullable(streamId),
                 field,
-                showDataTable,
-                showPieChart,
+                (showDataTable == null || !showDataTable) && (showPieChart == null || !showPieChart)
+                        ? true
+                        : firstNonNull(showDataTable, false),
+                firstNonNull(showPieChart, false),
                 Optional.ofNullable(limit),
                 Optional.ofNullable(dataTableLimit),
                 Optional.ofNullable(sortOrder),

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/dashboardV1/DashboardWidgetConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/facades/dashboardV1/DashboardWidgetConverter.java
@@ -41,7 +41,6 @@ import org.graylog2.contentpacks.model.entities.DashboardWidgetEntity;
 import org.graylog2.contentpacks.model.entities.WidgetConfig;
 import org.graylog2.contentpacks.model.entities.WidgetEntity;
 import org.graylog2.contentpacks.model.entities.references.ValueReference;
-import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -253,8 +252,8 @@ public class DashboardWidgetConverter {
         final List<WidgetEntity> result = new ArrayList<>(2);
         final WidgetEntity.Builder widgetEntityBuilder = aggregationWidgetBuilder();
 
-        final boolean showChart = config.getBoolean("show_pie_chart");
-        final boolean showTable = config.getBoolean("show_data_table");
+        final boolean showChart = config.getOptionalBoolean("show_pie_chart").orElse(false);
+        final boolean showTable = config.getOptionalBoolean("show_data_table").orElse(!showChart);
         final String field = config.getString("field");
         final String stackedFields = config.getOptionalString("stacked_fields").orElse("");
         final Integer limit = config.getOptionalInteger("limit").orElse(5);

--- a/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/WidgetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/contentpacks/model/entities/WidgetConfig.java
@@ -57,6 +57,11 @@ public class WidgetConfig {
         throw new ContentPackException("Could not find key " + key + " in config.");
     }
 
+    public Optional<Boolean> getOptionalBoolean(String key) {
+        final Boolean value = (Boolean)config.get(key);
+        return Optional.ofNullable(value);
+    }
+
     public int getInteger(String key) {
         Object value = config.get(key);
         if (value != null) {

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/V20191125144500_MigrateDashboardsToViewsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/V20191125144500_MigrateDashboardsToViewsTest.java
@@ -360,6 +360,19 @@ public class V20191125144500_MigrateDashboardsToViewsTest {
         verify(searchService, times(1)).save(any());
     }
 
+    @Test
+    @MongoDBFixtures("dashboard_with_missing_quickvalues_attributes.json")
+    public void migratesADashboardWithMissingQuickValuesAttributes() {
+        this.migration.upgrade();
+
+        final MigrationCompleted migrationCompleted = captureMigrationCompleted();
+        assertThat(migrationCompleted.migratedDashboardIds()).containsExactly("5ddf8ed5b2d44b2e04472992");
+        assertThat(migrationCompleted.widgetMigrationIds()).hasSize(2);
+
+        verify(viewService, times(1)).save(any());
+        verify(searchService, times(1)).save(any());
+    }
+
     private void assertSearchesWritten(int count, String expectedEntities) throws Exception {
         final ArgumentCaptor<Search> newSearchesCaptor = ArgumentCaptor.forClass(Search.class);
         verify(searchService, times(count)).save(newSearchesCaptor.capture());

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_missing_quickvalues_attributes.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_missing_quickvalues_attributes.json
@@ -8,16 +8,28 @@
       "title" : "Widgets with missing attributes.",
       "positions": {
         "4ce93e89-4771-4ce2-8b59-6dc058cbfd3b" : {
-          "width" : 8,
+          "width" : 4,
           "col" : 1,
-          "row" : 10,
+          "row" : 1,
           "height" : 3
         },
         "568c005a-11ec-4be9-acd7-b2aa509c07e0" : {
-          "width" : 2,
-          "col" : 7,
-          "row" : 1,
-          "height" : 2
+          "width" : 4,
+          "col" : 1,
+          "row" : 4,
+          "height" : 3
+        },
+        "e6a16d9a-23c0-4b7f-93b5-d790b5d64672" : {
+          "width" : 4,
+          "col" : 1,
+          "row" : 7,
+          "height" : 4
+        },
+        "5c12c588-be0c-436b-b999-ee18378efd45" : {
+          "width" : 4,
+          "col" : 1,
+          "row" : 10,
+          "height" : 4
         }
       },
       "widgets" : [
@@ -39,8 +51,49 @@
             "sort_order" : "desc",
             "stacked_fields" : "",
             "data_table_limit" : 50,
-            "interval": "minute",
-            "unknown_attribute": 42
+            "interval": "minute"
+          }
+        },
+        {
+          "creator_user_id" : "admin",
+          "cache_time" : 10,
+          "description" : "Cached Status Ratio",
+          "id" : "5c12c588-be0c-436b-b999-ee18378efd45",
+          "type" : "QUICKVALUES",
+          "config" : {
+            "timerange" : {
+              "type" : "relative",
+              "range" : 3600
+            },
+            "field" : "CacheCacheStatus",
+            "stream_id" : "5ddf8ed5b2d44b2e0447298c",
+            "query" : "",
+            "limit" : 5,
+            "show_pie_chart" : false,
+            "sort_order" : "desc",
+            "stacked_fields" : "",
+            "data_table_limit" : 50
+          }
+        },
+        {
+          "creator_user_id" : "admin",
+          "cache_time" : 10,
+          "description" : "Cached Status Ratio",
+          "id" : "e6a16d9a-23c0-4b7f-93b5-d790b5d64672",
+          "type" : "QUICKVALUES",
+          "config" : {
+            "timerange" : {
+              "type" : "relative",
+              "range" : 3600
+            },
+            "field" : "CacheCacheStatus",
+            "stream_id" : "5ddf8ed5b2d44b2e0447298c",
+            "query" : "",
+            "limit" : 5,
+            "show_data_table" : false,
+            "sort_order" : "desc",
+            "stacked_fields" : "",
+            "data_table_limit" : 50
           }
         },
         {
@@ -62,8 +115,50 @@
             "show_pie_chart" : false,
             "sort_order" : "desc",
             "stacked_fields" : "",
-            "data_table_limit" : 50,
-            "unknown_attribute": 42
+            "data_table_limit" : 50
+          }
+        },
+        {
+          "creator_user_id" : "admin",
+          "cache_time" : 10,
+          "description" : "Cached Status Ratio",
+          "id" : "2e3c5e76-bbfd-4ac3-a27b-7491a5cbf59a",
+          "type" : "QUICKVALUES",
+          "config" : {
+            "timerange" : {
+              "type" : "relative",
+              "range" : 3600
+            },
+            "field" : "CacheCacheStatus",
+            "stream_id" : "5ddf8ed5b2d44b2e0447298c",
+            "query" : "",
+            "limit" : 5,
+            "show_pie_chart" : true,
+            "sort_order" : "desc",
+            "stacked_fields" : "",
+            "data_table_limit" : 50
+          }
+        },
+        {
+          "creator_user_id" : "admin",
+          "cache_time" : 10,
+          "description" : "Cached Status Ratio",
+          "id" : "26a0a3e1-718f-4bfe-90a2-cb441390152d",
+          "type" : "QUICKVALUES",
+          "config" : {
+            "timerange" : {
+              "type" : "relative",
+              "range" : 3600
+            },
+            "field" : "CacheCacheStatus",
+            "stream_id" : "5ddf8ed5b2d44b2e0447298c",
+            "query" : "",
+            "limit" : 5,
+            "show_data_table" : true,
+            "show_pie_chart" : true,
+            "sort_order" : "desc",
+            "stacked_fields" : "",
+            "data_table_limit" : 50
           }
         }
       ]

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_missing_quickvalues_attributes.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_missing_quickvalues_attributes.json
@@ -1,0 +1,72 @@
+{
+  "dashboards": [
+    {
+      "_id" : { "$oid": "5ddf8ed5b2d44b2e04472992" },
+      "creator_user_id" : "admin",
+      "description" : "This dashboard does have quick values widgets missing attributes.",
+      "created_at" : { "$date": "2019-11-28T09:09:41.688Z" },
+      "title" : "Widgets with missing attributes.",
+      "positions": {
+        "4ce93e89-4771-4ce2-8b59-6dc058cbfd3b" : {
+          "width" : 8,
+          "col" : 1,
+          "row" : 10,
+          "height" : 3
+        },
+        "568c005a-11ec-4be9-acd7-b2aa509c07e0" : {
+          "width" : 2,
+          "col" : 7,
+          "row" : 1,
+          "height" : 2
+        }
+      },
+      "widgets" : [
+        {
+          "creator_user_id" : "admin",
+          "cache_time" : 10,
+          "description" : "Top Cached URIs",
+          "id" : "4ce93e89-4771-4ce2-8b59-6dc058cbfd3b",
+          "type" : "QUICKVALUES",
+          "config" : {
+            "timerange" : {
+              "type" : "relative",
+              "range" : 3600
+            },
+            "field" : "ClientRequestURI",
+            "stream_id" : "5ddf8ed5b2d44b2e0447298c",
+            "query" : "CacheCacheStatus:hit",
+            "limit" : 5,
+            "sort_order" : "desc",
+            "stacked_fields" : "",
+            "data_table_limit" : 50,
+            "interval": "minute",
+            "unknown_attribute": 42
+          }
+        },
+        {
+          "creator_user_id" : "admin",
+          "cache_time" : 10,
+          "description" : "Cached Status Ratio",
+          "id" : "568c005a-11ec-4be9-acd7-b2aa509c07e0",
+          "type" : "QUICKVALUES",
+          "config" : {
+            "timerange" : {
+              "type" : "relative",
+              "range" : 3600
+            },
+            "field" : "CacheCacheStatus",
+            "stream_id" : "5ddf8ed5b2d44b2e0447298c",
+            "query" : "",
+            "show_data_table" : false,
+            "limit" : 5,
+            "show_pie_chart" : false,
+            "sort_order" : "desc",
+            "stacked_fields" : "",
+            "data_table_limit" : 50,
+            "unknown_attribute": 42
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Under some circumstances, the `show_data_table` & `show_pie_chart`
attributes of legacy quick values widgets can be `null`, leading to NPEs
when migrating or installing legacy dashboards.

This PR is now handling the absence of these attributes. If they are
missing, they are handled the following way:

  - `show_data_table` is `true` if `show_pie_chart` is missing or
`false` and `false` otherwise, ensuring that at least one of both is created
  - `show_pie_charts` is `false` if missing

This logic is identical to the rendering logic of the legacy dashboard
code.

Fixes #7334.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.