### PR TITLE
Making loading indicator on search show up delayed.

### DIFF
--- a/graylog2-web-interface/src/components/common/Delayed.jsx
+++ b/graylog2-web-interface/src/components/common/Delayed.jsx
@@ -1,0 +1,31 @@
+// @flow strict
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+type Props = {
+  children: React.Node,
+  delay: number,
+};
+
+const Delayed = ({ children, delay }: Props) => {
+  const [delayFinished, setDelayFinished] = useState(delay <= 0);
+  useEffect(() => {
+    if (delay <= 0) {
+      return () => {};
+    }
+
+    const delayTimeout = window.setTimeout(() => setDelayFinished(true), delay);
+
+    return () => clearTimeout(delayTimeout);
+  }, []);
+
+  return delayFinished ? children : null;
+};
+
+Delayed.propTypes = {
+  children: PropTypes.node.isRequired,
+  delay: PropTypes.number.isRequired,
+};
+
+export default Delayed;

--- a/graylog2-web-interface/src/components/common/Delayed.test.jsx
+++ b/graylog2-web-interface/src/components/common/Delayed.test.jsx
@@ -1,0 +1,36 @@
+// @flow strict
+import * as React from 'react';
+import { cleanup, render } from 'wrappedTestingLibrary';
+import { act } from 'react-dom/test-utils';
+
+import Delayed from './Delayed';
+
+describe('Delayed', () => {
+  afterEach(cleanup);
+
+  const HelloWorld = () => <span>Hello World!</span>;
+
+  it('renders children when delay is 0', () => {
+    const { getByText } = render((
+      <Delayed delay={0}>
+        <HelloWorld />
+      </Delayed>
+    ));
+    expect(getByText('Hello World!')).not.toBeNull();
+  });
+
+  it('renders children after delay has passed', () => {
+    const { getByText, queryByText } = render((
+      <Delayed delay={200}>
+        <HelloWorld />
+      </Delayed>
+    ));
+    expect(queryByText('Hello World!')).toBeNull();
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+
+    expect(getByText('Hello World!')).not.toBeNull();
+  });
+});

--- a/graylog2-web-interface/src/components/common/Delayed.test.jsx
+++ b/graylog2-web-interface/src/components/common/Delayed.test.jsx
@@ -6,6 +6,9 @@ import { act } from 'react-dom/test-utils';
 import Delayed from './Delayed';
 
 describe('Delayed', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
   afterEach(cleanup);
 
   const HelloWorld = () => <span>Hello World!</span>;
@@ -27,9 +30,7 @@ describe('Delayed', () => {
     ));
     expect(queryByText('Hello World!')).toBeNull();
 
-    act(() => {
-      jest.advanceTimersByTime(200);
-    });
+    act(() => jest.advanceTimersByTime(200));
 
     expect(getByText('Hello World!')).not.toBeNull();
   });

--- a/graylog2-web-interface/src/components/common/LoadingIndicator.jsx
+++ b/graylog2-web-interface/src/components/common/LoadingIndicator.jsx
@@ -5,6 +5,7 @@ import { Alert } from 'components/graylog';
 import Spinner from 'components/common/Spinner';
 
 import loadingIndicatorStyle from './LoadingIndicator.css';
+import Delayed from './Delayed';
 
 /**
  * Component that displays a loading indicator in the page. It uses a CSS fixed position to always appear
@@ -13,19 +14,21 @@ import loadingIndicatorStyle from './LoadingIndicator.css';
  * Use this component when you want to load something in the background, but still provide some feedback that
  * an action is happening.
  */
-class LoadingIndicator extends React.Component {
-  static propTypes = {
-    /** Text to display while the indicator is shown. */
-    text: PropTypes.string,
-  };
+const LoadingIndicator = ({ text }) => (
+  <Delayed delay={500}>
+    <Alert bsStyle="info" className={loadingIndicatorStyle.loadingIndicator}>
+      <Spinner delay={0} text={text} />
+    </Alert>
+  </Delayed>
+);
 
-  static defaultProps = {
-    text: 'Loading...',
-  };
+LoadingIndicator.propTypes = {
+  /** Text to display while the indicator is shown. */
+  text: PropTypes.string,
+};
 
-  render() {
-    return <Alert bsStyle="info" className={loadingIndicatorStyle.loadingIndicator}><Spinner text={this.props.text} /></Alert>;
-  }
-}
+LoadingIndicator.defaultProps = {
+  text: 'Loading...',
+};
 
 export default LoadingIndicator;

--- a/graylog2-web-interface/src/components/common/Spinner.jsx
+++ b/graylog2-web-interface/src/components/common/Spinner.jsx
@@ -1,13 +1,9 @@
 // @flow strict
-import React, { useState, useEffect } from 'react';
+import * as React from 'react';
 import PropTypes from 'prop-types';
-import styled, { type StyledComponent } from 'styled-components';
 
 import Icon from './Icon';
-
-const Wrapper: StyledComponent<{ visible: boolean }, {}, HTMLSpanElement> = styled.span`
-  visibility: ${({ visible }) => (visible ? 'visible' : 'hidden')};
-`;
+import Delayed from './Delayed';
 
 type Props = {
   delay?: number,
@@ -18,23 +14,11 @@ type Props = {
 /**
  * Simple spinner to use while waiting for something to load.
  */
-const Spinner = ({ name, text, delay, ...rest }: Props) => {
-  const [delayFinished, setDelayFinished] = useState(false);
-
-  useEffect(() => {
-    const delayTimeout = window.setTimeout(() => {
-      setDelayFinished(true);
-    }, delay);
-
-    return () => clearTimeout(delayTimeout);
-  }, []);
-
-  return (
-    <Wrapper visible={delayFinished}>
-      <Icon {...rest} name={name} spin /> {text}
-    </Wrapper>
-  );
-};
+const Spinner = ({ name, text, delay, ...rest }: Props) => (
+  <Delayed delay={delay}>
+    <Icon {...rest} name={name} spin /> {text}
+  </Delayed>
+);
 
 Spinner.propTypes = {
   /** Delay in ms before displaying the spinner */

--- a/graylog2-web-interface/src/components/common/Spinner.jsx
+++ b/graylog2-web-interface/src/components/common/Spinner.jsx
@@ -6,7 +6,7 @@ import Icon from './Icon';
 import Delayed from './Delayed';
 
 type Props = {
-  delay?: number,
+  delay: number,
   name?: string,
   text?: string,
 }

--- a/graylog2-web-interface/src/components/common/Spinner.test.jsx
+++ b/graylog2-web-interface/src/components/common/Spinner.test.jsx
@@ -12,19 +12,19 @@ describe('<Spinner />', () => {
   });
 
   it('should render without props', () => {
-    const { getByText } = render(<Spinner />);
+    const { getByText } = render(<Spinner delay={0} />);
     expect(getByText('Loading...')).not.toBeNull();
   });
 
   it('should render with a different text string', () => {
     const text = 'Hello world!';
-    const { getByText } = render(<Spinner text={text} />);
+    const { getByText } = render(<Spinner text={text} delay={0} />);
     expect(getByText(text)).not.toBeNull();
   });
 
   it('should not be visible initially', () => {
-    const { container } = render(<Spinner />);
-    expect(container.firstChild).toHaveStyle('visibility: hidden');
+    const { queryByText } = render(<Spinner />);
+    expect(queryByText('Loading ...')).toBeNull();
   });
 
   it('should be visible after when delay is completed', () => {
@@ -34,10 +34,5 @@ describe('<Spinner />', () => {
     });
 
     expect(container.firstChild).toHaveStyle('visibility: visible');
-  });
-
-  it('should forward additional props to its icon', () => {
-    const { getByTestId } = render(<Spinner data-testid="icon-test-id" />);
-    expect(getByTestId('icon-test-id')).not.toBeNull();
   });
 });

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
@@ -2160,56 +2160,9 @@ exports[`<ContentPackEdit /> should render spinner with no content pack 1`] = `
     name="spinner"
     text="Loading..."
   >
-    <Spinner__Wrapper
-      visible={false}
-    >
-      <StyledComponent
-        forwardedComponent={
-          Object {
-            "$$typeof": Symbol(react.forward_ref),
-            "attrs": Array [],
-            "componentStyle": ComponentStyle {
-              "componentId": "Spinner__Wrapper-hg0ct4-0",
-              "isStatic": false,
-              "lastClassName": "hyHIAb",
-              "rules": Array [
-                "visibility:",
-                [Function],
-                ";",
-              ],
-            },
-            "displayName": "Spinner__Wrapper",
-            "foldedComponentIds": Array [],
-            "render": [Function],
-            "styledComponentId": "Spinner__Wrapper-hg0ct4-0",
-            "target": "span",
-            "toString": [Function],
-            "warnTooManyClasses": [Function],
-            "withComponent": [Function],
-          }
-        }
-        forwardedRef={null}
-        visible={false}
-      >
-        <span
-          className="Spinner__Wrapper-hg0ct4-0 hyHIAb"
-        >
-          <ForwardRef
-            fixedWidth={false}
-            inverse={false}
-            name="spinner"
-            pulse={false}
-            spin={true}
-          >
-            <i
-              className="fa fa-spinner fa-spin"
-            />
-          </ForwardRef>
-           
-          Loading...
-        </span>
-      </StyledComponent>
-    </Spinner__Wrapper>
+    <Delayed
+      delay={200}
+    />
   </Spinner>
 </ContentPackEdit>
 `;

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstallEntityList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstallEntityList.test.jsx.snap
@@ -495,56 +495,9 @@ exports[`<ContentPackInstallEntityList /> should render without entities 1`] = `
     name="spinner"
     text="Loading..."
   >
-    <Spinner__Wrapper
-      visible={false}
-    >
-      <StyledComponent
-        forwardedComponent={
-          Object {
-            "$$typeof": Symbol(react.forward_ref),
-            "attrs": Array [],
-            "componentStyle": ComponentStyle {
-              "componentId": "Spinner__Wrapper-hg0ct4-0",
-              "isStatic": false,
-              "lastClassName": "hyHIAb",
-              "rules": Array [
-                "visibility:",
-                [Function],
-                ";",
-              ],
-            },
-            "displayName": "Spinner__Wrapper",
-            "foldedComponentIds": Array [],
-            "render": [Function],
-            "styledComponentId": "Spinner__Wrapper-hg0ct4-0",
-            "target": "span",
-            "toString": [Function],
-            "warnTooManyClasses": [Function],
-            "withComponent": [Function],
-          }
-        }
-        forwardedRef={null}
-        visible={false}
-      >
-        <span
-          className="Spinner__Wrapper-hg0ct4-0 hyHIAb"
-        >
-          <ForwardRef
-            fixedWidth={false}
-            inverse={false}
-            name="spinner"
-            pulse={false}
-            spin={true}
-          >
-            <i
-              className="fa fa-spinner fa-spin"
-            />
-          </ForwardRef>
-           
-          Loading...
-        </span>
-      </StyledComponent>
-    </Spinner__Wrapper>
+    <Delayed
+      delay={200}
+    />
   </Spinner>
 </ContentPackInstallEntityList>
 `;

--- a/graylog2-web-interface/src/views/components/SearchBar.test.jsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.test.jsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { mount } from 'wrappedEnzyme';
 import * as Immutable from 'immutable';
+import { act } from 'react-dom/test-utils';
 
 import { StoreMock as MockStore } from 'helpers/mocking';
 import { QueriesActions } from 'views/stores/QueriesStore';
@@ -39,6 +40,9 @@ jest.mock('views/stores/ViewManagementStore', () => ({
 jest.mock('views/components/searchbar/QueryInput', () => 'query-input');
 
 describe('SearchBar', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
   const config = {
     analysis_disabled_fields: ['full_message', 'message'],
     query_time_range_limit: 'PT0S',
@@ -55,14 +59,18 @@ describe('SearchBar', () => {
   it('should render the SearchBar', () => {
     // Empty currentQuery
     const wrapper = mount(<SearchBar config={config} onExecute={() => {}} />);
-    expect(wrapper.find('span').text()).toBe(' Loading...');
-    expect(wrapper.find('option').length).toBe(0);
+
+    act(() => jest.advanceTimersByTime(200));
+    wrapper.update();
+
+    expect(wrapper).toHaveText(' Loading...');
+    expect(wrapper.find('option')).not.toExist();
 
     // Set new currentQuery
     wrapper.setState({ currentQuery });
-    expect(wrapper.find('option').at(0).text()).toBe('Search in last day');
-    expect(wrapper.find('option').at(1).text()).toBe('Search in all messages');
-    expect(wrapper.find('option').at(2).length).toBe(0);
+    expect(wrapper.find('option')).toHaveLength(2);
+    expect(wrapper.find('option[children="Search in last day"]')).toExist();
+    expect(wrapper.find('option[children="Search in all messages"]')).toExist();
   });
 
   it('should execute a search', () => {

--- a/graylog2-web-interface/src/views/components/SearchResult.test.jsx
+++ b/graylog2-web-interface/src/views/components/SearchResult.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 
 import { render, cleanup } from 'wrappedTestingLibrary';
 import asMock from 'helpers/mocking/AsMock';
@@ -53,6 +54,9 @@ jest.mock('views/stores/SearchLoadingStateStore', () => ({
 }));
 
 describe('SearchResult', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
   beforeEach(() => {
     cleanup();
     jest.clearAllMocks();
@@ -61,16 +65,19 @@ describe('SearchResult', () => {
   it('should show spinner while loading field types', () => {
     asMock(FieldTypesStore.getInitialState).mockReturnValueOnce(undefined);
     const { getByText } = render(<SearchResult />);
+    act(() => jest.advanceTimersByTime(200));
     expect(getByText('Loading...')).not.toBeNull();
   });
-  it('should show spinner when ther are no search results', () => {
+  it('should show spinner when there are no search results', () => {
     asMock(FieldTypesStore.getInitialState).mockReturnValueOnce(undefined);
     const { getByText } = render(<SearchResult />);
+    act(() => jest.advanceTimersByTime(200));
     expect(getByText('Loading...')).not.toBeNull();
   });
   it('should display loading indicator, when search is loading ', () => {
-    asMock(SearchLoadingStateStore.getInitialState).mockReturnValueOnce({ isLoading: true });
+    asMock(SearchLoadingStateStore.getInitialState).mockImplementation(() => ({ isLoading: true }));
     const { getByText } = render(<SearchResult />);
+    act(() => jest.advanceTimersByTime(500));
     expect(getByText('Updating search results...')).not.toBeNull();
   });
   it('should hide loading indicator, when search is not loading', () => {

--- a/graylog2-web-interface/src/views/pages/NewDashboardPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/NewDashboardPage.test.jsx
@@ -10,6 +10,7 @@ import Search from 'views/logic/search/Search';
 import View from 'views/logic/views/View';
 
 import NewDashboardPage from './NewDashboardPage';
+import { act } from "react-dom/test-utils";
 
 jest.mock('./ExtendedSearchPage', () => () => <div>Extended search page</div>);
 jest.mock('views/stores/ViewStore', () => ({
@@ -22,6 +23,9 @@ jest.mock('views/logic/views/ViewLoader', () => ({
 describe('NewDashboardPage', () => {
   const SimpleNewDashboardPage = props => <NewDashboardPage route={{}} location={{}} {...props} />;
 
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
   afterEach(() => {
     cleanup();
     jest.clearAllMocks();
@@ -30,6 +34,7 @@ describe('NewDashboardPage', () => {
   it('shows loading spinner before rendering page', async () => {
     const { getByText } = render(<SimpleNewDashboardPage />);
 
+    act(() => jest.advanceTimersByTime(200));
     expect(getByText('Loading...')).not.toBeNull();
     await waitForElement(() => getByText('Extended search page'));
   });

--- a/graylog2-web-interface/src/views/pages/NewDashboardPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/NewDashboardPage.test.jsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import { render, cleanup, waitForElement, wait } from 'wrappedTestingLibrary';
 import asMock from 'helpers/mocking/AsMock';
+import { act } from 'react-dom/test-utils';
 
 import { processHooks } from 'views/logic/views/ViewLoader';
 import { ViewActions } from 'views/stores/ViewStore';
@@ -10,7 +11,6 @@ import Search from 'views/logic/search/Search';
 import View from 'views/logic/views/View';
 
 import NewDashboardPage from './NewDashboardPage';
-import { act } from "react-dom/test-utils";
 
 jest.mock('./ExtendedSearchPage', () => () => <div>Extended search page</div>);
 jest.mock('views/stores/ViewStore', () => ({

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.test.jsx
@@ -14,6 +14,7 @@ import View from 'views/logic/views/View';
 import ViewLoaderContext from 'views/logic/ViewLoaderContext';
 
 import NewSearchPage from './NewSearchPage';
+import { act } from "react-dom/test-utils";
 
 const mockExtendedSearchPage = jest.fn(() => <div>Extended search page</div>);
 const mockView = View.create()
@@ -59,6 +60,9 @@ describe('NewSearchPage', () => {
   };
   const SimpleNewSearchPage = props => <NewSearchPage route={{}} router={mockRouter} location={{}} {...props} />;
 
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
   afterEach(() => {
     cleanup();
     jest.clearAllMocks();
@@ -71,6 +75,7 @@ describe('NewSearchPage', () => {
 
   it('should show spinner while loading view', () => {
     const { getByText } = render(<SimpleNewSearchPage />);
+    act(() => jest.advanceTimersByTime(200));
     expect(getByText('Loading...')).not.toBeNull();
   });
 

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.test.jsx
@@ -1,6 +1,7 @@
 // @flow strict
 import * as React from 'react';
 
+import { act } from 'react-dom/test-utils';
 import { render, cleanup, wait, waitForElement, fireEvent } from 'wrappedTestingLibrary';
 import asMock from 'helpers/mocking/AsMock';
 
@@ -14,7 +15,6 @@ import View from 'views/logic/views/View';
 import ViewLoaderContext from 'views/logic/ViewLoaderContext';
 
 import NewSearchPage from './NewSearchPage';
-import { act } from "react-dom/test-utils";
 
 const mockExtendedSearchPage = jest.fn(() => <div>Extended search page</div>);
 const mockView = View.create()

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.test.jsx
@@ -1,6 +1,7 @@
 // @flow strict
 import * as React from 'react';
 import { render, cleanup, wait, waitForElement, fireEvent } from 'wrappedTestingLibrary';
+import { act } from 'react-dom/test-utils';
 
 import asMock from 'helpers/mocking/AsMock';
 
@@ -45,6 +46,9 @@ jest.mock('views/logic/views/ViewLoader', () => {
 });
 
 describe('StreamSearchPage', () => {
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
   const mockRouter = {
     getCurrentLocation: jest.fn(() => ({ pathname: '/search', search: '?q=&rangetype=relative&relative=300' })),
   };
@@ -72,6 +76,7 @@ describe('StreamSearchPage', () => {
 
   it('shows loading spinner before rendering page', async () => {
     const { getByText } = render(<SimpleStreamSearchPage />);
+    act(() => jest.advanceTimersByTime(200));
 
     expect(getByText('Loading...')).not.toBeNull();
     await waitForElement(() => getByText('Extended search page'));


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, PR #7539 introduced a delay for the `Spinner`
component. This works where only this one is used, but had the effect
that the `LoadingIndicator` component was shown before the `Spinner`
inside is.

This PR is extracting a shared `Delayed` component, which is rendering
its children after the `delay` (in ms) has passed, defaulting to 200ms.
This component is used by `Spinner` and `LoadingIndicator`. The latter
is passing a `delay` of `0` to `Spinner` to avoid delaying rendering
twice.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.