### PR TITLE
Specify ES search timeout to match the HTTP request timeout

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/counts/CountsIT.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.indexer.counts;
 
+import com.github.joschi.jadconfig.util.Duration;
 import com.google.common.collect.ImmutableMap;
 import io.searchbox.core.Bulk;
 import io.searchbox.core.BulkResult;
@@ -66,7 +67,7 @@ public class CountsIT extends ElasticsearchBaseTest {
         client().createIndex(INDEX_NAME_2, 1, 0);
         client().waitForGreenStatus(INDEX_NAME_1, INDEX_NAME_2);
 
-        counts = new Counts(jestClient(), indexSetRegistry);
+        counts = new Counts(jestClient(), indexSetRegistry, Duration.minutes(1));
 
         final IndexSetConfig indexSetConfig1 = IndexSetConfig.builder()
                 .id("id-1")

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesIT.java
@@ -20,6 +20,7 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.joschi.jadconfig.util.Duration;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedSet;
 import org.elasticsearch.index.query.RangeQueryBuilder;
@@ -164,25 +165,16 @@ public class SearchesIT extends ElasticsearchBaseTest {
         when(indexRangeService.find(any(DateTime.class), any(DateTime.class))).thenReturn(INDEX_RANGES);
         when(indices.getAllMessageFieldsForIndices(any(String[].class))).thenReturn(ImmutableMap.of(INDEX_NAME, Collections.singleton("n")));
         metricRegistry = new MetricRegistry();
-        searches = new Searches(
-            new Configuration(),
-            indexRangeService,
-            metricRegistry,
-            streamService,
-            indices,
-            indexSetRegistry,
-                jestClient(),
-            new ScrollResult.Factory() {
-                @Override
-                public ScrollResult create(io.searchbox.core.SearchResult initialResult, String query, List<String> fields) {
-                    return new ScrollResult(jestClient(), new ObjectMapper(), initialResult, query, fields);
-                }
-                @Override
-                public ScrollResult create(io.searchbox.core.SearchResult initialResult, String query, String scroll, List<String> fields) {
-                    return new ScrollResult(jestClient(), new ObjectMapper(), initialResult, query, scroll, fields);
-                }
+        searches = new Searches(new Configuration(), indexRangeService, metricRegistry, streamService, indices, indexSetRegistry, jestClient(), new ScrollResult.Factory() {
+            @Override
+            public ScrollResult create(io.searchbox.core.SearchResult initialResult, String query, List<String> fields) {
+                return new ScrollResult(jestClient(), new ObjectMapper(), initialResult, query, fields);
             }
-        );
+            @Override
+            public ScrollResult create(io.searchbox.core.SearchResult initialResult, String query, String scroll, List<String> fields) {
+                return new ScrollResult(jestClient(), new ObjectMapper(), initialResult, query, scroll, fields);
+            }
+        }, Duration.minutes(1));
     }
 
     @Test


### PR DESCRIPTION
## Description
The `elasticsearch_request_timeout` configuration value will set the
HTTP request timeout of ES operations but it does not tell ES to cancel
the search request with that timeout. This means the request will
continue to run in ES to completion while the client has timed out. In
turn, this could cause the user to resubmit the request which would
issue another long running query to stack against and overwhelm the
ES cluster.

## Motivation and Context
Fixes #4614

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by monitoring `_tasks` for a search that times out in a few seconds and noticed that the task goes away when the request times out.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

