### PR TITLE
Implement bootstrap modal form for big display mode configuration modal

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalForm.jsx
@@ -103,7 +103,7 @@ class BootstrapModalForm extends React.Component {
         <Modal.Header closeButton>
           <Modal.Title>{title}</Modal.Title>
         </Modal.Header>
-        <form ref={(c) => { this.form = c; }} onSubmit={this.submit} {...formProps}>
+        <form ref={(c) => { this.form = c; }} onSubmit={this.submit} {...formProps} data-testid="modal-form">
           <Modal.Body>
             {body}
           </Modal.Body>

--- a/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.jsx
@@ -64,6 +64,7 @@ const ConfigurationModal = ({ onSave, view, show, onClose }: ConfigurationModalP
              required
              step={1}
              value={refreshInterval} />
+
       <FormGroup>
         <ControlLabel>Tabs</ControlLabel>
         <ul>
@@ -123,18 +124,18 @@ type Props = {
 };
 
 const BigDisplayModeConfiguration = ({ disabled, show, view }: Props) => {
-  const [configurationModalOpen, setConfigurationModalOpen] = useState(show);
+  const [showConfigurationModal, setShowConfigurationModal] = useState(show);
   const onSave = (config: Configuration) => redirectToBigDisplayMode(view, createQueryFromConfiguration(config, view));
 
   return (
     <React.Fragment>
-      {configurationModalOpen && (
-        <ConfigurationModal onClose={() => setConfigurationModalOpen(false)}
+      {showConfigurationModal && (
+        <ConfigurationModal onClose={() => setShowConfigurationModal(false)}
                             onSave={onSave}
                             show
                             view={view} />
       )}
-      <MenuItem disabled={disabled} onSelect={() => setConfigurationModalOpen(true)}>
+      <MenuItem disabled={disabled} onSelect={() => setShowConfigurationModal(true)}>
         <Icon name="desktop" /> Full Screen
       </MenuItem>
     </React.Fragment>

--- a/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.jsx
@@ -123,18 +123,18 @@ type Props = {
 };
 
 const BigDisplayModeConfiguration = ({ disabled, show, view }: Props) => {
-  const [modalOpen, setModalOpen] = useState(show);
+  const [configurationModalOpen, setConfigurationModalOpen] = useState(show);
   const onSave = (config: Configuration) => redirectToBigDisplayMode(view, createQueryFromConfiguration(config, view));
 
   return (
     <React.Fragment>
-      {modalOpen && (
-        <ConfigurationModal onClose={() => setModalOpen(false)}
+      {configurationModalOpen && (
+        <ConfigurationModal onClose={() => setConfigurationModalOpen(false)}
                             onSave={onSave}
                             show
                             view={view} />
       )}
-      <MenuItem disabled={disabled} onSelect={() => setModalOpen(true)}>
+      <MenuItem disabled={disabled} onSelect={() => setConfigurationModalOpen(true)}>
         <Icon name="desktop" /> Full Screen
       </MenuItem>
     </React.Fragment>

--- a/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.jsx
@@ -3,7 +3,8 @@ import React, { useCallback, useState } from 'react';
 import URI from 'urijs';
 import history from 'util/History';
 
-import { Button, Checkbox, ControlLabel, FormGroup, HelpBlock, MenuItem, Modal } from 'components/graylog';
+import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
+import { Checkbox, ControlLabel, FormGroup, HelpBlock, MenuItem } from 'components/graylog';
 import Input from 'components/bootstrap/Input';
 import { Icon } from 'components/common';
 import Routes from 'routing/Routes';
@@ -11,29 +12,29 @@ import View from 'views/logic/views/View';
 import queryTitle from 'views/logic/queries/QueryTitle';
 
 export type UntypedBigDisplayModeQuery = {|
-  tabs?: string,
   interval?: string,
   refresh?: string,
+  tabs?: string,
 |};
 
 type Configuration = {
-  refreshInterval: number,
-  queryTabs?: Array<number>,
   queryCycleInterval?: number,
+  queryTabs?: Array<number>,
+  refreshInterval: number,
 };
 
 type ConfigurationModalProps = {
+  onClose: () => void,
   onSave: (Configuration) => void,
-  onCancel: () => void,
+  show: boolean,
   view: View,
 };
 
-const ConfigurationModal = ({ onSave, onCancel, view }: ConfigurationModalProps) => {
+const ConfigurationModal = ({ onSave, view, show, onClose }: ConfigurationModalProps) => {
   const availableTabs = view.search.queries.keySeq().map((query, idx) => [
     idx,
     queryTitle(view, query.id),
   ]).toJS();
-
   const [refreshInterval, setRefreshInterval] = useState(10);
   const [queryTabs, setQueryTabs] = useState(availableTabs.map(([idx]) => idx));
   const [queryCycleInterval, setQueryCycleInterval] = useState(30);
@@ -46,58 +47,52 @@ const ConfigurationModal = ({ onSave, onCancel, view }: ConfigurationModalProps)
   }), [onSave, refreshInterval, queryTabs, queryCycleInterval]);
 
   return (
-    <Modal show bsSize="large" onHide={onCancel}>
-      <form onSubmit={_onSave} data-testid="display-mode-config-form">
-        <Modal.Header closeButton>
-          <Modal.Title>Configuring Full Screen</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <Input id="refresh-interval"
-                 type="number"
-                 min="1"
-                 name="refresh-interval"
-                 label="Refresh Interval"
-                 help="After how many seconds should the dashboard refresh?"
-                 onChange={({ target: { value } }) => setRefreshInterval(value ? Number.parseInt(value, 10) : value)}
-                 required
-                 step="1"
-                 value={refreshInterval} />
+    <BootstrapModalForm bsSize="large"
+                        onModalClose={onClose}
+                        onSubmitForm={_onSave}
+                        submitButtonText="Save"
+                        title="Configuring Full Screen"
+                        show={show}>
+      <Input autoFocus
+             id="refresh-interval"
+             type="number"
+             min="1"
+             name="refresh-interval"
+             label="Refresh Interval"
+             help="After how many seconds should the dashboard refresh?"
+             onChange={({ target: { value } }) => setRefreshInterval(value ? Number.parseInt(value, 10) : value)}
+             required
+             step={1}
+             value={refreshInterval} />
+      <FormGroup>
+        <ControlLabel>Tabs</ControlLabel>
+        <ul>
+          {availableTabs.map(([idx, title]) => (
+            <li key={`${idx}-${title}`}>
+              <Checkbox inline
+                        checked={queryTabs.includes(idx)}
+                        onChange={event => (event.target.checked ? addQueryTab(idx) : removeQueryTab(idx))}>
+                {title}
+              </Checkbox>
+            </li>
+          ))}
+        </ul>
+        <HelpBlock>
+          Select the query tabs to include in rotation.
+        </HelpBlock>
+      </FormGroup>
 
-          <FormGroup>
-            <ControlLabel>Tabs</ControlLabel>
-            <ul>
-              {availableTabs.map(([idx, title]) => (
-                <li key={`${idx}-${title}`}>
-                  <Checkbox inline
-                            checked={queryTabs.includes(idx)}
-                            onChange={event => (event.target.checked ? addQueryTab(idx) : removeQueryTab(idx))}>
-                    {title}
-                  </Checkbox>
-                </li>
-              ))}
-            </ul>
-            <HelpBlock>
-              Select the query tabs to include in rotation.
-            </HelpBlock>
-          </FormGroup>
-
-          <Input id="query-cycle-interval"
-                 type="number"
-                 min="1"
-                 name="query-cycle-interval"
-                 label="Tab cycle interval"
-                 help="After how many seconds should the next tab be shown?"
-                 onChange={({ target: { value } }) => setQueryCycleInterval(value ? Number.parseInt(value, 10) : value)}
-                 required
-                 step="1"
-                 value={queryCycleInterval} />
-        </Modal.Body>
-        <Modal.Footer>
-          <Button bsStyle="success" type="submit">Save</Button>
-          <Button onClick={onCancel}>Cancel</Button>
-        </Modal.Footer>
-      </form>
-    </Modal>
+      <Input id="query-cycle-interval"
+             type="number"
+             min="1"
+             name="query-cycle-interval"
+             label="Tab cycle interval"
+             help="After how many seconds should the next tab be shown?"
+             onChange={({ target: { value } }) => setQueryCycleInterval(value ? Number.parseInt(value, 10) : value)}
+             required
+             step="1"
+             value={queryCycleInterval} />
+    </BootstrapModalForm>
   );
 };
 
@@ -123,20 +118,23 @@ const createQueryFromConfiguration = (
 
 type Props = {
   disabled?: boolean,
+  show?: boolean,
   view: View,
-  show?: boolean
 };
 
-const BigDisplayModeConfiguration = ({ disabled, view, show }: Props) => {
-  const [showConfigurationModal, setShowConfigurationModal] = useState(show);
-  const onCancel = useCallback(() => setShowConfigurationModal(false), [setShowConfigurationModal]);
-
+const BigDisplayModeConfiguration = ({ disabled, show, view }: Props) => {
+  const [modalOpen, setModalOpen] = useState(show);
   const onSave = (config: Configuration) => redirectToBigDisplayMode(view, createQueryFromConfiguration(config, view));
 
   return (
     <React.Fragment>
-      {showConfigurationModal && <ConfigurationModal view={view} onCancel={onCancel} onSave={onSave} />}
-      <MenuItem disabled={disabled} onSelect={() => setShowConfigurationModal(true)}>
+      {modalOpen && (
+        <ConfigurationModal onClose={() => setModalOpen(false)}
+                            onSave={onSave}
+                            show
+                            view={view} />
+      )}
+      <MenuItem disabled={disabled} onSelect={() => setModalOpen(true)}>
         <Icon name="desktop" /> Full Screen
       </MenuItem>
     </React.Fragment>

--- a/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.test.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeConfiguration.test.jsx
@@ -108,7 +108,7 @@ describe('BigDisplayModeConfiguration', () => {
 
     it('on form submit', () => {
       const { getByTestId } = render(<BigDisplayModeConfiguration view={view} show />);
-      const form = getByTestId('display-mode-config-form');
+      const form = getByTestId('modal-form');
       expect(form).not.toBeNull();
 
       fireEvent.submit(form);
@@ -124,7 +124,7 @@ describe('BigDisplayModeConfiguration', () => {
 
       fireEvent.change(refreshInterval, { target: { value: 42 } });
 
-      const form = getByTestId('display-mode-config-form');
+      const form = getByTestId('modal-form');
       fireEvent.submit(form);
 
       expect(Routes.pluginRoute).toHaveBeenCalledWith('DASHBOARDS_TV_VIEWID');
@@ -137,7 +137,7 @@ describe('BigDisplayModeConfiguration', () => {
       const cycleInterval = getByLabelText('Tab cycle interval');
       fireEvent.change(cycleInterval, { target: { value: 4242 } });
 
-      const form = getByTestId('display-mode-config-form');
+      const form = getByTestId('modal-form');
       fireEvent.submit(form);
 
       expect(Routes.pluginRoute).toHaveBeenCalledWith('DASHBOARDS_TV_VIEWID');
@@ -151,7 +151,7 @@ describe('BigDisplayModeConfiguration', () => {
       const query1 = getByLabelText('Query#1');
       fireEvent.click(query1);
 
-      const form = getByTestId('display-mode-config-form');
+      const form = getByTestId('modal-form');
       fireEvent.submit(form);
 
       expect(Routes.pluginRoute).toHaveBeenCalledWith('DASHBOARDS_TV_VIEWID');


### PR DESCRIPTION
This PR is based on https://github.com/Graylog2/graylog2-server/pull/7574. The mentioned PR pins the `jsdom` version, otherwise the `BigDisplayModeConfiguration.test.jsx` would fail.

As described in #7229 we should unify the different modal implementations. This PR implements the `BootstrapModalForm` for the `BigDisplayModeConfiguration`

This PR is follow-up of: https://github.com/Graylog2/graylog2-server/pull/7571

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

