### PR TITLE
Use graylog data dir for netty tcnative libraries

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
@@ -91,6 +91,17 @@ public abstract class ServerBootstrap extends CmdLineTool {
         if (!isNoPidFile()) {
             savePidFile(getPidFile());
         }
+        setNettyNativeDefaults();
+    }
+
+    // Set these early in the startup because netty's NativeLibraryUtil uses a static initializer
+    private void setNettyNativeDefaults() {
+        if (System.getProperty("io.netty.native.workdir") == null) {
+            System.setProperty("io.netty.native.workdir", configuration.getNativeLibDir().toAbsolutePath().toString());
+        }
+        if (System.getProperty("io.netty.native.deleteLibAfterLoading") == null) {
+            System.setProperty("io.netty.native.deleteLibAfterLoading", "false");
+        }
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
+++ b/graylog2-server/src/main/java/org/graylog2/bootstrap/ServerBootstrap.java
@@ -91,14 +91,16 @@ public abstract class ServerBootstrap extends CmdLineTool {
         if (!isNoPidFile()) {
             savePidFile(getPidFile());
         }
+        // Set these early in the startup because netty's NativeLibraryUtil uses a static initializer
         setNettyNativeDefaults();
     }
 
-    // Set these early in the startup because netty's NativeLibraryUtil uses a static initializer
     private void setNettyNativeDefaults() {
+        // Give netty a better spot than /tmp to unpack its tcnative libraries
         if (System.getProperty("io.netty.native.workdir") == null) {
             System.setProperty("io.netty.native.workdir", configuration.getNativeLibDir().toAbsolutePath().toString());
         }
+        // Don't delete the native lib after unpacking, as this confuses needrestart(1) on some distributions
         if (System.getProperty("io.netty.native.deleteLibAfterLoading") == null) {
             System.setProperty("io.netty.native.deleteLibAfterLoading", "false");
         }

--- a/graylog2-server/src/main/java/org/graylog2/configuration/PathConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/PathConfiguration.java
@@ -42,6 +42,9 @@ public abstract class PathConfiguration {
     public Path getDataDir() {
         return dataDir;
     }
+    public Path getNativeLibDir() {
+        return dataDir.resolve("libnative");
+    }
 
     public Path getPluginDir() {
         return pluginDir;


### PR DESCRIPTION
At runtime, Netty copies its tcnative shared library to `io.netty.native.workdir` which defaults to /tmp.
Some users mount /tmp with a nonexec option, which disallows executable code in /tmp.
Therefore use graylogs `data_dir`/libnative as a new default workdir for netty.

Furthermore, disable the deleteLibAfterLoading feature, since this
confuses the needrestart(1) utility on some Linux distributions. (e.g. Debian)

Fixes #5762
