### PR TITLE
Guard against illegal regexes in whitelist

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/system/urlwhitelist/RegexWhitelistEntry.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/urlwhitelist/RegexWhitelistEntry.java
@@ -20,28 +20,37 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
-import com.google.auto.value.extension.memoized.Memoized;
 import org.graylog.autovalue.WithBeanGetter;
 
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 @AutoValue
 @WithBeanGetter
 @JsonAutoDetect
 public abstract class RegexWhitelistEntry implements WhitelistEntry {
-    @Memoized
-    protected Pattern cachedPattern() {
-        return Pattern.compile(value(), Pattern.DOTALL);
-    }
+    private Pattern pattern;
 
     @JsonCreator
     public static RegexWhitelistEntry create(@JsonProperty("id") String id, @JsonProperty("title") String title,
             @JsonProperty("value") String value) {
-        return new AutoValue_RegexWhitelistEntry(id, Type.REGEX, title, value);
+
+        // compile the pattern early so that we can catch illegal expressions asap
+        final Pattern pattern;
+        try {
+            pattern = Pattern.compile(value, Pattern.DOTALL);
+        } catch (PatternSyntaxException e) {
+            throw new IllegalArgumentException(
+                    "Cannot create whitelist entry for invalid regular expression '" + value + "': " + e.getMessage(),
+                    e);
+        }
+        final RegexWhitelistEntry whitelistEntry = new AutoValue_RegexWhitelistEntry(id, Type.REGEX, title, value);
+        whitelistEntry.pattern = pattern;
+        return whitelistEntry;
     }
 
     @Override
     public boolean isWhitelisted(String url) {
-        return cachedPattern().matcher(url).find();
+        return pattern.matcher(url).find();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/system/urlwhitelist/UrlWhitelistTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/system/urlwhitelist/UrlWhitelistTest.java
@@ -67,4 +67,9 @@ public class UrlWhitelistTest {
         UrlWhitelist.createEnabled(ImmutableList.of(LiteralWhitelistEntry.create("a", "a", "a"),
                 RegexWhitelistEntry.create("a", "b", "b")));
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidRegex() {
+        UrlWhitelist.createEnabled(ImmutableList.of(RegexWhitelistEntry.create("a", "b", "${")));
+    }
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Regex whitelist entries don't compile regexes lazily anymore.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We don't want to rely entirely on the frontend to make sure that only valid expressions are entered. Previously we would accept invalid expressions and end up with a broken whitelist because the pattern would be compiled on demand.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual test by sending a regex whitelist entry with `http://localhost/${` as its value via the API.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

