### PR TITLE
Display full height of data tables in reports (3.2)

### DIFF
--- a/graylog2-web-interface/src/views/bindings.enterpriseWidgets.test.jsx
+++ b/graylog2-web-interface/src/views/bindings.enterpriseWidgets.test.jsx
@@ -1,0 +1,32 @@
+// @flow strict
+import AggregationWidget from 'views/logic/aggregationbuilder/AggregationWidget';
+import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
+import Widget from 'views/logic/widgets/Widget';
+import DataTable from 'views/components/datatable/DataTable';
+import bindings from './bindings';
+
+describe('Views bindings enterprise widgets', () => {
+  const { enterpriseWidgets } = bindings;
+  type WidgetCondig = {
+    needsControlledHeight: (widget?: Widget) => boolean
+  }
+  const findWidgetConfig = type => enterpriseWidgets.find(widgetConfig => widgetConfig.type === type);
+
+  describe('Aggregations', () => {
+    // $FlowFixMe: We are assuming here it is generally present
+    const aggregationConfig: WidgetCondig = findWidgetConfig('AGGREGATION');
+    it('is present', () => {
+      expect(aggregationConfig).toBeDefined();
+    });
+    it('need a controlled height by default', () => {
+      expect(aggregationConfig.needsControlledHeight()).toBe(true);
+    });
+    it('do not need controlled height when visualization has type data table', () => {
+      const widget = AggregationWidget.builder()
+        .id('widget1')
+        .config(AggregationWidgetConfig.builder().visualization(DataTable.type).build())
+        .build();
+      expect(aggregationConfig.needsControlledHeight(widget)).toBe(false);
+    });
+  });
+});

--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import Routes from 'routing/Routes';
 import * as Permissions from 'views/Permissions';
+import { get } from 'lodash';
 
 import { MessageListHandler } from 'views/logic/searchtypes';
 import { MessageList } from 'views/components/widgets';
@@ -131,7 +132,7 @@ export default {
       defaultWidth: 6,
       visualizationComponent: MessageList,
       editComponent: EditMessageList,
-      needsControlledHeight: false,
+      needsControlledHeight: () => false,
       searchResultTransformer: (data: Array<*>) => data[0],
       searchTypes: MessageConfigGenerator,
       titleGenerator: () => 'Untitled Message Table',
@@ -143,7 +144,13 @@ export default {
       defaultWidth: 4,
       visualizationComponent: AggregationBuilder,
       editComponent: AggregationControls,
-      needsControlledHeight: true,
+      needsControlledHeight: (widget: Widget) => {
+        const widgetVisualization = get(widget, 'config.visualization');
+        const flexibleHeightWidgets = [
+          DataTable.type,
+        ];
+        return !flexibleHeightWidgets.find(visualization => visualization === widgetVisualization);
+      },
       searchResultTransformer: PivotTransformer,
       searchTypes: PivotConfigGenerator,
       titleGenerator: (widget: Widget) => {
@@ -159,7 +166,7 @@ export default {
     {
       type: 'default',
       visualizationComponent: UnknownWidget,
-      needsControlledHeight: true,
+      needsControlledHeight: () => true,
       editComponent: UnknownWidget,
       searchTypes: () => [],
     },


### PR DESCRIPTION
As described in https://github.com/Graylog2/graylog2-server/issues/7349 the data table is not fully visible in reports.

The reason is the visualization config in `bindings` returns `true` for the prop `needsControlledHeight`. With this PR we are checking the widget type to return `false` if the widget is a data table.

Please have a look at the related PR in the enterprise repo. 

Fixes #7349 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.