### PR TITLE
Ignoring `interval` field when migrating saved searches. (3.2)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/AbsoluteTimeRangeQuery.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/AbsoluteTimeRangeQuery.java
@@ -47,7 +47,8 @@ public abstract class AbsoluteTimeRangeQuery extends Query {
             @JsonProperty("query") String query,
             @JsonProperty("from") DateTime from,
             @JsonProperty("to") DateTime to,
-            @JsonProperty("streamId") @Nullable String streamId
+            @JsonProperty("streamId") @Nullable String streamId,
+            @JsonProperty("interval") @Nullable String ignored
     ) {
         return new AutoValue_AbsoluteTimeRangeQuery(rangeType, Optional.ofNullable(fields), query, Optional.ofNullable(streamId), from, to);
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/KeywordTimeRangeQuery.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/KeywordTimeRangeQuery.java
@@ -44,7 +44,8 @@ public abstract class KeywordTimeRangeQuery extends Query {
             @JsonProperty("fields") @Nullable String fields,
             @JsonProperty("query") String query,
             @JsonProperty("keyword") String keyword,
-            @JsonProperty("streamId") @Nullable String streamId
+            @JsonProperty("streamId") @Nullable String streamId,
+            @JsonProperty("interval") @Nullable String ignored
     ) {
         return new AutoValue_KeywordTimeRangeQuery(rangeType, Optional.ofNullable(fields), query, Optional.ofNullable(streamId), keyword);
     }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/RelativeTimeRangeQuery.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/savedsearch/RelativeTimeRangeQuery.java
@@ -44,7 +44,8 @@ public abstract class RelativeTimeRangeQuery extends Query {
             @JsonProperty("fields") @Nullable String fields,
             @JsonProperty("query") String query,
             @JsonProperty("relative") int relative,
-            @JsonProperty("streamId") @Nullable String streamId
+            @JsonProperty("streamId") @Nullable String streamId,
+            @JsonProperty("interval") @Nullable String ignored
     ) {
         return new AutoValue_RelativeTimeRangeQuery(rangeType, Optional.ofNullable(fields), query, Optional.ofNullable(streamId), relative);
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/V20191203120602_MigrateSavedSearchesToViewsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/V20191203120602_MigrateSavedSearchesToViewsTest.java
@@ -212,13 +212,52 @@ public class V20191203120602_MigrateSavedSearchesToViewsTest {
         assertSearchServiceCreated(1, resourceFile("sample_saved_search_without_message_row-expected_searches.json"));
     }
 
+    @Test
+    @MongoDBFixtures("sample_saved_search_relative_with_interval_field.json")
+    public void migrateSavedSearchRelativeWithIntervalField() throws Exception {
+        this.migration.upgrade();
+
+        final MigrationCompleted migrationCompleted = captureMigrationCompleted();
+        assertThat(migrationCompleted.savedSearchIds())
+                .containsExactly(new AbstractMap.SimpleEntry<>("5c7e5499f38ed7e1d8d6a613", "5de0e98900002a0017000002"));
+
+        assertViewServiceCreatedViews(1, resourceFile("sample_saved_search_relative_with_interval_field-expected_views.json"));
+        assertSearchServiceCreated(1, resourceFile("sample_saved_search_relative_with_interval_field-expected_searches.json"));
+    }
+
+    @Test
+    @MongoDBFixtures("sample_saved_search_absolute_with_interval_field.json")
+    public void migrateSavedSearchAbsoluteWithIntervalField() throws Exception {
+        this.migration.upgrade();
+
+        final MigrationCompleted migrationCompleted = captureMigrationCompleted();
+        assertThat(migrationCompleted.savedSearchIds())
+                .containsExactly(new AbstractMap.SimpleEntry<>("5de660b7b2d44b5813c1d7f6", "5de0e98900002a0017000002"));
+
+        assertViewServiceCreatedViews(1, resourceFile("sample_saved_search_absolute_with_interval_field-expected_views.json"));
+        assertSearchServiceCreated(1, resourceFile("sample_saved_search_absolute_with_interval_field-expected_searches.json"));
+    }
+
+    @Test
+    @MongoDBFixtures("sample_saved_search_keyword_with_interval_field.json")
+    public void migrateSavedSearchKeywordWithIntervalField() throws Exception {
+        this.migration.upgrade();
+
+        final MigrationCompleted migrationCompleted = captureMigrationCompleted();
+        assertThat(migrationCompleted.savedSearchIds())
+                .containsExactly(new AbstractMap.SimpleEntry<>("5de660c6b2d44b5813c1d806", "5de0e98900002a0017000002"));
+
+        assertViewServiceCreatedViews(1, resourceFile("sample_saved_search_keyword_with_interval_field-expected_views.json"));
+        assertSearchServiceCreated(1, resourceFile("sample_saved_search_keyword_with_interval_field-expected_searches.json"));
+    }
+
     private void assertViewServiceCreatedViews(int count, String viewsCollection) throws Exception {
         final ArgumentCaptor<View> newViewsCaptor = ArgumentCaptor.forClass(View.class);
         verify(viewService, times(count)).save(newViewsCaptor.capture());
         final List<View> newViews = newViewsCaptor.getAllValues();
         assertThat(newViews).hasSize(count);
 
-        JSONAssert.assertEquals(toJSON(newViews), viewsCollection, true);
+        JSONAssert.assertEquals(viewsCollection, toJSON(newViews), true);
     }
 
     private void assertSearchServiceCreated(int count, String searchCollection) throws Exception {

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_absolute_with_interval_field-expected_searches.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_absolute_with_interval_field-expected_searches.json
@@ -1,0 +1,53 @@
+[ {
+  "id" : "5de0e98900002a0017000001",
+  "queries" : [ {
+    "id" : "0000016e-b690-4273-0000-016eb690426f",
+    "timerange" : {
+      "type" : "absolute",
+      "from" : "2019-12-02T13:18:28.000Z",
+      "to" : "2019-12-03T13:18:29.000Z"
+    },
+    "query" : {
+      "type" : "elasticsearch",
+      "query_string" : "source:sophon"
+    },
+    "search_types" : [ {
+      "id" : "0000016e-b690-4272-0000-016eb690426f",
+      "name" : null,
+      "type" : "messages",
+      "limit" : 150,
+      "offset" : 0,
+      "query" : null,
+      "timerange" : null,
+      "streams" : [ ]
+    }, {
+      "id" : "0000016e-b690-4271-0000-016eb690426f",
+      "series" : [ {
+        "type" : "count",
+        "id" : "count()",
+        "field" : null
+      } ],
+      "name" : "chart",
+      "type" : "pivot",
+      "query" : null,
+      "sort" : [ ],
+      "filter" : null,
+      "timerange" : null,
+      "rollup" : true,
+      "streams" : [ ],
+      "row_groups" : [ {
+        "field" : "timestamp",
+        "interval" : {
+          "scaling" : 1.0,
+          "type" : "auto"
+        },
+        "type" : "time"
+      } ],
+      "column_groups" : [ ]
+    } ]
+  } ],
+  "parameters" : [ ],
+  "owner" : "admin",
+  "created_at" : "2019-12-03T13:18:47.602Z",
+  "requires" : { }
+} ]

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_absolute_with_interval_field-expected_views.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_absolute_with_interval_field-expected_views.json
@@ -1,0 +1,82 @@
+[ {
+  "id" : "5de0e98900002a0017000002",
+  "title" : "Saved Search: The Absolute Search",
+  "summary" : "This Search was migrated automatically from the \"The Absolute Search\" saved search.",
+  "description" : "",
+  "search_id" : "5de0e98900002a0017000001",
+  "state" : {
+    "0000016e-b690-4273-0000-016eb690426f" : {
+      "titles" : {
+        "widget" : {
+          "0000016e-b690-426f-0000-016eb690426f" : "Message Count",
+          "0000016e-b690-4270-0000-016eb690426f" : "All Messages"
+        }
+      },
+      "widgets" : [ {
+        "id" : "0000016e-b690-426f-0000-016eb690426f",
+        "config" : {
+          "sort" : [ ],
+          "row_pivots" : [ {
+            "field" : "timestamp",
+            "config" : {
+              "interval" : {
+                "type" : "auto",
+                "scaling" : null
+              }
+            },
+            "type" : "time"
+          } ],
+          "series" : [ {
+            "function" : "count()",
+            "config" : { }
+          } ],
+          "column_pivots" : [ ],
+          "visualization" : "bar",
+          "formatting_settings" : null,
+          "rollup" : true
+        },
+        "type" : "aggregation",
+        "query" : null,
+        "filter" : null,
+        "timerange" : null,
+        "streams" : [ ]
+      }, {
+        "id" : "0000016e-b690-4270-0000-016eb690426f",
+        "config" : {
+          "fields" : [ "timestamp", "source" ],
+          "show_message_row" : true
+        },
+        "type" : "messages",
+        "query" : null,
+        "timerange" : null,
+        "streams" : [ ]
+      } ],
+      "widget_mapping" : {
+        "0000016e-b690-426f-0000-016eb690426f" : [ "0000016e-b690-4271-0000-016eb690426f" ],
+        "0000016e-b690-4270-0000-016eb690426f" : [ "0000016e-b690-4272-0000-016eb690426f" ]
+      },
+      "positions" : {
+        "0000016e-b690-426f-0000-016eb690426f" : {
+          "col" : 1,
+          "row" : 1,
+          "height" : 2,
+          "width" : "Infinity"
+        },
+        "0000016e-b690-4270-0000-016eb690426f" : {
+          "col" : 1,
+          "row" : 3,
+          "height" : 6,
+          "width" : "Infinity"
+        }
+      },
+      "static_message_list_id" : null,
+      "display_mode_settings" : { },
+      "selected_fields" : null
+    }
+  },
+  "owner" : "admin",
+  "created_at" : "2019-12-03T13:18:47.602Z",
+  "type" : "SEARCH",
+  "requires" : { },
+  "properties" : [ ]
+} ]

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_absolute_with_interval_field.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_absolute_with_interval_field.json
@@ -1,0 +1,22 @@
+{
+  "saved_searches": [
+    {
+      "_id": {
+        "$oid": "5de660b7b2d44b5813c1d7f6"
+      },
+      "creator_user_id": "admin",
+      "created_at": {
+        "$date": "2019-12-03T13:18:47.602Z"
+      },
+      "title": "The Absolute Search",
+      "query": {
+        "from": "2019-12-02T13:18:28.000Z",
+        "to": "2019-12-03T13:18:29.000Z",
+        "rangeType": "absolute",
+        "fields": "message,source",
+        "query": "source:sophon",
+        "interval": "month"
+      }
+    }
+  ]
+}

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_keyword_with_interval_field-expected_searches.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_keyword_with_interval_field-expected_searches.json
@@ -1,0 +1,52 @@
+[ {
+  "id" : "5de0e98900002a0017000001",
+  "queries" : [ {
+    "id" : "0000016e-b690-4273-0000-016eb690426f",
+    "timerange" : {
+      "type" : "keyword",
+      "keyword" : "yesterday"
+    },
+    "query" : {
+      "type" : "elasticsearch",
+      "query_string" : "source:sophon"
+    },
+    "search_types" : [ {
+      "id" : "0000016e-b690-4272-0000-016eb690426f",
+      "name" : null,
+      "type" : "messages",
+      "limit" : 150,
+      "offset" : 0,
+      "query" : null,
+      "streams" : [ ],
+      "timerange" : null
+    }, {
+      "id" : "0000016e-b690-4271-0000-016eb690426f",
+      "series" : [ {
+        "type" : "count",
+        "id" : "count()",
+        "field" : null
+      } ],
+      "name" : "chart",
+      "type" : "pivot",
+      "query" : null,
+      "sort" : [ ],
+      "filter" : null,
+      "streams" : [ ],
+      "timerange" : null,
+      "rollup" : true,
+      "row_groups" : [ {
+        "field" : "timestamp",
+        "interval" : {
+          "scaling" : 1.0,
+          "type" : "auto"
+        },
+        "type" : "time"
+      } ],
+      "column_groups" : [ ]
+    } ]
+  } ],
+  "parameters" : [ ],
+  "owner" : "admin",
+  "created_at" : "2019-12-03T13:19:02.025Z",
+  "requires" : { }
+} ]

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_keyword_with_interval_field-expected_views.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_keyword_with_interval_field-expected_views.json
@@ -1,0 +1,82 @@
+[ {
+  "id" : "5de0e98900002a0017000002",
+  "title" : "Saved Search: Can I give you a keyword?",
+  "summary" : "This Search was migrated automatically from the \"Can I give you a keyword?\" saved search.",
+  "description" : "",
+  "search_id" : "5de0e98900002a0017000001",
+  "state" : {
+    "0000016e-b690-4273-0000-016eb690426f" : {
+      "titles" : {
+        "widget" : {
+          "0000016e-b690-426f-0000-016eb690426f" : "Message Count",
+          "0000016e-b690-4270-0000-016eb690426f" : "All Messages"
+        }
+      },
+      "widgets" : [ {
+        "id" : "0000016e-b690-426f-0000-016eb690426f",
+        "config" : {
+          "sort" : [ ],
+          "series" : [ {
+            "function" : "count()",
+            "config" : { }
+          } ],
+          "row_pivots" : [ {
+            "field" : "timestamp",
+            "config" : {
+              "interval" : {
+                "type" : "auto",
+                "scaling" : null
+              }
+            },
+            "type" : "time"
+          } ],
+          "column_pivots" : [ ],
+          "visualization" : "bar",
+          "formatting_settings" : null,
+          "rollup" : true
+        },
+        "type" : "aggregation",
+        "query" : null,
+        "filter" : null,
+        "streams" : [ ],
+        "timerange" : null
+      }, {
+        "id" : "0000016e-b690-4270-0000-016eb690426f",
+        "config" : {
+          "fields" : [ "timestamp", "source" ],
+          "show_message_row" : true
+        },
+        "type" : "messages",
+        "query" : null,
+        "streams" : [ ],
+        "timerange" : null
+      } ],
+      "widget_mapping" : {
+        "0000016e-b690-426f-0000-016eb690426f" : [ "0000016e-b690-4271-0000-016eb690426f" ],
+        "0000016e-b690-4270-0000-016eb690426f" : [ "0000016e-b690-4272-0000-016eb690426f" ]
+      },
+      "positions" : {
+        "0000016e-b690-426f-0000-016eb690426f" : {
+          "col" : 1,
+          "row" : 1,
+          "height" : 2,
+          "width" : "Infinity"
+        },
+        "0000016e-b690-4270-0000-016eb690426f" : {
+          "col" : 1,
+          "row" : 3,
+          "height" : 6,
+          "width" : "Infinity"
+        }
+      },
+      "selected_fields" : null,
+      "static_message_list_id" : null,
+      "display_mode_settings" : { }
+    }
+  },
+  "owner" : "admin",
+  "created_at" : "2019-12-03T13:19:02.025Z",
+  "type" : "SEARCH",
+  "requires" : { },
+  "properties" : [ ]
+} ]

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_keyword_with_interval_field.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_keyword_with_interval_field.json
@@ -1,0 +1,21 @@
+{
+  "saved_searches": [
+    {
+      "_id": {
+        "$oid": "5de660c6b2d44b5813c1d806"
+      },
+      "creator_user_id": "admin",
+      "created_at": {
+        "$date": "2019-12-03T13:19:02.025Z"
+      },
+      "title": "Can I give you a keyword?",
+      "query": {
+        "rangeType": "keyword",
+        "keyword": "yesterday",
+        "fields": "message,source",
+        "query": "source:sophon",
+        "interval": "hour"
+      }
+    }
+  ]
+}

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_relative_with_interval_field-expected_searches.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_relative_with_interval_field-expected_searches.json
@@ -1,0 +1,54 @@
+[
+  {
+    "id" : "5de0e98900002a0017000001",
+    "queries" : [ {
+      "id" : "0000016e-b690-4273-0000-016eb690426f",
+      "timerange" : {
+        "type" : "relative",
+        "range" : 3600
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : "source:sophon.home.int"
+      },
+      "search_types" : [ {
+        "id" : "0000016e-b690-4272-0000-016eb690426f",
+        "name" : null,
+        "type" : "messages",
+        "limit" : 150,
+        "offset" : 0,
+        "query" : null,
+        "timerange" : null,
+        "streams" : [ ]
+      }, {
+        "id" : "0000016e-b690-4271-0000-016eb690426f",
+        "series" : [ {
+          "type" : "count",
+          "id" : "count()",
+          "field" : null
+        } ],
+        "name" : "chart",
+        "type" : "pivot",
+        "query" : null,
+        "sort" : [ ],
+        "filter" : null,
+        "timerange" : null,
+        "rollup" : true,
+        "streams" : [ ],
+        "row_groups" : [ {
+          "type": "time",
+          "field" : "timestamp",
+          "interval" : {
+            "scaling" : 1.0,
+            "type" : "auto"
+          }
+        } ],
+        "column_groups" : [ ]
+      } ]
+    } ],
+    "parameters" : [ ],
+    "owner" : "admin",
+    "created_at" : "2019-03-05T10:51:05.900Z",
+    "requires" : { }
+  }
+]

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_relative_with_interval_field-expected_views.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_relative_with_interval_field-expected_views.json
@@ -1,0 +1,99 @@
+[
+  {
+    "id": "5de0e98900002a0017000002",
+    "title": "Saved Search: Sophon",
+    "summary": "This Search was migrated automatically from the \"Sophon\" saved search.",
+    "description": "",
+    "search_id": "5de0e98900002a0017000001",
+    "state": {
+      "0000016e-b690-4273-0000-016eb690426f": {
+        "titles": {
+          "widget": {
+            "0000016e-b690-426f-0000-016eb690426f": "Message Count",
+            "0000016e-b690-4270-0000-016eb690426f": "All Messages"
+          }
+        },
+        "widgets": [
+          {
+            "id": "0000016e-b690-426f-0000-016eb690426f",
+            "config": {
+              "sort": [],
+              "series": [
+                {
+                  "function": "count()",
+                  "config": {}
+                }
+              ],
+              "row_pivots": [
+                {
+                  "field": "timestamp",
+                  "config": {
+                    "interval": {
+                      "type": "auto",
+                      "scaling": null
+                    }
+                  },
+                  "type": "time"
+                }
+              ],
+              "column_pivots": [],
+              "rollup": true,
+              "visualization": "bar",
+              "formatting_settings": null
+            },
+            "type": "aggregation",
+            "query": null,
+            "filter": null,
+            "timerange": null,
+            "streams": []
+          },
+          {
+            "id": "0000016e-b690-4270-0000-016eb690426f",
+            "config": {
+              "fields": [
+                "timestamp",
+                "source",
+                "otherfield"
+              ],
+              "show_message_row": true
+            },
+            "type": "messages",
+            "query": null,
+            "timerange": null,
+            "streams": []
+          }
+        ],
+        "widget_mapping": {
+          "0000016e-b690-426f-0000-016eb690426f": [
+            "0000016e-b690-4271-0000-016eb690426f"
+          ],
+          "0000016e-b690-4270-0000-016eb690426f": [
+            "0000016e-b690-4272-0000-016eb690426f"
+          ]
+        },
+        "positions": {
+          "0000016e-b690-426f-0000-016eb690426f": {
+            "col": 1,
+            "row": 1,
+            "height": 2,
+            "width": "Infinity"
+          },
+          "0000016e-b690-4270-0000-016eb690426f": {
+            "col": 1,
+            "row": 3,
+            "height": 6,
+            "width": "Infinity"
+          }
+        },
+        "static_message_list_id": null,
+        "display_mode_settings": {},
+        "selected_fields": null
+      }
+    },
+    "owner": "admin",
+    "created_at": "2019-03-05T10:51:05.900Z",
+    "type": "SEARCH",
+    "requires": {},
+    "properties": []
+  }
+]

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_relative_with_interval_field.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191203120602_MigrateSavedSearchesToViewsSupport/sample_saved_search_relative_with_interval_field.json
@@ -1,0 +1,21 @@
+{
+  "saved_searches": [
+    {
+      "_id": {
+        "$oid": "5c7e5499f38ed7e1d8d6a613"
+      },
+      "creator_user_id": "admin",
+      "created_at": {
+        "$date": "2019-03-05T10:51:05.900Z"
+      },
+      "title": "Sophon",
+      "query": {
+        "rangeType": "relative",
+        "fields": "message,source,otherfield",
+        "relative": 3600,
+        "query": "source:sophon.home.int",
+        "interval": "month"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

For saved searches that have been created after changing the interval of
the message histogram on the search page, the migration turning them
into views-based searches fails, due to the unexpected `interval` field.

This PR is ignoring a potentially existing `interval` field, because we
do not rely on manual interval selection anymore. In most of the cases
the interval was selected, because the time range was bigger or smaller
than the default. In 3.2 we offer an automatic interval size selection,
which yields better results (especially when increasing the time range)
than manually selecting one.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.