### PR TITLE
Prevent default action for form submit event in `PivotConfiguration`. (3.2)

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationbuilder/PivotConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/PivotConfiguration.jsx
@@ -37,7 +37,7 @@ export default class PivotConfiguration extends React.Component {
     onClose(this.state);
   };
 
-  _onChange = (config) => this.setState({ config });
+  _onChange = config => this.setState({ config });
 
   render() {
     const { type } = this.props;

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/PivotConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/PivotConfiguration.jsx
@@ -31,10 +31,13 @@ export default class PivotConfiguration extends React.Component {
     };
   }
 
-  // eslint-disable-next-line react/destructuring-assignment
-  _onSubmit = () => this.props.onClose(this.state);
+  _onSubmit = (e) => {
+    e.preventDefault();
+    const { onClose } = this.props;
+    onClose(this.state);
+  };
 
-  _onChange = config => this.setState({ config });
+  _onChange = (config) => this.setState({ config });
 
   render() {
     const { type } = this.props;

--- a/graylog2-web-interface/src/views/components/common/EditableTitle.jsx
+++ b/graylog2-web-interface/src/views/components/common/EditableTitle.jsx
@@ -42,7 +42,8 @@ export default class EditableTitle extends React.Component {
     this.setState({ value: evt.target.value });
   };
 
-  _onSubmit = () => {
+  _onSubmit = (e) => {
+    e.preventDefault();
     const { value } = this.state;
     const { onChange, value: propsValue } = this.props;
     if (value !== '') {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, the default action for the form submit event triggered by submitting the `PivotConfiguration`/`EditableTitle` forms was not prevented. This lead to a redirect happening in some browsers (namely Safari), while working as expected on others (Chrome/ium).

This change is now preventing the form submit event to fix this for Safari and others.

Fixes #7806.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.