### PR TITLE
Partly revert timestamp based gl2_message_ids (#7290)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/buffers/processors/ProcessBufferProcessor.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/buffers/processors/ProcessBufferProcessor.java
@@ -139,7 +139,7 @@ public class ProcessBufferProcessor implements WorkHandler<MessageEvent> {
             if (!message.hasField(Message.FIELD_GL2_MESSAGE_ID) || isNullOrEmpty(message.getFieldAs(String.class, Message.FIELD_GL2_MESSAGE_ID))) {
                 // Set the message ID once all message processors have finished
                 // See documentation of Message.FIELD_GL2_MESSAGE_ID for details
-                message.addField(Message.FIELD_GL2_MESSAGE_ID, ulid.nextULID(message.getTimestamp().getMillis()));
+                message.addField(Message.FIELD_GL2_MESSAGE_ID, ulid.nextULID());
             }
 
             // The processing time should only be set once all message processors have finished


### PR DESCRIPTION
Sometimes the message processing doesn't leave us
with a valid DateTime Object at this point.

Fixes #7364

(cherry picked from commit bdb4e1bb2457887e274097b5872780b3847f6608)
