### PR TITLE
Consider current dashboard query filter and defined parameters when using message list pagination

### DIFF
--- a/graylog2-web-interface/src/views/actions/SearchActions.js
+++ b/graylog2-web-interface/src/views/actions/SearchActions.js
@@ -26,7 +26,10 @@ export type SearchExecutionResult = {
 type SearchActionsType = RefluxActions<{
   create: (Search) => Promise<CreateSearchResponse>,
   execute: (SearchExecutionState) => Promise<SearchExecutionResult>,
-  reexecuteSearchTypes: (searchTypes: {[searchTypeId: string]: { limit: number, offset: number }}, effectiveTimeRange?: TimeRange) => Promise<SearchExecutionResult>,
+  reexecuteSearchTypes: (
+    searchTypes: {[searchTypeId: string]: { limit: number, offset: number }},
+    effectiveTimeRange?: TimeRange,
+  ) => Promise<SearchExecutionResult>,
   executeWithCurrentState: () => Promise<SearchExecutionResult>,
   refresh: () => Promise<void>,
   get: (SearchId) => Promise<SearchJson>,

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.test.jsx
@@ -29,6 +29,12 @@ const MessageTableEntry = () => (
   </AdditionalContext.Consumer>
 );
 
+const mockEffectiveTimeRange = {
+  from: '2019-11-15T14:40:48.666Z',
+  to: '2019-11-29T14:40:48.666Z',
+  type: 'absolute',
+};
+
 jest.mock('views/components/messagelist/MessageTableEntry', () => ({}));
 jest.mock('stores/search/SearchStore', () => MockStore('searchSurroundingMessages'));
 jest.mock('views/stores/ViewStore', () => ({
@@ -55,7 +61,7 @@ jest.mock('views/stores/SearchStore', () => ({
           somequery: {
             searchTypes: {
               'search-type-id': {
-                effectiveTimerange: { from: '2019-11-15T14:40:48.666Z', to: '2019-11-29T14:40:48.666Z', type: 'absolute' },
+                effectiveTimerange: mockEffectiveTimeRange,
               },
             },
           },
@@ -161,21 +167,16 @@ describe('MessageList', () => {
   });
 
   it('reexecute query for search type, when using pagination', () => {
+    const searchTypePayload = { [data.id]: { limit: Messages.DEFAULT_LIMIT, offset: Messages.DEFAULT_LIMIT } };
     const config = MessagesWidgetConfig.builder().fields([]).build();
     const secondPageSize = 10;
-    const searchTypePayload = { [data.id]: { limit: Messages.DEFAULT_LIMIT, offset: Messages.DEFAULT_LIMIT } };
-    const effectiveTimerange = {
-      from: '2019-11-15T14:40:48.666Z',
-      to: '2019-11-29T14:40:48.666Z',
-      type: 'absolute',
-    };
     const wrapper = mount(<MessageList editing
                                        data={{ ...data, total: Messages.DEFAULT_LIMIT + secondPageSize }}
                                        fields={Immutable.List([])}
                                        config={config}
                                        setLoadingState={() => {}} />);
     wrapper.find('[aria-label="Next"]').simulate('click');
-    expect(SearchActions.reexecuteSearchTypes).toHaveBeenCalledWith(searchTypePayload, effectiveTimerange);
+    expect(SearchActions.reexecuteSearchTypes).toHaveBeenCalledWith(searchTypePayload, mockEffectiveTimeRange);
   });
 
   it('disables refresh actions, when using pagination', () => {

--- a/graylog2-web-interface/src/views/stores/SearchStore.js
+++ b/graylog2-web-interface/src/views/stores/SearchStore.js
@@ -3,7 +3,7 @@ import Reflux from 'reflux';
 import Bluebird from 'bluebird';
 import { debounce, get, isEqual } from 'lodash';
 
-import URLUtils from 'util/URLUtils';
+import { qualifyUrl } from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 
 import { SearchExecutionStateStore } from 'views/stores/SearchExecutionStateStore';
@@ -23,7 +23,7 @@ import type { WidgetMapping } from 'views/logic/views/View';
 import type { TimeRange } from 'views/logic/queries/Query';
 import { singletonStore } from 'views/logic/singleton';
 
-const createSearchUrl = URLUtils.qualifyUrl('/views/search');
+const createSearchUrl = qualifyUrl('/views/search');
 
 const displayError = (error) => {
   // eslint-disable-next-line no-console
@@ -32,7 +32,7 @@ const displayError = (error) => {
 
 Bluebird.config({ cancellation: true });
 
-const searchUrl = URLUtils.qualifyUrl('/views/search');
+const searchUrl = qualifyUrl('/views/search');
 
 export { SearchActions };
 
@@ -120,14 +120,18 @@ export const SearchStore = singletonStore(
     },
 
     reexecuteSearchTypes(searchTypes: MessageListOptions, effectiveTimerange?: TimeRange): Promise<SearchExecutionResult> {
+      const { parameterBindings, globalOverride } = this.executionState;
       const searchTypeIds = Object.keys(searchTypes);
-      const globalOverride: GlobalOverride = new GlobalOverride(
+      const globalQuery = globalOverride && globalOverride.query ? globalOverride.query : undefined;
+
+      const newGlobalOverride: GlobalOverride = new GlobalOverride(
         effectiveTimerange,
-        undefined,
+        globalQuery,
         searchTypeIds,
         searchTypes,
       );
-      const executionState = new SearchExecutionState(undefined, globalOverride);
+
+      const executionState = new SearchExecutionState(parameterBindings, newGlobalOverride);
       const handleSearchResult = (searchResult: SearchResult): SearchResult => {
         const updatedSearchTypes = searchResult.getSearchTypesFromResponse(searchTypeIds);
         const updatedResult = this.result.updateSearchTypes(updatedSearchTypes);

--- a/graylog2-web-interface/src/views/stores/SearchStore.js
+++ b/graylog2-web-interface/src/views/stores/SearchStore.js
@@ -3,7 +3,7 @@ import Reflux from 'reflux';
 import Bluebird from 'bluebird';
 import { debounce, get, isEqual } from 'lodash';
 
-import { qualifyUrl } from 'util/URLUtils';
+import URLUtils from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 
 import { SearchExecutionStateStore } from 'views/stores/SearchExecutionStateStore';
@@ -23,7 +23,7 @@ import type { WidgetMapping } from 'views/logic/views/View';
 import type { TimeRange } from 'views/logic/queries/Query';
 import { singletonStore } from 'views/logic/singleton';
 
-const createSearchUrl = qualifyUrl('/views/search');
+const createSearchUrl = URLUtils.qualifyUrl('/views/search');
 
 const displayError = (error) => {
   // eslint-disable-next-line no-console
@@ -32,7 +32,7 @@ const displayError = (error) => {
 
 Bluebird.config({ cancellation: true });
 
-const searchUrl = qualifyUrl('/views/search');
+const searchUrl = URLUtils.qualifyUrl('/views/search');
 
 export { SearchActions };
 


### PR DESCRIPTION
Backport of #7683 for 3.2

As described in https://github.com/Graylog2/graylog2-server/issues/7680 a message list widget with an own search query does not consider the dashboard search query filter when using the widget pagination.

With this PR we are considering the dashboard filter search query on every search re-execution. A search re-execution currently only happens when using the message list pagination.

Fixes #7680
And also fixes #7665

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

