### PR TITLE
Making `PermissionsMixin` proper ES6 module.

### DIFF
--- a/graylog2-web-interface/src/util/PermissionsMixin.js
+++ b/graylog2-web-interface/src/util/PermissionsMixin.js
@@ -16,35 +16,35 @@ const _permissionPredicate = (permissionSet, p) => {
   return (permissionSet.indexOf(`${p}:*`) > -1);
 };
 
-const PermissionsMixin = {
-  isPermitted(possessedPermissions, requiredPermissions) {
-    if (!requiredPermissions || requiredPermissions.length === 0) {
-      return true;
-    }
-    if (!possessedPermissions) {
-      return false;
-    }
-    if (_isWildCard(possessedPermissions)) {
-      return true;
-    }
-    if (requiredPermissions.every) {
-      return requiredPermissions.every(p => _permissionPredicate(possessedPermissions, p));
-    }
-    return _permissionPredicate(possessedPermissions, requiredPermissions);
-  },
-
-  isAnyPermitted(possessedPermissions, requiredPermissions) {
-    if (!requiredPermissions || requiredPermissions.length === 0) {
-      return true;
-    }
-    if (!possessedPermissions) {
-      return false;
-    }
-    if (_isWildCard(possessedPermissions)) {
-      return true;
-    }
-    return requiredPermissions.some(p => _permissionPredicate(possessedPermissions, p));
-  },
+export const isPermitted = (possessedPermissions, requiredPermissions) => {
+  if (!requiredPermissions || requiredPermissions.length === 0) {
+    return true;
+  }
+  if (!possessedPermissions) {
+    return false;
+  }
+  if (_isWildCard(possessedPermissions)) {
+    return true;
+  }
+  if (requiredPermissions.every) {
+    return requiredPermissions.every(p => _permissionPredicate(possessedPermissions, p));
+  }
+  return _permissionPredicate(possessedPermissions, requiredPermissions);
 };
+
+export const isAnyPermitted = (possessedPermissions, requiredPermissions) => {
+  if (!requiredPermissions || requiredPermissions.length === 0) {
+    return true;
+  }
+  if (!possessedPermissions) {
+    return false;
+  }
+  if (_isWildCard(possessedPermissions)) {
+    return true;
+  }
+  return requiredPermissions.some(p => _permissionPredicate(possessedPermissions, p));
+};
+
+const PermissionsMixin = { isPermitted, isAnyPermitted };
 
 export default PermissionsMixin;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, `PermissionsMixin` had a default export that was an
object containing two functions. A lot of consumers actually used named
imports for these functions, which is against ES module conventions,
resulting in webpack warnings since we do emit proper modules during
bundling.

This change is now fixing up the exports of `PermissionsMixin` by adding
two named exports for the used functions, but also keeping the default
export intact for consumers importing it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.