### PR TITLE
Reverting to stock lucene mode for `react-ace`.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/ace.js
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/ace.js
@@ -1,6 +1,7 @@
 import AceEditor from 'react-ace';
-import 'views/components/searchbar/queryinput/webpack-resolver';
+
 import 'views/components/searchbar/queryinput/ace-queryinput';
 import 'ace-builds/src-min-noconflict/ext-language_tools';
+import 'ace-builds/src-noconflict/mode-lucene';
 
 export default AceEditor;

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/ace.js
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/ace.js
@@ -1,7 +1,7 @@
 import AceEditor from 'react-ace';
 
 import 'views/components/searchbar/queryinput/ace-queryinput';
-import 'ace-builds/src-min-noconflict/ext-language_tools';
+import 'ace-builds/src-noconflict/ext-language_tools';
 import 'ace-builds/src-noconflict/mode-lucene';
 
 export default AceEditor;

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/webpack-resolver.js
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/webpack-resolver.js
@@ -1,6 +1,0 @@
-/* eslint-disable */
-ace.config.setModuleUrl(
-  'ace/mode/lucene',
-  // eslint-disable-next-line
-  require('file-loader!ace-builds/src-min-noconflict/mode-lucene.js')
-);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

After going back to `react-ace`, we can now use the stock `lucene` mode again, by `import`ing it and remove our custom loader code.

This has the added benefit that the recent `file-loader` update changed the module semantics and resulted in generating a `<script src="[object Module]"></script>` tag.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.