### PR TITLE
Fix act() warning and fetch error in frontend tests

### DIFF
--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.test.jsx
@@ -14,7 +14,6 @@ import ViewLoaderContext from 'views/logic/ViewLoaderContext';
 import Search from 'views/logic/search/Search';
 import StreamSearchPage from './StreamSearchPage';
 
-
 const mockExtendedSearchPage = jest.fn(() => <div>Extended search page</div>);
 const mockView = View.create()
   .toBuilder()

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.test.jsx
@@ -14,6 +14,7 @@ import ViewLoaderContext from 'views/logic/ViewLoaderContext';
 import Search from 'views/logic/search/Search';
 import StreamSearchPage from './StreamSearchPage';
 
+
 const mockExtendedSearchPage = jest.fn(() => <div>Extended search page</div>);
 const mockView = View.create()
   .toBuilder()
@@ -70,14 +71,11 @@ describe('StreamSearchPage', () => {
     jest.resetModules();
   });
 
-  it('should render minimal', async () => {
+  it('should render minimal and show loading spinner initially', async () => {
     const { getByText } = render(<SimpleStreamSearchPage />);
-    await waitForElement(() => getByText('Extended search page'));
-  });
 
-  it('should show spinner while loading view', () => {
-    const { getByText } = render(<SimpleStreamSearchPage />);
     expect(getByText('Loading...')).not.toBeNull();
+    await waitForElement(() => getByText('Extended search page'));
   });
 
   it('should create view with streamId passed from props', async () => {

--- a/graylog2-web-interface/src/views/spec/CreateNewDashboard.test.jsx
+++ b/graylog2-web-interface/src/views/spec/CreateNewDashboard.test.jsx
@@ -13,6 +13,22 @@ import AppRouter from 'routing/AppRouter';
 
 import viewsBindings from 'views/bindings';
 
+jest.mock('views/stores/DashboardsStore', () => ({
+  DashboardsActions: {
+    search: jest.fn(() => Promise.resolve()),
+  },
+  DashboardsStore: MockStore(
+    ['listen', () => jest.fn()],
+    ['getInitialState', () => ({
+      listen: [],
+      pagination: {
+        total: 100,
+        page: 1,
+        perPage: 20,
+      },
+    })],
+  ),
+}));
 jest.mock('stores/users/CurrentUserStore', () => MockStore(
   ['listen', () => jest.fn()],
   'get',


### PR DESCRIPTION
As described in https://github.com/Graylog2/graylog2-server/issues/7580 some frontend tests are throwing a warning.

This PR is getting rid of the `act()` warnings by combining the related tests with another meaningful test case, which have the state change in mind.
Here is an interesting article, I've read about the topic: https://kentcdodds.com/blog/write-fewer-longer-tests

This PR also fixes the fetch error, by mocking the part which is responsible for the fetch.

Fixes #7580.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

