### PR TITLE
Clean up styleguide sections

### DIFF
--- a/graylog2-web-interface/styleguide.config.js
+++ b/graylog2-web-interface/styleguide.config.js
@@ -66,10 +66,6 @@ module.exports = {
           components: 'src/components/configurationforms/[A-Z]*.jsx',
         },
         {
-          name: 'Inputs',
-          components: 'src/components/inputs/[A-Z]*.jsx',
-        },
-        {
           name: 'Visualizations',
           components: 'src/components/visualizations/[A-Z]*.jsx',
         },

--- a/graylog2-web-interface/styleguide.config.js
+++ b/graylog2-web-interface/styleguide.config.js
@@ -65,10 +65,6 @@ module.exports = {
           name: 'Configuration Forms',
           components: 'src/components/configurationforms/[A-Z]*.jsx',
         },
-        {
-          name: 'Visualizations',
-          components: 'src/components/visualizations/[A-Z]*.jsx',
-        },
       ],
     },
     {


### PR DESCRIPTION
Remove two sections from styleguide:
- Inputs: currently contains Graylog Inputs components, which are not common and should probably not be reused in other parts of the application
- Visualizations: After 3.2 this section is almost empty, so either we include new visualizations or we remove the section. I decided on the second option