### PR TITLE
Remove type from componentClass

### DIFF
--- a/graylog2-web-interface/src/components/common/JSONValueInput.jsx
+++ b/graylog2-web-interface/src/components/common/JSONValueInput.jsx
@@ -93,7 +93,7 @@ class JSONValueInput extends React.Component {
         <InputWrapper className={this.props.wrapperClassName}>
           <InputGroup>
             <FormControl type="text" onChange={this._onUpdate} value={this.state.value} required={this.props.required} />
-            <DropdownButton componentClass={InputGroup.Button.type}
+            <DropdownButton componentClass={InputGroup.Button}
                             id="input-dropdown-addon"
                             bsStyle={this.props.validationState === 'error' ? 'danger' : null}
                             title={OPTIONS.filter(o => o.value === this.props.valueType)[0].label}>

--- a/graylog2-web-interface/src/components/common/TimeUnitInput.jsx
+++ b/graylog2-web-interface/src/components/common/TimeUnitInput.jsx
@@ -213,7 +213,7 @@ const TimeUnitInput = createReactClass({
           <InputGroup>
             {(!required && !hideCheckbox) && checkbox}
             <FormControl type="number" disabled={!this._isChecked()} onChange={this._onUpdate} value={lodash.defaultTo(this._getEffectiveValue(), '')} />
-            <DropdownButton componentClass={InputGroup.Button.type}
+            <DropdownButton componentClass={InputGroup.Button}
                             id="input-dropdown-addon"
                             pullRight={pullRight}
                             title={unitOptions.filter(o => o.value === unit)[0].label}

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/pivottypes/TimeUnitTimeHistogramPivot.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/pivottypes/TimeUnitTimeHistogramPivot.jsx
@@ -33,7 +33,7 @@ const TimeUnitTimeHistogramPivot = ({ interval, onChange }: Props) => (
                    step="1"
                    min="1"
                    onChange={e => _changeValue(e, interval, onChange)} />
-      <DropdownButton componentClass={InputGroup.Button.type}
+      <DropdownButton componentClass={InputGroup.Button}
                       id="input-dropdown-addon"
                       title={TimeUnits[interval.unit] || ''}
                       onChange={newUnit => _changeUnit(newUnit, interval, onChange)}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
At some point in the ThemeProvider build I was getting build errors without the .type in place. It appears those were resolved but type was not removed.

Change componentClass={InputGroup.Button.type} to componentClass={InputGroup.Button}


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

