### PR TITLE
Validate view sharing request upon POST.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewSharingResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewSharingResource.java
@@ -34,7 +34,9 @@ import org.graylog2.shared.security.RestPermissions;
 import org.graylog2.shared.users.UserService;
 
 import javax.inject.Inject;
+import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
@@ -73,7 +75,7 @@ public class ViewSharingResource extends RestResource implements PluginRestResou
     @POST
     @ApiOperation("Configure sharing for a view")
     @AuditEvent(type = ViewsAuditEventTypes.VIEW_SHARING_CREATE)
-    public ViewSharing create(@ApiParam(name="id") @PathParam("id") @NotEmpty String id, ViewSharing viewSharing) {
+    public ViewSharing create(@ApiParam(name="id") @PathParam("id") @NotEmpty String id, @Valid @NotNull ViewSharing viewSharing) {
         ensureUserIsPermittedForView(id);
         ensureUserIsPermittedToEditView(id);
         return viewSharingService.create(viewSharing);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, a `POST` to `/views/{id}/share` did not check if the
supplied view sharing configuration in the body is present. This lead
to a NPE further down the stack when persisting the view sharing.

This change now adds the required annotations for the body parameter, checking its presence before handing it over to the `ViewSharingService`, avoiding the NPE and returning a 400 instead of a 500.
Unfortunately this just returns a plain text error message instead of a structured one, looking like this:

```
must not be null (path = ViewSharingResource.create.arg1, invalidValue = null)
```

This should be caught properly and turned into an `ApiError` in a subsequent PR.

Fixes #7688.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.