### PR TITLE
Add login form grid styling for smaller resolutions

### DIFF
--- a/graylog2-web-interface/src/pages/LoginPage.jsx
+++ b/graylog2-web-interface/src/pages/LoginPage.jsx
@@ -89,7 +89,7 @@ const LoginPage = createReactClass({
         <div>
           <div className="container" id="login-box">
             <Row>
-              <Col md={4} mdOffset={4} id="login-box-content" className="well">
+              <Col md={4} mdOffset={4} xs={6} xsOffset={3} id="login-box-content" className="well">
                 <legend><Icon name="group" /> Welcome to Graylog</legend>
                 {alert}
 


### PR DESCRIPTION
This PR adds grid styling for smaller resolutions to the login form.

Before (<= 990px)
![image](https://user-images.githubusercontent.com/46300478/75166315-fc80e900-5723-11ea-8712-b4e980a7ca41.png)

After:
![image](https://user-images.githubusercontent.com/46300478/75166287-f12dbd80-5723-11ea-982b-cc9a8c9bfc3d.png)

