### PR TITLE
Adding missing license header for `FieldTypesLookup` test/Updating snapshots.

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/FieldTypesLookupTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/FieldTypesLookupTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.views.search.elasticsearch;
 
 import com.google.common.collect.ImmutableSet;

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkForm.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/__snapshots__/BookmarkForm.test.jsx.snap
@@ -40,7 +40,7 @@ exports[`BookmarkForm render the BookmarkForm should render create new 1`] = `
                       "secondary": Object {
                         "due": "#F1F2F2",
                         "tre": "#DCE1E5",
-                        "uno": "#FF3B00",
+                        "uno": "#AD0707",
                       },
                       "tertiary": Object {
                         "cinque": "#FF6418",
@@ -481,7 +481,7 @@ exports[`BookmarkForm render the BookmarkForm should render disabled create new 
                       "secondary": Object {
                         "due": "#F1F2F2",
                         "tre": "#DCE1E5",
-                        "uno": "#FF3B00",
+                        "uno": "#AD0707",
                       },
                       "tertiary": Object {
                         "cinque": "#FF6418",
@@ -999,7 +999,7 @@ exports[`BookmarkForm render the BookmarkForm should render save 1`] = `
                       "secondary": Object {
                         "due": "#F1F2F2",
                         "tre": "#DCE1E5",
-                        "uno": "#FF3B00",
+                        "uno": "#AD0707",
                       },
                       "tertiary": Object {
                         "cinque": "#FF6418",


### PR DESCRIPTION
This PR is doing to things to fix the build:

1. In #7569, a PR was merged with a missing license header. Due to its
dependency on a PR in a different repo, it was merged with a red build. This PR is adding the missing license header so the build passes again.

2. In #7074 not all changes of the PR in snapshots were addresses. This PR is updating missed snapshots.
