### PR TITLE
Provide `useStore` React hook to sync functional component with store state

### DIFF
--- a/graylog2-web-interface/src/stores/__tests__/connect.test.jsx
+++ b/graylog2-web-interface/src/stores/__tests__/connect.test.jsx
@@ -197,7 +197,7 @@ describe('connect()', () => {
 
 describe('useStore', () => {
   const SimpleComponent = () => {
-    const { value } = useStore(SimpleStore, x => x) || {};
+    const { value } = useStore(SimpleStore) || {};
     return <span>{value ? `Value is: ${value}` : 'No value.'}</span>;
   };
 

--- a/graylog2-web-interface/src/stores/__tests__/connect.test.jsx
+++ b/graylog2-web-interface/src/stores/__tests__/connect.test.jsx
@@ -33,7 +33,7 @@ const SimpleStore: Store<{ value: number }> & Actions = Reflux.createStore({
     return this.state;
   },
   setValue(value) {
-    this.state = { value: value };
+    this.state = { value };
     this.trigger(this.state);
   },
   noop() {},
@@ -231,5 +231,22 @@ describe('useStore', () => {
     const wrapper = mount(<Component />);
     act(() => SimpleStore.setValue(42));
     expect(wrapper).toHaveText('Value is: 84');
+  });
+  it('does not rerender component if state does not change', () => {
+    let renderCount = 0;
+    const SimpleComponentWithRenderCounter = () => {
+      renderCount += 1;
+      const { value } = useStore(SimpleStore) || {};
+      return <span>{value ? `Value is: ${value}` : 'No value.'}</span>;
+    };
+    mount(<SimpleComponentWithRenderCounter />);
+
+    const beforeFirstSet = renderCount;
+    act(() => SimpleStore.setValue(42));
+    expect(renderCount).toEqual(beforeFirstSet + 1);
+
+    const beforeSecondSet = renderCount;
+    act(() => SimpleStore.setValue(42));
+    expect(renderCount).toEqual(beforeSecondSet);
   });
 });

--- a/graylog2-web-interface/src/stores/connect.jsx
+++ b/graylog2-web-interface/src/stores/connect.jsx
@@ -14,7 +14,14 @@ type ExtractComponentProps = <Props>(React.ComponentType<Props>) => Props;
 
 type ResultType<Stores> = $ObjMap<Stores, ExtractStoreState>;
 
-export function useStore<V, Store: StoreType<V>, R>(store: Store, propsMapper: ((V) => R)): R {
+type PropsMapper<V, R> = (V) => R;
+
+function id<V, R>(x: V) {
+  // $FlowFixMe: Casting by force
+  return (x: R);
+}
+
+export function useStore<V, Store: StoreType<V>, R>(store: Store, propsMapper: PropsMapper<V, R> = id): R {
   const [storeState, setStoreState] = useState(() => propsMapper(store.getInitialState()));
   useEffect(() => store.listen(newState => setStoreState(propsMapper(newState))), [store]);
   return storeState;

--- a/graylog2-web-interface/src/stores/connect.jsx
+++ b/graylog2-web-interface/src/stores/connect.jsx
@@ -1,5 +1,6 @@
 // @flow strict
 import * as React from 'react';
+import { useState, useEffect } from 'react';
 import { isFunction } from 'lodash';
 import isDeepEqual from './isDeepEqual';
 
@@ -12,6 +13,12 @@ type ExtractStoreState = <V, Store: StoreType<V>>(Store) => V;
 type ExtractComponentProps = <Props>(React.ComponentType<Props>) => Props;
 
 type ResultType<Stores> = $ObjMap<Stores, ExtractStoreState>;
+
+export function useStore<V, Store: StoreType<V>, R>(store: Store, propsMapper: ((V) => R)): R {
+  const [storeState, setStoreState] = useState(() => propsMapper(store.getInitialState()));
+  useEffect(() => store.listen(newState => setStoreState(propsMapper(newState))), [store]);
+  return storeState;
+}
 
 /**
  * Generating a higher order component wrapping an ES6 React component class, connecting it to the supplied stores.

--- a/graylog2-web-interface/src/stores/connect.jsx
+++ b/graylog2-web-interface/src/stores/connect.jsx
@@ -66,6 +66,7 @@ function connect<Stores: Object, Props, ComponentType: React.ComponentType<Props
 ): React.ComponentType<$Diff<$Call<ExtractComponentProps, ComponentType>, MappedProps>> {
   const wrappedComponentName = Component.displayName || Component.name || 'Unknown/Anonymous';
   class ConnectStoresWrapper extends React.Component<$Diff<$Call<ExtractComponentProps, ComponentType>, MappedProps>> {
+    // eslint-disable-next-line react/state-in-constructor
     state: ResultType<Stores>;
 
     unsubscribes: Array<() => void>;

--- a/graylog2-web-interface/src/stores/connect.jsx
+++ b/graylog2-web-interface/src/stores/connect.jsx
@@ -1,6 +1,6 @@
 // @flow strict
 import * as React from 'react';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { isFunction } from 'lodash';
 import isDeepEqual from './isDeepEqual';
 
@@ -23,7 +23,13 @@ function id<V, R>(x: V) {
 
 export function useStore<V, Store: StoreType<V>, R>(store: Store, propsMapper: PropsMapper<V, R> = id): R {
   const [storeState, setStoreState] = useState(() => propsMapper(store.getInitialState()));
-  useEffect(() => store.listen(newState => setStoreState(propsMapper(newState))), [store]);
+  const storeStateRef = useRef(storeState);
+  useEffect(() => store.listen((newState) => {
+    if (!isDeepEqual(newState, storeStateRef.current)) {
+      setStoreState(propsMapper(newState));
+      storeStateRef.current = newState;
+    }
+  }), [store]);
   return storeState;
 }
 


### PR DESCRIPTION
This change provides a `useStore` React hook which can be used in stateless components to consume a store's state. The benefit of this over wrapping a comment with `connect` is that no intermediate wrapper component needs to be created, making this a lightweight alternative.

Its usage looks like this:

```
const ShowRefreshInterval = () => {
  const { enabled, interval } = useStore(RefreshStore);
  return enabled ? `Refreshing every ${interval}ms` : 'Refresh disabled.';
};
```

It also uses a function mapping the store's state before returning it, if provided:

```
const ShowRefreshInterval = () => {
  const interval = useStore(RefreshStore, ({ interval }) => interval;
  return `Refreshing every ${interval}ms`;
};
```

`useStore` is properly typed, so if the store is of type `Store<V>` where `V` is the type of the state it provides, the props mapper function and the value returned by `useStore` will be properly typed as well.