### PR TITLE
Fix issue 7472 by using containsExactlyInAnyOrder instead of containsExactly

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewSharingResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewSharingResourceTest.java
@@ -88,7 +88,7 @@ public class ViewSharingResourceTest {
 
         final Set<UserShortSummary> users = this.viewSharingResource.summarizeUsers("viewId");
 
-        assertThat(users).containsExactly(
+        assertThat(users).containsExactlyInAnyOrder(
                 UserShortSummary.create("franz", "Franz Josef Strauss"),
                 UserShortSummary.create("friedrich", "Friedrich Merz")
         );
@@ -111,7 +111,7 @@ public class ViewSharingResourceTest {
 
         final Set<UserShortSummary> users = this.viewSharingResource.summarizeUsers("viewId");
 
-        assertThat(users).containsExactly(
+        assertThat(users).containsExactlyInAnyOrder(
                 UserShortSummary.create("franz", "Franz Josef Strauss"),
                 UserShortSummary.create("friedrich", "Friedrich Merz"),
                 UserShortSummary.create("peter", "Peter Altmaier")


### PR DESCRIPTION
This PR fixes #7472 
## Description
<!--- Describe your changes in detail -->
The fix uses containsExactlyInAnyOrder instead of containsExactly so that the test is more stable.
For detailed analysis, please refer to #7472 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

