### PR TITLE
Fix call of createNewVersionFromRev on undefined (#7442)

### DIFF
--- a/graylog2-web-interface/src/pages/EditContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/EditContentPackPage.jsx
@@ -40,9 +40,9 @@ const EditContentPackPage = createReactClass({
 
   componentDidMount() {
     const { params } = this.props;
-    const { contentPackRevisions } = this.state;
 
-    ContentPacksActions.get(params.contentPackId).then(() => {
+    ContentPacksActions.get(params.contentPackId).then((result) => {
+      const { contentPackRevisions } = result;
       const originContentPackRev = params.contentPackRev;
       const newContentPack = contentPackRevisions.createNewVersionFromRev(originContentPackRev);
       this.setState({ contentPack: newContentPack, contentPackEntities: cloneDeep(newContentPack.entities) });


### PR DESCRIPTION
Prior to this change, createNewVersionFromRev was called on undefined
because contentPackRevisions was assumed to be in the state after
ContentPacksActions.get was called, but it was not.

This change will use the parameter from then action of the get function
which contains the contentPackRevisions.

Fixes #6690

(cherry picked from commit 650c729fa2506da95eadcb7e1a7e71530ce02b30)
