### PR TITLE
Autosuggest `_exists_` operator in query input of search/dashboard page.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.js
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.js
@@ -2,13 +2,19 @@
 import * as Immutable from 'immutable';
 import { FieldTypesStore } from 'views/stores/FieldTypesStore';
 import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
-import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import type { FieldTypeMappingsList, FieldTypesStoreState } from 'views/stores/FieldTypesStore';
 
 import type { CompletionResult, Token } from '../ace-types';
 import type { Completer } from '../SearchBarAutocompletions';
 
-const _fieldResult = (field: FieldTypeMapping, score: number = 1, valuePosition: boolean = false): CompletionResult => {
+type Suggestion = $ReadOnly<{
+  name: string,
+  type: $ReadOnly<{
+    type: string,
+  }>,
+}>;
+
+const _fieldResult = (field: Suggestion, score: number = 1, valuePosition: boolean = false): CompletionResult => {
   const { name, type } = field;
   return {
     name,
@@ -18,7 +24,7 @@ const _fieldResult = (field: FieldTypeMapping, score: number = 1, valuePosition:
   };
 };
 
-export const existsOperator = {
+export const existsOperator: Suggestion = {
   name: '_exists_',
   type: {
     type: 'operator',
@@ -41,7 +47,9 @@ class FieldNameCompletion implements Completer {
 
   fields: FieldTypesStoreState;
 
-  constructor(staticSuggestions: Array<FieldTypeMapping> = [existsOperator]) {
+  staticSuggestions: Array<Suggestion>;
+
+  constructor(staticSuggestions: Array<Suggestion> = [existsOperator]) {
     this.staticSuggestions = staticSuggestions;
     this.fields = FieldTypesStore.getInitialState();
     FieldTypesStore.listen((newState) => {

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.test.jsx
@@ -25,7 +25,7 @@ describe('FieldNameCompletion', () => {
   it('returns empty list if inputs are empty', () => {
     asMock(FieldTypesStore.getInitialState).mockReturnValue(_createFieldTypesStoreState([]));
 
-    const completer = new FieldNameCompletion();
+    const completer = new FieldNameCompletion([]);
     expect(completer.getCompletions(null, null, '')).toEqual([]);
   });
 
@@ -36,14 +36,33 @@ describe('FieldNameCompletion', () => {
   });
 
   it('returns matching fields if prefix is present in at least one field name', () => {
-    const completer = new FieldNameCompletion();
+    const completer = new FieldNameCompletion([]);
     expect(completer.getCompletions(null, null, 'e').map(result => result.name))
       .toEqual(['source', 'message', 'timestamp']);
   });
 
   it('suffixes matching fields with colon', () => {
-    const completer = new FieldNameCompletion();
+    const completer = new FieldNameCompletion([]);
     expect(completer.getCompletions(null, null, 'e').map(result => result.value))
       .toEqual(['source:', 'message:', 'timestamp:']);
+  });
+
+  it('returns _exist_-operator if matching prefix', () => {
+    const completer = new FieldNameCompletion();
+    expect(completer.getCompletions(null, null, '_e').map(result => result.value))
+      .toEqual(['_exists_:']);
+  });
+
+  it('returns matching fields after _exists_-operator', () => {
+    const completer = new FieldNameCompletion();
+    expect(completer.getCompletions(null, { type: 'keyword', value: '_exists_:'}, 'e')
+      .map(result => result.name))
+      .toEqual(['source', 'message', 'timestamp']);
+  });
+
+  it('returns exists operator together with matching fields', () => {
+    const completer = new FieldNameCompletion();
+    expect(completer.getCompletions(null, null, 'e').map(result => result.name))
+      .toEqual(['_exists_', 'source', 'message', 'timestamp']);
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.test.jsx
@@ -55,7 +55,7 @@ describe('FieldNameCompletion', () => {
 
   it('returns matching fields after _exists_-operator', () => {
     const completer = new FieldNameCompletion();
-    expect(completer.getCompletions(null, { type: 'keyword', value: '_exists_:'}, 'e')
+    expect(completer.getCompletions(null, { type: 'keyword', value: '_exists_:' }, 'e')
       .map(result => result.name))
       .toEqual(['source', 'message', 'timestamp']);
   });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

*Should be backported to `3.2`.*

Before this change, the `_exists_` query operator was not suggested in the autocompletion of the query input in the new search. This change is adding it and completes any value following it with the set of fields.

Fixes #7441.
Refs #6909.

## Screenshots (if appropriate):
![Screen Shot 2020-02-25 at 17 07 33](https://user-images.githubusercontent.com/41929/75265697-919de380-57f1-11ea-87a6-79225823d9a3.png)
![Screen Shot 2020-02-25 at 17 07 42](https://user-images.githubusercontent.com/41929/75265705-9367a700-57f1-11ea-8d14-48ff00a0c5df.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.