### PR TITLE
Prevent default action for form submit event in `PivotConfiguration`.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationbuilder/PivotConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/PivotConfiguration.jsx
@@ -31,10 +31,13 @@ export default class PivotConfiguration extends React.Component {
     };
   }
 
-  // eslint-disable-next-line react/destructuring-assignment
-  _onSubmit = () => this.props.onClose(this.state);
+  _onSubmit = (e) => {
+    e.preventDefault();
+    const { onClose } = this.props;
+    onClose(this.state);
+  };
 
-  _onChange = config => this.setState({ config });
+  _onChange = (config) => this.setState({ config });
 
   render() {
     const { type } = this.props;

--- a/graylog2-web-interface/src/views/components/common/EditableTitle.jsx
+++ b/graylog2-web-interface/src/views/components/common/EditableTitle.jsx
@@ -42,7 +42,8 @@ export default class EditableTitle extends React.Component {
     this.setState({ value: evt.target.value });
   };
 
-  _onSubmit = () => {
+  _onSubmit = (e) => {
+    e.preventDefault();
     const { value } = this.state;
     const { onChange, value: propsValue } = this.props;
     if (value !== '') {

--- a/graylog2-web-interface/src/views/components/common/EditableTitle.jsx
+++ b/graylog2-web-interface/src/views/components/common/EditableTitle.jsx
@@ -15,20 +15,19 @@ export default class EditableTitle extends React.Component {
     onChange: () => {},
   };
 
-  state = {
-    editing: false,
-    // eslint-disable-next-line react/destructuring-assignment
-    value: this.props.value,
-  };
-
-  componentWillReceiveProps(nextProps) {
-    this.setState({ value: nextProps.value });
+  constructor(props) {
+    super(props);
+    const { value } = props;
+    this.state = {
+      editing: false,
+      value,
+    };
   }
 
   _toggleEditing = () => {
     const { disabled } = this.props;
     if (!disabled) {
-      this.setState(state => ({ editing: !state.editing }));
+      this.setState((state) => ({ editing: !state.editing }));
     }
   };
 

--- a/graylog2-web-interface/src/views/components/widgets/WidgetHeader.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetHeader.jsx
@@ -14,7 +14,7 @@ const LoadingSpinner = styled(Spinner)`
 const WidgetHeader = ({ children, onRename, hideDragHandle, title, loading }) => (
   <div className={styles.widgetHeader}>
     {hideDragHandle || <Icon name="bars" className={`widget-drag-handle ${styles.widgetDragHandle}`} />}{' '}
-    <EditableTitle disabled={!onRename} value={title} onChange={onRename} />
+    <EditableTitle key={title} disabled={!onRename} value={title} onChange={onRename} />
     {loading && <LoadingSpinner text="" delay={0} />}
     <span className={`pull-right ${styles.widgetActionDropdown}`}>
       {children}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note: This requires a backport to `3.2`.**

Before this change, the default action for the form submit event triggered by submitting the `PivotConfiguration`/`EditableTitle` forms was not prevented. This lead to a redirect happening in some browsers (namely Safari), while working as expected on others (Chrome/ium).

This change is now preventing the form submit event to fix this for Safari and others.

Fixes #7806.


<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.