### PR TITLE
Use LinkedHashSet for a deterministic order

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/utilities/IPSubnetConverter.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/IPSubnetConverter.java
@@ -22,7 +22,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 
 import java.net.UnknownHostException;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
@@ -31,7 +31,7 @@ import java.util.Set;
 public class IPSubnetConverter implements Converter<Set<IpSubnet>> {
     @Override
     public Set<IpSubnet> convertFrom(String value) {
-        final Set<IpSubnet> converted = new HashSet<>();
+        final Set<IpSubnet> converted = new LinkedHashSet<>();
         if (value != null) {
             Iterable<String> subnets = Splitter.on(',').trimResults().split(value);
             for (String subnet : subnets) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
For background information, please refer to #7542 

## Description
This PR aims to solve the problem about #7542 

## Motivation and Context
The fix is the use LinkedHashSet instead of HashSet. In this way, the iteration order will not be different any more and the code will be more stable.

## How Has This Been Tested?
The code after the fix has been tested already.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

