### PR TITLE
Trigger event upon search job creation.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchQueryString.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchQueryString.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 import org.graylog.plugins.views.search.engine.BackendQuery;
 
 @AutoValue
@@ -37,6 +38,25 @@ public abstract class ElasticsearchQueryString implements BackendQuery {
 
     public static Builder builder() {
         return new AutoValue_ElasticsearchQueryString.Builder().type(NAME);
+    }
+
+    abstract Builder toBuilder();
+
+    public ElasticsearchQueryString concatenate(ElasticsearchQueryString other) {
+        final String thisQueryString = Strings.nullToEmpty(this.queryString()).trim();
+        final String otherQueryString = Strings.nullToEmpty(other.queryString()).trim();
+
+        final StringBuilder finalStringBuilder = new StringBuilder(thisQueryString);
+        if (!thisQueryString.isEmpty() && !otherQueryString.isEmpty()) {
+            finalStringBuilder.append(" AND ");
+        }
+        if (!otherQueryString.isEmpty()) {
+            finalStringBuilder.append(otherQueryString);
+        }
+
+        return toBuilder()
+                .queryString(finalStringBuilder.toString())
+                .build();
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/events/SearchJobExecutionEvent.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/events/SearchJobExecutionEvent.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.views.search.events;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/events/SearchJobExecutionEvent.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/events/SearchJobExecutionEvent.java
@@ -1,0 +1,19 @@
+package org.graylog.plugins.views.search.events;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.google.auto.value.AutoValue;
+import org.graylog.plugins.views.search.SearchJob;
+import org.graylog2.plugin.database.users.User;
+import org.joda.time.DateTime;
+
+@AutoValue
+@JsonAutoDetect
+public abstract class SearchJobExecutionEvent {
+    public abstract User user();
+    public abstract SearchJob searchJob();
+    public abstract DateTime executionStart();
+
+    public static SearchJobExecutionEvent create(User user, SearchJob searchJob, DateTime executionStart) {
+        return new AutoValue_SearchJobExecutionEvent(user, searchJob, executionStart);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/SearchResource.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+import com.google.common.eventbus.EventBus;
 import com.google.common.util.concurrent.Uninterruptibles;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -38,12 +39,15 @@ import org.graylog.plugins.views.search.SearchMetadata;
 import org.graylog.plugins.views.search.db.SearchDbService;
 import org.graylog.plugins.views.search.db.SearchJobService;
 import org.graylog.plugins.views.search.engine.QueryEngine;
+import org.graylog.plugins.views.search.events.SearchJobExecutionEvent;
 import org.graylog.plugins.views.search.views.ViewDTO;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.audit.jersey.NoAuditEvent;
 import org.graylog2.plugin.rest.PluginRestResource;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,6 +93,7 @@ public class SearchResource extends RestResource implements PluginRestResource {
     private final PermittedStreams permittedStreams;
     private final SearchExecutionGuard executionGuard;
     private final SearchDomain searchDomain;
+    private final EventBus serverEventBus;
 
     @Inject
     public SearchResource(QueryEngine queryEngine,
@@ -97,7 +102,8 @@ public class SearchResource extends RestResource implements PluginRestResource {
                           ObjectMapper objectMapper,
                           PermittedStreams permittedStreams,
                           SearchExecutionGuard executionGuard,
-                          SearchDomain searchDomain) {
+                          SearchDomain searchDomain,
+                          EventBus serverEventBus) {
         this.queryEngine = queryEngine;
         this.searchDbService = searchDbService;
         this.searchJobService = searchJobService;
@@ -105,6 +111,7 @@ public class SearchResource extends RestResource implements PluginRestResource {
         this.permittedStreams = permittedStreams;
         this.executionGuard = executionGuard;
         this.searchDomain = searchDomain;
+        this.serverEventBus = serverEventBus;
     }
 
     @VisibleForTesting
@@ -164,7 +171,7 @@ public class SearchResource extends RestResource implements PluginRestResource {
     @ApiOperation(value = "Execute the referenced search query asynchronously",
             notes = "Starts a new search, irrespective whether or not another is already running")
     @Path("{id}/execute")
-    @AuditEvent(type = ViewsAuditEventTypes.SEARCH_JOB_CREATE)
+    @NoAuditEvent("Creating audit event manually in method body.")
     public Response executeQuery(@ApiParam(name = "id") @PathParam("id") String id,
                                  @ApiParam Map<String, Object> executionState) {
         Search search = getSearch(id);
@@ -177,11 +184,18 @@ public class SearchResource extends RestResource implements PluginRestResource {
 
         final SearchJob searchJob = searchJobService.create(search, username());
 
+        postAuditEvent(searchJob);
+
         final SearchJob runningSearchJob = queryEngine.execute(searchJob);
 
         return Response.created(URI.create(BASE_PATH + "/status/" + runningSearchJob.getId()))
                 .entity(runningSearchJob)
                 .build();
+    }
+
+    private void postAuditEvent(SearchJob searchJob) {
+        final SearchJobExecutionEvent searchJobExecutionEvent = SearchJobExecutionEvent.create(getCurrentUser(), searchJob, DateTime.now(DateTimeZone.UTC));
+        this.serverEventBus.post(searchJobExecutionEvent);
     }
 
     private ImmutableSet<String> loadAllAllowedStreamsForUser() {
@@ -199,7 +213,7 @@ public class SearchResource extends RestResource implements PluginRestResource {
     @POST
     @ApiOperation(value = "Execute a new synchronous search", notes = "Executes a new search and waits for its result")
     @Path("sync")
-    @AuditEvent(type = ViewsAuditEventTypes.SEARCH_EXECUTE)
+    @NoAuditEvent("Creating audit event manually in method body.")
     public Response executeSyncJob(@ApiParam Search search,
                                    @ApiParam(name = "timeout", defaultValue = "60000")
                                    @QueryParam("timeout") @DefaultValue("60000") long timeout) {
@@ -210,6 +224,8 @@ public class SearchResource extends RestResource implements PluginRestResource {
         guard(search);
 
         final SearchJob searchJob = queryEngine.execute(searchJobService.create(search, username));
+
+        postAuditEvent(searchJob);
 
         try {
             //noinspection UnstableApiUsage

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchQueryStringTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchQueryStringTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.plugins.views.search.elasticsearch;
 
 import org.junit.jupiter.api.Test;

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchQueryStringTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/elasticsearch/ElasticsearchQueryStringTest.java
@@ -1,0 +1,31 @@
+package org.graylog.plugins.views.search.elasticsearch;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ElasticsearchQueryStringTest {
+    private ElasticsearchQueryString create(String queryString) {
+        return ElasticsearchQueryString.builder().queryString(queryString).build();
+    }
+
+    @Test
+    void concatenatingTwoEmptyStringsReturnsEmptyString() {
+        assertThat(create("").concatenate(create("")).queryString()).isEmpty();
+    }
+
+    @Test
+    void concatenatingNonEmptyStringWithEmptyStringReturnsFirst() {
+        assertThat(create("_exists_:nf_version").concatenate(create("")).queryString()).isEqualTo("_exists_:nf_version");
+    }
+
+    @Test
+    void concatenatingEmptyStringWithNonEmptyStringReturnsSecond() {
+        assertThat(create("").concatenate(create("_exists_:nf_version")).queryString()).isEqualTo("_exists_:nf_version");
+    }
+
+    @Test
+    void concatenatingTwoNonEmptyStringsReturnsAppendedQueryString() {
+        assertThat(create("nf_bytes>200").concatenate(create("_exists_:nf_version")).queryString()).isEqualTo("nf_bytes>200 AND _exists_:nf_version");
+    }
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change implements creating and posting an event on the local node's
event bus whenever a search job is created and executed. This happens
for both synchronous and asynchronous execution.

Any component in the Graylog server can subscribe on these events and be
notified when the local node is executing a search job. The created
event includes:

  - the user executing the search job
  - the search job itself (which also includes the search)
  - the start of the execution

This is only a notification mechanism. There is no way a subscriber of
the event can take an effect on the search job execution.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.