### PR TITLE
Fix ClassCastException in MongoDbSession#getTimeout()

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/security/MongoDbSession.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/MongoDbSession.java
@@ -109,7 +109,7 @@ public class MongoDbSession extends PersistedImpl {
     public long getTimeout() {
         final Object timeout = fields.get("timeout");
         if (timeout == null) return 0;
-        return (Long) timeout;
+        return ((Number) timeout).longValue();
     }
 
     public Date getStartTimestamp() {


### PR DESCRIPTION
Cast the value to a Number instead of a Long and then use ".longValue()"
to avoid the exception.

This mostly happened when the session timeout was -1 and MongoDB
returned an integer instead of a long for that.

It has been broken for a long time but it never showed up because the
ExecutorServiceSessionValidationScheduler in shiro didn't catch
exceptions and had no uncaught exception handler.

Since shiro 1.5.0 this has been fixed and we see the ClassCastException
in the graylog logs. (we are still running shiro 1.4.0 in master, I noticed that in #7466)