### PR TITLE
Remove not needed @testing-library/jest-dom imports

### DIFF
--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.test.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.test.jsx
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import { render, waitForElement, cleanup, fireEvent, wait } from 'wrappedTestingLibrary';
 import selectEvent from 'react-select-event';
-import '@testing-library/jest-dom/extend-expect';
 
 import { GlobalOverrideActions } from 'views/stores/GlobalOverrideStore';
 import SearchActions from 'views/actions/SearchActions';

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.test.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.test.jsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import * as Immutable from 'immutable';
 import { mount } from 'wrappedEnzyme';
 import { render } from 'wrappedTestingLibrary';
-import '@testing-library/jest-dom/extend-expect';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import asMock from 'helpers/mocking/AsMock';

--- a/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.test.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.test.jsx
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import { render, cleanup, fireEvent, waitForElement } from 'wrappedTestingLibrary';
 import * as Immutable from 'immutable';
-import '@testing-library/jest-dom';
 
 import history from 'util/History';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/views/components/widgets/WidgetErrorBoundary.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetErrorBoundary.test.jsx
@@ -1,7 +1,6 @@
 // @flow strict
 import * as React from 'react';
 import { render, waitForElement } from 'wrappedTestingLibrary';
-import '@testing-library/jest-dom/extend-expect';
 
 import asMock from 'helpers/mocking/AsMock';
 import WidgetErrorBoundary from './WidgetErrorBoundary';


### PR DESCRIPTION
The import of `@testing-library/jest-dom` and `@testing-library/jest-dom/extend-expect` is no longer required for a specific test, because the import is now part of `wrappedTestingLibrary.jsx`