### PR TITLE
Disable ESlint rule react/static-property-placement

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -42,5 +42,6 @@ module.exports = {
     'react/jsx-props-no-spreading': 'off',
     'react/prefer-es6-class': 'off',
     'react/prefer-stateless-function': 'warn',
+    'react/static-property-placement': 'off',
   },
 };

--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -42,9 +42,6 @@ module.exports = {
     'react/jsx-props-no-spreading': 'off',
     'react/prefer-es6-class': 'off',
     'react/prefer-stateless-function': 'warn',
-    'react/static-property-placement': ['error', 'property assignment', {
-      contextType: 'static public field',
-      contextTypes: 'static public field',
-    }],
+    'react/static-property-placement': 'off',
   },
 };

--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -42,6 +42,9 @@ module.exports = {
     'react/jsx-props-no-spreading': 'off',
     'react/prefer-es6-class': 'off',
     'react/prefer-stateless-function': 'warn',
-    'react/static-property-placement': 'off',
+    'react/static-property-placement': ['error', 'property assignment', {
+      contextType: 'static public field',
+      contextTypes: 'static public field',
+    }],
   },
 };


### PR DESCRIPTION
With https://github.com/Graylog2/graylog2-server/pull/7586 we've updated the airbnb ESlint config.
One new newly introduced rule is the `react/static-property-placement`. 
The rule enforces that e.g. static attributes like prop types needs to be assigned outside of the class body.

This PR is disabling the rule, because it is has no real benefit and can be obstructive.
There is also a problem in with flow, when `contextType` is getting assigned outside of the class body.
