### PR TITLE
fix the link to ipfix docs.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/DocsHelper.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/DocsHelper.java
@@ -18,6 +18,7 @@ package org.graylog2.plugin;
 
 public enum DocsHelper {
     PAGE_SENDING_JSONPATH("sending_data.html#json-path-from-http-api-input"),
+    PAGE_SENDING_IPFIXPATH("integrations/inputs/ipfix_input.html"),
     PAGE_ES_CONFIGURATION("configuration/elasticsearch.html"),
     PAGE_LDAP_TROUBLESHOOTING("users_and_roles/external_auth.html#troubleshooting");
 


### PR DESCRIPTION
The details of the fix,is described in the issue below:
[354](https://github.com/Graylog2/graylog-plugin-integrations/issues/354)




## Description
The ipfix link is broken while navigating the links, system -> nodes -> details -> Available Inputs -> documentation.

## Motivation and Context
fix the broken documentation link for IPFIX.

## How Has This Been Tested?
-  tested this locally and is not working in my local, as the version is pointing to 3.3, if I manually
  change the version to 3.2 it works.
- needs to be backported to 3.2
 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

