### PR TITLE
Extract IndexLookup from ElasticsearchBackend

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackend.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackend.java
@@ -51,12 +51,7 @@ import org.graylog2.indexer.FieldTypeException;
 import org.graylog2.indexer.IndexHelper;
 import org.graylog2.indexer.IndexMapping;
 import org.graylog2.indexer.cluster.jest.JestUtils;
-import org.graylog2.indexer.ranges.IndexRange;
-import org.graylog2.indexer.ranges.IndexRangeService;
 import org.graylog2.plugin.Message;
-import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
-import org.graylog2.plugin.streams.Stream;
-import org.graylog2.streams.StreamService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,8 +79,7 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
     private final Map<String, Provider<ESSearchTypeHandler<? extends SearchType>>> elasticsearchSearchTypeHandlers;
     private final QueryStringParser queryStringParser;
     private final JestClient jestClient;
-    private final IndexRangeService indexRangeService;
-    private final StreamService streamService;
+    private final IndexLookup indexLookup;
     private final ESQueryDecorators esQueryDecorators;
     private final ESGeneratedQueryContext.Factory queryContextFactory;
 
@@ -93,15 +87,14 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
     public ElasticsearchBackend(Map<String, Provider<ESSearchTypeHandler<? extends SearchType>>> elasticsearchSearchTypeHandlers,
                                 QueryStringParser queryStringParser,
                                 JestClient jestClient,
-                                IndexRangeService indexRangeService,
-                                StreamService streamService,
+                                IndexLookup indexLookup,
                                 ESQueryDecorators esQueryDecorators,
                                 ESGeneratedQueryContext.Factory queryContextFactory) {
         this.elasticsearchSearchTypeHandlers = elasticsearchSearchTypeHandlers;
         this.queryStringParser = queryStringParser;
         this.jestClient = jestClient;
-        this.indexRangeService = indexRangeService;
-        this.streamService = streamService;
+        this.indexLookup = indexLookup;
+
         this.esQueryDecorators = esQueryDecorators;
         this.queryContextFactory = queryContextFactory;
     }
@@ -206,10 +199,6 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
         return Optional.empty();
     }
 
-    private Set<Stream> loadStreams(Set<String> streamIds) {
-        return streamService.loadByIds(streamIds);
-    }
-
     @Override
     public QueryResult doRun(SearchJob job, Query query, ESGeneratedQueryContext queryContext, Set<QueryResult> predecessorResults) {
         if (query.searchTypes().isEmpty()) {
@@ -222,13 +211,7 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
         LOG.debug("Running query {} for job {}", query.id(), job.getId());
         final HashMap<String, SearchType.Result> resultsMap = Maps.newHashMap();
 
-        final Set<Stream> usedStreams = loadStreams(query.usedStreamIds());
-
-        final IndexRangeContainsOneOfStreams indexRangeContainsOneOfStreams = new IndexRangeContainsOneOfStreams(usedStreams);
-        final Set<String> affectedIndices = indicesByTimeRange(query.timerange()).stream()
-                .filter(indexRangeContainsOneOfStreams)
-                .map(IndexRange::indexName)
-                .collect(Collectors.toSet());
+        final Set<String> affectedIndices = indexLookup.indexNamesForStreamsInTimeRange(query.usedStreamIds(), query.timerange());
 
         final Map<String, SearchSourceBuilder> searchTypeQueries = queryContext.searchTypeQueries();
         final List<String> searchTypeIds = new ArrayList<>(searchTypeQueries.keySet());
@@ -247,12 +230,7 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
                                         ? query.usedStreamIds()
                                         : searchType.effectiveStreams();
 
-                                final Set<Stream> usedStreamsOfSearchType = loadStreams(usedStreamIds);
-
-                                return Optional.of(indicesByTimeRange(query.effectiveTimeRange(searchType)).stream()
-                                        .filter(new IndexRangeContainsOneOfStreams(usedStreamsOfSearchType))
-                                        .map(IndexRange::indexName)
-                                        .collect(Collectors.toSet()));
+                                return Optional.of(indexLookup.indexNamesForStreamsInTimeRange(usedStreamIds, query.effectiveTimeRange(searchType)));
                             })
                             .orElse(affectedIndices);
 
@@ -302,8 +280,6 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
                 .build();
     }
 
-
-
     private Optional<ElasticsearchException> checkForFailedShards(SearchResult result) {
         // unwrap shard failure due to non-numeric mapping. this happens when searching across index sets
         // if at least one of the index sets comes back with a result, the overall result will have the aggregation
@@ -329,10 +305,6 @@ public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContex
         }
 
         return Optional.empty();
-    }
-
-    private Set<IndexRange> indicesByTimeRange(TimeRange timerange) {
-        return indexRangeService.find(timerange.getFrom(), timerange.getTo());
     }
 
     private Set<String> queryStringsFromFilter(Filter entry) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/IndexLookup.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/IndexLookup.java
@@ -1,0 +1,61 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.views.search.elasticsearch;
+
+import org.graylog2.indexer.ranges.IndexRange;
+import org.graylog2.indexer.ranges.IndexRangeService;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+import org.graylog2.plugin.streams.Stream;
+import org.graylog2.streams.StreamService;
+
+import javax.inject.Inject;
+import java.util.Collections;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+public class IndexLookup {
+    private final IndexRangeService indexRangeService;
+    private final StreamService streamService;
+
+    //this is only here for mocking purposes
+    BiFunction<IndexRange, Set<Stream>, Boolean> indexRangeContainsOneOfStreams = this::indexRangeContainsOneOfStreams;
+
+    @Inject
+    public IndexLookup(IndexRangeService indexRangeService, StreamService streamService) {
+        this.indexRangeService = indexRangeService;
+        this.streamService = streamService;
+    }
+
+    public Set<String> indexNamesForStreamsInTimeRange(Set<String> streamIds, TimeRange timeRange) {
+        if (streamIds.isEmpty())
+            return Collections.emptySet();
+
+        Set<Stream> usedStreams = streamService.loadByIds(streamIds);
+        SortedSet<IndexRange> candidateIndices = indexRangeService.find(timeRange.getFrom(), timeRange.getTo());
+
+        return candidateIndices.stream()
+                .filter(i -> indexRangeContainsOneOfStreams.apply(i, usedStreams))
+                .map(IndexRange::indexName)
+                .collect(Collectors.toSet());
+    }
+
+    private boolean indexRangeContainsOneOfStreams(IndexRange indexRange, Set<Stream> streams) {
+        return new IndexRangeContainsOneOfStreams(streams).test(indexRange);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendErrorHandlingTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendErrorHandlingTest.java
@@ -30,9 +30,7 @@ import org.graylog.plugins.views.search.SearchType;
 import org.graylog.plugins.views.search.elasticsearch.searchtypes.ESSearchTypeHandler;
 import org.graylog.plugins.views.search.errors.SearchError;
 import org.graylog2.indexer.ElasticsearchException;
-import org.graylog2.indexer.ranges.IndexRangeService;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
-import org.graylog2.streams.StreamService;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -59,10 +57,7 @@ public class ElasticsearchBackendErrorHandlingTest extends ElasticsearchBackendT
     private JestClient jestClient;
 
     @Mock
-    private IndexRangeService indexRangeService;
-
-    @Mock
-    private StreamService streamService;
+    protected IndexLookup indexLookup;
 
     @Mock
     private MultiSearchResult result;
@@ -83,12 +78,11 @@ public class ElasticsearchBackendErrorHandlingTest extends ElasticsearchBackendT
                 ),
                 new QueryStringParser(),
                 jestClient,
-                indexRangeService,
-                streamService,
+                indexLookup,
                 new ESQueryDecorators(Collections.emptySet()),
                 (elasticsearchBackend, ssb, job, query, results) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, job, query, results, fieldTypesLookup)
         );
-        when(streamService.loadByIds(any())).thenReturn(Collections.emptySet());
+        when(indexLookup.indexNamesForStreamsInTimeRange(any(), any())).thenReturn(Collections.emptySet());
 
         final SearchType searchType1 = mock(SearchType.class);
         when(searchType1.id()).thenReturn("deadbeef");

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendGeneratedRequestTestBase.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendGeneratedRequestTestBase.java
@@ -36,11 +36,9 @@ import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.SeriesSpec;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Average;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Max;
-import org.graylog2.indexer.ranges.IndexRangeService;
 import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
-import org.graylog2.streams.StreamService;
 import org.junit.Before;
 import org.junit.Rule;
 import org.mockito.ArgumentCaptor;
@@ -71,9 +69,7 @@ public class ElasticsearchBackendGeneratedRequestTestBase extends ElasticsearchB
     @Mock
     protected JestHttpClient jestClient;
     @Mock
-    protected IndexRangeService indexRangeService;
-    @Mock
-    protected StreamService streamService;
+    protected IndexLookup indexLookup;
 
     @Mock
     protected FieldTypesLookup fieldTypesLookup;
@@ -95,8 +91,7 @@ public class ElasticsearchBackendGeneratedRequestTestBase extends ElasticsearchB
         this.elasticsearchBackend = new ElasticsearchBackend(elasticSearchTypeHandlers,
                 queryStringParser,
                 jestClient,
-                indexRangeService,
-                streamService,
+                indexLookup,
                 new ESQueryDecorators.Fake(),
                 (elasticsearchBackend, ssb, job, query, results) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, job, query, results, fieldTypesLookup));
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendSearchTypesWithStreamsOverridesTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendSearchTypesWithStreamsOverridesTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.plugins.views.search.elasticsearch;
 
+import com.google.common.collect.ImmutableSet;
 import io.searchbox.core.MultiSearch;
 import org.graylog.plugins.views.search.Query;
 import org.graylog.plugins.views.search.SearchJob;
@@ -24,63 +25,32 @@ import org.graylog.plugins.views.search.filter.StreamFilter;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Average;
 import org.graylog.plugins.views.search.searchtypes.pivot.series.Max;
-import org.graylog2.indexer.ranges.IndexRange;
-import org.graylog2.plugin.streams.Stream;
-import org.joda.time.DateTime;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Answers;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.SortedSet;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ElasticsearchBackendSearchTypesWithStreamsOverridesTest extends ElasticsearchBackendGeneratedRequestTestBase {
-    @Rule
-    public MockitoRule rule = MockitoJUnit.rule();
-
     private final String stream1Id = "stream1Id";
     private final String stream2Id = "stream2Id";
-
-    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-    private Stream stream1;
-
-    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-    private Stream stream2;
 
     @Before
     public void setUp() throws Exception {
         when(jestClient.execute(any(), any())).thenReturn(resultFor(resourceFile("successfulMultiSearchResponse.json")));
-        final IndexRange indexRange1 = mock(IndexRange.class);
-        when(indexRange1.indexName()).thenReturn("index1");
-        when(indexRange1.streamIds()).thenReturn(Collections.singletonList(stream1Id));
-        final IndexRange indexRange2 = mock(IndexRange.class);
-        when(indexRange2.indexName()).thenReturn("index2");
-        when(indexRange2.streamIds()).thenReturn(Collections.singletonList(stream1Id));
-        final IndexRange indexRange3 = mock(IndexRange.class);
-        when(indexRange3.indexName()).thenReturn("index3");
-        when(indexRange3.streamIds()).thenReturn(Collections.singletonList(stream2Id));
-
-        final SortedSet<IndexRange> indexRanges = sortedSetOf(indexRange1, indexRange2, indexRange3);
-        when(indexRangeService.find(any(DateTime.class), any(DateTime.class))).thenReturn(indexRanges);
-
-        when(stream1.getId()).thenReturn(stream1Id);
-        when(stream2.getId()).thenReturn(stream2Id);
-        when(streamService.loadByIds(Collections.singleton(stream1Id))).thenReturn(Collections.singleton(stream1));
-        when(streamService.loadByIds(Collections.singleton(stream2Id))).thenReturn(Collections.singleton(stream2));
+        when(indexLookup.indexNamesForStreamsInTimeRange(eq(ImmutableSet.of(stream1Id)), any()))
+                .thenReturn(ImmutableSet.of("index1", "index2"));
+        when(indexLookup.indexNamesForStreamsInTimeRange(eq(ImmutableSet.of(stream2Id)), any()))
+                .thenReturn(ImmutableSet.of("index3"));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendTest.java
@@ -30,9 +30,7 @@ import org.graylog.plugins.views.search.filter.AndFilter;
 import org.graylog.plugins.views.search.filter.QueryStringFilter;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
 import org.graylog.plugins.views.search.searchtypes.pivot.Pivot;
-import org.graylog2.indexer.ranges.IndexRangeService;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
-import org.graylog2.streams.StreamService;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -58,8 +56,7 @@ public class ElasticsearchBackendTest {
         backend = new ElasticsearchBackend(handlers,
                 queryStringParser,
                 null,
-                mock(IndexRangeService.class),
-                mock(StreamService.class),
+                mock(IndexLookup.class),
                 new ESQueryDecorators.Fake(),
                 (elasticsearchBackend, ssb, job, query, results) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, job, query, results, fieldTypesLookup));
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendTestBase.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendTestBase.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.searchbox.core.MultiSearch;
 import io.searchbox.core.MultiSearchResult;
-import org.graylog2.indexer.ranges.IndexRange;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 
 import java.io.IOException;
@@ -30,11 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
-import java.util.SortedSet;
-import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -78,15 +73,5 @@ abstract class ElasticsearchBackendTestBase {
                     return null;
                 })
                 .collect(Collectors.toList());
-    }
-
-    SortedSet<IndexRange> sortedSetOf(IndexRange... indexRanges) {
-        final Comparator<IndexRange> indexRangeComparator = Comparator.comparing(IndexRange::indexName);
-
-        final TreeSet<IndexRange> indexRangeSets = new TreeSet<>(indexRangeComparator);
-
-        indexRangeSets.addAll(Arrays.asList(indexRanges));
-
-        return indexRangeSets;
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendUsingCorrectIndicesTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchBackendUsingCorrectIndicesTest.java
@@ -29,15 +29,9 @@ import org.graylog.plugins.views.search.elasticsearch.searchtypes.ESSearchTypeHa
 import org.graylog.plugins.views.search.filter.AndFilter;
 import org.graylog.plugins.views.search.filter.StreamFilter;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
-import org.graylog2.indexer.ranges.IndexRange;
-import org.graylog2.indexer.ranges.IndexRangeService;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
-import org.graylog2.plugin.streams.Stream;
-import org.graylog2.streams.StreamService;
-import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
-import org.joda.time.DateTimeZone;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -51,13 +45,9 @@ import org.mockito.junit.MockitoRule;
 import javax.inject.Provider;
 import java.util.Collections;
 import java.util.Map;
-import java.util.SortedSet;
-import java.util.TreeSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -73,10 +63,7 @@ public class ElasticsearchBackendUsingCorrectIndicesTest extends ElasticsearchBa
     public MockitoRule rule = MockitoJUnit.rule();
 
     @Mock
-    private IndexRangeService indexRangeService;
-
-    @Mock
-    private StreamService streamService;
+    private IndexLookup indexLookup;
 
     @Mock
     private JestHttpClient jestClient;
@@ -97,8 +84,7 @@ public class ElasticsearchBackendUsingCorrectIndicesTest extends ElasticsearchBa
         this.backend = new ElasticsearchBackend(handlers,
                 queryStringParser,
                 jestClient,
-                indexRangeService,
-                streamService,
+                indexLookup,
                 new ESQueryDecorators.Fake(),
                 (elasticsearchBackend, ssb, job, query, results) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, job, query, results, fieldTypesLookup));
     }
@@ -119,15 +105,13 @@ public class ElasticsearchBackendUsingCorrectIndicesTest extends ElasticsearchBa
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         // Some tests modify the time so we make sure to reset it after each test even if assertions fail
         DateTimeUtils.setCurrentMillisSystem();
     }
 
     @Test
     public void queryDoesNotFallBackToUsingAllIndicesWhenNoIndexRangesAreReturned() throws Exception {
-        when(indexRangeService.find(any(DateTime.class), any(DateTime.class))).thenReturn(new TreeSet<>());
-
         final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet());
         backend.doRun(job, query, context, Collections.emptySet());
 
@@ -140,20 +124,18 @@ public class ElasticsearchBackendUsingCorrectIndicesTest extends ElasticsearchBa
 
     @Test
     public void queryUsesCorrectTimerangeWhenDeterminingIndexRanges() throws Exception {
-        when(indexRangeService.find(any(DateTime.class), any(DateTime.class))).thenReturn(new TreeSet<>());
-
         final long datetimeFixture = 1530194810;
         DateTimeUtils.setCurrentMillisFixed(datetimeFixture);
 
         final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet());
         backend.doRun(job, query, context, Collections.emptySet());
 
-        final ArgumentCaptor<DateTime> fromCapture = ArgumentCaptor.forClass(DateTime.class);
-        final ArgumentCaptor<DateTime> toCapture = ArgumentCaptor.forClass(DateTime.class);
-        verify(indexRangeService, times(1)).find(fromCapture.capture(), toCapture.capture());
+        ArgumentCaptor<TimeRange> captor = ArgumentCaptor.forClass(TimeRange.class);
 
-        assertThat(fromCapture.getValue()).isEqualTo(new DateTime(datetimeFixture, DateTimeZone.UTC).minusSeconds(600));
-        assertThat(toCapture.getValue()).isEqualTo(new DateTime(datetimeFixture, DateTimeZone.UTC));
+        verify(indexLookup, times(1))
+                .indexNamesForStreamsInTimeRange(any(), captor.capture());
+
+        assertThat(captor.getValue()).isEqualTo(RelativeRange.create(600));
     }
 
     private Query dummyQuery(TimeRange timeRange) {
@@ -164,32 +146,16 @@ public class ElasticsearchBackendUsingCorrectIndicesTest extends ElasticsearchBa
                 .searchTypes(ImmutableSet.of(MessageList.builder().id("1").build()))
                 .build();
     }
-
     private Search dummySearch(Query... queries) {
         return Search.builder()
                 .id("search1")
                 .queries(ImmutableSet.copyOf(queries))
                 .build();
     }
+
     @Test
     public void queryUsesOnlyIndicesIncludingTimerangeAndStream() throws Exception {
         final String streamId = "streamId";
-        final Stream stream = mock(Stream.class, RETURNS_DEEP_STUBS);
-        when(stream.getId()).thenReturn(streamId);
-        when(streamService.loadByIds(Collections.singleton(streamId))).thenReturn(Collections.singleton(stream));
-
-        final IndexRange indexRange1 = mock(IndexRange.class);
-        when(indexRange1.indexName()).thenReturn("index1");
-        when(indexRange1.streamIds()).thenReturn(Collections.singletonList(streamId));
-        final IndexRange indexRange2 = mock(IndexRange.class);
-        when(indexRange2.indexName()).thenReturn("index2");
-        when(indexRange2.streamIds()).thenReturn(Collections.singletonList(streamId));
-        final IndexRange indexRange3 = mock(IndexRange.class);
-        when(indexRange3.indexName()).thenReturn("index3");
-        when(indexRange3.streamIds()).thenReturn(Collections.emptyList());
-
-        final SortedSet<IndexRange> indexRanges = sortedSetOf(indexRange1, indexRange2, indexRange3);
-        when(indexRangeService.find(any(DateTime.class), any(DateTime.class))).thenReturn(indexRanges);
 
         final Query query = dummyQuery(RelativeRange.create(600))
                 .toBuilder()
@@ -198,6 +164,9 @@ public class ElasticsearchBackendUsingCorrectIndicesTest extends ElasticsearchBa
         final Search search = dummySearch(query);
         final SearchJob job = new SearchJob("job1", search, "admin");
         final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet());
+
+        when(indexLookup.indexNamesForStreamsInTimeRange(ImmutableSet.of("streamId"), RelativeRange.create(600)))
+                .thenReturn(ImmutableSet.of("index1", "index2"));
 
         backend.doRun(job, query, context, Collections.emptySet());
 
@@ -209,58 +178,17 @@ public class ElasticsearchBackendUsingCorrectIndicesTest extends ElasticsearchBa
     }
 
     @Test
-    public void queryDoesNotFallBackToAllIndices() throws Exception {
-        final Search search = dummySearch(dummyQuery(RelativeRange.create(600)));
-        final SearchJob job = new SearchJob("job1", search, "admin");
-        final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet());
-
-        backend.doRun(job, query, context, Collections.emptySet());
-
-        verify(jestClient, times(1)).execute(clientRequestCaptor.capture(), any());
-
-        final MultiSearch clientRequest = clientRequestCaptor.getValue();
-        assertThat(clientRequest).isNotNull();
-        assertThat(indicesOf(clientRequest).get(0)).isNotEqualTo("_all");
-    }
-
-    @Test
     public void queryUsesOnlyIndicesBelongingToStream() throws Exception {
-        final String stream1id = "stream1id";
-        final Stream stream1 = mock(Stream.class, RETURNS_DEEP_STUBS);
-        when(stream1.getId()).thenReturn(stream1id);
-
-        final String stream2id = "stream2id";
-        final Stream stream2 = mock(Stream.class, RETURNS_DEEP_STUBS);
-        when(stream2.getId()).thenReturn(stream2id);
-
-        final String stream3id = "stream3id";
-        final Stream stream3 = mock(Stream.class, RETURNS_DEEP_STUBS);
-        when(stream3.getId()).thenReturn(stream3id);
-
-        final String stream4id = "stream4id";
-        final Stream stream4 = mock(Stream.class, RETURNS_DEEP_STUBS);
-        when(stream4.getId()).thenReturn(stream4id);
-
-        when(stream4.getIndexSet().isManagedIndex(eq("index2"))).thenReturn(true);
-
-        final IndexRange indexRange1 = mock(IndexRange.class);
-        when(indexRange1.indexName()).thenReturn("index1");
-        when(indexRange1.streamIds()).thenReturn(Collections.singletonList(stream1id));
-        final IndexRange indexRange2 = mock(IndexRange.class);
-        when(indexRange2.indexName()).thenReturn("index2");
-        when(indexRange2.streamIds()).thenReturn(null);
-
-        final SortedSet<IndexRange> indexRanges = sortedSetOf(indexRange1, indexRange2);
-        when(indexRangeService.find(any(DateTime.class), any(DateTime.class))).thenReturn(indexRanges);
-
-        when(streamService.loadByIds(any())).thenReturn(ImmutableSet.of(stream1, stream2, stream3, stream4));
 
         final Query query = dummyQuery(RelativeRange.create(600)).toBuilder()
-                .filter(AndFilter.and(StreamFilter.ofId(stream1id), StreamFilter.ofId(stream2id), StreamFilter.ofId(stream3id), StreamFilter.ofId(stream4id)))
+                .filter(AndFilter.and(StreamFilter.ofId("stream1"), StreamFilter.ofId("stream2")))
                 .build();
         final Search search = dummySearch(query);
         final SearchJob job = new SearchJob("job1", search, "admin");
         final ESGeneratedQueryContext context = backend.generate(job, query, Collections.emptySet());
+
+        when(indexLookup.indexNamesForStreamsInTimeRange(ImmutableSet.of("stream1", "stream2"), RelativeRange.create(600)))
+                .thenReturn(ImmutableSet.of("index1", "index2"));
 
         backend.doRun(job, query, context, Collections.emptySet());
 

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/IndexLookupTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/IndexLookupTest.java
@@ -72,14 +72,6 @@ class IndexLookupTest {
         assertThat(result).containsExactly(matchingIndexRange.indexName());
     }
 
-    private RelativeRange someTimeRange() {
-        try {
-            return RelativeRange.create(1);
-        } catch (InvalidRangeParametersException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     @Test
     void returnsEmptySetForEmptyStreamIds() {
         Set<String> result = sut.indexNamesForStreamsInTimeRange(emptySet(), someTimeRange());
@@ -96,6 +88,14 @@ class IndexLookupTest {
         Set<String> result = sut.indexNamesForStreamsInTimeRange(streamIds, someTimeRange());
 
         assertThat(result).isEmpty();
+    }
+
+    private RelativeRange someTimeRange() {
+        try {
+            return RelativeRange.create(1);
+        } catch (InvalidRangeParametersException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private List<IndexRange> mockSomeIndexRanges() {

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/IndexLookupTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/IndexLookupTest.java
@@ -1,0 +1,140 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.views.search.elasticsearch;
+
+import org.graylog2.indexer.ranges.IndexRange;
+import org.graylog2.indexer.ranges.IndexRangeService;
+import org.graylog2.plugin.database.Persisted;
+import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
+import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.graylog2.plugin.streams.Stream;
+import org.graylog2.streams.StreamService;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class IndexLookupTest {
+
+    private IndexRangeService indexRangeService;
+    private StreamService streamService;
+    private IndexLookup sut;
+
+    @BeforeEach
+    void setUp() {
+        indexRangeService = mock(IndexRangeService.class);
+        streamService = mock(StreamService.class);
+        sut = new IndexLookup(indexRangeService, streamService);
+    }
+
+    @Test
+    void findsIndicesBelongingToStreamsInTimeRange() {
+
+        Set<String> streamIds = mockStreams("s-1", "s-2");
+
+        List<IndexRange> indexRanges = mockSomeIndexRanges();
+
+        IndexRange matchingIndexRange = indexRanges.get(0);
+
+        sut.indexRangeContainsOneOfStreams = (i, s) -> i.equals(matchingIndexRange);
+
+        Set<String> result = sut.indexNamesForStreamsInTimeRange(streamIds, someTimeRange());
+
+        assertThat(result).containsExactly(matchingIndexRange.indexName());
+    }
+
+    private RelativeRange someTimeRange() {
+        try {
+            return RelativeRange.create(1);
+        } catch (InvalidRangeParametersException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void returnsEmptySetForEmptyStreamIds() {
+        Set<String> result = sut.indexNamesForStreamsInTimeRange(emptySet(), someTimeRange());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void returnsEmptySetIfNoIndicesFound() {
+        Set<String> streamIds = mockStreams("1", "2");
+
+        sut.indexRangeContainsOneOfStreams = (i, s) -> true;
+
+        Set<String> result = sut.indexNamesForStreamsInTimeRange(streamIds, someTimeRange());
+
+        assertThat(result).isEmpty();
+    }
+
+    private List<IndexRange> mockSomeIndexRanges() {
+        final IndexRange indexRange1 = mockIndexRange("index1");
+        final IndexRange indexRange2 = mockIndexRange("index2");
+
+        final SortedSet<IndexRange> indexRanges = sortedSetOf(indexRange1, indexRange2);
+        when(indexRangeService.find(any(DateTime.class), any(DateTime.class))).thenReturn(indexRanges);
+
+        return new ArrayList<>(indexRanges);
+    }
+
+    private Set<String> mockStreams(String... ids) {
+        Set<Stream> streams = Arrays.stream(ids).map(this::mockStream).collect(Collectors.toSet());
+
+        when(streamService.loadByIds(any())).thenReturn(streams);
+
+        return streams.stream().map(Persisted::getId).collect(Collectors.toSet());
+    }
+
+    private IndexRange mockIndexRange(String name) {
+        final IndexRange indexRange1 = mock(IndexRange.class);
+        when(indexRange1.indexName()).thenReturn(name);
+        return indexRange1;
+    }
+
+    private Stream mockStream(String id) {
+        final Stream s = mock(Stream.class, RETURNS_DEEP_STUBS);
+        when(s.getId()).thenReturn(id);
+        return s;
+    }
+
+    SortedSet<IndexRange> sortedSetOf(IndexRange... indexRanges) {
+        final Comparator<IndexRange> indexRangeComparator = Comparator.comparing(IndexRange::indexName);
+
+        final TreeSet<IndexRange> indexRangeSets = new TreeSet<>(indexRangeComparator);
+
+        indexRangeSets.addAll(java.util.Arrays.asList(indexRanges));
+
+        return indexRangeSets;
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/engine/QueryPlanTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/engine/QueryPlanTest.java
@@ -28,14 +28,13 @@ import org.graylog.plugins.views.search.elasticsearch.ESQueryDecorators;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchBackend;
 import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.FieldTypesLookup;
+import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
 import org.graylog.plugins.views.search.elasticsearch.QueryStringParser;
 import org.graylog.plugins.views.search.elasticsearch.searchtypes.ESMessageList;
 import org.graylog.plugins.views.search.elasticsearch.searchtypes.ESSearchTypeHandler;
 import org.graylog.plugins.views.search.searchtypes.MessageList;
-import org.graylog2.indexer.ranges.IndexRangeService;
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
-import org.graylog2.streams.StreamService;
 import org.junit.Test;
 
 import javax.inject.Provider;
@@ -61,8 +60,7 @@ public class QueryPlanTest {
         ElasticsearchBackend backend = new ElasticsearchBackend(handlers,
                 queryStringParser,
                 null,
-                mock(IndexRangeService.class),
-                mock(StreamService.class),
+                mock(IndexLookup.class),
                 new ESQueryDecorators.Fake(),
                 (elasticsearchBackend, ssb, job, query, results) -> new ESGeneratedQueryContext(elasticsearchBackend, ssb, job, query, results, fieldTypesLookup));
         queryEngine = new QueryEngine(ImmutableMap.of("elasticsearch", backend), Collections.emptySet());


### PR DESCRIPTION
Previously the lookup of indices for streams and time range was done
in `ElasticsearchBackend` by loading indices, streams, and then finding
matches. It was impossible to reuse this logic elsewhere.
Furthermore this made `ElasticsearchBackend` harder to test, because
a lot of setup was required to make sure that proper index ranges and
streams are loaded during the test.

The corresponding change in the enterprise plugin can be found here: https://github.com/Graylog2/graylog-plugin-enterprise/pull/1498
Note that the Jenkins builds for both PRs will be red, because of this dependency. Both PRs should be merged at the same time.

## Description
- Extracts that logic into a separate class `IndexLookup`
- Simplifies tests for `ElasticsearchBackend` accordingly
- Adds tests for `IndexLookup`

## Motivation and Context
- reuse the index lookup logic for #7709
- improve testability of `ElasticsearchBackend`

## How Has This Been Tested?
Local unit and integration tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


