### PR TITLE
Use containsExactlyInAnyOrder for better tests

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/plugin/lookup/LookupCacheKeyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/lookup/LookupCacheKeyTest.java
@@ -33,7 +33,7 @@ public class LookupCacheKeyTest {
         final LookupCacheKey cacheKey = LookupCacheKey.createFromJSON("prefix", "key");
         final JsonNode node = objectMapper.convertValue(cacheKey, JsonNode.class);
         assertThat(node.isObject()).isTrue();
-        assertThat(node.fieldNames()).containsExactly("prefix", "key");
+        assertThat(node.fieldNames()).containsExactlyInAnyOrder("prefix", "key");
         assertThat(node.path("prefix").isTextual()).isTrue();
         assertThat(node.path("prefix").asText()).isEqualTo("prefix");
         assertThat(node.path("key").isTextual()).isTrue();
@@ -45,7 +45,7 @@ public class LookupCacheKeyTest {
         final LookupCacheKey cacheKey = LookupCacheKey.createFromJSON("prefix", null);
         final JsonNode node = objectMapper.convertValue(cacheKey, JsonNode.class);
         assertThat(node.isObject()).isTrue();
-        assertThat(node.fieldNames()).containsExactly("prefix", "key");
+        assertThat(node.fieldNames()).containsExactlyInAnyOrder("prefix", "key");
         assertThat(node.path("prefix").isTextual()).isTrue();
         assertThat(node.path("prefix").asText()).isEqualTo("prefix");
         assertThat(node.path("key").isNull()).isTrue();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
For background information, please refer to #7594 

## Description
The fix uses containsExactlyInAnyOrder instead of containsExactly so that the test is more stable.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

