### PR TITLE
Reimplement "Replay search" button for dashboard widgets. (3.2)

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.jsx
@@ -1,0 +1,21 @@
+// @flow strict
+import * as React from 'react';
+import styled, { type StyledComponent } from 'styled-components';
+
+import { Icon } from 'components/common';
+
+const DitheredIcon: StyledComponent<{}, {}, HTMLElement> = styled(Icon)`
+    opacity: 0.3;
+    position: relative;
+    top: 3px;
+`;
+
+const ReplaySearchButton = () => {
+  return (
+    <DitheredIcon name="play" />
+  );
+};
+
+ReplaySearchButton.propTypes = {};
+
+export default ReplaySearchButton;

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.jsx
@@ -1,18 +1,62 @@
 // @flow strict
 import * as React from 'react';
+import { useContext } from 'react';
 import styled, { type StyledComponent } from 'styled-components';
+import Qs from 'qs';
 
 import { Icon } from 'components/common';
+import Routes from 'routing/Routes';
+import type { TimeRange } from 'views/logic/queries/Query';
+import DrilldownContext from '../contexts/DrilldownContext';
 
 const DitheredIcon: StyledComponent<{}, {}, HTMLElement> = styled(Icon)`
-    opacity: 0.3;
-    position: relative;
-    top: 3px;
+  opacity: 0.3;
+  position: relative;
+  top: 3px;
 `;
 
+const NeutralLink: StyledComponent<{}, {}, HTMLAnchorElement> = styled.a`
+  color: inherit;
+  text-decoration: none;
+  
+  &:visited {
+    color: inherit;
+  }
+`;
+
+const _searchTimerange = (timerange: TimeRange) => {
+  const { type } = timerange;
+  const result = { rangetype: type };
+
+  switch (timerange.type) {
+    case 'relative': return { ...result, relative: timerange.range };
+    case 'keyword': return { ...result, keyword: timerange.keyword };
+    case 'absolute': return { ...result, from: timerange.from, to: timerange.to };
+    default: return result;
+  }
+};
+
+const buildSearchLink = (timerange, query, streams) => {
+  const searchTimerange = _searchTimerange(timerange);
+
+  const params = {
+    ...searchTimerange,
+    q: query,
+  };
+  const paramsWithStreams = streams && streams.length > 0
+    ? { ...params, streams: streams.join(',') }
+    : params;
+
+  return `${Routes.SEARCH}?${Qs.stringify(paramsWithStreams)}`;
+};
+
 const ReplaySearchButton = () => {
+  const { query, timerange, streams } = useContext(DrilldownContext);
+  const searchLink = buildSearchLink(timerange, query.query_string, streams);
   return (
-    <DitheredIcon name="play" />
+    <NeutralLink href={searchLink} target="_blank" rel="noopener noreferrer" title="Replay search">
+      <DitheredIcon name="play" />
+    </NeutralLink>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.test.jsx
@@ -5,8 +5,8 @@ import { render } from '@testing-library/react';
 import ReplaySearchButton from './ReplaySearchButton';
 
 describe('ReplaySearchButton', () => {
-  it('should do something', () => {
-    const { container } = render(<ReplaySearchButton/>);
-    expect(container).not.toBeNull();
+  it('renders play button', () => {
+    const { getByTitle } = render(<ReplaySearchButton />);
+    expect(getByTitle("Replay search")).not.toBeNull();
   });
 });

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.test.jsx
@@ -1,0 +1,12 @@
+// @flow strict
+import * as React from 'react';
+import { render } from '@testing-library/react';
+
+import ReplaySearchButton from './ReplaySearchButton';
+
+describe('ReplaySearchButton', () => {
+  it('should do something', () => {
+    const { container } = render(<ReplaySearchButton/>);
+    expect(container).not.toBeNull();
+  });
+});

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.test.jsx
@@ -1,12 +1,77 @@
 // @flow strict
 import * as React from 'react';
-import { render } from '@testing-library/react';
+import { cleanup, render } from 'wrappedTestingLibrary';
 
+import { createElasticsearchQueryString } from 'views/logic/queries/Query';
+import type { ElasticsearchQueryString, TimeRange } from 'views/logic/queries/Query';
+import DrilldownContext from '../contexts/DrilldownContext';
 import ReplaySearchButton from './ReplaySearchButton';
 
+type OptionalOverrides = {
+  streams?: Array<string>,
+  query?: ElasticsearchQueryString,
+  timerange?: TimeRange,
+};
+
 describe('ReplaySearchButton', () => {
+  afterEach(cleanup);
   it('renders play button', () => {
     const { getByTitle } = render(<ReplaySearchButton />);
-    expect(getByTitle("Replay search")).not.toBeNull();
+    expect(getByTitle('Replay search')).not.toBeNull();
+  });
+  describe('generates link', () => {
+    const renderWithContext = ({ query, timerange, streams }: OptionalOverrides = {}) => {
+      const { getByTitle } = render((
+        <DrilldownContext.Consumer>
+          {context => (
+            <DrilldownContext.Provider value={{
+              query: query || context.query,
+              timerange: timerange || context.timerange,
+              streams: streams || context.streams,
+            }}>
+              <ReplaySearchButton />
+            </DrilldownContext.Provider>
+          )}
+        </DrilldownContext.Consumer>
+      ));
+      return getByTitle('Replay search');
+    };
+    it('from default drilldown context', () => {
+      const { getByTitle } = render(<ReplaySearchButton />);
+      const button = getByTitle('Replay search');
+
+      expect(button.href).toEqual('http://localhost/search?rangetype=relative&relative=300&q=');
+    });
+
+    it('opening in a new page', () => {
+      const button = renderWithContext();
+
+      expect(button.target).toEqual('_blank');
+      expect(button.rel).toEqual('noopener noreferrer');
+    });
+
+    it('including query string', () => {
+      const button = renderWithContext({ query: createElasticsearchQueryString('_exists_:nf_version') });
+
+      expect(button.href).toContain('q=_exists_%3Anf_version');
+    });
+
+    it('including timerange', () => {
+      const button = renderWithContext({
+        timerange: {
+          type: 'absolute',
+          from: '2020-01-10T13:23:42.000Z',
+          to: '2020-01-10T14:23:42.000Z',
+        },
+      });
+
+      expect(button.href).toContain('rangetype=absolute&from=2020-01-10T13%3A23%3A42.000Z&to=2020-01-10T14%3A23%3A42.000Z');
+    });
+
+    it('including streams', () => {
+      const button = renderWithContext({ streams: ['stream1', 'stream2', 'someotherstream'] });
+
+      expect(button.href).toContain('streams=stream1%2Cstream2%2Csomeotherstream');
+    });
   });
 });

--- a/graylog2-web-interface/src/views/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.jsx
@@ -45,6 +45,8 @@ import IfInteractive from '../dashboard/IfInteractive';
 import InteractiveContext from '../contexts/InteractiveContext';
 import CopyToDashboard from './CopyToDashboardForm';
 import WidgetErrorBoundary from './WidgetErrorBoundary';
+import IfDashboard from '../dashboard/IfDashboard';
+import ReplaySearchButton from './ReplaySearchButton';
 
 type Props = {
   id: string,
@@ -289,6 +291,10 @@ class Widget extends React.Component<Props, State> {
                             onRename={newTitle => TitlesActions.set('widget', id, newTitle)}
                             editing={editing}>
                 <IfInteractive>
+                  <IfDashboard>
+                    <ReplaySearchButton />
+                    {' '}
+                  </IfDashboard>
                   <WidgetHorizontalStretch widgetId={widget.id}
                                            widgetType={widget.type}
                                            onStretch={onPositionsChange}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is reimplementing the "Replay search" button for dashboard widgets. When pressed, it creates a new search (opening in a browser tab, so the users does not lose the current context), recreating the context of the widget (query, time range, streams), allowing the user to see the documents going in to the widget's results and/or starting a drilldown.

Fixes #7372.

## Screenshots (if appropriate):
![Screen Shot 2020-03-06 at 11 48 27](https://user-images.githubusercontent.com/41929/76077158-79bc2180-5fa0-11ea-87d9-f76ac2e1c705.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.