### PR TITLE
Prevent double qualification of route path for stream search page.

### DIFF
--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -224,6 +224,7 @@ const qualifyUrls = (routes, appPrefix) => {
 };
 
 const defaultExport = AppConfig.gl2AppPathPrefix() ? qualifyUrls(Routes, AppConfig.gl2AppPathPrefix()) : Routes;
+defaultExport.unqualified = Routes;
 
 /*
  * Global registry of plugin routes. Route names are generated automatically from the route path, by removing

--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -116,7 +116,7 @@ export default {
     { path: newDashboardsPath, component: NewDashboardPage, parentComponent: AppWithExtendedSearchBar },
     { path: showSearchPath, component: ShowViewPage, parentComponent: AppWithExtendedSearchBar },
     { path: dashboardsTvPath, component: ShowDashboardInBigDisplayMode, parentComponent: null },
-    { path: Routes.stream_search(':streamId'), component: StreamSearchPage, parentComponent: AppWithExtendedSearchBar },
+    { path: Routes.unqualified.stream_search(':streamId'), component: StreamSearchPage, parentComponent: AppWithExtendedSearchBar },
     { path: dashboardsPath, component: DashboardsPage },
     { path: showDashboardsPath, component: ShowViewPage, parentComponent: AppWithExtendedSearchBar },
     { path: extendedSearchPath, component: NewSearchPage, permissions: Permissions.ExtendedSearch.Use },

--- a/graylog2-web-interface/src/views/bindings.routes.test.jsx
+++ b/graylog2-web-interface/src/views/bindings.routes.test.jsx
@@ -1,0 +1,15 @@
+// @flow strict
+import { StreamSearchPage } from 'views/pages';
+import bindings from './bindings';
+
+jest.mock('util/AppConfig', () => ({
+  gl2ServerUrl: () => 'localhost:9000/api/',
+  gl2AppPathPrefix: jest.fn(() => '/gl2/'),
+}));
+
+describe('bindings.routes', () => {
+  it('Stream search route must be unqualified', () => {
+    const streamSearchPageRoute = bindings.routes.find(({ component }) => (component === StreamSearchPage));
+    expect(streamSearchPageRoute.path).toEqual('/streams/:streamId/search');
+  });
+});

--- a/graylog2-web-interface/src/views/bindings.routes.test.jsx
+++ b/graylog2-web-interface/src/views/bindings.routes.test.jsx
@@ -10,6 +10,9 @@ jest.mock('util/AppConfig', () => ({
 describe('bindings.routes', () => {
   it('Stream search route must be unqualified', () => {
     const streamSearchPageRoute = bindings.routes.find(({ component }) => (component === StreamSearchPage));
+    if (!streamSearchPageRoute) {
+      throw new Error('Stream search page route was not registered.');
+    }
     expect(streamSearchPageRoute.path).toEqual('/streams/:streamId/search');
   });
 });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As reported in #7447, the stream search page is not accessible when running the web interface behind a reverse proxy that adds a path prefix. This is related to the plugin route registration, which uses a route helper (`Routes.stream_search(':streamId')`) to ensure path consistency, which qualifies each path returned with the globally configured application path prefix. Unfortunately, all plugin route's are qualified once again before `react-router`'s consumption.

This PR is now exporting unqualified route from the global `Routes` file, which can be used for plugin routes to prevent double qualification.

*Requires a backport for 3.2.*

Fixes #7447.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

[Caddy](https://caddyserver.com) has been used, configured as a reverse proxy for the Graylog server with a path prefix of `/gl2`, with a `Caddyfile` like this:

```
localhost:2015 {
	proxy /gl2/ localhost:9000 {
		without /gl2/
	}
}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.