### PR TITLE
Reimplement "Replay search" button for dashboard widgets.

### DIFF
--- a/graylog2-web-interface/src/components/search/SearchLink.js
+++ b/graylog2-web-interface/src/components/search/SearchLink.js
@@ -1,0 +1,156 @@
+// @flow strict
+import * as Immutable from 'immutable';
+import URI from 'urijs';
+
+import Routes from 'routing/Routes';
+import type { QueryString, TimeRange } from 'views/logic/queries/Query';
+import { addToQuery, escape } from '../../views/logic/queries/QueryHelper';
+
+type InternalState = {
+  id: string,
+  timerange: TimeRange,
+  query: QueryString,
+  streams: Array<string>,
+  highlightedMessage: string,
+  filterFields: { [string]: mixed },
+};
+
+const _searchTimerange = (timerange: TimeRange) => {
+  const { type } = timerange;
+  const result = { rangetype: type };
+
+  switch (timerange.type) {
+    case 'relative': return { ...result, relative: timerange.range };
+    case 'keyword': return { ...result, keyword: timerange.keyword };
+    case 'absolute': return { ...result, from: timerange.from, to: timerange.to };
+    default: return result;
+  }
+};
+
+const _mergeFilterFieldsToQuery = (query: QueryString, filterFields: { [string]: mixed } = {}) => Object.keys(filterFields)
+  .filter(key => (filterFields[key] !== null && filterFields[key] !== undefined))
+  .map(key => `${key}:"${escape(String(filterFields[key]))}"`)
+  .reduce((prev, cur) => addToQuery(prev, cur), query ? query.query_string : '');
+
+export default class SearchLink {
+  _value: InternalState;
+
+  // eslint-disable-next-line no-undef
+  constructor(
+    id: $PropertyType<InternalState, 'id'>,
+    timerange: $PropertyType<InternalState, 'timerange'>,
+    query: $PropertyType<InternalState, 'query'>,
+    streams: $PropertyType<InternalState, 'streams'>,
+    highlightedMessage: $PropertyType<InternalState, 'highlightedMessage'>,
+    filterFields: $PropertyType<InternalState, 'filterFields'>,
+  ) {
+    this._value = {
+      id,
+      timerange,
+      query,
+      streams,
+      highlightedMessage,
+      filterFields,
+    };
+  }
+
+  get id() {
+    return this._value.id;
+  }
+
+  get timerange() {
+    return this._value.timerange;
+  }
+
+  get query() {
+    return this._value.query;
+  }
+
+  get streams() {
+    return this._value.streams;
+  }
+
+  get highlightedMessage() {
+    return this._value.highlightedMessage;
+  }
+
+  get filterFields() {
+    return this._value.filterFields;
+  }
+
+  static builder() {
+    // eslint-disable-next-line no-use-before-define
+    return new Builder();
+  }
+
+  toURL() {
+    const { id, query, highlightedMessage, streams, filterFields, timerange } = this._value;
+    const queryWithFilterFields = _mergeFilterFieldsToQuery(query, filterFields);
+
+    const searchTimerange = timerange ? _searchTimerange(timerange) : {};
+
+    const params = {
+      ...searchTimerange,
+      q: queryWithFilterFields === '' ? undefined : queryWithFilterFields,
+      highlightMessage: highlightedMessage,
+    };
+
+    const paramsWithStreams = streams && streams.length > 0
+      ? { ...params, streams: streams.join(',') }
+      : params;
+
+    const urlPrefix = id ? `${Routes.SEARCH}/${id}` : Routes.SEARCH;
+
+    const uri = new URI(urlPrefix)
+      .setSearch(paramsWithStreams);
+
+    return uri.toString();
+  }
+}
+
+type BuilderState = Immutable.Map<string, any>;
+
+class Builder {
+  value: BuilderState;
+
+  constructor(value: BuilderState = Immutable.Map()) {
+    this.value = value;
+  }
+
+  // eslint-disable-next-line no-undef
+  id(value: $PropertyType<InternalState, 'id'>) {
+    return new Builder(this.value.set('id', value));
+  }
+
+  timerange(value: $PropertyType<InternalState, 'timerange'>) {
+    return new Builder(this.value.set('timerange', value));
+  }
+
+  query(value: $PropertyType<InternalState, 'query'>) {
+    return new Builder(this.value.set('query', value));
+  }
+
+  streams(value: $PropertyType<InternalState, 'streams'>) {
+    return new Builder(this.value.set('streams', value));
+  }
+
+  highlightedMessage(value: $PropertyType<InternalState, 'highlightedMessage'>) {
+    return new Builder(this.value.set('highlightedMessage', value));
+  }
+
+  filterFields(value: $PropertyType<InternalState, 'filterFields'>) {
+    return new Builder(this.value.set('filterFields', value));
+  }
+
+  build() {
+    const {
+      id,
+      timerange,
+      query,
+      streams,
+      highlightedMessage,
+      filterFields,
+    } = this.value.toObject();
+    return new SearchLink(id, timerange, query, streams, highlightedMessage, filterFields);
+  }
+}

--- a/graylog2-web-interface/src/components/search/SearchLink.test.jsx
+++ b/graylog2-web-interface/src/components/search/SearchLink.test.jsx
@@ -1,0 +1,85 @@
+// @flow strict
+import { createElasticsearchQueryString } from 'views/logic/queries/Query';
+import SearchLink from './SearchLink';
+
+const urlPrefix = '/search';
+
+describe('SearchLink', () => {
+  it('renders the search route only with no parameters', () => {
+    const result = SearchLink.builder().build().toURL();
+
+    expect(result).toEqual(urlPrefix);
+  });
+
+  it('renders the search id', () => {
+    const result = SearchLink.builder().id('somesearchid').build().toURL();
+
+    expect(result).toEqual(`${urlPrefix}/somesearchid`);
+  });
+
+  it('includes the query string', () => {
+    const result = SearchLink.builder()
+      .query(createElasticsearchQueryString('foo:bar'))
+      .build()
+      .toURL();
+
+    expect(result).toEqual(`${urlPrefix}?q=foo%3Abar`);
+  });
+
+  it('includes the time range', () => {
+    const result = SearchLink.builder()
+      .timerange({ type: 'relative', range: 300 })
+      .build()
+      .toURL();
+
+    expect(result).toEqual(`${urlPrefix}?rangetype=relative&relative=300`);
+  });
+
+  it('includes the streams', () => {
+    const result = SearchLink.builder()
+      .streams(['stream1', 'otherstream', 'weird:stream:name'])
+      .build()
+      .toURL();
+
+    expect(result).toEqual(`${urlPrefix}?streams=stream1%2Cotherstream%2Cweird%3Astream%3Aname`);
+  });
+
+  it('includes the id of a highlighted message2', () => {
+    const result = SearchLink.builder()
+      .highlightedMessage('f24c4629-e047-41b7-b3d2-1d30228ea532')
+      .build()
+      .toURL();
+
+    expect(result).toEqual(`${urlPrefix}?highlightMessage=f24c4629-e047-41b7-b3d2-1d30228ea532`);
+  });
+
+  it('merges filter fields into the query string', () => {
+    const result = SearchLink.builder()
+      .query(createElasticsearchQueryString('foo:bar'))
+      .filterFields({ foo: 42, something: 'else' })
+      .build()
+      .toURL();
+
+    expect(result).toEqual(`${urlPrefix}?q=foo%3Abar+AND+foo%3A%2242%22+AND+something%3A%22else%22`);
+  });
+
+  it('combines all parameters', () => {
+    const result = SearchLink.builder()
+      .id('aGreatSearch')
+      .query(createElasticsearchQueryString('_exists_:nf_version'))
+      .timerange({ type: 'keyword', keyword: 'yesterday' })
+      .filterFields({ threat: true, nf_src_address_city_name: 'Berlin' })
+      .highlightedMessage('cd3b6032-4afe-42bd-9166-80ee28eac6c0')
+      .streams(['oneStream', 'anotherStream'])
+      .build()
+      .toURL();
+
+    expect(result).toEqual(
+      `${urlPrefix}/aGreatSearch?`
+      + 'rangetype=keyword&keyword=yesterday'
+      + '&q=_exists_%3Anf_version+AND+threat%3A%22true%22+AND+nf_src_address_city_name%3A%22Berlin%22'
+      + '&highlightMessage=cd3b6032-4afe-42bd-9166-80ee28eac6c0'
+      + '&streams=oneStream%2CanotherStream',
+    );
+  });
+});

--- a/graylog2-web-interface/src/components/search/SurroundingSearchButton.test.jsx
+++ b/graylog2-web-interface/src/components/search/SurroundingSearchButton.test.jsx
@@ -1,18 +1,10 @@
 // @flow strict
 import * as React from 'react';
-import { Map } from 'immutable';
 import { cleanup, fireEvent, render } from 'wrappedTestingLibrary';
 
-import { StoreMock as MockStore, asMock } from 'helpers/mocking';
-import { QueryFiltersStore } from 'views/stores/QueryFiltersStore';
-import { filtersForQuery } from 'views/logic/queries/Query';
+import DrilldownContext from 'views/components/contexts/DrilldownContext';
 import SurroundingSearchButton from './SurroundingSearchButton';
 import type { SearchesConfig } from './SearchConfig';
-import DrilldownContext from '../../views/components/contexts/DrilldownContext';
-
-jest.mock('views/stores/QueryFiltersStore', () => ({
-  QueryFiltersStore: MockStore(['getInitialState', jest.fn()], ['listen', jest.fn(() => () => {})]),
-}));
 
 const getOption = (optionText, getByText) => {
   const button = getByText('Show surrounding messages');
@@ -67,7 +59,7 @@ describe('SurroundingSearchButton', () => {
     const oneSecond = getOption('1 second', getByText);
 
     expect(oneSecond.href).toEqual(
-      'http://localhost/search?rangetype=absolute&from=2020-02-28T09%3A45%3A30.123Z&to=2020-02-28T09%3A45%3A32.123Z&q=&highlightMessage=foo-bar',
+      'http://localhost/search?rangetype=absolute&from=2020-02-28T09%3A45%3A30.123Z&to=2020-02-28T09%3A45%3A32.123Z&highlightMessage=foo-bar',
     );
   });
 
@@ -77,7 +69,7 @@ describe('SurroundingSearchButton', () => {
     const onlyAMinute = getOption('Only a minute', getByText);
 
     expect(onlyAMinute.href).toEqual(
-      'http://localhost/search?rangetype=absolute&from=2020-02-28T09%3A44%3A31.123Z&to=2020-02-28T09%3A46%3A31.123Z&q=&highlightMessage=foo-bar',
+      'http://localhost/search?rangetype=absolute&from=2020-02-28T09%3A44%3A31.123Z&to=2020-02-28T09%3A46%3A31.123Z&highlightMessage=foo-bar',
     );
   });
 
@@ -112,7 +104,6 @@ describe('SurroundingSearchButton', () => {
   });
   it('includes current set of streams in generated urls', () => {
     const streams = ['000000000000000000000001', '5c2e07eeba33a9681ad6070a', '5d2d9649e117dc4df84cf83c'];
-    asMock(QueryFiltersStore.getInitialState).mockReturnValueOnce(Map({ foobar: filtersForQuery(streams) }));
     const { getByText } = render((
       <DrilldownContext.Consumer>
         {drilldown => (
@@ -129,7 +120,6 @@ describe('SurroundingSearchButton', () => {
   });
 
   it('does not include a `streams` key in generated urls if none are selected', () => {
-    asMock(QueryFiltersStore.getInitialState).mockReturnValueOnce(Map());
     const { getByText } = renderButton();
 
     const option = getOption('1 second', getByText);

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.jsx
@@ -2,14 +2,11 @@
 import * as React from 'react';
 import { useContext } from 'react';
 import styled, { type StyledComponent } from 'styled-components';
-import Qs from 'qs';
 
 import { Icon } from 'components/common';
-import Routes from 'routing/Routes';
-import type { TimeRange } from 'views/logic/queries/Query';
-import DrilldownContext from '../contexts/DrilldownContext';
-import SearchLink from '../../../components/search/SearchLink';
+import SearchLink from 'components/search/SearchLink';
 import { createElasticsearchQueryString } from 'views/logic/queries/Query';
+import DrilldownContext from '../contexts/DrilldownContext';
 
 const DitheredIcon: StyledComponent<{}, {}, HTMLElement> = styled(Icon)`
   opacity: 0.3;

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.jsx
@@ -1,0 +1,21 @@
+// @flow strict
+import * as React from 'react';
+import styled, { type StyledComponent } from 'styled-components';
+
+import { Icon } from 'components/common';
+
+const DitheredIcon: StyledComponent<{}, {}, HTMLElement> = styled(Icon)`
+    opacity: 0.3;
+    position: relative;
+    top: 3px;
+`;
+
+const ReplaySearchButton = () => {
+  return (
+    <DitheredIcon name="play" />
+  );
+};
+
+ReplaySearchButton.propTypes = {};
+
+export default ReplaySearchButton;

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.jsx
@@ -1,18 +1,62 @@
 // @flow strict
 import * as React from 'react';
+import { useContext } from 'react';
 import styled, { type StyledComponent } from 'styled-components';
+import Qs from 'qs';
 
 import { Icon } from 'components/common';
+import Routes from 'routing/Routes';
+import type { TimeRange } from 'views/logic/queries/Query';
+import DrilldownContext from '../contexts/DrilldownContext';
 
 const DitheredIcon: StyledComponent<{}, {}, HTMLElement> = styled(Icon)`
-    opacity: 0.3;
-    position: relative;
-    top: 3px;
+  opacity: 0.3;
+  position: relative;
+  top: 3px;
 `;
 
+const NeutralLink: StyledComponent<{}, {}, HTMLAnchorElement> = styled.a`
+  color: inherit;
+  text-decoration: none;
+  
+  &:visited {
+    color: inherit;
+  }
+`;
+
+const _searchTimerange = (timerange: TimeRange) => {
+  const { type } = timerange;
+  const result = { rangetype: type };
+
+  switch (timerange.type) {
+    case 'relative': return { ...result, relative: timerange.range };
+    case 'keyword': return { ...result, keyword: timerange.keyword };
+    case 'absolute': return { ...result, from: timerange.from, to: timerange.to };
+    default: return result;
+  }
+};
+
+const buildSearchLink = (timerange, query, streams) => {
+  const searchTimerange = _searchTimerange(timerange);
+
+  const params = {
+    ...searchTimerange,
+    q: query,
+  };
+  const paramsWithStreams = streams && streams.length > 0
+    ? { ...params, streams: streams.join(',') }
+    : params;
+
+  return `${Routes.SEARCH}?${Qs.stringify(paramsWithStreams)}`;
+};
+
 const ReplaySearchButton = () => {
+  const { query, timerange, streams } = useContext(DrilldownContext);
+  const searchLink = buildSearchLink(timerange, query.query_string, streams);
   return (
-    <DitheredIcon name="play" />
+    <NeutralLink href={searchLink} target="_blank" rel="noopener noreferrer" title="Replay search">
+      <DitheredIcon name="play" />
+    </NeutralLink>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.jsx
@@ -8,6 +8,8 @@ import { Icon } from 'components/common';
 import Routes from 'routing/Routes';
 import type { TimeRange } from 'views/logic/queries/Query';
 import DrilldownContext from '../contexts/DrilldownContext';
+import SearchLink from '../../../components/search/SearchLink';
+import { createElasticsearchQueryString } from 'views/logic/queries/Query';
 
 const DitheredIcon: StyledComponent<{}, {}, HTMLElement> = styled(Icon)`
   opacity: 0.3;
@@ -24,31 +26,12 @@ const NeutralLink: StyledComponent<{}, {}, HTMLAnchorElement> = styled.a`
   }
 `;
 
-const _searchTimerange = (timerange: TimeRange) => {
-  const { type } = timerange;
-  const result = { rangetype: type };
-
-  switch (timerange.type) {
-    case 'relative': return { ...result, relative: timerange.range };
-    case 'keyword': return { ...result, keyword: timerange.keyword };
-    case 'absolute': return { ...result, from: timerange.from, to: timerange.to };
-    default: return result;
-  }
-};
-
-const buildSearchLink = (timerange, query, streams) => {
-  const searchTimerange = _searchTimerange(timerange);
-
-  const params = {
-    ...searchTimerange,
-    q: query,
-  };
-  const paramsWithStreams = streams && streams.length > 0
-    ? { ...params, streams: streams.join(',') }
-    : params;
-
-  return `${Routes.SEARCH}?${Qs.stringify(paramsWithStreams)}`;
-};
+const buildSearchLink = (timerange, query, streams) => SearchLink.builder()
+  .query(createElasticsearchQueryString(query))
+  .timerange(timerange)
+  .streams(streams)
+  .build()
+  .toURL();
 
 const ReplaySearchButton = () => {
   const { query, timerange, streams } = useContext(DrilldownContext);

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.test.jsx
@@ -5,8 +5,8 @@ import { render } from '@testing-library/react';
 import ReplaySearchButton from './ReplaySearchButton';
 
 describe('ReplaySearchButton', () => {
-  it('should do something', () => {
-    const { container } = render(<ReplaySearchButton/>);
-    expect(container).not.toBeNull();
+  it('renders play button', () => {
+    const { getByTitle } = render(<ReplaySearchButton />);
+    expect(getByTitle("Replay search")).not.toBeNull();
   });
 });

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.test.jsx
@@ -40,7 +40,7 @@ describe('ReplaySearchButton', () => {
       const { getByTitle } = render(<ReplaySearchButton />);
       const button = getByTitle('Replay search');
 
-      expect(button.href).toEqual('http://localhost/search?rangetype=relative&relative=300&q=');
+      expect(button.href).toEqual('http://localhost/search?rangetype=relative&relative=300');
     });
 
     it('opening in a new page', () => {

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.test.jsx
@@ -1,0 +1,12 @@
+// @flow strict
+import * as React from 'react';
+import { render } from '@testing-library/react';
+
+import ReplaySearchButton from './ReplaySearchButton';
+
+describe('ReplaySearchButton', () => {
+  it('should do something', () => {
+    const { container } = render(<ReplaySearchButton/>);
+    expect(container).not.toBeNull();
+  });
+});

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.test.jsx
@@ -1,12 +1,77 @@
 // @flow strict
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { cleanup, render } from 'wrappedTestingLibrary';
 
+import { createElasticsearchQueryString } from 'views/logic/queries/Query';
+import type { ElasticsearchQueryString, TimeRange } from 'views/logic/queries/Query';
+import DrilldownContext from '../contexts/DrilldownContext';
 import ReplaySearchButton from './ReplaySearchButton';
 
+type OptionalOverrides = {
+  streams?: Array<string>,
+  query?: ElasticsearchQueryString,
+  timerange?: TimeRange,
+};
+
 describe('ReplaySearchButton', () => {
+  afterEach(cleanup);
   it('renders play button', () => {
     const { getByTitle } = render(<ReplaySearchButton />);
-    expect(getByTitle("Replay search")).not.toBeNull();
+    expect(getByTitle('Replay search')).not.toBeNull();
+  });
+  describe('generates link', () => {
+    const renderWithContext = ({ query, timerange, streams }: OptionalOverrides = {}) => {
+      const { getByTitle } = render((
+        <DrilldownContext.Consumer>
+          {context => (
+            <DrilldownContext.Provider value={{
+              query: query || context.query,
+              timerange: timerange || context.timerange,
+              streams: streams || context.streams,
+            }}>
+              <ReplaySearchButton />
+            </DrilldownContext.Provider>
+          )}
+        </DrilldownContext.Consumer>
+      ));
+      return getByTitle('Replay search');
+    };
+    it('from default drilldown context', () => {
+      const { getByTitle } = render(<ReplaySearchButton />);
+      const button = getByTitle('Replay search');
+
+      expect(button.href).toEqual('http://localhost/search?rangetype=relative&relative=300&q=');
+    });
+
+    it('opening in a new page', () => {
+      const button = renderWithContext();
+
+      expect(button.target).toEqual('_blank');
+      expect(button.rel).toEqual('noopener noreferrer');
+    });
+
+    it('including query string', () => {
+      const button = renderWithContext({ query: createElasticsearchQueryString('_exists_:nf_version') });
+
+      expect(button.href).toContain('q=_exists_%3Anf_version');
+    });
+
+    it('including timerange', () => {
+      const button = renderWithContext({
+        timerange: {
+          type: 'absolute',
+          from: '2020-01-10T13:23:42.000Z',
+          to: '2020-01-10T14:23:42.000Z',
+        },
+      });
+
+      expect(button.href).toContain('rangetype=absolute&from=2020-01-10T13%3A23%3A42.000Z&to=2020-01-10T14%3A23%3A42.000Z');
+    });
+
+    it('including streams', () => {
+      const button = renderWithContext({ streams: ['stream1', 'stream2', 'someotherstream'] });
+
+      expect(button.href).toContain('streams=stream1%2Cstream2%2Csomeotherstream');
+    });
   });
 });

--- a/graylog2-web-interface/src/views/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.jsx
@@ -45,6 +45,8 @@ import IfInteractive from '../dashboard/IfInteractive';
 import InteractiveContext from '../contexts/InteractiveContext';
 import CopyToDashboard from './CopyToDashboardForm';
 import WidgetErrorBoundary from './WidgetErrorBoundary';
+import IfDashboard from '../dashboard/IfDashboard';
+import ReplaySearchButton from './ReplaySearchButton';
 
 type Props = {
   id: string,
@@ -289,6 +291,10 @@ class Widget extends React.Component<Props, State> {
                             onRename={newTitle => TitlesActions.set('widget', id, newTitle)}
                             editing={editing}>
                 <IfInteractive>
+                  <IfDashboard>
+                    <ReplaySearchButton />
+                    {' '}
+                  </IfDashboard>
                   <WidgetHorizontalStretch widgetId={widget.id}
                                            widgetType={widget.type}
                                            onStretch={onPositionsChange}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is reimplementing the "Replay search" button for dashboard widgets. When pressed, it creates a new search (opening in a browser tab, so the users does not lose the current context), recreating the context of the widget (query, time range, streams), allowing the user to see the documents going in to the widget's results and/or starting a drilldown.

In addition to what is contained in the backport (#7648), this PR also contains extracting the generation of search URLs to a separate class (`SearchLink`), which is reused in the surrounding search button.

Fixes #7372.

## Screenshots (if appropriate):
![Screen Shot 2020-03-06 at 11 48 27](https://user-images.githubusercontent.com/41929/76077158-79bc2180-5fa0-11ea-87d9-f76ac2e1c705.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.