### PR TITLE
Update react plotly.js to 2.4.0 (Backport of #7485 for 3.2)

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -101,7 +101,7 @@
     "react-leaflet": "^2.3.0",
     "react-mops": "v2.0.0-beta.0",
     "react-overlays": "^0.7.0",
-    "react-plotly.js": "^2.3.0",
+    "react-plotly.js": "^2.4.0",
     "react-portal": "^4.2.0",
     "react-resizable": "^1.8.0",
     "react-rnd": "^10.1.1",

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -7371,7 +7371,7 @@ graceful-fs@^4.1.15:
   dependencies:
     "@babel/preset-env" "7.6.3"
     babel-eslint "9.0.0"
-    eslint-config-graylog "file:../../../../Library/Caches/Yarn/v4/npm-graylog-web-plugin-3.2.2-SNAPSHOT-7ea79dd3-6340-412e-95b5-c45a1cd637dc-1582028105569/node_modules/eslint-config-graylog"
+    eslint-config-graylog "file:../../../../Library/Caches/Yarn/v4/npm-graylog-web-plugin-3.2.2-SNAPSHOT-b6a78be7-930a-45bf-924a-f5d369aa39ac-1582032066748/node_modules/eslint-config-graylog"
     html-webpack-plugin "3.2.0"
     javascript-natural-sort "0.7.1"
     jquery "3.4.1"
@@ -12736,10 +12736,10 @@ react-overlays@^0.7.0, react-overlays@^0.7.4:
     prop-types-extra "^1.0.1"
     warning "^3.0.0"
 
-react-plotly.js@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/react-plotly.js/-/react-plotly.js-2.3.0.tgz#c1e624e33e00e3c5bf7c482f3b80133097619070"
-  integrity sha512-+eNqIQtGe/WmgsZ+IDxOt8Zy/QXRTmbgqq+yID6dNsCG5zst946fZlLR+u0U7yt2z3IsatAyKAPXUZh5DHUR5Q==
+react-plotly.js@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/react-plotly.js/-/react-plotly.js-2.4.0.tgz#7a8fd89ffa126daa36a5855890282960e2e4eaf0"
+  integrity sha512-BCkxMe8yWqu3nP/hw9A1KCIuoL67WV5/k68SL9yhEkF6UG+pAuIev9Q3cMKtNkQJZhsYFpOmlqrpPjIdUFACOQ==
   dependencies:
     prop-types "^15.7.2"
 


### PR DESCRIPTION
Backport of #7485 for 3.2.
This PR is based on https://github.com/Graylog2/graylog2-server/pull/7488 which should be merge first.

This change is updating `react-plotly.js` from `v2.3.0` to `v2.4.0`.

- [Commits](https://github.com/plotly/react-plotly.js/compare/2.3.0...v2.4.0)