### PR TITLE
Create separate component for the default app content grid

### DIFF
--- a/graylog2-web-interface/src/components/layout/AppContentGrid.jsx
+++ b/graylog2-web-interface/src/components/layout/AppContentGrid.jsx
@@ -1,0 +1,28 @@
+// @flow strict
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import styled, { type StyledComponent } from 'styled-components';
+
+import { Grid } from 'components/graylog';
+
+type Props = {
+  children: React.Node
+}
+
+const Container: StyledComponent<Props, {}, HTMLDivElement> = styled.div`
+  padding: 15px 10px;
+`;
+
+const AppContentGrid = ({ children }: Props) => (
+  <Container>
+    <Grid fluid>
+      {children}
+    </Grid>
+  </Container>
+);
+
+AppContentGrid.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default AppContentGrid;

--- a/graylog2-web-interface/src/components/layout/AppContentGrid.jsx
+++ b/graylog2-web-interface/src/components/layout/AppContentGrid.jsx
@@ -13,8 +13,8 @@ const Container: StyledComponent<Props, {}, HTMLDivElement> = styled.div`
   padding: 15px 10px;
 `;
 
-const AppContentGrid = ({ children }: Props) => (
-  <Container>
+const AppContentGrid = ({ children, ...rest }: Props) => (
+  <Container {...rest}>
     <Grid fluid>
       {children}
     </Grid>

--- a/graylog2-web-interface/src/components/layout/AppContentGrid.test.jsx
+++ b/graylog2-web-interface/src/components/layout/AppContentGrid.test.jsx
@@ -1,0 +1,12 @@
+// @flow strict
+import * as React from 'react';
+import { render } from 'wrappedTestingLibrary';
+
+import AppContentGrid from './AppContentGrid';
+
+describe('AppContentGrid', () => {
+  it('renders its children', async () => {
+    const { getByText } = render(<AppContentGrid><div>The content</div></AppContentGrid>);
+    expect(getByText('The content')).not.toBeNull();
+  });
+});

--- a/graylog2-web-interface/src/routing/AppWithoutSearchBar.jsx
+++ b/graylog2-web-interface/src/routing/AppWithoutSearchBar.jsx
@@ -1,36 +1,30 @@
-import React from 'react';
+// @flow strict
+import * as React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 import { Col, Row } from 'components/graylog';
 import Footer from 'components/layout/Footer';
+import AppContentGrid from 'components/layout/AppContentGrid';
+
+type Props = {
+  children: React.Node
+}
 
 const StyledRow = styled(Row)`
   margin-bottom: 0;
 `;
 
-const StyledCol = styled(Col)`
-  margin-top: 10px;
-  padding: 5px 25px;
-
-  @media print {
-    width: 100%;
-  }
-`;
-
-const AppWithoutSearchBar = (props) => {
-  const { children } = props;
-  return (
-    <div className="container-fluid">
-      <StyledRow>
-        <StyledCol md={12}>
-          {children}
-        </StyledCol>
-      </StyledRow>
-      <Footer />
-    </div>
-  );
-};
+const AppWithoutSearchBar = ({ children }: Props) => (
+  <AppContentGrid>
+    <StyledRow>
+      <Col md={12}>
+        {children}
+      </Col>
+    </StyledRow>
+    <Footer />
+  </AppContentGrid>
+);
 
 AppWithoutSearchBar.propTypes = {
   children: PropTypes.node.isRequired,

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -71,23 +71,19 @@ const SearchArea = styled(AppContentGrid)`
 `;
 
 const ConnectedSideBar = connect(SideBar, { viewMetadata: ViewMetadataStore, searches: SearchStore },
-  props => Object.assign(
-    {},
-    props,
-    {
-      queryId: props.viewMetadata.activeQuery,
-      results: props.searches && props.searches.result ? props.searches.result.forId(props.viewMetadata.activeQuery) : undefined,
-    },
-  ));
+  (props) => ({
+
+    ...props,
+    queryId: props.viewMetadata.activeQuery,
+    results: props.searches && props.searches.result ? props.searches.result.forId(props.viewMetadata.activeQuery) : undefined,
+  }));
 const ConnectedFieldList = connect(FieldList, { fieldTypes: FieldTypesStore, viewMetadata: ViewMetadataStore },
-  props => Object.assign(
-    {},
-    props,
-    {
-      allFields: props.fieldTypes.all,
-      fields: props.fieldTypes.queryFields.get(props.viewMetadata.activeQuery, props.fieldTypes.all),
-    },
-  ));
+  (props) => ({
+
+    ...props,
+    allFields: props.fieldTypes.all,
+    fields: props.fieldTypes.queryFields.get(props.viewMetadata.activeQuery, props.fieldTypes.all),
+  }));
 
 type Props = {
   route: any,
@@ -161,7 +157,7 @@ const ExtendedSearchPage = ({ route, location = { query: {} }, router, searchRef
     });
 
     // Returning cleanup function used when unmounting
-    return () => { storeListenersUnsubscribes.forEach(unsubscribeFunc => unsubscribeFunc()); };
+    return () => { storeListenersUnsubscribes.forEach((unsubscribeFunc) => unsubscribeFunc()); };
   }, []);
 
   useSyncWithQueryParameters(query);
@@ -174,7 +170,7 @@ const ExtendedSearchPage = ({ route, location = { query: {} }, router, searchRef
         </IfDashboard>
       </IfInteractive>
       <InteractiveContext.Consumer>
-        {interactive => (
+        {(interactive) => (
           <ViewAdditionalContextProvider>
             <GridContainer id="main-row" interactive={interactive}>
               <IfInteractive>

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -8,6 +8,7 @@ import { withRouter } from 'react-router';
 
 import connect from 'stores/connect';
 import Footer from 'components/layout/Footer';
+import AppContentGrid from 'components/layout/AppContentGrid';
 
 import SideBar from 'views/components/sidebar/SideBar';
 import WithSearchStatus from 'views/components/WithSearchStatus';
@@ -17,7 +18,6 @@ import type {
   SearchRefreshConditionArguments,
 } from 'views/logic/hooks/SearchRefreshCondition';
 
-import { Grid } from 'components/graylog';
 import { FieldTypesStore, FieldTypesActions } from 'views/stores/FieldTypesStore';
 import { SearchStore, SearchActions } from 'views/stores/SearchStore';
 import { SearchExecutionStateStore } from 'views/stores/SearchExecutionStateStore';
@@ -60,19 +60,14 @@ const GridContainer: ComponentType<{ interactive: boolean }> = styled.div`
   ` : '')}
 `;
 
-const SearchArea = styled.div`
+const SearchArea = styled(AppContentGrid)`
   height: 100%;
   grid-column: 2;
   -ms-grid-column: 2;
   grid-row: 1;
   -ms-grid-row: 1;
-  padding: 15px;
   z-index: 1;
   overflow-y: auto;
-`;
-
-const SearchGrid = styled(Grid)`
-  width: 100%;
 `;
 
 const ConnectedSideBar = connect(SideBar, { viewMetadata: ViewMetadataStore, searches: SearchStore },
@@ -188,27 +183,25 @@ const ExtendedSearchPage = ({ route, location = { query: {} }, router, searchRef
                 </ConnectedSideBar>
               </IfInteractive>
               <SearchArea>
-                <SearchGrid>
-                  <IfInteractive>
-                    <HeaderElements />
-                    <IfDashboard>
-                      <DashboardSearchBarWithStatus onExecute={refreshIfNotUndeclared} />
-                    </IfDashboard>
-                    <IfSearch>
-                      <SearchBarWithStatus onExecute={refreshIfNotUndeclared} />
-                    </IfSearch>
+                <IfInteractive>
+                  <HeaderElements />
+                  <IfDashboard>
+                    <DashboardSearchBarWithStatus onExecute={refreshIfNotUndeclared} />
+                  </IfDashboard>
+                  <IfSearch>
+                    <SearchBarWithStatus onExecute={refreshIfNotUndeclared} />
+                  </IfSearch>
 
-                    <QueryBarElements />
+                  <QueryBarElements />
 
-                    <IfDashboard>
-                      <QueryBar />
-                    </IfDashboard>
-                  </IfInteractive>
-                  <HighlightMessageInQuery query={location.query}>
-                    <SearchResult />
-                  </HighlightMessageInQuery>
-                  <Footer />
-                </SearchGrid>
+                  <IfDashboard>
+                    <QueryBar />
+                  </IfDashboard>
+                </IfInteractive>
+                <HighlightMessageInQuery query={location.query}>
+                  <SearchResult />
+                </HighlightMessageInQuery>
+                <Footer />
               </SearchArea>
             </GridContainer>
           </ViewAdditionalContextProvider>


### PR DESCRIPTION
This PR extracts the default app content (bootstrap) grid into a separate component, which can be used e.g.  for the extended search page search area.

The main advantage is, we can adjust the related layout styling , like the default padding, in one place.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

