### PR TITLE
Fix field order in MessageTable head (3.2)

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
@@ -181,10 +181,7 @@ class MessageTable extends React.Component<Props, State> {
 
   _getSelectedFields = () => {
     const { selectedFields, config } = this.props;
-    if (config) {
-      return Immutable.Set(config.fields);
-    }
-    return selectedFields;
+    return Immutable.OrderedSet(config ? config.fields : selectedFields);
   };
 
   _toggleMessageDetail = (id: string) => {
@@ -204,13 +201,12 @@ class MessageTable extends React.Component<Props, State> {
     const { fields, activeQueryId, config } = this.props;
     const formattedMessages = this._getFormattedMessages();
     const selectedFields = this._getSelectedFields();
-    const selectedColumns = Immutable.OrderedSet(selectedFields);
     return (
       <div className="table-responsive">
         <Table className="table table-condensed" style={{ marginTop: 0 }}>
           <TableHead>
             <tr>
-              {selectedColumns.toSeq().map((selectedFieldName) => {
+              {selectedFields.toSeq().map((selectedFieldName) => {
                 return (
                   <th key={selectedFieldName}
                       style={this._columnStyle(selectedFieldName)}>
@@ -231,7 +227,7 @@ class MessageTable extends React.Component<Props, State> {
                                    disableSurroundingSearch
                                    message={message}
                                    showMessageRow={config && config.showMessageRow}
-                                   selectedFields={selectedColumns}
+                                   selectedFields={selectedFields}
                                    expanded={expandedMessages.contains(messageKey)}
                                    toggleDetail={this._toggleMessageDetail}
                                    highlight

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.test.jsx
@@ -61,4 +61,17 @@ describe('MessageTable', () => {
       expect(messageTableEntry).not.toBeEmptyRender();
     });
   });
+
+  it('renders config fields in table head with correct order', () => {
+    const configFields = ['gl2_receive_timestamp', 'user_id', 'gl2_source_input', 'gl2_message_id', 'ingest_time', 'http_method', 'action', 'source', 'ingest_time_hour', 'ingest_time_epoch'];
+    const configWithFields = MessagesWidgetConfig.builder().fields(configFields).build();
+    const wrapper = mount(<MessageTable messages={messages}
+                                        activeQueryId={activeQueryId}
+                                        fields={Immutable.List(fields)}
+                                        selectedFields={{}}
+                                        config={configWithFields} />);
+
+    const tableHeadFields = wrapper.find('Field').map(field => field.text());
+    expect(tableHeadFields).toEqual(configFields);
+  });
 });


### PR DESCRIPTION
As described in #6808, the field order in the message list table head can be wrong. This PR fixes the problem by using only an `Immutable.OrderedSet`.

This is the backport PR for 3.2

Fixes #6808.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.