### PR TITLE
Fix duplicating of query tab if no widget has been renamed.

### DIFF
--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { MenuItem } from 'components/graylog';
 
 import { QueriesActions } from 'views/stores/QueriesStore';
-import { ViewActions } from 'views/stores/ViewStore';
 import type { QueryId } from 'views/logic/queries/Query';
 import ViewState from 'views/logic/views/ViewState';
 

--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.jsx
@@ -45,10 +45,7 @@ class QueryTitle extends React.Component<Props, State> {
     onClose();
   };
 
-  _onDuplicate = (id: QueryId) => {
-    QueriesActions.duplicate(id)
-      .then(newQuery => ViewActions.selectQuery(newQuery.id));
-  };
+  _onDuplicate = (id: QueryId) => QueriesActions.duplicate(id);
 
   render() {
     const { editing, title } = this.state;

--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.test.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.test.jsx
@@ -49,7 +49,8 @@ describe('QueryTitle', () => {
       });
     });
 
-    it('selects new query after duplicating it', () => {
+    it('does not explicitly select new query after duplicating it', () => {
+      // Selecting the new query after duplication has become unnecessary, as `ViewStore#createQuery` does it already
       const wrapper = mount(
         <QueryTitle active
                     id="deadbeef"
@@ -61,8 +62,7 @@ describe('QueryTitle', () => {
       const duplicate = findAction(wrapper, 'Duplicate');
 
       return duplicate().then(() => {
-        expect(ViewActions.selectQuery).toHaveBeenCalled();
-        expect(asMock(ViewActions.selectQuery).mock.calls[0][0]).not.toBeNull();
+        expect(ViewActions.selectQuery).not.toHaveBeenCalled();
       });
     });
   });

--- a/graylog2-web-interface/src/views/components/queries/QueryTitle.test.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitle.test.jsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { mount } from 'wrappedEnzyme';
 
 import mockAction from 'helpers/mocking/MockAction';
-import asMock from 'helpers/mocking/AsMock';
 import { QueriesActions } from 'views/stores/QueriesStore';
 import { ViewActions } from 'views/stores/ViewStore';
 import Query from 'views/logic/queries/Query';

--- a/graylog2-web-interface/src/views/logic/views/ViewState.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewState.js
@@ -80,7 +80,7 @@ export default class ViewState {
     return this._value.widgetPositions;
   }
 
-  get staticMessageListId() : ?string {
+  get staticMessageListId(): ?string {
     return this._value.staticMessageListId;
   }
 

--- a/graylog2-web-interface/src/views/logic/views/ViewState.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewState.js
@@ -91,7 +91,7 @@ export default class ViewState {
       widgetIdTranslation[widget.id] = newWidget.id;
       return newWidget;
     });
-    const newWidgetTitles = this.titles.get(TitleTypes.Widget).mapEntries(([key, value]) => [widgetIdTranslation[key], value]);
+    const newWidgetTitles = this.titles.get(TitleTypes.Widget, Map()).mapEntries(([key, value]) => [widgetIdTranslation[key], value]);
     const newTitles = this.titles
       .set(TitleTypes.Widget, newWidgetTitles)
       .updateIn([TitleTypes.Tab, 'title'], value => (value ? `${value} (Copy)` : value));

--- a/graylog2-web-interface/src/views/logic/views/ViewState.test.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewState.test.js
@@ -1,0 +1,11 @@
+// @flow strict
+import ViewState from './ViewState';
+
+describe('ViewState', () => {
+  it('duplicates empty view state', () => {
+    const viewState = ViewState.create();
+    const viewState2 = viewState.duplicate();
+
+    expect(viewState2).toBeInstanceOf(ViewState);
+  });
+});


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, duplicating a query tab containing no widgets or
where no widget had been renamed or given a title before, would fail.
This happened because during query tab duplication the map of widget
titles was extracted from a nested titles structure, which - at this
point - does not contain a widget titles map.

In addition, a second error occurs after successfully duplicating a
query tab: the `QueryTitle` component tries to switch to the new query
tab by using the id of the new query supplied by the promise returned by
the duplication action. Unfortunately the duplication action does not
return the query id. Nonetheless, the new query tab is selected, because
of the `ViewStore#createQuery` action being called.

This change is doing two things:a

  * Fall back to an empty map if the widget titles map is not present at
this time.
  * Remove the explicit call to switch to the newly created query tab.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.