### PR TITLE
Update to netty-4.1.48

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,8 +131,8 @@
         <mongodb-driver.version>3.12.1</mongodb-driver.version>
         <mongojack.version>2.10.1</mongojack.version>
         <natty.version>0.13</natty.version>
-        <netty.version>4.1.45.Final</netty.version>
-        <netty-tcnative-boringssl-static.version>2.0.28.Final</netty-tcnative-boringssl-static.version>
+        <netty.version>4.1.48.Final</netty.version>
+        <netty-tcnative-boringssl-static.version>2.0.29.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>3.14.6</okhttp.version>
         <opencsv.version>2.3</opencsv.version>
         <os-platform-finder.version>1.2.3</os-platform-finder.version>


### PR DESCRIPTION
Also bump netty-tcnative-boringssl-static to 2.0.29.

Changelogs:
- https://netty.io/news/2020/02/28/4-1-46-Final.html
- https://netty.io/news/2020/03/09/4-1-47-Final.html
- https://netty.io/news/2020/03/17/4-1-48-Final.html