### PR TITLE
Updating `react-ace-builds` to v7.3.1.

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -91,7 +91,7 @@
     "plotly.js": "^1.48.1",
     "polished": "^3.4.1",
     "qs": "^6.3.0",
-    "react-ace-builds": "^7.2.4",
+    "react-ace-builds": "^7.3.1",
     "react-color": "^2.14.0",
     "react-day-picker": "^5.0.0",
     "react-dnd": "^7.0.2",

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -1960,10 +1960,10 @@ accepts@~1.3.7:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
-ace-builds@^1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/ace-builds/-/ace-builds-1.4.4.tgz#b1ad500f99b451710ce51d20f43313027e9fb73a"
-  integrity sha512-EQArUYup9c3lBv8meKBjisff/qhhQmU/6LnLhVDfxe+Bnjr0Lz7qhL4Mp8HpwNQzmCqLunjdPFuBtCELVVG6zw==
+ace-builds@^1.4.8:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/ace-builds/-/ace-builds-1.4.8.tgz#d14be41d30294a2a12581f0bcfee4b696481ffdd"
+  integrity sha512-8ZVAxwyCGAxQX8mOp9imSXH0hoSPkGfy8igJy+WO/7axL30saRhKgg1XPACSmxxPA7nfHVwM+ShWXT+vKsNuFg==
 
 acorn-dynamic-import@^4.0.0:
   version "4.0.0"
@@ -12591,12 +12591,12 @@ re-resizable@6.1.0:
   dependencies:
     fast-memoize "^2.5.1"
 
-react-ace-builds@^7.2.4:
-  version "7.2.4"
-  resolved "https://registry.yarnpkg.com/react-ace-builds/-/react-ace-builds-7.2.4.tgz#15224253608b94394e1ce63665bc02842d773c64"
-  integrity sha512-Qb3CPfVwF9xbpQYQd6IW/NfYAqZftG2saOS7cYLEpGU//8fy0gGnJ6dtErLAJpJ/5MbbLp9QBt8hNN5IECdT1A==
+react-ace-builds@^7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/react-ace-builds/-/react-ace-builds-7.3.1.tgz#5c1ffdb70f552985676182bd205a6019d6da8cdc"
+  integrity sha512-bfHKMLAFq7hlmXB2sQ7gJaJ0PjMnLNs6kfV6VCvPcQVeehe0XTgGGi6v5nitqkyDScjZpXBX67PlZstowNTXlQ==
   dependencies:
-    ace-builds "^1.4.4"
+    ace-builds "^1.4.8"
     diff-match-patch "^1.0.4"
     lodash.get "^4.4.2"
     lodash.isequal "^4.5.0"


### PR DESCRIPTION
Bumps `react-ace-builds` from `v7.2.4` to `v7.3.1`, therefore updating
`ace-builds` from `v1.4.4` to `v1.4.8`.

Changelogs:

  - `react-ace-builds`: https://github.com/manubb/react-ace-builds/blob/local/CHANGELOG.md
  - `ace-builds`: https://github.com/ajaxorg/ace-builds/blob/v1.4.8/ChangeLog.txt