### PR TITLE
Consider current dashboard query filter and defined parameters when using message list pagination

### DIFF
--- a/graylog2-web-interface/src/views/actions/SearchActions.js
+++ b/graylog2-web-interface/src/views/actions/SearchActions.js
@@ -28,7 +28,6 @@ type SearchActionsType = RefluxActions<{
   create: (Search) => Promise<CreateSearchResponse>,
   execute: (SearchExecutionState) => Promise<SearchExecutionResult>,
   reexecuteSearchTypes: (
-    executionState: SearchExecutionState,
     searchTypes: {[searchTypeId: string]: { limit: number, offset: number }},
     effectiveTimeRange?: TimeRange,
   ) => Promise<SearchExecutionResult>,

--- a/graylog2-web-interface/src/views/actions/SearchActions.js
+++ b/graylog2-web-interface/src/views/actions/SearchActions.js
@@ -4,7 +4,7 @@ import * as Immutable from 'immutable';
 
 import Search from 'views/logic/search/Search';
 import SearchResult from 'views/logic/SearchResult';
-import SearchExecutionState from 'views/logic/search/SearchExecutionState';
+import SearchExecutionState, { type ParameterBindings } from 'views/logic/search/SearchExecutionState';
 import Parameter from 'views/logic/parameters/Parameter';
 import View from 'views/logic/views/View';
 import type { SearchJson } from 'views/logic/search/Search';
@@ -27,7 +27,11 @@ export type SearchExecutionResult = {
 type SearchActionsType = RefluxActions<{
   create: (Search) => Promise<CreateSearchResponse>,
   execute: (SearchExecutionState) => Promise<SearchExecutionResult>,
-  reexecuteSearchTypes: (searchTypes: {[searchTypeId: string]: { limit: number, offset: number }}, effectiveTimeRange?: TimeRange) => Promise<SearchExecutionResult>,
+  reexecuteSearchTypes: (
+    parameterBindings: ParameterBindings,
+    searchTypes: {[searchTypeId: string]: { limit: number, offset: number }},
+    effectiveTimeRange?: TimeRange,
+  ) => Promise<SearchExecutionResult>,
   executeWithCurrentState: () => Promise<SearchExecutionResult>,
   refresh: () => Promise<void>,
   get: (SearchId) => Promise<SearchJson>,

--- a/graylog2-web-interface/src/views/actions/SearchActions.js
+++ b/graylog2-web-interface/src/views/actions/SearchActions.js
@@ -4,7 +4,7 @@ import * as Immutable from 'immutable';
 
 import Search from 'views/logic/search/Search';
 import SearchResult from 'views/logic/SearchResult';
-import SearchExecutionState, { type ParameterBindings } from 'views/logic/search/SearchExecutionState';
+import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import Parameter from 'views/logic/parameters/Parameter';
 import View from 'views/logic/views/View';
 import type { SearchJson } from 'views/logic/search/Search';
@@ -28,7 +28,7 @@ type SearchActionsType = RefluxActions<{
   create: (Search) => Promise<CreateSearchResponse>,
   execute: (SearchExecutionState) => Promise<SearchExecutionResult>,
   reexecuteSearchTypes: (
-    parameterBindings: ParameterBindings,
+    executionState: SearchExecutionState,
     searchTypes: {[searchTypeId: string]: { limit: number, offset: number }},
     effectiveTimeRange?: TimeRange,
   ) => Promise<SearchExecutionResult>,

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -13,8 +13,6 @@ import { SelectedFieldsStore } from 'views/stores/SelectedFieldsStore';
 import { ViewStore } from 'views/stores/ViewStore';
 import { SearchActions, SearchStore } from 'views/stores/SearchStore';
 import { RefreshActions } from 'views/stores/RefreshStore';
-import { SearchExecutionStateStore } from 'views/stores/SearchExecutionStateStore';
-import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
 import type { TimeRange } from 'views/logic/queries/Query';
 
@@ -66,7 +64,6 @@ type Props = {
   },
   data: { messages: Array<Object>, total: number, id: string },
   editing: boolean,
-  executionState: SearchExecutionState,
   fields: FieldTypeMappingsList,
   onConfigChange: (MessagesWidgetConfig) => Promise<void>,
   pageSize: number,
@@ -85,7 +82,6 @@ class MessageList extends React.Component<Props, State> {
       id: PropTypes.string.isRequired,
     }).isRequired,
     editing: PropTypes.bool.isRequired,
-    executionState: PropTypes.object.isRequired,
     fields: CustomPropTypes.FieldListType.isRequired,
     onConfigChange: PropTypes.func,
     pageSize: PropTypes.number,
@@ -120,12 +116,12 @@ class MessageList extends React.Component<Props, State> {
 
   _handlePageChange = (pageNo: number) => {
     // execute search with new offset
-    const { pageSize, searchTypes, data: { id: searchTypeId }, executionState, setLoadingState } = this.props;
+    const { pageSize, searchTypes, data: { id: searchTypeId }, setLoadingState } = this.props;
     const { effectiveTimerange } = searchTypes[searchTypeId];
     const searchTypePayload = { [searchTypeId]: { limit: pageSize, offset: pageSize * (pageNo - 1) } };
     RefreshActions.disable();
     setLoadingState(true);
-    SearchActions.reexecuteSearchTypes(executionState, searchTypePayload, effectiveTimerange).then((response) => {
+    SearchActions.reexecuteSearchTypes(searchTypePayload, effectiveTimerange).then((response) => {
       setLoadingState(false);
       this.setState({
         errors: response.result.errors,
@@ -198,7 +194,6 @@ export default connect(MessageList,
     selectedFields: SelectedFieldsStore,
     currentView: ViewStore,
     searches: SearchStore,
-    executionState: SearchExecutionStateStore,
   }, props => Object.assign(
     {},
     props,

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -13,6 +13,8 @@ import { SelectedFieldsStore } from 'views/stores/SelectedFieldsStore';
 import { ViewStore } from 'views/stores/ViewStore';
 import { SearchActions, SearchStore } from 'views/stores/SearchStore';
 import { RefreshActions } from 'views/stores/RefreshStore';
+import { SearchExecutionStateStore } from 'views/stores/SearchExecutionStateStore';
+import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
 import type { TimeRange } from 'views/logic/queries/Query';
 
@@ -70,6 +72,7 @@ type Props = {
   searchTypes: { [searchTypeId: string]: { effectiveTimerange: TimeRange }},
   selectedFields?: Immutable.Set<string>,
   setLoadingState: (loading: boolean) => void,
+  executionState: SearchExecutionState
 };
 
 class MessageList extends React.Component<Props, State> {
@@ -88,6 +91,7 @@ class MessageList extends React.Component<Props, State> {
     searchTypes: PropTypes.object.isRequired,
     selectedFields: PropTypes.object,
     setLoadingState: PropTypes.func.isRequired,
+    executionState: PropTypes.object.isRequired,
   };
 
   static defaultProps = {
@@ -116,12 +120,12 @@ class MessageList extends React.Component<Props, State> {
 
   _handlePageChange = (pageNo: number) => {
     // execute search with new offset
-    const { pageSize, searchTypes, data: { id: searchTypeId }, setLoadingState } = this.props;
+    const { pageSize, searchTypes, data: { id: searchTypeId }, executionState: { parameterBindings }, setLoadingState } = this.props;
     const { effectiveTimerange } = searchTypes[searchTypeId];
     const searchTypePayload = { [searchTypeId]: { limit: pageSize, offset: pageSize * (pageNo - 1) } };
     RefreshActions.disable();
     setLoadingState(true);
-    SearchActions.reexecuteSearchTypes(searchTypePayload, effectiveTimerange).then((response) => {
+    SearchActions.reexecuteSearchTypes(parameterBindings, searchTypePayload, effectiveTimerange).then((response) => {
       setLoadingState(false);
       this.setState({
         errors: response.result.errors,
@@ -194,6 +198,7 @@ export default connect(MessageList,
     selectedFields: SelectedFieldsStore,
     currentView: ViewStore,
     searches: SearchStore,
+    executionState: SearchExecutionStateStore,
   }, props => Object.assign(
     {},
     props,

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -66,13 +66,13 @@ type Props = {
   },
   data: { messages: Array<Object>, total: number, id: string },
   editing: boolean,
+  executionState: SearchExecutionState,
   fields: FieldTypeMappingsList,
   onConfigChange: (MessagesWidgetConfig) => Promise<void>,
   pageSize: number,
   searchTypes: { [searchTypeId: string]: { effectiveTimerange: TimeRange }},
   selectedFields?: Immutable.Set<string>,
   setLoadingState: (loading: boolean) => void,
-  executionState: SearchExecutionState
 };
 
 class MessageList extends React.Component<Props, State> {
@@ -85,13 +85,13 @@ class MessageList extends React.Component<Props, State> {
       id: PropTypes.string.isRequired,
     }).isRequired,
     editing: PropTypes.bool.isRequired,
+    executionState: PropTypes.object.isRequired,
     fields: CustomPropTypes.FieldListType.isRequired,
     onConfigChange: PropTypes.func,
     pageSize: PropTypes.number,
     searchTypes: PropTypes.object.isRequired,
     selectedFields: PropTypes.object,
     setLoadingState: PropTypes.func.isRequired,
-    executionState: PropTypes.object.isRequired,
   };
 
   static defaultProps = {

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -120,12 +120,12 @@ class MessageList extends React.Component<Props, State> {
 
   _handlePageChange = (pageNo: number) => {
     // execute search with new offset
-    const { pageSize, searchTypes, data: { id: searchTypeId }, executionState: { parameterBindings }, setLoadingState } = this.props;
+    const { pageSize, searchTypes, data: { id: searchTypeId }, executionState, setLoadingState } = this.props;
     const { effectiveTimerange } = searchTypes[searchTypeId];
     const searchTypePayload = { [searchTypeId]: { limit: pageSize, offset: pageSize * (pageNo - 1) } };
     RefreshActions.disable();
     setLoadingState(true);
-    SearchActions.reexecuteSearchTypes(parameterBindings, searchTypePayload, effectiveTimerange).then((response) => {
+    SearchActions.reexecuteSearchTypes(executionState, searchTypePayload, effectiveTimerange).then((response) => {
       setLoadingState(false);
       this.setState({
         errors: response.result.errors,

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
@@ -13,7 +13,6 @@ import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
 import { SelectedFieldsStore } from 'views/stores/SelectedFieldsStore';
 import { SearchActions } from 'views/stores/SearchStore';
 import { RefreshActions } from 'views/stores/RefreshStore';
-import { SearchExecutionStateStore } from 'views/stores/SearchExecutionStateStore';
 import * as messageList from 'views/components/messagelist';
 import InputsStore from 'stores/inputs/InputsStore';
 import MessageList from './MessageList';
@@ -38,12 +37,6 @@ const mockEffectiveTimeRange = {
 
 jest.mock('views/components/messagelist/MessageTableEntry', () => ({}));
 jest.mock('stores/search/SearchStore', () => MockStore('searchSurroundingMessages'));
-jest.mock('views/stores/SearchExecutionStateStore', () => ({
-  SearchExecutionStateStore: {
-    listen: jest.fn(),
-    getInitialState: jest.fn(() => ({})),
-  },
-}));
 jest.mock('views/stores/ViewStore', () => ({
   ViewStore: MockStore(
     'listen',
@@ -105,7 +98,6 @@ describe('MessageList', () => {
     ],
     total: 1,
   };
-  const searchTypePayload = { [data.id]: { limit: Messages.DEFAULT_LIMIT, offset: Messages.DEFAULT_LIMIT } };
   beforeEach(() => {
     // eslint-disable-next-line import/namespace
     messageList.MessageTableEntry = MessageTableEntry;
@@ -174,6 +166,7 @@ describe('MessageList', () => {
   });
 
   it('reexecute query for search type, when using pagination', () => {
+    const searchTypePayload = { [data.id]: { limit: Messages.DEFAULT_LIMIT, offset: Messages.DEFAULT_LIMIT } };
     const config = MessagesWidgetConfig.builder().fields([]).build();
     const secondPageSize = 10;
     const wrapper = mount(<MessageList editing
@@ -182,24 +175,7 @@ describe('MessageList', () => {
                                        config={config}
                                        setLoadingState={() => {}} />);
     wrapper.find('[aria-label="Next"]').simulate('click');
-    expect(SearchActions.reexecuteSearchTypes).toHaveBeenCalledWith({}, searchTypePayload, mockEffectiveTimeRange);
-  });
-
-  it('considere current execution state when using pagination', () => {
-    const executionState = {
-      parameterBindings: { mainDomain: { type: 'value', value: 'example.org' } },
-      globalOverride: { query: { type: 'elasticsearch', query_string: 'http_method:GET' } },
-    };
-    SearchExecutionStateStore.getInitialState.mockImplementationOnce(() => executionState);
-    const config = MessagesWidgetConfig.builder().fields([]).build();
-    const secondPageSize = 10;
-    const wrapper = mount(<MessageList editing
-                                       data={{ ...data, total: Messages.DEFAULT_LIMIT + secondPageSize }}
-                                       fields={Immutable.List([])}
-                                       config={config}
-                                       setLoadingState={() => {}} />);
-    wrapper.find('[aria-label="Next"]').simulate('click');
-    expect(SearchActions.reexecuteSearchTypes).toHaveBeenCalledWith(executionState, searchTypePayload, mockEffectiveTimeRange);
+    expect(SearchActions.reexecuteSearchTypes).toHaveBeenCalledWith(searchTypePayload, mockEffectiveTimeRange);
   });
 
   it('disables refresh actions, when using pagination', () => {

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
@@ -179,7 +179,6 @@ describe('MessageList', () => {
   it('reexecute query for search type, when using pagination', () => {
     const config = MessagesWidgetConfig.builder().fields([]).build();
     const secondPageSize = 10;
-
     const wrapper = mount(<MessageList editing
                                        data={{ ...data, total: Messages.DEFAULT_LIMIT + secondPageSize }}
                                        fields={Immutable.List([])}
@@ -189,7 +188,7 @@ describe('MessageList', () => {
     expect(SearchActions.reexecuteSearchTypes).toHaveBeenCalledWith({}, searchTypePayload, mockEffectiveTimeRange);
   });
 
-  it.only('reexecute query for search type, with provided parameter bindings when using pagination', () => {
+  it('reexecute query for search type, with provided parameter bindings when using pagination', () => {
     const executionState = { parameterBindings: { newParameter: { type: 'value', value: 'example.org' } } };
     SearchExecutionStateStore.getInitialState.mockImplementationOnce(() => executionState);
     const config = MessagesWidgetConfig.builder().fields([]).build();

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
@@ -39,7 +39,6 @@ const mockEffectiveTimeRange = {
 jest.mock('views/components/messagelist/MessageTableEntry', () => ({}));
 jest.mock('stores/search/SearchStore', () => MockStore('searchSurroundingMessages'));
 jest.mock('views/stores/SearchExecutionStateStore', () => ({
-  SearchExecutionStateActions: {},
   SearchExecutionStateStore: {
     listen: jest.fn(),
     getInitialState: jest.fn(() => ({

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
@@ -41,9 +41,7 @@ jest.mock('stores/search/SearchStore', () => MockStore('searchSurroundingMessage
 jest.mock('views/stores/SearchExecutionStateStore', () => ({
   SearchExecutionStateStore: {
     listen: jest.fn(),
-    getInitialState: jest.fn(() => ({
-      parameterBindings: {},
-    })),
+    getInitialState: jest.fn(() => ({})),
   },
 }));
 jest.mock('views/stores/ViewStore', () => ({
@@ -187,8 +185,11 @@ describe('MessageList', () => {
     expect(SearchActions.reexecuteSearchTypes).toHaveBeenCalledWith({}, searchTypePayload, mockEffectiveTimeRange);
   });
 
-  it('reexecute query for search type, with provided parameter bindings when using pagination', () => {
-    const executionState = { parameterBindings: { newParameter: { type: 'value', value: 'example.org' } } };
+  it('considere current execution state when using pagination', () => {
+    const executionState = {
+      parameterBindings: { mainDomain: { type: 'value', value: 'example.org' } },
+      globalOverride: { query: { type: 'elasticsearch', query_string: 'http_method:GET' } },
+    };
     SearchExecutionStateStore.getInitialState.mockImplementationOnce(() => executionState);
     const config = MessagesWidgetConfig.builder().fields([]).build();
     const secondPageSize = 10;
@@ -198,7 +199,7 @@ describe('MessageList', () => {
                                        config={config}
                                        setLoadingState={() => {}} />);
     wrapper.find('[aria-label="Next"]').simulate('click');
-    expect(SearchActions.reexecuteSearchTypes).toHaveBeenCalledWith(executionState.parameterBindings, searchTypePayload, mockEffectiveTimeRange);
+    expect(SearchActions.reexecuteSearchTypes).toHaveBeenCalledWith(executionState, searchTypePayload, mockEffectiveTimeRange);
   });
 
   it('disables refresh actions, when using pagination', () => {

--- a/graylog2-web-interface/src/views/stores/SearchStore.js
+++ b/graylog2-web-interface/src/views/stores/SearchStore.js
@@ -16,7 +16,7 @@ import Search from 'views/logic/search/Search';
 import type { CreateSearchResponse, SearchId, SearchExecutionResult } from 'views/actions/SearchActions';
 import GlobalOverride from 'views/logic/search/GlobalOverride';
 import type { MessageListOptions } from 'views/logic/search/GlobalOverride';
-import SearchExecutionState from 'views/logic/search/SearchExecutionState';
+import SearchExecutionState, { type ParameterBindings } from 'views/logic/search/SearchExecutionState';
 import View from 'views/logic/views/View';
 import Parameter from 'views/logic/parameters/Parameter';
 import type { WidgetMapping } from 'views/logic/views/types';
@@ -119,7 +119,7 @@ export const SearchStore = singletonStore(
       return this._executePromise(executionState, startActionPromise, handleSearchResult);
     },
 
-    reexecuteSearchTypes(searchTypes: MessageListOptions, effectiveTimerange?: TimeRange): Promise<SearchExecutionResult> {
+    reexecuteSearchTypes(parameterBindings: ParameterBindings, searchTypes: MessageListOptions, effectiveTimerange?: TimeRange): Promise<SearchExecutionResult> {
       const searchTypeIds = Object.keys(searchTypes);
       const globalOverride: GlobalOverride = new GlobalOverride(
         effectiveTimerange,
@@ -127,7 +127,7 @@ export const SearchStore = singletonStore(
         searchTypeIds,
         searchTypes,
       );
-      const executionState = new SearchExecutionState(undefined, globalOverride);
+      const executionState = new SearchExecutionState(parameterBindings, globalOverride);
       const handleSearchResult = (searchResult: SearchResult): SearchResult => {
         const updatedSearchTypes = searchResult.getSearchTypesFromResponse(searchTypeIds);
         const updatedResult = this.result.updateSearchTypes(updatedSearchTypes);

--- a/graylog2-web-interface/src/views/stores/SearchStore.js
+++ b/graylog2-web-interface/src/views/stores/SearchStore.js
@@ -3,7 +3,7 @@ import Reflux from 'reflux';
 import Bluebird from 'bluebird';
 import { debounce, get, isEqual } from 'lodash';
 
-import URLUtils from 'util/URLUtils';
+import { qualifyUrl } from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 
 import { SearchExecutionStateStore } from 'views/stores/SearchExecutionStateStore';
@@ -16,14 +16,14 @@ import Search from 'views/logic/search/Search';
 import type { CreateSearchResponse, SearchId, SearchExecutionResult } from 'views/actions/SearchActions';
 import GlobalOverride from 'views/logic/search/GlobalOverride';
 import type { MessageListOptions } from 'views/logic/search/GlobalOverride';
-import SearchExecutionState, { type ParameterBindings } from 'views/logic/search/SearchExecutionState';
+import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import View from 'views/logic/views/View';
 import Parameter from 'views/logic/parameters/Parameter';
 import type { WidgetMapping } from 'views/logic/views/types';
 import type { TimeRange } from 'views/logic/queries/Query';
 import { singletonStore } from 'views/logic/singleton';
 
-const createSearchUrl = URLUtils.qualifyUrl('/views/search');
+const createSearchUrl = qualifyUrl('/views/search');
 
 const displayError = (error) => {
   // eslint-disable-next-line no-console
@@ -32,7 +32,7 @@ const displayError = (error) => {
 
 Bluebird.config({ cancellation: true });
 
-const searchUrl = URLUtils.qualifyUrl('/views/search');
+const searchUrl = qualifyUrl('/views/search');
 
 export { SearchActions };
 

--- a/graylog2-web-interface/src/views/stores/SearchStore.js
+++ b/graylog2-web-interface/src/views/stores/SearchStore.js
@@ -119,15 +119,18 @@ export const SearchStore = singletonStore(
       return this._executePromise(executionState, startActionPromise, handleSearchResult);
     },
 
-    reexecuteSearchTypes(parameterBindings: ParameterBindings, searchTypes: MessageListOptions, effectiveTimerange?: TimeRange): Promise<SearchExecutionResult> {
+    reexecuteSearchTypes({ parameterBindings, globalOverride }: SearchExecutionState, searchTypes: MessageListOptions, effectiveTimerange?: TimeRange): Promise<SearchExecutionResult> {
       const searchTypeIds = Object.keys(searchTypes);
-      const globalOverride: GlobalOverride = new GlobalOverride(
+      const globalQuery = globalOverride && globalOverride.query ? globalOverride.query : undefined;
+
+      const newGlobalOverride: GlobalOverride = new GlobalOverride(
         effectiveTimerange,
-        undefined,
+        globalQuery,
         searchTypeIds,
         searchTypes,
       );
-      const executionState = new SearchExecutionState(parameterBindings, globalOverride);
+
+      const executionState = new SearchExecutionState(parameterBindings, newGlobalOverride);
       const handleSearchResult = (searchResult: SearchResult): SearchResult => {
         const updatedSearchTypes = searchResult.getSearchTypesFromResponse(searchTypeIds);
         const updatedResult = this.result.updateSearchTypes(updatedSearchTypes);

--- a/graylog2-web-interface/src/views/stores/SearchStore.js
+++ b/graylog2-web-interface/src/views/stores/SearchStore.js
@@ -119,7 +119,8 @@ export const SearchStore = singletonStore(
       return this._executePromise(executionState, startActionPromise, handleSearchResult);
     },
 
-    reexecuteSearchTypes({ parameterBindings, globalOverride }: SearchExecutionState, searchTypes: MessageListOptions, effectiveTimerange?: TimeRange): Promise<SearchExecutionResult> {
+    reexecuteSearchTypes(searchTypes: MessageListOptions, effectiveTimerange?: TimeRange): Promise<SearchExecutionResult> {
+      const { parameterBindings, globalOverride } = this.executionState;
       const searchTypeIds = Object.keys(searchTypes);
       const globalQuery = globalOverride && globalOverride.query ? globalOverride.query : undefined;
 


### PR DESCRIPTION
**Note: Needs a backport to `3.2`.**

As described in https://github.com/Graylog2/graylog2-server/issues/7680 a message list widget with an own search query does not consider the dashboard search query filter when using the widget pagination.

With this PR we are considering the dashboard filter search query on every search re-execution. A search re-execution currently only happens when using the message list pagination.

Fixes #7680
And also fixes #7665

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

