### PR TITLE
Fix vertical data table widget scrolling for safari

### DIFF
--- a/graylog2-web-interface/src/views/components/datatable/DataTable.css
+++ b/graylog2-web-interface/src/views/components/datatable/DataTable.css
@@ -7,7 +7,6 @@
 
 :local(.scrollContainer) {
     overflow: auto;
-    height: 100%;
 }
 
 :local(.leftAligned) {


### PR DESCRIPTION
As described in https://github.com/Graylog2/graylog2-server/issues/7344 the vertical scrolling in data table widgets does not work with safari. This PR is fixing the problem.

Fixes #7344

## How Has This Been Tested?
Tested the vertical and horizontal data table scrolling in Safari, Chrome and Firefox. Also tested the behaviour inside the aggregation builder.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

