### PR TITLE
Disable "Show top value" and "Statistics" field actions when field analysis is disabled

### DIFF
--- a/graylog2-web-interface/src/views/bindings.fieldActions.test.jsx
+++ b/graylog2-web-interface/src/views/bindings.fieldActions.test.jsx
@@ -48,6 +48,15 @@ describe('Views bindings field actions', () => {
       }))
         .toEqual(false);
     });
+    it('should be disabled when field analisys is disabled', () => {
+      expect(isEnabled({
+        ...defaultArguments,
+        field: 'something',
+        type: FieldTypes.STRING(),
+        contexts: { analysisDisabledFields: ['something'] },
+      }))
+        .toEqual(false);
+    });
   });
   describe('Statistics', () => {
     // $FlowFixMe: We are assuming here it is generally present
@@ -75,11 +84,12 @@ describe('Views bindings field actions', () => {
       }))
         .toEqual(true);
     });
-    it('should be disabled for decorated fields', () => {
+    it('should be disabled when field analisys is disabled', () => {
       expect(isEnabled({
         ...defaultArguments,
         field: 'something',
-        type: FieldType.create('string', [Properties.Decorated]),
+        type: FieldTypes.STRING(),
+        contexts: { analysisDisabledFields: ['something'] },
       }))
         .toEqual(false);
     });
@@ -118,6 +128,15 @@ describe('Views bindings field actions', () => {
       }))
         .toEqual(false);
     });
+    it('should be enabled when field analisys is disabled', () => {
+      expect(isEnabled({
+        ...defaultArguments,
+        field: 'something',
+        type: FieldTypes.STRING(),
+        contexts: { analysisDisabledFields: ['something'] },
+      }))
+        .toEqual(true);
+    });
   });
   describe('RemoveFromAllTables', () => {
     // $FlowFixMe: We are assuming here it is generally present
@@ -152,6 +171,15 @@ describe('Views bindings field actions', () => {
         type: FieldType.create('string', [Properties.Decorated]),
       }))
         .toEqual(false);
+    });
+    it('should be enabled when field analisys is disabled', () => {
+      expect(isEnabled({
+        ...defaultArguments,
+        field: 'something',
+        type: FieldTypes.STRING(),
+        contexts: { analysisDisabledFields: ['something'] },
+      }))
+        .toEqual(true);
     });
   });
 });

--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -109,7 +109,7 @@ ViewSharing.registerSubtype(SpecificUsers.Type, SpecificUsers);
 Parameter.registerSubtype(ValueParameter.type, ValueParameter);
 Parameter.registerSubtype(LookupTableParameter.type, LookupTableParameter);
 
-const isAnalysisDisabled = (field: string, analysisDisabledFields: string[] = []) => !!analysisDisabledFields.includes(field);
+const isAnalysisDisabled = (field: string, analysisDisabledFields: string[] = []) => analysisDisabledFields.includes(field);
 
 export default {
   pages: {

--- a/graylog2-web-interface/src/views/bindings.jsx
+++ b/graylog2-web-interface/src/views/bindings.jsx
@@ -109,6 +109,8 @@ ViewSharing.registerSubtype(SpecificUsers.Type, SpecificUsers);
 Parameter.registerSubtype(ValueParameter.type, ValueParameter);
 Parameter.registerSubtype(LookupTableParameter.type, LookupTableParameter);
 
+const isAnalysisDisabled = (field: string, analysisDisabledFields: string[] = []) => !!analysisDisabledFields.includes(field);
+
 export default {
   pages: {
     search: { component: NewSearchPage },
@@ -202,12 +204,12 @@ export default {
       type: 'aggregate',
       title: 'Show top values',
       handler: AggregateActionHandler,
-      isEnabled: (({ field, type }) => (!isFunction(field) && !type.isCompound() && !type.isDecorated()): ActionHandlerCondition),
+      isEnabled: (({ field, type, contexts: { analysisDisabledFields } }) => (!isFunction(field) && !type.isCompound() && !type.isDecorated() && !isAnalysisDisabled(field, analysisDisabledFields)): ActionHandlerCondition),
     },
     {
       type: 'statistics',
       title: 'Statistics',
-      isEnabled: (({ field, type }) => (!isFunction(field) && !type.isDecorated()): ActionHandlerCondition),
+      isEnabled: (({ field, type, contexts: { analysisDisabledFields } }) => (!isFunction(field) && !type.isDecorated() && !isAnalysisDisabled(field, analysisDisabledFields)): ActionHandlerCondition),
       handler: FieldStatisticsHandler,
     },
     {

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -21,11 +21,10 @@ import { Grid } from 'components/graylog';
 import { FieldTypesStore, FieldTypesActions } from 'views/stores/FieldTypesStore';
 import { SearchStore, SearchActions } from 'views/stores/SearchStore';
 import { SearchExecutionStateStore } from 'views/stores/SearchExecutionStateStore';
-import { SearchConfigActions } from 'views/stores/SearchConfigStore';
+import { SearchConfigActions, SearchConfigStore } from 'views/stores/SearchConfigStore';
 import { SearchMetadataActions } from 'views/stores/SearchMetadataStore';
 import { StreamsActions } from 'views/stores/StreamsStore';
 import { ViewActions, ViewStore } from 'views/stores/ViewStore';
-import ConfigurationsStore from 'stores/configurations/ConfigurationsStore';
 import HeaderElements from 'views/components/HeaderElements';
 import QueryBarElements from 'views/components/QueryBarElements';
 import WindowLeaveMessage from 'views/components/common/WindowLeaveMessage';
@@ -129,7 +128,7 @@ const DashboardSearchBarWithStatus = WithSearchStatus(DashboardSearchBar);
 
 const ViewAdditionalContextProvider = connect(
   AdditionalContext.Provider,
-  { view: ViewStore, configs: ConfigurationsStore },
+  { view: ViewStore, configs: SearchConfigStore },
   ({ view, configs: { searchesClusterConfig } }) => ({ value: { view: view.view, analysisDisabledFields: searchesClusterConfig.analysis_disabled_fields } }),
 );
 

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -25,6 +25,7 @@ import { SearchConfigActions } from 'views/stores/SearchConfigStore';
 import { SearchMetadataActions } from 'views/stores/SearchMetadataStore';
 import { StreamsActions } from 'views/stores/StreamsStore';
 import { ViewActions, ViewStore } from 'views/stores/ViewStore';
+import ConfigurationsStore from 'stores/configurations/ConfigurationsStore';
 import HeaderElements from 'views/components/HeaderElements';
 import QueryBarElements from 'views/components/QueryBarElements';
 import WindowLeaveMessage from 'views/components/common/WindowLeaveMessage';
@@ -126,7 +127,11 @@ const _refreshIfNotUndeclared = (searchRefreshHooks, executionState) => {
 const SearchBarWithStatus = WithSearchStatus(SearchBar);
 const DashboardSearchBarWithStatus = WithSearchStatus(DashboardSearchBar);
 
-const ViewAdditionalContextProvider = connect(AdditionalContext.Provider, { view: ViewStore }, ({ view }) => ({ value: { view: view.view } }));
+const ViewAdditionalContextProvider = connect(
+  AdditionalContext.Provider,
+  { view: ViewStore, configs: ConfigurationsStore },
+  ({ view, configs: { searchesClusterConfig } }) => ({ value: { view: view.view, analysisDisabledFields: searchesClusterConfig.analysis_disabled_fields } }),
+);
 
 const useStyle = () => {
   useEffect(() => {

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -180,39 +180,38 @@ const ExtendedSearchPage = ({ route, location = { query: {} }, router, searchRef
       </IfInteractive>
       <InteractiveContext.Consumer>
         {interactive => (
-          <GridContainer id="main-row" interactive={interactive}>
-            <IfInteractive>
-              <ConnectedSideBar>
-                <ConnectedFieldList />
-              </ConnectedSideBar>
-            </IfInteractive>
-            <SearchArea>
-              <SearchGrid>
-                <IfInteractive>
-                  <HeaderElements />
-                  <IfDashboard>
-                    <DashboardSearchBarWithStatus onExecute={refreshIfNotUndeclared} />
-                  </IfDashboard>
-                  <IfSearch>
-                    <SearchBarWithStatus onExecute={refreshIfNotUndeclared} />
-                  </IfSearch>
+          <ViewAdditionalContextProvider>
+            <GridContainer id="main-row" interactive={interactive}>
+              <IfInteractive>
+                <ConnectedSideBar>
+                  <ConnectedFieldList />
+                </ConnectedSideBar>
+              </IfInteractive>
+              <SearchArea>
+                <SearchGrid>
+                  <IfInteractive>
+                    <HeaderElements />
+                    <IfDashboard>
+                      <DashboardSearchBarWithStatus onExecute={refreshIfNotUndeclared} />
+                    </IfDashboard>
+                    <IfSearch>
+                      <SearchBarWithStatus onExecute={refreshIfNotUndeclared} />
+                    </IfSearch>
 
-                  <QueryBarElements />
+                    <QueryBarElements />
 
-                  <IfDashboard>
-                    <QueryBar />
-                  </IfDashboard>
-                </IfInteractive>
-
-                <ViewAdditionalContextProvider>
+                    <IfDashboard>
+                      <QueryBar />
+                    </IfDashboard>
+                  </IfInteractive>
                   <HighlightMessageInQuery query={location.query}>
                     <SearchResult />
                   </HighlightMessageInQuery>
-                </ViewAdditionalContextProvider>
-                <Footer />
-              </SearchGrid>
-            </SearchArea>
-          </GridContainer>
+                  <Footer />
+                </SearchGrid>
+              </SearchArea>
+            </GridContainer>
+          </ViewAdditionalContextProvider>
         )}
       </InteractiveContext.Consumer>
     </CurrentViewTypeProvider>

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.test.jsx
@@ -65,6 +65,15 @@ jest.mock('views/stores/FieldTypesStore', () => ({
     })],
   ),
 }));
+jest.mock('views/stores/SearchConfigStore', () => ({
+  SearchConfigStore: {
+    listen: () => jest.fn(),
+    getInitialState: () => ({
+      searchesClusterConfig: {},
+    }),
+  },
+  SearchConfigActions: {},
+}));
 jest.mock('components/layout/Footer', () => mockComponent('Footer'));
 jest.mock('views/components/QueryBar', () => mockComponent('QueryBar'));
 jest.mock('views/components/SearchResult', () => mockComponent('SearchResult'));
@@ -73,7 +82,6 @@ jest.mock('views/components/common/WindowLeaveMessage', () => mockComponent('Win
 jest.mock('views/components/WithSearchStatus', () => x => x);
 jest.mock('views/components/SearchBar', () => mockComponent('SearchBar'));
 jest.mock('views/components/DashboardSearchBar', () => mockComponent('DashboardSearchBar'));
-jest.mock('views/stores/SearchConfigStore', () => ({ SearchConfigStore: {}, SearchConfigActions: {} }));
 jest.mock('views/stores/SearchMetadataStore', () => ({ SearchMetadataActions: {}, SearchMetadataStore: {} }));
 jest.mock('views/logic/withPluginEntities', () => x => x);
 jest.mock('views/components/views/CurrentViewTypeProvider', () => jest.fn());


### PR DESCRIPTION
**Note: This PR requires a backport for 3.2**

As described in https://github.com/Graylog2/graylog2-server/issues/7508 field actions like "Show top values / aggregate" are enabled, even when the field is part of the list "UI analysis disabled for fields", which can be configured in System/Configurations.

With these changes we are simply checking if a field is part of the "analysis disabled fields" list, when determining if a field action should be enabled.

Please note, beside the mentioned "Show top values / aggregate" field action I've also added the check for the "Statistics" field action.

We need to merge the related enterprise PR first to avoid the failing test.

Fixes: #7508


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

