### PR TITLE
Use function instead of field for sort when migrating widgets. (#7478) (3.2)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/QuickValuesConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/QuickValuesConfig.java
@@ -94,7 +94,7 @@ public abstract class QuickValuesConfig extends WidgetConfigBase implements Widg
     }
 
     private SortConfig sort() {
-        return SeriesSortConfig.create(field(), order());
+        return SeriesSortConfig.create(series().function(), order());
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/V20191125144500_MigrateDashboardsToViewsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/V20191125144500_MigrateDashboardsToViewsTest.java
@@ -408,6 +408,19 @@ public class V20191125144500_MigrateDashboardsToViewsTest {
                 .containsExactlyInAnyOrder("table", "pie");
     }
 
+    @Test
+    @MongoDBFixtures("quickvalues_widget_with_sort_order.json")
+    public void migratesAQuickValuesWidgetWithSortOrder() throws Exception {
+        this.migration.upgrade();
+
+        final MigrationCompleted migrationCompleted = captureMigrationCompleted();
+        assertThat(migrationCompleted.migratedDashboardIds()).containsExactly("5b3b76caadbe1d0001417041");
+        assertThat(migrationCompleted.widgetMigrationIds()).hasSize(2);
+
+        assertViewsWritten(1, resourceFile("quickvalues_widget_with_sort_order-expected_views.json"));
+        assertSearchesWritten(1, resourceFile("quickvalues_widget_with_sort_order-expected_searches.json"));
+    }
+
 
     private void assertSearchesWritten(int count, String expectedEntities) throws Exception {
         final ArgumentCaptor<Search> newSearchesCaptor = ArgumentCaptor.forClass(Search.class);
@@ -415,7 +428,7 @@ public class V20191125144500_MigrateDashboardsToViewsTest {
         final List<Search> newSearches = newSearchesCaptor.getAllValues();
         assertThat(newSearches).hasSize(count);
 
-        JSONAssert.assertEquals(toJSON(newSearches), expectedEntities, false);
+        JSONAssert.assertEquals(expectedEntities, toJSON(newSearches), false);
     }
 
     private void assertViewsWritten(int count, String expectedEntities) throws Exception {
@@ -424,7 +437,7 @@ public class V20191125144500_MigrateDashboardsToViewsTest {
         final List<View> newViews = newViewsCaptor.getAllValues();
         assertThat(newViews).hasSize(count);
 
-        JSONAssert.assertEquals(toJSON(newViews), expectedEntities, false);
+        JSONAssert.assertEquals(expectedEntities, toJSON(newViews), false);
     }
 
     private MigrationCompleted captureMigrationCompleted() {

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_minimal_quickvalues_widget-expected_searches.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_minimal_quickvalues_widget-expected_searches.json
@@ -29,7 +29,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "facility",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -60,7 +60,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "facility",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_minimal_quickvalues_widget-expected_views.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_minimal_quickvalues_widget-expected_views.json
@@ -46,7 +46,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "facility",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "pie",
@@ -84,7 +84,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "facility",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/ops_dashboards-expected_searches.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/ops_dashboards-expected_searches.json
@@ -52,7 +52,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "ClientRequestURI",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -163,7 +163,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "ClientIpGeoCityCode",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -194,7 +194,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "ClientIpGeoCountry",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -225,7 +225,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "ClientRequestUserAgent",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -322,7 +322,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "ClientRequestMethod",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -376,7 +376,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "ClientRequestURI",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -434,7 +434,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "ClientRequestReferer",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -465,7 +465,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "ClientRequestProtocol",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -544,7 +544,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "EdgeResponseContentType",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -623,7 +623,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "ClientIpGeoCityCode",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -684,7 +684,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "ClientIpGeoCountry",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -715,7 +715,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "ClientDeviceType",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -787,7 +787,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "ClientRequestUserAgent",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -818,7 +818,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "ThreatType",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -849,7 +849,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "ThreatType",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -884,7 +884,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "ClientIP",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -940,7 +940,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "ClientIpGeoCountry",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -1032,7 +1032,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "ClientIpGeoCityCode",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -1133,7 +1133,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "OriginResponseStatusClass",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -1210,7 +1210,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "ClientRequestURI",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -1241,7 +1241,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "EdgeResponseStatusClass",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -1310,7 +1310,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "EdgeResponseStatusClass",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -1366,7 +1366,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "OriginResponseStatusClass",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -1481,7 +1481,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "ClientRequestURI",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -1599,7 +1599,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "CacheCacheStatus",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -1916,7 +1916,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "ClientRequestURI",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/ops_dashboards-expected_views.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/ops_dashboards-expected_views.json
@@ -52,7 +52,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "ClientIpGeoCityCode",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -90,7 +90,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "ClientRequestURI",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -196,7 +196,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "ClientIpGeoCountry",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -299,7 +299,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "ClientRequestUserAgent",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -473,7 +473,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "ClientIpGeoCityCode",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -511,7 +511,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "ClientDeviceType",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -619,7 +619,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "ClientRequestReferer",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -657,7 +657,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "ClientRequestURI",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -695,7 +695,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "ClientRequestProtocol",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -795,7 +795,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "ClientRequestMethod",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -833,7 +833,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "EdgeResponseContentType",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -902,7 +902,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "ClientIpGeoCountry",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -1086,7 +1086,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "ThreatType",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -1124,7 +1124,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "ClientIpGeoCityCode",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -1227,7 +1227,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "ThreatType",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -1265,7 +1265,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "ClientIpGeoCountry",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -1383,7 +1383,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "ClientRequestUserAgent",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -1421,7 +1421,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "ClientIP",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -1702,7 +1702,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "OriginResponseStatusClass",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "pie",
@@ -1740,7 +1740,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "OriginResponseStatusClass",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -1871,7 +1871,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "EdgeResponseStatusClass",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "pie",
@@ -1909,7 +1909,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "EdgeResponseStatusClass",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -1947,7 +1947,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "ClientRequestURI",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -1985,7 +1985,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "ClientRequestURI",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -2235,7 +2235,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "ClientRequestURI",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",
@@ -2273,7 +2273,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "CacheCacheStatus",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/quickvalues_widget_with_sort_order-expected_searches.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/quickvalues_widget_with_sort_order-expected_searches.json
@@ -1,0 +1,104 @@
+[
+  {
+    "id": "5de0e98900002a0017000001",
+    "queries": [
+      {
+        "id": "0000016e-b690-4273-0000-016eb690426f",
+        "timerange": {
+          "type": "relative",
+          "range": 300
+        },
+        "query": {
+          "type": "elasticsearch",
+          "query_string": ""
+        },
+        "search_types": [
+          {
+            "id": "0000016e-b690-4271-0000-016eb690426f",
+            "timerange": {
+              "type": "relative",
+              "range": 86400
+            },
+            "query": {
+              "type": "elasticsearch",
+              "query_string": ""
+            },
+            "streams": [
+              "5b3b7403adbe1d0001416d1d"
+            ],
+            "name": "chart",
+            "series": [
+              {
+                "type": "count",
+                "id": "count()",
+                "field": null
+              }
+            ],
+            "sort": [
+              {
+                "type": "series",
+                "field": "count()",
+                "direction": "Descending"
+              }
+            ],
+            "rollup": true,
+            "type": "pivot",
+            "filter": null,
+            "row_groups": [
+              {
+                "field": "request",
+                "limit": 500,
+                "type": "values"
+              }
+            ],
+            "column_groups": []
+          },
+          {
+            "id": "0000016e-b690-4272-0000-016eb690426f",
+            "timerange": {
+              "type": "relative",
+              "range": 86400
+            },
+            "query": {
+              "type": "elasticsearch",
+              "query_string": ""
+            },
+            "streams": [
+              "5b3b7403adbe1d0001416d1d"
+            ],
+            "name": "chart",
+            "series": [
+              {
+                "type": "count",
+                "id": "count()",
+                "field": null
+              }
+            ],
+            "sort": [
+              {
+                "type": "series",
+                "field": "count()",
+                "direction": "Ascending"
+              }
+            ],
+            "rollup": true,
+            "type": "pivot",
+            "filter": null,
+            "row_groups": [
+              {
+                "field": "request",
+                "limit": 500,
+                "type": "values"
+              }
+            ],
+            "column_groups": []
+          }
+        ]
+      }
+    ],
+    "parameters": [],
+    "owner": "admin",
+    "created_at": "2018-07-03T13:14:50.346Z",
+    "requires": {}
+  }
+]

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/quickvalues_widget_with_sort_order-expected_views.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/quickvalues_widget_with_sort_order-expected_views.json
@@ -1,0 +1,150 @@
+[
+  {
+    "id": "5b3b76caadbe1d0001417041",
+    "type": "DASHBOARD",
+    "title": "HTTP Access Logs",
+    "summary": "This dashboard was migrated automatically.",
+    "description": "All HTTP access log data",
+    "search_id": "5de0e98900002a0017000001",
+    "state": {
+      "0000016e-b690-4273-0000-016eb690426f": {
+        "titles": {
+          "widget": {
+            "0000016e-b690-426f-0000-016eb690426f": "Top 10 Requests (24h)",
+            "0000016e-b690-4270-0000-016eb690426f": "Bottom 10 Requests (24h)"
+          },
+          "tab": {
+            "title": "HTTP Access Logs"
+          }
+        },
+        "widgets": [
+          {
+            "id": "0000016e-b690-426f-0000-016eb690426f",
+            "type": "aggregation",
+            "filter": null,
+            "timerange": {
+              "type": "relative",
+              "range": 86400
+            },
+            "query": {
+              "type": "elasticsearch",
+              "query_string": ""
+            },
+            "streams": [
+              "5b3b7403adbe1d0001416d1d"
+            ],
+            "config": {
+              "row_pivots": [
+                {
+                  "field": "request",
+                  "type": "values",
+                  "config": {
+                    "limit": 500
+                  }
+                }
+              ],
+              "column_pivots": [],
+              "series": [
+                {
+                  "config": {
+                    "name": null
+                  },
+                  "function": "count()"
+                }
+              ],
+              "sort": [
+                {
+                  "type": "series",
+                  "field": "count()",
+                  "direction": "Descending"
+                }
+              ],
+              "visualization": "table",
+              "visualization_config": null,
+              "rollup": true,
+              "formatting_settings": null
+            }
+          },
+          {
+            "id": "0000016e-b690-4270-0000-016eb690426f",
+            "type": "aggregation",
+            "filter": null,
+            "timerange": {
+              "type": "relative",
+              "range": 86400
+            },
+            "query": {
+              "type": "elasticsearch",
+              "query_string": ""
+            },
+            "streams": [
+              "5b3b7403adbe1d0001416d1d"
+            ],
+            "config": {
+              "row_pivots": [
+                {
+                  "field": "request",
+                  "type": "values",
+                  "config": {
+                    "limit": 500
+                  }
+                }
+              ],
+              "column_pivots": [],
+              "series": [
+                {
+                  "config": {
+                    "name": null
+                  },
+                  "function": "count()"
+                }
+              ],
+              "sort": [
+                {
+                  "type": "series",
+                  "field": "count()",
+                  "direction": "Ascending"
+                }
+              ],
+              "visualization": "table",
+              "visualization_config": null,
+              "rollup": true,
+              "formatting_settings": null
+            }
+          }
+        ],
+        "widget_mapping": {
+          "0000016e-b690-4270-0000-016eb690426f": [
+            "0000016e-b690-4272-0000-016eb690426f"
+          ],
+          "0000016e-b690-426f-0000-016eb690426f": [
+            "0000016e-b690-4271-0000-016eb690426f"
+          ]
+        },
+        "positions": {
+          "0000016e-b690-4270-0000-016eb690426f": {
+            "col": 1,
+            "row": 13,
+            "height": 6,
+            "width": 4
+          },
+          "0000016e-b690-426f-0000-016eb690426f": {
+            "col": 1,
+            "row": 7,
+            "height": 6,
+            "width": 4
+          }
+        },
+        "selected_fields": null,
+        "static_message_list_id": null,
+        "display_mode_settings": {
+          "positions": {}
+        }
+      }
+    },
+    "owner": "admin",
+    "created_at": "2018-07-03T13:14:50.346Z",
+    "requires": {},
+    "properties": []
+  }
+]

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/quickvalues_widget_with_sort_order.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/quickvalues_widget_with_sort_order.json
@@ -1,0 +1,75 @@
+{
+  "dashboards": [
+    {
+      "_id": {
+        "$oid": "5b3b76caadbe1d0001417041"
+      },
+      "creator_user_id": "admin",
+      "description": "All HTTP access log data",
+      "created_at": {
+        "$date": "2018-07-03T13:14:50.346Z"
+      },
+      "positions": {
+        "48a82963-5c44-496e-aeae-cbf972c79e2f": {
+          "width": 4,
+          "col": 1,
+          "row": 7,
+          "height": 6
+        },
+        "9aac59bd-da65-46fe-b5b3-1df84a177dc0": {
+          "width": 4,
+          "col": 1,
+          "row": 13,
+          "height": 6
+        }
+      },
+      "title": "HTTP Access Logs",
+      "widgets": [
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Bottom 10 Requests (24h)",
+          "id": "9aac59bd-da65-46fe-b5b3-1df84a177dc0",
+          "type": "QUICKVALUES",
+          "config": {
+            "timerange": {
+              "type": "relative",
+              "range": 86400
+            },
+            "field": "request",
+            "stream_id": "5b3b7403adbe1d0001416d1d",
+            "query": "",
+            "show_data_table": true,
+            "limit": 10,
+            "show_pie_chart": false,
+            "sort_order": "asc",
+            "stacked_fields": "",
+            "data_table_limit": 500
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Top 10 Requests (24h)",
+          "id": "48a82963-5c44-496e-aeae-cbf972c79e2f",
+          "type": "QUICKVALUES",
+          "config": {
+            "timerange": {
+              "type": "relative",
+              "range": 86400
+            },
+            "field": "request",
+            "stream_id": "5b3b7403adbe1d0001416d1d",
+            "query": "",
+            "show_data_table": true,
+            "limit": 10,
+            "show_pie_chart": false,
+            "sort_order": "desc",
+            "stacked_fields": "",
+            "data_table_limit": 500
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/sample_dashboard-expected_searches.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/sample_dashboard-expected_searches.json
@@ -432,7 +432,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "facility",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,
@@ -463,7 +463,7 @@
       } ],
       "sort" : [ {
         "type" : "series",
-        "field" : "facility",
+        "field" : "count()",
         "direction" : "Descending"
       } ],
       "rollup" : true,

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/sample_dashboard-expected_views.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/sample_dashboard-expected_views.json
@@ -290,7 +290,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "facility",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "pie",
@@ -328,7 +328,7 @@
           } ],
           "sort" : [ {
             "type" : "series",
-            "field" : "facility",
+            "field" : "count()",
             "direction" : "Descending"
           } ],
           "visualization" : "table",


### PR DESCRIPTION
* Adding test case for correct migration of sorting (top/bottom values).

* Use series function instead of field name for sort.

* Adapting pre-existing test fixtures.

(cherry picked from commit 59b50d9759319be91563dd811e2726fcc6e8cef8)