### PR TITLE
Provide parameter bindings when using message list pagination

### DIFF
--- a/graylog2-web-interface/src/views/actions/SearchActions.js
+++ b/graylog2-web-interface/src/views/actions/SearchActions.js
@@ -4,7 +4,7 @@ import * as Immutable from 'immutable';
 
 import Search from 'views/logic/search/Search';
 import SearchResult from 'views/logic/SearchResult';
-import SearchExecutionState from 'views/logic/search/SearchExecutionState';
+import SearchExecutionState, { type ParameterBindings } from 'views/logic/search/SearchExecutionState';
 import Parameter from 'views/logic/parameters/Parameter';
 import View from 'views/logic/views/View';
 import type { SearchJson } from 'views/logic/search/Search';
@@ -27,7 +27,11 @@ export type SearchExecutionResult = {
 type SearchActionsType = RefluxActions<{
   create: (Search) => Promise<CreateSearchResponse>,
   execute: (SearchExecutionState) => Promise<SearchExecutionResult>,
-  reexecuteSearchTypes: (searchTypes: {[searchTypeId: string]: { limit: number, offset: number }}, effectiveTimeRange?: TimeRange) => Promise<SearchExecutionResult>,
+  reexecuteSearchTypes: (
+    parameterBindings: ParameterBindings,
+    searchTypes: {[searchTypeId: string]: { limit: number, offset: number }},
+    effectiveTimeRange?: TimeRange,
+  ) => Promise<SearchExecutionResult>,
   executeWithCurrentState: () => Promise<SearchExecutionResult>,
   refresh: () => Promise<void>,
   get: (SearchId) => Promise<SearchJson>,

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -13,6 +13,8 @@ import { SelectedFieldsStore } from 'views/stores/SelectedFieldsStore';
 import { ViewStore } from 'views/stores/ViewStore';
 import { SearchActions, SearchStore } from 'views/stores/SearchStore';
 import { RefreshActions } from 'views/stores/RefreshStore';
+import { SearchExecutionStateStore } from 'views/stores/SearchExecutionStateStore';
+import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
 import type { TimeRange } from 'views/logic/queries/Query';
 
@@ -70,6 +72,7 @@ type Props = {
   searchTypes: { [searchTypeId: string]: { effectiveTimerange: TimeRange }},
   selectedFields?: Immutable.Set<string>,
   setLoadingState: (loading: boolean) => void,
+  executionState: SearchExecutionState
 };
 
 class MessageList extends React.Component<Props, State> {
@@ -88,6 +91,7 @@ class MessageList extends React.Component<Props, State> {
     searchTypes: PropTypes.object.isRequired,
     selectedFields: PropTypes.object,
     setLoadingState: PropTypes.func.isRequired,
+    executionState: PropTypes.object.isRequired,
   };
 
   static defaultProps = {
@@ -116,12 +120,12 @@ class MessageList extends React.Component<Props, State> {
 
   _handlePageChange = (pageNo: number) => {
     // execute search with new offset
-    const { pageSize, searchTypes, data: { id: searchTypeId }, setLoadingState } = this.props;
+    const { pageSize, searchTypes, data: { id: searchTypeId }, executionState: { parameterBindings }, setLoadingState } = this.props;
     const { effectiveTimerange } = searchTypes[searchTypeId];
     const searchTypePayload = { [searchTypeId]: { limit: pageSize, offset: pageSize * (pageNo - 1) } };
     RefreshActions.disable();
     setLoadingState(true);
-    SearchActions.reexecuteSearchTypes(searchTypePayload, effectiveTimerange).then((response) => {
+    SearchActions.reexecuteSearchTypes(parameterBindings, searchTypePayload, effectiveTimerange).then((response) => {
       setLoadingState(false);
       this.setState({
         errors: response.result.errors,
@@ -194,6 +198,7 @@ export default connect(MessageList,
     selectedFields: SelectedFieldsStore,
     currentView: ViewStore,
     searches: SearchStore,
+    executionState: SearchExecutionStateStore,
   }, props => Object.assign(
     {},
     props,

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -66,13 +66,13 @@ type Props = {
   },
   data: { messages: Array<Object>, total: number, id: string },
   editing: boolean,
+  executionState: SearchExecutionState,
   fields: FieldTypeMappingsList,
   onConfigChange: (MessagesWidgetConfig) => Promise<void>,
   pageSize: number,
   searchTypes: { [searchTypeId: string]: { effectiveTimerange: TimeRange }},
   selectedFields?: Immutable.Set<string>,
   setLoadingState: (loading: boolean) => void,
-  executionState: SearchExecutionState
 };
 
 class MessageList extends React.Component<Props, State> {
@@ -85,13 +85,13 @@ class MessageList extends React.Component<Props, State> {
       id: PropTypes.string.isRequired,
     }).isRequired,
     editing: PropTypes.bool.isRequired,
+    executionState: PropTypes.object.isRequired,
     fields: CustomPropTypes.FieldListType.isRequired,
     onConfigChange: PropTypes.func,
     pageSize: PropTypes.number,
     searchTypes: PropTypes.object.isRequired,
     selectedFields: PropTypes.object,
     setLoadingState: PropTypes.func.isRequired,
-    executionState: PropTypes.object.isRequired,
   };
 
   static defaultProps = {

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
@@ -179,7 +179,6 @@ describe('MessageList', () => {
   it('reexecute query for search type, when using pagination', () => {
     const config = MessagesWidgetConfig.builder().fields([]).build();
     const secondPageSize = 10;
-
     const wrapper = mount(<MessageList editing
                                        data={{ ...data, total: Messages.DEFAULT_LIMIT + secondPageSize }}
                                        fields={Immutable.List([])}
@@ -189,7 +188,7 @@ describe('MessageList', () => {
     expect(SearchActions.reexecuteSearchTypes).toHaveBeenCalledWith({}, searchTypePayload, mockEffectiveTimeRange);
   });
 
-  it.only('reexecute query for search type, with provided parameter bindings when using pagination', () => {
+  it('reexecute query for search type, with provided parameter bindings when using pagination', () => {
     const executionState = { parameterBindings: { newParameter: { type: 'value', value: 'example.org' } } };
     SearchExecutionStateStore.getInitialState.mockImplementationOnce(() => executionState);
     const config = MessagesWidgetConfig.builder().fields([]).build();

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
@@ -39,7 +39,6 @@ const mockEffectiveTimeRange = {
 jest.mock('views/components/messagelist/MessageTableEntry', () => ({}));
 jest.mock('stores/search/SearchStore', () => MockStore('searchSurroundingMessages'));
 jest.mock('views/stores/SearchExecutionStateStore', () => ({
-  SearchExecutionStateActions: {},
   SearchExecutionStateStore: {
     listen: jest.fn(),
     getInitialState: jest.fn(() => ({

--- a/graylog2-web-interface/src/views/stores/SearchStore.js
+++ b/graylog2-web-interface/src/views/stores/SearchStore.js
@@ -16,7 +16,7 @@ import Search from 'views/logic/search/Search';
 import type { CreateSearchResponse, SearchId, SearchExecutionResult } from 'views/actions/SearchActions';
 import GlobalOverride from 'views/logic/search/GlobalOverride';
 import type { MessageListOptions } from 'views/logic/search/GlobalOverride';
-import SearchExecutionState from 'views/logic/search/SearchExecutionState';
+import SearchExecutionState, { type ParameterBindings } from 'views/logic/search/SearchExecutionState';
 import View from 'views/logic/views/View';
 import Parameter from 'views/logic/parameters/Parameter';
 import type { WidgetMapping } from 'views/logic/views/types';
@@ -119,7 +119,7 @@ export const SearchStore = singletonStore(
       return this._executePromise(executionState, startActionPromise, handleSearchResult);
     },
 
-    reexecuteSearchTypes(searchTypes: MessageListOptions, effectiveTimerange?: TimeRange): Promise<SearchExecutionResult> {
+    reexecuteSearchTypes(parameterBindings: ParameterBindings, searchTypes: MessageListOptions, effectiveTimerange?: TimeRange): Promise<SearchExecutionResult> {
       const searchTypeIds = Object.keys(searchTypes);
       const globalOverride: GlobalOverride = new GlobalOverride(
         effectiveTimerange,
@@ -127,7 +127,7 @@ export const SearchStore = singletonStore(
         searchTypeIds,
         searchTypes,
       );
-      const executionState = new SearchExecutionState(undefined, globalOverride);
+      const executionState = new SearchExecutionState(parameterBindings, globalOverride);
       const handleSearchResult = (searchResult: SearchResult): SearchResult => {
         const updatedSearchTypes = searchResult.getSearchTypesFromResponse(searchTypeIds);
         const updatedResult = this.result.updateSearchTypes(updatedSearchTypes);


### PR DESCRIPTION
As described in #7665 using the message list pagination throws an error, when the query contains a parameter. With these changes we always require the parameter bindings when re-executing the search.

**Note: This PR requires a backport for 3.2**

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

