### PR TITLE
Rename 'Aggregate' field action to 'Show top values' (3.2)

### DIFF
--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -200,7 +200,7 @@ export default {
     },
     {
       type: 'aggregate',
-      title: 'Aggregate',
+      title: 'Show top values',
       handler: AggregateActionHandler,
       isEnabled: (({ field, type }) => (!isFunction(field) && !type.isCompound() && !type.isDecorated()): ActionHandlerCondition),
     },


### PR DESCRIPTION
## Description
This PR will rename the field action `Aggregate` to `Show top values`. 

## Motivation and Context
After replacing the old search with the new view [a](https://community.graylog.org/t/rollback-3-2-3-1/13745/3) [lot](https://community.graylog.org/t/rollback-3-2-3-1/13745/7) [of](https://community.graylog.org/t/rollback-3-2-3-1/13745/24) [users](https://community.graylog.org/t/rollback-3-2-3-1/13745/39) could not find the Quick Values
anymore which were not represented by the `Aggregate` button.

But the term ``Aggregate`` is rather confusing as well as quick values. So we decided to rename
the button to `Show top values`. This better represents what will happen.

## How Has This Been Tested?
Open a search and click on a field action and there on `Show top values`.

## Screenshots (if appropriate):
![Graylog (6)](https://user-images.githubusercontent.com/448763/75888817-43f62c00-5e2c-11ea-8918-124661c82d21.png)

Fixes #7483 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.