### PR TITLE
Make session response creation pluggable

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/sessions/responses/DefaultSessionResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/sessions/responses/DefaultSessionResponse.java
@@ -27,7 +27,7 @@ import java.util.Date;
 @AutoValue
 @WithBeanGetter
 @JsonAutoDetect
-public abstract class SessionResponse {
+public abstract class DefaultSessionResponse {
     @JsonProperty("valid_until")
     public abstract Date validUntil();
 
@@ -38,9 +38,9 @@ public abstract class SessionResponse {
     public abstract String username();
 
     @JsonCreator
-    public static SessionResponse create(@JsonProperty("valid_until") Date validUntil,
+    public static DefaultSessionResponse create(@JsonProperty("valid_until") Date validUntil,
                                          @JsonProperty("session_id") String sessionId,
                                          @JsonProperty("username") String username) {
-        return new AutoValue_SessionResponse(validUntil, sessionId, username);
+        return new AutoValue_DefaultSessionResponse(validUntil, sessionId, username);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/sessions/responses/DefaultSessionResponseFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/sessions/responses/DefaultSessionResponseFactory.java
@@ -1,0 +1,61 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.models.system.sessions.responses;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.shiro.session.Session;
+import org.apache.shiro.subject.Subject;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import javax.inject.Inject;
+import java.util.Date;
+
+/**
+ * Creates a session response which contains the common attributes of the session.
+ */
+public class DefaultSessionResponseFactory implements SessionResponseFactory {
+
+    protected final ObjectMapper objectMapper;
+
+    @Inject
+    public DefaultSessionResponseFactory(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public JsonNode forSession(Session session) {
+        Date validUntil = getValidUntil(session);
+        String id = session.getId().toString();
+        String username = getSubjectFromSession(session).getPrincipal().toString();
+        return toJsonNode(DefaultSessionResponse.create(validUntil, id, username));
+    }
+
+    protected Date getValidUntil(Session session) {
+        return new DateTime(session.getLastAccessTime(), DateTimeZone.UTC).plus(session.getTimeout()).toDate();
+    }
+
+    protected Subject getSubjectFromSession(Session session) {
+        return new Subject.Builder().sessionId(session.getId())
+                .buildSubject();
+    }
+
+    protected JsonNode toJsonNode(Object object) {
+        return objectMapper.valueToTree(object);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/sessions/responses/SessionResponseFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/sessions/responses/SessionResponseFactory.java
@@ -1,0 +1,31 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.rest.models.system.sessions.responses;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.shiro.session.Session;
+
+/**
+ * Factory to create a JSON response for a given session. A plugin may provide a custom implementation, if additional
+ * attributes are required in the response.
+ */
+public interface SessionResponseFactory {
+    /**
+     * Create a JSON response for the given session.
+     */
+    JsonNode forSession(Session session);
+}

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/SecurityBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/SecurityBindings.java
@@ -19,6 +19,8 @@ package org.graylog2.shared.security;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.OptionalBinder;
 import org.graylog2.plugin.PluginModule;
+import org.graylog2.rest.models.system.sessions.responses.DefaultSessionResponseFactory;
+import org.graylog2.rest.models.system.sessions.responses.SessionResponseFactory;
 
 public class SecurityBindings extends PluginModule {
     @Override
@@ -29,5 +31,7 @@ public class SecurityBindings extends PluginModule {
 
         OptionalBinder.newOptionalBinder(binder(), ActorAwareAuthenticationTokenFactory.class)
                       .setDefault().to(ActorAwareUsernamePasswordTokenFactory.class);
+        OptionalBinder.newOptionalBinder(binder(), SessionResponseFactory.class)
+                .setDefault().to(DefaultSessionResponseFactory.class);
     }
 }


### PR DESCRIPTION
Allow plugins to customize the session creation response, being able to include further information for the user.

The reasoning behind this is to make it easier for the frontend to work with external authentication systems, which may need additional user information available in the server.