### PR TITLE
Remove `streams` parameter from URL if list of streams becomes empty.

### DIFF
--- a/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.js
+++ b/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.js
@@ -49,7 +49,7 @@ export const syncWithQueryParameters = (query: string, action: (string) => mixed
         .reduce((prev, [key, value]) => prev.setSearch(key, value), baseUri);
       const currentStreams = filtersToStreamSet(filter);
       const uri = currentStreams.isEmpty()
-        ? uriWithTimerange.toString()
+        ? uriWithTimerange.removeSearch('streams').toString()
         : uriWithTimerange.setSearch('streams', currentStreams.join(',')).toString();
       if (query !== uri) {
         action(uri);

--- a/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.test.jsx
+++ b/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.test.jsx
@@ -116,6 +116,15 @@ describe('SyncWithQueryParameters', () => {
       expect(history.push)
         .toHaveBeenCalledWith('/search?q=foo%3A42&rangetype=relative&relative=300&streams=stream1%2Cstream2');
     });
+    it('removes list of streams to query if they become empty', () => {
+      const viewWithStreams = createView(createSearch(lastFiveMinutes, []));
+      asMock(ViewStore.getInitialState).mockReturnValueOnce({ view: viewWithStreams });
+
+      syncWithQueryParameters('/search?q=foo%3A42&rangetype=relative&relative=300&streams=stream1%2Cstream2');
+
+      expect(history.push)
+        .toHaveBeenCalledWith('/search?q=foo%3A42&rangetype=relative&relative=300');
+    });
   });
   describe('useSyncWithQueryParameters', () => {
     afterEach(cleanup);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note: This needs a backport to `3.2`.**

Before this change, if the URL contains a set of streams, but the stream filters changes these to be empty, the `syncWithQueryParameters` function did not remove the `streams` parameter from the URL, but left it intact.

This lead to the last stream showing up again after removing it, because it is still part of the URL and will be added again by `bindSearchParamsFromQuery`. This is described in #7717.

The current PR changes `syncWithQueryParameters` to remove the `streams` query parameter from the URL if the set of current streams is empty.


Fixes #7717.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.