### PR TITLE
Remove rickshaw css import from styleguide config

### DIFF
--- a/graylog2-web-interface/styleguide.config.js
+++ b/graylog2-web-interface/styleguide.config.js
@@ -9,7 +9,6 @@ module.exports = {
     'opensans-npm-webfont',
     'stylesheets/bootstrap-submenus.less',
     'toastr/toastr.less',
-    'rickshaw/rickshaw.css',
     'stylesheets/typeahead.less',
     'injection/builtins.js',
   ],


### PR DESCRIPTION
With https://github.com/Graylog2/graylog2-server/pull/7338 we remove the rickshaw package. This PR removes the related, not needed styleguide css import.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

