### PR TITLE
Remove query_string from queries when exporting search to dashboard

### DIFF
--- a/graylog2-web-interface/src/views/logic/views/ViewTransformer.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewTransformer.js
@@ -30,11 +30,14 @@ const ViewTransformer = (searchView: View): View => {
       .widgets(widgets)
       .build();
   });
+  const newQueries = searchView.search.queries.map(query => query.toBuilder().query({ ...query.query, query_string: '' }).build());
+  const newSearch = searchView.search.toBuilder().queries(newQueries).build();
 
   return searchView.toBuilder()
     .newId()
     .type(View.Type.Dashboard)
     .state(newViewStateMap)
+    .search(newSearch)
     .build();
 };
 

--- a/graylog2-web-interface/src/views/logic/views/ViewTransformer.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewTransformer.js
@@ -30,7 +30,10 @@ const ViewTransformer = (searchView: View): View => {
       .widgets(widgets)
       .build();
   });
-  const newQueries = searchView.search.queries.map(query => query.toBuilder().query({ ...query.query, query_string: '' }).build());
+  // Remove query string attached to the existing search query
+  const newQueries = searchView.search.queries.map(
+    query => query.toBuilder().query({ ...query.query, query_string: '' }).build(),
+  );
   const newSearch = searchView.search.toBuilder().queries(newQueries).build();
 
   return searchView.toBuilder()

--- a/graylog2-web-interface/src/views/logic/views/ViewTransformer.search.fixture.json
+++ b/graylog2-web-interface/src/views/logic/views/ViewTransformer.search.fixture.json
@@ -5,7 +5,7 @@
       "id": "d3cf19bd-f933-4f7b-aa4a-e7cd3fc1c18e",
       "query": {
         "type": "elasticsearch",
-        "query_string": "author: \"Bernd Ahlers\""
+        "query_string": ""
       },
       "timerange": {
         "type": "relative",

--- a/graylog2-web-interface/src/views/logic/views/ViewTransformer.test.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewTransformer.test.js
@@ -49,7 +49,7 @@ describe('ViewTransformer', () => {
       expect(dashboardView.type).toBe(View.Type.Dashboard);
     });
 
-    it('should change the type', () => {
+    it('should change the id', () => {
       const query = Query.builder()
         .id('query-id')
         .timerange({ type: 'relative', range: 365 })
@@ -144,6 +144,27 @@ describe('ViewTransformer', () => {
       expect(dashboardView.state.get('query-id').widgets.first().timerange).toBeUndefined();
       expect(dashboardView.state.get('query-id').widgets.first().query).toBeUndefined();
       expect(dashboardView.state.get('query-id').widgets.first().streams).toStrictEqual(['1234-abcd']);
+    });
+
+    it('should remove the query_string from search queries', async () => {
+      const query = Query.builder()
+        .id('query-id')
+        .query({ type: 'elasticsearch', query_string: 'author: "Karl Marx"' })
+        .build();
+
+      const search = Search.builder()
+        .id('search-id')
+        .queries([query])
+        .build();
+
+      const searchView = View.builder()
+        .type(View.Type.Search)
+        .search(search)
+        .build();
+
+      const dashboardView = viewTransformer(searchView);
+
+      expect(dashboardView.search.queries.first().query).toEqual({ type: 'elasticsearch', query_string: '' });
     });
   });
 

--- a/graylog2-web-interface/src/views/logic/views/__snapshots__/ViewTransformer.test.js.snap
+++ b/graylog2-web-interface/src/views/logic/views/__snapshots__/ViewTransformer.test.js.snap
@@ -27,7 +27,7 @@ Object {
           },
           "id": "d3cf19bd-f933-4f7b-aa4a-e7cd3fc1c18e",
           "query": Object {
-            "query_string": "author: \\"Bernd Ahlers\\"",
+            "query_string": "",
             "type": "elasticsearch",
           },
           "search_types": Array [
@@ -123,7 +123,7 @@ Object {
             "filter": undefined,
             "id": "8209351b-407a-455b-9942-cefea43b76ae",
             "query": Object {
-              "query_string": "author: \\"Bernd Ahlers\\"",
+              "query_string": "",
               "type": "elasticsearch",
             },
             "streams": Array [
@@ -166,7 +166,7 @@ Object {
             "filter": undefined,
             "id": "527ed7fe-722d-4cf1-bd42-ed2b29a5a59a",
             "query": Object {
-              "query_string": "author: \\"Bernd Ahlers\\"",
+              "query_string": "",
               "type": "elasticsearch",
             },
             "streams": Array [


### PR DESCRIPTION
**Please note: This PR needs a backport for 3.2**

As described in #7732 we are currently not removing the `query_string` from the search queries when exporting a search to a dashboard. This can result in a not visible but invoked search query.
This is maybe also the reason for the following issue: https://github.com/Graylog2/graylog2-server/issues/7701

We still need to write a migration to remove the `query_string` from already exported searches. 

Fixes: #7732


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

