### PR TITLE
Handling absence of field types in search components. (Backport of #7538 for 3.2)

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.jsx
@@ -116,10 +116,12 @@ export default class AggregationControls extends React.Component<Props, State> {
     const sortDirection = Immutable.Set(sort.map(s => s.direction)).first();
 
     const formattedFields = fields
-      .map(fieldType => fieldType.name)
-      .valueSeq()
-      .toJS()
-      .sort(defaultCompare);
+      ? fields
+        .map(fieldType => fieldType.name)
+        .valueSeq()
+        .toJS()
+        .sort(defaultCompare)
+      : [];
     const formattedFieldsOptions = formattedFields.map(v => ({ label: v, value: v }));
     const suggester = new SeriesFunctionsSuggester(formattedFields);
 

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.test.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationControls.test.jsx
@@ -2,11 +2,12 @@
 import * as React from 'react';
 import * as Immutable from 'immutable';
 import { mount } from 'wrappedEnzyme';
-import { render } from 'wrappedTestingLibrary';
 import '@testing-library/jest-dom/extend-expect';
+import { cleanup, render } from 'wrappedTestingLibrary';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import asMock from 'helpers/mocking/AsMock';
+import suppressConsole from 'helpers/suppressConsole';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
 import AggregationControls from './AggregationControls';
@@ -20,6 +21,8 @@ jest.mock('graylog-web-plugin/plugin', () => ({
 class DummyVisualizationConfig extends VisualizationConfig {}
 
 describe('AggregationControls', () => {
+  afterEach(cleanup);
+
   // eslint-disable-next-line no-unused-vars, react/prop-types
   const DummyComponent = () => <div data-testid="dummy-component">The spice must flow.</div>;
   const children = <DummyComponent />;
@@ -36,6 +39,20 @@ describe('AggregationControls', () => {
       </AggregationControls>
     ));
     expect(getByTestId('dummy-component')).toHaveTextContent('The spice must flow.');
+  });
+
+  it('should render with `undefined` fields', () => {
+    suppressConsole(() => {
+      const { getByTestId } = render((
+        <AggregationControls config={config}
+                             // $FlowFixMe: Passing `undefined` fields on purpose
+                             fields={undefined}
+                             onChange={() => {}}>
+          {children}
+        </AggregationControls>
+      ));
+      expect(getByTestId('dummy-component')).toHaveTextContent('The spice must flow.');
+    });
   });
 
   // NOTE: Why is this testing `HoverForHelp` component?

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/PivotSelect.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/PivotSelect.jsx
@@ -1,4 +1,6 @@
-import React from 'react';
+// @flow strict
+import * as React from 'react';
+import * as Immutable from 'immutable';
 import PropTypes from 'prop-types';
 
 import connect from 'stores/connect';
@@ -40,7 +42,9 @@ const PivotSelect = ({ onChange, fields, value, ...props }) => {
   // eslint-disable-next-line react/prop-types
   const ValueComponent = ({ children, innerProps, ...rest }) => {
     const element = rest.data;
-    const fieldTypes = fields.all.filter(v => v.name === element.label);
+    const fieldTypes = fields && fields.all
+      ? fields.all.filter(v => v.name === element.label)
+      : Immutable.List();
     const fieldType = fieldTypes.isEmpty() ? FieldType.Unknown : fieldTypes.first().type;
     // eslint-disable-next-line react/prop-types
     const { className } = innerProps;

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/PivotSelect.test.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/PivotSelect.test.jsx
@@ -3,10 +3,11 @@ import React from 'react';
 import { mount } from 'wrappedEnzyme';
 import * as Immutable from 'immutable';
 
+import PivotGenerator from 'views/logic/searchtypes/aggregation/PivotGenerator';
+import FieldType from 'views/logic/fieldtypes/FieldType';
+import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
+import suppressConsole from 'helpers/suppressConsole';
 import PivotSelect from './PivotSelect';
-import PivotGenerator from '../../logic/searchtypes/aggregation/PivotGenerator';
-import FieldType from '../../logic/fieldtypes/FieldType';
-import FieldTypeMapping from '../../logic/fieldtypes/FieldTypeMapping';
 
 jest.mock('stores/connect', () => x => x);
 jest.mock('views/stores/FieldTypesStore', () => ({}));
@@ -16,6 +17,12 @@ describe('PivotSelect', () => {
   it('renders properly with minimal parameters', () => {
     const wrapper = mount(<PivotSelect onChange={() => {}} fields={Immutable.List()} value={[]} />);
     expect(wrapper).not.toBeEmptyRender();
+  });
+  it('renders properly with `undefined` fields', () => {
+    suppressConsole(() => {
+      const wrapper = mount(<PivotSelect onChange={() => {}} fields={undefined} value={[]} />);
+      expect(wrapper).not.toBeEmptyRender();
+    });
   });
   describe('upon pivot list change, field types are passed for new pivot generation', () => {
     it('using Unknown if field is not found', () => {

--- a/graylog2-web-interface/src/views/components/datatable/Headers.test.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/Headers.test.jsx
@@ -103,5 +103,16 @@ describe('Headers', () => {
       ));
       expectCorrectTypes(wrapper);
     });
+    it('renders with `null` fields', () => {
+      const series = [
+        seriesWithName('foo', 'Total Count'),
+        seriesWithName('avg(foo)', 'Average Foness'),
+      ];
+      mount((
+        <RenderHeaders series={series}
+                       // $FlowFixMe: Passing `null` fields on purpose
+                       fields={null} />
+      ));
+    });
   });
 });

--- a/graylog2-web-interface/src/views/logic/fieldtypes/FieldTypeFor.js
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/FieldTypeFor.js
@@ -12,7 +12,7 @@ const fieldTypeFor = (field: string, types: FieldTypeMappingsList): FieldType =>
     const { type } = inferTypeForSeries(Series.forFunction(field), types);
     return type;
   }
-  const fieldType = types.find(f => f.name === field);
+  const fieldType = types && types.find(f => f.name === field);
   return fieldType ? fieldType.type : FieldType.Unknown;
 };
 

--- a/graylog2-web-interface/src/views/logic/fieldtypes/FieldTypeFor.test.js
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/FieldTypeFor.test.js
@@ -10,6 +10,10 @@ describe('FieldTypeFor', () => {
     expect(fieldTypeFor('bar', [FieldTypeMapping.create('foo', FieldTypes.LONG())]))
       .toEqual(FieldType.Unknown);
   });
+  it('returns `FieldType.Unknown` if field types are `undefined`', () => {
+    // $FlowFixMe: Passing `undefined` types on purpose
+    expect(fieldTypeFor('', undefined)).toEqual(FieldType.Unknown);
+  });
   it('returns type of field if present', () => {
     expect(fieldTypeFor('foo', [FieldTypeMapping.create('foo', FieldTypes.LONG())]))
       .toEqual(FieldTypes.LONG());

--- a/graylog2-web-interface/src/views/logic/fieldtypes/InferTypeForSeries.js
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/InferTypeForSeries.js
@@ -27,7 +27,7 @@ const inferTypeForSeries = (series: Series, types: Array<FieldTypeMapping>): Fie
   }
 
   if (typePreservingFunctions.includes(type)) {
-    const mapping = types.find(t => (t.name === field));
+    const mapping = types && types.find(t => (t.name === field));
 
     if (!mapping) {
       return newMapping(FieldType.Unknown);

--- a/graylog2-web-interface/src/views/logic/fieldtypes/InferTypeForSeries.test.js
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/InferTypeForSeries.test.js
@@ -43,4 +43,10 @@ describe('InferTypeForSeries', () => {
     expect(inferTypeForSeries(Series.forFunction('avg(foo)'), []))
       .toEqual(FieldTypeMapping.create('avg(foo)', FieldType.Unknown));
   });
+
+  it('returns unknown if field types are `undefined`', () => {
+    // $FlowFixMe: passing invalid types parameter on purpose.
+    expect(inferTypeForSeries(Series.forFunction('avg(foo)'), undefined))
+      .toEqual(FieldTypeMapping.create('avg(foo)', FieldType.Unknown));
+  });
 });

--- a/graylog2-web-interface/src/views/stores/FieldTypesStore.js
+++ b/graylog2-web-interface/src/views/stores/FieldTypesStore.js
@@ -34,6 +34,9 @@ export const FieldTypesStore = singletonStore(
   () => Reflux.createStore({
     listenables: [FieldTypesActions],
 
+    _all: Immutable.List<FieldTypeMapping>(),
+    _queryFields: Immutable.Map<String, FieldTypeMappingsList>(),
+
     init() {
       this.all();
       this.listenTo(QueryFiltersStore, this.onQueryFiltersUpdate, this.onQueryFiltersUpdate);
@@ -60,7 +63,7 @@ export const FieldTypesStore = singletonStore(
         results.forEach(({ queryId, response }) => {
           combinedResult[queryId] = response;
         });
-        this.queryFields = Immutable.fromJS(combinedResult);
+        this._queryFields = Immutable.fromJS(combinedResult);
         this._trigger();
       });
     },
@@ -69,7 +72,7 @@ export const FieldTypesStore = singletonStore(
       const promise = fetch('GET', fieldTypesUrl)
         .then(this._deserializeFieldTypes)
         .then((response) => {
-          this.all = Immutable.fromJS(response);
+          this._all = Immutable.fromJS(response);
           this._trigger();
         });
 
@@ -90,8 +93,8 @@ export const FieldTypesStore = singletonStore(
 
     _state(): FieldTypesStoreState {
       return {
-        all: this.all,
-        queryFields: this.queryFields,
+        all: this._all,
+        queryFields: this._queryFields,
       };
     },
     _trigger() {


### PR DESCRIPTION
Backport of #7538 for 3.2

## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

*This PR requires a backport to `3.2`*

Before this change, there were a couple of places where the absence of
field types (when they have not been fetched from the backend on time or
the backend periodical did not finish its first run yet) caused
exceptions to be thrown in places of the code where full initialization
of field types was expected. Some of these were addressed in #7419, but
obviously not all, according to user reports.

This PR is trying to systematically approach this by having created a
state in the `FieldTypesStore` that provokes these exceptions, then
fixing them in all of the related components. In addition, systematic
improvements to the `FieldTypesStore` were made:

  * removing shadowing of `this.all` through the action _and_ the state
variable
  * initializing the state (`this._all` & `this._queryFields`) with
empty structures (`List`/`Map`) to avoid propagating `undefined`

Fixes #7365.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Commented out relevant parts of the actions of the `FieldTypesStore` to
create a permanent initial state. Navigating through related search
functionality.

- Added tests explicitly passing `undefined` to the related components.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.