### PR TITLE
Persist message list search type's sort option. (Backport of #7759 for 3.2)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/MessageList.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/searchtypes/MessageList.java
@@ -78,6 +78,7 @@ public abstract class MessageList implements SearchType {
     public abstract int offset();
 
     @Nullable
+    @JsonProperty
     public abstract List<Sort> sort();
 
     @JsonProperty


### PR DESCRIPTION
**This is the backport of #7759 for `3.2`**

## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


Before this change, the `sort` option for a message list search type was not persisted. This lead to sorting configuration having no effect when storing a search and executing it, only for the synchronous endpoint.

Fixes #7758.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.