### PR TITLE
Respect permissions for the current user role in UI Nav

### DIFF
--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -118,9 +118,11 @@ const Navigation = ({ permissions, fullName, location, loginName }) => {
             )
           }
 
-          <LinkContainer to={Routes.SYSTEM.NODES.LIST}>
-            <GlobalThroughput />
-          </LinkContainer>
+          <IfPermitted permissions={['throughput:read']}>
+            <LinkContainer to={Routes.SYSTEM.NODES.LIST}>
+              <GlobalThroughput />
+            </LinkContainer>
+          </IfPermitted>
           <ScratchpadToggle />
           <HelpMenu active={_isActive(location.pathname, Routes.GETTING_STARTED)} />
           <UserMenu fullName={fullName} loginName={loginName} />

--- a/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
@@ -57,8 +57,20 @@ describe('Navigation', () => {
     it('contains help menu', () => {
       expect(wrapper.find('HelpMenu')).toExist();
     });
-    it('contains global throughput', () => {
-      expect(wrapper.find('GlobalThroughput')).toExist();
+    describe('rendering global throughput', () => {
+      it('contains global throughput with the throughput:read role', () => {
+        const permissions = ['throughput:read'];
+        currentUser.permissions = permissions;
+        wrapper = mount(<Navigation permissions={permissions}
+                                    fullName="Sam Lowry"
+                                    location={{ pathname: '/' }}
+                                    loginName="slowry" />);
+
+        expect(wrapper.find('GlobalThroughput')).toExist();
+      });
+      it('does not contains global throughput without the proper roles', () => {
+        expect(wrapper.find('GlobalThroughput')).not.toExist();
+      });
     });
     it('contains notification badge', () => {
       expect(wrapper.find('NotificationBadge')).toExist();
@@ -150,8 +162,8 @@ describe('Navigation', () => {
     };
     it.each`
     permissions                    | count | links
-    ${[]}                          | ${4}  | ${['Streams', 'Alerts', 'Dashboards']}
-    ${['searches:absolute', 'searches:relative', 'searches:keyword']} | ${5}  | ${['Search']}
+    ${[]}                          | ${3}  | ${['Streams', 'Alerts', 'Dashboards']}
+    ${['searches:absolute', 'searches:relative', 'searches:keyword']} | ${4}  | ${['Search']}
   `('shows $links for user with $permissions permissions', verifyPermissions);
   });
 });

--- a/graylog2-web-interface/src/components/navigation/SystemMenu.jsx
+++ b/graylog2-web-interface/src/components/navigation/SystemMenu.jsx
@@ -102,20 +102,20 @@ const SystemMenu = ({ location }) => {
       <IfPermitted permissions={['users:list', 'roles:read']} anyPermissions>
         <NavigationLink path={Routes.SYSTEM.AUTHENTICATION.OVERVIEW} description="Authentication" />
       </IfPermitted>
-      <IfPermitted permissions={['dashboards:create', 'inputs:create', 'streams:create']}>
+      <IfPermitted permissions={['contentpack:read']}>
         <NavigationLink path={Routes.SYSTEM.CONTENTPACKS.LIST} description="Content Packs" />
       </IfPermitted>
-      <IfPermitted permissions={['inputs:edit']}>
+      <IfPermitted permissions={['inputs:read']}>
         <NavigationLink path={Routes.SYSTEM.GROKPATTERNS} description="Grok Patterns" />
       </IfPermitted>
-      <IfPermitted permissions={['inputs:edit']}>
+      <IfPermitted permissions={['lookuptables:read']}>
         <NavigationLink path={Routes.SYSTEM.LOOKUPTABLES.OVERVIEW} description="Lookup Tables" />
       </IfPermitted>
-      <IfPermitted permissions={['inputs:create']}>
+      <IfPermitted permissions={['pipeline:read', 'pipeline_rule:read']}>
         <NavigationLink path={Routes.SYSTEM.PIPELINES.OVERVIEW} description="Pipelines" />
       </IfPermitted>
       <NavigationLink path={Routes.SYSTEM.ENTERPRISE} description="Enterprise" />
-      <IfPermitted permissions={['inputs:edit']}>
+      <IfPermitted permissions={['sidecars:read', 'sidecar_collectors:read', 'sidecar_collector_configurations:read']}>
         <NavigationLink path={Routes.SYSTEM.SIDECARS.OVERVIEW} description="Sidecars" />
       </IfPermitted>
       {pluginSystemNavigations}

--- a/graylog2-web-interface/src/components/navigation/SystemMenu.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/SystemMenu.test.jsx
@@ -44,15 +44,17 @@ describe('SystemMenu', () => {
     permissions                    | count | links
     ${[]}                          | ${3}  | ${['Overview', 'Nodes', 'Enterprise']}
     ${['clusterconfigentry:read']} | ${4}  | ${['Configurations']}
-    ${['inputs:read']}             | ${4}  | ${['Inputs']}
+    ${['inputs:read']}             | ${5}  | ${['Inputs']}
     ${['outputs:read']}            | ${4}  | ${['Outputs']}
     ${['indices:read']}            | ${4}  | ${['Indices']}
     ${['loggers:read']}            | ${4}  | ${['Logging']}
     ${['users:list']}              | ${4}  | ${['Authentication']}
     ${['roles:read']}              | ${4}  | ${['Authentication']}
-    ${['dashboards:create', 'inputs:create', 'streams:create']} | ${5}  | ${['Content Packs']}
-    ${['inputs:edit']}             | ${6}  | ${['Grok Patterns', 'Lookup Tables', 'Sidecars']}
-    ${['inputs:create']}           | ${4}  | ${['Pipelines']}
+    ${['contentpack:read']}        | ${4}  | ${['Content Packs']}
+    ${['inputs:read']}             | ${5}  | ${['Grok Patterns']}
+    ${['lookuptables:read']}       | ${4}  | ${['Lookup Tables']}
+    ${['sidecars:read', 'sidecar_collectors:read', 'sidecar_collector_configurations:read']}>       | ${4}  | ${['Sidecars']}
+    ${['pipeline:read', 'pipeline_rule:read']} | ${4}  | ${['Pipelines']}
   `('shows $links for user with $permissions permissions', verifyPermissions);
   });
   describe('uses items from plugins:', () => {


### PR DESCRIPTION

## Description
The UI navigation bar did not get updated With the addition of the granular
permissions.

This will fix the following nav items:

* Hide the global throughput counter without `throughput:read`
* `System/Content Packs` -> from: `inputs:read`, to: `contentpacks:read`
* `System/Lookup Tables` -> from: `inputs:read`, to: `lookuptables:read`
* `System/Pipelines` -> from `inputs:read`, to `pipeline:read` or `pipeline_rule:read`
* `System/Sidecars` -> from `inputs:read`, to `sidecars:read` or `sidecar_collectors:read' or 'sidecar_collector_configurations:read`

## Motivation and Context
Fixes #5206


## How Has This Been Tested?
There are unit tests and verified running locally with the different roles

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

