### PR TITLE
Fix call of createNewVersionFromRev on undefined

### DIFF
--- a/graylog2-web-interface/src/pages/EditContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/EditContentPackPage.jsx
@@ -40,9 +40,9 @@ const EditContentPackPage = createReactClass({
 
   componentDidMount() {
     const { params } = this.props;
-    const { contentPackRevisions } = this.state;
 
-    ContentPacksActions.get(params.contentPackId).then(() => {
+    ContentPacksActions.get(params.contentPackId).then((result) => {
+      const { contentPackRevisions } = result;
       const originContentPackRev = params.contentPackRev;
       const newContentPack = contentPackRevisions.createNewVersionFromRev(originContentPackRev);
       this.setState({ contentPack: newContentPack, contentPackEntities: cloneDeep(newContentPack.entities) });


### PR DESCRIPTION
## Description, Motivation and Context
Prior to this change, createNewVersionFromRev was called on undefined
because contentPackRevisions was assumed to be in the state after
ContentPacksActions.get was called, but it was not.

This change will use the parameter from then action of the get function
which contains the contentPackRevisions.

Fixes #6690

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

