### PR TITLE
Improve widget legend positioning

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.jsx
@@ -124,24 +124,28 @@ class GenericPlot extends React.Component<Props, State> {
       autosize: true,
       showlegend: true,
       margin: {
-        autoexpand: true,
         t: 10,
         l: 40,
         r: 10,
-        b: 40,
+        b: 0,
         pad: 0,
       },
       legend: {
         orientation: 'h',
-        y: -0.14,
       },
       hoverlabel: {
         namelength: -1,
       },
+      yaxis: {
+        automargin: true,
+      },
+      xaxis: {
+        automargin: true,
+      },
     };
     const plotLayout = merge({}, defaultLayout, layout);
 
-    const style = { height: 'calc(100% - 10px)', width: '100%' };
+    const style = { height: '100%', width: '100%' };
 
     const config = { displayModeBar: false, doubleClick: false, responsive: true };
 

--- a/graylog2-web-interface/src/views/components/visualizations/XYPlot.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/XYPlot.jsx
@@ -40,10 +40,10 @@ const yLegendPosition = (containerHeight: number) => {
   if (containerHeight < 150) {
     return -0.6;
   }
-  if (containerHeight > 350) {
-    return -0.14;
+  if (containerHeight < 400) {
+    return -0.2;
   }
-  return -0.2;
+  return -0.14;
 };
 
 const XYPlot = ({

--- a/graylog2-web-interface/src/views/components/visualizations/XYPlot.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/XYPlot.jsx
@@ -30,9 +30,20 @@ type Props = {
     to: string,
   },
   getChartColor?: (Array<ChartConfig>, string) => ?string,
+  height?: number;
   setChartColor?: (ChartConfig, ColorMap) => ChartColor,
   plotLayout?: any,
   onZoom: (Query, string, string, ?ViewType) => boolean,
+};
+
+const yLegendPosition = (containerHeight: number) => {
+  if (containerHeight < 150) {
+    return -0.6;
+  }
+  if (containerHeight > 350) {
+    return -0.14;
+  }
+  return -0.2;
 };
 
 const XYPlot = ({
@@ -43,13 +54,13 @@ const XYPlot = ({
   effectiveTimerange,
   getChartColor,
   setChartColor,
+  height,
   plotLayout = {},
   onZoom = OnZoom,
 }: Props) => {
   const yaxis = { fixedrange: true, rangemode: 'tozero' };
-
-  const layout = merge({}, { yaxis }, plotLayout);
-
+  const legend = height ? { y: yLegendPosition(height) } : {};
+  const layout = merge({}, { yaxis, legend }, plotLayout);
   const viewType = useContext(ViewTypeContext);
   const _onZoom = useCallback(config.isTimeline
     ? (from, to) => onZoom(currentQuery, from, to, viewType)
@@ -97,6 +108,7 @@ XYPlot.propTypes = {
 XYPlot.defaultProps = {
   plotLayout: {},
   getChartColor: undefined,
+  height: undefined,
   setChartColor: undefined,
   effectiveTimerange: undefined,
   onZoom: OnZoom,

--- a/graylog2-web-interface/src/views/components/visualizations/XYPlot.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/XYPlot.jsx
@@ -59,8 +59,11 @@ const XYPlot = ({
   onZoom = OnZoom,
 }: Props) => {
   const yaxis = { fixedrange: true, rangemode: 'tozero' };
-  const legend = height ? { y: yLegendPosition(height) } : {};
-  const layout = merge({}, { yaxis, legend }, plotLayout);
+  const defaultLayout: {yaxis: Object, legend?: Object} = { yaxis };
+  if (height) {
+    defaultLayout.legend = { y: yLegendPosition(height) };
+  }
+  const layout = merge({}, defaultLayout, plotLayout);
   const viewType = useContext(ViewTypeContext);
   const _onZoom = useCallback(config.isTimeline
     ? (from, to) => onZoom(currentQuery, from, to, viewType)

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.jsx
@@ -107,4 +107,58 @@ describe('XYPlot', () => {
       xaxis: { range: ['2018-10-12T02:04:21Z', '2018-10-12T10:04:21Z'], type: 'date' },
     });
   });
+
+  it('sets correct plot legend position for small containers', () => {
+    const wrapper = mount((
+      <XYPlot chartData={chartData}
+              getChartColor={getChartColor}
+              setChartColor={setChartColor}
+              height={140}
+              config={config}
+              currentQuery={currentQuery}
+              timezone="UTC" />
+    ));
+    const genericPlot = wrapper.find('GenericPlot');
+    expect(genericPlot).toHaveProp('layout', {
+      yaxis: { fixedrange: true, rangemode: 'tozero' },
+      xaxis: { fixedrange: true },
+      legend: { y: -0.6 },
+    });
+  });
+
+  it('sets correct plot legend position for containers with medium height', () => {
+    const wrapper = mount((
+      <XYPlot chartData={chartData}
+              getChartColor={getChartColor}
+              setChartColor={setChartColor}
+              height={350}
+              config={config}
+              currentQuery={currentQuery}
+              timezone="UTC" />
+    ));
+    const genericPlot = wrapper.find('GenericPlot');
+    expect(genericPlot).toHaveProp('layout', {
+      yaxis: { fixedrange: true, rangemode: 'tozero' },
+      xaxis: { fixedrange: true },
+      legend: { y: -0.2 },
+    });
+  });
+
+  it('sets correct plot legend position for containers with huge height', () => {
+    const wrapper = mount((
+      <XYPlot chartData={chartData}
+              getChartColor={getChartColor}
+              setChartColor={setChartColor}
+              height={700}
+              config={config}
+              currentQuery={currentQuery}
+              timezone="UTC" />
+    ));
+    const genericPlot = wrapper.find('GenericPlot');
+    expect(genericPlot).toHaveProp('layout', {
+      yaxis: { fixedrange: true, rangemode: 'tozero' },
+      xaxis: { fixedrange: true },
+      legend: { y: -0.14 },
+    });
+  });
 });

--- a/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.jsx
@@ -23,7 +23,7 @@ const getChartColor = (fullData, name) => {
 
 const setChartColor = (chart, colors) => ({ line: { color: colors[chart.name] } });
 
-const AreaVisualization: VisualizationComponent = makeVisualization(({ config, data, effectiveTimerange }: VisualizationComponentProps) => {
+const AreaVisualization: VisualizationComponent = makeVisualization(({ config, data, effectiveTimerange, height }: VisualizationComponentProps) => {
   // $FlowFixMe: We need to assume it is a LineVisualizationConfig instance
   const visualizationConfig: AreaVisualizationConfig = config.visualizationConfig || AreaVisualizationConfig.empty();
   const { interpolation = 'linear' } = visualizationConfig;
@@ -49,6 +49,7 @@ const AreaVisualization: VisualizationComponent = makeVisualization(({ config, d
             plotLayout={layout}
             effectiveTimerange={effectiveTimerange}
             getChartColor={getChartColor}
+            height={height}
             setChartColor={setChartColor}
             chartData={chartDataResult} />
   );
@@ -57,6 +58,7 @@ const AreaVisualization: VisualizationComponent = makeVisualization(({ config, d
 AreaVisualization.propTypes = {
   config: AggregationType.isRequired,
   data: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
+  height: PropTypes.number,
 };
 
 export default AreaVisualization;

--- a/graylog2-web-interface/src/views/components/visualizations/area/__tests__/AreaVisualization.test.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/__tests__/AreaVisualization.test.jsx
@@ -40,6 +40,7 @@ describe('AreaVisualization', () => {
     expect(genericPlot).toHaveProp('layout', {
       yaxis: { fixedrange: true, rangemode: 'tozero' },
       xaxis: { range: ['2019-11-28T15:21:00Z', '2019-11-28T15:25:57Z'], type: 'date' },
+      legend: { y: -0.14 },
     });
     expect(genericPlot).toHaveProp('chartData', [
       {

--- a/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.jsx
@@ -30,7 +30,7 @@ const getChartColor = (fullData, name) => {
 
 const setChartColor = (chart, colors) => ({ marker: { color: colors[chart.name] } });
 
-const BarVisualization: VisualizationComponent = makeVisualization(({ config, data, effectiveTimerange }: VisualizationComponentProps) => {
+const BarVisualization: VisualizationComponent = makeVisualization(({ config, data, effectiveTimerange, height }: VisualizationComponentProps) => {
   const { visualizationConfig } = config;
   const layout = {};
 
@@ -56,6 +56,7 @@ const BarVisualization: VisualizationComponent = makeVisualization(({ config, da
             chartData={chartDataResult}
             effectiveTimerange={effectiveTimerange}
             getChartColor={getChartColor}
+            height={height}
             setChartColor={setChartColor}
             plotLayout={layout} />
   );
@@ -64,6 +65,7 @@ const BarVisualization: VisualizationComponent = makeVisualization(({ config, da
 BarVisualization.propTypes = {
   config: AggregationType.isRequired,
   data: PropTypes.object.isRequired,
+  height: PropTypes.number,
 };
 
 export default BarVisualization;

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.jsx
@@ -97,7 +97,6 @@ const _axisConfg = (chartHasContent) => {
   const axisConfig = {
     type: undefined,
     fixedrange: true,
-    automargin: true,
   };
   // Adding the axis type, without provided z data, would hide the empty grid
   if (chartHasContent) {
@@ -113,6 +112,9 @@ const _chartLayout = (heatmapData) => {
     yaxis: axisConfig,
     xaxis: axisConfig,
     plot_bgcolor: hasContent ? BG_COLOR : 'transparent',
+    margin: {
+      b: 40,
+    },
   };
 };
 

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/__tests__/HeatmapVisualization.test.jsx
@@ -23,7 +23,7 @@ describe('HeatmapVisualization', () => {
       .visualization('heatmap')
       .build();
     const effectiveTimerange = { type: 'absolute', from: '2019-10-22T11:54:35.850Z', to: '2019-10-29T11:53:50.000Z' };
-    const plotLayout = { yaxis: { type: 'category', fixedrange: true, automargin: true }, xaxis: { type: 'category', fixedrange: true, automargin: true }, plot_bgcolor: '#440154' };
+    const plotLayout = { yaxis: { type: 'category', fixedrange: true }, xaxis: { type: 'category', fixedrange: true }, plot_bgcolor: '#440154', margin: { b: 40 } };
     const plotChartData = [
       {
         type: 'heatmap',

--- a/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.jsx
@@ -24,8 +24,8 @@ const getChartColor = (fullData, name) => {
 
 const setChartColor = (chart, colors) => ({ line: { color: colors[chart.name] } });
 
-const LineVisualization: VisualizationComponent = makeVisualization(({ config, data, effectiveTimerange }: VisualizationComponentProps) => {
-  // $FlowFixMe: We need to assume it is a LineVisualizationConfig instance
+const LineVisualization: VisualizationComponent = makeVisualization(({ config, data, effectiveTimerange, height }: VisualizationComponentProps) => {
+// $FlowFixMe: We need to assume it is a LineVisualizationConfig instance
   const visualizationConfig: LineVisualizationConfig = config.visualizationConfig || LineVisualizationConfig.empty();
   const { interpolation = 'linear' } = visualizationConfig;
   const chartGenerator = useCallback((type, name, labels, values): ChartDefinition => ({
@@ -49,6 +49,7 @@ const LineVisualization: VisualizationComponent = makeVisualization(({ config, d
             plotLayout={layout}
             effectiveTimerange={effectiveTimerange}
             getChartColor={getChartColor}
+            height={height}
             setChartColor={setChartColor}
             chartData={chartDataResult} />
   );
@@ -57,6 +58,7 @@ const LineVisualization: VisualizationComponent = makeVisualization(({ config, d
 LineVisualization.propTypes = {
   config: AggregationType.isRequired,
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
+  height: PropTypes.number,
 };
 
 export default LineVisualization;

--- a/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.jsx
@@ -12,7 +12,7 @@ import XYPlot from '../XYPlot';
 
 const seriesGenerator = (type, name, labels, values) => ({ type, name, x: labels, y: values, mode: 'markers' });
 
-const ScatterVisualization: VisualizationComponent = makeVisualization(({ config, data, effectiveTimerange }: VisualizationComponentProps) => {
+const ScatterVisualization: VisualizationComponent = makeVisualization(({ config, data, effectiveTimerange, height }: VisualizationComponentProps) => {
   const chartDataResult = chartData(config, data.chart || Object.values(data)[0], 'scatter', seriesGenerator);
   const layout = {};
   if (config.eventAnnotation && data.events) {
@@ -24,6 +24,7 @@ const ScatterVisualization: VisualizationComponent = makeVisualization(({ config
     <XYPlot config={config}
             chartData={chartDataResult}
             plotLayout={layout}
+            height={height}
             effectiveTimerange={effectiveTimerange} />
   );
 }, 'scatter');
@@ -31,6 +32,7 @@ const ScatterVisualization: VisualizationComponent = makeVisualization(({ config
 ScatterVisualization.propTypes = {
   config: AggregationType.isRequired,
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
+  height: PropTypes.number,
 };
 
 export default ScatterVisualization;


### PR DESCRIPTION
There are a few cases where a chart legend is overlapping the x-axis labels.

You can sometimes see this behaviour on the main search page:
![image](https://user-images.githubusercontent.com/46300478/77447616-2810f500-6df0-11ea-8ec2-0868fb616c03.png)

I had an extensive look at the available plotly layout settings and could not find a perfectly dynamic solution. In the end I've added a small manual calculation, to create more dynamic layout and reduce the problematic cases to a minimum. This will e.g. fix the problem, visible in the above screenshot.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

