### PR TITLE
Show pivots with a value of zero in chart widgets

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/ChartData.js
+++ b/graylog2-web-interface/src/views/components/visualizations/ChartData.js
@@ -53,7 +53,7 @@ export const extractSeries = (keyJoiner: KeyJoiner = _defaultKeyJoiner, leafValu
     flatLeafs.forEach(([key, value]) => {
       const joinedKey = keyJoiner(value.key);
       const targetIdx = xLabels.findIndex(l => isEqual(l, key));
-      if (value.value) {
+      if (value.value === 0 || value.value) {
         set(valuesBySeries, [joinedKey, targetIdx], value.value);
       }
     });

--- a/graylog2-web-interface/src/views/components/visualizations/ChartData.js
+++ b/graylog2-web-interface/src/views/components/visualizations/ChartData.js
@@ -53,7 +53,7 @@ export const extractSeries = (keyJoiner: KeyJoiner = _defaultKeyJoiner, leafValu
     flatLeafs.forEach(([key, value]) => {
       const joinedKey = keyJoiner(value.key);
       const targetIdx = xLabels.findIndex(l => isEqual(l, key));
-      if (value.value === 0 || value.value) {
+      if (value.value !== null && value.value !== undefined) {
         set(valuesBySeries, [joinedKey, targetIdx], value.value);
       }
     });

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/ChartData.test.js
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/ChartData.test.js
@@ -72,6 +72,24 @@ describe('Chart helper functions', () => {
       expect(result).toHaveLength(2);
       expect(result).toEqual(expectedResult);
     });
+    it('should not remove data points with a value of zero', () => {
+      const input = readFixture('ChartData.test.withZeros.json');
+      const result = chartData(config, input, 'bar');
+      const expectedResult = [{
+        name: 'count()',
+        type: 'bar',
+        x: [
+          '2018-05-28T11:48:00.000Z',
+          '2018-05-28T11:49:00.000Z',
+          '2018-05-28T11:50:00.000Z',
+          '2018-05-28T11:52:00.000Z',
+          '2018-05-28T11:53:00.000Z',
+        ],
+        y: [7813, 0, 0, 0, 702],
+      }];
+      expect(result).toHaveLength(1);
+      expect(result).toEqual(expectedResult);
+    });
     it('should properly extract series from fixture with two column pivots', () => {
       const input = readFixture('ChartData.test.twoColumnPivots.json');
       const result = chartData(config, input, 'dummy');

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/ChartData.test.js
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/ChartData.test.js
@@ -90,6 +90,21 @@ describe('Chart helper functions', () => {
       expect(result).toHaveLength(1);
       expect(result).toEqual(expectedResult);
     });
+    it('should remove data points with a value of null or undefined', () => {
+      const input = readFixture('ChartData.test.withNullAndUndefined.json');
+      const result = chartData(config, input, 'bar');
+      const expectedResult = [{
+        name: 'count()',
+        type: 'bar',
+        x: [
+          '2018-05-28T11:48:00.000Z',
+          '2018-05-28T11:53:00.000Z',
+        ],
+        y: [7813, 702],
+      }];
+      expect(result).toHaveLength(1);
+      expect(result).toEqual(expectedResult);
+    });
     it('should properly extract series from fixture with two column pivots', () => {
       const input = readFixture('ChartData.test.twoColumnPivots.json');
       const result = chartData(config, input, 'dummy');

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/ChartData.test.withNullAndUndefined.json
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/ChartData.test.withNullAndUndefined.json
@@ -1,0 +1,95 @@
+[
+  {
+    "key": [
+      "2018-05-28T11:48:00.000Z"
+    ],
+    "values": [
+      {
+        "key": [
+          "count()"
+        ],
+        "value": 7813,
+        "rollup": true,
+        "source": "row-leaf"
+      }
+    ],
+    "source": "leaf"
+  },
+  {
+    "key": [
+      "2018-05-28T11:49:00.000Z"
+    ],
+    "values": [
+      {
+        "key": [
+          "count()"
+        ],
+        "value": null,
+        "rollup": true,
+        "source": "row-leaf"
+      }
+    ],
+    "source": "leaf"
+  },
+  {
+    "key": [
+      "2018-05-28T11:50:00.000Z"
+    ],
+    "values": [
+      {
+        "key": [
+          "count()"
+        ],
+        "rollup": true,
+        "source": "row-leaf"
+      }
+    ],
+    "source": "leaf"
+  },
+  {
+    "key": [
+      "2018-05-28T11:52:00.000Z"
+    ],
+    "values": [
+      {
+        "key": [
+          "count()"
+        ],
+        "value": null,
+        "rollup": true,
+        "source": "row-leaf"
+      }
+    ],
+    "source": "leaf"
+  },
+  {
+    "key": [
+      "2018-05-28T11:53:00.000Z"
+    ],
+    "values": [
+      {
+        "key": [
+          "count()"
+        ],
+        "value": 702,
+        "rollup": true,
+        "source": "row-leaf"
+      }
+    ],
+    "source": "leaf"
+  },
+  {
+    "key": [],
+    "values": [
+      {
+        "key": [
+          "count()"
+        ],
+        "value": 8515,
+        "rollup": true,
+        "source": "row-inner"
+      }
+    ],
+    "source": "non-leaf"
+  }
+]

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/ChartData.test.withZeros.json
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/ChartData.test.withZeros.json
@@ -1,0 +1,96 @@
+[
+  {
+    "key": [
+      "2018-05-28T11:48:00.000Z"
+    ],
+    "values": [
+      {
+        "key": [
+          "count()"
+        ],
+        "value": 7813,
+        "rollup": true,
+        "source": "row-leaf"
+      }
+    ],
+    "source": "leaf"
+  },
+  {
+    "key": [
+      "2018-05-28T11:49:00.000Z"
+    ],
+    "values": [
+      {
+        "key": [
+          "count()"
+        ],
+        "value": 0,
+        "rollup": true,
+        "source": "row-leaf"
+      }
+    ],
+    "source": "leaf"
+  },
+  {
+    "key": [
+      "2018-05-28T11:50:00.000Z"
+    ],
+    "values": [
+      {
+        "key": [
+          "count()"
+        ],
+        "value": 0,
+        "rollup": true,
+        "source": "row-leaf"
+      }
+    ],
+    "source": "leaf"
+  },
+  {
+    "key": [
+      "2018-05-28T11:52:00.000Z"
+    ],
+    "values": [
+      {
+        "key": [
+          "count()"
+        ],
+        "value": 0,
+        "rollup": true,
+        "source": "row-leaf"
+      }
+    ],
+    "source": "leaf"
+  },
+  {
+    "key": [
+      "2018-05-28T11:53:00.000Z"
+    ],
+    "values": [
+      {
+        "key": [
+          "count()"
+        ],
+        "value": 702,
+        "rollup": true,
+        "source": "row-leaf"
+      }
+    ],
+    "source": "leaf"
+  },
+  {
+    "key": [],
+    "values": [
+      {
+        "key": [
+          "count()"
+        ],
+        "value": 8515,
+        "rollup": true,
+        "source": "row-inner"
+      }
+    ],
+    "source": "non-leaf"
+  }
+]


### PR DESCRIPTION
With this PR, chart widgets display pivots with a value of zero. It looks like the one line I've adjusted is the only needed change.

I had a look at all different chart types with different compositions and could not find / think of a case were this could result in an unintended visualization.

Only when all values of e.g. a line chart are zero, the line is. hardly visible:
![image](https://user-images.githubusercontent.com/46300478/75696095-5006b000-5cab-11ea-88e0-4a7e3ad5766e.png)

I thought about starting the y-axis with a negative value, but I would not adjust the current behaviour only for this case. What do you think?

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

