### PR TITLE
Explicitly pass props to Popover in SelectPopover

### DIFF
--- a/graylog2-web-interface/src/components/common/SelectPopover.jsx
+++ b/graylog2-web-interface/src/components/common/SelectPopover.jsx
@@ -136,14 +136,6 @@ class SelectPopover extends React.Component {
     };
   }
 
-  // eslint-disable-next-line class-methods-use-this
-  pickPopoverProps(props) {
-    // eslint-disable-next-line react/forbid-foreign-prop-types
-    const popoverPropKeys = Object.keys(Popover.target.propTypes);
-
-    return lodash.pick(props, popoverPropKeys);
-  }
-
   renderDataFilter(items) {
     const { filterPlaceholder } = this.props;
     const { filterText } = this.state;
@@ -177,13 +169,15 @@ class SelectPopover extends React.Component {
       triggerAction,
       triggerNode,
       disabled,
-      ...otherProps
+      id,
+      title,
     } = this.props;
     const { filteredItems, selectedItems } = this.state;
-    const popoverProps = this.pickPopoverProps(otherProps);
-
     const popover = (
-      <Popover {...popoverProps} className={style.customPopover}>
+      <Popover id={id}
+               title={title}
+               placement={placement}
+               className={style.customPopover}>
         {displayDataFilter && this.renderDataFilter(items)}
         {selectedItems.length > 0 && this.renderClearSelectionItem()}
         <IsolatedScroll className={style.scrollableList}>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Before this change, Sidecar administration change was showing error due to propTypes on Popover inside SelectPopover. Which was used to filter SelectPopover to filter props to be passed to Popover. With these change we are explicitly passing the relevant props to Popover.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

