### PR TITLE
Include ipv6 addresses into messages

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/netflow/flows/NetFlowFormatter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/netflow/flows/NetFlowFormatter.java
@@ -73,11 +73,18 @@ public class NetFlowFormatter {
         if (octetCount == 0L) {
             octetCount = (long) fields.getOrDefault("fwd_flow_delta_bytes", 0L);
         }
-        final String srcAddr = (String) fields.get("ipv4_src_addr");
-        final String dstAddr = (String) fields.get("ipv4_dst_addr");
+        String srcAddr = (String) fields.get("ipv4_src_addr");
+        String dstAddr = (String) fields.get("ipv4_dst_addr");
         final Integer srcPort = (Integer) fields.get("l4_src_port");
         final Integer dstPort = (Integer) fields.get("l4_dst_port");
         final Short protocol = (Short) fields.get("protocol");
+
+        if (srcAddr == null) {
+            srcAddr = (String) fields.get("ipv6_src_addr");
+        }
+        if (dstAddr == null) {
+            dstAddr = (String) fields.get("ipv6_dst_addr");
+        }
 
         return String.format(Locale.ROOT, "NetFlowV9 [%s]:%d <> [%s]:%d proto:%d pkts:%d bytes:%d",
                 srcAddr, srcPort,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Code supports IPv6 address to be included into messages

## Description
<!--- Describe your changes in detail -->
The code checks if IPv4 is null, and defaults to the IPv6 address instead

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #6076 

## Screenshots (if appropriate):
![netflow-ipv6-addresses](https://user-images.githubusercontent.com/22039395/73698809-c82b8700-46a7-11ea-99e6-659de09ac095.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

