### PR TITLE
Increasing timeout for element finders in `CreateNewDashboard` test.

### DIFF
--- a/graylog2-web-interface/src/views/spec/CreateNewDashboard.test.jsx
+++ b/graylog2-web-interface/src/views/spec/CreateNewDashboard.test.jsx
@@ -53,9 +53,9 @@ describe('Create a new dashboard', () => {
     const { getByText, getAllByText } = render(<AppRouter />);
     history.push(Routes.DASHBOARDS);
 
-    const button = await waitForElement(() => getAllByText('Create new dashboard')[0]);
+    const button = await waitForElement(() => getAllByText('Create new dashboard')[0], { timeout: 15000 });
     fireEvent.click(button);
-    await waitForElement(() => getByText(/This dashboard has no widgets yet/));
+    await waitForElement(() => getByText(/This dashboard has no widgets yet/), { timeout: 15000 });
   });
 
   it('by going to the new dashboards endpoint', async () => {
@@ -63,6 +63,6 @@ describe('Create a new dashboard', () => {
 
     history.push(Routes.pluginRoute('DASHBOARDS_NEW'));
 
-    await waitForElement(() => getByText(/This dashboard has no widgets yet/));
+    await waitForElement(() => getByText(/This dashboard has no widgets yet/), { timeout: 15000 });
   });
 });


### PR DESCRIPTION
When run in parallel, the `CreateNewDashboard` test has turned out to be
flaky. A further attempt to increase the jest timeout for the test suite
did not fundamentally improve the situation.

This change is increasing the timeout for the individual element finders
in the test from the default of 4500ms to 15000ms, hoping to make the
test more reliable.