### PR TITLE
Reimplement props rest parameter usage for loading spinner component 

### DIFF
--- a/graylog2-web-interface/src/components/common/Spinner.jsx
+++ b/graylog2-web-interface/src/components/common/Spinner.jsx
@@ -11,16 +11,14 @@ const Wrapper: StyledComponent<{ visible: boolean }, {}, HTMLSpanElement> = styl
 
 type Props = {
   delay?: number,
-  fixedWidth?: boolean,
   name?: string,
-  pulse: boolean,
   text?: string,
 }
 
 /**
  * Simple spinner to use while waiting for something to load.
  */
-const Spinner = ({ name, text, delay, pulse, fixedWidth }: Props) => {
+const Spinner = ({ name, text, delay, ...rest }: Props) => {
   const [delayFinished, setDelayFinished] = useState(false);
 
   useEffect(() => {
@@ -33,7 +31,7 @@ const Spinner = ({ name, text, delay, pulse, fixedWidth }: Props) => {
 
   return (
     <Wrapper visible={delayFinished}>
-      <Icon name={name} spin pulse={pulse} fixedWidth={fixedWidth} /> {text}
+      <Icon {...rest} name={name} spin /> {text}
     </Wrapper>
   );
 };
@@ -45,18 +43,12 @@ Spinner.propTypes = {
   name: PropTypes.string,
   /** Text to show while loading. */
   text: PropTypes.string,
-  /** Use when different Icon widths throw off alignment. */
-  fixedWidth: PropTypes.bool,
-  /** Have Icon rotate with 8 steps */
-  pulse: PropTypes.bool,
 };
 
 Spinner.defaultProps = {
   name: 'spinner',
   text: 'Loading...',
   delay: 200,
-  fixedWidth: false,
-  pulse: false,
 };
 
 export default Spinner;

--- a/graylog2-web-interface/src/components/common/Spinner.test.jsx
+++ b/graylog2-web-interface/src/components/common/Spinner.test.jsx
@@ -35,4 +35,9 @@ describe('<Spinner />', () => {
 
     expect(container.firstChild).toHaveStyle('visibility: visible');
   });
+
+  it('should forward its props to its icon', () => {
+    const { getByTestId } = render(<Spinner data-testid="icon-test-id" />);
+    expect(getByTestId('icon-test-id')).not.toBeNull();
+  });
 });

--- a/graylog2-web-interface/src/components/common/Spinner.test.jsx
+++ b/graylog2-web-interface/src/components/common/Spinner.test.jsx
@@ -36,7 +36,7 @@ describe('<Spinner />', () => {
     expect(container.firstChild).toHaveStyle('visibility: visible');
   });
 
-  it('should forward its props to its icon', () => {
+  it('should forward additional props to its icon', () => {
     const { getByTestId } = render(<Spinner data-testid="icon-test-id" />);
     expect(getByTestId('icon-test-id')).not.toBeNull();
   });

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
@@ -2157,9 +2157,7 @@ exports[`<ContentPackEdit /> should render spinner with no content pack 1`] = `
 >
   <Spinner
     delay={200}
-    fixedWidth={false}
     name="spinner"
-    pulse={false}
     text="Loading..."
   >
     <Spinner__Wrapper

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstallEntityList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstallEntityList.test.jsx.snap
@@ -492,9 +492,7 @@ exports[`<ContentPackInstallEntityList /> should render without entities 1`] = `
 >
   <Spinner
     delay={200}
-    fixedWidth={false}
     name="spinner"
-    pulse={false}
     text="Loading..."
   >
     <Spinner__Wrapper


### PR DESCRIPTION
With https://github.com/Graylog2/graylog2-server/pull/7539 we removed the `...rest` parameter usage for the spinner component. After working with the current implementation I prefer the dynamic `...rest` parameter usage.
I forgot e.g. about the `className` prop and now adjusting the spinner style with `styled(Spinner)` is not working anymore. This problem is visible when using the pagination of a message list, currently the spinner beside the widget header has no margin.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

