### PR TITLE
Implement bootstrap modal wrapper components for search related modals

### DIFF
--- a/graylog2-web-interface/src/views/components/DebugOverlay.jsx
+++ b/graylog2-web-interface/src/views/components/DebugOverlay.jsx
@@ -8,14 +8,16 @@ import connect from 'stores/connect';
 
 import { Modal } from 'components/graylog';
 import BootstrapModalWrapper from 'components/bootstrap/BootstrapModalWrapper';
+
 import type { ViewStoreState } from 'views/stores/ViewStore';
 import type { SearchStoreState } from 'views/stores/SearchStore';
 
 type Props = {
   currentView: ViewStoreState,
+  onClose: () => void,
   searches: SearchStoreState,
-  onClose: () => void
 }
+
 const DebugOverlay = ({ currentView, searches, show, onClose }: Props) => (
   <BootstrapModalWrapper showModal={show} onHide={onClose}>
     <Modal.Body>
@@ -28,8 +30,8 @@ const DebugOverlay = ({ currentView, searches, show, onClose }: Props) => (
 
 DebugOverlay.propTypes = {
   currentView: PropTypes.object.isRequired,
-  searches: PropTypes.object.isRequired,
   onClose: PropTypes.func.isRequired,
+  searches: PropTypes.object.isRequired,
   show: PropTypes.bool.isRequired,
 };
 

--- a/graylog2-web-interface/src/views/components/DebugOverlay.jsx
+++ b/graylog2-web-interface/src/views/components/DebugOverlay.jsx
@@ -1,41 +1,34 @@
+// @flow strict
 import React from 'react';
 import PropTypes from 'prop-types';
-import createReactClass from 'create-react-class';
-import { Modal } from 'components/graylog';
 
 import { ViewStore } from 'views/stores/ViewStore';
 import { SearchStore } from 'views/stores/SearchStore';
 import connect from 'stores/connect';
 
-const DebugOverlay = createReactClass({
-  displayName: 'DebugOverlay',
+import { Modal } from 'components/graylog';
+import BootstrapModalWrapper from 'components/bootstrap/BootstrapModalWrapper';
+import type { ViewStoreState } from 'views/stores/ViewStore';
+import type { SearchStoreState } from 'views/stores/SearchStore';
 
-  propTypes: {
-    show: PropTypes.bool.isRequired,
-    onClose: PropTypes.func,
-  },
-
-  getDefaultProps() {
-    return {
-      onClose: () => {},
-    };
-  },
-
-  render() {
-    const { show, onClose } = this.props;
-    const modalBody = show && (
+type Props = {
+  currentView: ViewStoreState,
+  searches: SearchStoreState,
+  modalRef: BootstrapModalWrapper
+}
+const DebugOverlay = ({ currentView, searches, modalRef }: Props) => (
+  <BootstrapModalWrapper ref={modalRef}>
+    <Modal.Body>
       <textarea disabled
                 style={{ height: '80vh', width: '100%' }}
-                value={JSON.stringify(this.props, null, 2)} />
-    );
-    return (
-      <Modal onHide={onClose} show={show}>
-        <Modal.Body>
-          {modalBody}
-        </Modal.Body>
-      </Modal>
-    );
-  },
-});
+                value={JSON.stringify({ currentView, searches }, null, 2)} />
+    </Modal.Body>
+  </BootstrapModalWrapper>
+);
 
-export default connect(DebugOverlay, { views: ViewStore, searches: SearchStore });
+DebugOverlay.propTypes = {
+  currentView: PropTypes.object.isRequired,
+  searches: PropTypes.object.isRequired,
+};
+
+export default connect(DebugOverlay, { currentView: ViewStore, searches: SearchStore });

--- a/graylog2-web-interface/src/views/components/DebugOverlay.jsx
+++ b/graylog2-web-interface/src/views/components/DebugOverlay.jsx
@@ -16,6 +16,7 @@ type Props = {
   currentView: ViewStoreState,
   onClose: () => void,
   searches: SearchStoreState,
+  show: boolean,
 }
 
 const DebugOverlay = ({ currentView, searches, show, onClose }: Props) => (

--- a/graylog2-web-interface/src/views/components/DebugOverlay.jsx
+++ b/graylog2-web-interface/src/views/components/DebugOverlay.jsx
@@ -6,7 +6,7 @@ import { ViewStore } from 'views/stores/ViewStore';
 import { SearchStore } from 'views/stores/SearchStore';
 import connect from 'stores/connect';
 
-import { Modal } from 'components/graylog';
+import { Modal, Button } from 'components/graylog';
 import BootstrapModalWrapper from 'components/bootstrap/BootstrapModalWrapper';
 
 import type { ViewStoreState } from 'views/stores/ViewStore';
@@ -21,11 +21,17 @@ type Props = {
 
 const DebugOverlay = ({ currentView, searches, show, onClose }: Props) => (
   <BootstrapModalWrapper showModal={show} onHide={onClose}>
+    <Modal.Header closeButton>
+      <Modal.Title>Debug information</Modal.Title>
+    </Modal.Header>
     <Modal.Body>
       <textarea disabled
                 style={{ height: '80vh', width: '100%' }}
                 value={JSON.stringify({ currentView, searches }, null, 2)} />
     </Modal.Body>
+    <Modal.Footer>
+      <Button type="button" onClick={() => onClose()} bsStyle="primary">Close</Button>
+    </Modal.Footer>
   </BootstrapModalWrapper>
 );
 

--- a/graylog2-web-interface/src/views/components/DebugOverlay.jsx
+++ b/graylog2-web-interface/src/views/components/DebugOverlay.jsx
@@ -14,10 +14,10 @@ import type { SearchStoreState } from 'views/stores/SearchStore';
 type Props = {
   currentView: ViewStoreState,
   searches: SearchStoreState,
-  modalRef: BootstrapModalWrapper
+  onClose: () => void
 }
-const DebugOverlay = ({ currentView, searches, modalRef }: Props) => (
-  <BootstrapModalWrapper ref={modalRef}>
+const DebugOverlay = ({ currentView, searches, show, onClose }: Props) => (
+  <BootstrapModalWrapper showModal={show} onHide={onClose}>
     <Modal.Body>
       <textarea disabled
                 style={{ height: '80vh', width: '100%' }}
@@ -29,6 +29,8 @@ const DebugOverlay = ({ currentView, searches, modalRef }: Props) => (
 DebugOverlay.propTypes = {
   currentView: PropTypes.object.isRequired,
   searches: PropTypes.object.isRequired,
+  onClose: PropTypes.func.isRequired,
+  show: PropTypes.bool.isRequired,
 };
 
 export default connect(DebugOverlay, { currentView: ViewStore, searches: SearchStore });

--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { withRouter } from 'react-router';
@@ -36,9 +36,8 @@ const _hasUndeclaredParameters = (searchMetadata: SearchMetadata) => searchMetad
 const ViewActionsMenu = ({ view, isNewView, metadata, currentUser, router }) => {
   const [shareViewOpen, setShareViewOpen] = useState(false);
   const [debugOpen, setDebugOpen] = useState(false);
-  const [saveAsViewOpen, setSaveAsViewOpen] = useState(false);
-  const [editViewOpen, setEditViewOpen] = useState(false);
-
+  const saveNewModal = useRef<ViewPropertiesModal>();
+  const editModal = useRef<ViewPropertiesModal>();
   const hasUndeclaredParameters = _hasUndeclaredParameters(metadata);
   const allowedToEdit = _isAllowedToEdit(view, currentUser);
   const debugOverlay = AppConfig.gl2DevMode() && (
@@ -55,11 +54,11 @@ const ViewActionsMenu = ({ view, isNewView, metadata, currentUser, router }) => 
               disabled={isNewView || hasUndeclaredParameters || !allowedToEdit}>
         <Icon name="save" /> Save
       </Button>
-      <Button onClick={() => setSaveAsViewOpen(true)} disabled={hasUndeclaredParameters}>
+      <Button onClick={() => editModal.current.open()} disabled={hasUndeclaredParameters}>
         <Icon name="copy" /> Save as
       </Button>
       <DropdownButton title={<Icon name="ellipsis-h" />} id="query-tab-actions-dropdown" pullRight noCaret>
-        <MenuItem onSelect={() => setEditViewOpen(true)} disabled={isNewView || !allowedToEdit}>
+        <MenuItem onSelect={() => editModal.current.open()} disabled={isNewView || !allowedToEdit}>
           <Icon name="edit" /> Edit
         </MenuItem>
         <MenuItem onSelect={() => setShareViewOpen(true)} disabled={isNewView || !allowedToEdit}>
@@ -72,20 +71,14 @@ const ViewActionsMenu = ({ view, isNewView, metadata, currentUser, router }) => 
         </IfDashboard>
       </DropdownButton>
       <DebugOverlay show={debugOpen} onClose={() => setDebugOpen(false)} />
-      {saveAsViewOpen && (
-        <ViewPropertiesModal view={view.toBuilder().newId().build()}
-                             title="Save new dashboard"
-                             onSave={newView => onSaveAsView(newView, router)}
-                             show
-                             onClose={() => setSaveAsViewOpen(false)} />
-      )}
-      {editViewOpen && (
-        <ViewPropertiesModal view={view}
-                             title="Editing dashboard"
-                             onSave={updatedView => onSaveView(updatedView, router)}
-                             show
-                             onClose={() => setEditViewOpen(false)} />
-      )}
+      <ViewPropertiesModal view={view.toBuilder().newId().build()}
+                           title="Save new dashboard"
+                           onSave={newView => onSaveAsView(newView, router)}
+                           ref={saveNewModal} />
+      <ViewPropertiesModal view={view}
+                           title="Editing dashboard"
+                           onSave={updatedView => onSaveView(updatedView, router)}
+                           ref={editModal} />
       {shareViewOpen && <ShareViewModal view={view} show onClose={() => setShareViewOpen(false)} />}
     </ButtonGroup>
   );

--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
@@ -1,12 +1,11 @@
 // @flow strict
-import React, { useState, useRef } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { withRouter } from 'react-router';
 
 import { DropdownButton, MenuItem, Button, ButtonGroup } from 'components/graylog';
 import { Icon } from 'components/common';
-import BootstrapModalWrapper from 'components/bootstrap/BootstrapModalWrapper';
 
 import connect from 'stores/connect';
 import StoreProvider from 'injection/StoreProvider';
@@ -36,15 +35,15 @@ const _hasUndeclaredParameters = (searchMetadata: SearchMetadata) => searchMetad
 
 const ViewActionsMenu = ({ view, isNewView, metadata, currentUser, router }) => {
   const [shareViewOpen, setShareViewOpen] = useState(false);
-  const [debugViewOpen, setDebugViewOpen] = useState(false);
+  const [debugOpen, setDebugOpen] = useState(false);
   const [saveNewOpen, setSaveAsOpen] = useState(false);
-  const [editOpen, setEditOpen] = useState(false);
+  const [editViewOpen, setEditViewOpen] = useState(false);
   const hasUndeclaredParameters = _hasUndeclaredParameters(metadata);
   const allowedToEdit = _isAllowedToEdit(view, currentUser);
   const debugOverlay = AppConfig.gl2DevMode() && (
     <React.Fragment>
       <MenuItem divider />
-      <MenuItem onSelect={() => setDebugViewOpen(true)}>
+      <MenuItem onSelect={() => setDebugOpen(true)}>
         <Icon name="code" /> Debug
       </MenuItem>
     </React.Fragment>
@@ -62,7 +61,7 @@ const ViewActionsMenu = ({ view, isNewView, metadata, currentUser, router }) => 
         <Icon name="copy" /> Save as
       </Button>
       <DropdownButton title={<Icon name="ellipsis-h" />} id="query-tab-actions-dropdown" pullRight noCaret>
-        <MenuItem onSelect={() => setEditOpen(true)} disabled={isNewView || !allowedToEdit}>
+        <MenuItem onSelect={() => setEditViewOpen(true)} disabled={isNewView || !allowedToEdit}>
           <Icon name="edit" /> Edit
         </MenuItem>
         <MenuItem onSelect={() => setShareViewOpen(true)} disabled={isNewView || !allowedToEdit}>
@@ -74,7 +73,7 @@ const ViewActionsMenu = ({ view, isNewView, metadata, currentUser, router }) => 
           <BigDisplayModeConfiguration view={view} disabled={isNewView} />
         </IfDashboard>
       </DropdownButton>
-      {debugViewOpen && <DebugOverlay show onClose={() => setDebugViewOpen(false)} />}
+      {debugOpen && <DebugOverlay show onClose={() => setDebugOpen(false)} />}
       {saveNewOpen && (
         <ViewPropertiesModal show
                              view={view.toBuilder().newId().build()}
@@ -82,11 +81,11 @@ const ViewActionsMenu = ({ view, isNewView, metadata, currentUser, router }) => 
                              onClose={() => setSaveAsOpen(false)}
                              onSave={newView => onSaveAsView(newView, router)} />
       )}
-      {editOpen && (
+      {editViewOpen && (
         <ViewPropertiesModal show
                              view={view}
                              title="Editing dashboard"
-                             onClose={() => setEditOpen(false)}
+                             onClose={() => setEditViewOpen(false)}
                              onSave={updatedView => onSaveView(updatedView, router)} />
       )}
       {shareViewOpen && <ShareViewModal show view={view} onClose={() => setShareViewOpen(false)} />}

--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
@@ -6,6 +6,7 @@ import { withRouter } from 'react-router';
 
 import { DropdownButton, MenuItem, Button, ButtonGroup } from 'components/graylog';
 import { Icon } from 'components/common';
+import BootstrapModalWrapper from 'components/bootstrap/BootstrapModalWrapper';
 
 import connect from 'stores/connect';
 import StoreProvider from 'injection/StoreProvider';
@@ -35,7 +36,7 @@ const _hasUndeclaredParameters = (searchMetadata: SearchMetadata) => searchMetad
 
 const ViewActionsMenu = ({ view, isNewView, metadata, currentUser, router }) => {
   const [shareViewOpen, setShareViewOpen] = useState(false);
-  const [debugOpen, setDebugOpen] = useState(false);
+  const debugModal = useRef<BootstrapModalWrapper>();
   const saveNewModal = useRef<ViewPropertiesModal>();
   const editModal = useRef<ViewPropertiesModal>();
   const hasUndeclaredParameters = _hasUndeclaredParameters(metadata);
@@ -43,7 +44,7 @@ const ViewActionsMenu = ({ view, isNewView, metadata, currentUser, router }) => 
   const debugOverlay = AppConfig.gl2DevMode() && (
     <React.Fragment>
       <MenuItem divider />
-      <MenuItem onSelect={() => setDebugOpen(true)}>
+      <MenuItem onSelect={() => debugModal.current.open()}>
         <Icon name="code" /> Debug
       </MenuItem>
     </React.Fragment>
@@ -70,7 +71,7 @@ const ViewActionsMenu = ({ view, isNewView, metadata, currentUser, router }) => 
           <BigDisplayModeConfiguration view={view} disabled={isNewView} />
         </IfDashboard>
       </DropdownButton>
-      <DebugOverlay show={debugOpen} onClose={() => setDebugOpen(false)} />
+      <DebugOverlay ref={debugModal} />
       <ViewPropertiesModal view={view.toBuilder().newId().build()}
                            title="Save new dashboard"
                            onSave={newView => onSaveAsView(newView, router)}

--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
@@ -36,7 +36,7 @@ const _hasUndeclaredParameters = (searchMetadata: SearchMetadata) => searchMetad
 const ViewActionsMenu = ({ view, isNewView, metadata, currentUser, router }) => {
   const [shareViewOpen, setShareViewOpen] = useState(false);
   const [debugOpen, setDebugOpen] = useState(false);
-  const [saveNewOpen, setSaveAsOpen] = useState(false);
+  const [saveAsViewOpen, setSaveAsViewOpen] = useState(false);
   const [editViewOpen, setEditViewOpen] = useState(false);
   const hasUndeclaredParameters = _hasUndeclaredParameters(metadata);
   const allowedToEdit = _isAllowedToEdit(view, currentUser);
@@ -55,7 +55,7 @@ const ViewActionsMenu = ({ view, isNewView, metadata, currentUser, router }) => 
               data-testid="dashboard-save-button">
         <Icon name="save" /> Save
       </Button>
-      <Button onClick={() => setSaveAsOpen(true)}
+      <Button onClick={() => setSaveAsViewOpen(true)}
               disabled={hasUndeclaredParameters}
               data-testid="dashboard-save-as-button">
         <Icon name="copy" /> Save as
@@ -74,11 +74,11 @@ const ViewActionsMenu = ({ view, isNewView, metadata, currentUser, router }) => 
         </IfDashboard>
       </DropdownButton>
       {debugOpen && <DebugOverlay show onClose={() => setDebugOpen(false)} />}
-      {saveNewOpen && (
+      {saveAsViewOpen && (
         <ViewPropertiesModal show
                              view={view.toBuilder().newId().build()}
                              title="Save new dashboard"
-                             onClose={() => setSaveAsOpen(false)}
+                             onClose={() => setSaveAsViewOpen(false)}
                              onSave={newView => onSaveAsView(newView, router)} />
       )}
       {editViewOpen && (

--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
@@ -52,10 +52,13 @@ const ViewActionsMenu = ({ view, isNewView, metadata, currentUser, router }) => 
   return (
     <ButtonGroup>
       <Button onClick={() => onSaveView(view)}
-              disabled={isNewView || hasUndeclaredParameters || !allowedToEdit}>
+              disabled={isNewView || hasUndeclaredParameters || !allowedToEdit}
+              data-testid="dashboard-save-button">
         <Icon name="save" /> Save
       </Button>
-      <Button onClick={() => editModal.current.open()} disabled={hasUndeclaredParameters}>
+      <Button onClick={() => saveNewModal.current.open()}
+              disabled={hasUndeclaredParameters}
+              data-testid="dashboard-save-as-button">
         <Icon name="copy" /> Save as
       </Button>
       <DropdownButton title={<Icon name="ellipsis-h" />} id="query-tab-actions-dropdown" pullRight noCaret>

--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
@@ -36,15 +36,15 @@ const _hasUndeclaredParameters = (searchMetadata: SearchMetadata) => searchMetad
 
 const ViewActionsMenu = ({ view, isNewView, metadata, currentUser, router }) => {
   const [shareViewOpen, setShareViewOpen] = useState(false);
-  const debugModal = useRef<BootstrapModalWrapper>();
-  const saveNewModal = useRef<ViewPropertiesModal>();
-  const editModal = useRef<ViewPropertiesModal>();
+  const [debugViewOpen, setDebugViewOpen] = useState(false);
+  const [saveNewOpen, setSaveAsOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
   const hasUndeclaredParameters = _hasUndeclaredParameters(metadata);
   const allowedToEdit = _isAllowedToEdit(view, currentUser);
   const debugOverlay = AppConfig.gl2DevMode() && (
     <React.Fragment>
       <MenuItem divider />
-      <MenuItem onSelect={() => debugModal.current.open()}>
+      <MenuItem onSelect={() => setDebugViewOpen(true)}>
         <Icon name="code" /> Debug
       </MenuItem>
     </React.Fragment>
@@ -56,13 +56,13 @@ const ViewActionsMenu = ({ view, isNewView, metadata, currentUser, router }) => 
               data-testid="dashboard-save-button">
         <Icon name="save" /> Save
       </Button>
-      <Button onClick={() => saveNewModal.current.open()}
+      <Button onClick={() => setSaveAsOpen(true)}
               disabled={hasUndeclaredParameters}
               data-testid="dashboard-save-as-button">
         <Icon name="copy" /> Save as
       </Button>
       <DropdownButton title={<Icon name="ellipsis-h" />} id="query-tab-actions-dropdown" pullRight noCaret>
-        <MenuItem onSelect={() => editModal.current.open()} disabled={isNewView || !allowedToEdit}>
+        <MenuItem onSelect={() => setEditOpen(true)} disabled={isNewView || !allowedToEdit}>
           <Icon name="edit" /> Edit
         </MenuItem>
         <MenuItem onSelect={() => setShareViewOpen(true)} disabled={isNewView || !allowedToEdit}>
@@ -74,16 +74,22 @@ const ViewActionsMenu = ({ view, isNewView, metadata, currentUser, router }) => 
           <BigDisplayModeConfiguration view={view} disabled={isNewView} />
         </IfDashboard>
       </DropdownButton>
-      <DebugOverlay ref={debugModal} />
-      <ViewPropertiesModal view={view.toBuilder().newId().build()}
-                           title="Save new dashboard"
-                           onSave={newView => onSaveAsView(newView, router)}
-                           ref={saveNewModal} />
-      <ViewPropertiesModal view={view}
-                           title="Editing dashboard"
-                           onSave={updatedView => onSaveView(updatedView, router)}
-                           ref={editModal} />
-      {shareViewOpen && <ShareViewModal view={view} show onClose={() => setShareViewOpen(false)} />}
+      {debugViewOpen && <DebugOverlay show onClose={() => setDebugViewOpen(false)} />}
+      {saveNewOpen && (
+        <ViewPropertiesModal show
+                             view={view.toBuilder().newId().build()}
+                             title="Save new dashboard"
+                             onClose={() => setSaveAsOpen(false)}
+                             onSave={newView => onSaveAsView(newView, router)} />
+      )}
+      {editOpen && (
+        <ViewPropertiesModal show
+                             view={view}
+                             title="Editing dashboard"
+                             onClose={() => setEditOpen(false)}
+                             onSave={updatedView => onSaveView(updatedView, router)} />
+      )}
+      {shareViewOpen && <ShareViewModal show view={view} onClose={() => setShareViewOpen(false)} />}
     </ButtonGroup>
   );
 };

--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.test.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.test.jsx
@@ -1,0 +1,89 @@
+// @flow strict
+import React from 'react';
+import { cleanup, render, fireEvent } from 'wrappedTestingLibrary';
+
+import { StoreMock as MockStore } from 'helpers/mocking';
+
+import Search from 'views/logic/search/Search';
+import View from 'views/logic/views/View';
+
+import ViewActionsMenu from './ViewActionsMenu';
+
+
+const mockView = View.create().toBuilder().id('view-id').type(View.Type.Dashboard)
+  .search(Search.builder().build())
+  .createdAt(new Date('2019-10-16T14:38:44.681Z'))
+  .build();
+
+jest.mock('react-router', () => ({ withRouter: x => x }));
+jest.mock('views/stores/ViewStore', () => ({
+  ViewStore: {
+    getInitialState: () => ({ isNew: false, view: mockView }),
+    listen: () => jest.fn(),
+  },
+}));
+jest.mock('views/stores/SearchMetadataStore', () => ({
+  SearchMetadataStore: {
+    getInitialState: () => ({ undeclared: [] }),
+    listen: () => jest.fn(),
+  },
+}));
+jest.mock('stores/users/CurrentUserStore', () => MockStore(
+  ['listen', () => jest.fn()],
+  'get',
+  ['getInitialState', () => ({
+    currentUser: {
+      full_name: 'Betty Holberton',
+      username: 'betty',
+      permissions: ['dashboards:edit:view-id', 'view:edit:view-id'],
+      roles: ['Views Manager'],
+    },
+  })],
+));
+jest.mock('views/stores/SearchStore', () => ({
+  SearchActions: {
+    execute: jest.fn(() => Promise.resolve()),
+  },
+  SearchStore: {
+    listen: () => jest.fn(),
+    getInitialState: () => ({
+      result: {
+        forId: jest.fn(() => ({})),
+      },
+      widgetMapping: {},
+    }),
+  },
+}));
+
+jest.mock('views/stores/ViewSharingStore', () => ({
+  ViewSharingActions: {
+    create: jest.fn(() => Promise.resolve()),
+    get: jest.fn(() => Promise.resolve()),
+    remove: jest.fn(() => Promise.resolve()),
+    users: jest.fn(() => Promise.resolve()),
+  },
+}));
+
+describe('ViewActionsMenu', () => {
+  afterEach(cleanup);
+
+  it('should open modal to save new dashboard', () => {
+    const { getByTestId, getByText } = render(<ViewActionsMenu router={{}} />);
+    const saveAsMenuItem = getByTestId('dashboard-save-as-button');
+    fireEvent.click(saveAsMenuItem);
+    expect(getByText('Save new dashboard')).not.toBeNull();
+  });
+
+  it('should open edit dashboard meta information modal', () => {
+    const { getByText } = render(<ViewActionsMenu router={{}} />);
+    const editMenuItem = getByText(/Edit/i);
+    fireEvent.click(editMenuItem);
+    expect(getByText('Editing dashboard')).not.toBeNull();
+  });
+  it('should dashboard share modal', () => {
+    const { getByText } = render(<ViewActionsMenu router={{}} />);
+    const editMenuItem = getByText(/Share/i);
+    fireEvent.click(editMenuItem);
+    expect(getByText(/Who is supposed to access the dashboard/i)).not.toBeNull();
+  });
+});

--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.test.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.test.jsx
@@ -9,7 +9,6 @@ import View from 'views/logic/views/View';
 
 import ViewActionsMenu from './ViewActionsMenu';
 
-
 const mockView = View.create().toBuilder().id('view-id').type(View.Type.Dashboard)
   .search(Search.builder().build())
   .createdAt(new Date('2019-10-16T14:38:44.681Z'))
@@ -71,6 +70,7 @@ describe('ViewActionsMenu', () => {
     const { getByTestId, getByText } = render(<ViewActionsMenu router={{}} />);
     const saveAsMenuItem = getByTestId('dashboard-save-as-button');
     fireEvent.click(saveAsMenuItem);
+
     expect(getByText('Save new dashboard')).not.toBeNull();
   });
 
@@ -78,12 +78,14 @@ describe('ViewActionsMenu', () => {
     const { getByText } = render(<ViewActionsMenu router={{}} />);
     const editMenuItem = getByText(/Edit/i);
     fireEvent.click(editMenuItem);
+
     expect(getByText('Editing dashboard')).not.toBeNull();
   });
   it('should dashboard share modal', () => {
     const { getByText } = render(<ViewActionsMenu router={{}} />);
     const editMenuItem = getByText(/Share/i);
     fireEvent.click(editMenuItem);
+
     expect(getByText(/Who is supposed to access the dashboard/i)).not.toBeNull();
   });
 });

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Modal, Button } from 'components/graylog';
+import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import Input from 'components/bootstrap/Input';
 
 import type { TitlesMap } from 'views/stores/TitleTypes';
@@ -18,41 +18,32 @@ type Props = {
 }
 
 type State = {
-  show: boolean,
   titleDraft: string,
 }
 
 class QueryTitleEditModal extends React.Component<Props, State> {
+  modal: BootstrapModalForm = React.createRef();
+
   static propTypes = {
     onTitleChange: PropTypes.func.isRequired,
   };
 
   state = {
-    show: false,
     titleDraft: '',
   };
 
   open = (activeQueryTitle: string) => {
     this.setState({
-      show: true,
       titleDraft: activeQueryTitle,
     });
-  };
-
-  _close = () => {
-    this.setState({
-      show: false,
-      titleDraft: '',
-    });
-  };
+    this.modal.open();
+  }
 
   _onDraftSave = () => {
     const { titleDraft } = this.state;
     const { onTitleChange } = this.props;
-    if (titleDraft !== '') {
-      onTitleChange(titleDraft);
-      this._close();
-    }
+    onTitleChange(titleDraft);
+    this.modal.close();
   };
 
   _onDraftChange = (evt: SyntheticInputEvent<HTMLInputElement>) => {
@@ -60,28 +51,24 @@ class QueryTitleEditModal extends React.Component<Props, State> {
   };
 
   render() {
-    const { show, titleDraft } = this.state;
+    const { titleDraft } = this.state;
     return (
-      <Modal show={show} bsSize="large" onHide={this._close}>
-        <Modal.Header closeButton>
-          <Modal.Title>Editing query title</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <Input autoFocus
-                 help="The title of the query tab. It has a maximum length of 40 characters."
-                 id="title"
-                 label="Title"
-                 name="title"
-                 onChange={this._onDraftChange}
-                 maxLength={40}
-                 type="text"
-                 value={titleDraft} />
-        </Modal.Body>
-        <Modal.Footer>
-          <Button onClick={this._onDraftSave} bsStyle="success">Save</Button>
-          <Button onClick={this._close}>Cancel</Button>
-        </Modal.Footer>
-      </Modal>
+      <BootstrapModalForm ref={(modal) => { this.modal = modal; }}
+                          title="Editing query title"
+                          onSubmitForm={this._onDraftSave}
+                          submitButtonText="Save"
+                          bsSize="large">
+        <Input autoFocus
+               help="The title of the query tab. It has a maximum length of 40 characters."
+               id="title"
+               label="Title"
+               name="title"
+               onChange={this._onDraftChange}
+               maxLength={40}
+               required
+               type="text"
+               value={titleDraft} />
+      </BootstrapModalForm>
     );
   }
 }

--- a/graylog2-web-interface/src/views/components/views/ShareViewModal.jsx
+++ b/graylog2-web-interface/src/views/components/views/ShareViewModal.jsx
@@ -2,9 +2,9 @@
 import * as React from 'react';
 import { get } from 'lodash';
 
+import { FormGroup, HelpBlock, Radio } from 'components/graylog';
+import { BootstrapModalConfirm } from 'components/bootstrap';
 import Select from 'views/components/Select';
-
-import { FormGroup, HelpBlock, Modal, Radio, Button } from 'components/graylog';
 import Spinner from 'components/common/Spinner';
 import StoreProvider from 'injection/StoreProvider';
 import connect from 'stores/connect';
@@ -173,16 +173,12 @@ class ShareViewModal extends React.Component<Props, State> {
       </FormGroup>
     );
     return (
-      <Modal show={show} onHide={this._onClose}>
-        <Modal.Body>
-          <h3>Who is supposed to access the dashboard {view.title}?</h3>
-          {content}
-        </Modal.Body>
-        <Modal.Footer>
-          <Button onClick={this._onSave} bsStyle="success">Save</Button>
-          <Button onClick={this._onClose}>Cancel</Button>
-        </Modal.Footer>
-      </Modal>
+      <BootstrapModalConfirm showModal={show}
+                             onCancel={() => this._onClose()}
+                             onConfirm={() => this._onSave()}
+                             title={`Who is supposed to access the dashboard ${view.title}?`}>
+        {content}
+      </BootstrapModalConfirm>
     );
   }
 }

--- a/graylog2-web-interface/src/views/components/views/ShareViewModal.jsx
+++ b/graylog2-web-interface/src/views/components/views/ShareViewModal.jsx
@@ -173,10 +173,11 @@ class ShareViewModal extends React.Component<Props, State> {
       </FormGroup>
     );
     return (
-      <BootstrapModalConfirm showModal={show}
-                             onCancel={() => this._onClose()}
+      <BootstrapModalConfirm onCancel={() => this._onClose()}
                              onConfirm={() => this._onSave()}
-                             title={`Who is supposed to access the dashboard ${view.title}?`}>
+                             title={`Who is supposed to access the dashboard ${view.title}?`}
+                             confirmButtonText="Save"
+                             showModal={show}>
         {content}
       </BootstrapModalConfirm>
     );

--- a/graylog2-web-interface/src/views/components/views/ShareViewModal.jsx
+++ b/graylog2-web-interface/src/views/components/views/ShareViewModal.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { get } from 'lodash';
 
 import { FormGroup, HelpBlock, Radio } from 'components/graylog';
-import { BootstrapModalConfirm } from 'components/bootstrap';
+import BootstrapModalConfirm from 'components/bootstrap/BootstrapModalConfirm';
 import Select from 'views/components/Select';
 import Spinner from 'components/common/Spinner';
 import StoreProvider from 'injection/StoreProvider';

--- a/graylog2-web-interface/src/views/components/views/ShareViewModal.test.jsx
+++ b/graylog2-web-interface/src/views/components/views/ShareViewModal.test.jsx
@@ -2,6 +2,8 @@
 import * as React from 'react';
 import { mount } from 'wrappedEnzyme';
 
+import mockComponent from 'helpers/mocking/MockComponent';
+
 import { ViewSharingActions } from 'views/stores/ViewSharingStore';
 import AllUsersOfInstance from 'views/logic/views/sharing/AllUsersOfInstance';
 import ViewSharing from 'views/logic/views/sharing/ViewSharing';
@@ -11,6 +13,7 @@ const mockLoadRoles = jest.fn(() => Promise.resolve([]));
 
 ViewSharing.registerSubtype(AllUsersOfInstance.Type, AllUsersOfInstance);
 
+jest.mock('components/bootstrap/BootstrapModalForm', () => mockComponent('BootstrapModalForme'));
 jest.mock('stores/connect', () => x => x);
 jest.mock('injection/StoreProvider', () => ({
   getStore: (store) => {
@@ -98,7 +101,7 @@ describe('ShareViewModal', () => {
     const wrapper = mount(<ShareViewModal show view={view} currentUser={currentUser} onClose={onClose} />);
     setImmediate(() => {
       wrapper.update();
-      const button = wrapper.find('button[children="Save"]');
+      const button = wrapper.find('button[children="Confirm"]');
       button.simulate('click');
 
       expect(ViewSharingActions.create).not.toHaveBeenCalled();
@@ -112,7 +115,7 @@ describe('ShareViewModal', () => {
       wrapper.update();
       const allUsersOfInstanceRadio = wrapper.find('input[name="all_of_instance"]');
       allUsersOfInstanceRadio.simulate('change', { target: { name: 'all_of_instance' } });
-      const button = wrapper.find('button[children="Save"]');
+      const button = wrapper.find('button[children="Confirm"]');
       button.simulate('click');
 
       expect(ViewSharingActions.create).toHaveBeenCalledWith(view.id, AllUsersOfInstance.create(view.id));

--- a/graylog2-web-interface/src/views/components/views/ShareViewModal.test.jsx
+++ b/graylog2-web-interface/src/views/components/views/ShareViewModal.test.jsx
@@ -2,8 +2,6 @@
 import * as React from 'react';
 import { mount } from 'wrappedEnzyme';
 
-import mockComponent from 'helpers/mocking/MockComponent';
-
 import { ViewSharingActions } from 'views/stores/ViewSharingStore';
 import AllUsersOfInstance from 'views/logic/views/sharing/AllUsersOfInstance';
 import ViewSharing from 'views/logic/views/sharing/ViewSharing';
@@ -13,7 +11,6 @@ const mockLoadRoles = jest.fn(() => Promise.resolve([]));
 
 ViewSharing.registerSubtype(AllUsersOfInstance.Type, AllUsersOfInstance);
 
-jest.mock('components/bootstrap/BootstrapModalForm', () => mockComponent('BootstrapModalForme'));
 jest.mock('stores/connect', () => x => x);
 jest.mock('injection/StoreProvider', () => ({
   getStore: (store) => {

--- a/graylog2-web-interface/src/views/components/views/ShareViewModal.test.jsx
+++ b/graylog2-web-interface/src/views/components/views/ShareViewModal.test.jsx
@@ -98,7 +98,7 @@ describe('ShareViewModal', () => {
     const wrapper = mount(<ShareViewModal show view={view} currentUser={currentUser} onClose={onClose} />);
     setImmediate(() => {
       wrapper.update();
-      const button = wrapper.find('button[children="Confirm"]');
+      const button = wrapper.find('button[children="Save"]');
       button.simulate('click');
 
       expect(ViewSharingActions.create).not.toHaveBeenCalled();
@@ -112,7 +112,7 @@ describe('ShareViewModal', () => {
       wrapper.update();
       const allUsersOfInstanceRadio = wrapper.find('input[name="all_of_instance"]');
       allUsersOfInstanceRadio.simulate('change', { target: { name: 'all_of_instance' } });
-      const button = wrapper.find('button[children="Confirm"]');
+      const button = wrapper.find('button[children="Save"]');
       button.simulate('click');
 
       expect(ViewSharingActions.create).toHaveBeenCalledWith(view.id, AllUsersOfInstance.create(view.id));

--- a/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.jsx
+++ b/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.jsx
@@ -7,8 +7,6 @@ import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import Input from 'components/bootstrap/Input';
 
 export default class ViewPropertiesModal extends React.Component {
-  modal = React.createRef();
-
   static propTypes = {
     onClose: PropTypes.func.isRequired,
     onSave: PropTypes.func.isRequired,

--- a/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.jsx
+++ b/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.jsx
@@ -7,15 +7,12 @@ import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import Input from 'components/bootstrap/Input';
 
 export default class ViewPropertiesModal extends React.Component {
+  modal = React.createRef();
+
   static propTypes = {
     view: PropTypes.object.isRequired,
     title: PropTypes.string.isRequired,
     onSave: PropTypes.func.isRequired,
-    onClose: PropTypes.func,
-  };
-
-  static defaultProps = {
-    onClose: () => {},
   };
 
   constructor(props) {
@@ -32,6 +29,10 @@ export default class ViewPropertiesModal extends React.Component {
     if (title !== nextProps.title || !isEqual(view, nextProps.view)) {
       this.setState({ view: nextProps.view, title: nextProps.title });
     }
+  }
+
+  open = () => {
+    this.modal.open();
   }
 
   // eslint-disable-next-line consistent-return
@@ -51,26 +52,26 @@ export default class ViewPropertiesModal extends React.Component {
     }
   };
 
-  _onClose = () => {
-    const { onClose } = this.props;
-    onClose();
-  };
+  _cleanState = () => {
+    const { view, title } = this.props;
+    this.setState({ view, title });
+  }
 
   _onSave = () => {
-    const { onSave, onClose } = this.props;
+    const { onSave } = this.props;
     const { view } = this.state;
     onSave(view);
-    onClose();
+    this.modal.close();
   };
 
   render() {
     const { view: { title = '', summary = '', description = '' }, title: modalTitle } = this.state;
     return (
-      <BootstrapModalForm title={modalTitle}
+      <BootstrapModalForm ref={(modal) => { this.modal = modal; }}
+                          title={modalTitle}
+                          onModalClose={this._cleanState}
                           onSubmitForm={this._onSave}
-                          onModalClose={this._onClose}
                           submitButtonText="Save"
-                          show
                           bsSize="large">
         <Input id="title"
                type="text"

--- a/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.jsx
+++ b/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.jsx
@@ -10,9 +10,11 @@ export default class ViewPropertiesModal extends React.Component {
   modal = React.createRef();
 
   static propTypes = {
-    view: PropTypes.object.isRequired,
-    title: PropTypes.string.isRequired,
+    onClose: PropTypes.func.isRequired,
     onSave: PropTypes.func.isRequired,
+    show: PropTypes.bool.isRequired,
+    title: PropTypes.string.isRequired,
+    view: PropTypes.object.isRequired,
   };
 
   constructor(props) {
@@ -29,10 +31,6 @@ export default class ViewPropertiesModal extends React.Component {
     if (title !== nextProps.title || !isEqual(view, nextProps.view)) {
       this.setState({ view: nextProps.view, title: nextProps.title });
     }
-  }
-
-  open = () => {
-    this.modal.open();
   }
 
   // eslint-disable-next-line consistent-return
@@ -58,17 +56,19 @@ export default class ViewPropertiesModal extends React.Component {
   }
 
   _onSave = () => {
-    const { onSave } = this.props;
+    const { onClose, onSave } = this.props;
     const { view } = this.state;
     onSave(view);
-    this.modal.close();
+    onClose();
   };
 
   render() {
     const { view: { title = '', summary = '', description = '' }, title: modalTitle } = this.state;
+    const { onClose, show } = this.props;
     return (
-      <BootstrapModalForm ref={(modal) => { this.modal = modal; }}
+      <BootstrapModalForm show={show}
                           title={modalTitle}
+                          onCancel={onClose}
                           onModalClose={this._cleanState}
                           onSubmitForm={this._onSave}
                           submitButtonText="Save"

--- a/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.jsx
+++ b/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.jsx
@@ -50,11 +50,6 @@ export default class ViewPropertiesModal extends React.Component {
     }
   };
 
-  _cleanState = () => {
-    const { view, title } = this.props;
-    this.setState({ view, title });
-  }
-
   _onSave = () => {
     const { onClose, onSave } = this.props;
     const { view } = this.state;
@@ -69,7 +64,6 @@ export default class ViewPropertiesModal extends React.Component {
       <BootstrapModalForm show={show}
                           title={modalTitle}
                           onCancel={onClose}
-                          onModalClose={this._cleanState}
                           onSubmitForm={this._onSave}
                           submitButtonText="Save"
                           bsSize="large">

--- a/graylog2-web-interface/src/views/stores/SearchStore.js
+++ b/graylog2-web-interface/src/views/stores/SearchStore.js
@@ -36,7 +36,7 @@ const searchUrl = URLUtils.qualifyUrl('/views/search');
 
 export { SearchActions };
 
-type InternalState = {
+export type SearchStoreState = {
   search: Search,
   result: SearchResult,
   widgetMapping: WidgetMapping,
@@ -170,7 +170,7 @@ export const SearchStore = singletonStore(
       throw new Error('Unable to execute search when no search is loaded!');
     },
 
-    _state(): InternalState {
+    _state(): SearchStoreState {
       return { search: this.search, result: this.result, widgetMapping: this.widgetMapping };
     },
 


### PR DESCRIPTION
As described in https://github.com/Graylog2/graylog2-server/issues/7229 we are using different modal components. This PR::

- implements `BootstrapModalWrapper` for `DebugOverlay`
- implements `BootstrapModalForm` for `QueryEditTitle`
- implements `BootstrapModalConfirm` for `ShareViewModal`
- Adds test base and modal tests for `ViewActionsMenu`

At first I only worked with references (https://github.com/Graylog2/graylog2-server/commit/5939a1075091dff856e328428ffcbcd471d535c5) but directly mounting the modal components had some disadvantages. E.g. the `ShareViewModal` would do some not needed api requests, when opening any dashboard. Only mounting the modal component when they are visible has manly one disadvantage, the fade out animation will not be shown.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

