### PR TITLE
Split input modal into transport and codec

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/configuration/ConfigurationRequest.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/configuration/ConfigurationRequest.java
@@ -84,6 +84,7 @@ public class ConfigurationRequest {
         for (ConfigurationField f : fields.values()) {
             final Map<String, Object> config = Maps.newHashMap();
             config.put("type", f.getFieldType());
+            config.put("context", f.getContext());
             config.put("human_name", f.getHumanName());
             config.put("description", f.getDescription());
             config.put("default_value", f.getDefaultValue());

--- a/graylog2-server/src/main/java/org/graylog2/plugin/configuration/fields/AbstractConfigurationField.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/configuration/fields/AbstractConfigurationField.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 public abstract class AbstractConfigurationField implements ConfigurationField {
     protected final String field_type;
+    protected String context;
     protected final String name;
     protected final String humanName;
     protected final String description;
@@ -30,6 +31,7 @@ public abstract class AbstractConfigurationField implements ConfigurationField {
 
     public AbstractConfigurationField(String field_type, String name, String humanName, String description, ConfigurationField.Optional optional1) {
         this.field_type = field_type;
+        this.context = "";
         this.name = name;
         this.humanName = humanName;
         this.description = description;
@@ -44,6 +46,16 @@ public abstract class AbstractConfigurationField implements ConfigurationField {
     @Override
     public String getFieldType() {
         return field_type;
+    }
+
+    @Override
+    public String getContext() {
+        return context;
+    }
+
+    @Override
+    public void setContext(String context) {
+        this.context = context;
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/plugin/configuration/fields/ConfigurationField.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/configuration/fields/ConfigurationField.java
@@ -49,4 +49,9 @@ public interface ConfigurationField {
     default int getPosition() {
         return DEFAULT_POSITION;
     }
+    default void setContext(String context) {
+    }
+    default String getContext() {
+        return "";
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/MessageInput.java
@@ -392,7 +392,10 @@ public abstract class MessageInput implements Stoppable {
             final ConfigurationRequest transport = transportConfig.getRequestedConfiguration();
             final ConfigurationRequest codec = codecConfig.getRequestedConfiguration();
             final ConfigurationRequest r = new ConfigurationRequest();
+
+            transport.getFields().forEach((key, value) -> value.setContext("transport"));
             r.putAll(transport.getFields());
+            codec.getFields().forEach((key, value) -> value.setContext("codec"));
             r.putAll(codec.getFields());
 
             // give the codec the opportunity to override default values for certain configuration fields,

--- a/graylog2-web-interface/src/components/inputs/InputForm.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputForm.jsx
@@ -42,6 +42,7 @@ class InputForm extends React.Component {
     return (
       <ConfigurationForm {...this.props}
                          ref={(configurationForm) => { this.configurationForm = configurationForm; }}
+                         isInputForm
                          values={values}
                          titleValue={titleValue}
                          submitAction={this._onSubmit}>


### PR DESCRIPTION
Otherwise users can't see which config field is meant for transport
and which one for codec settings.

before:
![image](https://user-images.githubusercontent.com/3034831/76523415-b12b4200-6468-11ea-9bba-76b397dabea4.png)


after:
![image](https://user-images.githubusercontent.com/3034831/76523330-893bde80-6468-11ea-8770-e1c1979208d4.png)
