### PR TITLE
Add loaded state to Configurations page before rendering

### DIFF
--- a/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
+++ b/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
@@ -32,6 +32,8 @@ class ConfigurationsPage extends React.Component {
     loaded: false,
   }
 
+  checkLoadedTimer = undefined
+
   componentDidMount() {
     style.use();
     const { currentUser: { permissions } } = this.props;
@@ -51,6 +53,7 @@ class ConfigurationsPage extends React.Component {
 
   componentWillUnmount() {
     style.unuse();
+    this._clearTimeout();
   }
 
   _getConfig = (configType) => {
@@ -110,15 +113,21 @@ class ConfigurationsPage extends React.Component {
 
   _checkConfig = () => {
     const { configuration } = this.props;
-    setInterval(() => {
+    this.checkLoadedTimer = setTimeout(() => {
       if (Object.keys(configuration).length > 0) {
-        this.setState({ loaded: true });
+        this.setState({ loaded: true }, this._clearTimeout);
         return;
       }
 
       this._checkConfig();
     }, 100);
   };
+
+  _clearTimeout = () => {
+    if (this.checkLoadedTimer) {
+      clearTimeout(this.checkLoadedTimer);
+    }
+  }
 
   render() {
     const { loaded } = this.state;

--- a/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
+++ b/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
@@ -6,7 +6,7 @@ import { PluginStore } from 'graylog-web-plugin/plugin';
 import connect from 'stores/connect';
 import CombinedProvider from 'injection/CombinedProvider';
 
-import PermissionsMixin from 'util/PermissionsMixin';
+import { isPermitted } from 'util/PermissionsMixin';
 import SearchesConfig from 'components/configurations/SearchesConfig';
 import MessageProcessorsConfig from 'components/configurations/MessageProcessorsConfig';
 import SidecarConfig from 'components/configurations/SidecarConfig';
@@ -28,14 +28,20 @@ const EVENTS_CONFIG = 'org.graylog.events.configuration.EventsConfiguration';
 const URL_WHITELIST_CONFIG = 'org.graylog2.system.urlwhitelist.UrlWhitelist';
 
 class ConfigurationsPage extends React.Component {
+  state = {
+    loaded: false,
+  }
+
   componentDidMount() {
     style.use();
     const { currentUser: { permissions } } = this.props;
+    this._checkConfig();
+
     ConfigurationsActions.list(SEARCHES_CLUSTER_CONFIG);
     ConfigurationsActions.listMessageProcessorsConfig(MESSAGE_PROCESSORS_CONFIG);
     ConfigurationsActions.list(SIDECAR_CONFIG);
     ConfigurationsActions.list(EVENTS_CONFIG);
-    if (PermissionsMixin.isPermitted(permissions, ['urlwhitelist:read'])) {
+    if (isPermitted(permissions, ['urlwhitelist:read'])) {
       ConfigurationsActions.listWhiteListConfig(URL_WHITELIST_CONFIG);
     }
     PluginStore.exports('systemConfigurations').forEach((systemConfig) => {
@@ -102,58 +108,65 @@ class ConfigurationsPage extends React.Component {
     return rows;
   };
 
+  _checkConfig = () => {
+    const { configuration } = this.props;
+    setInterval(() => {
+      if (Object.keys(configuration).length > 0) {
+        this.setState({ loaded: true });
+        return;
+      }
+
+      this._checkConfig();
+    }, 100);
+  };
+
   render() {
+    const { loaded } = this.state;
     const { currentUser: { permissions } } = this.props;
-    const searchesConfig = this._getConfig(SEARCHES_CLUSTER_CONFIG);
-    const messageProcessorsConfig = this._getConfig(MESSAGE_PROCESSORS_CONFIG);
-    const sidecarConfig = this._getConfig(SIDECAR_CONFIG);
-    const eventsConfig = this._getConfig(EVENTS_CONFIG);
-    const urlWhiteListConfig = this._getConfig(URL_WHITELIST_CONFIG);
-    let searchesConfigComponent;
-    let messageProcessorsConfigComponent;
-    let sidecarConfigComponent;
-    let eventsConfigComponent;
-    let urlWhiteListConfigComponent;
-    if (searchesConfig) {
-      searchesConfigComponent = (
-        <SearchesConfig config={searchesConfig}
-                        updateConfig={this._onUpdate(SEARCHES_CLUSTER_CONFIG)} />
+    let Output = (
+      <Col md={12}>
+        <Spinner text="Loading Configuration Panel..." />
+      </Col>
+    );
+
+    if (loaded) {
+      const searchesConfig = this._getConfig(SEARCHES_CLUSTER_CONFIG);
+      const messageProcessorsConfig = this._getConfig(MESSAGE_PROCESSORS_CONFIG);
+      const sidecarConfig = this._getConfig(SIDECAR_CONFIG);
+      const eventsConfig = this._getConfig(EVENTS_CONFIG);
+      const urlWhiteListConfig = this._getConfig(URL_WHITELIST_CONFIG);
+
+      Output = (
+        <>
+          <Col md={6}>
+            <SearchesConfig config={searchesConfig}
+                            updateConfig={this._onUpdate(SEARCHES_CLUSTER_CONFIG)} />
+          </Col>
+          <Col md={6}>
+            <MessageProcessorsConfig config={messageProcessorsConfig}
+                                     updateConfig={this._onUpdate(MESSAGE_PROCESSORS_CONFIG)} />
+          </Col>
+          <Col md={6}>
+            <SidecarConfig config={sidecarConfig}
+                           updateConfig={this._onUpdate(SIDECAR_CONFIG)} />
+          </Col>
+          <Col md={6}>
+            <EventsConfig config={eventsConfig}
+                          updateConfig={this._onUpdate(this.EVENTS_CONFIG)} />
+          </Col>
+          {isPermitted(permissions, ['urlwhitelist:read']) && (
+          <Col md={6}>
+            <UrlWhiteListConfig config={urlWhiteListConfig}
+                                updateConfig={this._onUpdate(URL_WHITELIST_CONFIG)} />
+          </Col>
+          )}
+          <Col md={6}>
+            <DecoratorsConfig />
+          </Col>
+        </>
       );
-    } else {
-      searchesConfigComponent = (<Spinner />);
     }
-    if (messageProcessorsConfig) {
-      messageProcessorsConfigComponent = (
-        <MessageProcessorsConfig config={messageProcessorsConfig}
-                                 updateConfig={this._onUpdate(MESSAGE_PROCESSORS_CONFIG)} />
-      );
-    } else {
-      messageProcessorsConfigComponent = (<Spinner />);
-    }
-    if (sidecarConfig) {
-      sidecarConfigComponent = (
-        <SidecarConfig config={sidecarConfig}
-                       updateConfig={this._onUpdate(SIDECAR_CONFIG)} />
-      );
-    } else {
-      sidecarConfigComponent = (<Spinner />);
-    }
-    if (eventsConfig) {
-      eventsConfigComponent = (
-        <EventsConfig config={eventsConfig}
-                      updateConfig={this._onUpdate(this.EVENTS_CONFIG)} />
-      );
-    } else {
-      eventsConfigComponent = (<Spinner />);
-    }
-    if (urlWhiteListConfig) {
-      urlWhiteListConfigComponent = (
-        <UrlWhiteListConfig config={urlWhiteListConfig}
-                            updateConfig={this._onUpdate(URL_WHITELIST_CONFIG)} />
-      );
-    } else {
-      urlWhiteListConfigComponent = PermissionsMixin.isPermitted(permissions, ['urlwhitelist:read']) ? <Spinner /> : null;
-    }
+
     const pluginConfigRows = this._pluginConfigRows();
 
     return (
@@ -166,24 +179,7 @@ class ConfigurationsPage extends React.Component {
           </PageHeader>
 
           <Row className="content">
-            <Col md={6}>
-              {searchesConfigComponent}
-            </Col>
-            <Col md={6}>
-              {messageProcessorsConfigComponent}
-            </Col>
-            <Col md={6}>
-              {sidecarConfigComponent}
-            </Col>
-            <Col md={6}>
-              {eventsConfigComponent}
-            </Col>
-            <Col md={6}>
-              {urlWhiteListConfigComponent}
-            </Col>
-            <Col md={6}>
-              <DecoratorsConfig />
-            </Col>
+            {Output}
           </Row>
 
           {pluginConfigRows.length > 0 && (
@@ -203,7 +199,6 @@ class ConfigurationsPage extends React.Component {
     );
   }
 }
-
 
 ConfigurationsPage.propTypes = {
   configuration: PropTypes.object.isRequired,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds `loaded` state wrapper around configuration panel
Renders single `Spinner` until all the configuration options are ready

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Configurations panels were suffering from race conditions and very often fail to load.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/122591/76995209-85eb9b80-691d-11ea-9aa3-62923def9f5d.png)

![image](https://user-images.githubusercontent.com/122591/76995156-7409f880-691d-11ea-993f-adbc1da6c975.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

