### PR TITLE
Expand empty streams to default streams for Aggregation Alerting 3.2

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/PivotAggregationSearchTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/aggregation/PivotAggregationSearchTest.java
@@ -22,6 +22,7 @@ import org.graylog.events.processor.EventDefinition;
 import org.graylog.events.search.MoreSearch;
 import org.graylog.plugins.views.search.db.SearchJobService;
 import org.graylog.plugins.views.search.engine.QueryEngine;
+import org.graylog.plugins.views.search.rest.PermittedStreams;
 import org.graylog.plugins.views.search.searchtypes.pivot.PivotResult;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
@@ -47,6 +48,8 @@ public class PivotAggregationSearchTest {
     private EventDefinition eventDefinition;
     @Mock
     private MoreSearch moreSearch;
+    @Mock
+    private PermittedStreams permittedStreams;
 
     @Test
     public void testExtractValuesWithGroupBy() throws Exception {
@@ -76,7 +79,8 @@ public class PivotAggregationSearchTest {
                 searchJobService,
                 queryEngine,
                 EventsConfigurationTestProvider.create(),
-                moreSearch);
+                moreSearch,
+                permittedStreams);
 
         final PivotResult pivotResult = PivotResult.builder()
                 .id("test")
@@ -168,7 +172,8 @@ public class PivotAggregationSearchTest {
                 searchJobService,
                 queryEngine,
                 EventsConfigurationTestProvider.create(),
-                moreSearch);
+                moreSearch,
+                permittedStreams);
 
         final PivotResult pivotResult = PivotResult.builder()
                 .id("test")
@@ -237,7 +242,8 @@ public class PivotAggregationSearchTest {
                 searchJobService,
                 queryEngine,
                 EventsConfigurationTestProvider.create(),
-                moreSearch);
+                moreSearch,
+                permittedStreams);
 
         final PivotResult pivotResult = PivotResult.builder()
                 .id("test")


### PR DESCRIPTION
We cannot run a query with an empty stream list, because it will
be executed against all known indices in elastic search
and never yield a result.

Thus, like we already do in MoreSearch: If no streams are provided,
use all streams instead.

Fixes #7619