### PR TITLE
Keep DataTable rows up-to-date (#7657)

### DIFF
--- a/graylog2-web-interface/src/components/common/DataTable.jsx
+++ b/graylog2-web-interface/src/components/common/DataTable.jsx
@@ -83,14 +83,6 @@ class DataTable extends React.Component {
     };
   }
 
-  componentDidUpdate(previousProps) {
-    // We update the state with row if the filterKeys is empty other than that typeahead is handling the state
-    const { filterKeys, rows } = this.props;
-    if (filterKeys.length === 0 && !isEqual(previousProps.rows, rows)) {
-      this._updateState();
-    }
-  }
-
   getFormattedHeaders = () => {
     let i = 0;
     const { headerCellFormatter, headers } = this.props;
@@ -106,7 +98,7 @@ class DataTable extends React.Component {
   getFormattedDataRows = () => {
     let i = 0;
     const { sortByKey, sortBy, dataRowFormatter } = this.props;
-    let { filteredRows: sortedDataRows } = this.state;
+    let sortedDataRows = this._getEffectiveRows();
     if (sortByKey) {
       sortedDataRows = sortedDataRows.sort((a, b) => {
         return a[sortByKey].localeCompare(b[sortByKey]);
@@ -129,12 +121,11 @@ class DataTable extends React.Component {
     this.setState({ filteredRows });
   };
 
-  _updateState() {
-    const { rows } = this.props;
-    this.setState({
-      filteredRows: rows,
-    });
-  }
+  _getEffectiveRows = () => {
+    const { filteredRows } = this.state;
+    const { filterKeys, rows } = this.props;
+    return (filterKeys.length === 0 ? rows : filteredRows.filter(row => rows.some(r => isEqual(r, row))));
+  };
 
   render() {
     let filter;
@@ -152,7 +143,7 @@ class DataTable extends React.Component {
       useResponsiveTable,
       rows,
     } = this.props;
-    const { filteredRows } = this.state;
+    const effectiveRows = this._getEffectiveRows();
     if (filterKeys.length !== 0) {
       filter = (
         <div className="row">
@@ -176,7 +167,7 @@ class DataTable extends React.Component {
     let data;
     if (rows.length === 0) {
       data = <p>{noDataText}</p>;
-    } else if (filteredRows.length === 0) {
+    } else if (effectiveRows.length === 0) {
       data = <p>Filter does not match any data.</p>;
     } else {
       data = (

--- a/graylog2-web-interface/src/components/common/DataTable.test.jsx
+++ b/graylog2-web-interface/src/components/common/DataTable.test.jsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { mount } from 'wrappedEnzyme';
+import { cloneDeep } from 'lodash';
+
+import DataTable from 'components/common/DataTable';
+import TypeAheadDataFilter from 'components/common/TypeAheadDataFilter';
+
+const rowFormatter = row => <tr><td>{row.title}</td></tr>;
+
+const simulateTypeAheadFilter = (wrapper, filterText) => {
+  const filter = wrapper.find(TypeAheadDataFilter);
+  filter.instance().setState({ filterText: filterText });
+  filter.instance().filterData();
+};
+
+const filterRows = (rows, filterText) => {
+  return rows.filter(row => row.title.match(filterText));
+};
+
+describe('<DataTable />', () => {
+  const rows = [
+    { title: 'Row 1' },
+    { title: 'Row 2' },
+    { title: 'Foo 3' },
+  ];
+
+  it('should render with no rows', () => {
+    const wrapper = mount(<DataTable id="myDataTable" headers={['One']} rows={[]} dataRowFormatter={rowFormatter} />);
+    expect(wrapper.find('table')).toHaveLength(0);
+    expect(wrapper.text()).toBe('No data available.');
+  });
+
+  it('should render with rows', () => {
+    const wrapper = mount(
+      <DataTable id="myDataTable" headers={['One']} rows={rows} dataRowFormatter={rowFormatter} />,
+    );
+    expect(wrapper.find('tbody tr')).toHaveLength(rows.length);
+  });
+
+  it('should update rendered rows when array changes', () => {
+    const wrapper = mount(
+      <DataTable id="myDataTable" headers={['One']} rows={rows} dataRowFormatter={rowFormatter} />,
+    );
+    expect(wrapper.find('tbody tr')).toHaveLength(rows.length);
+
+    const [, ...nextRows] = rows;
+    expect(nextRows).toHaveLength(rows.length - 1);
+    wrapper.setProps({ rows: nextRows });
+    expect(wrapper.find('tbody tr')).toHaveLength(rows.length - 1);
+  });
+
+  it('should filter rows', () => {
+    const wrapper = mount(
+      <DataTable id="myDataTable" headers={['One']} rows={rows} dataRowFormatter={rowFormatter} filterKeys={['title']} />,
+    );
+    expect(wrapper.find('tbody tr')).toHaveLength(rows.length);
+
+    const filteredRows = filterRows(rows, /Row/);
+    expect(filteredRows).toHaveLength(rows.length - 1);
+    simulateTypeAheadFilter(wrapper, 'Row');
+    wrapper.update();
+    expect(wrapper.state('filteredRows')).toEqual(filteredRows);
+    expect(wrapper.find('tbody tr')).toHaveLength(rows.length - 1);
+  });
+
+  it('should keep filter when row in props change', () => {
+    const wrapper = mount(
+      <DataTable id="myDataTable" headers={['One']} rows={rows} dataRowFormatter={rowFormatter} filterKeys={['title']} />,
+    );
+    expect(wrapper.find('tbody tr')).toHaveLength(rows.length);
+    const filteredRows = filterRows(rows, /Row/);
+    simulateTypeAheadFilter(wrapper, 'Row');
+    wrapper.update();
+    expect(wrapper.state('filteredRows')).toEqual(filteredRows);
+    expect(wrapper.find('tbody tr')).toHaveLength(filteredRows.length);
+
+    const nextRows = rows.concat([{ title: 'Row 4' }]);
+    wrapper.setProps({ rows: nextRows });
+    const nextFilteredRows = filterRows(nextRows, /Row/);
+    // Length is the same as before, filtering is done by a children and needs an update
+    expect(wrapper.find('tbody tr')).toHaveLength(filteredRows.length);
+    wrapper.update();
+    expect(wrapper.find('tbody tr')).toHaveLength(nextFilteredRows.length);
+  });
+
+  it('should not try to render removed rows', () => {
+    const wrapper = mount(
+      <DataTable id="myDataTable" headers={['One']} rows={rows} dataRowFormatter={rowFormatter} filterKeys={['title']} />,
+    );
+    expect(wrapper.find('tbody tr')).toHaveLength(rows.length);
+    const filteredRows = filterRows(rows, /Row/);
+    simulateTypeAheadFilter(wrapper, 'Row');
+    wrapper.update();
+    expect(wrapper.state('filteredRows')).toEqual(filteredRows);
+    expect(wrapper.find('tbody tr')).toHaveLength(filteredRows.length);
+
+    // Ensure this also works with deep comparison
+    const clonedRows = cloneDeep(filteredRows);
+    const [, ...nextRows] = clonedRows;
+    wrapper.setProps({ rows: nextRows });
+    const nextFilteredRows = filterRows(nextRows, /Row/);
+    // Check that we don't render the row we deleted, even if filtering is done by a children and needs an update
+    expect(wrapper.find('tbody tr')).toHaveLength(nextFilteredRows.length);
+    wrapper.update();
+    expect(wrapper.find('tbody tr')).toHaveLength(nextFilteredRows.length);
+  });
+});


### PR DESCRIPTION
Backport of #7657 for 3.2

> To fix issue #5965, we moved some code calculating the effective rows
into `componentDidUpdate`. This unfortunately has the effect that when
we receive new rows in the props, we may try to render an unexisting
row once, before updating the list that is kept in the component's
state, causing #7544.
>
> To avoid that situation, this commit will avoid using `filteredRows`
when the `DataTable` doesn't have any `filterKeys`, that is, when we
don't display a filter. In summary:
>
>- `DataTable` without filter: use rows coming from the props instead of
  syncing them in the component state
>- `DataTable` with filter: filter takes care of updating the
  `filteredRows` state key, but `DataTable` filters out any keys that are
  not in `rows`
>
>Fixes #7544
