### PR TITLE
Prevent read timeout exception

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/ExceptionLoggingChannelHandler.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/ExceptionLoggingChannelHandler.java
@@ -25,17 +25,16 @@ import org.slf4j.Logger;
 public class ExceptionLoggingChannelHandler extends ChannelInboundHandlerAdapter {
     private final MessageInput input;
     private final Logger logger;
-    private final boolean doesTransportHaveKeepAliveEnabled;
+    private final boolean keepAliveEnabled;
 
     public ExceptionLoggingChannelHandler(MessageInput input, Logger logger) {
         this(input, logger, false);
     }
 
-    public ExceptionLoggingChannelHandler(MessageInput input, Logger logger,
-                                          boolean doesTransportHaveKeepAliveEnabled) {
+    public ExceptionLoggingChannelHandler(MessageInput input, Logger logger, boolean keepAliveEnabled) {
         this.input = input;
         this.logger = logger;
-        this.doesTransportHaveKeepAliveEnabled = doesTransportHaveKeepAliveEnabled;
+        this.keepAliveEnabled = keepAliveEnabled;
     }
 
     @Override
@@ -46,8 +45,8 @@ public class ExceptionLoggingChannelHandler extends ChannelInboundHandlerAdapter
                     input.getName(),
                     input.getId(),
                     ctx.channel());
-        } else if(this.doesTransportHaveKeepAliveEnabled && cause instanceof ReadTimeoutException) {
-            if(logger.isTraceEnabled()) {
+        } else if (this.keepAliveEnabled && cause instanceof ReadTimeoutException) {
+            if (logger.isTraceEnabled()) {
                 logger.trace("KeepAlive Timeout in input [{}/{}] (channel {})",
                         input.getName(),
                         input.getId(),

--- a/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/ExceptionLoggingChannelHandler.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/transports/netty/ExceptionLoggingChannelHandler.java
@@ -18,16 +18,24 @@ package org.graylog2.inputs.transports.netty;
 
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.timeout.ReadTimeoutException;
 import org.graylog2.plugin.inputs.MessageInput;
 import org.slf4j.Logger;
 
 public class ExceptionLoggingChannelHandler extends ChannelInboundHandlerAdapter {
     private final MessageInput input;
     private final Logger logger;
+    private final boolean doesTransportHaveKeepAliveEnabled;
 
     public ExceptionLoggingChannelHandler(MessageInput input, Logger logger) {
+        this(input, logger, false);
+    }
+
+    public ExceptionLoggingChannelHandler(MessageInput input, Logger logger,
+                                          boolean doesTransportHaveKeepAliveEnabled) {
         this.input = input;
         this.logger = logger;
+        this.doesTransportHaveKeepAliveEnabled = doesTransportHaveKeepAliveEnabled;
     }
 
     @Override
@@ -38,6 +46,13 @@ public class ExceptionLoggingChannelHandler extends ChannelInboundHandlerAdapter
                     input.getName(),
                     input.getId(),
                     ctx.channel());
+        } else if(this.doesTransportHaveKeepAliveEnabled && cause instanceof ReadTimeoutException) {
+            if(logger.isTraceEnabled()) {
+                logger.trace("KeepAlive Timeout in input [{}/{}] (channel {})",
+                        input.getName(),
+                        input.getId(),
+                        ctx.channel());
+            }
         } else {
             logger.error("Error in Input [{}/{}] (channel {}) (cause {})",
                     input.getName(),

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
@@ -245,10 +245,7 @@ public abstract class AbstractTcpTransport extends NettyTransport {
             handlers.put("codec-aggregator", () -> new ByteBufMessageAggregationHandler(aggregator, localRegistry));
         }
         handlers.put("rawmessage-handler", () -> new RawMessageHandler(input));
-        handlers.put("exception-logger", () -> {
-            boolean doesTransportHaveKeepAliveEnabled = this.tcpKeepalive;
-            return new ExceptionLoggingChannelHandler(input, LOG, doesTransportHaveKeepAliveEnabled);
-        });
+        handlers.put("exception-logger", () -> new ExceptionLoggingChannelHandler(input, LOG, this.tcpKeepalive));
 
         return handlers;
     }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/inputs/transports/AbstractTcpTransport.java
@@ -245,7 +245,10 @@ public abstract class AbstractTcpTransport extends NettyTransport {
             handlers.put("codec-aggregator", () -> new ByteBufMessageAggregationHandler(aggregator, localRegistry));
         }
         handlers.put("rawmessage-handler", () -> new RawMessageHandler(input));
-        handlers.put("exception-logger", () -> new ExceptionLoggingChannelHandler(input, LOG));
+        handlers.put("exception-logger", () -> {
+            boolean doesTransportHaveKeepAliveEnabled = this.tcpKeepalive;
+            return new ExceptionLoggingChannelHandler(input, LOG, doesTransportHaveKeepAliveEnabled);
+        });
 
         return handlers;
     }


### PR DESCRIPTION
(copy of https://github.com/Graylog2/graylog2-server/pull/5936)

It's reasonable to let users configure a timeout for keepalive connections but this event should not be logged as an error when the time expires.

## Description
The user can configure the GelfHTTPInput to timeout after a certain amount of time. The input also supports tcp keep alive. If both of these settings are enabled ( say timeout after 1 hour and keepalive ) then an error will be logged in the graylog server logs when the persistent connection is terminated by netty ( ``ReadTimeoutException``)

I don't think this timeout should log an error in the internal graylog server logs. 

## Motivation and Context
I saw the read timeout exception messages in the server logs and was worried messages were getting dropped. This change will change the log message to be a ``TRACE`` level instead of ``ERROR``

## How Has This Been Tested?
Manual testing
* I built Graylog locally and verified that the error message shows up before the change on timeout. After the fix the message only shows up at trace level

Automated testing
* The cost/value of unit testing seems to be low in this case..there would be a lot of mocking and don't see any examples in the code base of unit testing logger statements. Open to suggestions though

Impact to other code
* None: this code simply changes error logging to trace logging for a specific case

Testing Environment
* MacOSX Mojave

## Screenshots (if appropriate):
After the fix
![image](https://user-images.githubusercontent.com/1031710/57588442-0b661a00-74c9-11e9-9faa-1e6a29aab4f9.png)


## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. 
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
* ran the existing tests tests. Only ones that failed were some IT tests that expect something listening on 19200 which I don't have setup.. everything else passed
