### PR TITLE
Registering callbacks even if search refresh condition hooks fail.

### DIFF
--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -148,12 +148,12 @@ const ExtendedSearchPage = ({ route, location = { query: {} }, router, searchRef
     StreamsActions.refresh();
 
     let storeListenersUnsubscribes = Immutable.List();
-    refreshIfNotUndeclared().then(() => {
+    refreshIfNotUndeclared().finally(() => {
       storeListenersUnsubscribes = storeListenersUnsubscribes
         .push(SearchActions.refresh.listen(refreshIfNotUndeclared))
         .push(ViewActions.search.completed.listen(refreshIfNotUndeclared));
       return null;
-    }, () => { });
+    });
 
     // Returning cleanup function used when unmounting
     return () => { storeListenersUnsubscribes.forEach(unsubscribeFunc => unsubscribeFunc()); };

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.test.jsx
@@ -179,7 +179,6 @@ describe('ExtendedSearchPage', () => {
     expect(ViewActions.search.completed.listen).toHaveBeenCalled();
   });
   it('registers to ViewActions.search.completed even if search refresh condition fails', () => {
-
     mount(<SimpleExtendedSearchPage searchRefreshHools={[() => false]} />);
 
     expect(ViewActions.search.completed.listen).toHaveBeenCalled();

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.test.jsx
@@ -178,6 +178,12 @@ describe('ExtendedSearchPage', () => {
 
     expect(ViewActions.search.completed.listen).toHaveBeenCalled();
   });
+  it('registers to ViewActions.search.completed even if search refresh condition fails', () => {
+
+    mount(<SimpleExtendedSearchPage searchRefreshHools={[() => false]} />);
+
+    expect(ViewActions.search.completed.listen).toHaveBeenCalled();
+  });
   it('unregisters from ViewActions.search.completed upon unmount', () => {
     const unsubscribe = jest.fn();
     ViewActions.search.completed.listen = jest.fn(() => unsubscribe);


### PR DESCRIPTION
## Description
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note: This needs a backport to `3.2`.**

Before this change, the `ExtendedSearchPage` component did not register
callbacks for `ViewActions.search.completed` & `SearchActions.refresh`
if the search refresh condition returned `false` on the initial attempt.

The impact of this is that e.g. when the enterprise plugin is installed
and a search page is opened with an initial query that has unregistered
parameters, the callbacks are never registered and therefore from this
point future updates to the search or refresh requests are not handled.

This change is registering callbacks in any case, regardless of the
search refresh condition results.


<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.