### PR TITLE
Improve search url sync, by avoiding unnecessary entries in browser history (3.2)

### DIFF
--- a/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.js
+++ b/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.js
@@ -26,7 +26,7 @@ const extractTimerangeParams = (timerange) => {
   }
 };
 
-export const syncWithQueryParameters = (query: string) => {
+export const syncWithQueryParameters = (query: string, action: (string) => mixed = history.push) => {
   const { view } = ViewStore.getInitialState() || {};
   if (view && view.type === View.Type.Search) {
     const { queries } = view.search;
@@ -45,14 +45,14 @@ export const syncWithQueryParameters = (query: string) => {
         .reduce((prev, [key, value]) => prev.setSearch(key, value), baseUri)
         .toString();
       if (query !== uri) {
-        history.push(uri);
+        action(uri);
       }
     }
   }
 };
 
 export const useSyncWithQueryParameters = (query: string) => {
-  useEffect(() => syncWithQueryParameters(query), []);
+  useEffect(() => syncWithQueryParameters(query, history.replace), []);
   useActionListeners(
     [QueriesActions.query.completed, QueriesActions.timerange.completed],
     () => syncWithQueryParameters(query),

--- a/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.test.jsx
+++ b/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.test.jsx
@@ -13,7 +13,7 @@ jest.mock('views/stores/ViewStore', () => ({
     getInitialState: jest.fn(),
   },
 }));
-jest.mock('util/History', () => ({ push: jest.fn() }));
+jest.mock('util/History', () => ({ push: jest.fn(), replace: jest.fn() }));
 
 describe('SyncWithQueryParameters', () => {
   it('does not do anything if no view is loaded', () => {
@@ -103,6 +103,13 @@ describe('SyncWithQueryParameters', () => {
 
       expect(history.push)
         .toHaveBeenCalledWith('/search?q=foo%3A42&rangetype=keyword&keyword=Last+five+minutes');
+    });
+    it('by calling the provided action', () => {
+      asMock(ViewStore.getInitialState).mockReturnValueOnce({ view });
+
+      syncWithQueryParameters('/search', history.replace);
+
+      expect(history.replace).toHaveBeenCalledWith('/search?q=foo%3A42&rangetype=relative&relative=600');
     });
   });
 });

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.test.jsx
@@ -24,6 +24,7 @@ import ExtendedSearchPage from './ExtendedSearchPage';
 
 jest.mock('react-router', () => ({ withRouter: x => x }));
 jest.mock('components/layout/Footer', () => <div />);
+jest.mock('util/History', () => ({ push: jest.fn() }));
 jest.mock('views/stores/ViewMetadataStore', () => ({
   ViewMetadataStore: MockStore(
     ['listen', () => jest.fn()],


### PR DESCRIPTION
Opening the search page, stream search page or loaded search page, results in multiple browser history entries (e.g. `/search` and `/search?q=&rangetype=relative&relative=300`) for the same page. With these changes we are just appending the default query params when needed, but still support using the browser navigation to switch between different states of the current search (e.g. after changing time range).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.