### PR TITLE
Don't expose KafkaJournalConfiguration via the HTTP API

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/KafkaJournalConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/KafkaJournalConfiguration.java
@@ -16,68 +16,36 @@
  */
 package org.graylog2.plugin;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.joschi.jadconfig.Parameter;
 import com.github.joschi.jadconfig.util.Size;
 import org.graylog2.configuration.PathConfiguration;
 import org.joda.time.Duration;
 
-import javax.validation.constraints.NotNull;
 import java.nio.file.Path;
-import java.util.Objects;
 
 public class KafkaJournalConfiguration extends PathConfiguration {
 
     public KafkaJournalConfiguration() { }
 
-    @JsonCreator
-    public KafkaJournalConfiguration(@NotNull @JsonProperty("directory") Path messageJournalDir,
-                                     @JsonProperty("segment_size") long messageJournalSegmentSize,
-                                     @JsonProperty("segment_age") Duration messageJournalSegmentAge,
-                                     @JsonProperty("max_size") long messageJournalMaxSize,
-                                     @JsonProperty("max_age") Duration messageJournalMaxAge,
-                                     @JsonProperty("flush_interval") long messageJournalFlushInterval,
-                                     @JsonProperty("flush_age") Duration messageJournalFlushAge) {
-        this.messageJournalDir = Objects.requireNonNull(messageJournalDir);
-        this.messageJournalSegmentSize = Size.bytes(messageJournalSegmentSize);
-        this.messageJournalSegmentAge = messageJournalSegmentAge;
-        this.messageJournalMaxSize = Size.bytes(messageJournalMaxSize);
-        this.messageJournalMaxAge = messageJournalMaxAge;
-        this.messageJournalFlushInterval = messageJournalFlushInterval;
-        this.messageJournalFlushAge = messageJournalFlushAge;
-    }
-
     @Parameter(value = "message_journal_dir", required = true)
-    @JsonProperty("directory")
     private Path messageJournalDir = DEFAULT_DATA_DIR.resolve("journal");
 
     @Parameter("message_journal_segment_size")
-    @JsonProperty("segment_size")
     private Size messageJournalSegmentSize = Size.megabytes(100L);
 
     @Parameter("message_journal_segment_age")
-    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
-    @JsonProperty("segment_age")
     private Duration messageJournalSegmentAge = Duration.standardHours(1L);
 
     @Parameter("message_journal_max_size")
-    @JsonProperty("max_size")
     private Size messageJournalMaxSize = Size.gigabytes(5L);
 
     @Parameter("message_journal_max_age")
-    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
-    @JsonProperty("max_age")
     private Duration messageJournalMaxAge = Duration.standardHours(12L);
 
     @Parameter("message_journal_flush_interval")
-    @JsonProperty("flush_interval")
     private long messageJournalFlushInterval = 1_000_000L;
 
     @Parameter("message_journal_flush_age")
-    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
-    @JsonProperty("flush_age")
     private Duration messageJournalFlushAge = Duration.standardMinutes(1L);
 
     public Path getMessageJournalDir() {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/JournalResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/JournalResource.java
@@ -27,6 +27,7 @@ import org.graylog2.Configuration;
 import org.graylog2.plugin.KafkaJournalConfiguration;
 import org.graylog2.plugin.ThrottleState;
 import org.graylog2.rest.resources.system.responses.JournalSummaryResponse;
+import org.graylog2.rest.resources.system.responses.KafkaJournalConfigurationSummary;
 import org.graylog2.shared.journal.Journal;
 import org.graylog2.shared.journal.KafkaJournal;
 import org.graylog2.shared.rest.resources.RestResource;
@@ -84,7 +85,7 @@ public class JournalResource extends RestResource {
                                                         Size.bytes(throttleState.journalSizeLimit),
                                                         kafkaJournal.numberOfSegments(),
                                                         new DateTime(oldestSegment, DateTimeZone.UTC),
-                                                        kafkaJournalConfiguration
+                                                        KafkaJournalConfigurationSummary.of(kafkaJournalConfiguration)
             );
 
         }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/responses/JournalSummaryResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/responses/JournalSummaryResponse.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.joschi.jadconfig.util.Size;
 import com.google.auto.value.AutoValue;
 import org.graylog.autovalue.WithBeanGetter;
-import org.graylog2.plugin.KafkaJournalConfiguration;
 import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
@@ -43,7 +42,7 @@ public abstract class JournalSummaryResponse {
                                                        Size journalSizeLimit,
                                                        int numberOfSegments,
                                                        DateTime oldestSegment,
-                                                       KafkaJournalConfiguration kafkaJournalConfiguration) {
+                                                       KafkaJournalConfigurationSummary kafkaJournalConfiguration) {
         return JournalSummaryResponse.create(true,
                 appendEventsPerSec,
                 readEventsPerSec,
@@ -64,7 +63,7 @@ public abstract class JournalSummaryResponse {
                                                 @JsonProperty("journal_size_limit") long journalSizeLimit,
                                                 @JsonProperty("number_of_segments") int numberOfSegments,
                                                 @JsonProperty("oldest_segment") DateTime oldestSegment,
-                                                @JsonProperty("journal_config") KafkaJournalConfiguration kafkaJournalConfiguration) {
+                                                @JsonProperty("journal_config") KafkaJournalConfigurationSummary kafkaJournalConfiguration) {
         return JournalSummaryResponse.create(enabled,
                 appendEventsPerSec,
                 readEventsPerSec,
@@ -84,7 +83,7 @@ public abstract class JournalSummaryResponse {
                                                 Size journalSizeLimit,
                                                 int numberOfSegments,
                                                 DateTime oldestSegment,
-                                                KafkaJournalConfiguration kafkaJournalConfiguration) {
+                                                KafkaJournalConfigurationSummary kafkaJournalConfiguration) {
         return new AutoValue_JournalSummaryResponse(enabled,
                 appendEventsPerSec,
                 readEventsPerSec,
@@ -124,5 +123,5 @@ public abstract class JournalSummaryResponse {
 
     @JsonProperty
     @Nullable
-    public abstract KafkaJournalConfiguration journalConfig();
+    public abstract KafkaJournalConfigurationSummary journalConfig();
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/responses/KafkaJournalConfigurationSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/responses/KafkaJournalConfigurationSummary.java
@@ -1,0 +1,86 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.resources.system.responses;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import org.graylog.autovalue.WithBeanGetter;
+import org.graylog2.plugin.KafkaJournalConfiguration;
+import org.joda.time.Duration;
+
+import java.nio.file.Path;
+
+@AutoValue
+@WithBeanGetter
+@JsonAutoDetect
+public abstract class KafkaJournalConfigurationSummary {
+    private static final String FIELD_DIRECTORY = "directory";
+    private static final String FIELD_SEGMENT_SIZE = "segment_size";
+    private static final String FIELD_SEGMENT_AGE = "segment_age";
+    private static final String FIELD_MAX_SIZE = "max_size";
+    private static final String FIELD_MAX_AGE = "max_age";
+    private static final String FIELD_FLUSH_INTERVAL = "flush_interval";
+    private static final String FIELD_FLUSH_AGE = "flush_age";
+
+    @JsonProperty(FIELD_DIRECTORY)
+    public abstract Path directory();
+
+    @JsonProperty(FIELD_SEGMENT_SIZE)
+    public abstract long segmentSize();
+
+    @JsonProperty(FIELD_SEGMENT_AGE)
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+    public abstract Duration segmentAge();
+
+    @JsonProperty(FIELD_MAX_SIZE)
+    public abstract long maxSize();
+
+    @JsonProperty(FIELD_MAX_AGE)
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+    public abstract Duration maxAge();
+
+    @JsonProperty(FIELD_FLUSH_INTERVAL)
+    public abstract long flushInterval();
+
+    @JsonProperty(FIELD_FLUSH_AGE)
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+    public abstract Duration flushAge();
+
+    public static KafkaJournalConfigurationSummary of(KafkaJournalConfiguration config) {
+        return create(config.getMessageJournalDir(),
+                config.getMessageJournalSegmentSize().toBytes(),
+                config.getMessageJournalSegmentAge(),
+                config.getMessageJournalMaxSize().toBytes(),
+                config.getMessageJournalMaxAge(),
+                config.getMessageJournalFlushInterval(),
+                config.getMessageJournalFlushAge());
+    }
+
+    @JsonCreator
+    public static KafkaJournalConfigurationSummary create(@JsonProperty(FIELD_DIRECTORY) Path directory,
+                                                          @JsonProperty(FIELD_SEGMENT_SIZE) long segmentSize,
+                                                          @JsonProperty(FIELD_SEGMENT_AGE) Duration segmentAge,
+                                                          @JsonProperty(FIELD_MAX_SIZE) long maxSize,
+                                                          @JsonProperty(FIELD_MAX_AGE) Duration maxAge,
+                                                          @JsonProperty(FIELD_FLUSH_INTERVAL) long flushInterval,
+                                                          @JsonProperty(FIELD_FLUSH_AGE) Duration flushAge) {
+        return new AutoValue_KafkaJournalConfigurationSummary(directory, segmentSize, segmentAge, maxSize, maxAge, flushInterval, flushAge);
+    }
+}


### PR DESCRIPTION
This fixes the "/api/cluster/<node-id>/journal" API endpoint to not
throw an error anymore.

In #7359 we introduced the PathConfiguration#getNativeLibDir() method
and this broke deserialization of the JournalSummaryResponse because
"#getNativeLibDir" was automatically serialized but couldn't be
deserialized.

This change introduces a new KafkaJournalConfigurationSummary value that
we can serialize and deserialize in the API. Using this also avoids
exposing new fields from Pathconfiguration or KafkaJournalConfiguration
automatically.
This also removes the constructor and jackson annotations in
KafkaJournalConfiguration beacuse they are not needed anymore.

Fixes #7521