### PR TITLE
Fix act() warning in NewDashboardPage test by summarizing test case

### DIFF
--- a/graylog2-web-interface/src/views/pages/NewDashboardPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/NewDashboardPage.test.jsx
@@ -27,7 +27,7 @@ describe('NewDashboardPage', () => {
     jest.clearAllMocks();
   });
 
-  it('should render minimal and show loading spinner initially', async () => {
+  it('shows loading spinner before rendering page', async () => {
     const { getByText } = render(<SimpleNewDashboardPage />);
 
     expect(getByText('Loading...')).not.toBeNull();

--- a/graylog2-web-interface/src/views/pages/NewDashboardPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/NewDashboardPage.test.jsx
@@ -27,14 +27,11 @@ describe('NewDashboardPage', () => {
     jest.clearAllMocks();
   });
 
-  it('should render minimal', async () => {
+  it('should render minimal and show loading spinner initially', async () => {
     const { getByText } = render(<SimpleNewDashboardPage />);
-    await waitForElement(() => getByText('Extended search page'));
-  });
 
-  it('should show spinner while loading dashboard', () => {
-    const { getByText } = render(<SimpleNewDashboardPage />);
     expect(getByText('Loading...')).not.toBeNull();
+    await waitForElement(() => getByText('Extended search page'));
   });
 
   it('should create new view with type dashboard on mount', async () => {

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.test.jsx
@@ -70,7 +70,7 @@ describe('StreamSearchPage', () => {
     jest.resetModules();
   });
 
-  it('should render minimal and show loading spinner initially', async () => {
+  it('shows loading spinner before rendering page', async () => {
     const { getByText } = render(<SimpleStreamSearchPage />);
 
     expect(getByText('Loading...')).not.toBeNull();


### PR DESCRIPTION
Follow-up PR for #7630.

As described in #7580 some frontend tests are throwing a warning. The `NewDashboardPage.test.jsx` also throwed an `act()` warning, because the component changed after the test has been finished. I fixed this issue by summarizing the related test cases.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

