### PR TITLE
Fix vertical data table scrolling for safari (Backport of #7352 for 3.2)

### DIFF
--- a/graylog2-web-interface/src/views/components/datatable/DataTable.css
+++ b/graylog2-web-interface/src/views/components/datatable/DataTable.css
@@ -7,7 +7,6 @@
 
 :local(.scrollContainer) {
     overflow: auto;
-    height: 100%;
 }
 
 :local(.leftAligned) {


### PR DESCRIPTION
Backport PR for https://github.com/Graylog2/graylog2-server/pull/7352

As described in #7344 the vertical scrolling in data table widgets does not work with safari. This PR is fixing the problem.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

