### PR TITLE
Using field type of sort field for unmapped type in message list. (3.2)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/ViewsBindings.java
@@ -25,8 +25,8 @@ import org.graylog.plugins.views.migrations.V20190127111728_MigrateWidgetFormatS
 import org.graylog.plugins.views.migrations.V20190304102700_MigrateMessageListStructure;
 import org.graylog.plugins.views.migrations.V20190805115800_RemoveDashboardStateFromViews;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.V20191125144500_MigrateDashboardsToViews;
-import org.graylog.plugins.views.migrations.V20191204000000_RemoveLegacyViewsPermissions;
 import org.graylog.plugins.views.migrations.V20191203120602_MigrateSavedSearchesToViewsSupport.V20191203120602_MigrateSavedSearchesToViews;
+import org.graylog.plugins.views.migrations.V20191204000000_RemoveLegacyViewsPermissions;
 import org.graylog.plugins.views.migrations.V20200204122000_MigrateUntypedViewsToDashboards.V20200204122000_MigrateUntypedViewsToDashboards;
 import org.graylog.plugins.views.search.SearchRequirements;
 import org.graylog.plugins.views.search.SearchRequiresParameterSupport;
@@ -34,6 +34,7 @@ import org.graylog.plugins.views.search.ValueParameter;
 import org.graylog.plugins.views.search.db.InMemorySearchJobService;
 import org.graylog.plugins.views.search.db.SearchJobService;
 import org.graylog.plugins.views.search.db.SearchesCleanUpJob;
+import org.graylog.plugins.views.search.elasticsearch.ESGeneratedQueryContext;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.filter.AndFilter;
 import org.graylog.plugins.views.search.filter.OrFilter;
@@ -157,6 +158,7 @@ public class ViewsBindings extends ViewsModule {
 
         install(new FactoryModuleBuilder().build(ViewRequirements.Factory.class));
         install(new FactoryModuleBuilder().build(SearchRequirements.Factory.class));
+        install(new FactoryModuleBuilder().build(ESGeneratedQueryContext.Factory.class));
 
         registerViewRequirement(RequiresParameterSupport.class);
         registerSearchRequirement(SearchRequiresParameterSupport.class);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/ESGeneratedQueryContext.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/ESGeneratedQueryContext.java
@@ -19,6 +19,8 @@ package org.graylog.plugins.views.search.elasticsearch;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.inject.assistedinject.Assisted;
+import com.google.inject.assistedinject.AssistedInject;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
@@ -51,18 +53,38 @@ public class ESGeneratedQueryContext implements GeneratedQueryContext {
     private final Query query;
     private final Set<QueryResult> results;
 
-    public ESGeneratedQueryContext(ElasticsearchBackend elasticsearchBackend, SearchSourceBuilder ssb, SearchJob job, Query query, Set<QueryResult> results) {
+    private final FieldTypesLookup fieldTypes;
+
+    @AssistedInject
+    public ESGeneratedQueryContext(
+            @Assisted ElasticsearchBackend elasticsearchBackend,
+            @Assisted SearchSourceBuilder ssb,
+            @Assisted SearchJob job,
+            @Assisted Query query,
+            @Assisted Set<QueryResult> results,
+            FieldTypesLookup fieldTypes) {
         this.elasticsearchBackend = elasticsearchBackend;
         this.ssb = ssb;
         this.job = job;
         this.query = query;
         this.results = results;
+        this.fieldTypes = fieldTypes;
+    }
+
+    public interface Factory {
+        ESGeneratedQueryContext create(
+                ElasticsearchBackend elasticsearchBackend,
+                SearchSourceBuilder ssb,
+                SearchJob job,
+                Query query,
+                Set<QueryResult> results
+        );
     }
 
     public SearchSourceBuilder searchSourceBuilder(SearchType searchType) {
         return this.searchTypeQueries.computeIfAbsent(searchType.id(), (ignored) -> {
             final QueryBuilder queryBuilder = generateFilterClause(searchType.filter())
-                    .map(filterClause -> (QueryBuilder)new BoolQueryBuilder().must(ssb.query()).must(filterClause))
+                    .map(filterClause -> (QueryBuilder) new BoolQueryBuilder().must(ssb.query()).must(filterClause))
                     .orElse(ssb.query());
             return ssb.copyWithNewSlice(ssb.slice()).query(queryBuilder);
         });
@@ -101,6 +123,10 @@ public class ESGeneratedQueryContext implements GeneratedQueryContext {
 
     public void addAggregations(Collection<AggregationBuilder> builders, SearchType searchType) {
         builders.forEach(builder -> this.searchTypeQueries().get(searchType.id()).aggregation(builder));
+    }
+
+    public Optional<String> fieldType(Set<String> streamIds, String field) {
+        return fieldTypes.getType(streamIds, field);
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackend.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackend.java
@@ -78,7 +78,6 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.graylog2.indexer.cluster.jest.JestUtils.deduplicateErrors;
 
-
 public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContext> {
     private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchBackend.class);
 
@@ -88,6 +87,7 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
     private final IndexRangeService indexRangeService;
     private final StreamService streamService;
     private final ESQueryDecorators esQueryDecorators;
+    private final ESGeneratedQueryContext.Factory queryContextFactory;
 
     @Inject
     public ElasticsearchBackend(Map<String, Provider<ESSearchTypeHandler<? extends SearchType>>> elasticsearchSearchTypeHandlers,
@@ -95,13 +95,15 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
                                 JestClient jestClient,
                                 IndexRangeService indexRangeService,
                                 StreamService streamService,
-                                ESQueryDecorators esQueryDecorators) {
+                                ESQueryDecorators esQueryDecorators,
+                                ESGeneratedQueryContext.Factory queryContextFactory) {
         this.elasticsearchSearchTypeHandlers = elasticsearchSearchTypeHandlers;
         this.queryStringParser = queryStringParser;
         this.jestClient = jestClient;
         this.indexRangeService = indexRangeService;
         this.streamService = streamService;
         this.esQueryDecorators = esQueryDecorators;
+        this.queryContextFactory = queryContextFactory;
     }
 
     private QueryBuilder normalizeQueryString(String queryString) {
@@ -131,7 +133,7 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
                 .from(0)
                 .size(0);
 
-        final ESGeneratedQueryContext queryContext = new ESGeneratedQueryContext(this, searchSourceBuilder, job, query, results);
+        final ESGeneratedQueryContext queryContext = queryContextFactory.create(this, searchSourceBuilder, job, query, results);
         for (SearchType searchType : searchTypes) {
             final SearchSourceBuilder searchTypeSourceBuilder = queryContext.searchSourceBuilder(searchType);
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/FieldTypesLookup.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/FieldTypesLookup.java
@@ -1,0 +1,54 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.views.search.elasticsearch;
+
+import com.google.common.collect.Sets;
+import org.graylog2.indexer.fieldtypes.FieldTypeDTO;
+import org.graylog2.indexer.fieldtypes.IndexFieldTypesService;
+
+import javax.inject.Inject;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class FieldTypesLookup {
+    private final IndexFieldTypesService indexFieldTypesService;
+
+    @Inject
+    public FieldTypesLookup(IndexFieldTypesService indexFieldTypesService) {
+        this.indexFieldTypesService = indexFieldTypesService;
+    }
+
+    private Map<String, Set<String>> get(Set<String> streamIds) {
+        return this.indexFieldTypesService.findForStreamIds(streamIds)
+                .stream()
+                .flatMap(indexFieldTypes -> indexFieldTypes.fields().stream())
+                .collect(Collectors.toMap(
+                        FieldTypeDTO::fieldName,
+                        fieldType -> Collections.singleton(fieldType.physicalType()),
+                        Sets::union
+                ));
+    }
+
+    public Optional<String> getType(Set<String> streamIds, String field) {
+        final Map<String, Set<String>> allFieldTypes = this.get(streamIds);
+        final Set<String> fieldTypes = allFieldTypes.get(field);
+        return fieldTypes == null || fieldTypes.size() > 1 ? Optional.empty() : fieldTypes.stream().findFirst();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesService.java
@@ -23,6 +23,7 @@ import org.bson.types.ObjectId;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.database.MongoDBUpsertRetryer;
+import org.graylog2.streams.StreamService;
 import org.mongojack.DBQuery;
 import org.mongojack.JacksonDBCollection;
 import org.mongojack.WriteResult;
@@ -30,7 +31,10 @@ import org.mongojack.WriteResult;
 import javax.inject.Inject;
 import java.util.Collection;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Manages the "index_field_types" MongoDB collection.
@@ -39,10 +43,13 @@ public class IndexFieldTypesService {
     private static final String FIELDS_FIELD_NAMES = String.format(Locale.US, "%s.%s", IndexFieldTypesDTO.FIELD_FIELDS, FieldTypeDTO.FIELD_NAME);
 
     private final JacksonDBCollection<IndexFieldTypesDTO, ObjectId> db;
+    private final StreamService streamService;
 
     @Inject
     public IndexFieldTypesService(MongoConnection mongoConnection,
+                                  StreamService streamService,
                                   MongoJackObjectMapperProvider objectMapperProvider) {
+        this.streamService = streamService;
         this.db = JacksonDBCollection.wrap(mongoConnection.getDatabase().getCollection("index_field_types"),
                 IndexFieldTypesDTO.class,
                 ObjectId.class,
@@ -103,6 +110,13 @@ public class IndexFieldTypesService {
         return findByQuery(DBQuery.is(IndexFieldTypesDTO.FIELD_INDEX_SET_ID, indexSetId));
     }
 
+    private Collection<IndexFieldTypesDTO> findForIndexSets(Collection<String> indexSetIds) {
+        return findByQuery(DBQuery.or(
+                indexSetIds.stream().map(indexSetId -> DBQuery.is(IndexFieldTypesDTO.FIELD_INDEX_SET_ID, indexSetId))
+                        .toArray(DBQuery.Query[]::new)
+        ));
+    }
+
     public Collection<IndexFieldTypesDTO> findForFieldNames(Collection<String> fieldNames) {
         return findByQuery(DBQuery.in(FIELDS_FIELD_NAMES, fieldNames));
     }
@@ -114,6 +128,16 @@ public class IndexFieldTypesService {
         );
 
         return findByQuery(query);
+    }
+
+    public Collection<IndexFieldTypesDTO> findForStreamIds(Collection<String> streamIds) {
+        final Set<String> indexSetIds = streamService.loadByIds(streamIds)
+                .stream()
+                .filter(Objects::nonNull)
+                .map(stream -> stream.getIndexSet().getConfig().id())
+                .collect(Collectors.toSet());
+
+        return findForIndexSets(indexSetIds);
     }
 
     public Collection<IndexFieldTypesDTO> findAll() {

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendErrorHandlingTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendErrorHandlingTest.java
@@ -76,6 +76,7 @@ public class ElasticsearchBackendErrorHandlingTest extends ElasticsearchBackendT
 
     @Before
     public void setUp() throws Exception {
+        final FieldTypesLookup fieldTypesLookup = mock(FieldTypesLookup.class);
         this.backend = new ElasticsearchBackend(
                 ImmutableMap.of(
                         "dummy", () -> mock(DummyHandler.class)
@@ -84,7 +85,8 @@ public class ElasticsearchBackendErrorHandlingTest extends ElasticsearchBackendT
                 jestClient,
                 indexRangeService,
                 streamService,
-                new ESQueryDecorators(Collections.emptySet())
+                new ESQueryDecorators(Collections.emptySet()),
+                (elasticsearchBackend, ssb, job, query, results) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, job, query, results, fieldTypesLookup)
         );
         when(streamService.loadByIds(any())).thenReturn(Collections.emptySet());
 
@@ -114,7 +116,8 @@ public class ElasticsearchBackendErrorHandlingTest extends ElasticsearchBackendT
                 new SearchSourceBuilder(),
                 searchJob,
                 query,
-                Collections.emptySet()
+                Collections.emptySet(),
+                mock(FieldTypesLookup.class)
         );
 
         searchTypes.forEach(queryContext::searchSourceBuilder);

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendGeneratedRequestTestBase.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendGeneratedRequestTestBase.java
@@ -75,19 +75,30 @@ public class ElasticsearchBackendGeneratedRequestTestBase extends ElasticsearchB
     @Mock
     protected StreamService streamService;
 
+    @Mock
+    protected FieldTypesLookup fieldTypesLookup;
+
+    protected Map<String, Provider<ESSearchTypeHandler<? extends SearchType>>> elasticSearchTypeHandlers;
+
     @Captor
     protected ArgumentCaptor<MultiSearch> clientRequestCaptor;
 
     @Before
     public void setUpSUT() {
-        Map<String, Provider<ESSearchTypeHandler<? extends SearchType>>> elasticSearchTypeHandlers = new HashMap<>();
+        this.elasticSearchTypeHandlers = new HashMap<>();
         final Map<String, ESPivotBucketSpecHandler<? extends BucketSpec, ? extends Aggregation>> bucketHandlers = Collections.emptyMap();
         final Map<String, ESPivotSeriesSpecHandler<? extends SeriesSpec, ? extends Aggregation>> seriesHandlers = new HashMap<>();
         seriesHandlers.put(Average.NAME, new ESAverageHandler());
         seriesHandlers.put(Max.NAME, new ESMaxHandler());
         elasticSearchTypeHandlers.put(Pivot.NAME, () -> new ESPivot(bucketHandlers, seriesHandlers));
 
-        this.elasticsearchBackend = new ElasticsearchBackend(elasticSearchTypeHandlers, queryStringParser, jestClient, indexRangeService, streamService, new ESQueryDecorators.Fake());
+        this.elasticsearchBackend = new ElasticsearchBackend(elasticSearchTypeHandlers,
+                queryStringParser,
+                jestClient,
+                indexRangeService,
+                streamService,
+                new ESQueryDecorators.Fake(),
+                (elasticsearchBackend, ssb, job, query, results) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, job, query, results, fieldTypesLookup));
     }
 
     SearchJob searchJobForQuery(Query query) {

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendTest.java
@@ -53,8 +53,15 @@ public class ElasticsearchBackendTest {
         Map<String, Provider<ESSearchTypeHandler<? extends SearchType>>> handlers = Maps.newHashMap();
         handlers.put(MessageList.NAME, () -> new ESMessageList(new ESQueryDecorators.Fake()));
 
+        final FieldTypesLookup fieldTypesLookup = mock(FieldTypesLookup.class);
         final QueryStringParser queryStringParser = new QueryStringParser();
-        backend = new ElasticsearchBackend(handlers, queryStringParser, null, mock(IndexRangeService.class), mock(StreamService.class), new ESQueryDecorators.Fake());
+        backend = new ElasticsearchBackend(handlers,
+                queryStringParser,
+                null,
+                mock(IndexRangeService.class),
+                mock(StreamService.class),
+                new ESQueryDecorators.Fake(),
+                (elasticsearchBackend, ssb, job, query, results) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, job, query, results, fieldTypesLookup));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendUsingCorrectIndicesTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendUsingCorrectIndicesTest.java
@@ -93,7 +93,14 @@ public class ElasticsearchBackendUsingCorrectIndicesTest extends ElasticsearchBa
     public void setupSUT() throws Exception {
         when(jestClient.execute(any(), any())).thenReturn(resultFor(resourceFile("successfulResponseWithSingleQuery.json")));
 
-        this.backend = new ElasticsearchBackend(handlers, queryStringParser, jestClient, indexRangeService, streamService, new ESQueryDecorators.Fake());
+        final FieldTypesLookup fieldTypesLookup = mock(FieldTypesLookup.class);
+        this.backend = new ElasticsearchBackend(handlers,
+                queryStringParser,
+                jestClient,
+                indexRangeService,
+                streamService,
+                new ESQueryDecorators.Fake(),
+                (elasticsearchBackend, ssb, job, query, results) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, job, query, results, fieldTypesLookup));
     }
 
     @Before

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/FieldTypesLookupTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/FieldTypesLookupTest.java
@@ -1,0 +1,92 @@
+package org.graylog.plugins.views.search.elasticsearch;
+
+import com.google.common.collect.ImmutableSet;
+import org.graylog2.indexer.fieldtypes.FieldTypeDTO;
+import org.graylog2.indexer.fieldtypes.IndexFieldTypesDTO;
+import org.graylog2.indexer.fieldtypes.IndexFieldTypesService;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FieldTypesLookupTest {
+    private IndexFieldTypesService indexFieldTypesService;
+    private FieldTypesLookup fieldTypesLookup;
+
+    @Before
+    public void setUp() {
+        this.indexFieldTypesService = mock(IndexFieldTypesService.class);
+        this.fieldTypesLookup = new FieldTypesLookup(indexFieldTypesService);
+    }
+
+    @Test
+    public void returnsEmptyOptionalIfFieldTypesAreEmpty() {
+        final Optional<String> result = this.fieldTypesLookup.getType(Collections.singleton("SomeStream"), "somefield");
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void returnsEmptyOptionalIfStreamsAreEmpty() {
+        final Optional<String> result = this.fieldTypesLookup.getType(Collections.emptySet(), "somefield");
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void returnsEmptyOptionalIfMultipleTypesExistForField() {
+        when(this.indexFieldTypesService.findForStreamIds(Collections.singleton("stream1"))).thenReturn(ImmutableSet.of(
+                IndexFieldTypesDTO.create("indexSet1", "stream1", ImmutableSet.of(
+                        FieldTypeDTO.create("somefield", "long")
+                )),
+                IndexFieldTypesDTO.create("indexSet2", "stream1", ImmutableSet.of(
+                        FieldTypeDTO.create("somefield", "float")
+                ))
+        ));
+
+        final Optional<String> result = this.fieldTypesLookup.getType(Collections.singleton("stream1"), "somefield");
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void returnsEmptyOptionalIfNoTypesExistForStream() {
+        when(this.indexFieldTypesService.findForStreamIds(Collections.singleton("stream1"))).thenReturn(ImmutableSet.of(
+                IndexFieldTypesDTO.create("indexSet1", "stream1", ImmutableSet.of(
+                        FieldTypeDTO.create("somefield", "long")
+                ))
+        ));
+
+        final Optional<String> result = this.fieldTypesLookup.getType(Collections.singleton("stream2"), "somefield");
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void returnsFieldTypeIfSingleTypeExistsForFieldInStream() {
+        when(this.indexFieldTypesService.findForStreamIds(Collections.singleton("stream1"))).thenReturn(ImmutableSet.of(
+                IndexFieldTypesDTO.create("indexSet1", "stream1", ImmutableSet.of(
+                        FieldTypeDTO.create("somefield", "long")
+                ))
+        ));
+
+        final Optional<String> result = this.fieldTypesLookup.getType(Collections.singleton("stream1"), "somefield");
+        assertThat(result).contains("long");
+    }
+
+    @Test
+    public void returnsFieldTypeIfSingleTypeExistsForFieldInAllStreams() {
+        when(this.indexFieldTypesService.findForStreamIds(ImmutableSet.of("stream1", "stream2"))).thenReturn(ImmutableSet.of(
+                IndexFieldTypesDTO.create("indexSet1", "stream1", ImmutableSet.of(
+                        FieldTypeDTO.create("somefield", "long")
+                )),
+                IndexFieldTypesDTO.create("indexSet2", "stream2", ImmutableSet.of(
+                        FieldTypeDTO.create("somefield", "long")
+                ))
+        ));
+
+        final Optional<String> result = this.fieldTypesLookup.getType(ImmutableSet.of("stream1", "stream2"), "somefield");
+        assertThat(result).contains("long");
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/FieldTypesLookupTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/FieldTypesLookupTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.views.search.elasticsearch;
 
 import com.google.common.collect.ImmutableSet;

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/engine/QueryPlanTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/engine/QueryPlanTest.java
@@ -23,9 +23,11 @@ import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.Search;
 import org.graylog.plugins.views.search.SearchJob;
 import org.graylog.plugins.views.search.SearchType;
+import org.graylog.plugins.views.search.elasticsearch.ESGeneratedQueryContext;
 import org.graylog.plugins.views.search.elasticsearch.ESQueryDecorators;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchBackend;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
+import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
 import org.graylog.plugins.views.search.elasticsearch.searchtypes.ESMessageList;
 import org.graylog.plugins.views.search.elasticsearch.searchtypes.ESSearchTypeHandler;
@@ -54,8 +56,15 @@ public class QueryPlanTest {
         Map<String, Provider<ESSearchTypeHandler<? extends SearchType>>> handlers = Maps.newHashMap();
         handlers.put(MessageList.NAME, () -> new ESMessageList(new ESQueryDecorators.Fake()));
 
+        final FieldTypesLookup fieldTypesLookup = mock(FieldTypesLookup.class);
         final QueryStringParser queryStringParser = new QueryStringParser();
-        ElasticsearchBackend backend = new ElasticsearchBackend(handlers, queryStringParser, null, mock(IndexRangeService.class), mock(StreamService.class), new ESQueryDecorators.Fake());
+        ElasticsearchBackend backend = new ElasticsearchBackend(handlers,
+                queryStringParser,
+                null,
+                mock(IndexRangeService.class),
+                mock(StreamService.class),
+                new ESQueryDecorators.Fake(),
+                (elasticsearchBackend, ssb, job, query, results) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, job, query, results, fieldTypesLookup));
         queryEngine = new QueryEngine(ImmutableMap.of("elasticsearch", backend), Collections.emptySet());
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesServiceTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnectionRule;
+import org.graylog2.streams.StreamService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -33,6 +34,7 @@ import java.util.Set;
 import static com.google.common.collect.ImmutableSet.of;
 import static com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb.InMemoryMongoRuleBuilder.newInMemoryMongoDbRule;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class IndexFieldTypesServiceTest {
     @ClassRule
@@ -45,7 +47,8 @@ public class IndexFieldTypesServiceTest {
     @Before
     public void setUp() throws Exception {
         final MongoJackObjectMapperProvider objectMapperProvider = new MongoJackObjectMapperProvider(new ObjectMapper());
-        this.dbService = new IndexFieldTypesService(mongoRule.getMongoConnection(), objectMapperProvider);
+        final StreamService streamService = mock(StreamService.class);
+        this.dbService = new IndexFieldTypesService(mongoRule.getMongoConnection(), streamService, objectMapperProvider);
     }
 
     @After

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/MongoFieldTypeLookupTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/MongoFieldTypeLookupTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnectionRule;
+import org.graylog2.streams.StreamService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -34,6 +35,7 @@ import java.util.Set;
 import static com.google.common.collect.ImmutableSet.of;
 import static com.lordofthejars.nosqlunit.mongodb.InMemoryMongoDb.InMemoryMongoRuleBuilder.newInMemoryMongoDbRule;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 public class MongoFieldTypeLookupTest {
     @ClassRule
@@ -47,7 +49,8 @@ public class MongoFieldTypeLookupTest {
     @Before
     public void setUp() throws Exception {
         final MongoJackObjectMapperProvider objectMapperProvider = new MongoJackObjectMapperProvider(new ObjectMapper());
-        this.dbService = new IndexFieldTypesService(mongoRule.getMongoConnection(), objectMapperProvider);
+        final StreamService streamService = mock(StreamService.class);
+        this.dbService = new IndexFieldTypesService(mongoRule.getMongoConnection(), streamService, objectMapperProvider);
         this.lookup = new MongoFieldTypeLookup(dbService, new FieldTypeMapper());
     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note: Requires backport to `3.2`.**

Before this change, no `unmapped_type` option was passed to Elasticsearch, when a field was used for sorting retrieved messages. This has the effect that when a field that is being sorted on is not present in all indices, an exception is thrown from ES.

This change is doing these things to address this:

  * Providing a map of field types to all search types through the `ESGeneratedQueryContext`, scoped to the effective streams of this search type
  * Using field types to look up the type of all fields used sorting
  * Adding the `unmapped_type` option to a sort in the `ESMessageList` class, using the retrieved field type for the respective field

Fixes #6490.

(cherry picked from commit ce377d5031f60c6d90aa3d0e42a76ebd4a13594a)

Resolved Conflicts:
-	graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesServiceTest.java
-	graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/MongoFieldTypeLookupTest.java

-> replaced testcontainers-based mongodb setup with nosqlunit-based, because that's still in use for 3.2

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
