### PR TITLE
Implementing `shouldComponentUpdate` for `connect`.

### DIFF
--- a/graylog2-web-interface/src/components/common/URLWhiteListFormModal.jsx
+++ b/graylog2-web-interface/src/components/common/URLWhiteListFormModal.jsx
@@ -27,7 +27,7 @@ type Props = {
   onUpdate: () => void,
   configuration: {},
   currentUser: {permissions: Array<string>},
-  urlType: 'regex' | 'literal',
+  urlType: 'regex' | 'literal' | '',
 };
 
 

--- a/graylog2-web-interface/src/stores/__tests__/EqualityCheck.fixtures.js
+++ b/graylog2-web-interface/src/stores/__tests__/EqualityCheck.fixtures.js
@@ -1,0 +1,30 @@
+// @flow strict
+import { List, Map } from 'immutable';
+
+type MixedMapsAndObjects = { [string]: Map<string, { [string]: Map<string, number> }> };
+
+export const mapWithObject = (): Map<string, { [string]: number }> => Map({ foo: { bar: 42 } });
+export const listWithObject = (): List<{ [string]: { [string]: number } }> => List([{ foo: { bar: 42 } }]);
+export const objectWithMap = (): { [string]: Map<string, number> } => ({ foo: Map({ bar: 42 }) });
+export const arrayOfMaps = (): Array<Map<string, number>> => [Map({ foo: 23 }), Map({ bar: 42 })];
+export const mixedMapsAndObjects = (): MixedMapsAndObjects => ({ foo: Map({ bar: { baz: Map({ qux: 42 }) } }) });
+
+export class AlwaysEqual {
+  equals = () => {
+    return true;
+  };
+}
+
+export class NeverEqual {
+  equals = () => {
+    return false;
+  };
+}
+
+export class NonValueClass {
+  value: number;
+
+  constructor(value: number) {
+    this.value = value;
+  }
+}

--- a/graylog2-web-interface/src/stores/__tests__/connect.test.jsx
+++ b/graylog2-web-interface/src/stores/__tests__/connect.test.jsx
@@ -6,7 +6,18 @@ import PropTypes from 'prop-types';
 import { Map, List } from 'immutable';
 
 import { asMock } from 'helpers/mocking/index';
-import connect from './connect';
+import {
+  arrayOfMaps,
+  listWithObject,
+  mapWithObject,
+  mixedMapsAndObjects,
+  objectWithMap,
+  AlwaysEqual,
+  NeverEqual,
+  NonValueClass,
+} from './EqualityCheck.fixtures';
+
+import connect from '../connect';
 
 const SimpleComponentWithoutStores = () => <span>Hello World!</span>;
 
@@ -41,26 +52,6 @@ SimpleComponentWithDummyStore.propTypes = {
 SimpleComponentWithDummyStore.defaultProps = {
   simpleStore: undefined,
 };
-
-class AlwaysEqual {
-  equals(other) {
-    return true;
-  }
-}
-
-class NeverEqual {
-  equals(other) {
-    return false;
-  }
-}
-
-class NonValueClass {
-  value: number;
-
-  constructor(value: number) {
-    this.value = value;
-  }
-}
 
 describe('connect()', () => {
   it('does not do anything if no stores are provided', () => {
@@ -165,6 +156,11 @@ describe('connect()', () => {
     ${new AlwaysEqual()}     | ${new NeverEqual()}      | ${false}  | ${'value class which is always equal'}
     ${new NeverEqual()}      | ${new AlwaysEqual()}     | ${true}   | ${'value class which is never equal'}
     ${new NonValueClass(23)} | ${new NonValueClass(42)} | ${true}   | ${'value class which is never equal'}
+    ${mapWithObject()}       | ${mapWithObject()}       | ${false}  | ${'immutable maps containing objects'}
+    ${listWithObject()}      | ${listWithObject()}      | ${false}  | ${'immutable lists containing objects'}
+    ${objectWithMap()}       | ${objectWithMap()}       | ${false}  | ${'objects containing immutable maps'}
+    ${arrayOfMaps()}         | ${arrayOfMaps()}         | ${false}  | ${'arrays containing immutable maps'}
+    ${mixedMapsAndObjects()} | ${mixedMapsAndObjects()} | ${false}  | ${'nested immutable maps and objects'}
   `('compares $description and returns $result', verifyShouldComponentUpdate);
   });
 });

--- a/graylog2-web-interface/src/stores/__tests__/isDeepEqual.test.jsx
+++ b/graylog2-web-interface/src/stores/__tests__/isDeepEqual.test.jsx
@@ -1,0 +1,51 @@
+// @flow strict
+import { Map, List } from 'immutable';
+import {
+  arrayOfMaps,
+  listWithObject,
+  mapWithObject,
+  mixedMapsAndObjects,
+  objectWithMap,
+  AlwaysEqual,
+  NeverEqual,
+  NonValueClass,
+} from './EqualityCheck.fixtures';
+
+import isDeepEqual from '../isDeepEqual';
+
+describe('isDeepEqual', () => {
+  const verifyIsDeepEqual = ({ initial, next, result }) => expect(isDeepEqual(initial, next)).toBe(result);
+
+  it.each`
+    initial                  | next                     | result    | description
+    ${undefined}             | ${undefined}             | ${true}   | ${'equal undefined values'}
+    ${undefined}             | ${null}                  | ${false}  | ${'from undefined to null value'}
+    ${undefined}             | ${42}                    | ${false}  | ${'from undefined to numeric value'}
+    ${42}                    | ${42}                    | ${true}   | ${'equal numeric values'}
+    ${42}                    | ${23}                    | ${false}  | ${'non-equal numeric values'}
+    ${'Hello there!'}        | ${'Hello there!'}        | ${true}   | ${'equal string values'}
+    ${'Hello there!'}        | ${'Hello World!'}        | ${false}  | ${'non-equal string values'}
+    ${{}}                    | ${{}}                    | ${true}   | ${'equal empty objects'}
+    ${{ bar: 23 }}           | ${{ bar: 23 }}           | ${true}  | ${'equal objects'}
+    ${{ bar: 23 }}           | ${{ bar: 42 }}           | ${false}  | ${'non-equal objects'}
+    ${[]}                    | ${[]}                    | ${true}   | ${'equal empty arrays'}
+    ${[23]}                  | ${[23]}                  | ${true}   | ${'equal arrays'}
+    ${[23]}                  | ${[42]}                  | ${false}  | ${'non-equal arrays'}
+    ${Map()}                 | ${Map()}                 | ${true}   | ${'equal empty immutable maps'}
+    ${Map({ bar: 23 })}      | ${Map({ bar: 23 })}      | ${true}   | ${'equal immutable maps'}
+    ${Map({ bar: 23 })}      | ${Map({ bar: 42 })}      | ${false}  | ${'non-equal immutable maps'}
+    ${List()}                | ${List()}                | ${true}   | ${'equal empty immutable lists'}
+    ${List([23])}            | ${List([23])}            | ${true}   | ${'equal immutable lists'}
+    ${List([23])}            | ${List([42])}            | ${false}  | ${'non-equal immutable lists'}
+    ${new AlwaysEqual()}     | ${new AlwaysEqual()}     | ${true}   | ${'value class which is always equal'}
+    ${new NeverEqual()}      | ${new NeverEqual()}      | ${false}  | ${'value class which is never equal'}
+    ${new AlwaysEqual()}     | ${new NeverEqual()}      | ${true}   | ${'value class which is always equal'}
+    ${new NeverEqual()}      | ${new AlwaysEqual()}     | ${false}  | ${'value class which is never equal'}
+    ${new NonValueClass(23)} | ${new NonValueClass(42)} | ${false}   | ${'value class which is never equal'}
+    ${mapWithObject()}       | ${mapWithObject()}       | ${true}   | ${'immutable maps containing objects'}
+    ${listWithObject()}      | ${listWithObject()}      | ${true}   | ${'immutable lists containing objects'}
+    ${objectWithMap()}       | ${objectWithMap()}       | ${true}   | ${'objects containing immutable maps'}
+    ${arrayOfMaps()}         | ${arrayOfMaps()}         | ${true}   | ${'arrays containing immutable maps'}
+    ${mixedMapsAndObjects()} | ${mixedMapsAndObjects()} | ${true}   | ${'nested immutable maps and objects'}
+  `('compares $description and returns $result', verifyIsDeepEqual);
+});

--- a/graylog2-web-interface/src/stores/connect.jsx
+++ b/graylog2-web-interface/src/stores/connect.jsx
@@ -101,7 +101,7 @@ function connect<Stores: Object, Props, ComponentType: React.ComponentType<Props
 
     render() {
       const nextProps = this._genProps(this.state);
-      const { key, ref, ...componentProps } = this.props;
+      const { ref, ...componentProps } = this.props;
 
       return <Component {...nextProps} {...componentProps} />;
     }

--- a/graylog2-web-interface/src/stores/connect.jsx
+++ b/graylog2-web-interface/src/stores/connect.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ListenerMethods } from 'reflux';
 import { isEqualWith, isFunction } from 'lodash';
 import * as Immutable from 'immutable';
+import isDeepEqual from './isDeepEqual';
 
 const _isEqual = (first, second) => {
   if (first && first.equals && isFunction(first.equals)) {
@@ -84,7 +85,7 @@ export default (Component, stores, mapProps = props => props) => {
       const thisChildProps = this._genProps(this.state);
       const nextChildProps = this._genProps(nextState);
 
-      return !(isEqualWith(thisChildProps, nextChildProps, _isEqual) && isEqualWith(this.props, nextProps, _isEqual));
+      return !(isDeepEqual(thisChildProps, nextChildProps) && isDeepEqual(this.props, nextProps, _isEqual));
     }
 
     _genProps = (state) => {

--- a/graylog2-web-interface/src/stores/connect.jsx
+++ b/graylog2-web-interface/src/stores/connect.jsx
@@ -9,6 +9,7 @@ type StoreType<State> = {
 };
 
 type ExtractStoreState = <V, Store: StoreType<V>>(Store) => V;
+type ExtractComponentProps = <Props>(React.ComponentType<Props>) => Props;
 
 type ResultType<Stores> = $ObjMap<Stores, ExtractStoreState>;
 
@@ -38,13 +39,13 @@ type ResultType<Stores> = $ObjMap<Stores, ExtractStoreState>;
  *
  */
 
-function connect<Stores: Object, PropsBefore, MappedProps>(
-  Component: React.ComponentType<PropsBefore>,
+function connect<Stores: Object, Props, ComponentType: React.ComponentType<Props>, MappedProps>(
+  Component: ComponentType,
   stores: Stores,
   mapProps: (ResultType<Stores>) => MappedProps = props => props,
-): React.ComponentType<$Diff<PropsBefore, MappedProps>> {
+): React.ComponentType<$Diff<$Call<ExtractComponentProps, ComponentType>, MappedProps>> {
   const wrappedComponentName = Component.displayName || Component.name || 'Unknown/Anonymous';
-  class ConnectStoresWrapper extends React.Component<$Diff<PropsBefore, MappedProps>> {
+  class ConnectStoresWrapper extends React.Component<$Diff<$Call<ExtractComponentProps, ComponentType>, MappedProps>> {
     state: ResultType<Stores>;
 
     unsubscribes: Array<() => void>;

--- a/graylog2-web-interface/src/stores/connect.jsx
+++ b/graylog2-web-interface/src/stores/connect.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ListenerMethods } from 'reflux';
-import { isEqualWith, isFunction } from 'lodash';
+import { isFunction } from 'lodash';
 import * as Immutable from 'immutable';
 import isDeepEqual from './isDeepEqual';
 

--- a/graylog2-web-interface/src/stores/connect.test.jsx
+++ b/graylog2-web-interface/src/stores/connect.test.jsx
@@ -1,9 +1,11 @@
-/* eslint-disable react/no-multi-comp */
+// @flow strict
 import React from 'react';
 import { mount } from 'wrappedEnzyme';
 import Reflux from 'reflux';
 import PropTypes from 'prop-types';
+import { Map, List } from 'immutable';
 
+import { asMock } from 'helpers/mocking/index';
 import connect from './connect';
 
 const SimpleComponentWithoutStores = () => <span>Hello World!</span>;
@@ -39,6 +41,26 @@ SimpleComponentWithDummyStore.propTypes = {
 SimpleComponentWithDummyStore.defaultProps = {
   simpleStore: undefined,
 };
+
+class AlwaysEqual {
+  equals(other) {
+    return true;
+  }
+}
+
+class NeverEqual {
+  equals(other) {
+    return false;
+  }
+}
+
+class NonValueClass {
+  value: number;
+
+  constructor(value: number) {
+    this.value = value;
+  }
+}
 
 describe('connect()', () => {
   it('does not do anything if no stores are provided', () => {
@@ -93,5 +115,56 @@ describe('connect()', () => {
   it('does not fail when anonymous component is passed', () => {
     const Component = connect(() => <span>hello!</span>, { simpleStore: SimpleStore });
     expect(Component.displayName).toEqual('ConnectStoresWrapper[Unknown/Anonymous] stores=simpleStore');
+  });
+
+  describe('generates `shouldComponentUpdate`', () => {
+    const Component = () => <span>Hello!</span>;
+    const SimplestStore = ({
+      getInitialState: jest.fn(),
+      listen: jest.fn(() => () => {}),
+    });
+    it('comparing empty values properly', () => {
+      const ComponentClass = connect(Component, {});
+      const component = new ComponentClass({});
+
+      expect(component.shouldComponentUpdate({}, {})).toBeFalsy();
+    });
+    const verifyShouldComponentUpdate = ({ initial, next, result }) => {
+      asMock(SimplestStore.getInitialState).mockReturnValue(initial);
+      const ComponentClass = connect(Component, { foo: SimplestStore });
+
+      const component = new ComponentClass({});
+      expect(component.shouldComponentUpdate({}, { foo: next })).toBe(result);
+
+      const componentWithProps = new ComponentClass({ someProp: initial });
+      expect(componentWithProps.shouldComponentUpdate({ someProp: next }, { foo: initial })).toBe(result);
+    };
+    it.each`
+    initial                  | next                     | result    | description
+    ${undefined}             | ${undefined}             | ${false}  | ${'equal undefined values'}
+    ${undefined}             | ${null}                  | ${true}   | ${'from undefined to null value'}
+    ${undefined}             | ${42}                    | ${true}   | ${'from undefined to numeric value'}
+    ${42}                    | ${42}                    | ${false}  | ${'equal numeric values'}
+    ${42}                    | ${23}                    | ${true}   | ${'non-equal numeric values'}
+    ${'Hello there!'}        | ${'Hello there!'}        | ${false}  | ${'equal string values'}
+    ${'Hello there!'}        | ${'Hello World!'}        | ${true}   | ${'non-equal string values'}
+    ${{}}                    | ${{}}                    | ${false}  | ${'equal empty objects'}
+    ${{ bar: 23 }}           | ${{ bar: 23 }}           | ${false}  | ${'equal objects'}
+    ${{ bar: 23 }}           | ${{ bar: 42 }}           | ${true}   | ${'non-equal objects'}
+    ${[]}                    | ${[]}                    | ${false}  | ${'equal empty arrays'}
+    ${[23]}                  | ${[23]}                  | ${false}  | ${'equal arrays'}
+    ${[23]}                  | ${[42]}                  | ${true}   | ${'non-equal arrays'}
+    ${Map()}                 | ${Map()}                 | ${false}  | ${'equal empty immutable maps'}
+    ${Map({ bar: 23 })}      | ${Map({ bar: 23 })}      | ${false}  | ${'equal immutable maps'}
+    ${Map({ bar: 23 })}      | ${Map({ bar: 42 })}      | ${true}   | ${'non-equal immutable maps'}
+    ${List()}                | ${List()}                | ${false}  | ${'equal empty immutable lists'}
+    ${List([23])}            | ${List([23])}            | ${false}  | ${'equal immutable lists'}
+    ${List([23])}            | ${List([42])}            | ${true}   | ${'non-equal immutable lists'}
+    ${new AlwaysEqual()}     | ${new AlwaysEqual()}     | ${false}  | ${'value class which is always equal'}
+    ${new NeverEqual()}      | ${new NeverEqual()}      | ${true}   | ${'value class which is never equal'}
+    ${new AlwaysEqual()}     | ${new NeverEqual()}      | ${false}  | ${'value class which is always equal'}
+    ${new NeverEqual()}      | ${new AlwaysEqual()}     | ${true}   | ${'value class which is never equal'}
+    ${new NonValueClass(23)} | ${new NonValueClass(42)} | ${true}   | ${'value class which is never equal'}
+  `('compares $description and returns $result', verifyShouldComponentUpdate);
   });
 });

--- a/graylog2-web-interface/src/stores/isDeepEqual.js
+++ b/graylog2-web-interface/src/stores/isDeepEqual.js
@@ -1,0 +1,20 @@
+// @flow strict
+import { isEqualWith, isFunction } from 'lodash';
+
+const hasFn = (obj, fn) => (obj && obj[fn] && isFunction(obj[fn]));
+const hasEquals = obj => hasFn(obj, 'equals');
+const isImmutable = obj => hasFn(obj, 'toJS');
+
+const _isEqual = (first, second) => {
+  if (isImmutable(first) && isImmutable(second)) {
+    return isEqualWith(first.toJS(), second.toJS(), _isEqual);
+  }
+  if (hasEquals(first)) {
+    return first.equals(second);
+  }
+  return undefined;
+};
+
+const isDeepEqual = (first: any, second: any): boolean => isEqualWith(first, second, _isEqual);
+
+export default isDeepEqual;

--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -92,14 +92,10 @@ import UnknownWidget from './components/widgets/UnknownWidget';
 
 Widget.registerSubtype(AggregationWidget.type, AggregationWidget);
 Widget.registerSubtype(MessagesWidget.type, MessagesWidget);
-// $FlowFixMe: type is not undefined in this case.
 VisualizationConfig.registerSubtype(WorldMapVisualization.type, WorldMapVisualizationConfig);
-// $FlowFixMe: type is not undefined in this case.
 VisualizationConfig.registerSubtype(BarVisualization.type, BarVisualizationConfig);
 VisualizationConfig.registerSubtype(NumberVisualization.type, NumberVisualizationConfig);
-// $FlowFixMe: type is not undefined in this case.
 VisualizationConfig.registerSubtype(LineVisualization.type, LineVisualizationConfig);
-// $FlowFixMe: type is not undefined in this case.
 VisualizationConfig.registerSubtype(AreaVisualization.type, AreaVisualizationConfig);
 
 ViewSharing.registerSubtype(AllUsersOfInstance.Type, AllUsersOfInstance);

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.jsx
@@ -27,7 +27,7 @@ type EventResult = {
   name: 'events',
 };
 
-export type VisualizationComponentProps = {|
+export type VisualizationComponentProps = {
   config: AggregationWidgetConfig,
   data: { [string]: Rows, events?: Events },
   editing?: boolean,
@@ -37,11 +37,18 @@ export type VisualizationComponentProps = {|
   onChange: OnVisualizationConfigChange,
   width: number,
   toggleEdit: () => void,
-|};
+};
 
 export type VisualizationComponent =
-  { type?: string, propTypes?: any }
+  { type: string, propTypes?: any }
   & React.ComponentType<VisualizationComponentProps>;
+
+export const makeVisualization = (component: React.ComponentType<VisualizationComponentProps>, type: string): VisualizationComponent => {
+  // $FlowFixMe: Casting by force
+  const visualizationComponent: VisualizationComponent = component;
+  visualizationComponent.type = type;
+  return visualizationComponent;
+};
 
 const _visualizationForType = (type: string): VisualizationComponent => {
   const visualizationTypes = PluginStore.exports('visualizationTypes');

--- a/graylog2-web-interface/src/views/components/datatable/DataTable.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTable.jsx
@@ -1,11 +1,12 @@
 // @flow strict
-import React, { useContext, useEffect } from 'react';
+import * as React from 'react';
+import { useContext, useEffect } from 'react';
 import * as Immutable from 'immutable';
 import { flatten, isEqual, uniqWith } from 'lodash';
 
+import connect from 'stores/connect';
 import expandRows from 'views/logic/ExpandRows';
 import { defaultCompare } from 'views/logic/DefaultCompare';
-import connect from 'stores/connect';
 
 import { ViewStore } from 'views/stores/ViewStore';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
@@ -18,6 +19,8 @@ import deduplicateValues from './DeduplicateValues';
 import Headers from './Headers';
 import styles from './DataTable.css';
 import RenderCompletionCallback from '../widgets/RenderCompletionCallback';
+import type { VisualizationComponent } from '../aggregationbuilder/AggregationBuilder';
+import { makeVisualization } from '../aggregationbuilder/AggregationBuilder';
 
 type Props = {
   config: AggregationWidgetConfig,
@@ -118,7 +121,6 @@ const DataTable = ({ config, currentView, data, fields }: Props) => {
   );
 };
 
-const ConnectedDataTable = connect(DataTable, { currentView: ViewStore });
-ConnectedDataTable.type = 'table';
+const ConnectedDataTable: VisualizationComponent = makeVisualization(connect(DataTable, { currentView: ViewStore }), 'table');
 
 export default ConnectedDataTable;

--- a/graylog2-web-interface/src/views/components/datatable/DataTable.test.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTable.test.jsx
@@ -41,6 +41,22 @@ describe('DataTable', () => {
   const rowPivot = new Pivot('timestamp', 'time', { interval: 'auto' });
   const series = new Series('count()');
 
+  const SimplifiedDataTable = props => (
+    <DataTable config={AggregationWidgetConfig.builder().build()}
+               currentView={currentView}
+               data={{}}
+               fields={Immutable.List([])}
+               effectiveTimerange={{
+                 type: 'relative',
+                 range: 300,
+               }}
+               toggleEdit={() => {}}
+               onChange={() => {}}
+               height={200}
+               width={300}
+               {...props} />
+  );
+
   it('should render with empty data', () => {
     const config = AggregationWidgetConfig.builder()
       .rowPivots([])
@@ -50,11 +66,8 @@ describe('DataTable', () => {
       .visualization('table')
       .rollup(true)
       .build();
-    const wrapper = mount(<DataTable config={config}
-                                     currentView={currentView}
-                                     data={{}}
-                                     fields={Immutable.List([])} />);
-    expect(wrapper).toMatchSnapshot();
+    const wrapper = mount(<SimplifiedDataTable config={config} />);
+    expect(wrapper.children()).toMatchSnapshot();
   });
 
   it('should render with filled data with rollup', () => {
@@ -66,11 +79,9 @@ describe('DataTable', () => {
       .visualization('table')
       .rollup(true)
       .build();
-    const wrapper = mount(<DataTable config={config}
-                                     currentView={currentView}
-                                     data={data}
-                                     fields={Immutable.List([])} />);
-    expect(wrapper).toMatchSnapshot();
+    const wrapper = mount(<SimplifiedDataTable config={config}
+                                               data={data} />);
+    expect(wrapper.children()).toMatchSnapshot();
   });
 
   it('should render for legacy search result with id as key', () => {
@@ -83,10 +94,8 @@ describe('DataTable', () => {
       .rollup(true)
       .build();
 
-    const wrapper = mount(<DataTable config={config}
-                                     currentView={currentView}
-                                     data={{ 'd8e311db-276c-46e4-ba75-57bf1e0b4d35': rows }}
-                                     fields={Immutable.List([])} />);
+    const wrapper = mount(<SimplifiedDataTable config={config}
+                                               data={{ 'd8e311db-276c-46e4-ba75-57bf1e0b4d35': rows }} />);
     expect(wrapper).toIncludeText('hulud.net');
   });
 
@@ -99,11 +108,9 @@ describe('DataTable', () => {
       .visualization('table')
       .rollup(false)
       .build();
-    const wrapper = mount(<DataTable config={config}
-                                     currentView={currentView}
-                                     data={data}
-                                     fields={Immutable.List([])} />);
-    expect(wrapper).toMatchSnapshot();
+    const wrapper = mount(<SimplifiedDataTable config={config}
+                                               data={data} />);
+    expect(wrapper.children()).toMatchSnapshot();
   });
 
   it('renders column pivot header without offset when rollup is disabled', () => {
@@ -130,11 +137,9 @@ describe('DataTable', () => {
       .visualization('table')
       .rollup(false)
       .build();
-    const wrapper = mount(<DataTable config={config}
-                                     currentView={currentView}
-                                     data={protocolData}
-                                     fields={Immutable.List([])} />);
-    expect(wrapper).toMatchSnapshot();
+    const wrapper = mount(<SimplifiedDataTable config={config}
+                                               data={protocolData} />);
+    expect(wrapper.children()).toMatchSnapshot();
   });
 
   it('passes inferred types to fields', () => {
@@ -191,10 +196,9 @@ describe('DataTable', () => {
       FieldTypeMapping.create('bytes', FieldTypes.LONG()),
       FieldTypeMapping.create('timestamp', FieldTypes.DATE()),
     ]);
-    const wrapper = mount(<DataTable config={config}
-                                     currentView={currentView}
-                                     data={dataWithMoreSeries}
-                                     fields={fields} />);
+    const wrapper = mount(<SimplifiedDataTable config={config}
+                                               fields={fields}
+                                               data={dataWithMoreSeries} />);
 
     const expectFieldType = (elem, type) => expect(wrapper.find(elem).props().type).toEqual(type);
 
@@ -217,16 +221,10 @@ describe('DataTable', () => {
       .visualization('table')
       .rollup(true)
       .build();
-    const Component = () => (
-      <DataTable config={config}
-                 currentView={currentView}
-                 data={[]}
-                 fields={Immutable.List([])} />
-    );
     const onRenderComplete = jest.fn();
     mount((
       <RenderCompletionCallback.Provider value={onRenderComplete}>
-        <Component />
+        <SimplifiedDataTable config={config} />
       </RenderCompletionCallback.Provider>
     ));
     expect(onRenderComplete).toHaveBeenCalled();

--- a/graylog2-web-interface/src/views/components/datatable/__snapshots__/DataTable.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/datatable/__snapshots__/DataTable.test.jsx.snap
@@ -65,7 +65,17 @@ exports[`DataTable renders column pivot header without offset when rollup is dis
       ],
     }
   }
+  effectiveTimerange={
+    Object {
+      "range": 300,
+      "type": "relative",
+    }
+  }
   fields={Immutable.List []}
+  height={200}
+  onChange={[Function]}
+  toggleEdit={[Function]}
+  width={300}
 >
   <DataTable
     config={
@@ -131,7 +141,17 @@ exports[`DataTable renders column pivot header without offset when rollup is dis
         ],
       }
     }
+    effectiveTimerange={
+      Object {
+        "range": 300,
+        "type": "relative",
+      }
+    }
     fields={Immutable.List []}
+    height={200}
+    onChange={[Function]}
+    toggleEdit={[Function]}
+    width={300}
   >
     <div
       className="container"
@@ -1037,7 +1057,17 @@ exports[`DataTable should render with empty data 1`] = `
     }
   }
   data={Object {}}
+  effectiveTimerange={
+    Object {
+      "range": 300,
+      "type": "relative",
+    }
+  }
   fields={Immutable.List []}
+  height={200}
+  onChange={[Function]}
+  toggleEdit={[Function]}
+  width={300}
 >
   <DataTable
     config={
@@ -1059,7 +1089,17 @@ exports[`DataTable should render with empty data 1`] = `
       }
     }
     data={Object {}}
+    effectiveTimerange={
+      Object {
+        "range": 300,
+        "type": "relative",
+      }
+    }
     fields={Immutable.List []}
+    height={200}
+    onChange={[Function]}
+    toggleEdit={[Function]}
+    width={300}
   >
     <div
       className="container"
@@ -1242,7 +1282,17 @@ exports[`DataTable should render with filled data with rollup 1`] = `
       ],
     }
   }
+  effectiveTimerange={
+    Object {
+      "range": 300,
+      "type": "relative",
+    }
+  }
   fields={Immutable.List []}
+  height={200}
+  onChange={[Function]}
+  toggleEdit={[Function]}
+  width={300}
 >
   <DataTable
     config={
@@ -1317,7 +1367,17 @@ exports[`DataTable should render with filled data with rollup 1`] = `
         ],
       }
     }
+    effectiveTimerange={
+      Object {
+        "range": 300,
+        "type": "relative",
+      }
+    }
     fields={Immutable.List []}
+    height={200}
+    onChange={[Function]}
+    toggleEdit={[Function]}
+    width={300}
   >
     <div
       className="container"
@@ -2494,7 +2554,17 @@ exports[`DataTable should render with filled data without rollup 1`] = `
       ],
     }
   }
+  effectiveTimerange={
+    Object {
+      "range": 300,
+      "type": "relative",
+    }
+  }
   fields={Immutable.List []}
+  height={200}
+  onChange={[Function]}
+  toggleEdit={[Function]}
+  width={300}
 >
   <DataTable
     config={
@@ -2569,7 +2639,17 @@ exports[`DataTable should render with filled data without rollup 1`] = `
         ],
       }
     }
+    effectiveTimerange={
+      Object {
+        "range": 300,
+        "type": "relative",
+      }
+    }
     fields={Immutable.List []}
+    height={200}
+    onChange={[Function]}
+    toggleEdit={[Function]}
+    width={300}
   >
     <div
       className="container"

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkControls.jsx
@@ -56,11 +56,7 @@ class BookmarkControls extends React.Component<Props, State> {
     viewStoreState: PropTypes.object.isRequired,
     currentUser: PropTypes.shape({
       username: PropTypes.string.isRequired,
-    }),
-  };
-
-  static defaultProps = {
-    currentUser: undefined,
+    }).isRequired,
   };
 
   constructor(props: Props) {

--- a/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkList.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/bookmark/BookmarkList.jsx
@@ -29,13 +29,12 @@ type State = {
 class BookmarkList extends React.Component<Props, State> {
   static propTypes = {
     toggleModal: PropTypes.func.isRequired,
-    deleteBookmark: PropTypes.func,
+    deleteBookmark: PropTypes.func.isRequired,
     views: PropTypes.object,
   };
 
   static defaultProps = {
     views: {},
-    deleteBookmark: () => {},
   };
 
   constructor(props) {

--- a/graylog2-web-interface/src/views/components/sidebar/FieldTypeIcon.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/FieldTypeIcon.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 
 import { Icon } from 'components/common';
 
+import FieldType from 'views/logic/fieldtypes/FieldType';
 import styles from './FieldTypeIcon.css';
-import FieldType from '../../logic/fieldtypes/FieldType';
 
 const iconClass = (type) => {
   switch (type) {

--- a/graylog2-web-interface/src/views/components/sidebar/SideBar.test.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/SideBar.test.jsx
@@ -2,75 +2,59 @@ import React from 'react';
 import { mount } from 'wrappedEnzyme';
 import PropTypes from 'prop-types';
 
+import { StoreMock as MockStore } from 'helpers/mocking';
 import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
-import { CombinedProviderMock, StoreMock } from 'helpers/mocking';
 import View from 'views/logic/views/View';
-import QueryResult from '../../logic/QueryResult';
+import QueryResult from 'views/logic/QueryResult';
+import SideBar from './SideBar';
 
-// eslint-disable-next-line global-require
-const loadSUT = () => require('./SideBar');
+const mockCurrentUser = { timezone: 'UTC' };
+jest.mock('stores/users/CurrentUserStore', () => MockStore(['get', () => mockCurrentUser], ['getInitialState', () => ({ mockCurrentUser })]));
+jest.mock('stores/sessions/SessionStore', () => MockStore('isLoggedIn'));
 
 describe('<Sidebar />', () => {
-  let TestComponent;
-  let viewMetaData;
-  let queryResult;
-  let query;
+  const viewMetaData = {
+    activeQuery: '34efae1e-e78e-48ab-ab3f-e83c8611a683',
+    description: 'A description',
+    id: '5b34f4c44880a54df9616380',
+    summary: 'query summary',
+    title: 'Query Title',
+  };
+  const effectiveTimerange = { type: 'absolute', from: '2018-08-28T14:34:26.192Z', to: '2018-08-28T14:39:26.192Z' };
+  const duration = 64;
+  const timestamp = '2018-08-28T14:39:26.127Z';
+  const query = {
+    filter: { type: 'or', filters: [] },
+    id: '34efae1e-e78e-48ab-ab3f-e83c8611a683',
+    query: { type: 'elasticsearch', query_string: '*' },
+    search_types: [],
+    timerange: { type: 'relative', range: 300 },
+  };
+  const errors = [];
+  const executionStats = { effective_timerange: effectiveTimerange, duration, timestamp };
+  const queryResult = new QueryResult({ execution_stats: executionStats, query, errors });
 
-  beforeEach(() => {
-    TestComponent = class TestComponentClass extends React.Component {
-      static propTypes = {
-        maximumHeight: PropTypes.number,
-      }
-
-      static defaultProps = {
-        maximumHeight: undefined,
-      }
-
-      getContainerHeight() {
-        const { maximumHeight } = this.props;
-        return maximumHeight;
-      }
-
-      render() {
-        expect(this.props).toHaveProperty('maximumHeight');
-        return <div id="martian">Marc Watney</div>;
-      }
+  class TestComponent extends React.Component {
+    static propTypes = {
+      maximumHeight: PropTypes.number,
     };
 
-    viewMetaData = {
-      activeQuery: '34efae1e-e78e-48ab-ab3f-e83c8611a683',
-      description: 'A description',
-      id: '5b34f4c44880a54df9616380',
-      summary: 'query summary',
-      title: 'Query Title',
+    static defaultProps = {
+      maximumHeight: undefined,
     };
 
-    const effectiveTimerange = { type: 'absolute', from: '2018-08-28T14:34:26.192Z', to: '2018-08-28T14:39:26.192Z' };
-    const duration = 64;
-    const timestamp = '2018-08-28T14:39:26.127Z';
-    query = {
-      filter: { type: 'or', filters: [] },
-      id: '34efae1e-e78e-48ab-ab3f-e83c8611a683',
-      query: { type: 'elasticsearch', query_string: '*' },
-      search_types: [],
-      timerange: { type: 'relative', range: 300 },
-    };
-    const errors = [];
-    const executionStats = { effective_timerange: effectiveTimerange, duration, timestamp };
-    queryResult = new QueryResult({ execution_stats: executionStats, query, errors });
+    getContainerHeight() {
+      const { maximumHeight } = this.props;
+      return maximumHeight;
+    }
 
-    const currentUser = { timezone: 'UTC' };
-    const CurrentUserStore = StoreMock('listen', ['get', () => currentUser], ['getInitialState', () => ({ currentUser })]);
-    const SessionStore = StoreMock('listen');
-    const combinedProviderMock = new CombinedProviderMock({
-      CurrentUser: { CurrentUserStore },
-      Session: { SessionStore },
-    });
-    jest.doMock('injection/CombinedProvider', () => combinedProviderMock);
-  });
+    render() {
+      expect(this.props).toHaveProperty('maximumHeight');
+      return <div id="martian">Marc Watney</div>;
+    }
+  }
 
   it('should render and open when clicking on header', () => {
-    const SideBar = loadSUT();
     const wrapper = mount(
       <SideBar viewMetadata={viewMetaData}
                toggleOpen={jest.fn}
@@ -90,7 +74,6 @@ describe('<Sidebar />', () => {
       id: '5b34f4c44880a54df9616380',
     };
 
-    const SideBar = loadSUT();
     const wrapper = mount(
       <SideBar viewMetadata={emptyViewMetaData}
                toggleOpen={jest.fn}
@@ -111,7 +94,6 @@ describe('<Sidebar />', () => {
       id: '5b34f4c44880a54df9616380',
     };
 
-    const SideBar = loadSUT();
     const wrapper = mount(
       <ViewTypeContext.Provider value={View.Type.Search}>
         <SideBar viewMetadata={emptyViewMetaData}
@@ -133,7 +115,6 @@ describe('<Sidebar />', () => {
       id: '5b34f4c44880a54df9616380',
     };
 
-    const SideBar = loadSUT();
     const wrapper = mount(
       <ViewTypeContext.Provider value={View.Type.Dashboard}>
         <SideBar viewMetadata={emptyViewMetaData}
@@ -150,7 +131,6 @@ describe('<Sidebar />', () => {
   });
 
   it('should render a summary and descirption, for dashboard view', () => {
-    const SideBar = loadSUT();
     const wrapper = mount(
       <ViewTypeContext.Provider value={View.Type.Dashboard}>
         <SideBar viewMetadata={viewMetaData}
@@ -169,7 +149,6 @@ describe('<Sidebar />', () => {
   });
 
   it('should not render a summary and descirption, if the view is not a dashboard', () => {
-    const SideBar = loadSUT();
     const wrapper = mount(
       <SideBar viewMetadata={viewMetaData}
                toggleOpen={jest.fn}
@@ -186,7 +165,6 @@ describe('<Sidebar />', () => {
   });
 
   it('should render widget create options', () => {
-    const SideBar = loadSUT();
     const wrapper = mount(
       <SideBar viewMetadata={viewMetaData}
                toggleOpen={jest.fn}
@@ -202,7 +180,6 @@ describe('<Sidebar />', () => {
   });
 
   it('should render passed children', () => {
-    const SideBar = loadSUT();
     const wrapper = mount(
       <SideBar viewMetadata={viewMetaData}
                toggleOpen={jest.fn}
@@ -218,7 +195,6 @@ describe('<Sidebar />', () => {
   });
 
   it('should close a section when clicking on its title', () => {
-    const SideBar = loadSUT();
     const wrapper = mount(
       <SideBar viewMetadata={viewMetaData}
                toggleOpen={jest.fn}

--- a/graylog2-web-interface/src/views/components/views/CurrentViewTypeProvider.jsx
+++ b/graylog2-web-interface/src/views/components/views/CurrentViewTypeProvider.jsx
@@ -1,16 +1,26 @@
 // @flow strict
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import connect from 'stores/connect';
 
-import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
 import { ViewStore } from 'views/stores/ViewStore';
+import type { ViewType } from 'views/logic/views/View';
+import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
 
-const CurrentViewTypeProvider = connect(
-  ({ type, children }) => <ViewTypeContext.Provider value={type}>{children}</ViewTypeContext.Provider>,
+type Props = {
+  type: ?ViewType,
+  children: React.Node,
+};
+
+const CurrentViewTypeProvider = ({ type, children }: Props) => <ViewTypeContext.Provider value={type}>{children}</ViewTypeContext.Provider>;
+
+CurrentViewTypeProvider.propTypes = {
+  type: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default connect(
+  CurrentViewTypeProvider,
   { view: ViewStore },
-  ({ view }) => ({ type: view && view.view ? view.view.type : undefined }),
+  ({ view }) => ({ type: (view && view.view) ? view.view.type : undefined }),
 );
-
-CurrentViewTypeProvider.propTypes = {};
-
-export default CurrentViewTypeProvider;

--- a/graylog2-web-interface/src/views/components/views/ShareViewModal.test.jsx
+++ b/graylog2-web-interface/src/views/components/views/ShareViewModal.test.jsx
@@ -5,6 +5,7 @@ import { mount } from 'wrappedEnzyme';
 import { ViewSharingActions } from 'views/stores/ViewSharingStore';
 import AllUsersOfInstance from 'views/logic/views/sharing/AllUsersOfInstance';
 import ViewSharing from 'views/logic/views/sharing/ViewSharing';
+import View from 'views/logic/views/View';
 import ShareViewModal from './ShareViewModal';
 
 const mockLoadRoles = jest.fn(() => Promise.resolve([]));
@@ -36,7 +37,7 @@ jest.mock('views/stores/ViewSharingStore', () => ({
 }));
 
 describe('ShareViewModal', () => {
-  const view = { id: 'deadbeef', title: 'My fabulous view' };
+  const view = View.builder().id('deadbeef').title('My fabulous view').build();
   const currentUser = { roles: [], permissions: [] };
   const onClose = jest.fn();
 

--- a/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.jsx
@@ -7,6 +7,7 @@ import toPlotly from 'views/logic/aggregationbuilder/visualizations/Interpolatio
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { AggregationType } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import AreaVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig';
+import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
 import type { ChartDefinition } from '../ChartData';
 import XYPlot from '../XYPlot';
 import { chartData } from '../ChartData';
@@ -22,7 +23,7 @@ const getChartColor = (fullData, name) => {
 
 const setChartColor = (chart, colors) => ({ line: { color: colors[chart.name] } });
 
-const AreaVisualization: VisualizationComponent = ({ config, data, effectiveTimerange }: VisualizationComponentProps) => {
+const AreaVisualization: VisualizationComponent = makeVisualization(({ config, data, effectiveTimerange }: VisualizationComponentProps) => {
   // $FlowFixMe: We need to assume it is a LineVisualizationConfig instance
   const visualizationConfig: AreaVisualizationConfig = config.visualizationConfig || AreaVisualizationConfig.empty();
   const { interpolation = 'linear' } = visualizationConfig;
@@ -51,13 +52,11 @@ const AreaVisualization: VisualizationComponent = ({ config, data, effectiveTime
             setChartColor={setChartColor}
             chartData={chartDataResult} />
   );
-};
+}, 'area');
 
 AreaVisualization.propTypes = {
   config: AggregationType.isRequired,
   data: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
 };
-
-AreaVisualization.type = 'area';
 
 export default AreaVisualization;

--- a/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.jsx
@@ -4,8 +4,9 @@ import PropTypes from 'prop-types';
 
 import { AggregationType } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
-
 import EventHandler from 'views/logic/searchtypes/events/EventHandler';
+import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
+
 import { chartData } from '../ChartData';
 import XYPlot from '../XYPlot';
 
@@ -29,7 +30,7 @@ const getChartColor = (fullData, name) => {
 
 const setChartColor = (chart, colors) => ({ marker: { color: colors[chart.name] } });
 
-const BarVisualization: VisualizationComponent = ({ config, data, effectiveTimerange }: VisualizationComponentProps) => {
+const BarVisualization: VisualizationComponent = makeVisualization(({ config, data, effectiveTimerange }: VisualizationComponentProps) => {
   const { visualizationConfig } = config;
   const layout = {};
 
@@ -58,13 +59,11 @@ const BarVisualization: VisualizationComponent = ({ config, data, effectiveTimer
             setChartColor={setChartColor}
             plotLayout={layout} />
   );
-};
+}, 'bar');
 
 BarVisualization.propTypes = {
   config: AggregationType.isRequired,
   data: PropTypes.object.isRequired,
 };
-
-BarVisualization.type = 'bar';
 
 export default BarVisualization;

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.jsx
@@ -6,6 +6,7 @@ import { values, merge, fill, find, isEmpty, get } from 'lodash';
 
 import { AggregationType } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
+import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
 import type { ChartDefinition, ExtractedSeries } from '../ChartData';
 
 import GenericPlot from '../GenericPlot';
@@ -117,20 +118,18 @@ const _chartLayout = (heatmapData) => {
 
 const _leafSourceMatcher = ({ source }) => source.endsWith('leaf') && source !== 'row-leaf';
 
-const HeatmapVisualization: VisualizationComponent = ({ config, data }: VisualizationComponentProps) => {
+const HeatmapVisualization: VisualizationComponent = makeVisualization(({ config, data }: VisualizationComponentProps) => {
   const rows = data.chart || Object.values(data)[0];
   const heatmapData = chartData(config, rows, 'heatmap', _generateSeries, _formatSeries, _leafSourceMatcher);
   const layout = _chartLayout(heatmapData);
   return (
     <GenericPlot chartData={heatmapData} layout={layout} />
   );
-};
+}, 'heatmap');
 
 HeatmapVisualization.propTypes = {
   config: AggregationType.isRequired,
   data: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
 };
-
-HeatmapVisualization.type = 'heatmap';
 
 export default HeatmapVisualization;

--- a/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.jsx
@@ -7,6 +7,7 @@ import type { VisualizationComponent, VisualizationComponentProps } from 'views/
 import LineVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/LineVisualizationConfig';
 import toPlotly from 'views/logic/aggregationbuilder/visualizations/Interpolation';
 import EventHandler from 'views/logic/searchtypes/events/EventHandler';
+import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
 
 import type { ChartDefinition } from '../ChartData';
 import { chartData } from '../ChartData';
@@ -23,7 +24,7 @@ const getChartColor = (fullData, name) => {
 
 const setChartColor = (chart, colors) => ({ line: { color: colors[chart.name] } });
 
-const LineVisualization: VisualizationComponent = ({ config, data, effectiveTimerange }: VisualizationComponentProps) => {
+const LineVisualization: VisualizationComponent = makeVisualization(({ config, data, effectiveTimerange }: VisualizationComponentProps) => {
   // $FlowFixMe: We need to assume it is a LineVisualizationConfig instance
   const visualizationConfig: LineVisualizationConfig = config.visualizationConfig || LineVisualizationConfig.empty();
   const { interpolation = 'linear' } = visualizationConfig;
@@ -51,13 +52,11 @@ const LineVisualization: VisualizationComponent = ({ config, data, effectiveTime
             setChartColor={setChartColor}
             chartData={chartDataResult} />
   );
-};
+}, 'line');
 
 LineVisualization.propTypes = {
   config: AggregationType.isRequired,
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
-
-LineVisualization.type = 'line';
 
 export default LineVisualization;

--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.jsx
@@ -12,7 +12,11 @@ import DecoratedValue from 'views/components/messagelist/decoration/DecoratedVal
 import CustomHighlighting from 'views/components/messagelist/CustomHighlighting';
 import RenderCompletionCallback from 'views/components/widgets/RenderCompletionCallback';
 import NumberVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/NumberVisualizationConfig';
-import type { VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
+import type {
+  VisualizationComponent,
+  VisualizationComponentProps,
+} from 'views/components/aggregationbuilder/AggregationBuilder';
+import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
 import Trend from './Trend';
 import AutoFontSizer from './AutoFontSizer';
 import type { CurrentViewType } from '../../CustomPropTypes';
@@ -123,7 +127,6 @@ const NumberVisualization = ({ config: { visualizationConfig = NumberVisualizati
   );
 };
 
-const ConnectedNumberVisualization = connect(NumberVisualization, { currentView: ViewStore });
-ConnectedNumberVisualization.type = 'numeric';
+const ConnectedNumberVisualization: VisualizationComponent = makeVisualization(connect(NumberVisualization, { currentView: ViewStore }), 'numeric');
 
 export default ConnectedNumberVisualization;

--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.test.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.test.jsx
@@ -6,6 +6,7 @@ import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import { FieldTypes } from 'views/logic/fieldtypes/FieldType';
 import RenderCompletionCallback from 'views/components/widgets/RenderCompletionCallback';
 import NumberVisualization from './NumberVisualization';
+import AggregationWidgetConfig from '../../../logic/aggregationbuilder/AggregationWidgetConfig';
 
 jest.mock('react-sizeme', () => ({
   SizeMe: ({ children: fn }) => fn({ size: { width: 320, height: 240 } }),
@@ -45,27 +46,32 @@ describe('NumberVisualization', () => {
   const currentView = { activeQuery: 'dead-beef' };
   const fields = List([FieldTypeMapping.create('lines_add', FieldTypes.INT())]);
 
+  const SimplifiedNumberVisualization = (props = {}) => (
+    <NumberVisualization data={data}
+                         width={200}
+                         height={200}
+                         fields={fields}
+                         currentView={currentView}
+                         onChange={() => {}}
+                         toggleEdit={() => {}}
+                         effectiveTimerange={{
+                           type: 'relative',
+                           range: 300,
+                         }}
+                         config={AggregationWidgetConfig.builder().build()}
+                         {...props} />
+  );
+
   it('should render a number visualization', () => {
-    const wrapper = mount(<NumberVisualization data={data}
-                                               width={200}
-                                               height={200}
-                                               fields={fields}
-                                               currentView={currentView} />);
-    expect(wrapper).toMatchSnapshot();
+    const wrapper = mount(<SimplifiedNumberVisualization />);
+    expect(wrapper.find(NumberVisualization)).toMatchSnapshot();
   });
 
   it('calls render completion callback after first render', (done) => {
-    const Component = () => (
-      <NumberVisualization data={data}
-                           width={200}
-                           height={200}
-                           fields={fields}
-                           currentView={currentView} />
-    );
     const onRenderComplete = jest.fn(done);
     mount((
       <RenderCompletionCallback.Provider value={onRenderComplete}>
-        <Component />
+        <SimplifiedNumberVisualization />
       </RenderCompletionCallback.Provider>
     ));
   });
@@ -85,31 +91,25 @@ describe('NumberVisualization', () => {
         ],
       }],
     };
-    const wrapper = mount(<NumberVisualization data={dataWithZeroValue}
-                                               width={300}
-                                               height={300}
-                                               fields={fields}
-                                               currentView={currentView} />);
+    const wrapper = mount(<SimplifiedNumberVisualization data={dataWithZeroValue} />);
     expect(wrapper).toHaveText('0');
   });
   it('renders N/A if value is null', () => {
-    const dataWithZeroValue = [{
-      key: [],
-      source: 'leaf',
-      values: [
-        {
-          key: ['count()'],
-          rollup: true,
-          source: 'row-leaf',
-          value: null,
-        },
-      ],
-    }];
-    const wrapper = mount(<NumberVisualization data={dataWithZeroValue}
-                                               width={300}
-                                               height={300}
-                                               fields={fields}
-                                               currentView={currentView} />);
+    const dataWithZeroValue = {
+      chart: [{
+        key: [],
+        source: 'leaf',
+        values: [
+          {
+            key: ['count()'],
+            rollup: true,
+            source: 'row-leaf',
+            value: null,
+          },
+        ],
+      }],
+    };
+    const wrapper = mount(<SimplifiedNumberVisualization data={dataWithZeroValue} />);
     expect(wrapper).toHaveText('N/A');
   });
 });

--- a/graylog2-web-interface/src/views/components/visualizations/number/__snapshots__/NumberVisualization.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/visualizations/number/__snapshots__/NumberVisualization.test.jsx.snap
@@ -2,6 +2,19 @@
 
 exports[`NumberVisualization should render a number visualization 1`] = `
 <NumberVisualization
+  config={
+    Object {
+      "column_pivots": Array [],
+      "event_annotation": false,
+      "formatting_settings": undefined,
+      "rollup": true,
+      "row_pivots": Array [],
+      "series": Array [],
+      "sort": Array [],
+      "visualization": undefined,
+      "visualization_config": undefined,
+    }
+  }
   currentView={
     Object {
       "activeQuery": "dead-beef",
@@ -27,6 +40,12 @@ exports[`NumberVisualization should render a number visualization 1`] = `
       ],
     }
   }
+  effectiveTimerange={
+    Object {
+      "range": 300,
+      "type": "relative",
+    }
+  }
   fields={
     Immutable.List [
       FieldTypeMapping {
@@ -47,6 +66,8 @@ exports[`NumberVisualization should render a number visualization 1`] = `
     ]
   }
   height={200}
+  onChange={[Function]}
+  toggleEdit={[Function]}
   width={200}
 >
   <NumberVisualization__SingleItemGrid>

--- a/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.jsx
@@ -7,6 +7,7 @@ import type {
   VisualizationComponent,
   VisualizationComponentProps,
 } from 'views/components/aggregationbuilder/AggregationBuilder';
+import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
 
 import GenericPlot from '../GenericPlot';
 import { chartData } from '../ChartData';
@@ -60,17 +61,15 @@ const setChartColor = (chart, colorMap) => {
   return { marker: { colors } };
 };
 
-const PieVisualization: VisualizationComponent = ({ config, data }: VisualizationComponentProps) => (
+const PieVisualization: VisualizationComponent = makeVisualization(({ config, data }: VisualizationComponentProps) => (
   <GenericPlot chartData={chartData(config, data.chart || Object.values(data)[0], 'pie', _generateSeries)}
                getChartColor={getChartColor}
                setChartColor={setChartColor} />
-);
+), 'pie');
 
 PieVisualization.propTypes = {
   config: AggregationType.isRequired,
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
-
-PieVisualization.type = 'pie';
 
 export default PieVisualization;

--- a/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.jsx
@@ -5,13 +5,14 @@ import PropTypes from 'prop-types';
 import EventHandler from 'views/logic/searchtypes/events/EventHandler';
 import { AggregationType } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
+import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
 
 import { chartData } from '../ChartData';
 import XYPlot from '../XYPlot';
 
 const seriesGenerator = (type, name, labels, values) => ({ type, name, x: labels, y: values, mode: 'markers' });
 
-const ScatterVisualization: VisualizationComponent = ({ config, data, effectiveTimerange }: VisualizationComponentProps) => {
+const ScatterVisualization: VisualizationComponent = makeVisualization(({ config, data, effectiveTimerange }: VisualizationComponentProps) => {
   const chartDataResult = chartData(config, data.chart || Object.values(data)[0], 'scatter', seriesGenerator);
   const layout = {};
   if (config.eventAnnotation && data.events) {
@@ -25,13 +26,11 @@ const ScatterVisualization: VisualizationComponent = ({ config, data, effectiveT
             plotLayout={layout}
             effectiveTimerange={effectiveTimerange} />
   );
-};
+}, 'scatter');
 
 ScatterVisualization.propTypes = {
   config: AggregationType.isRequired,
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
-
-ScatterVisualization.type = 'scatter';
 
 export default ScatterVisualization;

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/WorldMapVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/WorldMapVisualization.jsx
@@ -9,6 +9,7 @@ import Viewport from 'views/logic/aggregationbuilder/visualizations/Viewport';
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 import type Pivot from 'views/logic/aggregationbuilder/Pivot';
+import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
 
 import MapVisualization from './MapVisualization';
 import { extractSeries, formatSeries, getLeafsFromRows, getXLabelsFromLeafs } from '../ChartData';
@@ -38,7 +39,7 @@ const _formatSeriesForMap = (rowPivots: Array<Pivot>) => {
   });
 };
 
-const WorldMapVisualization: VisualizationComponent = ({ config, data, editing, onChange, width, ...rest }: VisualizationComponentProps) => {
+const WorldMapVisualization: VisualizationComponent = makeVisualization(({ config, data, editing, onChange, width, ...rest }: VisualizationComponentProps) => {
   const { rowPivots } = config;
   const onRenderComplete = useContext(RenderCompletionCallback);
   const hasMetric = !isEmpty(config.series);
@@ -77,7 +78,7 @@ const WorldMapVisualization: VisualizationComponent = ({ config, data, editing, 
                       markerRadiusSize={markerRadiusSize}
                       onChange={_onChange} />
   );
-};
+}, 'map');
 
 WorldMapVisualization.propTypes = {
   config: AggregationType.isRequired,
@@ -85,7 +86,5 @@ WorldMapVisualization.propTypes = {
   onChange: PropTypes.func.isRequired,
   width: PropTypes.number.isRequired,
 };
-
-WorldMapVisualization.type = 'map';
 
 export default WorldMapVisualization;

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -15,6 +15,8 @@ import { SearchActions, SearchStore } from 'views/stores/SearchStore';
 import { RefreshActions } from 'views/stores/RefreshStore';
 import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
 import type { TimeRange } from 'views/logic/queries/Query';
+import type { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
+import type { ViewStoreState } from 'views/stores/ViewStore';
 
 import { PaginatedList } from 'components/common';
 import CustomPropTypes from 'views/components/CustomPropTypes';
@@ -23,7 +25,6 @@ import ErrorWidget from 'views/components/widgets/ErrorWidget';
 import SortConfig from 'views/logic/aggregationbuilder/SortConfig';
 
 import RenderCompletionCallback from './RenderCompletionCallback';
-import type { FieldTypeMappingsList } from '../../stores/FieldTypesStore';
 
 const { InputsActions } = CombinedProvider.get('Inputs');
 
@@ -56,12 +57,7 @@ type State = {
 
 type Props = {
   config: MessagesWidgetConfig,
-  currentView: {
-    activeQuery: string,
-    view: {
-      id: number,
-    },
-  },
+  currentView: ViewStoreState,
   data: { messages: Array<Object>, total: number, id: string },
   editing: boolean,
   fields: FieldTypeMappingsList,

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -87,7 +87,7 @@ class MessageList extends React.Component<Props, State> {
   };
 
   static defaultProps = {
-    onConfigChange: () => {},
+    onConfigChange: () => Promise.resolve(),
     pageSize: Messages.DEFAULT_LIMIT,
     selectedFields: Immutable.Set(),
   };

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
@@ -1,10 +1,10 @@
 // @flow strict
+import isDeepEqual from 'stores/isDeepEqual';
 import { DEFAULT_RANGE_TYPE } from 'views/Constants';
-
 import { QueriesActions } from 'views/stores/QueriesStore';
 import type { ViewHook } from 'views/logic/hooks/ViewHook';
 import View from 'views/logic/views/View';
-import { createElasticsearchQueryString, filtersForQuery } from '../logic/queries/Query';
+import { createElasticsearchQueryString, filtersForQuery } from 'views/logic/queries/Query';
 
 const _getTimerange = (query = {}) => {
   const type = query.rangetype || DEFAULT_RANGE_TYPE;
@@ -64,9 +64,12 @@ const bindSearchParamsFromQuery: ViewHook = ({ query, view }) => {
   if (streams) {
     queryBuilder = queryBuilder.filter(streams);
   }
+  const newQuery = queryBuilder.build();
 
-  return QueriesActions.update(firstQuery.id, queryBuilder.build())
-    .then(() => true, () => false);
+  return isDeepEqual(newQuery, firstQuery)
+    ? Promise.resolve(true)
+    : QueriesActions.update(firstQuery.id, queryBuilder.build())
+      .then(() => true, () => false);
 };
 
 export default bindSearchParamsFromQuery;

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidget.js
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidget.js
@@ -1,9 +1,9 @@
-import { Map, is } from 'immutable';
+import { Map } from 'immutable';
 
+import isDeepEqual from 'stores/isDeepEqual';
 import isEqualForSearch from 'views/stores/isEqualForSearch';
 import AggregationWidgetConfig from './AggregationWidgetConfig';
 import Widget from '../widgets/Widget';
-import isDeepEqual from '../../../stores/isDeepEqual';
 
 export default class AggregationWidget extends Widget {
   constructor(id, config, filter, timerange, query, streams) {

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidget.js
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidget.js
@@ -1,7 +1,9 @@
 import { Map, is } from 'immutable';
 
+import isEqualForSearch from 'views/stores/isEqualForSearch';
 import AggregationWidgetConfig from './AggregationWidgetConfig';
 import Widget from '../widgets/Widget';
+import isDeepEqual from '../../../stores/isDeepEqual';
 
 export default class AggregationWidget extends Widget {
   constructor(id, config, filter, timerange, query, streams) {
@@ -28,7 +30,14 @@ export default class AggregationWidget extends Widget {
 
   equals(other) {
     if (other instanceof AggregationWidget) {
-      return ['id', 'config', 'filter', 'timerange', 'query', 'streams'].every(key => is(this[key], other[key]));
+      return ['id', 'config', 'filter', 'timerange', 'query', 'streams'].every(key => isDeepEqual(this[key], other[key]));
+    }
+    return false;
+  }
+
+  equalsForSearch(other) {
+    if (other instanceof AggregationWidget) {
+      return ['id', 'config', 'filter', 'timerange', 'query', 'streams'].every(key => isEqualForSearch(this[key], other[key]));
     }
     return false;
   }

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidgetConfig.js
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/AggregationWidgetConfig.js
@@ -1,7 +1,9 @@
 // @flow strict
 import * as Immutable from 'immutable';
 
+import isDeepEqual from 'stores/isDeepEqual';
 import { TIMESTAMP_FIELD } from 'views/Constants';
+import isEqualForSearch from 'views/stores/isEqualForSearch';
 import Pivot from './Pivot';
 import Series from './Series';
 import VisualizationConfig from './visualizations/VisualizationConfig';
@@ -144,10 +146,27 @@ export default class AggregationWidgetConfig extends WidgetConfig {
   }
 
   equals(other: any) {
-    const { is } = Immutable;
+    if (other instanceof AggregationWidgetConfig) {
+      return [
+        'columnPivots',
+        'rowPivots',
+        'series',
+        'sort',
+        'rollup',
+        'eventAnnotation',
+        'visualizationConfig',
+        'visualization',
+        'formattingSettings',
+      ]
+        .every(key => isDeepEqual(this[key], other[key]));
+    }
+    return false;
+  }
+
+  equalsForSearch(other: any) {
     if (other instanceof AggregationWidgetConfig) {
       return ['rowPivots', 'columnPivots', 'series', 'sort', 'rollup', 'eventAnnotation', 'visualizationConfig']
-        .every(key => is(Immutable.fromJS(this[key]), Immutable.fromJS(other[key])));
+        .every(key => isEqualForSearch(this[key], other[key]));
     }
     return false;
   }

--- a/graylog2-web-interface/src/views/logic/queries/Query.js
+++ b/graylog2-web-interface/src/views/logic/queries/Query.js
@@ -34,7 +34,7 @@ export type ElasticsearchQueryString = {
 export const createElasticsearchQueryString = (query: string = ''): ElasticsearchQueryString => ({ type: 'elasticsearch', query_string: query });
 
 const _streamFilters = (selectedStreams: Array<string>): Array<Immutable.Map<string, string>> => {
-  return selectedStreams.map(stream => Immutable.Map({ type: 'stream', id: stream, }));
+  return selectedStreams.map(stream => Immutable.Map({ type: 'stream', id: stream }));
 };
 
 export const filtersForQuery = (streams: ?Array<string>): ?FilterType => {

--- a/graylog2-web-interface/src/views/logic/queries/Query.js
+++ b/graylog2-web-interface/src/views/logic/queries/Query.js
@@ -1,7 +1,8 @@
 // @flow strict
 import * as Immutable from 'immutable';
 import uuid from 'uuid/v4';
-import { isEqual } from 'lodash';
+
+import isDeepEqual from 'stores/isDeepEqual';
 
 export type QueryId = string;
 
@@ -33,7 +34,7 @@ export type ElasticsearchQueryString = {
 export const createElasticsearchQueryString = (query: string = ''): ElasticsearchQueryString => ({ type: 'elasticsearch', query_string: query });
 
 const _streamFilters = (selectedStreams: Array<string>): Array<Immutable.Map<string, string>> => {
-  return selectedStreams.map(stream => Immutable.Map({ type: 'stream', id: stream }));
+  return selectedStreams.map(stream => Immutable.Map({ type: 'stream', id: stream, }));
 };
 
 export const filtersForQuery = (streams: ?Array<string>): ?FilterType => {
@@ -129,10 +130,10 @@ export default class Query {
     }
 
     if (this.id !== other.id
-      || !isEqual(this.query, other.query)
-      || !isEqual(this.timerange, other.timerange)
-      || !Immutable.is(this.filter, other.filter)
-      || !Immutable.is(this.searchTypes, other.searchTypes)) {
+      || !isDeepEqual(this.query, other.query)
+      || !isDeepEqual(this.timerange, other.timerange)
+      || !isDeepEqual(this.filter, other.filter)
+      || !isDeepEqual(this.searchTypes, other.searchTypes)) {
       return false;
     }
 

--- a/graylog2-web-interface/src/views/logic/views/ViewState.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewState.js
@@ -1,6 +1,7 @@
 // @flow strict
-import { List, Map, fromJS, is } from 'immutable';
+import { List, Map, fromJS } from 'immutable';
 
+import isDeepEqual from 'stores/isDeepEqual';
 import Widget from 'views/logic/widgets/Widget';
 import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import TitleTypes from 'views/stores/TitleTypes';
@@ -118,16 +119,12 @@ export default class ViewState {
       return false;
     }
 
-    if (this.fields !== other.fields
-      || !is(this.titles, other.titles)
-      || this.widgets !== other.widgets
-      || !is(this.widgetMapping, other.widgetMapping)
-      || this.widgetPositions !== other.widgetPositions
-      || !is(this.formatting !== other.formatting)) {
-      return false;
-    }
-
-    return true;
+    return isDeepEqual(this.fields, other.fields)
+      && isDeepEqual(this.titles, other.titles)
+      && isDeepEqual(this.widgets, other.widgets)
+      && isDeepEqual(this.widgetMapping, other.widgetMapping)
+      && isDeepEqual(this.widgetPositions, other.widgetPositions)
+      && isDeepEqual(this.formatting, other.formatting);
   }
 
   toJSON() {

--- a/graylog2-web-interface/src/views/logic/widgets/MessagesWidget.js
+++ b/graylog2-web-interface/src/views/logic/widgets/MessagesWidget.js
@@ -1,6 +1,8 @@
 // @flow strict
-import { Map, is } from 'immutable';
+import { Map } from 'immutable';
 
+import isDeepEqual from 'stores/isDeepEqual';
+import isEqualForSearch from 'views/stores/isEqualForSearch';
 import Widget from './Widget';
 import MessagesWidgetConfig from './MessagesWidgetConfig';
 import type { QueryString, TimeRange } from '../queries/Query';
@@ -20,7 +22,14 @@ export default class MessagesWidget extends Widget {
 
   equals(other: any) {
     if (other instanceof MessagesWidget) {
-      return ['id', 'config', 'filter', 'timerange', 'query', 'streams'].every(key => is(this._value[key], other[key]));
+      return ['id', 'config', 'filter', 'timerange', 'query', 'streams'].every(key => isDeepEqual(this._value[key], other[key]));
+    }
+    return false;
+  }
+
+  equals(other: any) {
+    if (other instanceof MessagesWidget) {
+      return ['id', 'config', 'filter', 'timerange', 'query', 'streams'].every(key => isEqualForSearch(this._value[key], other[key]));
     }
     return false;
   }

--- a/graylog2-web-interface/src/views/logic/widgets/MessagesWidget.js
+++ b/graylog2-web-interface/src/views/logic/widgets/MessagesWidget.js
@@ -27,7 +27,7 @@ export default class MessagesWidget extends Widget {
     return false;
   }
 
-  equals(other: any) {
+  equalsForSearch(other: any) {
     if (other instanceof MessagesWidget) {
       return ['id', 'config', 'filter', 'timerange', 'query', 'streams'].every(key => isEqualForSearch(this._value[key], other[key]));
     }

--- a/graylog2-web-interface/src/views/logic/widgets/MessagesWidgetConfig.js
+++ b/graylog2-web-interface/src/views/logic/widgets/MessagesWidgetConfig.js
@@ -1,6 +1,8 @@
 // @flow strict
 import * as Immutable from 'immutable';
 
+import isDeepEqual from 'stores/isDeepEqual';
+import isEqualForSearch from 'views/stores/isEqualForSearch';
 import SortConfig from 'views/logic/aggregationbuilder/SortConfig';
 import type { SortConfigJson } from 'views/logic/aggregationbuilder/SortConfig';
 import Direction from 'views/logic/aggregationbuilder/Direction';
@@ -72,7 +74,17 @@ export default class MessagesWidgetConfig extends WidgetConfig {
   }
 
   equals(other: any): boolean {
-    return other instanceof MessagesWidgetConfig && other.decorators === this.decorators && other.sort === this.sort;
+    return other instanceof MessagesWidgetConfig
+      && isDeepEqual(this.decorators, other.decorators)
+      && isDeepEqual(this.fields, other.fields)
+      && isDeepEqual(this.sort, other.sort)
+      && this.showMessageRow === other.showMessageRow;
+  }
+
+  equalsForSearch(other: any): boolean {
+    return other instanceof MessagesWidgetConfig
+      && isEqualForSearch(other.decorators, this.decorators)
+      && isEqualForSearch(other.sort, this.sort);
   }
 
   // eslint-disable-next-line no-use-before-define

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.test.jsx
@@ -76,7 +76,7 @@ jest.mock('views/components/DashboardSearchBar', () => mockComponent('DashboardS
 jest.mock('views/stores/SearchConfigStore', () => ({ SearchConfigStore: {}, SearchConfigActions: {} }));
 jest.mock('views/stores/SearchMetadataStore', () => ({ SearchMetadataActions: {}, SearchMetadataStore: {} }));
 jest.mock('views/logic/withPluginEntities', () => x => x);
-jest.mock('views/components/views/CurrentViewTypeProvider', () => jest.fn());
+jest.mock('views/components/views/CurrentViewTypeProvider', () => ({ children }) => <ViewTypeContext.Provider value={View.Type.Dashboard}>{children}</ViewTypeContext.Provider>);
 
 const mockPromise = (res) => {
   const promise = Promise.resolve(res);
@@ -106,7 +106,6 @@ describe('ExtendedSearchPage', () => {
     SearchMetadataStore.listen = jest.fn(() => jest.fn());
     // $FlowFixMe: Somehow flow does not see the `listen` property.
     SearchActions.refresh = mockAction(jest.fn(() => Promise.resolve()));
-    CurrentViewTypeProvider.mockImplementation(({ children }) => <ViewTypeContext.Provider value={View.Type.Dashboard}>{children}</ViewTypeContext.Provider>);
   });
 
   const SimpleExtendedSearchPage = props => (

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.test.jsx
@@ -76,7 +76,7 @@ jest.mock('views/components/DashboardSearchBar', () => mockComponent('DashboardS
 jest.mock('views/stores/SearchConfigStore', () => ({ SearchConfigStore: {}, SearchConfigActions: {} }));
 jest.mock('views/stores/SearchMetadataStore', () => ({ SearchMetadataActions: {}, SearchMetadataStore: {} }));
 jest.mock('views/logic/withPluginEntities', () => x => x);
-jest.mock('views/components/views/CurrentViewTypeProvider', () => ({ children }) => <ViewTypeContext.Provider value={View.Type.Dashboard}>{children}</ViewTypeContext.Provider>);
+jest.mock('views/components/views/CurrentViewTypeProvider', () => jest.fn());
 
 const mockPromise = (res) => {
   const promise = Promise.resolve(res);
@@ -106,6 +106,7 @@ describe('ExtendedSearchPage', () => {
     SearchMetadataStore.listen = jest.fn(() => jest.fn());
     // $FlowFixMe: Somehow flow does not see the `listen` property.
     SearchActions.refresh = mockAction(jest.fn(() => Promise.resolve()));
+    asMock(CurrentViewTypeProvider).mockImplementation(({ children }) => <ViewTypeContext.Provider value={View.Type.Dashboard}>{children}</ViewTypeContext.Provider>);
   });
 
   const SimpleExtendedSearchPage = props => (

--- a/graylog2-web-interface/src/views/stores/RefreshStore.js
+++ b/graylog2-web-interface/src/views/stores/RefreshStore.js
@@ -39,8 +39,7 @@ export const RefreshStore = singletonStore(
     },
 
     setInterval(interval: number) {
-      this.refreshConfig.interval = interval;
-      this.refreshConfig.enabled = true;
+      this.refreshConfig = { interval, enabled: true };
 
       if (this.intervalId) {
         clearInterval(this.intervalId);
@@ -51,7 +50,7 @@ export const RefreshStore = singletonStore(
     },
 
     enable() {
-      this.refreshConfig.enabled = true;
+      this.refreshConfig = { ...this.refreshConfig, enabled: true };
       if (!this.intervalId) {
         this.intervalId = setInterval(SearchActions.executeWithCurrentState, this.refreshConfig.interval);
       }
@@ -59,7 +58,7 @@ export const RefreshStore = singletonStore(
     },
 
     disable() {
-      this.refreshConfig.enabled = false;
+      this.refreshConfig = { ...this.refreshConfig, enabled: false };
       if (this.intervalId) {
         clearInterval(this.intervalId);
         this.intervalId = undefined;
@@ -68,7 +67,8 @@ export const RefreshStore = singletonStore(
     },
 
     _trigger() {
-      this.trigger(this.refreshConfig);
+      const { enabled, interval } = this.refreshConfig;
+      this.trigger({ enabled, interval });
     },
   }),
 );

--- a/graylog2-web-interface/src/views/stores/ViewStore.js
+++ b/graylog2-web-interface/src/views/stores/ViewStore.js
@@ -17,6 +17,7 @@ import SearchActions from 'views/actions/SearchActions';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
 import type { QueryId } from 'views/logic/queries/Query';
 import { ViewManagementActions } from './ViewManagementStore';
+import isEqualForSearch from './isEqualForSearch';
 
 export type ViewStoreState = {
   activeQuery: QueryId,
@@ -176,7 +177,7 @@ export const ViewStore: ViewStoreType = singletonStore(
       }
       const oldWidgets = get(this.view, 'state') && this.view.state.map(s => s.widgets);
       const newWidgets = get(view, 'state') && view.state.map(s => s.widgets);
-      if (!isEqualWith(oldWidgets, newWidgets, Immutable.is)) {
+      if (!isEqualForSearch(oldWidgets, newWidgets)) {
         const newView = UpdateSearchForWidgets(view);
         return [newView, true];
       }

--- a/graylog2-web-interface/src/views/stores/ViewStore.js
+++ b/graylog2-web-interface/src/views/stores/ViewStore.js
@@ -1,7 +1,7 @@
 // @flow strict
 import Reflux from 'reflux';
 import * as Immutable from 'immutable';
-import { get, isEqualWith } from 'lodash';
+import { get } from 'lodash';
 
 import type { RefluxActions, Store } from 'stores/StoreTypes';
 import UpdateSearchForWidgets from 'views/logic/views/UpdateSearchForWidgets';

--- a/graylog2-web-interface/src/views/stores/isEqualForSearch.js
+++ b/graylog2-web-interface/src/views/stores/isEqualForSearch.js
@@ -1,0 +1,24 @@
+// @flow strict
+import { isEqualWith, isFunction } from 'lodash';
+
+const hasFn = (obj, fn) => (obj && obj[fn] && isFunction(obj[fn]));
+const hasEquals = obj => hasFn(obj, 'equals');
+const hasEqualsForSearch = obj => hasFn(obj, 'equalsForSearch');
+const isImmutable = obj => hasFn(obj, 'toJS');
+
+const _isEqual = (first, second) => {
+  if (hasEqualsForSearch(first)) {
+    return first.equalsForSearch(second);
+  }
+  if (isImmutable(first) && isImmutable(second)) {
+    return isEqualWith(first.toJS(), second.toJS(), _isEqual);
+  }
+  if (hasEquals(first)) {
+    return first.equals(second);
+  }
+  return undefined;
+};
+
+const isEqualForSearch = (first: any, second: any): boolean => isEqualWith(first, second, _isEqual);
+
+export default isEqualForSearch;

--- a/graylog2-web-interface/src/views/stores/isEqualForSearch.test.jsx
+++ b/graylog2-web-interface/src/views/stores/isEqualForSearch.test.jsx
@@ -1,7 +1,66 @@
 // @flow strict
 import isEqualForSearch from './isEqualForSearch';
+import { List, Map } from 'immutable';
+import {
+  arrayOfMaps,
+  listWithObject,
+  mapWithObject,
+  mixedMapsAndObjects,
+  objectWithMap,
+  AlwaysEqual,
+  NeverEqual,
+  NonValueClass,
+} from '../../stores/__tests__/EqualityCheck.fixtures';
+
+export class AlwaysEqualForSearch {
+  equalsForSearch = () => {
+    return true;
+  };
+}
+
+export class NeverEqualForSearch {
+  equalsForSearch = () => {
+    return false;
+  };
+}
+
 
 describe('isEqualForSearch', () => {
-  it('should do something', () => {
-  });
+  const verifyIsEqualForSearch = ({ initial, next, result }) => expect(isEqualForSearch(initial, next)).toBe(result);
+  it.each`
+    initial                  | next                     | result    | description
+    ${undefined}             | ${undefined}             | ${true}   | ${'equal undefined values'}
+    ${undefined}             | ${null}                  | ${false}  | ${'from undefined to null value'}
+    ${undefined}             | ${42}                    | ${false}  | ${'from undefined to numeric value'}
+    ${42}                    | ${42}                    | ${true}   | ${'equal numeric values'}
+    ${42}                    | ${23}                    | ${false}  | ${'non-equal numeric values'}
+    ${'Hello there!'}        | ${'Hello there!'}        | ${true}   | ${'equal string values'}
+    ${'Hello there!'}        | ${'Hello World!'}        | ${false}  | ${'non-equal string values'}
+    ${{}}                    | ${{}}                    | ${true}   | ${'equal empty objects'}
+    ${{ bar: 23 }}           | ${{ bar: 23 }}           | ${true}  | ${'equal objects'}
+    ${{ bar: 23 }}           | ${{ bar: 42 }}           | ${false}  | ${'non-equal objects'}
+    ${[]}                    | ${[]}                    | ${true}   | ${'equal empty arrays'}
+    ${[23]}                  | ${[23]}                  | ${true}   | ${'equal arrays'}
+    ${[23]}                  | ${[42]}                  | ${false}  | ${'non-equal arrays'}
+    ${Map()}                 | ${Map()}                 | ${true}   | ${'equal empty immutable maps'}
+    ${Map({ bar: 23 })}      | ${Map({ bar: 23 })}      | ${true}   | ${'equal immutable maps'}
+    ${Map({ bar: 23 })}      | ${Map({ bar: 42 })}      | ${false}  | ${'non-equal immutable maps'}
+    ${List()}                | ${List()}                | ${true}   | ${'equal empty immutable lists'}
+    ${List([23])}            | ${List([23])}            | ${true}   | ${'equal immutable lists'}
+    ${List([23])}            | ${List([42])}            | ${false}  | ${'non-equal immutable lists'}
+    ${new AlwaysEqual()}     | ${new AlwaysEqual()}     | ${true}   | ${'value class which is always equal'}
+    ${new NeverEqual()}      | ${new NeverEqual()}      | ${false}  | ${'value class which is never equal'}
+    ${new AlwaysEqual()}     | ${new NeverEqual()}      | ${true}   | ${'value class which is always equal'}
+    ${new NeverEqual()}      | ${new AlwaysEqual()}     | ${false}  | ${'value class which is never equal'}
+    ${new AlwaysEqualForSearch()} | ${new AlwaysEqualForSearch()} | ${true}   | ${'value class which is always equal'}
+    ${new NeverEqualForSearch()}  | ${new NeverEqualForSearch()}  | ${false}  | ${'value class which is never equal'}
+    ${new AlwaysEqualForSearch()} | ${new NeverEqualForSearch()}  | ${true}   | ${'value class which is always equal'}
+    ${new NeverEqualForSearch()}  | ${new AlwaysEqualForSearch()} | ${false}  | ${'value class which is never equal'}
+    ${new NonValueClass(23)} | ${new NonValueClass(42)} | ${false}   | ${'value class which is never equal'}
+    ${mapWithObject()}       | ${mapWithObject()}       | ${true}   | ${'immutable maps containing objects'}
+    ${listWithObject()}      | ${listWithObject()}      | ${true}   | ${'immutable lists containing objects'}
+    ${objectWithMap()}       | ${objectWithMap()}       | ${true}   | ${'objects containing immutable maps'}
+    ${arrayOfMaps()}         | ${arrayOfMaps()}         | ${true}   | ${'arrays containing immutable maps'}
+    ${mixedMapsAndObjects()} | ${mixedMapsAndObjects()} | ${true}   | ${'nested immutable maps and objects'}
+  `('compares $description and returns $result', verifyIsEqualForSearch);
 });

--- a/graylog2-web-interface/src/views/stores/isEqualForSearch.test.jsx
+++ b/graylog2-web-interface/src/views/stores/isEqualForSearch.test.jsx
@@ -1,6 +1,6 @@
 // @flow strict
-import isEqualForSearch from './isEqualForSearch';
 import { List, Map } from 'immutable';
+
 import {
   arrayOfMaps,
   listWithObject,
@@ -10,7 +10,8 @@ import {
   AlwaysEqual,
   NeverEqual,
   NonValueClass,
-} from '../../stores/__tests__/EqualityCheck.fixtures';
+} from 'stores/__tests__/EqualityCheck.fixtures';
+import isEqualForSearch from './isEqualForSearch';
 
 export class AlwaysEqualForSearch {
   equalsForSearch = () => {

--- a/graylog2-web-interface/src/views/stores/isEqualForSearch.test.jsx
+++ b/graylog2-web-interface/src/views/stores/isEqualForSearch.test.jsx
@@ -1,0 +1,7 @@
+// @flow strict
+import isEqualForSearch from './isEqualForSearch';
+
+describe('isEqualForSearch', () => {
+  it('should do something', () => {
+  });
+});

--- a/graylog2-web-interface/test/helpers/mocking/StoreMock.js
+++ b/graylog2-web-interface/test/helpers/mocking/StoreMock.js
@@ -1,12 +1,18 @@
-export default function (...args) {
-  const store = {};
-  const methodsToMock = ['listen', 'getInitialState', ...args];
-  Array.from(methodsToMock).forEach((method) => {
+// @flow strict
+type MockMethod = string | [string, Function];
+
+export default function (...args: Array<MockMethod>) {
+  const store = {
+    // eslint-disable-next-line func-call-spacing,no-spaced-func
+    listen: jest.fn<[], () => void>(() => () => {}),
+    getInitialState: jest.fn<[], void>(),
+  };
+  Array.from(args).forEach((method) => {
     if (Array.isArray(method)) {
-      // eslint-disable-next-line prefer-destructuring
-      store[method[0]] = method[1];
+      const [name, fn] = method;
+      store[name] = fn;
     } else {
-      store[method] = jest.fn();
+      store[method] = jest.fn<[], void>();
     }
   });
 

--- a/graylog2-web-interface/test/helpers/mocking/StoreMock.js
+++ b/graylog2-web-interface/test/helpers/mocking/StoreMock.js
@@ -1,6 +1,7 @@
 export default function (...args) {
   const store = {};
-  Array.from(args).forEach((method) => {
+  const methodsToMock = ['listen', 'getInitialState', ...args];
+  Array.from(methodsToMock).forEach((method) => {
     if (Array.isArray(method)) {
       // eslint-disable-next-line prefer-destructuring
       store[method[0]] = method[1];


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In the web interface we are using a `connect` HOC which can be used to wrap another component and specify a map of Reflux stores, whose states are synchronized with the props of the component. This allows us to use Reflux stores in functional and class-based components. This works by generating a component that gets the initial state of all stores and listens to them and update the props of its child component on every store update.

Before this change, a component wrapped with the `connect` HOC was rerendered whenever a store updated, even if the state of the store remained the same. E.g.:

  - Component `Foo` uses `connect` to synchronize with `FooStore`, but is only interested in the key `bar` of its state: `connect(FooComponent, { foo: FooStore }, ({ foo: { bar } }) => ({ bar }))`
  - `FooStore` triggers an update, because the `foo` key is updated: `this.trigger({ foo: 42 })`
  -  `FooComponent` is rerendered although `bar` is not updated

To prevent this, this PR implements a `shouldComponentUpdate` method for each generated wrapper component and returns the result of a deep equality check for the _generated_ props (after applying the props mapper function) of its child component.
Although deep equality checks are generally discouraged, this still improves rendering times for e.g. the search by ~40%.

**Note:**

While doing this, it was noticed that the `RefreshControls` did trigger starting/stopping the auto refresh of a search/dashboard, but they did not render the correct state. This was traced back to the `RefreshStore` mutating its state inline, which is generally an anti-pattern and a source for subtle bugs. In this case it lead to `shouldComponentUpdate` always lead to false, because the state of the store before and after the update appeared to be identical (due to inline mutation). This was fixed in this PR as well. **There might be other cases like this hidden in the source code.** A structural search in the code base did not reveal other cases like this which have an effect, but this should therefore not be backported to `3.2` and instead tested well in `master` for `3.3`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

