### PR TITLE
Fix field name extraction in dashboard migration (#7448)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/viewwidgets/Series.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/viewwidgets/Series.java
@@ -28,7 +28,7 @@ public abstract class Series {
     private static final String FIELD_CONFIG = "config";
     private static final String FIELD_FUNCTION = "function";
 
-    private static final Pattern destructuringPattern = Pattern.compile("(\\w+)\\((\\w+)?\\)");
+    private static final Pattern destructuringPattern = Pattern.compile("(\\w+)\\(([\\w@-]+)?\\)");
 
     @JsonProperty(FIELD_CONFIG)
     public abstract SeriesConfig config();

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/viewwidgets/SeriesTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/viewwidgets/SeriesTest.java
@@ -17,31 +17,44 @@
 package org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.viewwidgets;
 
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.SeriesSpec;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
-class SeriesTest {
+@RunWith(Parameterized.class)
+public class SeriesTest {
 
-    @ParameterizedTest
-    @ValueSource(strings = {
-            "simple",
-            "mixedCasING",
-            "with_underscore",
-            "_leadingunderscore",
-            "trailingunderscore_",
-            "with-dash",
-            "-leadingdash",
-            "trailingdash-",
-            "with@at",
-            "@leadingat",
-            "trailingat_",
-            "-@_"
-    })
-    void canDestructureAllValidFieldNames(String fieldName) {
+    private final String fieldName;
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"simple"},
+                {"mixedCasING"},
+                {"with_underscore"},
+                {"_leadingunderscore"},
+                {"trailingunderscore_"},
+                {"with-dash"},
+                {"-leadingdash"},
+                {"trailingdash-"},
+                {"with@at"},
+                {"@leadingat"},
+                {"trailingat_"},
+                {"-@_"}
+        });
+    }
+
+    public SeriesTest(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    @Test
+    public void canDestructureAllValidFieldNames() {
 
         Series sut = Series.builder().function("avg(" + fieldName + ")").build();
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/viewwidgets/SeriesTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/viewwidgets/SeriesTest.java
@@ -1,0 +1,52 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.viewwidgets;
+
+import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.SeriesSpec;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class SeriesTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "simple",
+            "mixedCasING",
+            "with_underscore",
+            "_leadingunderscore",
+            "trailingunderscore_",
+            "with-dash",
+            "-leadingdash",
+            "trailingdash-",
+            "with@at",
+            "@leadingat",
+            "trailingat_",
+            "-@_"
+    })
+    void canDestructureAllValidFieldNames(String fieldName) {
+
+        Series sut = Series.builder().function("avg(" + fieldName + ")").build();
+
+        SeriesSpec seriesSpec = sut.toSeriesSpec();
+
+        assertThat(seriesSpec.field()).contains(fieldName);
+    }
+}


### PR DESCRIPTION
The extraction of field names from series widgets' function
expression assumed that field names could contain only
alphanumeric characters and underscores.
Actually they may contain `-` and `@` as well.

(cherry picked from commit 27269f2dfe36c12bd88adad661e613660eeb5cca)
