### PR TITLE
Display all LDAP mapped groups

### DIFF
--- a/graylog2-web-interface/src/components/ldap/LdapComponent.jsx
+++ b/graylog2-web-interface/src/components/ldap/LdapComponent.jsx
@@ -18,6 +18,16 @@ import LdapComponentStyle from './LdapComponent.css';
 const { RolesStore } = CombinedProvider.get('Roles');
 const { LdapActions } = CombinedProvider.get('Ldap');
 
+const GroupMappingLink = ({ text, onClick }) => {
+  return (
+    <Button bsStyle="link" bsSize="xs" className="btn-text" onClick={onClick}>{text}</Button>
+  );
+};
+GroupMappingLink.propTypes = {
+  text: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
+};
+
 const HelperText = {
   activeDirectory: {
     SYSTEM_USERNAME: (
@@ -63,7 +73,7 @@ const HelperText = {
       <span>
         The default Graylog role determines whether a user created via Active Directory can access the entire system, or has limited access.<br />
         You can assign additional permissions by{' '}
-        <Button bsStyle="link" bsSize="xs" className="btn-text" onClick={onClickHandler}>mapping Active Directory groups to Graylog roles</Button>,{' '}
+        <GroupMappingLink text="mapping Active Directory groups to Graylog roles" onClick={onClickHandler} />,{' '}
         or you can assign additional Graylog roles to Active Directory users below.
       </span>
     ),
@@ -117,7 +127,7 @@ const HelperText = {
       <span>
         The default Graylog role determines whether a user created via LDAP can access the entire system, or has limited access.<br />
         You can assign additional permissions by{' '}
-        <Button bsStyle="link" bsSize="xs" className="btn-text" onClick={onClickHandler}>mapping LDAP groups to Graylog roles</Button>,{' '}
+        <GroupMappingLink text="mapping LDAP groups to Graylog roles" onClick={onClickHandler} />,{' '}
         or you can assign additional Graylog roles to LDAP users below.
       </span>
     ),
@@ -472,6 +482,13 @@ class LdapComponent extends React.Component {
               <Row className="row-sm">
                 <Col sm={12}>
                   <legend>4. Group Mapping <small>(optional)</small></legend>
+                </Col>
+                <Col md={9} mdOffset={3}>
+                  <Panel bsStyle="warning">
+                    Take some time to review the{' '}
+                    <GroupMappingLink text={`${isAD ? 'AD' : 'LDAP'} group mapping`} onClick={this._onShowGroups} />{' '}
+                    after making changes in this section.
+                  </Panel>
                 </Col>
               </Row>
               <Input type="text"

--- a/graylog2-web-interface/src/components/ldap/LdapComponent.jsx
+++ b/graylog2-web-interface/src/components/ldap/LdapComponent.jsx
@@ -1,26 +1,22 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
-import Reflux from 'reflux';
 import URI from 'urijs';
 import naturalSort from 'javascript-natural-sort';
+import { cloneDeep } from 'lodash';
 
 import { Row, Col, Panel, FormGroup, ControlLabel, Button } from 'components/graylog';
 import { Input, InputWrapper } from 'components/bootstrap';
 
 import { MultiSelect, Select, Spinner } from 'components/common';
-import ObjectUtils from 'util/ObjectUtils';
 
-import StoreProvider from 'injection/StoreProvider';
-import ActionsProvider from 'injection/ActionsProvider';
+import CombinedProvider from 'injection/CombinedProvider';
 import TestLdapConnection from './TestLdapConnection';
 import TestLdapLogin from './TestLdapLogin';
 import LdapComponentStyle from './LdapComponent.css';
 
 
-const RolesStore = StoreProvider.getStore('Roles');
-const LdapStore = StoreProvider.getStore('Ldap');
-const LdapActions = ActionsProvider.getActions('Ldap');
+const { RolesStore } = CombinedProvider.get('Roles');
+const { LdapActions } = CombinedProvider.get('Ldap');
 
 const HelperText = {
   activeDirectory: {
@@ -67,7 +63,7 @@ const HelperText = {
       <span>
         The default Graylog role determines whether a user created via Active Directory can access the entire system, or has limited access.<br />
         You can assign additional permissions by{' '}
-        <a href="#" onClick={onClickHandler}>mapping Active Directory groups to Graylog roles</a>,{' '}
+        <Button bsStyle="link" bsSize="xs" className="btn-text" onClick={onClickHandler}>mapping Active Directory groups to Graylog roles</Button>,{' '}
         or you can assign additional Graylog roles to Active Directory users below.
       </span>
     ),
@@ -86,8 +82,8 @@ const HelperText = {
     SYSTEM_PASSWORD: ('The password for the initial connection to the LDAP server.'),
     SEARCH_BASE: (
       <span>
-        The base tree to limit the LDAP search query to, e.g. <code className="text-nowrap">cn=users,dc=example,dc=com
-        </code>.
+        The base tree to limit the LDAP search query to, e.g.{' '}
+        <code className="text-nowrap">cn=users,dc=example,dc=com </code>.
       </span>
     ),
     SEARCH_PATTERN: (
@@ -121,7 +117,7 @@ const HelperText = {
       <span>
         The default Graylog role determines whether a user created via LDAP can access the entire system, or has limited access.<br />
         You can assign additional permissions by{' '}
-        <a href="#" onClick={onClickHandler}>mapping LDAP groups to Graylog roles</a>,{' '}
+        <Button bsStyle="link" bsSize="xs" className="btn-text" onClick={onClickHandler}>mapping LDAP groups to Graylog roles</Button>,{' '}
         or you can assign additional Graylog roles to LDAP users below.
       </span>
     ),
@@ -131,66 +127,58 @@ const HelperText = {
   },
 };
 
-const LdapComponent = createReactClass({
-  displayName: 'LdapComponent',
-  mixins: [Reflux.listenTo(LdapStore, '_onLdapSettingsChange', '_onLdapSettingsChange')],
-
-  propTypes: {
+class LdapComponent extends React.Component {
+  static propTypes = {
     onCancel: PropTypes.func.isRequired,
     onShowGroups: PropTypes.func.isRequired,
-  },
+  };
 
-  getInitialState() {
-    return {
-      ldapSettings: undefined,
-      ldapUri: undefined,
-      roles: undefined,
-      showPasswordInput: true,
-    };
-  },
+  state = {
+    ldapSettings: undefined,
+    ldapUri: undefined,
+    roles: undefined,
+    hidePasswordInput: true,
+  };
 
   componentDidMount() {
+    LdapActions.loadSettings().then(this._onLdapSettingsChange);
     RolesStore.loadRoles().then((roles) => {
       this.setState({ roles: this._formatAdditionalRoles(roles) });
     });
-  },
+  }
 
-  _formatAdditionalRoles(roles) {
+  _formatAdditionalRoles = (roles) => {
     return roles
       .sort((r1, r2) => naturalSort(r1.name.toLowerCase(), r2.name.toLowerCase()))
       .map((r) => {
         return { label: r.name, value: r.name };
       });
-  },
+  };
 
-  _onLdapSettingsChange(state) {
-    if (!state.ldapSettings) {
-      return;
-    }
-
-    // Clone settings object, so we don't the store reference
-    const settings = ObjectUtils.clone(state.ldapSettings);
+  _onLdapSettingsChange = (ldapSettings) => {
+    const settings = cloneDeep(ldapSettings);
     const ldapUri = new URI(settings.ldap_uri);
     this.setState({ ldapSettings: settings, ldapUri: ldapUri, hidePasswordInput: settings.system_password_set });
-  },
+  };
 
-  _isLoading() {
-    return !this.state.ldapSettings || !this.state.roles;
-  },
+  _isLoading = () => {
+    const { ldapSettings, roles } = this.state;
+    return !ldapSettings || !roles;
+  };
 
-  _bindChecked(ev, value) {
+  _bindChecked = (ev, value) => {
     this._setSetting(ev.target.name, typeof value === 'undefined' ? ev.target.checked : value);
-  },
+  };
 
-  _bindValue(ev) {
+  _bindValue = (ev) => {
     this._setSetting(ev.target.name, ev.target.value);
-  },
+  };
 
-  _updateSsl(ev) {
+  _updateSsl = (ev) => {
     this._setUriScheme(ev.target.checked ? 'ldaps' : 'ldap');
-  },
+  };
 
-  _setSetting(attribute, value) {
+  _setSetting = (attribute, value) => {
     const newState = {};
 
     let formattedValue = value;
@@ -201,75 +189,85 @@ const LdapComponent = createReactClass({
     }
 
     // Clone state to not modify it directly
-    const settings = ObjectUtils.clone(this.state.ldapSettings);
+    const { ldapSettings } = this.state;
+    const settings = cloneDeep(ldapSettings);
     settings[attribute] = formattedValue;
     newState.ldapSettings = settings;
     newState.serverConnectionStatus = {};
     this.setState(newState);
-  },
+  };
 
-  _setUriScheme(scheme) {
-    const ldapUri = this.state.ldapUri.clone();
-    ldapUri.scheme(scheme);
-    this._setSetting('ldap_uri', ldapUri);
-  },
+  _setUriScheme = (scheme) => {
+    const { ldapUri } = this.state;
+    const nextLdapUri = ldapUri.clone();
+    nextLdapUri.scheme(scheme);
+    this._setSetting('ldap_uri', nextLdapUri);
+  };
 
-  _uriScheme() {
-    return `${this.state.ldapUri.scheme()}://`;
-  },
+  _uriScheme = () => {
+    const { ldapUri } = this.state;
+    return `${ldapUri.scheme()}://`;
+  };
 
-  _setUriHost(host) {
-    const ldapUri = this.state.ldapUri.clone();
-    ldapUri.hostname(host);
-    this._setSetting('ldap_uri', ldapUri);
-  },
+  _setUriHost = (host) => {
+    const { ldapUri } = this.state;
+    const nextLdapUri = ldapUri.clone();
+    nextLdapUri.hostname(host);
+    this._setSetting('ldap_uri', nextLdapUri);
+  };
 
-  _uriHost() {
-    return this.state.ldapUri.hostname();
-  },
+  _uriHost = () => {
+    const { ldapUri } = this.state;
+    return ldapUri.hostname();
+  };
 
-  _setUriPort(port) {
-    const ldapUri = this.state.ldapUri.clone();
-    ldapUri.port(port);
-    this._setSetting('ldap_uri', ldapUri);
-  },
+  _setUriPort = (port) => {
+    const { ldapUri } = this.state;
+    const nextLdapUri = ldapUri.clone();
+    nextLdapUri.port(port);
+    this._setSetting('ldap_uri', nextLdapUri);
+  };
 
-  _uriPort() {
-    return this.state.ldapUri.port();
-  },
+  _uriPort = () => {
+    const { ldapUri } = this.state;
+    return ldapUri.port();
+  };
 
-  _setAdditionalDefaultGroups(rolesString) {
+  _setAdditionalDefaultGroups = (rolesString) => {
     // only keep non-empty entries
     const roles = rolesString.split(',').filter(v => v !== '');
     this._setSetting('additional_default_groups', roles);
-  },
+  };
 
-  _saveSettings(event) {
+  _saveSettings = (event) => {
     event.preventDefault();
-    LdapActions.update(this.state.ldapSettings);
-  },
+    const { ldapSettings } = this.state;
+    LdapActions.update(ldapSettings);
+  };
 
-  _onShowGroups(event) {
+  _onShowGroups = (event) => {
     event.preventDefault();
-    this.props.onShowGroups();
-  },
+    const { onShowGroups } = this.props;
+    onShowGroups();
+  };
 
-  _showPasswordInput() {
+  _showPasswordInput = () => {
     this.setState({ hidePasswordInput: false });
-  },
+  };
 
   render() {
     if (this._isLoading()) {
       return <Spinner />;
     }
 
-    const isAD = this.state.ldapSettings.active_directory;
-    const disabled = !this.state.ldapSettings.enabled;
+    const { hidePasswordInput, ldapSettings, ldapUri, roles: rolesOptions } = this.state;
+    const { onCancel } = this.props;
+
+    const isAD = ldapSettings.active_directory;
+    const disabled = !ldapSettings.enabled;
     const help = isAD ? HelperText.activeDirectory : HelperText.ldap;
 
-    const rolesOptions = this.state.roles;
-
-    const ldapPasswordInput = this.state.hidePasswordInput
+    const ldapPasswordInput = hidePasswordInput
       ? (
         <FormGroup controlId="system_password">
           <ControlLabel className="col-sm-3">System Password</ControlLabel>
@@ -287,13 +285,13 @@ const LdapComponent = createReactClass({
                wrapperClassName="col-sm-9"
                placeholder="System Password"
                label="System Password"
-               value={this.state.ldapSettings.system_password}
+               value={ldapSettings.system_password}
                help={help.SYSTEM_PASSWORD}
                onChange={this._bindValue}
                disabled={disabled} />
       );
 
-    const additionalDefaultGroups = this.state.ldapSettings.additional_default_groups;
+    const additionalDefaultGroups = ldapSettings.additional_default_groups;
     const additionalDefaultGroupsString = Array.isArray(additionalDefaultGroups)
       ? additionalDefaultGroups.join(',')
       : additionalDefaultGroups;
@@ -308,7 +306,7 @@ const LdapComponent = createReactClass({
                    help="User accounts will be taken from LDAP/Active Directory, the administrator account will still be available."
                    wrapperClassName="col-sm-offset-3 col-sm-9"
                    name="enabled"
-                   checked={this.state.ldapSettings.enabled}
+                   checked={ldapSettings.enabled}
                    onChange={this._bindChecked} />
 
             <fieldset>
@@ -321,76 +319,83 @@ const LdapComponent = createReactClass({
                      labelClassName="col-sm-3"
                      wrapperClassName="col-sm-9"
                      label="Server Type">
-                <label className="radio-inline">
-                  <input type="radio"
-                         name="active_directory"
-                         checked={!isAD}
-                         disabled={disabled}
-                         onChange={ev => this._bindChecked(ev, false)} />
+                <>
+                  <label className="radio-inline" htmlFor="ldap-checkbox">
+                    <input type="radio"
+                           name="active_directory"
+                           id="ldap-checkbox"
+                           checked={!isAD}
+                           disabled={disabled}
+                           onChange={ev => this._bindChecked(ev, false)} />
                   LDAP
-                </label>
-                <label className="radio-inline">
-                  <input type="radio"
-                         name="active_directory"
-                         checked={isAD}
-                         disabled={disabled}
-                         onChange={ev => this._bindChecked(ev, true)} />
+                  </label>
+                  <label className="radio-inline" htmlFor="ad-checkbox">
+                    <input type="radio"
+                           name="active_directory"
+                           id="ad-checkbox"
+                           checked={isAD}
+                           disabled={disabled}
+                           onChange={ev => this._bindChecked(ev, true)} />
                   Active Directory
-                </label>
+                  </label>
+                </>
               </Input>
 
               <Input id="ldap-uri-host"
                      labelClassName="col-sm-3"
                      wrapperClassName="col-sm-9"
                      label="Server Address">
-                <div className="input-group">
-                  <span className="input-group-addon">{this._uriScheme()}</span>
-                  <input type="text"
-                         className="form-control"
-                         id="ldap-uri-host"
-                         value={this._uriHost()}
-                         placeholder="Hostname"
-                         required
-                         onChange={ev => this._setUriHost(ev.target.value)}
-                         disabled={disabled} />
-                  <span className="input-group-addon input-group-separator">:</span>
-                  <input type="number"
-                         className="form-control"
-                         id="ldap-uri-port"
-                         value={this._uriPort()}
-                         min="1"
-                         max="65535"
-                         placeholder="Port"
-                         required
-                         style={{ width: 120 }}
-                         onChange={ev => this._setUriPort(ev.target.value)}
-                         disabled={disabled} />
-                </div>
-                <label className="checkbox-inline">
-                  <input type="checkbox"
-                         name="ssl"
-                         checked={this.state.ldapUri.scheme() === 'ldaps'}
-                         onChange={this._updateSsl}
-                         disabled={disabled} /> SSL
-                </label>
-                <label className="checkbox-inline">
-                  <input type="checkbox"
-                         name="use_start_tls"
-                         value="true"
-                         id="ldap-uri-starttls"
-                         checked={this.state.ldapSettings.use_start_tls}
-                         onChange={this._bindChecked}
-                         disabled={disabled} /> StartTLS
-                </label>
-                <label className="checkbox-inline">
-                  <input type="checkbox"
-                         name="trust_all_certificates"
-                         value="true"
-                         id="trust-all-certificates"
-                         checked={this.state.ldapSettings.trust_all_certificates}
-                         onChange={this._bindChecked}
-                         disabled={disabled} /> Allow self-signed certificates
-                </label>
+                <>
+                  <div className="input-group">
+                    <span className="input-group-addon">{this._uriScheme()}</span>
+                    <input type="text"
+                           className="form-control"
+                           id="ldap-uri-host"
+                           value={this._uriHost()}
+                           placeholder="Hostname"
+                           required
+                           onChange={ev => this._setUriHost(ev.target.value)}
+                           disabled={disabled} />
+                    <span className="input-group-addon input-group-separator">:</span>
+                    <input type="number"
+                           className="form-control"
+                           id="ldap-uri-port"
+                           value={this._uriPort()}
+                           min="1"
+                           max="65535"
+                           placeholder="Port"
+                           required
+                           style={{ width: 120 }}
+                           onChange={ev => this._setUriPort(ev.target.value)}
+                           disabled={disabled} />
+                  </div>
+                  <label className="checkbox-inline" htmlFor="ldap-ssl-checkbox">
+                    <input type="checkbox"
+                           name="ssl"
+                           id="ldap-ssl-checkbox"
+                           checked={ldapUri.scheme() === 'ldaps'}
+                           onChange={this._updateSsl}
+                           disabled={disabled} /> SSL
+                  </label>
+                  <label className="checkbox-inline" htmlFor="ldap-uri-starttls">
+                    <input type="checkbox"
+                           name="use_start_tls"
+                           value="true"
+                           id="ldap-uri-starttls"
+                           checked={ldapSettings.use_start_tls}
+                           onChange={this._bindChecked}
+                           disabled={disabled} /> StartTLS
+                  </label>
+                  <label className="checkbox-inline" htmlFor="trust-all-certificates">
+                    <input type="checkbox"
+                           name="trust_all_certificates"
+                           value="true"
+                           id="trust-all-certificates"
+                           checked={ldapSettings.trust_all_certificates}
+                           onChange={this._bindChecked}
+                           disabled={disabled} /> Allow self-signed certificates
+                  </label>
+                </>
               </Input>
 
               <Input type="text"
@@ -400,7 +405,7 @@ const LdapComponent = createReactClass({
                      wrapperClassName="col-sm-9"
                      placeholder="System User DN"
                      label="System Username"
-                     value={this.state.ldapSettings.system_username}
+                     value={ldapSettings.system_username}
                      help={help.SYSTEM_USERNAME}
                      onChange={this._bindValue}
                      disabled={disabled} />
@@ -414,7 +419,7 @@ const LdapComponent = createReactClass({
                   <legend>2. Connection Test</legend>
                 </Col>
               </Row>
-              <TestLdapConnection ldapSettings={this.state.ldapSettings} ldapUri={this.state.ldapUri} disabled={disabled} />
+              <TestLdapConnection ldapSettings={ldapSettings} ldapUri={ldapUri} disabled={disabled} />
             </fieldset>
 
             <fieldset>
@@ -430,7 +435,7 @@ const LdapComponent = createReactClass({
                      wrapperClassName="col-sm-9"
                      placeholder="Search Base"
                      label="Search Base DN"
-                     value={this.state.ldapSettings.search_base}
+                     value={ldapSettings.search_base}
                      help={help.SEARCH_BASE}
                      onChange={this._bindValue}
                      disabled={disabled}
@@ -443,7 +448,7 @@ const LdapComponent = createReactClass({
                      wrapperClassName="col-sm-9"
                      placeholder="Search Pattern"
                      label="User Search Pattern"
-                     value={this.state.ldapSettings.search_pattern}
+                     value={ldapSettings.search_pattern}
                      help={help.SEARCH_PATTERN}
                      onChange={this._bindValue}
                      disabled={disabled}
@@ -456,7 +461,7 @@ const LdapComponent = createReactClass({
                      wrapperClassName="col-sm-9"
                      placeholder="Display Name Attribute"
                      label="Display Name attribute"
-                     value={this.state.ldapSettings.display_name_attribute}
+                     value={ldapSettings.display_name_attribute}
                      help={help.DISPLAY_NAME}
                      onChange={this._bindValue}
                      disabled={disabled}
@@ -476,7 +481,7 @@ const LdapComponent = createReactClass({
                      wrapperClassName="col-sm-9"
                      placeholder="Group Search Base"
                      label="Group Search Base DN"
-                     value={this.state.ldapSettings.group_search_base}
+                     value={ldapSettings.group_search_base}
                      help={help.GROUP_SEARCH_BASE}
                      onChange={this._bindValue}
                      disabled={disabled} />
@@ -488,7 +493,7 @@ const LdapComponent = createReactClass({
                      wrapperClassName="col-sm-9"
                      placeholder="Group Search Pattern"
                      label="Group Search Pattern"
-                     value={this.state.ldapSettings.group_search_pattern}
+                     value={ldapSettings.group_search_pattern}
                      help={help.GROUP_PATTERN}
                      onChange={this._bindValue}
                      disabled={disabled} />
@@ -500,7 +505,7 @@ const LdapComponent = createReactClass({
                      wrapperClassName="col-sm-9"
                      placeholder="Group Id Attribute"
                      label="Group Name Attribute"
-                     value={this.state.ldapSettings.group_id_attribute}
+                     value={ldapSettings.group_id_attribute}
                      help={help.GROUP_ID}
                      onChange={this._bindValue}
                      disabled={disabled} />
@@ -512,7 +517,7 @@ const LdapComponent = createReactClass({
                      help={help.defaultGroup(this._onShowGroups)}>
                 <Select options={rolesOptions}
                         disabled={disabled}
-                        value={this.state.ldapSettings.default_group}
+                        value={ldapSettings.default_group}
                         onChange={role => this._setSetting('default_group', role)}
                         placeholder="Choose a default role" />
               </Input>
@@ -554,7 +559,7 @@ const LdapComponent = createReactClass({
                   <legend>5. Login test</legend>
                 </Col>
               </Row>
-              <TestLdapLogin ldapSettings={this.state.ldapSettings} disabled={disabled} />
+              <TestLdapLogin ldapSettings={ldapSettings} disabled={disabled} />
             </fieldset>
 
             <fieldset>
@@ -566,7 +571,7 @@ const LdapComponent = createReactClass({
               <div className="form-group">
                 <Col sm={9} smOffset={3}>
                   <Button type="submit" bsStyle="primary" className="save-button-margin">Save LDAP settings</Button>
-                  <Button onClick={this.props.onCancel}>Cancel</Button>
+                  <Button onClick={onCancel}>Cancel</Button>
                 </Col>
               </div>
             </fieldset>
@@ -574,7 +579,7 @@ const LdapComponent = createReactClass({
         </Col>
       </Row>
     );
-  },
-});
+  }
+}
 
 export default LdapComponent;

--- a/graylog2-web-interface/src/components/ldap/LdapComponent.jsx
+++ b/graylog2-web-interface/src/components/ldap/LdapComponent.jsx
@@ -485,7 +485,7 @@ class LdapComponent extends React.Component {
                 </Col>
                 <Col md={9} mdOffset={3}>
                   <Panel bsStyle="warning">
-                    Take some time to review the{' '}
+                    Remember to review the{' '}
                     <GroupMappingLink text={`${isAD ? 'AD' : 'LDAP'} group mapping`} onClick={this._onShowGroups} />{' '}
                     after making changes in this section.
                   </Panel>

--- a/graylog2-web-interface/src/components/ldap/LdapGroupsComponent.jsx
+++ b/graylog2-web-interface/src/components/ldap/LdapGroupsComponent.jsx
@@ -1,19 +1,16 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Immutable from 'immutable';
-import { Row, Col, Panel, Button } from 'components/graylog';
-import naturalSort from 'javascript-natural-sort';
+import { Button, Col, Panel, Row } from 'components/graylog';
 
 import { Input } from 'components/bootstrap';
 import { Spinner } from 'components/common';
+import { naturalSortIgnoreCase } from 'util/SortUtils';
 
-import ActionsProvider from 'injection/ActionsProvider';
+import CombinedProvider from 'injection/CombinedProvider';
 
-import StoreProvider from 'injection/StoreProvider';
-
-const LdapGroupsActions = ActionsProvider.getActions('LdapGroups');
-const RolesStore = StoreProvider.getStore('Roles');
-const LdapGroupsStore = StoreProvider.getStore('LdapGroups');
+const { LdapGroupsActions } = CombinedProvider.get('LdapGroups');
+const { RolesStore } = CombinedProvider.get('Roles');
 
 class LdapGroupsComponent extends React.Component {
   static propTypes = {
@@ -22,15 +19,15 @@ class LdapGroupsComponent extends React.Component {
   };
 
   state = {
-    groups: Immutable.Set.of(),
-    roles: Immutable.Set.of(),
-    mapping: Immutable.Map(),
+    groups: undefined,
+    roles: undefined,
+    mapping: undefined,
     groupsErrorMessage: null,
   };
 
   componentDidMount() {
-    LdapGroupsActions.loadMapping.triggerPromise().then(mapping => this.setState({ mapping: Immutable.Map(mapping) }));
-    LdapGroupsActions.loadGroups.triggerPromise()
+    LdapGroupsActions.loadMapping().then(mapping => this.setState({ mapping: Immutable.Map(mapping) }));
+    LdapGroupsActions.loadGroups()
       .then(
         groups => this.setState({ groups: Immutable.Set(groups) }),
         (error) => {
@@ -45,54 +42,57 @@ class LdapGroupsComponent extends React.Component {
   _updateMapping = (event) => {
     const role = event.target.value;
     const group = event.target.getAttribute('data-group');
+    const { mapping } = this.state;
     if (role === '') {
-      this.setState({ mapping: this.state.mapping.delete(group) });
+      this.setState({ mapping: mapping.delete(group) });
     } else {
-      this.setState({ mapping: this.state.mapping.set(group, role) });
+      this.setState({ mapping: mapping.set(group, role) });
     }
   };
 
   _saveMapping = (event) => {
     event.preventDefault();
-    LdapGroupsActions.saveMapping(this.state.mapping.toJS());
+    const { mapping } = this.state;
+    LdapGroupsActions.saveMapping(mapping.toJS());
   };
 
-  _onShowConfig = (event) => {
-    event.preventDefault();
-    this.props.onShowConfig();
+  _onShowConfig = () => {
+    const { onShowConfig } = this.props;
+    onShowConfig();
   };
 
   _isLoading = () => {
-    return !(this.state.mapping && this.state.groups && this.state.roles);
+    const { groups, mapping, roles } = this.state;
+    return !(mapping && groups && roles);
   };
 
   render() {
     if (this._isLoading()) {
       return <Spinner />;
     }
+    const { groups, groupsErrorMessage, mapping, roles } = this.state;
+    const { onCancel } = this.props;
 
-    if (this.state.groupsErrorMessage) {
+    if (groupsErrorMessage) {
       return (
         <Panel header="Error: Unable to load LDAP groups" bsStyle="danger">
-          The error message was:<br />{this.state.groupsErrorMessage.message}
+          The error message was:<br />{groupsErrorMessage.message}
         </Panel>
       );
     }
 
-    naturalSort.insensitive = true; // sigh
-
-    const options = this.state.roles.sort(naturalSort).map((role) => {
+    const options = roles.sort((r1, r2) => naturalSortIgnoreCase(r1.name, r2.name)).map((role) => {
       return <option key={role.name} value={role.name}>{role.name}</option>;
     });
 
-    const content = this.state.groups.sort(naturalSort).map((group) => {
+    const content = groups.sort(naturalSortIgnoreCase).map((group) => {
       return (
         <li key={group}>
           <Input id={`${group}-select`}
                  label={group}
                  data-group={group}
                  type="select"
-                 value={this.state.mapping.get(group, '')}
+                 value={mapping.get(group, '')}
                  onChange={this._updateMapping}
                  labelClassName="col-sm-2"
                  wrapperClassName="col-sm-5">
@@ -103,15 +103,12 @@ class LdapGroupsComponent extends React.Component {
       );
     });
 
-    naturalSort.insensitive = false; // sigh 2
-
     if (content.size === 0) {
       return (
-        <p>
-          No LDAP/Active Directory groups found. Please verify that your{' '}
-          <a href="#" onClick={this._onShowConfig}>LDAP group mapping</a>{' '}
-          settings are correct.
-        </p>
+        <Panel header="No LDAP/Active Directory groups found" bsStyle="info">
+          <p>Please verify that your LDAP group mapping settings are correct.</p>
+          <Button bsSize="sm" onClick={this._onShowConfig}>Open LDAP settings</Button>
+        </Panel>
       );
     }
     return (
@@ -122,7 +119,7 @@ class LdapGroupsComponent extends React.Component {
           </Col>
           <Col md={10} mdPush={2}>
             <Button type="submit" bsStyle="primary" className="save-button-margin">Save</Button>
-            <Button onClick={this.props.onCancel}>Cancel</Button>
+            <Button onClick={onCancel}>Cancel</Button>
           </Col>
         </Row>
       </form>

--- a/graylog2-web-interface/src/components/ldap/LdapGroupsComponent.jsx
+++ b/graylog2-web-interface/src/components/ldap/LdapGroupsComponent.jsx
@@ -9,8 +9,10 @@ import { Spinner } from 'components/common';
 import { naturalSortIgnoreCase } from 'util/SortUtils';
 
 import CombinedProvider from 'injection/CombinedProvider';
+import connect from 'stores/connect';
 
 const { LdapGroupsActions } = CombinedProvider.get('LdapGroups');
+const { LdapStore } = CombinedProvider.get('Ldap');
 const { RolesStore } = CombinedProvider.get('Roles');
 
 const StyledLegend = styled.legend`
@@ -19,6 +21,7 @@ const StyledLegend = styled.legend`
 
 class LdapGroupsComponent extends React.Component {
   static propTypes = {
+    ldapSettings: PropTypes.object.isRequired,
     onCancel: PropTypes.func.isRequired,
     onShowConfig: PropTypes.func.isRequired,
   };
@@ -91,6 +94,16 @@ class LdapGroupsComponent extends React.Component {
   };
 
   render() {
+    const { ldapSettings } = this.props;
+    if (!ldapSettings.enabled) {
+      return (
+        <Panel header="LDAP is disabled" bsStyle="info">
+          <p>Please enable and configure LDAP to proceed.</p>
+          <Button bsSize="sm" onClick={this._onShowConfig}>Open LDAP settings</Button>
+        </Panel>
+      );
+    }
+
     if (this._isLoading()) {
       return <Spinner />;
     }
@@ -152,4 +165,5 @@ class LdapGroupsComponent extends React.Component {
   }
 }
 
-export default LdapGroupsComponent;
+export default connect(LdapGroupsComponent, { ldapStore: LdapStore },
+  ({ ldapStore, ...otherProps }) => ({ ...otherProps, ldapSettings: ldapStore.ldapSettings }));

--- a/graylog2-web-interface/src/components/ldap/LdapGroupsComponent.jsx
+++ b/graylog2-web-interface/src/components/ldap/LdapGroupsComponent.jsx
@@ -120,7 +120,7 @@ class LdapGroupsComponent extends React.Component {
 
     if (groups.size === 0 && mapping.size === 0) {
       return (
-        <Panel header="No LDAP/Active Directory groups found" bsStyle="info">
+        <Panel header="No LDAP groups found" bsStyle="info">
           <p>Please verify that your LDAP group mapping settings are correct.</p>
           <Button bsSize="sm" onClick={this._onShowConfig}>Open LDAP settings</Button>
         </Panel>
@@ -138,17 +138,21 @@ class LdapGroupsComponent extends React.Component {
       <form className="form-horizontal" onSubmit={this._saveMapping}>
         <Row>
           <Col md={12}>
-            <StyledLegend>Group mapping from LDAP/Active Directory</StyledLegend>
-            <p>Assign Graylog roles to LDAP/Active Directory groups.</p>
+            <StyledLegend>Group mapping from LDAP</StyledLegend>
             {currentLdapSearchGroups.size === 0
-              ? 'No LDAP/Active Directory groups found, please verify your LDAP group mapping settings.'
-              : this._renderGroupMappingInputs(currentLdapSearchGroups, options)}
+              ? <p>No LDAP groups found, please verify your LDAP group mapping settings.</p>
+              : (
+                <>
+                  <p>Assign Graylog roles to LDAP groups.</p>
+                  {this._renderGroupMappingInputs(currentLdapSearchGroups, options)}
+                </>
+              )}
 
             {previousMappings.size > 0 && (
               <>
                 <StyledLegend>Previously configured group mapping</StyledLegend>
                 <p>
-                  Some LDAP/Active Directory groups not matching your current settings were previously assigned Graylog
+                  Some LDAP groups not matching your current settings were previously assigned Graylog
                   roles. <strong>This mapping is still active for users logging into Graylog until you remove it.</strong>
                 </p>
                 {this._renderGroupMappingInputs(previousMappings, options)}

--- a/graylog2-web-interface/src/components/ldap/TestLdapLogin.jsx
+++ b/graylog2-web-interface/src/components/ldap/TestLdapLogin.jsx
@@ -127,8 +127,8 @@ const TestLdapLogin = createReactClass({
 
     const attributes = Object.keys(loginStatus.result.entry).map((key) => {
       return [
-        <dt>{key}</dt>,
-        <dd>{loginStatus.result.entry[key]}</dd>,
+        <dt key={`${key}-dt`}>{key}</dt>,
+        <dd key={`${key}-dd`}>{loginStatus.result.entry[key]}</dd>,
       ];
     });
     const formattedEntry = (attributes.length > 0 ? <dl>{attributes}</dl>


### PR DESCRIPTION
In the LDAP group mapping page, display groups having a mapping configured, regardless if they match the current group configuration or not. This let users remove previously configured mappings if they ever changed their group configuration.

Additionally, add a reminder in the LDAP configuration page to review group mapping after changes in the group configuration are made.

Fixes #7502