### PR TITLE
Suffixing field names in auto completion with colon (':').

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.js
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.js
@@ -11,8 +11,8 @@ import type { Completer } from '../SearchBarAutocompletions';
 const _fieldResult = (field: FieldTypeMapping, score: number = 1): CompletionResult => {
   const { name, type } = field;
   return {
-    name: name,
-    value: name,
+    name,
+    value: `${name}:`,
     score,
     meta: type.type,
   };

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.test.jsx
@@ -1,0 +1,7 @@
+// @flow strict
+import FieldNameCompletion from './FieldNameCompletion';
+
+describe('FieldNameCompletion', () => {
+  it('should do something', () => {
+  });
+});

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.test.jsx
@@ -1,7 +1,49 @@
 // @flow strict
+import { StoreMock as MockStore } from 'helpers/mocking';
+import asMock from 'helpers/mocking/AsMock';
+import { FieldTypesStore } from 'views/stores/FieldTypesStore';
+
 import FieldNameCompletion from './FieldNameCompletion';
 
+jest.mock('views/stores/FieldTypesStore', () => ({
+  FieldTypesStore: MockStore(
+    'listen',
+    ['getInitialState', jest.fn(() => ({ all: [], queryFields: { get: () => [] } }))],
+  ),
+}));
+
+const _createField = name => ({ name, type: { type: 'string' } });
+const dummyFields = ['source', 'message', 'timestamp'].map(_createField);
+
+const _createQueryFields = fields => ({ get: () => fields });
+const _createFieldTypesStoreState = fields => ({ all: fields, queryFields: _createQueryFields(fields) });
+
 describe('FieldNameCompletion', () => {
-  it('should do something', () => {
+  beforeEach(() => {
+    asMock(FieldTypesStore.getInitialState).mockReturnValue(_createFieldTypesStoreState(dummyFields));
+  });
+  it('returns empty list if inputs are empty', () => {
+    asMock(FieldTypesStore.getInitialState).mockReturnValue(_createFieldTypesStoreState([]));
+
+    const completer = new FieldNameCompletion();
+    expect(completer.getCompletions(null, null, '')).toEqual([]);
+  });
+
+  it('returns matching fields if prefix is present in one field name', () => {
+    const completer = new FieldNameCompletion();
+    expect(completer.getCompletions(null, null, 'mess').map(result => result.name))
+      .toEqual(['message']);
+  });
+
+  it('returns matching fields if prefix is present in at least one field name', () => {
+    const completer = new FieldNameCompletion();
+    expect(completer.getCompletions(null, null, 'e').map(result => result.name))
+      .toEqual(['source', 'message', 'timestamp']);
+  });
+
+  it('suffixes matching fields with colon', () => {
+    const completer = new FieldNameCompletion();
+    expect(completer.getCompletions(null, null, 'e').map(result => result.value))
+      .toEqual(['source:', 'message:', 'timestamp:']);
   });
 });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The legacy search suffixed field names in the query input's
auto-completion with a colon, as most users would want to write a value
next, after completing the field name. The new search does not do this
yet.

This change is suffixing all field names suggested for field completion
with a colon.

*Needs to be backported to `3.2`.*

Fixes #7408.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.