### PR TITLE
Popover Theme TypeError

### DIFF
--- a/graylog2-web-interface/src/components/graylog/Popover.jsx
+++ b/graylog2-web-interface/src/components/graylog/Popover.jsx
@@ -1,46 +1,46 @@
+import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { Popover as BoostrapPopover } from 'react-bootstrap';
 import styled, { css } from 'styled-components';
 import { darken, opacify, transparentize } from 'polished';
+import GraylogThemeProvider from 'theme/GraylogThemeProvider';
 
-const Popover = styled(BoostrapPopover)(({ theme }) => {
+const StyledPopover = styled(BoostrapPopover)(({ theme }) => {
   const borderColor = transparentize(0.8, theme.color.primary.tre);
 
   return css`
-    && {
-      background-color: ${theme.color.primary.due};
-      border-color: ${borderColor};
+    background-color: ${theme.color.primary.due};
+    border-color: ${borderColor};
 
-      &.top > .arrow {
-        border-top-color: ${opacify(0.05, borderColor)};
+    &.top > .arrow {
+      border-top-color: ${opacify(0.05, borderColor)};
 
-        &::after {
-          border-top-color: ${theme.color.primary.due};
-        }
+      &::after {
+        border-top-color: ${theme.color.primary.due};
       }
+    }
 
-      &.right > .arrow {
-        border-right-color: ${opacify(0.05, borderColor)};
+    &.right > .arrow {
+      border-right-color: ${opacify(0.05, borderColor)};
 
-        &::after {
-          border-right-color: ${theme.color.primary.due};
-        }
+      &::after {
+        border-right-color: ${theme.color.primary.due};
       }
+    }
 
-      &.bottom > .arrow {
-        border-bottom-color: ${opacify(0.05, borderColor)};
+    &.bottom > .arrow {
+      border-bottom-color: ${opacify(0.05, borderColor)};
 
-        &::after {
-          border-bottom-color: ${theme.color.primary.due};
-        }
+      &::after {
+        border-bottom-color: ${theme.color.primary.due};
       }
+    }
 
-      &.left > .arrow {
-        border-left-color: ${opacify(0.05, borderColor)};
+    &.left > .arrow {
+      border-left-color: ${opacify(0.05, borderColor)};
 
-        &::after {
-          border-left-color: ${theme.color.primary.due};
-        }
+      &::after {
+        border-left-color: ${theme.color.primary.due};
       }
     }
 
@@ -49,6 +49,14 @@ const Popover = styled(BoostrapPopover)(({ theme }) => {
     }
   `;
 });
+
+const Popover = (allProps) => {
+  return (
+    <GraylogThemeProvider>
+      <StyledPopover {...allProps} />
+    </GraylogThemeProvider>
+  );
+};
 
 /** @component */
 export default Popover;

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkForm.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkForm.test.jsx.snap
@@ -27,377 +27,412 @@ exports[`BookmarkForm render the BookmarkForm should render create new 1`] = `
             id="bookmark-popover"
             title="Name of search"
           >
-            <StyledComponent
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "Popover-wd1j0g-0",
-                    "isStatic": false,
-                    "lastClassName": "dQcVSD",
-                    "rules": Array [
-                      [Function],
-                    ],
-                  },
-                  "displayName": "Popover",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "Popover-wd1j0g-0",
-                  "target": [Function],
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
-              id="bookmark-popover"
-              title="Name of search"
-            >
-              <Popover
-                bsClass="popover"
-                className="Popover-wd1j0g-0 dQcVSD"
-                id="bookmark-popover"
-                placement="right"
-                title="Name of search"
-              >
-                <div
-                  className="Popover-wd1j0g-0 dQcVSD popover right"
-                  id="bookmark-popover"
-                  role="tooltip"
-                  style={
-                    Object {
-                      "display": "block",
-                      "left": undefined,
-                      "top": undefined,
-                    }
+            <GraylogThemeProvider>
+              <ThemeProvider
+                theme={
+                  Object {
+                    "color": Object {
+                      "primary": Object {
+                        "due": "#FFF",
+                        "tre": "#1F1F1F",
+                        "uno": "#FF3633",
+                      },
+                      "secondary": Object {
+                        "due": "#F1F2F2",
+                        "tre": "#DCE1E5",
+                        "uno": "#FF3B00",
+                      },
+                      "tertiary": Object {
+                        "cinque": "#FF6418",
+                        "due": "#6DC6E7",
+                        "quattro": "#9E1F63",
+                        "sei": "#FFD200",
+                        "tre": "#8DC63F",
+                        "uno": "#16ACE3",
+                      },
+                    },
+                    "mode": "teinte",
                   }
+                }
+              >
+                <Popover__StyledPopover
+                  id="bookmark-popover"
+                  title="Name of search"
                 >
-                  <div
-                    className="arrow"
-                    style={
+                  <StyledComponent
+                    forwardedComponent={
                       Object {
-                        "left": undefined,
-                        "top": undefined,
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "Popover__StyledPopover-wd1j0g-0",
+                          "isStatic": false,
+                          "lastClassName": "lbOgZZ",
+                          "rules": Array [
+                            [Function],
+                          ],
+                        },
+                        "displayName": "Popover__StyledPopover",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "Popover__StyledPopover-wd1j0g-0",
+                        "target": [Function],
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
                       }
                     }
-                  />
-                  <h3
-                    className="popover-title"
+                    forwardedRef={null}
+                    id="bookmark-popover"
+                    title="Name of search"
                   >
-                    Name of search
-                  </h3>
-                  <div
-                    className="popover-content"
-                  >
-                    <form>
-                      <Component
-                        validationState={null}
+                    <Popover
+                      bsClass="popover"
+                      className="Popover__StyledPopover-wd1j0g-0 lbOgZZ"
+                      id="bookmark-popover"
+                      placement="right"
+                      title="Name of search"
+                    >
+                      <div
+                        className="Popover__StyledPopover-wd1j0g-0 lbOgZZ popover right"
+                        id="bookmark-popover"
+                        role="tooltip"
+                        style={
+                          Object {
+                            "display": "block",
+                            "left": undefined,
+                            "top": undefined,
+                          }
+                        }
                       >
-                        <FormGroup__StyledFormGroup
-                          validationState={null}
-                        >
-                          <StyledComponent
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "SIZES": Array [
-                                  "large",
-                                  "small",
-                                ],
-                                "attrs": Array [],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "FormGroup__StyledFormGroup-sc-1wv4cm9-0",
-                                  "isStatic": false,
-                                  "lastClassName": "ekazNr",
-                                  "rules": Array [
-                                    [Function],
-                                    ";",
-                                  ],
-                                },
-                                "displayName": "FormGroup__StyledFormGroup",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "FormGroup__StyledFormGroup-sc-1wv4cm9-0",
-                                "target": [Function],
-                                "toString": [Function],
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
+                        <div
+                          className="arrow"
+                          style={
+                            Object {
+                              "left": undefined,
+                              "top": undefined,
                             }
-                            forwardedRef={null}
-                            validationState={null}
-                          >
-                            <FormGroup
-                              bsClass="form-group"
-                              className="FormGroup__StyledFormGroup-sc-1wv4cm9-0 ekazNr"
+                          }
+                        />
+                        <h3
+                          className="popover-title"
+                        >
+                          Name of search
+                        </h3>
+                        <div
+                          className="popover-content"
+                        >
+                          <form>
+                            <Component
                               validationState={null}
                             >
-                              <div
-                                className="FormGroup__StyledFormGroup-sc-1wv4cm9-0 ekazNr form-group"
+                              <FormGroup__StyledFormGroup
+                                validationState={null}
                               >
-                                <ControlLabel>
-                                  <StyledComponent
-                                    forwardedComponent={
-                                      Object {
-                                        "$$typeof": Symbol(react.forward_ref),
-                                        "attrs": Array [],
-                                        "componentStyle": ComponentStyle {
-                                          "componentId": "ControlLabel-sc-1edmum5-0",
-                                          "isStatic": false,
-                                          "lastClassName": "iZJNbd",
-                                          "rules": Array [
-                                            [Function],
-                                          ],
-                                        },
-                                        "displayName": "ControlLabel",
-                                        "foldedComponentIds": Array [],
-                                        "render": [Function],
-                                        "styledComponentId": "ControlLabel-sc-1edmum5-0",
-                                        "target": [Function],
-                                        "toString": [Function],
-                                        "warnTooManyClasses": [Function],
-                                        "withComponent": [Function],
-                                      }
-                                    }
-                                    forwardedRef={null}
-                                  >
-                                    <ControlLabel
-                                      bsClass="control-label"
-                                      className="ControlLabel-sc-1edmum5-0 iZJNbd"
-                                      srOnly={false}
-                                    >
-                                      <label
-                                        className="ControlLabel-sc-1edmum5-0 iZJNbd control-label"
-                                      >
-                                        Title
-                                      </label>
-                                    </ControlLabel>
-                                  </StyledComponent>
-                                </ControlLabel>
-                                <FormControl
-                                  onChange={[Function]}
-                                  placeholder="Enter title"
-                                  type="text"
-                                  value="new Title"
-                                >
-                                  <StyledComponent
-                                    forwardedComponent={
-                                      Object {
-                                        "$$typeof": Symbol(react.forward_ref),
-                                        "Feedback": [Function],
-                                        "SIZES": Array [
-                                          "small",
-                                          "large",
+                                <StyledComponent
+                                  forwardedComponent={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "SIZES": Array [
+                                        "large",
+                                        "small",
+                                      ],
+                                      "attrs": Array [],
+                                      "componentStyle": ComponentStyle {
+                                        "componentId": "FormGroup__StyledFormGroup-sc-1wv4cm9-0",
+                                        "isStatic": false,
+                                        "lastClassName": "ekazNr",
+                                        "rules": Array [
+                                          [Function],
+                                          ";",
                                         ],
-                                        "Static": [Function],
-                                        "attrs": Array [],
-                                        "componentStyle": ComponentStyle {
-                                          "componentId": "FormControl-sc-1amoaox-0",
-                                          "isStatic": false,
-                                          "lastClassName": "eOArng",
-                                          "rules": Array [
-                                            [Function],
-                                          ],
-                                        },
-                                        "displayName": "FormControl",
-                                        "foldedComponentIds": Array [],
-                                        "render": [Function],
-                                        "styledComponentId": "FormControl-sc-1amoaox-0",
-                                        "target": [Function],
-                                        "toString": [Function],
-                                        "warnTooManyClasses": [Function],
-                                        "withComponent": [Function],
-                                      }
+                                      },
+                                      "displayName": "FormGroup__StyledFormGroup",
+                                      "foldedComponentIds": Array [],
+                                      "render": [Function],
+                                      "styledComponentId": "FormGroup__StyledFormGroup-sc-1wv4cm9-0",
+                                      "target": [Function],
+                                      "toString": [Function],
+                                      "warnTooManyClasses": [Function],
+                                      "withComponent": [Function],
                                     }
-                                    forwardedRef={null}
-                                    onChange={[Function]}
-                                    placeholder="Enter title"
-                                    type="text"
-                                    value="new Title"
+                                  }
+                                  forwardedRef={null}
+                                  validationState={null}
+                                >
+                                  <FormGroup
+                                    bsClass="form-group"
+                                    className="FormGroup__StyledFormGroup-sc-1wv4cm9-0 ekazNr"
+                                    validationState={null}
                                   >
-                                    <FormControl
-                                      bsClass="form-control"
-                                      className="FormControl-sc-1amoaox-0 eOArng"
-                                      componentClass="input"
-                                      onChange={[Function]}
-                                      placeholder="Enter title"
-                                      type="text"
-                                      value="new Title"
+                                    <div
+                                      className="FormGroup__StyledFormGroup-sc-1wv4cm9-0 ekazNr form-group"
                                     >
-                                      <input
-                                        className="FormControl-sc-1amoaox-0 eOArng form-control"
+                                      <ControlLabel>
+                                        <StyledComponent
+                                          forwardedComponent={
+                                            Object {
+                                              "$$typeof": Symbol(react.forward_ref),
+                                              "attrs": Array [],
+                                              "componentStyle": ComponentStyle {
+                                                "componentId": "ControlLabel-sc-1edmum5-0",
+                                                "isStatic": false,
+                                                "lastClassName": "iZJNbd",
+                                                "rules": Array [
+                                                  [Function],
+                                                ],
+                                              },
+                                              "displayName": "ControlLabel",
+                                              "foldedComponentIds": Array [],
+                                              "render": [Function],
+                                              "styledComponentId": "ControlLabel-sc-1edmum5-0",
+                                              "target": [Function],
+                                              "toString": [Function],
+                                              "warnTooManyClasses": [Function],
+                                              "withComponent": [Function],
+                                            }
+                                          }
+                                          forwardedRef={null}
+                                        >
+                                          <ControlLabel
+                                            bsClass="control-label"
+                                            className="ControlLabel-sc-1edmum5-0 iZJNbd"
+                                            srOnly={false}
+                                          >
+                                            <label
+                                              className="ControlLabel-sc-1edmum5-0 iZJNbd control-label"
+                                            >
+                                              Title
+                                            </label>
+                                          </ControlLabel>
+                                        </StyledComponent>
+                                      </ControlLabel>
+                                      <FormControl
                                         onChange={[Function]}
                                         placeholder="Enter title"
                                         type="text"
                                         value="new Title"
-                                      />
-                                    </FormControl>
-                                  </StyledComponent>
-                                </FormControl>
-                              </div>
-                            </FormGroup>
-                          </StyledComponent>
-                        </FormGroup__StyledFormGroup>
-                      </Component>
-                      <ForwardRef
-                        bsStyle="info"
-                        className="button"
-                        disabled={false}
-                        onClick={[Function]}
-                        type="submit"
-                      >
-                        <Button
-                          bsStyle="info"
-                          className="button"
-                          disabled={false}
-                          onClick={[Function]}
-                          type="submit"
-                        >
-                          <StyledComponent
-                            bsStyle="info"
-                            className="button"
-                            disabled={false}
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "SIZES": Array [
-                                  "large",
-                                  "small",
-                                  "xsmall",
-                                ],
-                                "STYLES": Array [
-                                  "success",
-                                  "warning",
-                                  "danger",
-                                  "info",
-                                  "default",
-                                  "primary",
-                                  "link",
-                                ],
-                                "attrs": Array [],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "Button-c9cbmb-0",
-                                  "isStatic": false,
-                                  "lastClassName": "gZfKUo",
-                                  "rules": Array [
-                                    [Function],
-                                  ],
-                                },
-                                "displayName": "Button",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "Button-c9cbmb-0",
-                                "target": [Function],
-                                "toString": [Function],
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
-                            }
-                            forwardedRef={null}
-                            onClick={[Function]}
-                            type="submit"
-                          >
-                            <Button
-                              active={false}
-                              block={false}
-                              bsClass="btn"
+                                      >
+                                        <StyledComponent
+                                          forwardedComponent={
+                                            Object {
+                                              "$$typeof": Symbol(react.forward_ref),
+                                              "Feedback": [Function],
+                                              "SIZES": Array [
+                                                "small",
+                                                "large",
+                                              ],
+                                              "Static": [Function],
+                                              "attrs": Array [],
+                                              "componentStyle": ComponentStyle {
+                                                "componentId": "FormControl-sc-1amoaox-0",
+                                                "isStatic": false,
+                                                "lastClassName": "eOArng",
+                                                "rules": Array [
+                                                  [Function],
+                                                ],
+                                              },
+                                              "displayName": "FormControl",
+                                              "foldedComponentIds": Array [],
+                                              "render": [Function],
+                                              "styledComponentId": "FormControl-sc-1amoaox-0",
+                                              "target": [Function],
+                                              "toString": [Function],
+                                              "warnTooManyClasses": [Function],
+                                              "withComponent": [Function],
+                                            }
+                                          }
+                                          forwardedRef={null}
+                                          onChange={[Function]}
+                                          placeholder="Enter title"
+                                          type="text"
+                                          value="new Title"
+                                        >
+                                          <FormControl
+                                            bsClass="form-control"
+                                            className="FormControl-sc-1amoaox-0 eOArng"
+                                            componentClass="input"
+                                            onChange={[Function]}
+                                            placeholder="Enter title"
+                                            type="text"
+                                            value="new Title"
+                                          >
+                                            <input
+                                              className="FormControl-sc-1amoaox-0 eOArng form-control"
+                                              onChange={[Function]}
+                                              placeholder="Enter title"
+                                              type="text"
+                                              value="new Title"
+                                            />
+                                          </FormControl>
+                                        </StyledComponent>
+                                      </FormControl>
+                                    </div>
+                                  </FormGroup>
+                                </StyledComponent>
+                              </FormGroup__StyledFormGroup>
+                            </Component>
+                            <ForwardRef
                               bsStyle="info"
-                              className="button Button-c9cbmb-0 gZfKUo"
+                              className="button"
                               disabled={false}
                               onClick={[Function]}
                               type="submit"
                             >
-                              <button
-                                className="button Button-c9cbmb-0 gZfKUo btn btn-info"
+                              <Button
+                                bsStyle="info"
+                                className="button"
                                 disabled={false}
                                 onClick={[Function]}
                                 type="submit"
                               >
-                                Create new
-                              </button>
-                            </Button>
-                          </StyledComponent>
-                        </Button>
-                      </ForwardRef>
-                      <ForwardRef
-                        bsStyle="default"
-                        className="button"
-                        onClick={[Function]}
-                      >
-                        <Button
-                          bsStyle="default"
-                          className="button"
-                          onClick={[Function]}
-                        >
-                          <StyledComponent
-                            bsStyle="default"
-                            className="button"
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "SIZES": Array [
-                                  "large",
-                                  "small",
-                                  "xsmall",
-                                ],
-                                "STYLES": Array [
-                                  "success",
-                                  "warning",
-                                  "danger",
-                                  "info",
-                                  "default",
-                                  "primary",
-                                  "link",
-                                ],
-                                "attrs": Array [],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "Button-c9cbmb-0",
-                                  "isStatic": false,
-                                  "lastClassName": "iKWoaE",
-                                  "rules": Array [
-                                    [Function],
-                                  ],
-                                },
-                                "displayName": "Button",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "Button-c9cbmb-0",
-                                "target": [Function],
-                                "toString": [Function],
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
-                            }
-                            forwardedRef={null}
-                            onClick={[Function]}
-                          >
-                            <Button
-                              active={false}
-                              block={false}
-                              bsClass="btn"
+                                <StyledComponent
+                                  bsStyle="info"
+                                  className="button"
+                                  disabled={false}
+                                  forwardedComponent={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "SIZES": Array [
+                                        "large",
+                                        "small",
+                                        "xsmall",
+                                      ],
+                                      "STYLES": Array [
+                                        "success",
+                                        "warning",
+                                        "danger",
+                                        "info",
+                                        "default",
+                                        "primary",
+                                        "link",
+                                      ],
+                                      "attrs": Array [],
+                                      "componentStyle": ComponentStyle {
+                                        "componentId": "Button-c9cbmb-0",
+                                        "isStatic": false,
+                                        "lastClassName": "gZfKUo",
+                                        "rules": Array [
+                                          [Function],
+                                        ],
+                                      },
+                                      "displayName": "Button",
+                                      "foldedComponentIds": Array [],
+                                      "render": [Function],
+                                      "styledComponentId": "Button-c9cbmb-0",
+                                      "target": [Function],
+                                      "toString": [Function],
+                                      "warnTooManyClasses": [Function],
+                                      "withComponent": [Function],
+                                    }
+                                  }
+                                  forwardedRef={null}
+                                  onClick={[Function]}
+                                  type="submit"
+                                >
+                                  <Button
+                                    active={false}
+                                    block={false}
+                                    bsClass="btn"
+                                    bsStyle="info"
+                                    className="button Button-c9cbmb-0 gZfKUo"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    type="submit"
+                                  >
+                                    <button
+                                      className="button Button-c9cbmb-0 gZfKUo btn btn-info"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="submit"
+                                    >
+                                      Create new
+                                    </button>
+                                  </Button>
+                                </StyledComponent>
+                              </Button>
+                            </ForwardRef>
+                            <ForwardRef
                               bsStyle="default"
-                              className="button Button-c9cbmb-0 iKWoaE"
-                              disabled={false}
+                              className="button"
                               onClick={[Function]}
                             >
-                              <button
-                                className="button Button-c9cbmb-0 iKWoaE btn btn-default"
-                                disabled={false}
+                              <Button
+                                bsStyle="default"
+                                className="button"
                                 onClick={[Function]}
-                                type="button"
                               >
-                                Cancel
-                              </button>
-                            </Button>
-                          </StyledComponent>
-                        </Button>
-                      </ForwardRef>
-                    </form>
-                  </div>
-                </div>
-              </Popover>
-            </StyledComponent>
+                                <StyledComponent
+                                  bsStyle="default"
+                                  className="button"
+                                  forwardedComponent={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "SIZES": Array [
+                                        "large",
+                                        "small",
+                                        "xsmall",
+                                      ],
+                                      "STYLES": Array [
+                                        "success",
+                                        "warning",
+                                        "danger",
+                                        "info",
+                                        "default",
+                                        "primary",
+                                        "link",
+                                      ],
+                                      "attrs": Array [],
+                                      "componentStyle": ComponentStyle {
+                                        "componentId": "Button-c9cbmb-0",
+                                        "isStatic": false,
+                                        "lastClassName": "iKWoaE",
+                                        "rules": Array [
+                                          [Function],
+                                        ],
+                                      },
+                                      "displayName": "Button",
+                                      "foldedComponentIds": Array [],
+                                      "render": [Function],
+                                      "styledComponentId": "Button-c9cbmb-0",
+                                      "target": [Function],
+                                      "toString": [Function],
+                                      "warnTooManyClasses": [Function],
+                                      "withComponent": [Function],
+                                    }
+                                  }
+                                  forwardedRef={null}
+                                  onClick={[Function]}
+                                >
+                                  <Button
+                                    active={false}
+                                    block={false}
+                                    bsClass="btn"
+                                    bsStyle="default"
+                                    className="button Button-c9cbmb-0 iKWoaE"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                  >
+                                    <button
+                                      className="button Button-c9cbmb-0 iKWoaE btn btn-default"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      Cancel
+                                    </button>
+                                  </Button>
+                                </StyledComponent>
+                              </Button>
+                            </ForwardRef>
+                          </form>
+                        </div>
+                      </div>
+                    </Popover>
+                  </StyledComponent>
+                </Popover__StyledPopover>
+              </ThemeProvider>
+            </GraylogThemeProvider>
           </Popover>
         </mock-position>
       </MockPosition>
@@ -433,454 +468,489 @@ exports[`BookmarkForm render the BookmarkForm should render disabled create new 
             id="bookmark-popover"
             title="Name of search"
           >
-            <StyledComponent
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "Popover-wd1j0g-0",
-                    "isStatic": false,
-                    "lastClassName": "dQcVSD",
-                    "rules": Array [
-                      [Function],
-                    ],
-                  },
-                  "displayName": "Popover",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "Popover-wd1j0g-0",
-                  "target": [Function],
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
-              id="bookmark-popover"
-              title="Name of search"
-            >
-              <Popover
-                bsClass="popover"
-                className="Popover-wd1j0g-0 dQcVSD"
-                id="bookmark-popover"
-                placement="right"
-                title="Name of search"
-              >
-                <div
-                  className="Popover-wd1j0g-0 dQcVSD popover right"
-                  id="bookmark-popover"
-                  role="tooltip"
-                  style={
-                    Object {
-                      "display": "block",
-                      "left": undefined,
-                      "top": undefined,
-                    }
+            <GraylogThemeProvider>
+              <ThemeProvider
+                theme={
+                  Object {
+                    "color": Object {
+                      "primary": Object {
+                        "due": "#FFF",
+                        "tre": "#1F1F1F",
+                        "uno": "#FF3633",
+                      },
+                      "secondary": Object {
+                        "due": "#F1F2F2",
+                        "tre": "#DCE1E5",
+                        "uno": "#FF3B00",
+                      },
+                      "tertiary": Object {
+                        "cinque": "#FF6418",
+                        "due": "#6DC6E7",
+                        "quattro": "#9E1F63",
+                        "sei": "#FFD200",
+                        "tre": "#8DC63F",
+                        "uno": "#16ACE3",
+                      },
+                    },
+                    "mode": "teinte",
                   }
+                }
+              >
+                <Popover__StyledPopover
+                  id="bookmark-popover"
+                  title="Name of search"
                 >
-                  <div
-                    className="arrow"
-                    style={
+                  <StyledComponent
+                    forwardedComponent={
                       Object {
-                        "left": undefined,
-                        "top": undefined,
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "Popover__StyledPopover-wd1j0g-0",
+                          "isStatic": false,
+                          "lastClassName": "lbOgZZ",
+                          "rules": Array [
+                            [Function],
+                          ],
+                        },
+                        "displayName": "Popover__StyledPopover",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "Popover__StyledPopover-wd1j0g-0",
+                        "target": [Function],
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
                       }
                     }
-                  />
-                  <h3
-                    className="popover-title"
+                    forwardedRef={null}
+                    id="bookmark-popover"
+                    title="Name of search"
                   >
-                    Name of search
-                  </h3>
-                  <div
-                    className="popover-content"
-                  >
-                    <form>
-                      <Component
-                        validationState={null}
+                    <Popover
+                      bsClass="popover"
+                      className="Popover__StyledPopover-wd1j0g-0 lbOgZZ"
+                      id="bookmark-popover"
+                      placement="right"
+                      title="Name of search"
+                    >
+                      <div
+                        className="Popover__StyledPopover-wd1j0g-0 lbOgZZ popover right"
+                        id="bookmark-popover"
+                        role="tooltip"
+                        style={
+                          Object {
+                            "display": "block",
+                            "left": undefined,
+                            "top": undefined,
+                          }
+                        }
                       >
-                        <FormGroup__StyledFormGroup
-                          validationState={null}
-                        >
-                          <StyledComponent
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "SIZES": Array [
-                                  "large",
-                                  "small",
-                                ],
-                                "attrs": Array [],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "FormGroup__StyledFormGroup-sc-1wv4cm9-0",
-                                  "isStatic": false,
-                                  "lastClassName": "ekazNr",
-                                  "rules": Array [
-                                    [Function],
-                                    ";",
-                                  ],
-                                },
-                                "displayName": "FormGroup__StyledFormGroup",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "FormGroup__StyledFormGroup-sc-1wv4cm9-0",
-                                "target": [Function],
-                                "toString": [Function],
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
+                        <div
+                          className="arrow"
+                          style={
+                            Object {
+                              "left": undefined,
+                              "top": undefined,
                             }
-                            forwardedRef={null}
-                            validationState={null}
-                          >
-                            <FormGroup
-                              bsClass="form-group"
-                              className="FormGroup__StyledFormGroup-sc-1wv4cm9-0 ekazNr"
+                          }
+                        />
+                        <h3
+                          className="popover-title"
+                        >
+                          Name of search
+                        </h3>
+                        <div
+                          className="popover-content"
+                        >
+                          <form>
+                            <Component
                               validationState={null}
                             >
-                              <div
-                                className="FormGroup__StyledFormGroup-sc-1wv4cm9-0 ekazNr form-group"
+                              <FormGroup__StyledFormGroup
+                                validationState={null}
                               >
-                                <ControlLabel>
-                                  <StyledComponent
-                                    forwardedComponent={
-                                      Object {
-                                        "$$typeof": Symbol(react.forward_ref),
-                                        "attrs": Array [],
-                                        "componentStyle": ComponentStyle {
-                                          "componentId": "ControlLabel-sc-1edmum5-0",
-                                          "isStatic": false,
-                                          "lastClassName": "iZJNbd",
-                                          "rules": Array [
-                                            [Function],
-                                          ],
-                                        },
-                                        "displayName": "ControlLabel",
-                                        "foldedComponentIds": Array [],
-                                        "render": [Function],
-                                        "styledComponentId": "ControlLabel-sc-1edmum5-0",
-                                        "target": [Function],
-                                        "toString": [Function],
-                                        "warnTooManyClasses": [Function],
-                                        "withComponent": [Function],
-                                      }
-                                    }
-                                    forwardedRef={null}
-                                  >
-                                    <ControlLabel
-                                      bsClass="control-label"
-                                      className="ControlLabel-sc-1edmum5-0 iZJNbd"
-                                      srOnly={false}
-                                    >
-                                      <label
-                                        className="ControlLabel-sc-1edmum5-0 iZJNbd control-label"
-                                      >
-                                        Title
-                                      </label>
-                                    </ControlLabel>
-                                  </StyledComponent>
-                                </ControlLabel>
-                                <FormControl
-                                  onChange={[Function]}
-                                  placeholder="Enter title"
-                                  type="text"
-                                  value="new Title"
-                                >
-                                  <StyledComponent
-                                    forwardedComponent={
-                                      Object {
-                                        "$$typeof": Symbol(react.forward_ref),
-                                        "Feedback": [Function],
-                                        "SIZES": Array [
-                                          "small",
-                                          "large",
+                                <StyledComponent
+                                  forwardedComponent={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "SIZES": Array [
+                                        "large",
+                                        "small",
+                                      ],
+                                      "attrs": Array [],
+                                      "componentStyle": ComponentStyle {
+                                        "componentId": "FormGroup__StyledFormGroup-sc-1wv4cm9-0",
+                                        "isStatic": false,
+                                        "lastClassName": "ekazNr",
+                                        "rules": Array [
+                                          [Function],
+                                          ";",
                                         ],
-                                        "Static": [Function],
-                                        "attrs": Array [],
-                                        "componentStyle": ComponentStyle {
-                                          "componentId": "FormControl-sc-1amoaox-0",
-                                          "isStatic": false,
-                                          "lastClassName": "eOArng",
-                                          "rules": Array [
-                                            [Function],
-                                          ],
-                                        },
-                                        "displayName": "FormControl",
-                                        "foldedComponentIds": Array [],
-                                        "render": [Function],
-                                        "styledComponentId": "FormControl-sc-1amoaox-0",
-                                        "target": [Function],
-                                        "toString": [Function],
-                                        "warnTooManyClasses": [Function],
-                                        "withComponent": [Function],
-                                      }
+                                      },
+                                      "displayName": "FormGroup__StyledFormGroup",
+                                      "foldedComponentIds": Array [],
+                                      "render": [Function],
+                                      "styledComponentId": "FormGroup__StyledFormGroup-sc-1wv4cm9-0",
+                                      "target": [Function],
+                                      "toString": [Function],
+                                      "warnTooManyClasses": [Function],
+                                      "withComponent": [Function],
                                     }
-                                    forwardedRef={null}
-                                    onChange={[Function]}
-                                    placeholder="Enter title"
-                                    type="text"
-                                    value="new Title"
+                                  }
+                                  forwardedRef={null}
+                                  validationState={null}
+                                >
+                                  <FormGroup
+                                    bsClass="form-group"
+                                    className="FormGroup__StyledFormGroup-sc-1wv4cm9-0 ekazNr"
+                                    validationState={null}
                                   >
-                                    <FormControl
-                                      bsClass="form-control"
-                                      className="FormControl-sc-1amoaox-0 eOArng"
-                                      componentClass="input"
-                                      onChange={[Function]}
-                                      placeholder="Enter title"
-                                      type="text"
-                                      value="new Title"
+                                    <div
+                                      className="FormGroup__StyledFormGroup-sc-1wv4cm9-0 ekazNr form-group"
                                     >
-                                      <input
-                                        className="FormControl-sc-1amoaox-0 eOArng form-control"
+                                      <ControlLabel>
+                                        <StyledComponent
+                                          forwardedComponent={
+                                            Object {
+                                              "$$typeof": Symbol(react.forward_ref),
+                                              "attrs": Array [],
+                                              "componentStyle": ComponentStyle {
+                                                "componentId": "ControlLabel-sc-1edmum5-0",
+                                                "isStatic": false,
+                                                "lastClassName": "iZJNbd",
+                                                "rules": Array [
+                                                  [Function],
+                                                ],
+                                              },
+                                              "displayName": "ControlLabel",
+                                              "foldedComponentIds": Array [],
+                                              "render": [Function],
+                                              "styledComponentId": "ControlLabel-sc-1edmum5-0",
+                                              "target": [Function],
+                                              "toString": [Function],
+                                              "warnTooManyClasses": [Function],
+                                              "withComponent": [Function],
+                                            }
+                                          }
+                                          forwardedRef={null}
+                                        >
+                                          <ControlLabel
+                                            bsClass="control-label"
+                                            className="ControlLabel-sc-1edmum5-0 iZJNbd"
+                                            srOnly={false}
+                                          >
+                                            <label
+                                              className="ControlLabel-sc-1edmum5-0 iZJNbd control-label"
+                                            >
+                                              Title
+                                            </label>
+                                          </ControlLabel>
+                                        </StyledComponent>
+                                      </ControlLabel>
+                                      <FormControl
                                         onChange={[Function]}
                                         placeholder="Enter title"
                                         type="text"
                                         value="new Title"
-                                      />
-                                    </FormControl>
-                                  </StyledComponent>
-                                </FormControl>
-                              </div>
-                            </FormGroup>
-                          </StyledComponent>
-                        </FormGroup__StyledFormGroup>
-                      </Component>
-                      <ForwardRef
-                        bsStyle="primary"
-                        className="button"
-                        onClick={[Function]}
-                        type="submit"
-                      >
-                        <Button
-                          bsStyle="primary"
-                          className="button"
-                          onClick={[Function]}
-                          type="submit"
-                        >
-                          <StyledComponent
-                            bsStyle="primary"
-                            className="button"
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "SIZES": Array [
-                                  "large",
-                                  "small",
-                                  "xsmall",
-                                ],
-                                "STYLES": Array [
-                                  "success",
-                                  "warning",
-                                  "danger",
-                                  "info",
-                                  "default",
-                                  "primary",
-                                  "link",
-                                ],
-                                "attrs": Array [],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "Button-c9cbmb-0",
-                                  "isStatic": false,
-                                  "lastClassName": "ghlLDE",
-                                  "rules": Array [
-                                    [Function],
-                                  ],
-                                },
-                                "displayName": "Button",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "Button-c9cbmb-0",
-                                "target": [Function],
-                                "toString": [Function],
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
-                            }
-                            forwardedRef={null}
-                            onClick={[Function]}
-                            type="submit"
-                          >
-                            <Button
-                              active={false}
-                              block={false}
-                              bsClass="btn"
+                                      >
+                                        <StyledComponent
+                                          forwardedComponent={
+                                            Object {
+                                              "$$typeof": Symbol(react.forward_ref),
+                                              "Feedback": [Function],
+                                              "SIZES": Array [
+                                                "small",
+                                                "large",
+                                              ],
+                                              "Static": [Function],
+                                              "attrs": Array [],
+                                              "componentStyle": ComponentStyle {
+                                                "componentId": "FormControl-sc-1amoaox-0",
+                                                "isStatic": false,
+                                                "lastClassName": "eOArng",
+                                                "rules": Array [
+                                                  [Function],
+                                                ],
+                                              },
+                                              "displayName": "FormControl",
+                                              "foldedComponentIds": Array [],
+                                              "render": [Function],
+                                              "styledComponentId": "FormControl-sc-1amoaox-0",
+                                              "target": [Function],
+                                              "toString": [Function],
+                                              "warnTooManyClasses": [Function],
+                                              "withComponent": [Function],
+                                            }
+                                          }
+                                          forwardedRef={null}
+                                          onChange={[Function]}
+                                          placeholder="Enter title"
+                                          type="text"
+                                          value="new Title"
+                                        >
+                                          <FormControl
+                                            bsClass="form-control"
+                                            className="FormControl-sc-1amoaox-0 eOArng"
+                                            componentClass="input"
+                                            onChange={[Function]}
+                                            placeholder="Enter title"
+                                            type="text"
+                                            value="new Title"
+                                          >
+                                            <input
+                                              className="FormControl-sc-1amoaox-0 eOArng form-control"
+                                              onChange={[Function]}
+                                              placeholder="Enter title"
+                                              type="text"
+                                              value="new Title"
+                                            />
+                                          </FormControl>
+                                        </StyledComponent>
+                                      </FormControl>
+                                    </div>
+                                  </FormGroup>
+                                </StyledComponent>
+                              </FormGroup__StyledFormGroup>
+                            </Component>
+                            <ForwardRef
                               bsStyle="primary"
-                              className="button Button-c9cbmb-0 ghlLDE"
-                              disabled={false}
+                              className="button"
                               onClick={[Function]}
                               type="submit"
                             >
-                              <button
-                                className="button Button-c9cbmb-0 ghlLDE btn btn-primary"
-                                disabled={false}
+                              <Button
+                                bsStyle="primary"
+                                className="button"
                                 onClick={[Function]}
                                 type="submit"
                               >
-                                Save
-                              </button>
-                            </Button>
-                          </StyledComponent>
-                        </Button>
-                      </ForwardRef>
-                      <ForwardRef
-                        bsStyle="info"
-                        className="button"
-                        disabled={true}
-                        onClick={[Function]}
-                        type="submit"
-                      >
-                        <Button
-                          bsStyle="info"
-                          className="button"
-                          disabled={true}
-                          onClick={[Function]}
-                          type="submit"
-                        >
-                          <StyledComponent
-                            bsStyle="info"
-                            className="button"
-                            disabled={true}
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "SIZES": Array [
-                                  "large",
-                                  "small",
-                                  "xsmall",
-                                ],
-                                "STYLES": Array [
-                                  "success",
-                                  "warning",
-                                  "danger",
-                                  "info",
-                                  "default",
-                                  "primary",
-                                  "link",
-                                ],
-                                "attrs": Array [],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "Button-c9cbmb-0",
-                                  "isStatic": false,
-                                  "lastClassName": "gZfKUo",
-                                  "rules": Array [
-                                    [Function],
-                                  ],
-                                },
-                                "displayName": "Button",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "Button-c9cbmb-0",
-                                "target": [Function],
-                                "toString": [Function],
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
-                            }
-                            forwardedRef={null}
-                            onClick={[Function]}
-                            type="submit"
-                          >
-                            <Button
-                              active={false}
-                              block={false}
-                              bsClass="btn"
+                                <StyledComponent
+                                  bsStyle="primary"
+                                  className="button"
+                                  forwardedComponent={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "SIZES": Array [
+                                        "large",
+                                        "small",
+                                        "xsmall",
+                                      ],
+                                      "STYLES": Array [
+                                        "success",
+                                        "warning",
+                                        "danger",
+                                        "info",
+                                        "default",
+                                        "primary",
+                                        "link",
+                                      ],
+                                      "attrs": Array [],
+                                      "componentStyle": ComponentStyle {
+                                        "componentId": "Button-c9cbmb-0",
+                                        "isStatic": false,
+                                        "lastClassName": "ghlLDE",
+                                        "rules": Array [
+                                          [Function],
+                                        ],
+                                      },
+                                      "displayName": "Button",
+                                      "foldedComponentIds": Array [],
+                                      "render": [Function],
+                                      "styledComponentId": "Button-c9cbmb-0",
+                                      "target": [Function],
+                                      "toString": [Function],
+                                      "warnTooManyClasses": [Function],
+                                      "withComponent": [Function],
+                                    }
+                                  }
+                                  forwardedRef={null}
+                                  onClick={[Function]}
+                                  type="submit"
+                                >
+                                  <Button
+                                    active={false}
+                                    block={false}
+                                    bsClass="btn"
+                                    bsStyle="primary"
+                                    className="button Button-c9cbmb-0 ghlLDE"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    type="submit"
+                                  >
+                                    <button
+                                      className="button Button-c9cbmb-0 ghlLDE btn btn-primary"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="submit"
+                                    >
+                                      Save
+                                    </button>
+                                  </Button>
+                                </StyledComponent>
+                              </Button>
+                            </ForwardRef>
+                            <ForwardRef
                               bsStyle="info"
-                              className="button Button-c9cbmb-0 gZfKUo"
+                              className="button"
                               disabled={true}
                               onClick={[Function]}
                               type="submit"
                             >
-                              <button
-                                className="button Button-c9cbmb-0 gZfKUo btn btn-info"
+                              <Button
+                                bsStyle="info"
+                                className="button"
                                 disabled={true}
                                 onClick={[Function]}
                                 type="submit"
                               >
-                                Save as
-                              </button>
-                            </Button>
-                          </StyledComponent>
-                        </Button>
-                      </ForwardRef>
-                      <ForwardRef
-                        bsStyle="default"
-                        className="button"
-                        onClick={[Function]}
-                      >
-                        <Button
-                          bsStyle="default"
-                          className="button"
-                          onClick={[Function]}
-                        >
-                          <StyledComponent
-                            bsStyle="default"
-                            className="button"
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "SIZES": Array [
-                                  "large",
-                                  "small",
-                                  "xsmall",
-                                ],
-                                "STYLES": Array [
-                                  "success",
-                                  "warning",
-                                  "danger",
-                                  "info",
-                                  "default",
-                                  "primary",
-                                  "link",
-                                ],
-                                "attrs": Array [],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "Button-c9cbmb-0",
-                                  "isStatic": false,
-                                  "lastClassName": "iKWoaE",
-                                  "rules": Array [
-                                    [Function],
-                                  ],
-                                },
-                                "displayName": "Button",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "Button-c9cbmb-0",
-                                "target": [Function],
-                                "toString": [Function],
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
-                            }
-                            forwardedRef={null}
-                            onClick={[Function]}
-                          >
-                            <Button
-                              active={false}
-                              block={false}
-                              bsClass="btn"
+                                <StyledComponent
+                                  bsStyle="info"
+                                  className="button"
+                                  disabled={true}
+                                  forwardedComponent={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "SIZES": Array [
+                                        "large",
+                                        "small",
+                                        "xsmall",
+                                      ],
+                                      "STYLES": Array [
+                                        "success",
+                                        "warning",
+                                        "danger",
+                                        "info",
+                                        "default",
+                                        "primary",
+                                        "link",
+                                      ],
+                                      "attrs": Array [],
+                                      "componentStyle": ComponentStyle {
+                                        "componentId": "Button-c9cbmb-0",
+                                        "isStatic": false,
+                                        "lastClassName": "gZfKUo",
+                                        "rules": Array [
+                                          [Function],
+                                        ],
+                                      },
+                                      "displayName": "Button",
+                                      "foldedComponentIds": Array [],
+                                      "render": [Function],
+                                      "styledComponentId": "Button-c9cbmb-0",
+                                      "target": [Function],
+                                      "toString": [Function],
+                                      "warnTooManyClasses": [Function],
+                                      "withComponent": [Function],
+                                    }
+                                  }
+                                  forwardedRef={null}
+                                  onClick={[Function]}
+                                  type="submit"
+                                >
+                                  <Button
+                                    active={false}
+                                    block={false}
+                                    bsClass="btn"
+                                    bsStyle="info"
+                                    className="button Button-c9cbmb-0 gZfKUo"
+                                    disabled={true}
+                                    onClick={[Function]}
+                                    type="submit"
+                                  >
+                                    <button
+                                      className="button Button-c9cbmb-0 gZfKUo btn btn-info"
+                                      disabled={true}
+                                      onClick={[Function]}
+                                      type="submit"
+                                    >
+                                      Save as
+                                    </button>
+                                  </Button>
+                                </StyledComponent>
+                              </Button>
+                            </ForwardRef>
+                            <ForwardRef
                               bsStyle="default"
-                              className="button Button-c9cbmb-0 iKWoaE"
-                              disabled={false}
+                              className="button"
                               onClick={[Function]}
                             >
-                              <button
-                                className="button Button-c9cbmb-0 iKWoaE btn btn-default"
-                                disabled={false}
+                              <Button
+                                bsStyle="default"
+                                className="button"
                                 onClick={[Function]}
-                                type="button"
                               >
-                                Cancel
-                              </button>
-                            </Button>
-                          </StyledComponent>
-                        </Button>
-                      </ForwardRef>
-                    </form>
-                  </div>
-                </div>
-              </Popover>
-            </StyledComponent>
+                                <StyledComponent
+                                  bsStyle="default"
+                                  className="button"
+                                  forwardedComponent={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "SIZES": Array [
+                                        "large",
+                                        "small",
+                                        "xsmall",
+                                      ],
+                                      "STYLES": Array [
+                                        "success",
+                                        "warning",
+                                        "danger",
+                                        "info",
+                                        "default",
+                                        "primary",
+                                        "link",
+                                      ],
+                                      "attrs": Array [],
+                                      "componentStyle": ComponentStyle {
+                                        "componentId": "Button-c9cbmb-0",
+                                        "isStatic": false,
+                                        "lastClassName": "iKWoaE",
+                                        "rules": Array [
+                                          [Function],
+                                        ],
+                                      },
+                                      "displayName": "Button",
+                                      "foldedComponentIds": Array [],
+                                      "render": [Function],
+                                      "styledComponentId": "Button-c9cbmb-0",
+                                      "target": [Function],
+                                      "toString": [Function],
+                                      "warnTooManyClasses": [Function],
+                                      "withComponent": [Function],
+                                    }
+                                  }
+                                  forwardedRef={null}
+                                  onClick={[Function]}
+                                >
+                                  <Button
+                                    active={false}
+                                    block={false}
+                                    bsClass="btn"
+                                    bsStyle="default"
+                                    className="button Button-c9cbmb-0 iKWoaE"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                  >
+                                    <button
+                                      className="button Button-c9cbmb-0 iKWoaE btn btn-default"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      Cancel
+                                    </button>
+                                  </Button>
+                                </StyledComponent>
+                              </Button>
+                            </ForwardRef>
+                          </form>
+                        </div>
+                      </div>
+                    </Popover>
+                  </StyledComponent>
+                </Popover__StyledPopover>
+              </ThemeProvider>
+            </GraylogThemeProvider>
           </Popover>
         </mock-position>
       </MockPosition>
@@ -916,454 +986,489 @@ exports[`BookmarkForm render the BookmarkForm should render save 1`] = `
             id="bookmark-popover"
             title="Name of search"
           >
-            <StyledComponent
-              forwardedComponent={
-                Object {
-                  "$$typeof": Symbol(react.forward_ref),
-                  "attrs": Array [],
-                  "componentStyle": ComponentStyle {
-                    "componentId": "Popover-wd1j0g-0",
-                    "isStatic": false,
-                    "lastClassName": "dQcVSD",
-                    "rules": Array [
-                      [Function],
-                    ],
-                  },
-                  "displayName": "Popover",
-                  "foldedComponentIds": Array [],
-                  "render": [Function],
-                  "styledComponentId": "Popover-wd1j0g-0",
-                  "target": [Function],
-                  "toString": [Function],
-                  "warnTooManyClasses": [Function],
-                  "withComponent": [Function],
-                }
-              }
-              forwardedRef={null}
-              id="bookmark-popover"
-              title="Name of search"
-            >
-              <Popover
-                bsClass="popover"
-                className="Popover-wd1j0g-0 dQcVSD"
-                id="bookmark-popover"
-                placement="right"
-                title="Name of search"
-              >
-                <div
-                  className="Popover-wd1j0g-0 dQcVSD popover right"
-                  id="bookmark-popover"
-                  role="tooltip"
-                  style={
-                    Object {
-                      "display": "block",
-                      "left": undefined,
-                      "top": undefined,
-                    }
+            <GraylogThemeProvider>
+              <ThemeProvider
+                theme={
+                  Object {
+                    "color": Object {
+                      "primary": Object {
+                        "due": "#FFF",
+                        "tre": "#1F1F1F",
+                        "uno": "#FF3633",
+                      },
+                      "secondary": Object {
+                        "due": "#F1F2F2",
+                        "tre": "#DCE1E5",
+                        "uno": "#FF3B00",
+                      },
+                      "tertiary": Object {
+                        "cinque": "#FF6418",
+                        "due": "#6DC6E7",
+                        "quattro": "#9E1F63",
+                        "sei": "#FFD200",
+                        "tre": "#8DC63F",
+                        "uno": "#16ACE3",
+                      },
+                    },
+                    "mode": "teinte",
                   }
+                }
+              >
+                <Popover__StyledPopover
+                  id="bookmark-popover"
+                  title="Name of search"
                 >
-                  <div
-                    className="arrow"
-                    style={
+                  <StyledComponent
+                    forwardedComponent={
                       Object {
-                        "left": undefined,
-                        "top": undefined,
+                        "$$typeof": Symbol(react.forward_ref),
+                        "attrs": Array [],
+                        "componentStyle": ComponentStyle {
+                          "componentId": "Popover__StyledPopover-wd1j0g-0",
+                          "isStatic": false,
+                          "lastClassName": "lbOgZZ",
+                          "rules": Array [
+                            [Function],
+                          ],
+                        },
+                        "displayName": "Popover__StyledPopover",
+                        "foldedComponentIds": Array [],
+                        "render": [Function],
+                        "styledComponentId": "Popover__StyledPopover-wd1j0g-0",
+                        "target": [Function],
+                        "toString": [Function],
+                        "warnTooManyClasses": [Function],
+                        "withComponent": [Function],
                       }
                     }
-                  />
-                  <h3
-                    className="popover-title"
+                    forwardedRef={null}
+                    id="bookmark-popover"
+                    title="Name of search"
                   >
-                    Name of search
-                  </h3>
-                  <div
-                    className="popover-content"
-                  >
-                    <form>
-                      <Component
-                        validationState={null}
+                    <Popover
+                      bsClass="popover"
+                      className="Popover__StyledPopover-wd1j0g-0 lbOgZZ"
+                      id="bookmark-popover"
+                      placement="right"
+                      title="Name of search"
+                    >
+                      <div
+                        className="Popover__StyledPopover-wd1j0g-0 lbOgZZ popover right"
+                        id="bookmark-popover"
+                        role="tooltip"
+                        style={
+                          Object {
+                            "display": "block",
+                            "left": undefined,
+                            "top": undefined,
+                          }
+                        }
                       >
-                        <FormGroup__StyledFormGroup
-                          validationState={null}
-                        >
-                          <StyledComponent
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "SIZES": Array [
-                                  "large",
-                                  "small",
-                                ],
-                                "attrs": Array [],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "FormGroup__StyledFormGroup-sc-1wv4cm9-0",
-                                  "isStatic": false,
-                                  "lastClassName": "ekazNr",
-                                  "rules": Array [
-                                    [Function],
-                                    ";",
-                                  ],
-                                },
-                                "displayName": "FormGroup__StyledFormGroup",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "FormGroup__StyledFormGroup-sc-1wv4cm9-0",
-                                "target": [Function],
-                                "toString": [Function],
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
+                        <div
+                          className="arrow"
+                          style={
+                            Object {
+                              "left": undefined,
+                              "top": undefined,
                             }
-                            forwardedRef={null}
-                            validationState={null}
-                          >
-                            <FormGroup
-                              bsClass="form-group"
-                              className="FormGroup__StyledFormGroup-sc-1wv4cm9-0 ekazNr"
+                          }
+                        />
+                        <h3
+                          className="popover-title"
+                        >
+                          Name of search
+                        </h3>
+                        <div
+                          className="popover-content"
+                        >
+                          <form>
+                            <Component
                               validationState={null}
                             >
-                              <div
-                                className="FormGroup__StyledFormGroup-sc-1wv4cm9-0 ekazNr form-group"
+                              <FormGroup__StyledFormGroup
+                                validationState={null}
                               >
-                                <ControlLabel>
-                                  <StyledComponent
-                                    forwardedComponent={
-                                      Object {
-                                        "$$typeof": Symbol(react.forward_ref),
-                                        "attrs": Array [],
-                                        "componentStyle": ComponentStyle {
-                                          "componentId": "ControlLabel-sc-1edmum5-0",
-                                          "isStatic": false,
-                                          "lastClassName": "iZJNbd",
-                                          "rules": Array [
-                                            [Function],
-                                          ],
-                                        },
-                                        "displayName": "ControlLabel",
-                                        "foldedComponentIds": Array [],
-                                        "render": [Function],
-                                        "styledComponentId": "ControlLabel-sc-1edmum5-0",
-                                        "target": [Function],
-                                        "toString": [Function],
-                                        "warnTooManyClasses": [Function],
-                                        "withComponent": [Function],
-                                      }
-                                    }
-                                    forwardedRef={null}
-                                  >
-                                    <ControlLabel
-                                      bsClass="control-label"
-                                      className="ControlLabel-sc-1edmum5-0 iZJNbd"
-                                      srOnly={false}
-                                    >
-                                      <label
-                                        className="ControlLabel-sc-1edmum5-0 iZJNbd control-label"
-                                      >
-                                        Title
-                                      </label>
-                                    </ControlLabel>
-                                  </StyledComponent>
-                                </ControlLabel>
-                                <FormControl
-                                  onChange={[Function]}
-                                  placeholder="Enter title"
-                                  type="text"
-                                  value="new Title"
-                                >
-                                  <StyledComponent
-                                    forwardedComponent={
-                                      Object {
-                                        "$$typeof": Symbol(react.forward_ref),
-                                        "Feedback": [Function],
-                                        "SIZES": Array [
-                                          "small",
-                                          "large",
+                                <StyledComponent
+                                  forwardedComponent={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "SIZES": Array [
+                                        "large",
+                                        "small",
+                                      ],
+                                      "attrs": Array [],
+                                      "componentStyle": ComponentStyle {
+                                        "componentId": "FormGroup__StyledFormGroup-sc-1wv4cm9-0",
+                                        "isStatic": false,
+                                        "lastClassName": "ekazNr",
+                                        "rules": Array [
+                                          [Function],
+                                          ";",
                                         ],
-                                        "Static": [Function],
-                                        "attrs": Array [],
-                                        "componentStyle": ComponentStyle {
-                                          "componentId": "FormControl-sc-1amoaox-0",
-                                          "isStatic": false,
-                                          "lastClassName": "eOArng",
-                                          "rules": Array [
-                                            [Function],
-                                          ],
-                                        },
-                                        "displayName": "FormControl",
-                                        "foldedComponentIds": Array [],
-                                        "render": [Function],
-                                        "styledComponentId": "FormControl-sc-1amoaox-0",
-                                        "target": [Function],
-                                        "toString": [Function],
-                                        "warnTooManyClasses": [Function],
-                                        "withComponent": [Function],
-                                      }
+                                      },
+                                      "displayName": "FormGroup__StyledFormGroup",
+                                      "foldedComponentIds": Array [],
+                                      "render": [Function],
+                                      "styledComponentId": "FormGroup__StyledFormGroup-sc-1wv4cm9-0",
+                                      "target": [Function],
+                                      "toString": [Function],
+                                      "warnTooManyClasses": [Function],
+                                      "withComponent": [Function],
                                     }
-                                    forwardedRef={null}
-                                    onChange={[Function]}
-                                    placeholder="Enter title"
-                                    type="text"
-                                    value="new Title"
+                                  }
+                                  forwardedRef={null}
+                                  validationState={null}
+                                >
+                                  <FormGroup
+                                    bsClass="form-group"
+                                    className="FormGroup__StyledFormGroup-sc-1wv4cm9-0 ekazNr"
+                                    validationState={null}
                                   >
-                                    <FormControl
-                                      bsClass="form-control"
-                                      className="FormControl-sc-1amoaox-0 eOArng"
-                                      componentClass="input"
-                                      onChange={[Function]}
-                                      placeholder="Enter title"
-                                      type="text"
-                                      value="new Title"
+                                    <div
+                                      className="FormGroup__StyledFormGroup-sc-1wv4cm9-0 ekazNr form-group"
                                     >
-                                      <input
-                                        className="FormControl-sc-1amoaox-0 eOArng form-control"
+                                      <ControlLabel>
+                                        <StyledComponent
+                                          forwardedComponent={
+                                            Object {
+                                              "$$typeof": Symbol(react.forward_ref),
+                                              "attrs": Array [],
+                                              "componentStyle": ComponentStyle {
+                                                "componentId": "ControlLabel-sc-1edmum5-0",
+                                                "isStatic": false,
+                                                "lastClassName": "iZJNbd",
+                                                "rules": Array [
+                                                  [Function],
+                                                ],
+                                              },
+                                              "displayName": "ControlLabel",
+                                              "foldedComponentIds": Array [],
+                                              "render": [Function],
+                                              "styledComponentId": "ControlLabel-sc-1edmum5-0",
+                                              "target": [Function],
+                                              "toString": [Function],
+                                              "warnTooManyClasses": [Function],
+                                              "withComponent": [Function],
+                                            }
+                                          }
+                                          forwardedRef={null}
+                                        >
+                                          <ControlLabel
+                                            bsClass="control-label"
+                                            className="ControlLabel-sc-1edmum5-0 iZJNbd"
+                                            srOnly={false}
+                                          >
+                                            <label
+                                              className="ControlLabel-sc-1edmum5-0 iZJNbd control-label"
+                                            >
+                                              Title
+                                            </label>
+                                          </ControlLabel>
+                                        </StyledComponent>
+                                      </ControlLabel>
+                                      <FormControl
                                         onChange={[Function]}
                                         placeholder="Enter title"
                                         type="text"
                                         value="new Title"
-                                      />
-                                    </FormControl>
-                                  </StyledComponent>
-                                </FormControl>
-                              </div>
-                            </FormGroup>
-                          </StyledComponent>
-                        </FormGroup__StyledFormGroup>
-                      </Component>
-                      <ForwardRef
-                        bsStyle="primary"
-                        className="button"
-                        onClick={[Function]}
-                        type="submit"
-                      >
-                        <Button
-                          bsStyle="primary"
-                          className="button"
-                          onClick={[Function]}
-                          type="submit"
-                        >
-                          <StyledComponent
-                            bsStyle="primary"
-                            className="button"
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "SIZES": Array [
-                                  "large",
-                                  "small",
-                                  "xsmall",
-                                ],
-                                "STYLES": Array [
-                                  "success",
-                                  "warning",
-                                  "danger",
-                                  "info",
-                                  "default",
-                                  "primary",
-                                  "link",
-                                ],
-                                "attrs": Array [],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "Button-c9cbmb-0",
-                                  "isStatic": false,
-                                  "lastClassName": "ghlLDE",
-                                  "rules": Array [
-                                    [Function],
-                                  ],
-                                },
-                                "displayName": "Button",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "Button-c9cbmb-0",
-                                "target": [Function],
-                                "toString": [Function],
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
-                            }
-                            forwardedRef={null}
-                            onClick={[Function]}
-                            type="submit"
-                          >
-                            <Button
-                              active={false}
-                              block={false}
-                              bsClass="btn"
+                                      >
+                                        <StyledComponent
+                                          forwardedComponent={
+                                            Object {
+                                              "$$typeof": Symbol(react.forward_ref),
+                                              "Feedback": [Function],
+                                              "SIZES": Array [
+                                                "small",
+                                                "large",
+                                              ],
+                                              "Static": [Function],
+                                              "attrs": Array [],
+                                              "componentStyle": ComponentStyle {
+                                                "componentId": "FormControl-sc-1amoaox-0",
+                                                "isStatic": false,
+                                                "lastClassName": "eOArng",
+                                                "rules": Array [
+                                                  [Function],
+                                                ],
+                                              },
+                                              "displayName": "FormControl",
+                                              "foldedComponentIds": Array [],
+                                              "render": [Function],
+                                              "styledComponentId": "FormControl-sc-1amoaox-0",
+                                              "target": [Function],
+                                              "toString": [Function],
+                                              "warnTooManyClasses": [Function],
+                                              "withComponent": [Function],
+                                            }
+                                          }
+                                          forwardedRef={null}
+                                          onChange={[Function]}
+                                          placeholder="Enter title"
+                                          type="text"
+                                          value="new Title"
+                                        >
+                                          <FormControl
+                                            bsClass="form-control"
+                                            className="FormControl-sc-1amoaox-0 eOArng"
+                                            componentClass="input"
+                                            onChange={[Function]}
+                                            placeholder="Enter title"
+                                            type="text"
+                                            value="new Title"
+                                          >
+                                            <input
+                                              className="FormControl-sc-1amoaox-0 eOArng form-control"
+                                              onChange={[Function]}
+                                              placeholder="Enter title"
+                                              type="text"
+                                              value="new Title"
+                                            />
+                                          </FormControl>
+                                        </StyledComponent>
+                                      </FormControl>
+                                    </div>
+                                  </FormGroup>
+                                </StyledComponent>
+                              </FormGroup__StyledFormGroup>
+                            </Component>
+                            <ForwardRef
                               bsStyle="primary"
-                              className="button Button-c9cbmb-0 ghlLDE"
-                              disabled={false}
+                              className="button"
                               onClick={[Function]}
                               type="submit"
                             >
-                              <button
-                                className="button Button-c9cbmb-0 ghlLDE btn btn-primary"
-                                disabled={false}
+                              <Button
+                                bsStyle="primary"
+                                className="button"
                                 onClick={[Function]}
                                 type="submit"
                               >
-                                Save
-                              </button>
-                            </Button>
-                          </StyledComponent>
-                        </Button>
-                      </ForwardRef>
-                      <ForwardRef
-                        bsStyle="info"
-                        className="button"
-                        disabled={false}
-                        onClick={[Function]}
-                        type="submit"
-                      >
-                        <Button
-                          bsStyle="info"
-                          className="button"
-                          disabled={false}
-                          onClick={[Function]}
-                          type="submit"
-                        >
-                          <StyledComponent
-                            bsStyle="info"
-                            className="button"
-                            disabled={false}
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "SIZES": Array [
-                                  "large",
-                                  "small",
-                                  "xsmall",
-                                ],
-                                "STYLES": Array [
-                                  "success",
-                                  "warning",
-                                  "danger",
-                                  "info",
-                                  "default",
-                                  "primary",
-                                  "link",
-                                ],
-                                "attrs": Array [],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "Button-c9cbmb-0",
-                                  "isStatic": false,
-                                  "lastClassName": "gZfKUo",
-                                  "rules": Array [
-                                    [Function],
-                                  ],
-                                },
-                                "displayName": "Button",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "Button-c9cbmb-0",
-                                "target": [Function],
-                                "toString": [Function],
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
-                            }
-                            forwardedRef={null}
-                            onClick={[Function]}
-                            type="submit"
-                          >
-                            <Button
-                              active={false}
-                              block={false}
-                              bsClass="btn"
+                                <StyledComponent
+                                  bsStyle="primary"
+                                  className="button"
+                                  forwardedComponent={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "SIZES": Array [
+                                        "large",
+                                        "small",
+                                        "xsmall",
+                                      ],
+                                      "STYLES": Array [
+                                        "success",
+                                        "warning",
+                                        "danger",
+                                        "info",
+                                        "default",
+                                        "primary",
+                                        "link",
+                                      ],
+                                      "attrs": Array [],
+                                      "componentStyle": ComponentStyle {
+                                        "componentId": "Button-c9cbmb-0",
+                                        "isStatic": false,
+                                        "lastClassName": "ghlLDE",
+                                        "rules": Array [
+                                          [Function],
+                                        ],
+                                      },
+                                      "displayName": "Button",
+                                      "foldedComponentIds": Array [],
+                                      "render": [Function],
+                                      "styledComponentId": "Button-c9cbmb-0",
+                                      "target": [Function],
+                                      "toString": [Function],
+                                      "warnTooManyClasses": [Function],
+                                      "withComponent": [Function],
+                                    }
+                                  }
+                                  forwardedRef={null}
+                                  onClick={[Function]}
+                                  type="submit"
+                                >
+                                  <Button
+                                    active={false}
+                                    block={false}
+                                    bsClass="btn"
+                                    bsStyle="primary"
+                                    className="button Button-c9cbmb-0 ghlLDE"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    type="submit"
+                                  >
+                                    <button
+                                      className="button Button-c9cbmb-0 ghlLDE btn btn-primary"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="submit"
+                                    >
+                                      Save
+                                    </button>
+                                  </Button>
+                                </StyledComponent>
+                              </Button>
+                            </ForwardRef>
+                            <ForwardRef
                               bsStyle="info"
-                              className="button Button-c9cbmb-0 gZfKUo"
+                              className="button"
                               disabled={false}
                               onClick={[Function]}
                               type="submit"
                             >
-                              <button
-                                className="button Button-c9cbmb-0 gZfKUo btn btn-info"
+                              <Button
+                                bsStyle="info"
+                                className="button"
                                 disabled={false}
                                 onClick={[Function]}
                                 type="submit"
                               >
-                                Save as
-                              </button>
-                            </Button>
-                          </StyledComponent>
-                        </Button>
-                      </ForwardRef>
-                      <ForwardRef
-                        bsStyle="default"
-                        className="button"
-                        onClick={[Function]}
-                      >
-                        <Button
-                          bsStyle="default"
-                          className="button"
-                          onClick={[Function]}
-                        >
-                          <StyledComponent
-                            bsStyle="default"
-                            className="button"
-                            forwardedComponent={
-                              Object {
-                                "$$typeof": Symbol(react.forward_ref),
-                                "SIZES": Array [
-                                  "large",
-                                  "small",
-                                  "xsmall",
-                                ],
-                                "STYLES": Array [
-                                  "success",
-                                  "warning",
-                                  "danger",
-                                  "info",
-                                  "default",
-                                  "primary",
-                                  "link",
-                                ],
-                                "attrs": Array [],
-                                "componentStyle": ComponentStyle {
-                                  "componentId": "Button-c9cbmb-0",
-                                  "isStatic": false,
-                                  "lastClassName": "iKWoaE",
-                                  "rules": Array [
-                                    [Function],
-                                  ],
-                                },
-                                "displayName": "Button",
-                                "foldedComponentIds": Array [],
-                                "render": [Function],
-                                "styledComponentId": "Button-c9cbmb-0",
-                                "target": [Function],
-                                "toString": [Function],
-                                "warnTooManyClasses": [Function],
-                                "withComponent": [Function],
-                              }
-                            }
-                            forwardedRef={null}
-                            onClick={[Function]}
-                          >
-                            <Button
-                              active={false}
-                              block={false}
-                              bsClass="btn"
+                                <StyledComponent
+                                  bsStyle="info"
+                                  className="button"
+                                  disabled={false}
+                                  forwardedComponent={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "SIZES": Array [
+                                        "large",
+                                        "small",
+                                        "xsmall",
+                                      ],
+                                      "STYLES": Array [
+                                        "success",
+                                        "warning",
+                                        "danger",
+                                        "info",
+                                        "default",
+                                        "primary",
+                                        "link",
+                                      ],
+                                      "attrs": Array [],
+                                      "componentStyle": ComponentStyle {
+                                        "componentId": "Button-c9cbmb-0",
+                                        "isStatic": false,
+                                        "lastClassName": "gZfKUo",
+                                        "rules": Array [
+                                          [Function],
+                                        ],
+                                      },
+                                      "displayName": "Button",
+                                      "foldedComponentIds": Array [],
+                                      "render": [Function],
+                                      "styledComponentId": "Button-c9cbmb-0",
+                                      "target": [Function],
+                                      "toString": [Function],
+                                      "warnTooManyClasses": [Function],
+                                      "withComponent": [Function],
+                                    }
+                                  }
+                                  forwardedRef={null}
+                                  onClick={[Function]}
+                                  type="submit"
+                                >
+                                  <Button
+                                    active={false}
+                                    block={false}
+                                    bsClass="btn"
+                                    bsStyle="info"
+                                    className="button Button-c9cbmb-0 gZfKUo"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                    type="submit"
+                                  >
+                                    <button
+                                      className="button Button-c9cbmb-0 gZfKUo btn btn-info"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="submit"
+                                    >
+                                      Save as
+                                    </button>
+                                  </Button>
+                                </StyledComponent>
+                              </Button>
+                            </ForwardRef>
+                            <ForwardRef
                               bsStyle="default"
-                              className="button Button-c9cbmb-0 iKWoaE"
-                              disabled={false}
+                              className="button"
                               onClick={[Function]}
                             >
-                              <button
-                                className="button Button-c9cbmb-0 iKWoaE btn btn-default"
-                                disabled={false}
+                              <Button
+                                bsStyle="default"
+                                className="button"
                                 onClick={[Function]}
-                                type="button"
                               >
-                                Cancel
-                              </button>
-                            </Button>
-                          </StyledComponent>
-                        </Button>
-                      </ForwardRef>
-                    </form>
-                  </div>
-                </div>
-              </Popover>
-            </StyledComponent>
+                                <StyledComponent
+                                  bsStyle="default"
+                                  className="button"
+                                  forwardedComponent={
+                                    Object {
+                                      "$$typeof": Symbol(react.forward_ref),
+                                      "SIZES": Array [
+                                        "large",
+                                        "small",
+                                        "xsmall",
+                                      ],
+                                      "STYLES": Array [
+                                        "success",
+                                        "warning",
+                                        "danger",
+                                        "info",
+                                        "default",
+                                        "primary",
+                                        "link",
+                                      ],
+                                      "attrs": Array [],
+                                      "componentStyle": ComponentStyle {
+                                        "componentId": "Button-c9cbmb-0",
+                                        "isStatic": false,
+                                        "lastClassName": "iKWoaE",
+                                        "rules": Array [
+                                          [Function],
+                                        ],
+                                      },
+                                      "displayName": "Button",
+                                      "foldedComponentIds": Array [],
+                                      "render": [Function],
+                                      "styledComponentId": "Button-c9cbmb-0",
+                                      "target": [Function],
+                                      "toString": [Function],
+                                      "warnTooManyClasses": [Function],
+                                      "withComponent": [Function],
+                                    }
+                                  }
+                                  forwardedRef={null}
+                                  onClick={[Function]}
+                                >
+                                  <Button
+                                    active={false}
+                                    block={false}
+                                    bsClass="btn"
+                                    bsStyle="default"
+                                    className="button Button-c9cbmb-0 iKWoaE"
+                                    disabled={false}
+                                    onClick={[Function]}
+                                  >
+                                    <button
+                                      className="button Button-c9cbmb-0 iKWoaE btn btn-default"
+                                      disabled={false}
+                                      onClick={[Function]}
+                                      type="button"
+                                    >
+                                      Cancel
+                                    </button>
+                                  </Button>
+                                </StyledComponent>
+                              </Button>
+                            </ForwardRef>
+                          </form>
+                        </div>
+                      </div>
+                    </Popover>
+                  </StyledComponent>
+                </Popover__StyledPopover>
+              </ThemeProvider>
+            </GraylogThemeProvider>
           </Popover>
         </mock-position>
       </MockPosition>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Wrapping Popover with GraylogThemeProvider

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It was discovered that `Popover.jsx:7 Uncaught TypeError: Cannot read property 'primary' of undefined` began after #7067 merged

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/122591/75469074-f7a27c00-5953-11ea-801f-e2a8e6db216a.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

