### PR TITLE
Support passing streams for new search in URL.

### DIFF
--- a/graylog2-web-interface/src/components/search/SurroundingSearchButton.jsx
+++ b/graylog2-web-interface/src/components/search/SurroundingSearchButton.jsx
@@ -1,18 +1,15 @@
 // @flow strict
 import * as React from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
-import * as Immutable from 'immutable';
 import Qs from 'qs';
 import moment from 'moment';
 import naturalSort from 'javascript-natural-sort';
 
 import Routes from 'routing/Routes';
-import connect from 'stores/connect';
 import { DropdownButton, MenuItem } from 'components/graylog';
 import { addToQuery, escape } from 'views/logic/queries/QueryHelper';
-import { QueryFiltersStore } from 'views/stores/QueryFiltersStore';
-import type { FilterType } from 'views/logic/queries/Query';
-import { filtersToStreamSet } from 'views/logic/queries/Query';
+import DrilldownContext from 'views/components/contexts/DrilldownContext';
 import type { SearchesConfig } from './SearchConfig';
 
 const buildTimeRangeOptions = ({ surrounding_timerange_options: surroundingTimerangeOptions = {} }) => Object.entries(surroundingTimerangeOptions)
@@ -58,12 +55,11 @@ type Props = {
   timestamp: string,
   id: string,
   messageFields: { [string]: mixed },
-  queryFilters: ?FilterType,
 };
 
-const SurroundingSearchButton = ({ searchConfig, timestamp, id, messageFields, queryFilters }: Props) => {
+const SurroundingSearchButton = ({ searchConfig, timestamp, id, messageFields }: Props) => {
+  const { streams } = useContext(DrilldownContext);
   const timeRangeOptions = buildTimeRangeOptions(searchConfig);
-  const streams = filtersToStreamSet(queryFilters).toJS();
   const menuItems = Object.keys(timeRangeOptions)
     .sort((a, b) => naturalSort(a, b))
     .map(range => (
@@ -86,8 +82,4 @@ SurroundingSearchButton.propTypes = {
   messageFields: PropTypes.object.isRequired,
 };
 
-export default connect(
-  SurroundingSearchButton,
-  { queryFilters: QueryFiltersStore },
-  ({ queryFilters = Immutable.Map() }) => ({ queryFilters: queryFilters.first() }),
-);
+export default SurroundingSearchButton;

--- a/graylog2-web-interface/src/components/search/SurroundingSearchButton.jsx
+++ b/graylog2-web-interface/src/components/search/SurroundingSearchButton.jsx
@@ -1,13 +1,18 @@
 // @flow strict
-import PropTypes from 'prop-types';
 import * as React from 'react';
+import PropTypes from 'prop-types';
+import * as Immutable from 'immutable';
 import Qs from 'qs';
 import moment from 'moment';
+import naturalSort from 'javascript-natural-sort';
 
 import Routes from 'routing/Routes';
+import connect from 'stores/connect';
 import { DropdownButton, MenuItem } from 'components/graylog';
-import naturalSort from 'javascript-natural-sort';
 import { addToQuery, escape } from 'views/logic/queries/QueryHelper';
+import { QueryFiltersStore } from 'views/stores/QueryFiltersStore';
+import type { FilterType } from 'views/logic/queries/Query';
+import { filtersToStreamSet } from 'views/logic/queries/Query';
 import type { SearchesConfig } from './SearchConfig';
 
 const buildTimeRangeOptions = ({ surrounding_timerange_options: surroundingTimerangeOptions = {} }) => Object.entries(surroundingTimerangeOptions)
@@ -19,10 +24,10 @@ const buildFilterFields = (messageFields, searchConfig) => {
   return surroundingFilterFields.reduce((prev, cur) => ({ ...prev, [cur]: messageFields[cur] }), {});
 };
 
-const buildSearchLink = (id, fromTime, toTime, fields, filter) => {
-  const query = Object.keys(filter)
-    .filter(key => (filter[key] !== null && filter[key] !== undefined))
-    .map(key => `${key}:"${escape(filter[key])}"`)
+const buildSearchLink = (id, fromTime, toTime, fields, filterFields, streams) => {
+  const query = Object.keys(filterFields)
+    .filter(key => (filterFields[key] !== null && filterFields[key] !== undefined))
+    .map(key => `${key}:"${escape(filterFields[key])}"`)
     .reduce((prev, cur) => addToQuery(prev, cur), '');
 
   const params = {
@@ -33,16 +38,19 @@ const buildSearchLink = (id, fromTime, toTime, fields, filter) => {
     highlightMessage: id,
     fields,
   };
+  const paramsWithStreams = streams && streams.length > 0
+    ? { ...params, streams: streams.join(',') }
+    : params;
 
-  return `${Routes.SEARCH}?${Qs.stringify(params)}`;
+  return `${Routes.SEARCH}?${Qs.stringify(paramsWithStreams)}`;
 };
 
-const searchLink = (range, timestamp, id, messageFields, searchConfig) => {
+const searchLink = (range, timestamp, id, messageFields, searchConfig, streams) => {
   const fromTime = moment(timestamp).subtract(Number(range), 'seconds').toISOString();
   const toTime = moment(timestamp).add(Number(range), 'seconds').toISOString();
   const filterFields = buildFilterFields(messageFields, searchConfig);
 
-  return buildSearchLink(id, fromTime, toTime, [], filterFields);
+  return buildSearchLink(id, fromTime, toTime, [], filterFields, streams);
 };
 
 type Props = {
@@ -50,14 +58,16 @@ type Props = {
   timestamp: string,
   id: string,
   messageFields: { [string]: mixed },
+  queryFilters: ?FilterType,
 };
 
-const SurroundingSearchButton = ({ searchConfig, timestamp, id, messageFields }: Props) => {
+const SurroundingSearchButton = ({ searchConfig, timestamp, id, messageFields, queryFilters }: Props) => {
   const timeRangeOptions = buildTimeRangeOptions(searchConfig);
+  const streams = filtersToStreamSet(queryFilters).toJS();
   const menuItems = Object.keys(timeRangeOptions)
     .sort((a, b) => naturalSort(a, b))
     .map(range => (
-      <MenuItem key={range} href={searchLink(range, timestamp, id, messageFields, searchConfig)} target="_blank" rel="noopener noreferrer">
+      <MenuItem key={range} href={searchLink(range, timestamp, id, messageFields, searchConfig, streams)} target="_blank" rel="noopener noreferrer">
         {timeRangeOptions[range]}
       </MenuItem>
     ));
@@ -76,4 +86,8 @@ SurroundingSearchButton.propTypes = {
   messageFields: PropTypes.object.isRequired,
 };
 
-export default SurroundingSearchButton;
+export default connect(
+  SurroundingSearchButton,
+  { queryFilters: QueryFiltersStore },
+  ({ queryFilters = Immutable.Map() }) => ({ queryFilters: queryFilters.first() }),
+);

--- a/graylog2-web-interface/src/components/search/SurroundingSearchButton.test.jsx
+++ b/graylog2-web-interface/src/components/search/SurroundingSearchButton.test.jsx
@@ -1,9 +1,17 @@
 // @flow strict
 import * as React from 'react';
+import { Map } from 'immutable';
 import { cleanup, fireEvent, render } from 'wrappedTestingLibrary';
 
+import { StoreMock as MockStore, asMock } from 'helpers/mocking';
+import { QueryFiltersStore } from 'views/stores/QueryFiltersStore';
+import { filtersForQuery } from 'views/logic/queries/Query';
 import SurroundingSearchButton from './SurroundingSearchButton';
 import type { SearchesConfig } from './SearchConfig';
+
+jest.mock('views/stores/QueryFiltersStore', () => ({
+  QueryFiltersStore: MockStore(['getInitialState', jest.fn()], ['listen', jest.fn(() => () => {})]),
+}));
 
 const getOption = (optionText, getByText) => {
   const button = getByText('Show surrounding messages');
@@ -98,5 +106,23 @@ describe('SurroundingSearchButton', () => {
     const option = getOption('1 second', getByText);
 
     expect(option.href).toContain('highlightMessage=foo-bar');
+  });
+  it('includes current set of streams in generated urls', () => {
+    const streams = ['000000000000000000000001', '5c2e07eeba33a9681ad6070a', '5d2d9649e117dc4df84cf83c'];
+    asMock(QueryFiltersStore.getInitialState).mockReturnValueOnce(Map({ foobar: filtersForQuery(streams) }));
+    const { getByText } = renderButton();
+
+    const option = getOption('1 second', getByText);
+
+    expect(option.href).toContain('streams=000000000000000000000001%2C5c2e07eeba33a9681ad6070a%2C5d2d9649e117dc4df84cf83c');
+  });
+
+  it('does not include a `streams` key in generated urls if none are selected', () => {
+    asMock(QueryFiltersStore.getInitialState).mockReturnValueOnce(Map());
+    const { getByText } = renderButton();
+
+    const option = getOption('1 second', getByText);
+
+    expect(option.href).not.toContain('streams=');
   });
 });

--- a/graylog2-web-interface/src/components/search/SurroundingSearchButton.test.jsx
+++ b/graylog2-web-interface/src/components/search/SurroundingSearchButton.test.jsx
@@ -8,6 +8,7 @@ import { QueryFiltersStore } from 'views/stores/QueryFiltersStore';
 import { filtersForQuery } from 'views/logic/queries/Query';
 import SurroundingSearchButton from './SurroundingSearchButton';
 import type { SearchesConfig } from './SearchConfig';
+import DrilldownContext from '../../views/components/contexts/DrilldownContext';
 
 jest.mock('views/stores/QueryFiltersStore', () => ({
   QueryFiltersStore: MockStore(['getInitialState', jest.fn()], ['listen', jest.fn(() => () => {})]),
@@ -36,13 +37,15 @@ describe('SurroundingSearchButton', () => {
       PT1M: 'Only a minute',
     },
   };
-  const renderButton = (props = {}) => render((
+  const TestComponent = props => (
     <SurroundingSearchButton searchConfig={searchConfig}
                              timestamp="2020-02-28T09:45:31.123Z"
                              id="foo-bar"
                              messageFields={{}}
                              {...props} />
-  ));
+  );
+
+  const renderButton = (props = {}) => render(<TestComponent {...props} />);
   it('renders a button with a "Show surrounding messages" caption', () => {
     const { getByText } = renderButton();
     expect(getByText('Show surrounding messages')).toBeTruthy();
@@ -110,7 +113,15 @@ describe('SurroundingSearchButton', () => {
   it('includes current set of streams in generated urls', () => {
     const streams = ['000000000000000000000001', '5c2e07eeba33a9681ad6070a', '5d2d9649e117dc4df84cf83c'];
     asMock(QueryFiltersStore.getInitialState).mockReturnValueOnce(Map({ foobar: filtersForQuery(streams) }));
-    const { getByText } = renderButton();
+    const { getByText } = render((
+      <DrilldownContext.Consumer>
+        {drilldown => (
+          <DrilldownContext.Provider value={{ ...drilldown, streams }}>
+            <TestComponent />
+          </DrilldownContext.Provider>
+        )}
+      </DrilldownContext.Consumer>
+    ));
 
     const option = getOption('1 second', getByText);
 

--- a/graylog2-web-interface/src/views/components/WidgetGrid.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.jsx
@@ -16,6 +16,7 @@ import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import WidgetContext from 'views/components/contexts/WidgetContext';
 import Widget from './widgets/Widget';
 import { PositionsMap, WidgetDataMap, WidgetErrorsMap, WidgetsMap } from './widgets/WidgetPropTypes';
+import DrilldownContextProvider from './contexts/DrilldownContextProvider';
 
 const defaultTitleGenerator = w => `Untitled ${w.type.replace('_', ' ').split(' ').map(_.capitalize).join(' ')}`;
 
@@ -91,23 +92,25 @@ class WidgetGrid extends React.Component {
 
       returnedWidgets.widgets.push(
         <div key={widget.id} className={style.widgetContainer}>
-          <WidgetContext.Provider value={widget}>
-            <AdditionalContext.Provider value={{ widget }}>
-              <Widget key={widgetId}
-                      id={widgetId}
-                      widget={widget}
-                      data={widgetData}
-                      errors={widgetErrors}
-                      height={height}
-                      position={returnedWidgets.positions[widgetId]}
-                      width={width}
-                      allFields={allFields}
-                      fields={fields}
-                      onPositionsChange={onPositionsChange}
-                      onSizeChange={this._onWidgetSizeChange}
-                      title={widgetTitle} />
-            </AdditionalContext.Provider>
-          </WidgetContext.Provider>
+          <DrilldownContextProvider widget={widget}>
+            <WidgetContext.Provider value={widget}>
+              <AdditionalContext.Provider value={{ widget }}>
+                <Widget key={widgetId}
+                        id={widgetId}
+                        widget={widget}
+                        data={widgetData}
+                        errors={widgetErrors}
+                        height={height}
+                        position={returnedWidgets.positions[widgetId]}
+                        width={width}
+                        allFields={allFields}
+                        fields={fields}
+                        onPositionsChange={onPositionsChange}
+                        onSizeChange={this._onWidgetSizeChange}
+                        title={widgetTitle} />
+              </AdditionalContext.Provider>
+            </WidgetContext.Provider>
+          </DrilldownContextProvider>
         </div>,
       );
     });

--- a/graylog2-web-interface/src/views/components/contexts/DrilldownContext.jsx
+++ b/graylog2-web-interface/src/views/components/contexts/DrilldownContext.jsx
@@ -1,0 +1,20 @@
+// @flow strict
+import * as React from 'react';
+import type { QueryString, TimeRange } from 'views/logic/queries/Query';
+import { createElasticsearchQueryString } from 'views/logic/queries/Query';
+
+export type Drilldown = {
+  query: QueryString,
+  streams: Array<string>,
+  timerange: TimeRange,
+};
+
+const defaultValue: Drilldown = {
+  query: createElasticsearchQueryString(''),
+  streams: [],
+  timerange: { type: 'relative', range: 300 },
+};
+
+const DrilldownContext = React.createContext<Drilldown>(defaultValue);
+
+export default DrilldownContext;

--- a/graylog2-web-interface/src/views/components/contexts/DrilldownContextProvider.jsx
+++ b/graylog2-web-interface/src/views/components/contexts/DrilldownContextProvider.jsx
@@ -1,0 +1,51 @@
+// @flow strict
+import * as React from 'react';
+import { useContext } from 'react';
+
+import connect from 'stores/connect';
+import Widget from 'views/logic/widgets/Widget';
+import View from 'views/logic/views/View';
+import Query, { createElasticsearchQueryString, filtersToStreamSet } from 'views/logic/queries/Query';
+import { CurrentQueryStore } from 'views/stores/CurrentQueryStore';
+import { GlobalOverrideStore } from 'views/stores/GlobalOverrideStore';
+import GlobalOverride from 'views/logic/search/GlobalOverride';
+
+import DrilldownContext from './DrilldownContext';
+import ViewTypeContext from './ViewTypeContext';
+import type { Drilldown } from './DrilldownContext';
+
+type Props = {
+  children: React.Node,
+  widget: Widget,
+  globalOverride: ?GlobalOverride,
+  currentQuery: Query,
+};
+
+const DrilldownContextProvider = ({ children, widget, globalOverride, currentQuery }: Props) => {
+  const viewType = useContext(ViewTypeContext);
+
+  if (viewType === View.Type.Dashboard) {
+    const { streams, timerange, query } = widget;
+    const value: Drilldown = {
+      streams,
+      timerange: (globalOverride && globalOverride.timerange ? globalOverride.timerange : timerange) || { type: 'relative', range: 300 },
+      query: (globalOverride && globalOverride.query ? globalOverride.query : query) || createElasticsearchQueryString(''),
+    };
+    return <DrilldownContext.Provider value={value}>{children}</DrilldownContext.Provider>;
+  }
+  if (currentQuery) {
+    const streams = filtersToStreamSet(currentQuery.filter).toJS();
+    const { timerange, query } = currentQuery;
+    const value: Drilldown = { streams, timerange, query };
+    return <DrilldownContext.Provider value={value}>{children}</DrilldownContext.Provider>;
+  }
+  return children;
+};
+
+export default connect(
+  DrilldownContextProvider,
+  {
+    currentQuery: CurrentQueryStore,
+    globalOverride: GlobalOverrideStore,
+  },
+);

--- a/graylog2-web-interface/src/views/components/contexts/DrilldownContextProvider.test.jsx
+++ b/graylog2-web-interface/src/views/components/contexts/DrilldownContextProvider.test.jsx
@@ -1,0 +1,96 @@
+// @flow strict
+import * as React from 'react';
+import { useContext } from 'react';
+import { mount } from 'wrappedEnzyme';
+
+import { StoreMock as mockStore, asMock } from 'helpers/mocking';
+import View from 'views/logic/views/View';
+import MessagesWidget from 'views/logic/widgets/MessagesWidget';
+import Query, { createElasticsearchQueryString, filtersForQuery } from 'views/logic/queries/Query';
+import { GlobalOverrideStore } from 'views/stores/GlobalOverrideStore';
+import GlobalOverride from 'views/logic/search/GlobalOverride';
+import { CurrentQueryStore } from 'views/stores/CurrentQueryStore';
+
+import DrilldownContextProvider from './DrilldownContextProvider';
+import DrilldownContext from './DrilldownContext';
+import ViewTypeContext from './ViewTypeContext';
+
+jest.mock('views/stores/CurrentQueryStore', () => ({
+  CurrentQueryStore: mockStore(['listen', () => () => {}], ['getInitialState', jest.fn(() => null)]),
+}));
+jest.mock('views/stores/GlobalOverrideStore', () => ({
+  GlobalOverrideStore: mockStore(['listen', () => () => {}], ['getInitialState', jest.fn()]),
+}));
+describe('DrilldownContextProvider', () => {
+  // eslint-disable-next-line no-unused-vars
+  const Consumer = ({ streams, timerange, query }) => null;
+  const TestComponent = () => {
+    const { streams, timerange, query } = useContext(DrilldownContext);
+    return <Consumer streams={streams} timerange={timerange} query={query} />;
+  };
+  const widget = MessagesWidget.builder()
+    .streams(['stream1', 'stream2'])
+    .timerange({ type: 'relative', range: 1800 })
+    .query(createElasticsearchQueryString('foo:42'))
+    .build();
+
+  const expectDrilldown = (expectedStreams, expectedTimerange, expectedQuery, wrapper) => {
+    const consumer = wrapper.find('Consumer');
+    const { streams, timerange, query } = consumer.props();
+    expect(streams).toEqual(expectedStreams);
+    expect(timerange).toEqual(expectedTimerange);
+    expect(query).toEqual(expectedQuery);
+  };
+  const renderSUT = viewType => mount(
+    <ViewTypeContext.Provider value={viewType}>
+      <DrilldownContextProvider widget={widget}>
+        <TestComponent />
+      </DrilldownContextProvider>
+    </ViewTypeContext.Provider>
+  );
+  describe('if current view is a dashboard', () => {
+    it('passes current query, streams & timerange of widget if global override is not set', () => {
+      const wrapper = renderSUT(View.Type.Dashboard);
+      expectDrilldown(['stream1', 'stream2'],
+        { type: 'relative', range: 1800 },
+        { type: 'elasticsearch', query_string: 'foo:42' },
+        wrapper);
+    });
+    it('passes query & timerange of global override, streams of widget', () => {
+      asMock(GlobalOverrideStore.getInitialState)
+        .mockReturnValue(GlobalOverride.create(
+          { type: 'absolute', from: '2020-01-10T13:23:42.000Z', to: '2020-01-10T14:23:42.000Z' },
+          createElasticsearchQueryString('something:"else"'),
+        ));
+      const wrapper = renderSUT(View.Type.Dashboard);
+      expectDrilldown(['stream1', 'stream2'],
+        { type: 'absolute', from: '2020-01-10T13:23:42.000Z', to: '2020-01-10T14:23:42.000Z' },
+        { type: 'elasticsearch', query_string: 'something:"else"' },
+        wrapper);
+    });
+  });
+  describe('if current view is a search', () => {
+    it('passes default values if no current query is present', () => {
+      const wrapper = renderSUT(View.Type.Search);
+      expectDrilldown([],
+        { type: 'relative', range: 300 },
+        { type: 'elasticsearch', query_string: '' },
+        wrapper);
+    });
+    it('passes values from current query if present', () => {
+      const query = Query.builder()
+        .query(createElasticsearchQueryString('foo:"bar"'))
+        // $FlowFixMe: We know it is defined
+        .filter(filtersForQuery(['onestream', 'anotherstream']))
+        .timerange({ type: 'keyword', keyword: 'last year' })
+        .build();
+
+      asMock(CurrentQueryStore.getInitialState).mockReturnValueOnce(query);
+      const wrapper = renderSUT(View.Type.Search);
+      expectDrilldown(['onestream', 'anotherstream'],
+        { type: 'keyword', keyword: 'last year' },
+        { type: 'elasticsearch', query_string: 'foo:"bar"' },
+        wrapper);
+    });
+  });
+});

--- a/graylog2-web-interface/src/views/components/contexts/DrilldownContextProvider.test.jsx
+++ b/graylog2-web-interface/src/views/components/contexts/DrilldownContextProvider.test.jsx
@@ -46,7 +46,7 @@ describe('DrilldownContextProvider', () => {
       <DrilldownContextProvider widget={widget}>
         <TestComponent />
       </DrilldownContextProvider>
-    </ViewTypeContext.Provider>
+    </ViewTypeContext.Provider>,
   );
   describe('if current view is a dashboard', () => {
     it('passes current query, streams & timerange of widget if global override is not set', () => {

--- a/graylog2-web-interface/src/views/components/messagelist/MessageActions.test.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageActions.test.jsx
@@ -1,6 +1,6 @@
 // @flow strict
 import * as React from 'react';
-import { render } from 'wrappedTestingLibrary';
+import { cleanup, render } from 'wrappedTestingLibrary';
 import * as Immutable from 'immutable';
 
 import type { SearchesConfig } from 'components/search/SearchConfig';
@@ -21,6 +21,8 @@ const searchConfig: SearchesConfig = {
 };
 
 describe('MessageActions', () => {
+  afterEach(cleanup);
+
   const renderActions = (props = {}) => render((
     <MessageActions index="some-index"
                     id="some-id"

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.js
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.js
@@ -124,7 +124,11 @@ describe('BindSearchParamsFromQuery should', () => {
 
     const expectedFilter = Immutable.Map({
       type: 'or',
-      filters: [{ id: 'stream1', type: 'stream' }, { id: 'stream2', type: 'stream' }, { id: 'stream3', type: 'stream' }],
+      filters: [
+        Immutable.Map({ type: 'stream', id: 'stream1' }),
+        Immutable.Map({ type: 'stream', id: 'stream2' }),
+        Immutable.Map({ type: 'stream', id: 'stream3' }),
+      ],
     });
     expect(QueriesActions.update)
       .toHaveBeenCalledWith(

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.js
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.test.js
@@ -1,4 +1,6 @@
 // @flow strict
+import * as Immutable from 'immutable';
+
 import View from 'views/logic/views/View';
 import Query from 'views/logic/queries/Query';
 import Search from 'views/logic/search/Search';
@@ -110,5 +112,36 @@ describe('BindSearchParamsFromQuery should', () => {
         MOCK_VIEW_QUERY_ID,
         expect.objectContaining({ timerange: expectedTimerange }),
       );
+  });
+
+  it('update streams of new search when comma-separated streams parameter was supplied', async () => {
+    const input = {
+      ...defaultInput,
+      query: { streams: 'stream1, stream2,  stream3 ' },
+    };
+
+    await bindSearchParamsFromQuery(input);
+
+    const expectedFilter = Immutable.Map({
+      type: 'or',
+      filters: [{ id: 'stream1', type: 'stream' }, { id: 'stream2', type: 'stream' }, { id: 'stream3', type: 'stream' }],
+    });
+    expect(QueriesActions.update)
+      .toHaveBeenCalledWith(
+        MOCK_VIEW_QUERY_ID,
+        expect.objectContaining({ filter: expectedFilter }),
+      );
+  });
+
+  it('do not update streams of new search when streams parameter was supplied but is empty', async () => {
+    const input = {
+      ...defaultInput,
+      query: { streams: '' },
+    };
+
+    await bindSearchParamsFromQuery(input);
+
+    expect(QueriesActions.update)
+      .not.toHaveBeenCalled();
   });
 });

--- a/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.test.jsx
+++ b/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.test.jsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { cleanup, render } from 'wrappedTestingLibrary';
 import history from 'util/History';
+import * as Immutable from 'immutable';
 
 import asMock from 'helpers/mocking/AsMock';
 import { ViewStore } from 'views/stores/ViewStore';
@@ -34,7 +35,7 @@ const createSearch = (timerange: TimeRange = lastFiveMinutes, streams: Array<str
   .queries([
     Query.builder()
       .timerange(timerange)
-      .filter(filtersForQuery(streams))
+      .filter(filtersForQuery(streams) || Immutable.Map())
       .query(createElasticsearchQueryString(queryString))
       .build(),
   ])

--- a/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.test.jsx
+++ b/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.test.jsx
@@ -8,12 +8,36 @@ import { syncWithQueryParameters } from './SyncWithQueryParameters';
 import Query, { createElasticsearchQueryString } from '../logic/queries/Query';
 import Search from '../logic/search/Search';
 
+jest.mock('views/stores/QueryFiltersStore', () => ({
+  QueryFiltersActions: {
+    streams: {
+      completed: {
+        listen: jest.fn(),
+      },
+    },
+  },
+}));
+
 jest.mock('views/stores/ViewStore', () => ({
   ViewStore: {
     getInitialState: jest.fn(),
   },
 }));
 jest.mock('util/History', () => ({ push: jest.fn(), replace: jest.fn() }));
+
+const createSearch = (timerange, queryString = 'foo:42') => Search.builder()
+  .queries([
+    Query.builder()
+      .timerange(timerange)
+      .query(createElasticsearchQueryString(queryString))
+      .build(),
+  ])
+  .build();
+
+const createView = (search, type = View.Type.Search) => View.builder()
+  .type(type)
+  .search(search)
+  .build();
 
 describe('SyncWithQueryParameters', () => {
   it('does not do anything if no view is loaded', () => {
@@ -28,19 +52,7 @@ describe('SyncWithQueryParameters', () => {
     expect(history.push).not.toHaveBeenCalled();
   });
   describe('if current view is search, adds state to history', () => {
-    const view = View.builder()
-      .type(View.Type.Search)
-      .search(
-        Search.builder()
-          .queries([
-            Query.builder()
-              .timerange({ type: 'relative', range: 600 })
-              .query(createElasticsearchQueryString('foo:42'))
-              .build(),
-          ])
-          .build(),
-      )
-      .build();
+    const view = createView(createSearch({ type: 'relative', range: 600 }));
     it('with current time range and query', () => {
       asMock(ViewStore.getInitialState).mockReturnValueOnce({ view });
 
@@ -56,23 +68,11 @@ describe('SyncWithQueryParameters', () => {
       expect(history.push).toHaveBeenCalledWith('/search?somevalue=23&somethingelse=foo&q=foo%3A42&rangetype=relative&relative=600');
     });
     it('if time range is absolute', () => {
-      const viewWithAbsoluteTimerange = View.builder()
-        .type(View.Type.Search)
-        .search(
-          Search.builder()
-            .queries([
-              Query.builder()
-                .timerange({
-                  type: 'absolute',
-                  from: '2019-01-12T13:42:23.000Z',
-                  to: '2020-01-12T13:42:23.000Z',
-                })
-                .query(createElasticsearchQueryString('foo:42'))
-                .build(),
-            ])
-            .build(),
-        )
-        .build();
+      const viewWithAbsoluteTimerange = createView(createSearch({
+        type: 'absolute',
+        from: '2019-01-12T13:42:23.000Z',
+        to: '2020-01-12T13:42:23.000Z',
+      }));
       asMock(ViewStore.getInitialState).mockReturnValueOnce({ view: viewWithAbsoluteTimerange });
 
       syncWithQueryParameters('/search');
@@ -81,22 +81,10 @@ describe('SyncWithQueryParameters', () => {
         .toHaveBeenCalledWith('/search?q=foo%3A42&rangetype=absolute&from=2019-01-12T13%3A42%3A23.000Z&to=2020-01-12T13%3A42%3A23.000Z');
     });
     it('if time range is keyword time range', () => {
-      const viewWithAbsoluteTimerange = View.builder()
-        .type(View.Type.Search)
-        .search(
-          Search.builder()
-            .queries([
-              Query.builder()
-                .timerange({
-                  type: 'keyword',
-                  keyword: 'Last five minutes',
-                })
-                .query(createElasticsearchQueryString('foo:42'))
-                .build(),
-            ])
-            .build(),
-        )
-        .build();
+      const viewWithAbsoluteTimerange = createView(createSearch({
+        type: 'keyword',
+        keyword: 'Last five minutes',
+      }));
       asMock(ViewStore.getInitialState).mockReturnValueOnce({ view: viewWithAbsoluteTimerange });
 
       syncWithQueryParameters('/search');

--- a/graylog2-web-interface/src/views/logic/queries/Query.js
+++ b/graylog2-web-interface/src/views/logic/queries/Query.js
@@ -5,7 +5,7 @@ import { isEqual } from 'lodash';
 
 export type QueryId = string;
 
-type FilterType = Immutable.Map<string, any>;
+export type FilterType = Immutable.Map<string, any>;
 type SearchTypeList = Array<any>;
 type InternalBuilderState = Immutable.Map<string, any>;
 

--- a/graylog2-web-interface/src/views/logic/queries/Query.js
+++ b/graylog2-web-interface/src/views/logic/queries/Query.js
@@ -32,8 +32,8 @@ export type ElasticsearchQueryString = {
 
 export const createElasticsearchQueryString = (query: string = ''): ElasticsearchQueryString => ({ type: 'elasticsearch', query_string: query });
 
-const _streamFilters = (selectedStreams: Array<string>): Array<{ type: string, id: string }> => {
-  return selectedStreams.map(stream => ({ type: 'stream', id: stream }));
+const _streamFilters = (selectedStreams: Array<string>): Array<Immutable.Map<string, string>> => {
+  return selectedStreams.map(stream => Immutable.Map({ type: 'stream', id: stream }));
 };
 
 export const filtersForQuery = (streams: ?Array<string>): ?FilterType => {

--- a/graylog2-web-interface/src/views/logic/queries/Query.js
+++ b/graylog2-web-interface/src/views/logic/queries/Query.js
@@ -47,6 +47,18 @@ export const filtersForQuery = (streams: ?Array<string>): ?FilterType => {
   });
 };
 
+export const filtersToStreamSet = (filter: ?Immutable.Map<string, any>): Immutable.Set<string> => {
+  if (!filter) {
+    return Immutable.Set();
+  }
+  const type = filter.get('type');
+  if (type === 'stream') {
+    return Immutable.Set([filter.get('id')]);
+  }
+  const filters = filter.get('filters', Immutable.List());
+  return filters.map(filtersToStreamSet).reduce((prev, cur) => prev.merge(cur), Immutable.Set());
+};
+
 export type QueryString = ElasticsearchQueryString;
 
 export type TimeRangeTypes = 'relative' | 'absolute' | 'keyword';

--- a/graylog2-web-interface/src/views/logic/queries/Query.test.jsx
+++ b/graylog2-web-interface/src/views/logic/queries/Query.test.jsx
@@ -1,0 +1,54 @@
+// @flow strict
+import { List, Map, Set } from 'immutable';
+import { filtersToStreamSet } from './Query';
+
+describe('Query', () => {
+  describe('filtersToStreamSet', () => {
+    const singleFilter = Map({
+      type: 'stream',
+      filters: null,
+      id: '000000000000000000000001',
+      title: null,
+    });
+
+    const filter = Map({
+      type: 'or',
+      filters: List([
+        Map({
+          type: 'stream',
+          filters: null,
+          id: '000000000000000000000001',
+          title: null,
+        }),
+        Map({
+          type: 'stream',
+          filters: null,
+          id: '5c2e07eeba33a9681ad6070a',
+          title: null,
+        }),
+        Map({
+          type: 'stream',
+          filters: null,
+          id: '5d2d9649e117dc4df84cf83c',
+          title: null,
+        }),
+      ]),
+    });
+
+    it('returns empty set of stream ids from empty filter', () => {
+      expect(filtersToStreamSet(null)).toEqual(Set());
+    });
+    it('returns set of stream ids from simple filter', () => {
+      expect(filtersToStreamSet(singleFilter)).toEqual(Set([
+        '000000000000000000000001',
+      ]));
+    });
+    it('returns set of stream ids from two-level filter', () => {
+      expect(filtersToStreamSet(filter)).toEqual(Set([
+        '000000000000000000000001',
+        '5c2e07eeba33a9681ad6070a',
+        '5d2d9649e117dc4df84cf83c',
+      ]));
+    });
+  });
+});

--- a/graylog2-web-interface/test/helpers/mocking/index.js
+++ b/graylog2-web-interface/test/helpers/mocking/index.js
@@ -1,3 +1,4 @@
 export { default as CombinedProviderMock } from './CombinedProviderMock';
 export { default as StoreMock } from './StoreMock';
 export { default as StoreProviderMock } from './StoreProviderMock';
+export { default as asMock } from './AsMock';


### PR DESCRIPTION
## Description
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note: Requires #7612 to be merged before. Needs a backport for `3.2`.**

This change is adding support for passing a list of stream ids in a search URL which is used to preselect streams for the newly generated search.

In addition, it uses the currently selected streams to generate URLs in the surrounding search button, so after clicking one of its options, the newly opened search also contains the previously selected streams.

Infrastructurally, this PR introduces a `DrilldownContext`, which supplies the current query, timerange & streams to a widget and its actions. It comes with a `DrilldownContextProvider` component, which consumes the related stores to provide an accurate drilldown context, regardless if the current view is a search or a dashboard or if the global override is used on the latter.

Fixes #6408.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.