### PR TITLE
Handle message fields types not being available (on time).

### DIFF
--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.jsx
@@ -61,7 +61,7 @@ const isDecoratedField = (field, decorationStats) => decorationStats
 
 const fieldType = (fieldName, { decoration_stats: decorationStats }, fields) => (isDecoratedField(fieldName, decorationStats)
   ? FieldType.Decorated
-  : fields.find(t => t.name === fieldName, undefined, FieldTypeMapping.create(fieldName, FieldType.Unknown)).type);
+  : ((fields && fields.find(f => f.name === fieldName)) || { type: FieldType.Unknown }).type);
 
 const MessageTableEntry = ({
   disableSurroundingSearch,

--- a/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageTableEntry.jsx
@@ -10,7 +10,6 @@ import { StreamsStore } from 'views/stores/StreamsStore';
 import { SearchConfigStore } from 'views/stores/SearchConfigStore';
 
 import FieldType from 'views/logic/fieldtypes/FieldType';
-import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import type { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
 
 import MessageDetail from './MessageDetail';

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
@@ -144,7 +144,7 @@ class MessageTable extends React.Component<Props, State> {
     fields: CustomPropTypes.FieldListType.isRequired,
     messages: PropTypes.arrayOf(PropTypes.object).isRequired,
     selectedFields: PropTypes.object,
-  }
+  };
 
   static defaultProps = {
     selectedFields: Immutable.Set(),
@@ -164,7 +164,7 @@ class MessageTable extends React.Component<Props, State> {
   };
 
   _fieldTypeFor = (fieldName: string, fields: Immutable.List) => {
-    return (fields.find(f => f.name === fieldName) || { type: FieldType.Unknown }).type;
+    return ((fields && fields.find(f => f.name === fieldName)) || { type: FieldType.Unknown }).type;
   };
 
   _getFormattedMessages = (): Array<Object> => {

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.test.jsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { mount } from 'wrappedEnzyme';
 import * as Immutable from 'immutable';
 
+import suppressConsole from 'helpers/suppressConsole';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import FieldType from 'views/logic/fieldtypes/FieldType';
 import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
@@ -45,5 +46,19 @@ describe('MessageTable', () => {
     const messageTableEntry = wrapper.find('MessageTableEntry');
     const td = messageTableEntry.find('td').at(0);
     expect(td.text()).toContain('frank.txt');
+  });
+
+  it('renders a table entry for messages, even if fields are `undefined`', () => {
+    // Suppressing console to disable props warning because of `fields` being `undefined`.
+    suppressConsole(() => {
+      const wrapper = mount(<MessageTable messages={messages}
+                                          activeQueryId={activeQueryId}
+                                          // $FlowFixMe: violating contract on purpose
+                                          fields={undefined}
+                                          selectedFields={{}}
+                                          config={config} />);
+      const messageTableEntry = wrapper.find('MessageTableEntry');
+      expect(messageTableEntry).not.toBeEmptyRender();
+    });
   });
 });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, several users reported that under some circumstances
the message list widget raises an exception. Following the stack trace,
it looks like field types might not be available (being `undefined`) and
the `find` method called on it nevertheless, resulting in an exception.
This might be because of either a race condition or a missing/empty API
response.

I was unable to reproduce the error in my development setup while using
the product, even not by delaying the fields types store's response.
Nevertheless, I was able to reproduce it in the added test case, by
deliberately providing an `undefined` `fields` prop, allowing me to fix
the related code lines.

Fixes #7365.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.