### PR TITLE
Improve logging for tests, include future react deprecation warning.

### DIFF
--- a/graylog2-web-interface/test/console-warnings-fail-tests.js
+++ b/graylog2-web-interface/test/console-warnings-fail-tests.js
@@ -1,0 +1,27 @@
+import { format } from 'util';
+
+/* eslint-disable no-console */
+
+const oldConsoleWarn = console.warn;
+const oldConsoleError = console.error;
+
+const ignoredWarnings = [
+  'react-async-component-lifecycle-hooks',
+  'react-unsafe-component-lifecycles',
+];
+
+const ignoreWarning = args => (!args[0] || ignoredWarnings.filter(warning => args[0].includes(warning)).length > 0);
+
+console.warn = jest.fn((...args) => {
+  if (!ignoreWarning(args)) {
+    throw new Error(format(...args));
+  }
+  oldConsoleWarn(...args);
+});
+
+console.error = jest.fn((...args) => {
+  if (!ignoreWarning(args)) {
+    throw new Error(format(...args));
+  }
+  oldConsoleError(...args);
+});

--- a/graylog2-web-interface/test/console-warnings-fail-tests.test.js
+++ b/graylog2-web-interface/test/console-warnings-fail-tests.test.js
@@ -1,7 +1,7 @@
 // @flow strict
 /* eslint-disable no-console */
 // eslint-disable-next-line no-unused-vars
-const unused = require('./console-warnings-fail-tests');
+import unused from './console-warnings-fail-tests';
 
 describe('console-warnings-fail-tests', () => {
   describe('console.error', () => {

--- a/graylog2-web-interface/test/console-warnings-fail-tests.test.js
+++ b/graylog2-web-interface/test/console-warnings-fail-tests.test.js
@@ -1,6 +1,6 @@
 // @flow strict
 /* eslint-disable no-console */
-// eslint-disable-next-line no-unused-vars
+// eslint-disable-next-line no-unused-vars, import/default
 import unused from './console-warnings-fail-tests';
 
 describe('console-warnings-fail-tests', () => {

--- a/graylog2-web-interface/test/console-warnings-fail-tests.test.js
+++ b/graylog2-web-interface/test/console-warnings-fail-tests.test.js
@@ -1,9 +1,26 @@
-// @flow strict
 /* eslint-disable no-console */
-// eslint-disable-next-line no-unused-vars, import/default
-import unused from './console-warnings-fail-tests';
 
 describe('console-warnings-fail-tests', () => {
+  /*
+  We are suppressing console output for the following tests here. We are not reusing `suppressConsole`, as it does not
+  work well with the order of wrapping original `console` and importing/requiring the actual SUT module, also it does
+  not currently suppress `console.warn`.
+   */
+  let oldConsoleWarn;
+  let oldConsoleError;
+  beforeAll(() => {
+    oldConsoleWarn = console.warn;
+    oldConsoleError = console.error;
+    console.warn = () => {};
+    console.error = () => {};
+    // eslint-disable-next-line no-unused-vars, global-require
+    const unused = require('./console-warnings-fail-tests');
+  });
+
+  afterAll(() => {
+    console.warn = oldConsoleWarn;
+    console.error = oldConsoleError;
+  });
   describe('console.error', () => {
     it('throws error if used', () => {
       expect(() => { console.error('hello there!'); }).toThrowError(new Error('hello there!'));

--- a/graylog2-web-interface/test/console-warnings-fail-tests.test.js
+++ b/graylog2-web-interface/test/console-warnings-fail-tests.test.js
@@ -1,0 +1,33 @@
+// @flow strict
+/* eslint-disable no-console */
+// eslint-disable-next-line no-unused-vars
+const unused = require('./console-warnings-fail-tests');
+
+describe('console-warnings-fail-tests', () => {
+  describe('console.error', () => {
+    it('throws error if used', () => {
+      expect(() => { console.error('hello there!'); }).toThrowError(new Error('hello there!'));
+    });
+    it('does not throw error if containing react deprecation notice', () => {
+      expect(() => {
+        console.error('Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.');
+      }).not.toThrow();
+    });
+    it('does not throw error if called without arguments', () => {
+      expect(() => { console.error(); }).not.toThrow();
+    });
+  });
+  describe('console.warn', () => {
+    it('throws error if used', () => {
+      expect(() => { console.warn('hello there!'); }).toThrowError(new Error('hello there!'));
+    });
+    it('does not throw error if containing react deprecation notice', () => {
+      expect(() => {
+        console.warn('Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.');
+      }).not.toThrow();
+    });
+    it('does not throw error if called without arguments', () => {
+      expect(() => { console.warn(); }).not.toThrow();
+    });
+  });
+});

--- a/graylog2-web-interface/test/setup-jest.jsx
+++ b/graylog2-web-interface/test/setup-jest.jsx
@@ -1,9 +1,7 @@
-/* eslint-disable no-console */
 import jQuery from 'jquery';
 import { configure } from 'wrappedEnzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import registerBuiltinStores from 'injection/registerBuiltinStores';
-import { format } from 'util';
 
 global.$ = jQuery;
 global.jQuery = jQuery;
@@ -11,15 +9,3 @@ global.jQuery = jQuery;
 registerBuiltinStores();
 
 configure({ adapter: new Adapter() });
-
-const consoleWarn = console.warn;
-
-console.warn = jest.fn((...args) => {
-  if (!args[0] || !args[0].includes('react-async-component-lifecycle-hooks')) {
-    consoleWarn(format(...args));
-  }
-});
-
-console.error = jest.fn((...args) => {
-  throw new Error(format(...args));
-});


### PR DESCRIPTION
In preparation of updating to React 16.12.0, the `console.error/warn`
handlers for our tests are improved in this PR to make it easier to add
additional patterns for deprecation warnings that should not be handled
as test failures.