### PR TITLE
Unify styled-component component type definitions

### DIFF
--- a/graylog2-web-interface/src/components/configurations/decorators/StreamSelect.jsx
+++ b/graylog2-web-interface/src/components/configurations/decorators/StreamSelect.jsx
@@ -1,7 +1,7 @@
 // @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { type StyledComponent } from 'styled-components';
 
 import Select from 'components/common/Select';
 import type { Stream } from 'stores/streams/StreamsStore';
@@ -10,7 +10,7 @@ import { defaultCompare } from 'views/logic/DefaultCompare';
 export const DEFAULT_STREAM_ID = '000000000000000000000001';
 export const DEFAULT_SEARCH_ID = 'DEFAULT_SEARCH';
 
-const SelectContainer: React.ComponentType<{}> = styled.div`
+const SelectContainer: StyledComponent<{}, {}, HTMLDivElement> = styled.div`
   margin-bottom: 10px;
 `;
 

--- a/graylog2-web-interface/src/views/components/EmptyValue.jsx
+++ b/graylog2-web-interface/src/views/components/EmptyValue.jsx
@@ -1,8 +1,8 @@
 // @flow strict
 import * as React from 'react';
-import styled from 'styled-components';
+import styled, { type StyledComponent } from 'styled-components';
 
-const Container: React.ComponentType<{}> = styled.i`
+const Container: StyledComponent<{}, {}, HTMLElement> = styled.i`
   color: darkgray;
 `;
 

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { Col, Row } from 'components/graylog';
 import * as Immutable from 'immutable';
 import { PluginStore } from 'graylog-web-plugin/plugin';
-import styled from 'styled-components';
+import styled, { type StyledComponent } from 'styled-components';
 
 import CustomPropTypes from 'views/components/CustomPropTypes';
 import { defaultCompare } from 'views/logic/DefaultCompare';
@@ -33,7 +33,7 @@ type State = {
   config: AggregationWidgetConfig,
 };
 
-const Container: React.ComponentType<{}> = styled.div`
+const Container: StyledComponent<{}, {}, HTMLDivElement> = styled.div`
   display: grid;
   grid-template-rows: auto minmax(auto, 1fr);
   height: 100%;

--- a/graylog2-web-interface/src/views/components/horizontalspacer/HorizontalSpacer.jsx
+++ b/graylog2-web-interface/src/views/components/horizontalspacer/HorizontalSpacer.jsx
@@ -1,7 +1,7 @@
 // @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { type StyledComponent } from 'styled-components';
 
 /**
  * Component to display horisontal space.
@@ -16,7 +16,7 @@ type Props = {
   className?: string,
 };
 
-const Spacer: React.ComponentType<Props> = styled.div`
+const Spacer: StyledComponent<Props, {}, HTMLDivElement> = styled.div`
   width: 100%;
   height: ${props => props.height}px;
 `;

--- a/graylog2-web-interface/src/views/components/sidebar/NavItem.styles.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/NavItem.styles.jsx
@@ -1,13 +1,12 @@
 // @flow strict
-import * as React from 'react';
-import styled, { css } from 'styled-components';
+import styled, { type StyledComponent, css } from 'styled-components';
 
 type StyleProps = {
   isSelected: boolean,
   expandRight: boolean,
 };
 
-export const Title: React.ComponentType<StyleProps> = styled.div(({ isSelected, expandRight }) => css`
+export const Title: StyledComponent<StyleProps, {}, HTMLDivElement> = styled.div(({ isSelected, expandRight }) => css`
   padding: 9px 10px;
   display: flex;
   align-items: center;
@@ -31,7 +30,7 @@ export const Title: React.ComponentType<StyleProps> = styled.div(({ isSelected, 
   `)}
 `);
 
-export const TitleText: React.ComponentType<{}> = styled.div`
+export const TitleText: StyledComponent<{}, {}, HTMLDivElement> = styled.div`
   font-size: 16px;
   display: inline;
   margin-left: 10px;
@@ -39,14 +38,14 @@ export const TitleText: React.ComponentType<{}> = styled.div`
   white-space: nowrap;
 `;
 
-export const TitleIcon: React.ComponentType<{}> = styled.div`
+export const TitleIcon: StyledComponent<{}, {}, HTMLDivElement> = styled.div`
   width: 25px;
   text-align: center;
   font-size: 20px;
   cursor: pointer;
 `;
 
-export const Content: React.ComponentType<StyleProps> = styled.div(({ isSelected, expandRight }) => css`
+export const Content: StyledComponent<StyleProps, {}, HTMLDivElement> = styled.div(({ isSelected, expandRight }) => css`
   color: #666666;
   background: #FFFFFF;
   box-shadow:

--- a/graylog2-web-interface/src/views/components/sidebar/Sidebar.styles.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/Sidebar.styles.jsx
@@ -1,9 +1,8 @@
-import * as React from 'react';
-import styled from 'styled-components';
-
+// @flow strict
+import styled, { type StyledComponent } from 'styled-components';
 import { Title as NavItemTitle } from './NavItem.styles';
 
-export const Container: React.ComponentType<{ open: boolean }> = styled.div`
+export const Container: StyledComponent<{ open: boolean }, {}, HTMLDivElement> = styled.div`
   grid-area: sidebar;
   z-index: 3;
   background: #393939;
@@ -17,7 +16,7 @@ export const Container: React.ComponentType<{ open: boolean }> = styled.div`
   box-shadow: 3px 0 3px rgba(0, 0, 0, .25);
 `;
 
-export const ContentOverlay = styled.div`
+export const ContentOverlay: StyledComponent<{}, {}, HTMLDivElement> = styled.div`
   position: fixed;
   top: 0;
   bottom: 0;
@@ -26,28 +25,30 @@ export const ContentOverlay = styled.div`
   background: rgba(3, 3, 3, 0.25);
 `;
 
-export const SidebarHeader: React.ComponentType<{open: boolean, hasTitle: boolean}> = styled(NavItemTitle)(({ open, hasTitle }) => {
-  let justifyContent = 'center';
-  if (open && hasTitle) justifyContent = 'space-between';
-  if (open && !hasTitle) justifyContent = 'flex-end';
-  return `justify-content: ${justifyContent}`;
-});
+export const SidebarHeader: StyledComponent<{open: boolean, hasTitle: boolean}, {}, React.ComponentType> = styled(NavItemTitle)`
+  ${(({ open, hasTitle }) => {
+    let justifyContent = 'center';
+    if (open && hasTitle) justifyContent = 'space-between';
+    if (open && !hasTitle) justifyContent = 'flex-end';
+    return `justify-content: ${justifyContent}`;
+  })}
+`;
 
-export const Headline = styled.h3`
+export const Headline: StyledComponent<{}, {}, HTMLHeadingElement> = styled.h3`
   color: inherit;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 `;
 
-export const ToggleIcon = styled.div`
+export const ToggleIcon: StyledComponent<{}, {}, HTMLDivElement> = styled.div`
   width: 25px;
   text-align: center;
   font-size: 20px;
   cursor: pointer;
 `;
 
-export const HorizontalRuler = styled.div`
+export const HorizontalRuler: StyledComponent<{}, {}, HTMLDivElement> = styled.div`
   width: 100%;
   padding: 0 10px;
   margin: 5px 0 10px 0;

--- a/graylog2-web-interface/src/views/components/visualizations/number/AutoFontSizer.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/AutoFontSizer.jsx
@@ -1,8 +1,8 @@
 // @flow strict
-import React, { type Element, type ElementRef, type AbstractComponent, useEffect, useRef, useState } from 'react';
-import styled from 'styled-components';
+import React, { type Element, type ElementRef, useEffect, useRef, useState } from 'react';
+import styled, { type StyledComponent } from 'styled-components';
 
-const FontSize: AbstractComponent<{ fontSize: number }> = styled.div`
+const FontSize: StyledComponent<{ fontSize: number }, {}, HTMLDivElement> = styled.div`
   height: 100%;
   width: 100%;
   font-size: ${props => `${props.fontSize}px`};

--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.jsx
@@ -1,6 +1,6 @@
 // @flow strict
-import React, { type AbstractComponent, useContext, useEffect, useRef } from 'react';
-import styled from 'styled-components';
+import React, { useContext, useEffect, useRef } from 'react';
+import styled, { type StyledComponent } from 'styled-components';
 import { SizeMe } from 'react-sizeme';
 
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
@@ -17,7 +17,7 @@ import Trend from './Trend';
 import AutoFontSizer from './AutoFontSizer';
 import type { CurrentViewType } from '../../CustomPropTypes';
 
-const GridContainer: AbstractComponent<{}> = styled.div`
+const GridContainer: StyledComponent<{}, {}, HTMLDivElement> = styled.div`
   display: grid;
   grid-template-columns: 1fr;
   grid-template-rows: 4fr 1fr;

--- a/graylog2-web-interface/src/views/components/visualizations/number/Trend.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/Trend.jsx
@@ -1,6 +1,6 @@
 // @flow strict
 import * as React from 'react';
-import styled, { css } from 'styled-components';
+import styled, { type StyledComponent, css } from 'styled-components';
 import numeral from 'numeral';
 
 import { teinte, util } from 'theme';
@@ -18,7 +18,7 @@ type Props = {
   trendPreference: TrendPreference,
 };
 
-const Background: React.AbstractComponent<{trend: ?string}> = styled.div(({ trend }) => {
+const Background: StyledComponent<{trend: ?string}, {}, HTMLDivElement> = styled.div(({ trend }) => {
   const bgColor = trend && trend === TREND_GOOD ? teinte.tertiary.tre : teinte.tertiary.quattro;
 
   return css`

--- a/graylog2-web-interface/src/views/components/widgets/UnknownWidget.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/UnknownWidget.jsx
@@ -1,8 +1,7 @@
 // @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
-import type { StyledComponent } from 'styled-components';
+import styled, { type StyledComponent } from 'styled-components';
 
 import { Icon } from 'components/common';
 import ClipboardButton from 'components/common/ClipboardButton';


### PR DESCRIPTION
This PR unifies the type definitions for all styled components by using the StyledComponent type from styled-components instead of React.ComponentType or React.AbstractComponent.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

