### PR TITLE
Only show dashboard delete button for users with correct permissions

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
@@ -195,7 +195,7 @@ public class ViewsResource extends RestResource implements PluginRestResource {
     @ApiOperation("Delete view")
     @AuditEvent(type = ViewsAuditEventTypes.VIEW_DELETE)
     public ViewDTO delete(@ApiParam(name="id") @PathParam("id") @NotEmpty String id) {
-        checkPermission(ViewsRestPermissions.VIEW_EDIT, id);
+        checkPermission(ViewsRestPermissions.VIEW_DELETE, id);
         final ViewDTO dto = loadView(id);
         dbService.delete(id);
         removeUserPermissions(dto);

--- a/graylog2-web-interface/src/views/components/views/ViewList.jsx
+++ b/graylog2-web-interface/src/views/components/views/ViewList.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import { ButtonToolbar, DropdownButton, MenuItem } from 'components/graylog';
+import IfPermitted from 'components/common/IfPermitted';
 
 import { PaginatedList, SearchForm, Spinner, EntityList } from 'components/common';
 import View from './View';
@@ -72,11 +73,13 @@ const ViewList = createReactClass({
 
   itemActionsFactory(view) {
     return (
-      <ButtonToolbar>
-        <DropdownButton title="Actions" id={`view-actions-dropdown-${view.id}`} bsSize="small" pullRight>
-          <MenuItem onSelect={this.handleViewDelete(view)}>Delete</MenuItem>
-        </DropdownButton>
-      </ButtonToolbar>
+      <IfPermitted permissions={['*']}>
+        <ButtonToolbar>
+          <DropdownButton title="Actions" id={`view-actions-dropdown-${view.id}`} bsSize="small" pullRight>
+            <MenuItem onSelect={this.handleViewDelete(view)}>Delete</MenuItem>
+          </DropdownButton>
+        </ButtonToolbar>
+      </IfPermitted>
     );
   },
 

--- a/graylog2-web-interface/src/views/components/views/ViewList.jsx
+++ b/graylog2-web-interface/src/views/components/views/ViewList.jsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useReducer } from 'react';
 import PropTypes from 'prop-types';
-import { ButtonToolbar, DropdownButton, MenuItem } from 'components/graylog';
-import IfPermitted from 'components/common/IfPermitted';
 
+import { ButtonToolbar, DropdownButton, MenuItem } from 'components/graylog';
 import { PaginatedList, SearchForm, Spinner, EntityList } from 'components/common';
+import IfPermitted from 'components/common/IfPermitted';
 import View from './View';
 
 const itemActionsFactory = (view, onViewDelete) => {


### PR DESCRIPTION
**We need to merge https://github.com/Graylog2/graylog2-server/pull/7817 first, it changes the backend permissions for view deletions. Otherwise the frontend permission check will not match.**

As described in https://github.com/Graylog2/graylog2-server/issues/7730 a user without the permissions to delete a dashboard still sees the `Delete` action in the dashboard action menu.

Fixes: https://github.com/Graylog2/graylog2-server/issues/7730


## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

