### PR TITLE
Fix cluster journal statistic api endpoint

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/PathConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/PathConfiguration.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.configuration;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.github.joschi.jadconfig.Parameter;
 
 import java.nio.file.Path;
@@ -42,6 +43,7 @@ public abstract class PathConfiguration {
     public Path getDataDir() {
         return dataDir;
     }
+    @JsonIgnore
     public Path getNativeLibDir() {
         return dataDir.resolve("libnative");
     }


### PR DESCRIPTION
This fixes the "/api/cluster/journal" API endpoint to not throw an error anymore.
In #7359 we introduced the PathConfiguration#getNativeLibDir() method
and this broke deserialization of the JournalSummaryResponse because
"#getNativeLibDir" was automatically serialized but couldn't be
deserialized.

@JsonIgnore this attribute.

Fixes #7521

refs https://github.com/Graylog2/graylog2-server/pull/7526