### PR TITLE
Support legacy (pre 3.2) search result in data table visualization.

### DIFF
--- a/graylog2-web-interface/src/views/components/datatable/DataTable.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTable.jsx
@@ -68,7 +68,7 @@ const DataTable = ({ config, currentView, data, fields }: Props) => {
   useEffect(onRenderComplete, [onRenderComplete]);
 
   const { columnPivots, rowPivots, series, rollup } = config;
-  const { chart: rows = [] } = data || {};
+  const rows = data.chart || Object.values(data)[0] || [];
 
   const rowFieldNames = rowPivots.map<string>(pivot => pivot.field);
   const columnFieldNames = columnPivots.map(pivot => pivot.field);

--- a/graylog2-web-interface/src/views/components/datatable/DataTable.test.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTable.test.jsx
@@ -18,22 +18,23 @@ jest.mock('stores/users/CurrentUserStore', () => MockStore('listen', 'get'));
 describe('DataTable', () => {
   const currentView = { activeQuery: 'deadbeef-23' };
 
-  const data = {
-    chart: [{
-      key: ['2018-10-04T09:43:50.000Z'],
-      source: 'leaf',
-      values: [{
-        key: ['hulud.net', 'count()'],
-        rollup: false,
-        source: 'col-leaf',
-        value: 408,
-      }, {
-        key: ['count()'],
-        rollup: true,
-        source: 'row-leaf',
-        value: 408,
-      }],
+  const rows = [{
+    key: ['2018-10-04T09:43:50.000Z'],
+    source: 'leaf',
+    values: [{
+      key: ['hulud.net', 'count()'],
+      rollup: false,
+      source: 'col-leaf',
+      value: 408,
+    }, {
+      key: ['count()'],
+      rollup: true,
+      source: 'row-leaf',
+      value: 408,
     }],
+  }];
+  const data = {
+    chart: rows,
   };
 
   const columnPivot = new Pivot('source', 'values', { limit: 15 });
@@ -70,6 +71,23 @@ describe('DataTable', () => {
                                      data={data}
                                      fields={Immutable.List([])} />);
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render for legacy search result with id as key', () => {
+    const config = AggregationWidgetConfig.builder()
+      .rowPivots([rowPivot])
+      .columnPivots([columnPivot])
+      .series([series])
+      .sort([])
+      .visualization('table')
+      .rollup(true)
+      .build();
+
+    const wrapper = mount(<DataTable config={config}
+                                     currentView={currentView}
+                                     data={{ 'd8e311db-276c-46e4-ba75-57bf1e0b4d35': rows }}
+                                     fields={Immutable.List([])} />);
+    expect(wrapper).toIncludeText('hulud.net');
   });
 
   it('should render with filled data without rollup', () => {


### PR DESCRIPTION
## Description
## Motivation and Context

*Needs to be backported to `3.2`.*

Before `3.2`, search types did not had a `name` attribute. In 5ee5115 an
optional name attribute defined by the caller was introduced. Views
created before this, did not contain it and search results are scoped
with the search key id instead. This is handled by all visualizations
but the data table.

This leads to views containing data tables not rendering properly in
`3.2`, if they had been created before `3.2`, as reported in #7565.

This change is now adding support and tests for this for the data table.

Fixes #7565.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.