### PR TITLE
Adding option to share current search to bookmark controls.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.jsx
@@ -32,6 +32,7 @@ type Props = {
   viewStoreState: ViewStoreState,
   currentUser: {
     username: string,
+    permissions: Array<string>,
   },
 };
 
@@ -39,6 +40,7 @@ type State = {
   showForm: boolean,
   showList: boolean,
   showCSVExport: boolean,
+  showShareSearch: boolean,
   newTitle: string,
 };
 

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.test.jsx
@@ -10,9 +10,9 @@ import ViewLoaderContext from 'views/logic/ViewLoaderContext';
 import mockAction from 'helpers/mocking/MockAction';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import NewViewLoaderContext from 'views/logic/NewViewLoaderContext';
+import * as Permissions from 'views/Permissions';
 
 import BookmarkControls from './BookmarkControls';
-import * as Permissions from '../../../Permissions';
 
 const mockUser = {
   username: 'someone',
@@ -29,6 +29,7 @@ describe('BookmarkControls', () => {
   const createViewStoreState = (dirty = true, id) => ({
     activeQuery: '',
     view: View.builder()
+      // $FlowFixMe: allowing `undefined` on purpose
       .id(id)
       .title('title')
       .description('description')

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.test.jsx
@@ -2,6 +2,8 @@
 import React from 'react';
 import { mount } from 'wrappedEnzyme';
 
+import asMock from 'helpers/mocking/AsMock';
+import CurrentUserStore from 'stores/users/CurrentUserStore';
 import View from 'views/logic/views/View';
 import Search from 'views/logic/search/Search';
 import ViewLoaderContext from 'views/logic/ViewLoaderContext';
@@ -10,14 +12,28 @@ import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import NewViewLoaderContext from 'views/logic/NewViewLoaderContext';
 
 import BookmarkControls from './BookmarkControls';
+import * as Permissions from '../../../Permissions';
+
+const mockUser = {
+  username: 'someone',
+  permissions: [],
+};
+
+jest.mock('stores/users/CurrentUserStore', () => ({
+  getInitialState: jest.fn(() => ({ currentUser: mockUser })),
+  listen: jest.fn(() => {}),
+  get: jest.fn(() => mockUser),
+}));
 
 describe('BookmarkControls', () => {
-  const createViewStoreState = (dirty = true) => ({
+  const createViewStoreState = (dirty = true, id) => ({
     activeQuery: '',
     view: View.builder()
+      .id(id)
       .title('title')
       .description('description')
       .search(Search.create().toBuilder().id('id-beef').build())
+      .owner('owningUser')
       .build(),
     dirty,
   });
@@ -51,6 +67,69 @@ describe('BookmarkControls', () => {
       setImmediate(() => {
         expect(onLoadView).toHaveBeenCalledTimes(1);
         done();
+      });
+    });
+    describe('has "Share search" option', () => {
+      it('includes the option to share the current search', () => {
+        const wrapper = mount(<BookmarkControls viewStoreState={createViewStoreState(false, 'some-id')} />);
+
+        expect(wrapper.find('MenuItem[title="Share search"]')).toExist();
+      });
+
+      it('which should be disabled if current user is neither owner nor permitted to edit search', () => {
+        const wrapper = mount(<BookmarkControls viewStoreState={createViewStoreState(false, 'some-id')} />);
+
+        const shareSearch = wrapper.find('MenuItem[title="Share search"]');
+
+        expect(shareSearch).toBeDisabled();
+      });
+      it('which should be enabled if current user is owner of search', () => {
+        const owningUser = {
+          username: 'owningUser',
+          permissions: [],
+        };
+        asMock(CurrentUserStore.getInitialState).mockReturnValue({ currentUser: owningUser });
+        const wrapper = mount(<BookmarkControls viewStoreState={createViewStoreState(false, 'some-id')} />);
+
+        const shareSearch = wrapper.find('MenuItem[title="Share search"]');
+
+        expect(shareSearch).not.toBeDisabled();
+      });
+      it('which should be enabled if current user is permitted to edit search', () => {
+        const owningUser = {
+          username: 'powerfulUser',
+          permissions: [Permissions.View.Edit('some-id')],
+        };
+        asMock(CurrentUserStore.getInitialState).mockReturnValue({ currentUser: owningUser });
+        const wrapper = mount(<BookmarkControls viewStoreState={createViewStoreState(false, 'some-id')} />);
+
+        const shareSearch = wrapper.find('MenuItem[title="Share search"]');
+
+        expect(shareSearch).not.toBeDisabled();
+      });
+      it('which should be enabled if current user is admin', () => {
+        const owningUser = {
+          username: 'powerfulUser',
+          permissions: ['*'],
+        };
+        asMock(CurrentUserStore.getInitialState).mockReturnValue({ currentUser: owningUser });
+        const wrapper = mount(<BookmarkControls viewStoreState={createViewStoreState(false, 'some-id')} />);
+
+        const shareSearch = wrapper.find('MenuItem[title="Share search"]');
+
+        expect(shareSearch).not.toBeDisabled();
+      });
+      it('which should be disabled if search is unsaved', () => {
+        const owningUser = {
+          username: 'powerfulUser',
+          permissions: ['*'],
+        };
+        asMock(CurrentUserStore.getInitialState).mockReturnValue({ currentUser: owningUser });
+        const wrapper = mount(<BookmarkControls viewStoreState={createViewStoreState(false)} />);
+
+        const shareSearch = wrapper.find('MenuItem[title="Share search"]');
+
+        expect(shareSearch).toBeDisabled();
       });
     });
   });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR adds the option in the bookmark controls to share the current search with other users, if the current search has already been saved and if the current user is permitted to edit the current search (the user is either the owner or owns the required permissions).

## Screenshots (if appropriate):
![Screen Shot 2020-03-11 at 17 07 11](https://user-images.githubusercontent.com/41929/76438053-c8135b00-63ba-11ea-80a8-73f652c0291f.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.