### PR TITLE
Handle null `fields` when migrating saved searches.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/V20191203120602_MigrateSavedSearchesToViews.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/V20191203120602_MigrateSavedSearchesToViews.java
@@ -28,7 +28,6 @@ import org.graylog.plugins.views.migrations.V20191203120602_MigrateSavedSearches
 import org.graylog.plugins.views.migrations.V20191203120602_MigrateSavedSearchesToViewsSupport.search.SearchService;
 import org.graylog.plugins.views.migrations.V20191203120602_MigrateSavedSearchesToViewsSupport.search.SearchType;
 import org.graylog.plugins.views.migrations.V20191203120602_MigrateSavedSearchesToViewsSupport.view.AggregationWidget;
-import org.graylog.plugins.views.migrations.V20191203120602_MigrateSavedSearchesToViewsSupport.view.MessagesWidget;
 import org.graylog.plugins.views.migrations.V20191203120602_MigrateSavedSearchesToViewsSupport.view.Position;
 import org.graylog.plugins.views.migrations.V20191203120602_MigrateSavedSearchesToViewsSupport.view.RandomObjectIdProvider;
 import org.graylog.plugins.views.migrations.V20191203120602_MigrateSavedSearchesToViewsSupport.view.RandomUUIDProvider;
@@ -114,7 +113,7 @@ public class V20191203120602_MigrateSavedSearchesToViews extends Migration {
         final String messageListId = randomUUIDProvider.get();
         final Set<ViewWidget> widgets = ImmutableSet.of(
                 AggregationWidget.create(histogramId),
-                MessagesWidget.create(messageListId, savedSearch.query().fieldsList())
+                savedSearch.query().toMessagesWidget(messageListId)
         );
         final Map<String, Set<String>> widgetMapping = new HashMap<>(widgets.size());
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/AbsoluteTimeRangeQuery.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/AbsoluteTimeRangeQuery.java
@@ -29,7 +29,7 @@ import java.util.Optional;
 
 @AutoValue
 @JsonAutoDetect
-public abstract class AbsoluteTimeRangeQuery implements Query {
+public abstract class AbsoluteTimeRangeQuery extends Query {
     public static final String type = "absolute";
 
     public abstract DateTime from();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/AbsoluteTimeRangeQuery.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/AbsoluteTimeRangeQuery.java
@@ -32,10 +32,6 @@ import java.util.Optional;
 public abstract class AbsoluteTimeRangeQuery implements Query {
     public static final String type = "absolute";
 
-    public abstract String rangeType();
-    public abstract String fields();
-    public abstract String query();
-
     public abstract DateTime from();
     public abstract DateTime to();
 
@@ -53,6 +49,6 @@ public abstract class AbsoluteTimeRangeQuery implements Query {
             @JsonProperty("to") DateTime to,
             @JsonProperty("streamId") @Nullable String streamId
     ) {
-        return new AutoValue_AbsoluteTimeRangeQuery(Optional.ofNullable(streamId), rangeType, fields, query, from, to);
+        return new AutoValue_AbsoluteTimeRangeQuery(rangeType, Optional.ofNullable(fields), query, Optional.ofNullable(streamId), from, to);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/AbsoluteTimeRangeQuery.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/AbsoluteTimeRangeQuery.java
@@ -47,7 +47,7 @@ public abstract class AbsoluteTimeRangeQuery implements Query {
     @JsonCreator
     static AbsoluteTimeRangeQuery create(
             @JsonProperty("rangeType") String rangeType,
-            @JsonProperty("fields") String fields,
+            @JsonProperty("fields") @Nullable String fields,
             @JsonProperty("query") String query,
             @JsonProperty("from") DateTime from,
             @JsonProperty("to") DateTime to,

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/KeywordTimeRangeQuery.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/KeywordTimeRangeQuery.java
@@ -31,10 +31,6 @@ import java.util.Optional;
 public abstract class KeywordTimeRangeQuery implements Query {
     public static final String type = "keyword";
 
-    public abstract String rangeType();
-    public abstract String fields();
-    public abstract String query();
-
     public abstract String keyword();
 
     @Override
@@ -50,6 +46,6 @@ public abstract class KeywordTimeRangeQuery implements Query {
             @JsonProperty("keyword") String keyword,
             @JsonProperty("streamId") @Nullable String streamId
     ) {
-        return new AutoValue_KeywordTimeRangeQuery(Optional.ofNullable(streamId), rangeType, fields, query, keyword);
+        return new AutoValue_KeywordTimeRangeQuery(rangeType, Optional.ofNullable(fields), query, Optional.ofNullable(streamId), keyword);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/KeywordTimeRangeQuery.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/KeywordTimeRangeQuery.java
@@ -45,7 +45,7 @@ public abstract class KeywordTimeRangeQuery implements Query {
     @JsonCreator
     static KeywordTimeRangeQuery create(
             @JsonProperty("rangeType") String rangeType,
-            @JsonProperty("fields") String fields,
+            @JsonProperty("fields") @Nullable String fields,
             @JsonProperty("query") String query,
             @JsonProperty("keyword") String keyword,
             @JsonProperty("streamId") @Nullable String streamId

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/KeywordTimeRangeQuery.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/KeywordTimeRangeQuery.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 
 @AutoValue
 @JsonAutoDetect
-public abstract class KeywordTimeRangeQuery implements Query {
+public abstract class KeywordTimeRangeQuery extends Query {
     public static final String type = "keyword";
 
     public abstract String keyword();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/Query.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/Query.java
@@ -34,18 +34,18 @@ import java.util.stream.Collectors;
         @JsonSubTypes.Type(value = KeywordTimeRangeQuery.class, name = KeywordTimeRangeQuery.type),
         @JsonSubTypes.Type(value = RelativeTimeRangeQuery.class, name = RelativeTimeRangeQuery.type)
 })
-public interface Query {
-    String TIMESTAMP_FIELD = "timestamp";
-    List<String> DEFAULT_FIELDS = ImmutableList.of(TIMESTAMP_FIELD, "source", "message");
+public abstract class Query {
+    private final String TIMESTAMP_FIELD = "timestamp";
+    private final List<String> DEFAULT_FIELDS = ImmutableList.of(TIMESTAMP_FIELD, "source", "message");
 
-    String rangeType();
-    Optional<String> fields();
-    String query();
-    Optional<String> streamId();
+    abstract String rangeType();
+    abstract Optional<String> fields();
+    public abstract String query();
+    public abstract Optional<String> streamId();
 
-    TimeRange toTimeRange();
+    public abstract TimeRange toTimeRange();
 
-    default MessagesWidget toMessagesWidget(String messageListId) {
+    public MessagesWidget toMessagesWidget(String messageListId) {
         final List<String> usedFieldsWithoutMessage = fieldsList().stream()
                 .filter(field -> !field.equals("message"))
                 .collect(Collectors.toList());
@@ -54,7 +54,7 @@ public interface Query {
         return MessagesWidget.create(messageListId, usedFieldsWithoutMessage, showMessageRow);
     }
 
-    default List<String> addTimestampFieldIfMissing(List<String> fields) {
+    private List<String> addTimestampFieldIfMissing(List<String> fields) {
         if (!fields.contains(TIMESTAMP_FIELD)) {
             final List<String> fieldsWithTimestamp = new ArrayList<>(fields.size() + 1);
             fieldsWithTimestamp.add(TIMESTAMP_FIELD);
@@ -64,7 +64,7 @@ public interface Query {
         return fields;
     }
 
-    default List<String> fieldsList() {
+    private List<String> fieldsList() {
         //noinspection UnstableApiUsage
         return fields()
                 .filter(fields -> !fields.trim().isEmpty())

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/Query.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/Query.java
@@ -54,19 +54,22 @@ public interface Query {
         return MessagesWidget.create(messageListId, usedFieldsWithoutMessage, showMessageRow);
     }
 
+    default List<String> addTimestampFieldIfMissing(List<String> fields) {
+        if (!fields.contains(TIMESTAMP_FIELD)) {
+            final List<String> fieldsWithTimestamp = new ArrayList<>(fields.size() + 1);
+            fieldsWithTimestamp.add(TIMESTAMP_FIELD);
+            fieldsWithTimestamp.addAll(fields);
+            return fieldsWithTimestamp;
+        }
+        return fields;
+    }
+
     default List<String> fieldsList() {
+        //noinspection UnstableApiUsage
         return fields()
                 .filter(fields -> !fields.trim().isEmpty())
                 .map(fields -> Splitter.on(",").splitToList(fields))
-                .map(fields -> {
-                    if (!fields.contains(TIMESTAMP_FIELD)) {
-                        final List<String> fieldsWithTimestamp = new ArrayList<>(fields.size() + 1);
-                        fieldsWithTimestamp.add(TIMESTAMP_FIELD);
-                        fieldsWithTimestamp.addAll(fields);
-                        return fieldsWithTimestamp;
-                    }
-                    return fields;
-                })
+                .map(this::addTimestampFieldIfMissing)
                 .orElse(DEFAULT_FIELDS);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/RelativeTimeRangeQuery.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/RelativeTimeRangeQuery.java
@@ -44,7 +44,7 @@ public abstract class RelativeTimeRangeQuery implements Query {
     @JsonCreator
     static RelativeTimeRangeQuery create(
             @JsonProperty("rangeType") String rangeType,
-            @JsonProperty("fields") String fields,
+            @JsonProperty("fields") @Nullable String fields,
             @JsonProperty("query") String query,
             @JsonProperty("relative") int relative,
             @JsonProperty("streamId") @Nullable String streamId

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/RelativeTimeRangeQuery.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/RelativeTimeRangeQuery.java
@@ -28,7 +28,7 @@ import java.util.Optional;
 
 @AutoValue
 @JsonAutoDetect
-public abstract class RelativeTimeRangeQuery implements Query {
+public abstract class RelativeTimeRangeQuery extends Query {
     public static final String type = "relative";
 
     public abstract int relative();

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/RelativeTimeRangeQuery.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/RelativeTimeRangeQuery.java
@@ -31,9 +31,6 @@ import java.util.Optional;
 public abstract class RelativeTimeRangeQuery implements Query {
     public static final String type = "relative";
 
-    public abstract String rangeType();
-    public abstract String fields();
-    public abstract String query();
     public abstract int relative();
 
     @Override
@@ -49,6 +46,6 @@ public abstract class RelativeTimeRangeQuery implements Query {
             @JsonProperty("relative") int relative,
             @JsonProperty("streamId") @Nullable String streamId
     ) {
-        return new AutoValue_RelativeTimeRangeQuery(Optional.ofNullable(streamId), rangeType, fields, query, relative);
+        return new AutoValue_RelativeTimeRangeQuery(rangeType, Optional.ofNullable(fields), query, Optional.ofNullable(streamId), relative);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/view/MessagesWidget.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/view/MessagesWidget.java
@@ -71,7 +71,7 @@ public abstract class MessagesWidget implements ViewWidget {
         return Collections.singleton(MessagesSearchType.create(randomUUIDProvider.get()));
     }
 
-    public static MessagesWidget create(String id, List<String> fields) {
-        return new AutoValue_MessagesWidget(id, MessagesWidgetConfig.create(fields));
+    public static MessagesWidget create(String id, List<String> fields, boolean showMessageRow) {
+        return new AutoValue_MessagesWidget(id, MessagesWidgetConfig.create(fields, showMessageRow));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/view/MessagesWidgetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/view/MessagesWidgetConfig.java
@@ -29,11 +29,9 @@ public abstract class MessagesWidgetConfig {
     public abstract List<String> fields();
 
     @JsonProperty("show_message_row")
-    public boolean showMessageRow() {
-        return true;
-    }
+    public abstract boolean showMessageRow();
 
-    public static MessagesWidgetConfig create(List<String> fields) {
-        return new AutoValue_MessagesWidgetConfig(fields);
+    public static MessagesWidgetConfig create(List<String> fields, boolean showMessageRow) {
+        return new AutoValue_MessagesWidgetConfig(fields, showMessageRow);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/V20191203120602_MigrateSavedSearchesToViewsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/V20191203120602_MigrateSavedSearchesToViewsTest.java
@@ -187,6 +187,19 @@ public class V20191203120602_MigrateSavedSearchesToViewsTest {
     }
 
     @Test
+    @MongoDBFixtures("sample_saved_search_with_empty_fields.json")
+    public void migrateSavedSearchWithEmptyFields() throws Exception {
+        this.migration.upgrade();
+
+        final MigrationCompleted migrationCompleted = captureMigrationCompleted();
+        assertThat(migrationCompleted.savedSearchIds())
+                .containsExactly(new AbstractMap.SimpleEntry<>("5de660b7b2d44b5813c1d7f6", "5de0e98900002a0017000002"));
+
+        assertViewServiceCreatedViews(1, resourceFile("sample_saved_search_with_missing_fields-expected_views.json"));
+        assertSearchServiceCreated(1, resourceFile("sample_saved_search_with_missing_fields-expected_searches.json"));
+    }
+
+    @Test
     @MongoDBFixtures("sample_saved_search_with_missing_fields.json")
     public void migrateSavedSearchWithoutMessageRow() throws Exception {
         this.migration.upgrade();

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/V20191203120602_MigrateSavedSearchesToViewsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/V20191203120602_MigrateSavedSearchesToViewsTest.java
@@ -186,6 +186,19 @@ public class V20191203120602_MigrateSavedSearchesToViewsTest {
         assertSearchServiceCreated(1, resourceFile("sample_saved_search_with_missing_fields-expected_searches.json"));
     }
 
+    @Test
+    @MongoDBFixtures("sample_saved_search_with_missing_fields.json")
+    public void migrateSavedSearchWithoutMessageRow() throws Exception {
+        this.migration.upgrade();
+
+        final MigrationCompleted migrationCompleted = captureMigrationCompleted();
+        assertThat(migrationCompleted.savedSearchIds())
+                .containsExactly(new AbstractMap.SimpleEntry<>("5de660b7b2d44b5813c1d7f6", "5de0e98900002a0017000002"));
+
+        assertViewServiceCreatedViews(1, resourceFile("sample_saved_search_with_missing_fields-expected_views.json"));
+        assertSearchServiceCreated(1, resourceFile("sample_saved_search_with_missing_fields-expected_searches.json"));
+    }
+
     private void assertViewServiceCreatedViews(int count, String viewsCollection) throws Exception {
         final ArgumentCaptor<View> newViewsCaptor = ArgumentCaptor.forClass(View.class);
         verify(viewService, times(count)).save(newViewsCaptor.capture());

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/V20191203120602_MigrateSavedSearchesToViewsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/V20191203120602_MigrateSavedSearchesToViewsTest.java
@@ -173,6 +173,19 @@ public class V20191203120602_MigrateSavedSearchesToViewsTest {
         assertSearchServiceCreated(1, resourceFile("sample_saved_search_with_stream-expected_searches.json"));
     }
 
+    @Test
+    @MongoDBFixtures("sample_saved_search_with_missing_fields.json")
+    public void migrateSavedSearchWithMissingFields() throws Exception {
+        this.migration.upgrade();
+
+        final MigrationCompleted migrationCompleted = captureMigrationCompleted();
+        assertThat(migrationCompleted.savedSearchIds())
+                .containsExactly(new AbstractMap.SimpleEntry<>("5de660b7b2d44b5813c1d7f6", "5de0e98900002a0017000002"));
+
+        assertViewServiceCreatedViews(1, resourceFile("sample_saved_search_with_missing_fields-expected_views.json"));
+        assertSearchServiceCreated(1, resourceFile("sample_saved_search_with_missing_fields-expected_searches.json"));
+    }
+
     private void assertViewServiceCreatedViews(int count, String viewsCollection) throws Exception {
         final ArgumentCaptor<View> newViewsCaptor = ArgumentCaptor.forClass(View.class);
         verify(viewService, times(count)).save(newViewsCaptor.capture());

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/V20191203120602_MigrateSavedSearchesToViewsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/V20191203120602_MigrateSavedSearchesToViewsTest.java
@@ -200,16 +200,16 @@ public class V20191203120602_MigrateSavedSearchesToViewsTest {
     }
 
     @Test
-    @MongoDBFixtures("sample_saved_search_with_missing_fields.json")
+    @MongoDBFixtures("sample_saved_search_without_message_row.json")
     public void migrateSavedSearchWithoutMessageRow() throws Exception {
         this.migration.upgrade();
 
         final MigrationCompleted migrationCompleted = captureMigrationCompleted();
         assertThat(migrationCompleted.savedSearchIds())
-                .containsExactly(new AbstractMap.SimpleEntry<>("5de660b7b2d44b5813c1d7f6", "5de0e98900002a0017000002"));
+                .containsExactly(new AbstractMap.SimpleEntry<>("5c7e5499f38ed7e1d8d6a613", "5de0e98900002a0017000002"));
 
-        assertViewServiceCreatedViews(1, resourceFile("sample_saved_search_with_missing_fields-expected_views.json"));
-        assertSearchServiceCreated(1, resourceFile("sample_saved_search_with_missing_fields-expected_searches.json"));
+        assertViewServiceCreatedViews(1, resourceFile("sample_saved_search_without_message_row-expected_views.json"));
+        assertSearchServiceCreated(1, resourceFile("sample_saved_search_without_message_row-expected_searches.json"));
     }
 
     private void assertViewServiceCreatedViews(int count, String viewsCollection) throws Exception {

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_absolute-expected_views.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_absolute-expected_views.json
@@ -43,7 +43,7 @@
       }, {
         "id" : "0000016e-b690-4270-0000-016eb690426f",
         "config" : {
-          "fields" : [ "message", "source" ],
+          "fields" : [ "timestamp", "source" ],
           "show_message_row" : true
         },
         "type" : "messages",

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_keyword-expected_views.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_keyword-expected_views.json
@@ -43,7 +43,7 @@
       }, {
         "id" : "0000016e-b690-4270-0000-016eb690426f",
         "config" : {
-          "fields" : [ "message", "source" ],
+          "fields" : [ "timestamp", "source" ],
           "show_message_row" : true
         },
         "type" : "messages",

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_relative-expected_views.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_relative-expected_views.json
@@ -51,7 +51,7 @@
             "id": "0000016e-b690-4270-0000-016eb690426f",
             "config": {
               "fields": [
-                "message",
+                "timestamp",
                 "source"
               ],
               "show_message_row": true

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_with_empty_fields-expected_searches.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_with_empty_fields-expected_searches.json
@@ -1,0 +1,62 @@
+[ {
+  "id" : "5de0e98900002a0017000001",
+  "queries" : [ {
+    "id" : "0000016e-b690-4273-0000-016eb690426f",
+    "timerange" : {
+      "type" : "absolute",
+      "from" : "2019-12-02T13:18:28.000Z",
+      "to" : "2019-12-03T13:18:29.000Z"
+    },
+    "filter" : {
+      "type" : "or",
+      "filters" : [
+        {
+          "type" : "stream",
+          "id" : "5ddf8ed5b2d44b2e0447298c"
+        }
+      ]
+    },
+    "query" : {
+      "type" : "elasticsearch",
+      "query_string" : "source:sophon"
+    },
+    "search_types" : [ {
+      "id" : "0000016e-b690-4272-0000-016eb690426f",
+      "name" : null,
+      "type" : "messages",
+      "limit" : 150,
+      "offset" : 0,
+      "query" : null,
+      "timerange" : null,
+      "streams" : [ ]
+    }, {
+      "id" : "0000016e-b690-4271-0000-016eb690426f",
+      "series" : [ {
+        "type" : "count",
+        "id" : "count()",
+        "field" : null
+      } ],
+      "name" : "chart",
+      "type" : "pivot",
+      "query" : null,
+      "sort" : [ ],
+      "filter" : null,
+      "timerange" : null,
+      "rollup" : true,
+      "streams" : [ ],
+      "row_groups" : [ {
+        "field" : "timestamp",
+        "interval" : {
+          "scaling" : 1.0,
+          "type" : "auto"
+        },
+        "type" : "time"
+      } ],
+      "column_groups" : [ ]
+    } ]
+  } ],
+  "parameters" : [ ],
+  "owner" : "admin",
+  "created_at" : "2019-12-03T13:18:47.602Z",
+  "requires" : { }
+} ]

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_with_empty_fields-expected_views.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_with_empty_fields-expected_views.json
@@ -1,0 +1,82 @@
+[ {
+  "id" : "5de0e98900002a0017000002",
+  "title" : "Saved Search: The Absolute Search on a stream",
+  "summary" : "This Search was migrated automatically from the \"The Absolute Search on a stream\" saved search.",
+  "description" : "",
+  "search_id" : "5de0e98900002a0017000001",
+  "state" : {
+    "0000016e-b690-4273-0000-016eb690426f" : {
+      "titles" : {
+        "widget" : {
+          "0000016e-b690-426f-0000-016eb690426f" : "Message Count",
+          "0000016e-b690-4270-0000-016eb690426f" : "All Messages"
+        }
+      },
+      "widgets" : [ {
+        "id" : "0000016e-b690-426f-0000-016eb690426f",
+        "config" : {
+          "sort" : [ ],
+          "row_pivots" : [ {
+            "field" : "timestamp",
+            "config" : {
+              "interval" : {
+                "type" : "auto",
+                "scaling" : null
+              }
+            },
+            "type" : "time"
+          } ],
+          "series" : [ {
+            "function" : "count()",
+            "config" : { }
+          } ],
+          "column_pivots" : [ ],
+          "visualization" : "bar",
+          "formatting_settings" : null,
+          "rollup" : true
+        },
+        "type" : "aggregation",
+        "query" : null,
+        "filter" : null,
+        "timerange" : null,
+        "streams" : [ ]
+      }, {
+        "id" : "0000016e-b690-4270-0000-016eb690426f",
+        "config" : {
+          "fields" : [ "timestamp", "source" ],
+          "show_message_row" : true
+        },
+        "type" : "messages",
+        "query" : null,
+        "timerange" : null,
+        "streams" : [ ]
+      } ],
+      "widget_mapping" : {
+        "0000016e-b690-426f-0000-016eb690426f" : [ "0000016e-b690-4271-0000-016eb690426f" ],
+        "0000016e-b690-4270-0000-016eb690426f" : [ "0000016e-b690-4272-0000-016eb690426f" ]
+      },
+      "positions" : {
+        "0000016e-b690-426f-0000-016eb690426f" : {
+          "col" : 1,
+          "row" : 1,
+          "height" : 2,
+          "width" : "Infinity"
+        },
+        "0000016e-b690-4270-0000-016eb690426f" : {
+          "col" : 1,
+          "row" : 3,
+          "height" : 6,
+          "width" : "Infinity"
+        }
+      },
+      "static_message_list_id" : null,
+      "display_mode_settings" : { },
+      "selected_fields" : null
+    }
+  },
+  "owner" : "admin",
+  "created_at" : "2019-12-03T13:18:47.602Z",
+  "type" : "SEARCH",
+  "requires" : { },
+  "properties" : [ ]
+} ]

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_with_empty_fields.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_with_empty_fields.json
@@ -1,0 +1,22 @@
+{
+  "saved_searches": [
+    {
+      "_id": {
+        "$oid": "5de660b7b2d44b5813c1d7f6"
+      },
+      "creator_user_id": "admin",
+      "created_at": {
+        "$date": "2019-12-03T13:18:47.602Z"
+      },
+      "title": "The Absolute Search on a stream",
+      "query": {
+        "from": "2019-12-02T13:18:28.000Z",
+        "to": "2019-12-03T13:18:29.000Z",
+        "rangeType": "absolute",
+        "query": "source:sophon",
+        "streamId": "5ddf8ed5b2d44b2e0447298c",
+        "fields": ""
+      }
+    }
+  ]
+}

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_with_missing_fields-expected_searches.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_with_missing_fields-expected_searches.json
@@ -1,0 +1,62 @@
+[ {
+  "id" : "5de0e98900002a0017000001",
+  "queries" : [ {
+    "id" : "0000016e-b690-4273-0000-016eb690426f",
+    "timerange" : {
+      "type" : "absolute",
+      "from" : "2019-12-02T13:18:28.000Z",
+      "to" : "2019-12-03T13:18:29.000Z"
+    },
+    "filter" : {
+      "type" : "or",
+      "filters" : [
+        {
+          "type" : "stream",
+          "id" : "5ddf8ed5b2d44b2e0447298c"
+        }
+      ]
+    },
+    "query" : {
+      "type" : "elasticsearch",
+      "query_string" : "source:sophon"
+    },
+    "search_types" : [ {
+      "id" : "0000016e-b690-4272-0000-016eb690426f",
+      "name" : null,
+      "type" : "messages",
+      "limit" : 150,
+      "offset" : 0,
+      "query" : null,
+      "timerange" : null,
+      "streams" : [ ]
+    }, {
+      "id" : "0000016e-b690-4271-0000-016eb690426f",
+      "series" : [ {
+        "type" : "count",
+        "id" : "count()",
+        "field" : null
+      } ],
+      "name" : "chart",
+      "type" : "pivot",
+      "query" : null,
+      "sort" : [ ],
+      "filter" : null,
+      "timerange" : null,
+      "rollup" : true,
+      "streams" : [ ],
+      "row_groups" : [ {
+        "field" : "timestamp",
+        "interval" : {
+          "scaling" : 1.0,
+          "type" : "auto"
+        },
+        "type" : "time"
+      } ],
+      "column_groups" : [ ]
+    } ]
+  } ],
+  "parameters" : [ ],
+  "owner" : "admin",
+  "created_at" : "2019-12-03T13:18:47.602Z",
+  "requires" : { }
+} ]

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_with_missing_fields-expected_views.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_with_missing_fields-expected_views.json
@@ -1,0 +1,82 @@
+[ {
+  "id" : "5de0e98900002a0017000002",
+  "title" : "Saved Search: The Absolute Search on a stream",
+  "summary" : "This Search was migrated automatically from the \"The Absolute Search on a stream\" saved search.",
+  "description" : "",
+  "search_id" : "5de0e98900002a0017000001",
+  "state" : {
+    "0000016e-b690-4273-0000-016eb690426f" : {
+      "titles" : {
+        "widget" : {
+          "0000016e-b690-426f-0000-016eb690426f" : "Message Count",
+          "0000016e-b690-4270-0000-016eb690426f" : "All Messages"
+        }
+      },
+      "widgets" : [ {
+        "id" : "0000016e-b690-426f-0000-016eb690426f",
+        "config" : {
+          "sort" : [ ],
+          "row_pivots" : [ {
+            "field" : "timestamp",
+            "config" : {
+              "interval" : {
+                "type" : "auto",
+                "scaling" : null
+              }
+            },
+            "type" : "time"
+          } ],
+          "series" : [ {
+            "function" : "count()",
+            "config" : { }
+          } ],
+          "column_pivots" : [ ],
+          "visualization" : "bar",
+          "formatting_settings" : null,
+          "rollup" : true
+        },
+        "type" : "aggregation",
+        "query" : null,
+        "filter" : null,
+        "timerange" : null,
+        "streams" : [ ]
+      }, {
+        "id" : "0000016e-b690-4270-0000-016eb690426f",
+        "config" : {
+          "fields" : [ "timestamp", "source" ],
+          "show_message_row" : true
+        },
+        "type" : "messages",
+        "query" : null,
+        "timerange" : null,
+        "streams" : [ ]
+      } ],
+      "widget_mapping" : {
+        "0000016e-b690-426f-0000-016eb690426f" : [ "0000016e-b690-4271-0000-016eb690426f" ],
+        "0000016e-b690-4270-0000-016eb690426f" : [ "0000016e-b690-4272-0000-016eb690426f" ]
+      },
+      "positions" : {
+        "0000016e-b690-426f-0000-016eb690426f" : {
+          "col" : 1,
+          "row" : 1,
+          "height" : 2,
+          "width" : "Infinity"
+        },
+        "0000016e-b690-4270-0000-016eb690426f" : {
+          "col" : 1,
+          "row" : 3,
+          "height" : 6,
+          "width" : "Infinity"
+        }
+      },
+      "static_message_list_id" : null,
+      "display_mode_settings" : { },
+      "selected_fields" : null
+    }
+  },
+  "owner" : "admin",
+  "created_at" : "2019-12-03T13:18:47.602Z",
+  "type" : "SEARCH",
+  "requires" : { },
+  "properties" : [ ]
+} ]

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_with_missing_fields.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_with_missing_fields.json
@@ -1,0 +1,21 @@
+{
+  "saved_searches": [
+    {
+      "_id": {
+        "$oid": "5de660b7b2d44b5813c1d7f6"
+      },
+      "creator_user_id": "admin",
+      "created_at": {
+        "$date": "2019-12-03T13:18:47.602Z"
+      },
+      "title": "The Absolute Search on a stream",
+      "query": {
+        "from": "2019-12-02T13:18:28.000Z",
+        "to": "2019-12-03T13:18:29.000Z",
+        "rangeType": "absolute",
+        "query": "source:sophon",
+        "streamId": "5ddf8ed5b2d44b2e0447298c"
+      }
+    }
+  ]
+}

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_with_stream-expected_views.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_with_stream-expected_views.json
@@ -43,7 +43,7 @@
       }, {
         "id" : "0000016e-b690-4270-0000-016eb690426f",
         "config" : {
-          "fields" : [ "message", "source" ],
+          "fields" : [ "timestamp", "source" ],
           "show_message_row" : true
         },
         "type" : "messages",

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_without_message_row-expected_searches.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_without_message_row-expected_searches.json
@@ -1,0 +1,54 @@
+[
+  {
+    "id" : "5de0e98900002a0017000001",
+    "queries" : [ {
+      "id" : "0000016e-b690-4273-0000-016eb690426f",
+      "timerange" : {
+        "type" : "relative",
+        "range" : 3600
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : "source:sophon.home.int"
+      },
+      "search_types" : [ {
+        "id" : "0000016e-b690-4272-0000-016eb690426f",
+        "name" : null,
+        "type" : "messages",
+        "limit" : 150,
+        "offset" : 0,
+        "query" : null,
+        "timerange" : null,
+        "streams" : [ ]
+      }, {
+        "id" : "0000016e-b690-4271-0000-016eb690426f",
+        "series" : [ {
+          "type" : "count",
+          "id" : "count()",
+          "field" : null
+        } ],
+        "name" : "chart",
+        "type" : "pivot",
+        "query" : null,
+        "sort" : [ ],
+        "filter" : null,
+        "timerange" : null,
+        "rollup" : true,
+        "streams" : [ ],
+        "row_groups" : [ {
+          "type": "time",
+          "field" : "timestamp",
+          "interval" : {
+            "scaling" : 1.0,
+            "type" : "auto"
+          }
+        } ],
+        "column_groups" : [ ]
+      } ]
+    } ],
+    "parameters" : [ ],
+    "owner" : "admin",
+    "created_at" : "2019-03-05T10:51:05.900Z",
+    "requires" : { }
+  }
+]

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_without_message_row-expected_views.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_without_message_row-expected_views.json
@@ -1,0 +1,99 @@
+[
+  {
+    "id": "5de0e98900002a0017000002",
+    "title": "Saved Search: Sophon",
+    "summary": "This Search was migrated automatically from the \"Sophon\" saved search.",
+    "description": "",
+    "search_id": "5de0e98900002a0017000001",
+    "state": {
+      "0000016e-b690-4273-0000-016eb690426f": {
+        "titles": {
+          "widget": {
+            "0000016e-b690-426f-0000-016eb690426f": "Message Count",
+            "0000016e-b690-4270-0000-016eb690426f": "All Messages"
+          }
+        },
+        "widgets": [
+          {
+            "id": "0000016e-b690-426f-0000-016eb690426f",
+            "config": {
+              "sort": [],
+              "series": [
+                {
+                  "function": "count()",
+                  "config": {}
+                }
+              ],
+              "row_pivots": [
+                {
+                  "field": "timestamp",
+                  "config": {
+                    "interval": {
+                      "type": "auto",
+                      "scaling": null
+                    }
+                  },
+                  "type": "time"
+                }
+              ],
+              "column_pivots": [],
+              "rollup": true,
+              "visualization": "bar",
+              "formatting_settings": null
+            },
+            "type": "aggregation",
+            "query": null,
+            "filter": null,
+            "timerange": null,
+            "streams": []
+          },
+          {
+            "id": "0000016e-b690-4270-0000-016eb690426f",
+            "config": {
+              "fields": [
+                "timestamp",
+                "source",
+                "otherfield"
+              ],
+              "show_message_row": false
+            },
+            "type": "messages",
+            "query": null,
+            "timerange": null,
+            "streams": []
+          }
+        ],
+        "widget_mapping": {
+          "0000016e-b690-426f-0000-016eb690426f": [
+            "0000016e-b690-4271-0000-016eb690426f"
+          ],
+          "0000016e-b690-4270-0000-016eb690426f": [
+            "0000016e-b690-4272-0000-016eb690426f"
+          ]
+        },
+        "positions": {
+          "0000016e-b690-426f-0000-016eb690426f": {
+            "col": 1,
+            "row": 1,
+            "height": 2,
+            "width": "Infinity"
+          },
+          "0000016e-b690-4270-0000-016eb690426f": {
+            "col": 1,
+            "row": 3,
+            "height": 6,
+            "width": "Infinity"
+          }
+        },
+        "static_message_list_id": null,
+        "display_mode_settings": {},
+        "selected_fields": null
+      }
+    },
+    "owner": "admin",
+    "created_at": "2019-03-05T10:51:05.900Z",
+    "type": "SEARCH",
+    "requires": {},
+    "properties": []
+  }
+]

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_without_message_row.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_without_message_row.json
@@ -1,0 +1,20 @@
+{
+  "saved_searches": [
+    {
+      "_id": {
+        "$oid": "5c7e5499f38ed7e1d8d6a613"
+      },
+      "creator_user_id": "admin",
+      "created_at": {
+        "$date": "2019-03-05T10:51:05.900Z"
+      },
+      "title": "Sophon",
+      "query": {
+        "rangeType": "relative",
+        "fields": "source,otherfield",
+        "relative": 3600,
+        "query": "source:sophon.home.int"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, when a saved search was missing a `fields` property
(which is defining a set of fields being shown in the message list), the
migration would fail.

This change is now making `fields` optional and uses a default set of
fields if absent.

In addition it does:

  - explicitly include the `timestamp` field in the field selection
  - conditionally select the message row for the newly created message
widget depending on the presence of the `message` field in the original
saved search

Fixes #7362.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually creating a saved search with no `fields` property, migrating
it, checking the result.
Adding test cases that reproduce some corner cases.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.