### PR TITLE
Reset dropdown overlay placement, when previously defined opposite placement is no longer suitable

### DIFF
--- a/graylog2-web-interface/src/views/components/OverlayDropdown.jsx
+++ b/graylog2-web-interface/src/views/components/OverlayDropdown.jsx
@@ -33,6 +33,9 @@ const OverlayDropdown = ({ children, menuContainer, onToggle, placement, show, t
 
     if (dropdownLeft + dropdownWidth >= document.body.clientWidth) {
       setCurrentPlacement(oppositePlacement[currentPlacement]);
+    } else if (currentPlacement !== placement) {
+      // reset placement, when previously defined opposite placement is no longer suitable
+      setCurrentPlacement(placement);
     }
   };
 

--- a/graylog2-web-interface/src/views/components/OverlayDropdown.jsx
+++ b/graylog2-web-interface/src/views/components/OverlayDropdown.jsx
@@ -28,14 +28,13 @@ const OverlayDropdown = ({ children, menuContainer, onToggle, placement, show, t
   const toggleTarget = React.createRef();
 
   const handleOverlayEntering = (dropdownElem) => {
-    const dropdownLeft = dropdownElem.offsetLeft;
+    const dropdownOffsetLeft = dropdownElem.offsetLeft;
     const dropdownWidth = dropdownElem.offsetWidth;
-
-    if (dropdownLeft + dropdownWidth >= document.body.clientWidth) {
+    const overflowRight = dropdownOffsetLeft + dropdownWidth >= document.body.clientWidth;
+    const overflowLeft = dropdownOffsetLeft < 0;
+    const trimmedDropdown = (overflowLeft && currentPlacement === 'left') || (overflowRight && currentPlacement === 'right');
+    if (trimmedDropdown) {
       setCurrentPlacement(oppositePlacement[currentPlacement]);
-    } else if (currentPlacement !== placement) {
-      // reset placement, when previously defined opposite placement is no longer suitable
-      setCurrentPlacement(placement);
     }
   };
 


### PR DESCRIPTION
As described here: https://github.com/Graylog2/graylog2-server/pull/7631#pullrequestreview-369469482 the overlay dropdown placement can be wrong. This happens when you:

1. Have a widget on the right side of the search page grid
2. Use the context menu
3. Move the widget to the left side
4. Use the context menu again.

This PR fixes the problem by resetting the placement, when the opposite placement is no longer suitable.

**I will create backport for 3.2 once this PR got merged**

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

