### PR TITLE
Suppress system notification for whitelist error from test alert

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationTestData.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationTestData.java
@@ -30,7 +30,9 @@ import org.graylog2.plugin.Tools;
 import org.graylog2.plugin.rest.ValidationResult;
 import org.graylog2.plugin.streams.Stream;
 
-class NotificationTestData {
+public class NotificationTestData {
+    public static final String TEST_NOTIFICATION_ID = "1234";
+
     static EventNotificationContext getDummyContext(NotificationDto notificationDto, String userName) {
         final EventDto eventDto = EventDto.builder()
                 .alert(true)
@@ -51,7 +53,7 @@ class NotificationTestData {
 
         final EventDefinitionDto eventDefinitionDto = EventDefinitionDto.builder()
                 .alert(true)
-                .id("1234")
+                .id(TEST_NOTIFICATION_ID)
                 .title("Event Definition Test Title")
                 .description("Event Definition Test Description")
                 .config(new EventProcessorConfig() {
@@ -90,7 +92,7 @@ class NotificationTestData {
                 ).build();
 
         return EventNotificationContext.builder()
-                .notificationId("1234")
+                .notificationId(TEST_NOTIFICATION_ID)
                 .notificationConfig(notificationDto.config())
                 .event(eventDto)
                 .eventDefinition(eventDefinitionDto)

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationTestData.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationTestData.java
@@ -31,7 +31,7 @@ import org.graylog2.plugin.rest.ValidationResult;
 import org.graylog2.plugin.streams.Stream;
 
 public class NotificationTestData {
-    public static final String TEST_NOTIFICATION_ID = "1234";
+    public static final String TEST_NOTIFICATION_ID = "this-is-a-test-notification";
 
     static EventNotificationContext getDummyContext(NotificationDto notificationDto, String userName) {
         final EventDto eventDto = EventDto.builder()

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotification.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotification.java
@@ -29,6 +29,7 @@ import org.graylog.events.notifications.EventNotification;
 import org.graylog.events.notifications.EventNotificationContext;
 import org.graylog.events.notifications.EventNotificationModelData;
 import org.graylog.events.notifications.EventNotificationService;
+import org.graylog.events.notifications.NotificationTestData;
 import org.graylog.events.notifications.PermanentEventNotificationException;
 import org.graylog.events.notifications.TemporaryEventNotificationException;
 import org.graylog.events.processor.EventDefinitionDto;
@@ -87,7 +88,9 @@ public class HTTPEventNotification implements EventNotification {
         final EventNotificationModelData model = getModel(ctx, backlog);
 
         if (!whitelistService.isWhitelisted(config.url())) {
-            publishSystemNotificationForWhitelistFailure(config.url(), model.eventDefinitionTitle());
+            if (!NotificationTestData.TEST_NOTIFICATION_ID.equals(ctx.notificationId())) {
+                publishSystemNotificationForWhitelistFailure(config.url(), model.eventDefinitionTitle());
+            }
             throw new TemporaryEventNotificationException("URL <" + config.url() + "> is not whitelisted.");
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When a HTTP event notification fails due to an URL Whitelist error, we now check if the failed event notification was a test-notification. If that's the case, the global system notification showing the whitelist error will be suppressed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When an HTTP event notification is tested and the whitelist entered was not whitelisted, a sticky system notification would show up, indicating the whitelist error. This system notification was however only meant to be triggered during the execution of "real" alerts.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Quick manual test via the frontend.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

