### PR TITLE
Fixing flow types for `immutable.js` by adding custom typedef file.

### DIFF
--- a/graylog2-web-interface/flow-typed/npm/immutable_vx.x.x.js
+++ b/graylog2-web-interface/flow-typed/npm/immutable_vx.x.x.js
@@ -550,6 +550,7 @@ declare module 'immutable' {
     static<K, V>(iterable?: ESIterable<[K, V]>): OrderedMap<K, V>;
 
     static isOrderedMap(maybeOrderedMap: any): boolean;
+    set<K_, V_>(key: K_, value: V_): OrderedMap<K | K_, V | V_>;
   }
 
   declare class Set<T> extends SetCollection<T> {

--- a/graylog2-web-interface/flow-typed/npm/immutable_vx.x.x.js
+++ b/graylog2-web-interface/flow-typed/npm/immutable_vx.x.x.js
@@ -591,6 +591,7 @@ declare module 'immutable' {
 
   // OrderedSets have nothing that Sets do not have. We do not need to override constructor & other statics
   declare class OrderedSet<T> extends Set<T> {
+    static<T>(iterable?: ESIterable<T>): OrderedSet<T>;
     static isOrderedSet(maybeOrderedSet: any): boolean;
   }
 

--- a/graylog2-web-interface/src/views/actions/SearchActions.js
+++ b/graylog2-web-interface/src/views/actions/SearchActions.js
@@ -1,5 +1,6 @@
 // @flow strict
 import Reflux from 'reflux';
+import * as Immutable from 'immutable';
 
 import Search from 'views/logic/search/Search';
 import SearchResult from 'views/logic/SearchResult';
@@ -30,7 +31,7 @@ type SearchActionsType = RefluxActions<{
   executeWithCurrentState: () => Promise<SearchExecutionResult>,
   refresh: () => Promise<void>,
   get: (SearchId) => Promise<SearchJson>,
-  parameters: (Array<Parameter>) => Promise<View>,
+  parameters: ((Array<Parameter> | Immutable.List<Parameter>)) => Promise<View>,
 }>;
 
 const SearchActions: SearchActionsType = singletonActions(

--- a/graylog2-web-interface/src/views/actions/SearchActions.js
+++ b/graylog2-web-interface/src/views/actions/SearchActions.js
@@ -3,7 +3,6 @@ import Reflux from 'reflux';
 
 import Search from 'views/logic/search/Search';
 import SearchResult from 'views/logic/SearchResult';
-import type { WidgetMapping } from 'views/logic/views/View';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import Parameter from 'views/logic/parameters/Parameter';
 import View from 'views/logic/views/View';
@@ -11,6 +10,7 @@ import type { SearchJson } from 'views/logic/search/Search';
 import { singletonActions } from 'views/logic/singleton';
 import type { RefluxActions } from 'stores/StoreTypes';
 import type { TimeRange } from 'views/logic/queries/Query';
+import type { WidgetMapping } from 'views/logic/views/types';
 
 export type CreateSearchResponse = {
   search: Search,

--- a/graylog2-web-interface/src/views/components/SearchBar.jsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.jsx
@@ -35,7 +35,7 @@ type Props = {
   },
   disableSearch: boolean,
   onExecute: () => void,
-  queryFilters: Immutable.Map,
+  queryFilters: Immutable.Map<any, any>,
 };
 
 const SearchBar = ({ availableStreams, config, currentQuery, disableSearch = false, onExecute: performSearch, queryFilters }: Props) => {

--- a/graylog2-web-interface/src/views/components/SearchResult.jsx
+++ b/graylog2-web-interface/src/views/components/SearchResult.jsx
@@ -12,12 +12,12 @@ import { CurrentViewStateStore } from 'views/stores/CurrentViewStateStore';
 import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
 import { WidgetStore } from 'views/stores/WidgetStore';
 import { SearchLoadingStateStore } from 'views/stores/SearchLoadingStateStore';
-import type { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
 import type { QueryId } from 'views/logic/queries/Query';
 import ViewState from 'views/logic/views/ViewState';
 import TSearchResult from 'views/logic/SearchResult';
 import LoadingIndicator from 'components/common/LoadingIndicator';
 import { Row, Col } from 'components/graylog';
+import type { FieldTypesStoreState } from '../stores/FieldTypesStore';
 
 const SearchLoadingIndicator = connect(
   ({ searchLoadingState }) => (searchLoadingState.isLoading && <LoadingIndicator text="Updating search results..." />),
@@ -27,7 +27,7 @@ const SearchLoadingIndicator = connect(
 const QueryWithWidgets = connect(Query, { widgets: WidgetStore });
 
 type Props = {
-  fieldTypes: FieldTypeMappingsList,
+  fieldTypes: FieldTypesStoreState,
   queryId: QueryId,
   searches: TSearchResult,
   viewState: {

--- a/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.test.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.test.jsx
@@ -10,6 +10,7 @@ import View from 'views/logic/views/View';
 import Search from 'views/logic/search/Search';
 import Query from 'views/logic/queries/Query';
 import ViewState from 'views/logic/views/ViewState';
+import type { ViewStateMap } from 'views/logic/views/View';
 import BigDisplayModeConfiguration from './BigDisplayModeConfiguration';
 
 expect.extend({ toBeDisabled });
@@ -31,11 +32,11 @@ const createViewWithQueries = () => {
     Query.builder().id('query-id-2').build(),
     Query.builder().id('other-query-id').build(),
   ];
-  const states = {
+  const states: ViewStateMap = Immutable.Map({
     'query-id-1': ViewState.create(),
     'query-id-2': ViewState.builder().titles(Immutable.fromJS({ tab: { title: 'My awesome Query tab' } })).build(),
     'other-query-id': ViewState.create(),
-  };
+  });
   const searchWithQueries = search.toBuilder()
     .queries(queries)
     .build();

--- a/graylog2-web-interface/src/views/components/datatable/DataTable.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTable.jsx
@@ -70,11 +70,11 @@ const DataTable = ({ config, currentView, data, fields }: Props) => {
   const { columnPivots, rowPivots, series, rollup } = config;
   const { chart: rows = [] } = data || {};
 
-  const rowFieldNames = rowPivots.map(pivot => pivot.field);
+  const rowFieldNames = rowPivots.map<string>(pivot => pivot.field);
   const columnFieldNames = columnPivots.map(pivot => pivot.field);
 
   const seriesToMerge = rollup ? series : [];
-  const effectiveFields = new Immutable.OrderedSet(rowFieldNames).merge(seriesToMerge.map(({ effectiveName }) => effectiveName));
+  const effectiveFields = Immutable.OrderedSet(rowFieldNames).merge(seriesToMerge.map(({ effectiveName }) => effectiveName));
 
   const expandedRows = expandRows(rowFieldNames.slice(), columnFieldNames.slice(), rows.filter(r => r.source === 'leaf'));
 

--- a/graylog2-web-interface/src/views/components/datatable/DataTableEntry.test.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTableEntry.test.jsx
@@ -1,6 +1,6 @@
 // @flow strict
 import * as React from 'react';
-import * as Immutable from 'immutable';
+import { List, OrderedSet } from 'immutable';
 import { mount } from 'wrappedEnzyme';
 
 import mockComponent from 'helpers/mocking/MockComponent';
@@ -8,13 +8,13 @@ import mockComponent from 'helpers/mocking/MockComponent';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import { FieldTypes } from 'views/logic/fieldtypes/FieldType';
 import Series from 'views/logic/aggregationbuilder/Series';
+import SeriesConfig from 'views/logic/aggregationbuilder/SeriesConfig';
 import DataTableEntry from './DataTableEntry';
-import SeriesConfig from '../../logic/aggregationbuilder/SeriesConfig';
 import EmptyValue from '../EmptyValue';
 
 jest.mock('views/components/common/UserTimezoneTimestamp', () => mockComponent('UserTimezoneTimestamp'));
 
-const fields = Immutable.OrderedSet(['nf_dst_address', 'count()', 'max(timestamp)', 'card(timestamp)']);
+const fields = OrderedSet(['nf_dst_address', 'count()', 'max(timestamp)', 'card(timestamp)']);
 const item = {
   nf_dst_address: '192.168.1.24',
   nf_proto_name: {
@@ -57,7 +57,7 @@ describe('DataTableEntry', () => {
                         fields={fields}
                         item={item}
                         series={series}
-                        types={[]}
+                        types={List([])}
                         valuePath={valuePath} />
       </table>
     ));
@@ -80,7 +80,7 @@ describe('DataTableEntry', () => {
                         fields={fields}
                         item={item}
                         series={series}
-                        types={types}
+                        types={List(types)}
                         valuePath={valuePath} />
       </table>
     ));
@@ -101,7 +101,7 @@ describe('DataTableEntry', () => {
                         fields={fields}
                         item={item}
                         series={series}
-                        types={[]}
+                        types={List([])}
                         valuePath={valuePath} />
       </table>
     ));
@@ -111,7 +111,7 @@ describe('DataTableEntry', () => {
   });
 
   it('does not render `Empty Value` for deduplicated values', () => {
-    const fieldsWithDeduplicatedValues = Immutable.OrderedSet(['nf_dst_address', 'nf_dst_port']);
+    const fieldsWithDeduplicatedValues = OrderedSet(['nf_dst_address', 'nf_dst_port']);
     const itemWithDeduplicatedValues = {
       nf_dst_port: 443,
     };
@@ -123,7 +123,7 @@ describe('DataTableEntry', () => {
                         fields={fieldsWithDeduplicatedValues}
                         item={itemWithDeduplicatedValues}
                         series={series}
-                        types={[]}
+                        types={List([])}
                         valuePath={valuePath} />
       </table>
     ));
@@ -141,7 +141,7 @@ describe('DataTableEntry', () => {
                           fields={fields}
                           item={item}
                           series={series}
-                          types={[timestampTypeMapping]}
+                          types={List([timestampTypeMapping])}
                           valuePath={valuePath} />
         </table>
       ));
@@ -153,7 +153,7 @@ describe('DataTableEntry', () => {
       const itemWithRenamedSeries = {
         'Last Timestamp': 1554106041841,
       };
-      const fieldsWithRenamedSeries = Immutable.OrderedSet(['Last Timestamp']);
+      const fieldsWithRenamedSeries = OrderedSet(['Last Timestamp']);
 
       const wrapper = mount((
         <table>
@@ -163,7 +163,7 @@ describe('DataTableEntry', () => {
                           fields={fieldsWithRenamedSeries}
                           item={itemWithRenamedSeries}
                           series={renamedSeries}
-                          types={[timestampTypeMapping]}
+                          types={List([timestampTypeMapping])}
                           valuePath={[]} />
         </table>
       ));
@@ -187,7 +187,7 @@ describe('DataTableEntry', () => {
         'Last Timestamp': 1554106041841,
         'card(timestamp)': 20,
       };
-      const fieldsWithRenamedSeries = Immutable.OrderedSet(['nf_dst_address', 'count()', 'Last Timestamp', 'card(timestamp)']);
+      const fieldsWithRenamedSeries = OrderedSet(['nf_dst_address', 'count()', 'Last Timestamp', 'card(timestamp)']);
 
       const wrapper = mount((
         <table>
@@ -197,7 +197,7 @@ describe('DataTableEntry', () => {
                           fields={fieldsWithRenamedSeries}
                           item={itemWithRenamedSeries}
                           series={renamedSeries}
-                          types={[timestampTypeMapping]}
+                          types={List([timestampTypeMapping])}
                           valuePath={valuePath} />
         </table>
       ));

--- a/graylog2-web-interface/src/views/components/datatable/Headers.test.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/Headers.test.jsx
@@ -1,9 +1,9 @@
 // @flow strict
 import * as React from 'react';
+import * as Immutable from 'immutable';
 import { mount } from 'wrappedEnzyme';
 
 import Series from 'views/logic/aggregationbuilder/Series';
-import type { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
 import { FieldTypes } from 'views/logic/fieldtypes/FieldType';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
@@ -30,7 +30,7 @@ describe('Headers', () => {
     series?: Array<Series>,
     rollup?: boolean,
     actualColumnPivotFields?: Array<Array<string>>,
-    fields?: FieldTypeMappingsList,
+    fields?: Array<FieldTypeMapping>,
   };
   /* eslint-enable react/require-default-props */
 
@@ -50,7 +50,7 @@ describe('Headers', () => {
                  series={series}
                  rollup={rollup}
                  actualColumnPivotFields={actualColumnPivotFields}
-                 fields={fields} />
+                 fields={Immutable.List(fields)} />
       </thead>
     </table>
   );

--- a/graylog2-web-interface/src/views/components/datatable/Headers.test.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/Headers.test.jsx
@@ -7,9 +7,9 @@ import Series from 'views/logic/aggregationbuilder/Series';
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
 import { FieldTypes } from 'views/logic/fieldtypes/FieldType';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
+import SeriesConfig from 'views/logic/aggregationbuilder/SeriesConfig';
 
 import Headers from './Headers';
-import SeriesConfig from '../../logic/aggregationbuilder/SeriesConfig';
 
 jest.mock('components/common/Timestamp', () => 'Timestamp');
 jest.mock('logic/datetimes/DateTime', () => 'DateTime');

--- a/graylog2-web-interface/src/views/components/datatable/__snapshots__/DataTableEntry.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/datatable/__snapshots__/DataTableEntry.test.jsx.snap
@@ -73,7 +73,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
         },
       ]
     }
-    types={Array []}
+    types={Immutable.List []}
     valuePath={
       Array [
         Object {

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.jsx
@@ -1,5 +1,6 @@
 // @flow strict
 import * as React from 'react';
+import * as Immutable from 'immutable';
 import { render, cleanup, fireEvent, wait } from 'wrappedTestingLibrary';
 
 import QueryTitleEditModal from './QueryTitleEditModal';
@@ -17,7 +18,7 @@ describe('QueryTitleEditModal', () => {
     let modalRef;
     const { queryByText } = render(
       <QueryTitleEditModal ref={(ref) => { modalRef = ref; }}
-                           onTitleChange={() => Promise.resolve()} />,
+                           onTitleChange={() => Promise.resolve(Immutable.Map())} />,
     );
     // Modal should not be visible initially
     expect(queryByText(modalHeadline)).toBeNull();
@@ -30,7 +31,7 @@ describe('QueryTitleEditModal', () => {
     let modalRef;
     const { getByDisplayValue } = render(
       <QueryTitleEditModal ref={(ref) => { modalRef = ref; }}
-                           onTitleChange={() => Promise.resolve()} />,
+                           onTitleChange={() => Promise.resolve(Immutable.Map())} />,
     );
     openModal(modalRef);
     expect(getByDisplayValue('CurrentTitle')).not.toBeNull();

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -22,6 +22,7 @@ import MessageTable from 'views/components/widgets/MessageTable';
 import ErrorWidget from 'views/components/widgets/ErrorWidget';
 
 import RenderCompletionCallback from './RenderCompletionCallback';
+import type { FieldTypeMappingsList } from '../../stores/FieldTypesStore';
 
 const { InputsActions } = CombinedProvider.get('Inputs');
 
@@ -41,7 +42,7 @@ type State = {
 }
 
 type Props = {
-  fields: Array<string>,
+  fields: FieldTypeMappingsList,
   pageSize: number,
   config: MessagesWidgetConfig,
   data: { messages: Array<Object>, total: number, id: string },

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -41,11 +41,11 @@ type State = {
 }
 
 type Props = {
-  fields: {},
+  fields: Array<string>,
   pageSize: number,
   config: MessagesWidgetConfig,
   data: { messages: Array<Object>, total: number, id: string },
-  selectedFields?: {},
+  selectedFields?: Immutable.Set<string>,
   searchTypes: { [searchTypeId: string]: { effectiveTimerange: TimeRange }},
   setLoadingState: (loading: boolean) => void,
   currentView: {
@@ -93,7 +93,7 @@ class MessageList extends React.Component<Props, State> {
     if (currentPage !== 1) {
       this.setState({ currentPage: 1, errors: [] });
     }
-  }
+  };
 
   _handlePageChange = (pageNo: number) => {
     // execute search with new offset
@@ -109,7 +109,7 @@ class MessageList extends React.Component<Props, State> {
         currentPage: pageNo,
       });
     });
-  }
+  };
 
   _getListKey = () => {
     // When the component receives new messages, we want to reset the scroll position, by defining a new key or the MessageTable.
@@ -121,7 +121,7 @@ class MessageList extends React.Component<Props, State> {
       return `${defaultKey}-${firstMessageId}`;
     }
     return defaultKey;
-  }
+  };
 
   static contextType = RenderCompletionCallback;
 

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import { AdditionalContext } from 'views/logic/ActionContext';
 import MessageFieldsFilter from 'logic/message/MessageFieldsFilter';
 import FieldType from 'views/logic/fieldtypes/FieldType';
+import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
 import CustomPropTypes from 'views/components/CustomPropTypes';
 
@@ -128,13 +129,13 @@ const TableHead = styled.thead`
 `;
 
 type State = {
-  expandedMessages: Immutable.Set,
+  expandedMessages: Immutable.Set<string>,
 }
 
 type Props = {
-  fields: {},
+  fields: Array<string>,
   config: MessagesWidgetConfig,
-  selectedFields?: {},
+  selectedFields?: Immutable.Set<string>,
   activeQueryId: string,
   messages: Array<Object>
 };
@@ -149,7 +150,7 @@ class MessageTable extends React.Component<Props, State> {
   };
 
   static defaultProps = {
-    selectedFields: Immutable.Set(),
+    selectedFields: Immutable.Set<string>(),
   };
 
   state = {
@@ -165,7 +166,7 @@ class MessageTable extends React.Component<Props, State> {
     return {};
   };
 
-  _fieldTypeFor = (fieldName: string, fields: Immutable.List) => {
+  _fieldTypeFor = (fieldName: string, fields: Immutable.List<FieldTypeMapping>) => {
     return ((fields && fields.find(f => f.name === fieldName)) || { type: FieldType.Unknown }).type;
   };
 
@@ -183,7 +184,7 @@ class MessageTable extends React.Component<Props, State> {
 
   _getSelectedFields = () => {
     const { selectedFields, config } = this.props;
-    return Immutable.OrderedSet(config ? config.fields : selectedFields);
+    return Immutable.OrderedSet<string>(config ? config.fields : selectedFields);
   };
 
   _toggleMessageDetail = (id: string) => {

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
@@ -133,11 +133,15 @@ type State = {
 }
 
 type Props = {
-  fields: Array<string>,
+  fields: Immutable.List<FieldTypeMapping>,
   config: MessagesWidgetConfig,
   selectedFields?: Immutable.Set<string>,
   activeQueryId: string,
   messages: Array<Object>
+};
+
+type DefaultProps = {
+  selectedFields: Immutable.Set<string>,
 };
 
 class MessageTable extends React.Component<Props, State> {
@@ -149,17 +153,17 @@ class MessageTable extends React.Component<Props, State> {
     selectedFields: PropTypes.object,
   };
 
-  static defaultProps = {
+  static defaultProps: DefaultProps = {
     selectedFields: Immutable.Set<string>(),
   };
 
   state = {
-    expandedMessages: Immutable.Set(),
+    expandedMessages: Immutable.Set<string>(),
   };
 
   _columnStyle = (fieldName: string) => {
     const { fields } = this.props;
-    const selectedFields = Immutable.OrderedSet(fields);
+    const selectedFields = Immutable.OrderedSet<string>(fields);
     if (fieldName.toLowerCase() === 'source' && selectedFields.size > 1) {
       return { width: 180 };
     }
@@ -182,9 +186,9 @@ class MessageTable extends React.Component<Props, State> {
     }));
   };
 
-  _getSelectedFields = () => {
+  _getSelectedFields = (): Immutable.OrderedSet<string> => {
     const { selectedFields, config } = this.props;
-    return Immutable.OrderedSet<string>(config ? config.fields : selectedFields);
+    return Immutable.OrderedSet<string>(config ? config.fields : (selectedFields || Immutable.Set<string>()));
   };
 
   _toggleMessageDetail = (id: string) => {

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.test.jsx
@@ -31,7 +31,7 @@ describe('MessageTable', () => {
     const wrapper = mount(<MessageTable messages={messages}
                                         activeQueryId={activeQueryId}
                                         fields={Immutable.List(fields)}
-                                        selectedFields={{}}
+                                        selectedFields={Immutable.Set()}
                                         config={config} />);
     const th = wrapper.find('th').at(0);
     expect(th.text()).toContain('file_name');
@@ -41,7 +41,7 @@ describe('MessageTable', () => {
     const wrapper = mount(<MessageTable messages={messages}
                                         activeQueryId={activeQueryId}
                                         fields={Immutable.List(fields)}
-                                        selectedFields={{}}
+                                        selectedFields={Immutable.Set()}
                                         config={config} />);
     const messageTableEntry = wrapper.find('MessageTableEntry');
     const td = messageTableEntry.find('td').at(0);
@@ -55,7 +55,7 @@ describe('MessageTable', () => {
                                           activeQueryId={activeQueryId}
                                           // $FlowFixMe: violating contract on purpose
                                           fields={undefined}
-                                          selectedFields={{}}
+                                          selectedFields={Immutable.Set()}
                                           config={config} />);
       const messageTableEntry = wrapper.find('MessageTableEntry');
       expect(messageTableEntry).not.toBeEmptyRender();
@@ -68,7 +68,7 @@ describe('MessageTable', () => {
     const wrapper = mount(<MessageTable messages={messages}
                                         activeQueryId={activeQueryId}
                                         fields={Immutable.List(fields)}
-                                        selectedFields={{}}
+                                        selectedFields={Immutable.Set()}
                                         config={configWithFields} />);
 
     const tableHeadFields = wrapper.find('Field').map(field => field.text());

--- a/graylog2-web-interface/src/views/components/widgets/Widget.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.test.jsx
@@ -87,7 +87,7 @@ describe('<Widget />', () => {
   const search = View.builder()
     .search(searchSearch)
     .type(View.Type.Dashboard)
-    .state(Map.of('query-id', viewState))
+    .state(Map({ 'query-id': viewState }))
     .id('search-1')
     .title('search 1')
     .build();

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
@@ -51,7 +51,8 @@ const bindSearchParamsFromQuery: ViewHook = ({ query, view }) => {
     queryBuilder = queryBuilder.timerange(timerange);
   }
 
-  return QueriesActions.update(firstQuery.id, queryBuilder.build());
+  return QueriesActions.update(firstQuery.id, queryBuilder.build())
+    .then(() => true, () => false);
 };
 
 export default bindSearchParamsFromQuery;

--- a/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.js
+++ b/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.js
@@ -6,6 +6,7 @@ import history from 'util/History';
 import { ViewStore } from 'views/stores/ViewStore';
 import View from 'views/logic/views/View';
 import { QueriesActions } from 'views/actions/QueriesActions';
+import type { TimeRange } from 'views/logic/queries/Query';
 
 const useActionListeners = (actions, callback, dependencies) => {
   useEffect(() => {
@@ -14,11 +15,11 @@ const useActionListeners = (actions, callback, dependencies) => {
   }, dependencies);
 };
 
-const extractTimerangeParams = (timerange) => {
+const extractTimerangeParams = (timerange: TimeRange) => {
   const { type } = timerange;
   const result = { rangetype: type };
 
-  switch (type) {
+  switch (timerange.type) {
     case 'relative': return Object.entries({ ...result, relative: timerange.range });
     case 'keyword': return Object.entries({ ...result, keyword: timerange.keyword });
     case 'absolute': return Object.entries({ ...result, from: timerange.from, to: timerange.to });

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidgetConfig.js
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidgetConfig.js
@@ -115,7 +115,7 @@ export default class AggregationWidgetConfig extends WidgetConfig {
 
   toBuilder() {
     // eslint-disable-next-line no-use-before-define
-    return new Builder(Immutable.Map(this._value));
+    return new Builder(Immutable.Map((this._value: { [string]: any })));
   }
 
   toJSON() {

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/Series.js
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/Series.js
@@ -98,7 +98,7 @@ export default class Series {
 
   toBuilder() {
     // eslint-disable-next-line no-use-before-define
-    return new Builder(Immutable.Map(this._value));
+    return new Builder(Immutable.Map((this._value: { [string]: any })));
   }
 }
 

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/SortConfig.js
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/SortConfig.js
@@ -99,7 +99,7 @@ type BuilderState = Immutable.Map<string, any>;
 class Builder {
   value: BuilderState;
 
-  constructor(value: Immutable.Map = Immutable.Map()) {
+  constructor(value: BuilderState = Immutable.Map()) {
     this.value = value;
   }
 

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/BarVisualizationConfig.js
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/BarVisualizationConfig.js
@@ -49,10 +49,11 @@ export default class BarVisualizationConfig extends VisualizationConfig {
   }
 }
 
+type InternalBuilderState = Immutable.Map<string, any>;
 class Builder {
-  value: Immutable.Map<BarVisualizationConfigType>;
+  value: InternalBuilderState;
 
-  constructor(value: BarVisualizationConfigType = Immutable.Map()) {
+  constructor(value: InternalBuilderState = Immutable.Map()) {
     this.value = value;
   }
 

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/NumberVisualizationConfig.js
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/NumberVisualizationConfig.js
@@ -36,7 +36,7 @@ export default class NumberVisualizationConfig extends VisualizationConfig {
 
   toBuilder() {
     // eslint-disable-next-line no-use-before-define
-    return new Builder(Immutable.Map(this._value));
+    return new Builder(Immutable.Map((this._value: { [string]: any })));
   }
 
   static create(

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/Viewport.js
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/Viewport.js
@@ -57,10 +57,11 @@ export default class Viewport {
   }
 }
 
+type InternalBuilderState = Immutable.Map<string, any>;
 class Builder {
-  value: Immutable.Map<State>;
+  value: InternalBuilderState;
 
-  constructor(value: State = Immutable.Map()) {
+  constructor(value: InternalBuilderState = Immutable.Map()) {
     this.value = value;
   }
 

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/WorldMapVisualizationConfig.js
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/visualizations/WorldMapVisualizationConfig.js
@@ -57,10 +57,11 @@ export default class WorldMapVisualizationConfig extends VisualizationConfig {
   }
 }
 
+type InternalBuilderState = Immutable.Map<string, any>;
 class Builder {
-  value: Immutable.Map<State>;
+  value: InternalBuilderState;
 
-  constructor(value: Immutable.Map<State> = Immutable.Map()) {
+  constructor(value: InternalBuilderState = Immutable.Map()) {
     this.value = value;
   }
 

--- a/graylog2-web-interface/src/views/logic/fieldtypes/FieldType.js
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/FieldType.js
@@ -21,7 +21,7 @@ export type FieldName = string;
 export type FieldValue = any;
 
 class FieldType {
-  value: Immutable.Map<string, *>;
+  value: Immutable.Map<string, any>;
 
   constructor(type: string, properties: Array<Property>, indexNames: Array<string>) {
     this.value = Immutable.Map({ type, properties: Immutable.Set(properties), indexNames: Immutable.Set(indexNames) });

--- a/graylog2-web-interface/src/views/logic/fieldtypes/FieldTypeFor.js
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/FieldTypeFor.js
@@ -1,8 +1,6 @@
 // @flow strict
-
 import Series, { isFunction } from 'views/logic/aggregationbuilder/Series';
 import type { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
-
 
 import inferTypeForSeries from './InferTypeForSeries';
 import FieldType from './FieldType';

--- a/graylog2-web-interface/src/views/logic/fieldtypes/FieldTypeFor.js
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/FieldTypeFor.js
@@ -4,8 +4,9 @@ import type { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
 
 import inferTypeForSeries from './InferTypeForSeries';
 import FieldType from './FieldType';
+import FieldTypeMapping from './FieldTypeMapping';
 
-const fieldTypeFor = (field: string, types: FieldTypeMappingsList): FieldType => {
+const fieldTypeFor = (field: string, types: (FieldTypeMappingsList | Array<FieldTypeMapping>)): FieldType => {
   if (isFunction(field)) {
     const { type } = inferTypeForSeries(Series.forFunction(field), types);
     return type;

--- a/graylog2-web-interface/src/views/logic/fieldtypes/InferTypeForSeries.js
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/InferTypeForSeries.js
@@ -1,6 +1,6 @@
 // @flow strict
-
 import Series, { parseSeries } from 'views/logic/aggregationbuilder/Series';
+import type { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
 
 import FieldType, { FieldTypes } from './FieldType';
 import FieldTypeMapping from './FieldTypeMapping';
@@ -11,7 +11,7 @@ const constantTypeFunctions = {
   count: FieldTypes.LONG,
 };
 
-const inferTypeForSeries = (series: Series, types: Array<FieldTypeMapping>): FieldTypeMapping => {
+const inferTypeForSeries = (series: Series, types: (FieldTypeMappingsList | Array<FieldTypeMapping>)): FieldTypeMapping => {
   const definition = parseSeries(series.function);
   const newMapping = type => FieldTypeMapping.create(series.function, type);
   if (definition === null) {

--- a/graylog2-web-interface/src/views/logic/parameters/LookupTableParameter.js
+++ b/graylog2-web-interface/src/views/logic/parameters/LookupTableParameter.js
@@ -97,7 +97,7 @@ export default class LookupTableParameter extends Parameter {
 class Builder {
   value: InternalBuilderState;
 
-  constructor(value: Immutable.Map = Immutable.Map()) {
+  constructor(value: InternalBuilderState = Immutable.Map()) {
     this.value = value;
   }
 

--- a/graylog2-web-interface/src/views/logic/parameters/ParameterBinding.js
+++ b/graylog2-web-interface/src/views/logic/parameters/ParameterBinding.js
@@ -66,22 +66,22 @@ export default class ParameterBinding {
 }
 
 class Builder {
-  value: InternalStateBuilder;
+  _value: InternalStateBuilder;
 
-  constructor(value: Immutable.Map<string, *> = Immutable.Map()) {
-    this.value = value;
+  constructor(value: InternalStateBuilder = Immutable.Map()) {
+    this._value = value;
   }
 
   type(value: string): Builder {
-    return new Builder(this.value.set('type', value));
+    return new Builder(this._value.set('type', value));
   }
 
   value(value: string): Builder {
-    return new Builder(this.value.set('value', value));
+    return new Builder(this._value.set('value', value));
   }
 
   build(): ParameterBinding {
-    const { type, value } = this.value.toObject();
+    const { type, value } = this._value.toObject();
     return new ParameterBinding(type, value);
   }
 }

--- a/graylog2-web-interface/src/views/logic/parameters/ValueParameter.js
+++ b/graylog2-web-interface/src/views/logic/parameters/ValueParameter.js
@@ -63,7 +63,7 @@ export default class ValueParameter extends Parameter {
 class Builder {
   value: InternalBuilderState;
 
-  constructor(value: Immutable.Map = Immutable.Map()) {
+  constructor(value: InternalBuilderState = Immutable.Map()) {
     this.value = value;
   }
 

--- a/graylog2-web-interface/src/views/logic/queries/Query.js
+++ b/graylog2-web-interface/src/views/logic/queries/Query.js
@@ -36,15 +36,15 @@ const _streamFilters = (selectedStreams: Array<string>): Array<{ type: string, i
   return selectedStreams.map(stream => ({ type: 'stream', id: stream }));
 };
 
-export const filtersForQuery = (streams: ?Array<string>) => {
+export const filtersForQuery = (streams: ?Array<string>): ?FilterType => {
   if (!streams || streams.length === 0) {
     return null;
   }
   const streamFilters = _streamFilters(streams);
-  return {
+  return Immutable.Map({
     type: 'or',
     filters: streamFilters,
-  };
+  });
 };
 
 export type QueryString = ElasticsearchQueryString;

--- a/graylog2-web-interface/src/views/logic/queries/Query.js
+++ b/graylog2-web-interface/src/views/logic/queries/Query.js
@@ -100,9 +100,12 @@ export default class Query {
   toBuilder(): Builder {
     const { id, query, timerange, filter, searchTypes } = this._value;
     // eslint-disable-next-line no-use-before-define
-    return Query.builder().id(id).query(query).timerange(timerange)
-      .filter(filter)
+    const builder = Query.builder()
+      .id(id)
+      .query(query)
+      .timerange(timerange)
       .searchTypes(searchTypes);
+    return filter ? builder.filter(filter) : builder;
   }
 
   equals(other: any): boolean {

--- a/graylog2-web-interface/src/views/logic/queries/Query.js
+++ b/graylog2-web-interface/src/views/logic/queries/Query.js
@@ -51,21 +51,21 @@ export type QueryString = ElasticsearchQueryString;
 
 export type TimeRangeTypes = 'relative' | 'absolute' | 'keyword';
 
-export type RelativeTimeRange = {
+export type RelativeTimeRange = {|
   type: 'relative',
   range: number,
-};
+|};
 
-export type AbsoluteTimeRange = {
+export type AbsoluteTimeRange = {|
   type: 'absolute',
   from: string,
   to: string,
-};
+|};
 
-export type KeywordTimeRange = {
+export type KeywordTimeRange = {|
   type: 'keyword',
   keyword: string,
-};
+|};
 
 export type TimeRange = RelativeTimeRange | AbsoluteTimeRange | KeywordTimeRange;
 

--- a/graylog2-web-interface/src/views/logic/queries/QueryGenerator.js
+++ b/graylog2-web-interface/src/views/logic/queries/QueryGenerator.js
@@ -7,10 +7,9 @@ import type { QueryId } from './Query';
 export default (streamId: ?string, id: QueryId = uuid()): Query => {
   const streamIds = streamId ? [streamId] : null;
   const streamFilter = filtersForQuery(streamIds);
-  return Query.builder()
+  const builder = Query.builder()
     .id(id)
     .query(createElasticsearchQueryString())
-    .filter(streamFilter)
-    .timerange(DEFAULT_TIMERANGE)
-    .build();
+    .timerange(DEFAULT_TIMERANGE);
+  return streamFilter ? builder.filter(streamFilter).build() : builder.build();
 };

--- a/graylog2-web-interface/src/views/logic/search/GlobalOverride.js
+++ b/graylog2-web-interface/src/views/logic/search/GlobalOverride.js
@@ -84,7 +84,7 @@ type InternalBuilderState = Immutable.Map<string, any>;
 class Builder {
   value: InternalBuilderState;
 
-  constructor(value: Immutable.Map = Immutable.Map()) {
+  constructor(value: InternalBuilderState = Immutable.Map()) {
     this.value = value;
   }
 

--- a/graylog2-web-interface/src/views/logic/search/Search.js
+++ b/graylog2-web-interface/src/views/logic/search/Search.js
@@ -26,7 +26,7 @@ export type QuerySet = Immutable.Set<Query>;
 export default class Search {
   _value: InternalState;
 
-  constructor(id: SearchId, queries: Array<Query>, parameters: Array<Parameter>) {
+  constructor(id: SearchId, queries: (Array<Query> | QuerySet), parameters: Array<Parameter>) {
     this._value = { id, queries: Immutable.OrderedSet(queries), parameters: Immutable.Set(parameters) };
   }
 
@@ -101,7 +101,7 @@ class Builder {
     return this.id(ObjectID().toString());
   }
 
-  queries(value: Array<Query>): Builder {
+  queries(value: (Array<Query> | QuerySet)): Builder {
     return new Builder(this.value.set('queries', value));
   }
 

--- a/graylog2-web-interface/src/views/logic/search/SearchExecutionState.js
+++ b/graylog2-web-interface/src/views/logic/search/SearchExecutionState.js
@@ -66,7 +66,7 @@ type InternalBuilderState = Immutable.Map<string, any>;
 class Builder {
   value: InternalBuilderState;
 
-  constructor(value: Immutable.Map = Immutable.Map()) {
+  constructor(value: InternalBuilderState = Immutable.Map()) {
     this.value = value;
   }
 

--- a/graylog2-web-interface/src/views/logic/search/SearchExecutionState.js
+++ b/graylog2-web-interface/src/views/logic/search/SearchExecutionState.js
@@ -86,6 +86,6 @@ class Builder {
 
 const getParameterBindingValue = (executionState: SearchExecutionState, parameterName: string) => executionState.parameterBindings.get(parameterName, ParameterBinding.empty()).value;
 
-const getParameterBindingsAsMap = (bindings: ParameterBindings) => bindings.flatMap((binding: ParameterBinding, name: string) => ({ [name]: binding.value }));
+const getParameterBindingsAsMap = (bindings: ParameterBindings) => bindings.flatMap<string, string>((binding: ParameterBinding, name: string) => ({ [name]: binding.value }));
 
 export { getParameterBindingsAsMap, getParameterBindingValue };

--- a/graylog2-web-interface/src/views/logic/search/SearchExecutionState.js
+++ b/graylog2-web-interface/src/views/logic/search/SearchExecutionState.js
@@ -86,6 +86,6 @@ class Builder {
 
 const getParameterBindingValue = (executionState: SearchExecutionState, parameterName: string) => executionState.parameterBindings.get(parameterName, ParameterBinding.empty()).value;
 
-const getParameterBindingsAsMap = (bindings: ParameterBindings) => bindings.flatMap<string, string>((binding: ParameterBinding, name: string) => ({ [name]: binding.value }));
+const getParameterBindingsAsMap = (bindings: ParameterBindings) => bindings.flatMap<string, string>((binding: ParameterBinding, name: string) => Immutable.Map({ [name]: binding.value }));
 
 export { getParameterBindingsAsMap, getParameterBindingValue };

--- a/graylog2-web-interface/src/views/logic/search/SearchMetadata.js
+++ b/graylog2-web-interface/src/views/logic/search/SearchMetadata.js
@@ -27,9 +27,9 @@ export default class SearchMetadata {
     const allUsedParameterNames: Array<string> = queryMetadata.valueSeq()
       .reduce((acc: Array<string>, meta: QueryMetadata) => [...acc, ...meta.usedParameterNames.toJS()], []);
     const declaredParameterNames: Array<string> = declaredParameters.keySeq().toJS();
-    const used: Array<Parameter> = Immutable.Set(allUsedParameterNames.filter(parameterName => declaredParameterNames.includes(parameterName))
+    const used = Immutable.Set(allUsedParameterNames.filter(parameterName => declaredParameterNames.includes(parameterName))
       .map((parameterName: string) => declaredParameters.get(parameterName)));
-    const undeclared: Array<string> = Immutable.Set(allUsedParameterNames.filter(parameterName => !declaredParameterNames.includes(parameterName)));
+    const undeclared = Immutable.Set(allUsedParameterNames.filter(parameterName => !declaredParameterNames.includes(parameterName)));
 
     this._value = { queryMetadata, declaredParameters, used, undeclared };
   }

--- a/graylog2-web-interface/src/views/logic/searchtypes/MessageConfigGenerator.test.jsx
+++ b/graylog2-web-interface/src/views/logic/searchtypes/MessageConfigGenerator.test.jsx
@@ -5,11 +5,13 @@ import MessagesWidgetConfig from '../widgets/MessagesWidgetConfig';
 
 describe('MessageConfigGenerator', () => {
   it('generates basic search type from message widget', () => {
-    const widget = MessagesWidget.builder().config(
-      MessagesWidgetConfig.builder()
-        .decorators([])
-        .build(),
-    ).build();
+    // $FlowFixMe: We need to force this being a `MessagesWidget`
+    const widget: MessagesWidget = MessagesWidget.builder()
+      .config(
+        MessagesWidgetConfig.builder()
+          .decorators([])
+          .build(),
+      ).build();
 
     const result = MessageConfigGenerator(widget);
 
@@ -20,11 +22,13 @@ describe('MessageConfigGenerator', () => {
       { id: 'decorator1', type: 'something', config: {}, stream: null, order: 0 },
       { id: 'decorator2', type: 'something else', config: {}, stream: null, order: 1 },
     ];
-    const widget = MessagesWidget.builder().config(
-      MessagesWidgetConfig.builder()
-        .decorators(decorators)
-        .build(),
-    ).build();
+    // $FlowFixMe: We need to force this being a `MessagesWidget`
+    const widget: MessagesWidget = MessagesWidget.builder()
+      .config(
+        MessagesWidgetConfig.builder()
+          .decorators(decorators)
+          .build(),
+      ).build();
 
     const result = MessageConfigGenerator(widget);
 

--- a/graylog2-web-interface/src/views/logic/searchtypes/SearchTypesGenerator.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/SearchTypesGenerator.js
@@ -5,7 +5,7 @@ import Widget from 'views/logic/widgets/Widget';
 
 import { widgetDefinition } from '../Widgets';
 import searchTypeDefinition from '../SearchType';
-import type { WidgetMapping } from '../views/View';
+import type { WidgetMapping } from '../views/types';
 
 const filterForWidget = widget => (widget.filter ? { filter: { type: 'query_string', query: widget.filter } } : {});
 

--- a/graylog2-web-interface/src/views/logic/searchtypes/SearchTypesGenerator.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/SearchTypesGenerator.js
@@ -35,7 +35,7 @@ export default (widgets: Array<Widget>): ResultType => {
       }
       const { defaults = {} } = typeDefinition || {};
       const { config, widgetId, ...rest } = searchType;
-      return new Immutable.Map(defaults)
+      return Immutable.Map(defaults)
         .merge(rest)
         .merge(config)
         .merge(

--- a/graylog2-web-interface/src/views/logic/searchtypes/SearchTypesGenerator.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/SearchTypesGenerator.js
@@ -5,15 +5,16 @@ import Widget from 'views/logic/widgets/Widget';
 
 import { widgetDefinition } from '../Widgets';
 import searchTypeDefinition from '../SearchType';
+import type { WidgetMapping } from '../views/View';
 
 const filterForWidget = widget => (widget.filter ? { filter: { type: 'query_string', query: widget.filter } } : {});
 
 export type ResultType = {
   searchTypes: Immutable.Set<Immutable.Map<string, any>>,
-  widgetMapping: Immutable.Map<string, Immutable.Set<string>>,
+  widgetMapping: WidgetMapping,
 };
 
-export default (widgets: Array<Widget>): ResultType => {
+export default (widgets: (Array<Widget> | Immutable.List<Widget>)): ResultType => {
   let widgetMapping = Immutable.Map();
   const searchTypes = widgets
     .map(widget => widgetDefinition(widget.type)

--- a/graylog2-web-interface/src/views/logic/searchtypes/SearchTypesGenerator.test.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/SearchTypesGenerator.test.js
@@ -37,8 +37,8 @@ describe('SearchTypesGenerator', () => {
     const widgetWithFilterId = widgetMapping.get('widgetWithFilter').first();
     const widgetWithoutFilterId = widgetMapping.get('widgetWithoutFilter').first();
 
-    const searchTypeWithFilter = searchTypes.find(w => (w.get('id') === widgetWithFilterId)).toJS();
-    const searchTypeWithoutFilter = searchTypes.find(w => (w.get('id') === widgetWithoutFilterId)).toJS();
+    const searchTypeWithFilter = searchTypes.find(w => (w.get('id') === widgetWithFilterId), null, Immutable.Map()).toJS();
+    const searchTypeWithoutFilter = searchTypes.find(w => (w.get('id') === widgetWithoutFilterId), null, Immutable.Map()).toJS();
 
     expect(searchTypeWithFilter.filter).toEqual({ query: 'source: foo', type: 'query_string' });
     expect(searchTypeWithoutFilter.filter).toBeUndefined();

--- a/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotConfigGenerator.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotConfigGenerator.js
@@ -84,7 +84,7 @@ export default ({ config }: { config: AggregationWidgetConfig }) => {
 };
 
 class ConfigBuilder {
-  value: Set;
+  value: Set<any>;
 
   constructor(values: Array<any>) {
     this.value = Set.of(...values);
@@ -95,7 +95,7 @@ class ConfigBuilder {
     return this;
   }
 
-  build() {
+  build(): Array<any> {
     return this.value.toArray();
   }
 

--- a/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotConfigGenerator.test.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotConfigGenerator.test.js
@@ -37,7 +37,11 @@ describe('PivotConfigGenerator', () => {
         id: expect.any(String),
       },
     });
-    expect(result[1].timerange.id).toEqual(result[0].id);
+    const [{ id }, { timerange }] = result;
+    if (!timerange) {
+      throw new Error('Expected `timerange` on generated config, but not present!');
+    }
+    expect(timerange.id).toEqual(id);
   });
 
   it('should add a event annotation config when configured', () => {
@@ -65,7 +69,11 @@ describe('PivotConfigGenerator', () => {
         { interval: { type: 'timeunit', unit: timeUnit, value: 1 } },
       ));
       const result = PivotConfigGenerator({ config });
-      const [{ config: { row_groups: [pivot] } }] = result;
+      const [{ config: pivotConfig }] = result;
+      if (!pivotConfig) {
+        throw new Error('Expected `config` in first element of result is missing!');
+      }
+      const { row_groups: [pivot] } = pivotConfig;
       const { interval: { timeunit } } = pivot;
       expect(timeunit).toEqual(expectedMappedTimeUnit);
     };

--- a/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.test.js
+++ b/graylog2-web-interface/src/views/logic/valueactions/AddToQueryHandler.test.js
@@ -40,7 +40,7 @@ describe('AddToQueryHandler', () => {
     const query = Query.builder()
       .query({ type: 'elasticsearch', query_string: '' })
       .build();
-    queries = Immutable.Map({ queryId: query });
+    queries = Immutable.OrderedMap({ queryId: query });
 
     const addToQueryHandler = new AddToQueryHandler();
 
@@ -59,7 +59,7 @@ describe('AddToQueryHandler', () => {
     const query = Query.builder()
       .query({ type: 'elasticsearch', query_string: '' })
       .build();
-    queries = Immutable.Map({ queryId: query });
+    queries = Immutable.OrderedMap({ queryId: query });
 
     const addToQueryHandler = new AddToQueryHandler();
 
@@ -67,7 +67,7 @@ describe('AddToQueryHandler', () => {
       .query({ type: 'elasticsearch', query_string: 'foo:23' })
       .build();
 
-    queriesStoreListen(Immutable.Map({ anotherQueryId: newQuery }));
+    queriesStoreListen(Immutable.OrderedMap({ anotherQueryId: newQuery }));
 
     return addToQueryHandler.handle({ queryId: 'anotherQueryId', field: 'bar', value: 42, type: new FieldType('keyword', [], []), contexts: { view } })
       .then(() => {

--- a/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.js
+++ b/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.js
@@ -44,9 +44,9 @@ const CopyWidgetToDashboard = (widgetId: string, search: View, dashboard: View):
 
   if (match) {
     const [widget, queryId] = match;
-    const { timerange, query, filter = List.of() } = queryMap.get(queryId);
+    const { timerange, query, filter = Map() } = queryMap.get(queryId);
 
-    const streams = filter.get('filters', List.of())
+    const streams = (filter ? filter.get('filters', List.of()) : List.of())
       .filter(value => Map.isMap(value) && value.get('type') === 'stream')
       .map(value => value.get('id'))
       .toList()

--- a/graylog2-web-interface/src/views/logic/views/View.js
+++ b/graylog2-web-interface/src/views/logic/views/View.js
@@ -197,10 +197,11 @@ export default class View {
   }
 }
 
+type InternalBuilderState = Immutable.Map<string, any>
 class Builder {
-  value: Immutable.Map<string, any>;
+  value: InternalBuilderState;
 
-  constructor(value: Immutable.Map = Immutable.Map()) {
+  constructor(value: InternalBuilderState = Immutable.Map()) {
     this.value = value;
   }
 

--- a/graylog2-web-interface/src/views/logic/views/View.js
+++ b/graylog2-web-interface/src/views/logic/views/View.js
@@ -5,6 +5,7 @@ import ObjectID from 'bson-objectid';
 import ViewState from './ViewState';
 import Search from '../search/Search';
 import type { QueryId } from '../queries/Query';
+import type { WidgetMapping } from './types';
 
 export type Properties = Immutable.List<any>;
 
@@ -33,7 +34,6 @@ type InternalState = {
   requires: Requirements,
 };
 
-export type WidgetMapping = Immutable.Map<string, Immutable.Set<String>>;
 export type ViewJson = {
   id: string,
   type: ViewType,

--- a/graylog2-web-interface/src/views/logic/views/View.js
+++ b/graylog2-web-interface/src/views/logic/views/View.js
@@ -33,7 +33,7 @@ type InternalState = {
   requires: Requirements,
 };
 
-export type WidgetMapping = Immutable.Map<string, string>;
+export type WidgetMapping = Immutable.Map<string, Immutable.Set<String>>;
 export type ViewJson = {
   id: string,
   type: ViewType,

--- a/graylog2-web-interface/src/views/logic/views/View.js
+++ b/graylog2-web-interface/src/views/logic/views/View.js
@@ -6,6 +6,7 @@ import ViewState from './ViewState';
 import Search from '../search/Search';
 import type { QueryId } from '../queries/Query';
 import type { WidgetMapping } from './types';
+import type { ViewStateJson } from './ViewState';
 
 export type Properties = Immutable.List<any>;
 
@@ -42,7 +43,7 @@ export type ViewJson = {
   description: string,
   search_id: string,
   properties: Properties,
-  state: { [QueryId]: ViewState },
+  state: { [QueryId]: ViewStateJson },
   created_at: Date,
   owner: string,
   requires: Requirements,

--- a/graylog2-web-interface/src/views/logic/views/View.js
+++ b/graylog2-web-interface/src/views/logic/views/View.js
@@ -241,8 +241,8 @@ class Builder {
     return new Builder(this.value.set('properties', value));
   }
 
-  state(value: ViewStateMap): Builder {
-    return new Builder(this.value.set('state', Immutable.fromJS(value)));
+  state(value: (ViewStateMap | { [QueryId]: ViewState })): Builder {
+    return new Builder(this.value.set('state', Immutable.Map(value)));
   }
 
   createdAt(value: Date): Builder {

--- a/graylog2-web-interface/src/views/logic/views/ViewLoader.test.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewLoader.test.js
@@ -8,6 +8,7 @@ import { ViewActions } from 'views/stores/ViewStore';
 import Search from '../search/Search';
 import View from './View';
 import ViewLoader from './ViewLoader';
+import type { ViewJson } from './View';
 
 jest.mock('views/stores/ViewManagementStore', () => ({
   ViewManagementActions: {},
@@ -19,13 +20,14 @@ jest.mock('views/stores/ViewStore', () => ({
   ViewActions: {},
 }));
 
-const viewJson = {
+const viewJson: ViewJson = {
   id: 'foo',
+  type: 'SEARCH',
   title: 'Foo',
   summary: 'summary',
   description: 'Foo',
   search_id: 'foosearch',
-  properties: {},
+  properties: Immutable.List(),
   state: {},
   created_at: new Date('2019-05-24T12:34:04.993Z'),
   owner: 'admin',
@@ -45,10 +47,11 @@ describe('ViewLoader', () => {
       expect(result).toEqual(
         View.builder()
           .id('foo')
+          .type('SEARCH')
           .title('Foo')
           .summary('summary')
           .description('Foo')
-          .properties({})
+          .properties(Immutable.List())
           .state(Immutable.Map())
           .createdAt(new Date('2019-05-24T12:34:04.993Z'))
           .owner('admin')
@@ -56,8 +59,8 @@ describe('ViewLoader', () => {
             Search.create()
               .toBuilder()
               .id('foosearch')
-              .parameters(Immutable.Set())
-              .queries(Immutable.OrderedSet())
+              .parameters([])
+              .queries([])
               .build(),
           )
           .requires({})

--- a/graylog2-web-interface/src/views/logic/views/ViewState.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewState.js
@@ -7,9 +7,9 @@ import TitleTypes from 'views/stores/TitleTypes';
 import type { TitlesMap } from 'views/stores/TitleTypes';
 import type { FormattingSettingsJSON } from './formatting/FormattingSettings';
 import FormattingSettings from './formatting/FormattingSettings';
+import type { WidgetMapping } from './types';
 
 type FieldNameList = Array<string>;
-type WidgetMapping = Map<string, Set<string>>;
 type State = {
   fields: FieldNameList,
   formatting: FormattingSettings,

--- a/graylog2-web-interface/src/views/logic/views/ViewState.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewState.js
@@ -4,12 +4,11 @@ import { List, Map, fromJS, is } from 'immutable';
 import Widget from 'views/logic/widgets/Widget';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import TitleTypes from 'views/stores/TitleTypes';
-import type { TitlesMap } from 'views/stores/TitleTypes';
+import type { TitlesMap, TitleType } from 'views/stores/TitleTypes';
+import type { WidgetPositionJSON } from 'views/logic/widgets/WidgetPosition';
 import type { FormattingSettingsJSON } from './formatting/FormattingSettings';
 import FormattingSettings from './formatting/FormattingSettings';
 import type { WidgetMapping } from './types';
-import type { WidgetPositionJSON } from 'views/logic/widgets/WidgetPosition';
-import type { TitleType } from '../../stores/TitleTypes';
 
 type FieldNameList = Array<string>;
 type State = {

--- a/graylog2-web-interface/src/views/logic/views/ViewState.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewState.js
@@ -16,7 +16,7 @@ type State = {
   titles: TitlesMap,
   widgets: List<Widget>,
   widgetMapping: WidgetMapping,
-  widgetPositions: { [string]: WidgetPosition },
+  widgetPositions: Map<string, WidgetPosition>,
   staticMessageListId?: string,
 };
 
@@ -43,7 +43,7 @@ export default class ViewState {
     widgetPositions: { [string]: WidgetPosition },
     formatting: FormattingSettings,
     staticMessageListId?: string) {
-    this._value = { fields, titles, widgets: List(widgets), widgetMapping, widgetPositions, formatting, staticMessageListId };
+    this._value = { fields, titles, widgets: List(widgets), widgetMapping, widgetPositions: Map(widgetPositions), formatting, staticMessageListId };
   }
 
   static create(): ViewState {
@@ -76,7 +76,7 @@ export default class ViewState {
   }
 
   get widgetPositions(): { [string]: WidgetPosition } {
-    return this._value.widgetPositions;
+    return this._value.widgetPositions.toJS();
   }
 
   get staticMessageListId(): ?string {

--- a/graylog2-web-interface/src/views/logic/views/ViewState.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewState.js
@@ -9,6 +9,7 @@ import type { FormattingSettingsJSON } from './formatting/FormattingSettings';
 import FormattingSettings from './formatting/FormattingSettings';
 import type { WidgetMapping } from './types';
 import type { WidgetPositionJSON } from 'views/logic/widgets/WidgetPosition';
+import type { TitleType } from '../../stores/TitleTypes';
 
 type FieldNameList = Array<string>;
 type State = {
@@ -176,7 +177,7 @@ class Builder {
     return new Builder(this.value.set('formatting', value));
   }
 
-  titles(value: TitlesMap): Builder {
+  titles(value: (TitlesMap | { [TitleType]: { [string]: string } })): Builder {
     return new Builder(this.value.set('titles', fromJS(value)));
   }
 

--- a/graylog2-web-interface/src/views/logic/views/ViewState.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewState.js
@@ -189,7 +189,7 @@ class Builder {
     return new Builder(this.value.set('widgetMapping', value));
   }
 
-  widgetPositions(value: Map<string, WidgetPosition>): Builder {
+  widgetPositions(value: (Map<string, WidgetPosition> | { [string]: WidgetPosition })): Builder {
     return new Builder(this.value.set('widgetPositions', Map(value)));
   }
 

--- a/graylog2-web-interface/src/views/logic/views/ViewState.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewState.js
@@ -181,8 +181,8 @@ class Builder {
     return new Builder(this.value.set('titles', fromJS(value)));
   }
 
-  widgets(value: List<Widget>): Builder {
-    return new Builder(this.value.set('widgets', value));
+  widgets(value: (List<Widget> | Array<Widget>)): Builder {
+    return new Builder(this.value.set('widgets', List(value)));
   }
 
   widgetMapping(value: WidgetMapping): Builder {

--- a/graylog2-web-interface/src/views/logic/views/ViewState.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewState.js
@@ -22,7 +22,7 @@ type State = {
 
 type BuilderState = Map<string, any>;
 
-type JsonState = {
+export type ViewStateJson = {
   formatting?: FormattingSettingsJSON,
   positions: { [string]: WidgetPosition },
   selected_fields: FieldNameList,
@@ -142,7 +142,7 @@ export default class ViewState {
     };
   }
 
-  static fromJSON(value: JsonState): ViewState {
+  static fromJSON(value: ViewStateJson): ViewState {
     // eslint-disable-next-line camelcase
     const { selected_fields, titles, widgets, widget_mapping, positions, formatting } = value;
     return ViewState.builder()

--- a/graylog2-web-interface/src/views/logic/views/ViewState.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewState.js
@@ -8,6 +8,7 @@ import type { TitlesMap } from 'views/stores/TitleTypes';
 import type { FormattingSettingsJSON } from './formatting/FormattingSettings';
 import FormattingSettings from './formatting/FormattingSettings';
 import type { WidgetMapping } from './types';
+import type { WidgetPositionJSON } from 'views/logic/widgets/WidgetPosition';
 
 type FieldNameList = Array<string>;
 type State = {
@@ -24,12 +25,11 @@ type BuilderState = Map<string, any>;
 
 export type ViewStateJson = {
   formatting?: FormattingSettingsJSON,
-  positions: { [string]: WidgetPosition },
+  positions: { [string]: WidgetPositionJSON },
   selected_fields: FieldNameList,
   titles: TitlesMap,
   widgets: Array<any>,
   widget_mapping: WidgetMapping,
-  positions: { [string]: WidgetPosition },
   staticMessageListId?: string,
 };
 
@@ -143,14 +143,13 @@ export default class ViewState {
   }
 
   static fromJSON(value: ViewStateJson): ViewState {
-    // eslint-disable-next-line camelcase
-    const { selected_fields, titles, widgets, widget_mapping, positions, formatting } = value;
+    const { selected_fields: selectedFields, titles, widgets, widget_mapping: widgetMapping, positions, formatting } = value;
     return ViewState.builder()
       .titles(fromJS(titles))
       .widgets(List(widgets.map(w => Widget.fromJSON(w))))
-      .widgetMapping(fromJS(widget_mapping))
-      .fields(selected_fields)
-      .widgetPositions(Map(positions).map(v => WidgetPosition.fromJSON(v)))
+      .widgetMapping(fromJS(widgetMapping))
+      .fields(selectedFields)
+      .widgetPositions(Map(positions).map(WidgetPosition.fromJSON))
       .formatting(formatting ? FormattingSettings.fromJSON(formatting) : FormattingSettings.empty())
       .build();
   }

--- a/graylog2-web-interface/src/views/logic/views/ViewStateGenerator.test.jsx
+++ b/graylog2-web-interface/src/views/logic/views/ViewStateGenerator.test.jsx
@@ -32,6 +32,9 @@ describe('ViewStateGenerator', () => {
 
     expect(mockList).toHaveBeenCalledWith();
     const messageTableWidget = result.widgets.find(widget => widget.type === MessagesWidget.type);
+    if (!messageTableWidget) {
+      throw new Error('Unable to find message table widget in generated view state.');
+    }
     expect(messageTableWidget.config.decorators).toEqual([{ id: 'decorator1', stream: 'foobar', order: 0, type: 'something' }]);
   });
   it('adds decorators for default search to message table if stream id is `null`', async () => {
@@ -43,6 +46,9 @@ describe('ViewStateGenerator', () => {
 
     expect(mockList).toHaveBeenCalledWith();
     const messageTableWidget = result.widgets.find(widget => widget.type === MessagesWidget.type);
+    if (!messageTableWidget) {
+      throw new Error('Unable to find message table widget in generated view state.');
+    }
     expect(messageTableWidget.config.decorators).toEqual([{ id: 'decorator2', stream: null, order: 0, type: 'something' }]);
   });
   it('does not add decorators for current stream to message table if none exist for this stream', async () => {
@@ -54,6 +60,9 @@ describe('ViewStateGenerator', () => {
 
     expect(mockList).toHaveBeenCalledWith();
     const messageTableWidget = result.widgets.find(widget => widget.type === MessagesWidget.type);
+    if (!messageTableWidget) {
+      throw new Error('Unable to find message table widget in generated view state.');
+    }
     expect(messageTableWidget.config.decorators).toEqual([]);
   });
   it('does not add decorators for current stream to message table if none exist at all', async () => {
@@ -61,6 +70,9 @@ describe('ViewStateGenerator', () => {
 
     expect(mockList).toHaveBeenCalledWith();
     const messageTableWidget = result.widgets.find(widget => widget.type === MessagesWidget.type);
+    if (!messageTableWidget) {
+      throw new Error('Unable to find message table widget in generated view state.');
+    }
     expect(messageTableWidget.config.decorators).toEqual([]);
   });
   it('does not add decorators for default search to message table if none exist at all', async () => {
@@ -68,6 +80,9 @@ describe('ViewStateGenerator', () => {
 
     expect(mockList).toHaveBeenCalledWith();
     const messageTableWidget = result.widgets.find(widget => widget.type === MessagesWidget.type);
+    if (!messageTableWidget) {
+      throw new Error('Unable to find message table widget in generated view state.');
+    }
     expect(messageTableWidget.config.decorators).toEqual([]);
   });
 });

--- a/graylog2-web-interface/src/views/logic/views/ViewTransformer.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewTransformer.js
@@ -10,10 +10,10 @@ import ViewState from './ViewState';
 
 const ViewTransformer = (searchView: View): View => {
   const queryMap: Map<QueryId, Query> = Map(searchView.search.queries.map(q => [q.id, q]));
-  const newViewStateMap: ViewStateMap = (searchView.state || Map.of()).map((viewState: ViewState, queryId: string) => {
-    const { timerange, query, filter = List.of() } = queryMap.get(queryId);
+  const newViewStateMap: ViewStateMap = (searchView.state || Map()).map((viewState: ViewState, queryId: string) => {
+    const { timerange, query, filter = Map() } = queryMap.get(queryId);
 
-    const streams = filter.get('filters', List.of())
+    const streams = (filter ? filter.get('filters', List()) : List())
       .filter(value => Map.isMap(value) && value.get('type') === 'stream')
       .map(value => value.get('id'))
       .toList()

--- a/graylog2-web-interface/src/views/logic/views/ViewTransformer.test.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewTransformer.test.js
@@ -84,7 +84,7 @@ describe('ViewTransformer', () => {
 
       const viewState: ViewState = await ViewStateGenerator(View.Type.Search);
 
-      const viewStateMap: ViewStateMap = Map.of('query-id', viewState);
+      const viewStateMap: ViewStateMap = Map({ 'query-id': viewState });
       const searchView = View.builder()
         .type(View.Type.Search)
         .state(viewStateMap)
@@ -109,7 +109,7 @@ describe('ViewTransformer', () => {
 
       const viewState: ViewState = await ViewStateGenerator(View.Type.Search);
 
-      const viewStateMap: ViewStateMap = Map.of('query-id', viewState);
+      const viewStateMap: ViewStateMap = Map({ 'query-id': viewState });
       const searchView = View.builder()
         .type(View.Type.Search)
         .state(viewStateMap)
@@ -124,7 +124,7 @@ describe('ViewTransformer', () => {
     it('should add the streams to the widget', async () => {
       const query = Query.builder()
         .id('query-id')
-        .filter({ type: 'or', filters: List.of(Map.of('type', 'stream', 'id', '1234-abcd')) })
+        .filter(Map({ type: 'or', filters: List([Map({ type: 'stream', id: '1234-abcd' })]) }))
         .build();
 
       const search = Search.builder()
@@ -134,7 +134,7 @@ describe('ViewTransformer', () => {
 
       const viewState: ViewState = await ViewStateGenerator(View.Type.Search);
 
-      const viewStateMap: ViewStateMap = Map.of('query-id', viewState);
+      const viewStateMap: ViewStateMap = Map({ 'query-id': viewState });
       const searchView = View.builder()
         .type(View.Type.Search)
         .state(viewStateMap)

--- a/graylog2-web-interface/src/views/logic/views/__snapshots__/CopyWidgetToDashboard.test.js.snap
+++ b/graylog2-web-interface/src/views/logic/views/__snapshots__/CopyWidgetToDashboard.test.js.snap
@@ -13,17 +13,17 @@ Object {
       "formatting": Object {
         "highlighting": Array [],
       },
-      "positions": Object {
-        "32889f0b-fe5a-4f18-baa0-773869d49af3": Object {
-          "col": 1,
-          "height": 6,
-          "row": 10,
-          "width": "Infinity",
-        },
+      "positions": Immutable.Map {
         "546b13fe-eae7-4fb8-abb9-e0e3a907c3e6": Object {
           "col": 1,
           "height": 3,
           "row": 5,
+          "width": "Infinity",
+        },
+        "32889f0b-fe5a-4f18-baa0-773869d49af3": Object {
+          "col": 1,
+          "height": 6,
+          "row": 10,
           "width": "Infinity",
         },
         "8532ff94-2881-42b4-b26d-080d09305e95": Object {

--- a/graylog2-web-interface/src/views/logic/views/__snapshots__/UpdateSearchForWidgets.test.js.snap
+++ b/graylog2-web-interface/src/views/logic/views/__snapshots__/UpdateSearchForWidgets.test.js.snap
@@ -13,9 +13,33 @@ Object {
       "formatting": Object {
         "highlighting": Array [],
       },
-      "positions": Object {
+      "positions": Immutable.Map {
+        "98ccf13e-6dec-4362-bcf3-a4776f457061": Object {
+          "col": 1,
+          "height": 2,
+          "row": 7,
+          "width": "Infinity",
+        },
+        "ef9e676a-2d08-4433-b082-2617878a6e59": Object {
+          "col": 1,
+          "height": 6,
+          "row": 9,
+          "width": "Infinity",
+        },
+        "c78e9a51-2e36-4ec4-86de-9df4d29f0863": Object {
+          "col": 1,
+          "height": 2,
+          "row": 1,
+          "width": 4,
+        },
         "3d568826-fe3d-413a-99a6-09e51d82c851": Object {
           "col": 9,
+          "height": 2,
+          "row": 1,
+          "width": 4,
+        },
+        "fb496a41-4358-4bc8-b19f-244c71fe9143": Object {
+          "col": 5,
           "height": 2,
           "row": 1,
           "width": 4,
@@ -26,40 +50,16 @@ Object {
           "row": 3,
           "width": 4,
         },
-        "98ccf13e-6dec-4362-bcf3-a4776f457061": Object {
-          "col": 1,
-          "height": 2,
-          "row": 7,
-          "width": "Infinity",
-        },
-        "c78e9a51-2e36-4ec4-86de-9df4d29f0863": Object {
-          "col": 1,
-          "height": 2,
-          "row": 1,
-          "width": 4,
-        },
-        "dc4a61b2-26e6-468e-bac2-f7702846ca92": Object {
-          "col": 9,
-          "height": 4,
-          "row": 3,
-          "width": 4,
-        },
         "ec997825-6065-4fb7-ba86-427e74109ee4": Object {
           "col": 5,
           "height": 4,
           "row": 3,
           "width": 4,
         },
-        "ef9e676a-2d08-4433-b082-2617878a6e59": Object {
-          "col": 1,
-          "height": 6,
-          "row": 9,
-          "width": "Infinity",
-        },
-        "fb496a41-4358-4bc8-b19f-244c71fe9143": Object {
-          "col": 5,
-          "height": 2,
-          "row": 1,
+        "dc4a61b2-26e6-468e-bac2-f7702846ca92": Object {
+          "col": 9,
+          "height": 4,
+          "row": 3,
           "width": 4,
         },
       },

--- a/graylog2-web-interface/src/views/logic/views/__snapshots__/ViewTransformer.test.js.snap
+++ b/graylog2-web-interface/src/views/logic/views/__snapshots__/ViewTransformer.test.js.snap
@@ -82,7 +82,7 @@ Object {
         "formatting": Object {
           "highlighting": Array [],
         },
-        "positions": Object {
+        "positions": Immutable.Map {
           "527ed7fe-722d-4cf1-bd42-ed2b29a5a59a": Object {
             "col": 1,
             "height": 2,

--- a/graylog2-web-interface/src/views/logic/views/types.js
+++ b/graylog2-web-interface/src/views/logic/views/types.js
@@ -1,0 +1,4 @@
+// @flow strict
+import * as Immutable from 'immutable';
+
+export type WidgetMapping = Immutable.Map<string, Immutable.Set<String>>;

--- a/graylog2-web-interface/src/views/logic/widgets/MessagesWidget.js
+++ b/graylog2-web-interface/src/views/logic/widgets/MessagesWidget.js
@@ -1,23 +1,26 @@
+// @flow strict
 import { Map, is } from 'immutable';
 
 import Widget from './Widget';
 import MessagesWidgetConfig from './MessagesWidgetConfig';
+import type { QueryString, TimeRange } from '../queries/Query';
+import type { WidgetState } from './Widget';
 
 export default class MessagesWidget extends Widget {
-  constructor(id, config, filter, timerange, query, streams) {
+  constructor(id: string, config: any, filter: ?string, timerange: ?TimeRange, query: ?QueryString, streams: Array<string> = []) {
     super(id, MessagesWidget.type, config, filter, timerange, query, streams);
   }
 
   static type = 'messages';
 
-  static fromJSON(value) {
+  static fromJSON(value: WidgetState) {
     const { id, config, filter, timerange, query, streams } = value;
     return new MessagesWidget(id, MessagesWidgetConfig.fromJSON(config), filter, timerange, query, streams);
   }
 
-  equals(other) {
+  equals(other: any) {
     if (other instanceof MessagesWidget) {
-      return ['id', 'config', 'filter', 'timerange', 'query', 'streams'].every(key => is(this[key], other[key]));
+      return ['id', 'config', 'filter', 'timerange', 'query', 'streams'].every(key => is(this._value[key], other[key]));
     }
     return false;
   }
@@ -33,13 +36,13 @@ export default class MessagesWidget extends Widget {
     return new Builder();
   }
 
-  static isMessagesWidget(widget = {}) {
-    return widget.type === MessagesWidget.type;
+  static isMessagesWidget(widget: Widget) {
+    return widget && widget.type === MessagesWidget.type;
   }
 }
 
 class Builder extends Widget.Builder {
-  build() {
+  build(): MessagesWidget {
     const { id, config, filter, timerange, query, streams } = this.value.toObject();
     return new MessagesWidget(id, config, filter, timerange, query, streams);
   }

--- a/graylog2-web-interface/src/views/logic/widgets/MessagesWidgetConfig.js
+++ b/graylog2-web-interface/src/views/logic/widgets/MessagesWidgetConfig.js
@@ -44,7 +44,7 @@ export default class MessagesWidgetConfig extends WidgetConfig {
 
   toBuilder() {
     // eslint-disable-next-line no-use-before-define
-    return new Builder(Immutable.Map(this._value));
+    return new Builder(Immutable.Map<string, any>(this._value));
   }
 
   toJSON() {

--- a/graylog2-web-interface/src/views/logic/widgets/MessagesWidgetConfig.js
+++ b/graylog2-web-interface/src/views/logic/widgets/MessagesWidgetConfig.js
@@ -44,7 +44,7 @@ export default class MessagesWidgetConfig extends WidgetConfig {
 
   toBuilder() {
     // eslint-disable-next-line no-use-before-define
-    return new Builder(Immutable.Map<string, any>(this._value));
+    return new Builder(Immutable.Map((this._value: { [string]: any })));
   }
 
   toJSON() {

--- a/graylog2-web-interface/src/views/logic/widgets/Widget.js
+++ b/graylog2-web-interface/src/views/logic/widgets/Widget.js
@@ -5,7 +5,7 @@ import uuid from 'uuid/v4';
 import type { QueryString, TimeRange } from 'views/logic/queries/Query';
 import { singleton } from '../singleton';
 
-type State = {
+export type WidgetState = {
   id: string,
   type: string,
   config: any,
@@ -16,7 +16,7 @@ type State = {
 };
 
 class Widget {
-  _value: State;
+  _value: WidgetState;
 
   // eslint-disable-next-line no-use-before-define
   static Builder: typeof Builder;
@@ -70,7 +70,7 @@ class Widget {
     return { id, type: type.toLocaleLowerCase(), config, filter, timerange, query, streams };
   }
 
-  static fromJSON(value: State): Widget {
+  static fromJSON(value: WidgetState): Widget {
     const { id, type, config, filter, timerange, query, streams } = value;
     const implementingClass = Widget.__registrations[type.toLocaleLowerCase()];
 

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -155,7 +155,7 @@ const ExtendedSearchPage = ({ route, location = { query: {} }, router, searchRef
     }, () => { });
 
     // Returning cleanup function used when unmounting
-    return () => storeListenersUnsubscribes.forEach(unsubscribeFunc => unsubscribeFunc());
+    return () => { storeListenersUnsubscribes.forEach(unsubscribeFunc => unsubscribeFunc()); };
   }, []);
 
   useSyncWithQueryParameters(query);

--- a/graylog2-web-interface/src/views/pages/ShowViewPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/ShowViewPage.test.jsx
@@ -1,5 +1,6 @@
 // @flow strict
 import * as React from 'react';
+import { List } from 'immutable';
 import { mount } from 'wrappedEnzyme';
 
 import Routes from 'routing/Routes';
@@ -40,14 +41,14 @@ jest.mock('util/History', () => ({}));
 jest.mock('./ExtendedSearchPage', () => 'extended-search-page');
 
 describe('ShowViewPage', () => {
-  const viewJson = {
+  const viewJson: ViewJson = {
     id: 'foo',
     type: 'DASHBOARD',
     title: 'Foo',
     summary: 'summary',
     description: 'Foo',
     search_id: 'foosearch',
-    properties: {},
+    properties: List<any>(),
     state: {},
     dashboard_state: { widgets: [], positions: [] },
     created_at: new Date(),

--- a/graylog2-web-interface/src/views/stores/ChartColorRulesStore.js
+++ b/graylog2-web-interface/src/views/stores/ChartColorRulesStore.js
@@ -57,8 +57,7 @@ const ChartColorRulesStore = singletonStore(
           return Object.entries(chartColors).map(([key, value]) => ({ widgetId, name: key, color: value }));
         }
         return null;
-      }).filter(rules => (rules !== null))
-        .reduce((prev, cur) => [...prev, ...cur], []);
+      }).reduce((prev, cur) => (cur === null ? prev : [...prev, ...cur]), []);
 
       if (!isEqual(this.state, newRules)) {
         this.state = newRules;

--- a/graylog2-web-interface/src/views/stores/CurrentViewStateStore.js
+++ b/graylog2-web-interface/src/views/stores/CurrentViewStateStore.js
@@ -13,6 +13,7 @@ import { singletonActions, singletonStore } from 'views/logic/singleton';
 import { ViewStore } from './ViewStore';
 import { ViewStatesActions, ViewStatesStore } from './ViewStatesStore';
 import type { TitleType } from './TitleTypes';
+import ViewState from '../logic/views/ViewState';
 
 type CurrentViewStateActionsType = RefluxActions<{
   fields: (Immutable.Set<string>) => Promise<*>,
@@ -118,7 +119,7 @@ export const CurrentViewStateStore = singletonStore(
       CurrentViewStateActions.formatting.promise(promise);
     },
 
-    _activeState() {
+    _activeState(): ViewState {
       return this.states.get(this.activeQuery);
     },
 

--- a/graylog2-web-interface/src/views/stores/CurrentViewStateStore.test.js
+++ b/graylog2-web-interface/src/views/stores/CurrentViewStateStore.test.js
@@ -68,7 +68,7 @@ describe('CurrentViewStateStore', () => {
       .height(5)
       .width(6)
       .build();
-    const expectedWidgets = [oldViewState.widgets[0], MessagesWidget.builder().id('feed').build()];
+    const expectedWidgets = [oldViewState.widgets.get(0), MessagesWidget.builder().id('feed').build()];
     const expectedWidgetPosition = { [oldWidgetId]: newWidgetPositionDead, feed: newWidgetPositionFeed };
     const expectedViewState = viewState.toBuilder()
       .widgetPositions(expectedWidgetPosition)

--- a/graylog2-web-interface/src/views/stores/FieldTypesStore.js
+++ b/graylog2-web-interface/src/views/stores/FieldTypesStore.js
@@ -26,7 +26,7 @@ export const FieldTypesActions: FieldTypesActionsType = singletonActions(
 export type FieldTypeMappingsList = Immutable.List<FieldTypeMapping>;
 export type FieldTypesStoreState = {
   all: FieldTypeMappingsList,
-  queryFields: Immutable.Map<String, FieldTypeMappingsList>,
+  queryFields: Immutable.Map<string, FieldTypeMappingsList>,
 };
 
 export const FieldTypesStore = singletonStore(

--- a/graylog2-web-interface/src/views/stores/HighlightingRulesStore.js
+++ b/graylog2-web-interface/src/views/stores/HighlightingRulesStore.js
@@ -2,7 +2,6 @@
 import Reflux from 'reflux';
 import * as Immutable from 'immutable';
 import { get, isEqual } from 'lodash';
-import type { RecordFactory, RecordOf } from 'immutable';
 
 import type { RefluxActions } from 'stores/StoreTypes';
 import ViewState from 'views/logic/views/ViewState';
@@ -28,9 +27,9 @@ const HighlightingRulesActions: HighlightingRulesActionsType = singletonActions(
 );
 
 type KeyProps = { field: string, value: Value };
-type KeyType = RecordOf<KeyProps>;
+type KeyType = Immutable.Record<KeyProps>;
 
-const makeKey: RecordFactory<KeyProps> = Immutable.Record({ field: null, value: null });
+const makeKey = Immutable.Record({ field: null, value: null });
 
 type StateType = Immutable.OrderedMap<KeyType, string>;
 

--- a/graylog2-web-interface/src/views/stores/QueriesStore.test.jsx
+++ b/graylog2-web-interface/src/views/stores/QueriesStore.test.jsx
@@ -44,7 +44,7 @@ describe('QueriesStore', () => {
     const queries = [query1];
     const callback = asMock(ViewStore).listen.mock.calls[0][0];
     const unsubscribe = QueriesStore.listen((newQueries) => {
-      expect(newQueries).toEqual(new Immutable.OrderedMap<QueryId, Query>({ query1 }));
+      expect(newQueries).toEqual(Immutable.OrderedMap<QueryId, Query>({ query1 }));
       done();
     });
     callback({

--- a/graylog2-web-interface/src/views/stores/QueriesStore.test.jsx
+++ b/graylog2-web-interface/src/views/stores/QueriesStore.test.jsx
@@ -83,11 +83,11 @@ describe('QueriesStore', () => {
         .catch(error => expect(error).toEqual(new Error('Invalid time range type: invalid')));
     });
     it('does not do anything if type stays the same', () => QueriesActions.rangeType('query1', 'relative')
-      .then(newQueries => expect(newQueries).toEqual(new Immutable.OrderedMap<QueryId, Query>({ query1 }))));
+      .then(newQueries => expect(newQueries).toEqual(Immutable.OrderedMap<QueryId, Query>({ query1 }))));
     it('translates current relative time range parameters to absolute ones when switching to absolute',
       () => QueriesActions.rangeType('query1', 'absolute')
         .then(newQueries => expect(newQueries)
-          .toEqual(new Immutable.OrderedMap<QueryId, Query>({
+          .toEqual(Immutable.OrderedMap<QueryId, Query>({
             query1: query1.toBuilder()
               .timerange({
                 type: 'absolute',
@@ -99,7 +99,7 @@ describe('QueriesStore', () => {
     it('translates current relative time range parameters to keyword when switching to keyword',
       () => QueriesActions.rangeType('query1', 'keyword')
         .then(newQueries => expect(newQueries)
-          .toEqual(new Immutable.OrderedMap<QueryId, Query>({
+          .toEqual(Immutable.OrderedMap<QueryId, Query>({
             query1: query1.toBuilder()
               .timerange({
                 type: 'keyword',

--- a/graylog2-web-interface/src/views/stores/SearchStore.js
+++ b/graylog2-web-interface/src/views/stores/SearchStore.js
@@ -19,7 +19,7 @@ import type { MessageListOptions } from 'views/logic/search/GlobalOverride';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import View from 'views/logic/views/View';
 import Parameter from 'views/logic/parameters/Parameter';
-import type { WidgetMapping } from 'views/logic/views/View';
+import type { WidgetMapping } from 'views/logic/views/types';
 import type { TimeRange } from 'views/logic/queries/Query';
 import { singletonStore } from 'views/logic/singleton';
 

--- a/graylog2-web-interface/src/views/stores/SelectedFieldsStore.js
+++ b/graylog2-web-interface/src/views/stores/SelectedFieldsStore.js
@@ -50,7 +50,7 @@ export const SelectedFieldsStore = singletonStore(
       CurrentViewStateActions.fields(this.selectedFields.remove(field));
     },
     set(fields: Array<string>) {
-      CurrentViewStateActions.fields(fields);
+      CurrentViewStateActions.fields(Set(fields));
     },
     _state() {
       return this.selectedFields;

--- a/graylog2-web-interface/src/views/stores/ViewStore.js
+++ b/graylog2-web-interface/src/views/stores/ViewStore.js
@@ -7,7 +7,7 @@ import type { RefluxActions, Store } from 'stores/StoreTypes';
 import UpdateSearchForWidgets from 'views/logic/views/UpdateSearchForWidgets';
 import ViewGenerator from 'views/logic/views/ViewGenerator';
 import { QueriesActions } from 'views/actions/QueriesActions';
-import type { Properties, ViewType } from 'views/logic/views/View';
+import type { Properties, ViewType, ViewStateMap } from 'views/logic/views/View';
 import View from 'views/logic/views/View';
 import type { QuerySet } from 'views/logic/search/Search';
 import Search from 'views/logic/search/Search';
@@ -31,7 +31,7 @@ type ViewActionsType = RefluxActions<{
   properties: (Properties) => Promise<void>,
   search: (Search) => Promise<View>,
   selectQuery: (string) => Promise<string>,
-  state: (ViewState) => Promise<View>,
+  state: (ViewStateMap) => Promise<View>,
   update: (View) => Promise<ViewStoreState>,
 }>;
 

--- a/graylog2-web-interface/src/views/test/ViewFixtures.js
+++ b/graylog2-web-interface/src/views/test/ViewFixtures.js
@@ -1,4 +1,5 @@
 // @flow strict
+import * as Immutable from 'immutable';
 
 import View from 'views/logic/views/View';
 import type { ViewJson } from 'views/logic/views/View';
@@ -11,8 +12,8 @@ const simpleView = (): View => View.builder()
   .summary('summary')
   .description('Foo')
   .search(Search.create().toBuilder().id('foosearch').build())
-  .properties({})
-  .state({})
+  .properties(Immutable.List())
+  .state(Immutable.Map())
   .createdAt(new Date())
   .owner('admin')
   .requires({})


### PR DESCRIPTION
This PR is the first (and biggest) in a series of changes aiming to
restore proper flow typing for external dependencies. We are
unfortunately ignoring `node_modules` completely for flow, due to these
reasons:

  * type checking all files in `node_modules` costs time and memory
  * type checking of `node_modules` might result in errors in 3rd party
deps which we do not control, due to them being written for an older,
less strict version of flow

At the same time, we want to have proper type checking for _our usages_
of external dependencies, `immutable.js` being the biggest and most
important piece being used in flow-typed code so far. Therefore, the
proposition is to remove `node_modules` from the `[ignore]` part of
`.flowconfig` and move it into a `[declarations]` block, which leads to
it being used for declarations, but not being type-checked itself.

Doing this results in >260 flow errors being thrown that need to be
addressed, which would result in a gigantic PR. Therefore, I have
decided to perform the conversion in two steps:

  1. Not changing `.flowconfig`, but adding a proper typedef file for
`immutable.js` to `flow-typed` and fixing all resulting errors
  2. Moving `node_modules` from `[ignore]` to `[declarations]` and
fixing the remaining errors

This PR is performing 1.), adding a custom(!) typedef file based on the
one included in `3.8.2` to `flow-typed` and fixing the errors found by
flow. While fixing these, the following order was used to determine the
kind of change to ease reviewing:

  1. If an error is fixable by adding an explicit type annotation, this
is preferred
  2. If a code change is necessary, but it can be done either in the
test or the SUT, the first is preferred
  3. Doing a code change in the SUT/module itself

This order is used to keep the required code changes in productive code
to a minimum and therefore make reviewing this PR easier. Nevertheless,
it leads to the changes not being perfect, there are a couple of areas
where flow types could be improved, but this should be performed in
future, smaller PRs. This PR is solely targeted to add flow types and
eliminate resulting flow errors with minimal productive code changes.

The custom flow typedef file for `immutable.js` is required, because the
one included in the package is missing e.g. statics (for instantiation)
for `OrderedMap` & `OrderedSet` which we use quite often. In addition,
upgrading to `immutable.js` 4.0 was not an option right now, as it has
semantic changes that require rewriting parts of the code.