### PR TITLE
Migrating InputStatusService

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
@@ -30,6 +30,7 @@ import org.graylog2.indexer.ranges.LegacyMongoIndexRangeService;
 import org.graylog2.indexer.ranges.MongoIndexRangeService;
 import org.graylog2.inputs.InputService;
 import org.graylog2.inputs.InputServiceImpl;
+import org.graylog2.inputs.persistence.InputStatusService;
 import org.graylog2.notifications.NotificationService;
 import org.graylog2.notifications.NotificationServiceImpl;
 import org.graylog2.savedsearches.SavedSearchService;
@@ -68,5 +69,6 @@ public class PersistenceServicesBindings extends AbstractModule {
         bind(SavedSearchService.class).to(SavedSearchServiceImpl.class);
         bind(LdapSettingsService.class).to(LdapSettingsServiceImpl.class);
         bind(MongoDBSessionService.class).to(MongoDBSessionServiceImpl.class);
+        bind(InputStatusService.class).asEagerSingleton();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/persistence/InputStateData.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/persistence/InputStateData.java
@@ -1,0 +1,71 @@
+package org.graylog2.inputs.persistence;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+import java.util.Objects;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
+        property = InputStateData.TYPE_FIELD,
+        visible = true,
+        defaultImpl = InputStateData.Fallback.class
+)
+public interface InputStateData {
+    String TYPE_FIELD = "type";
+
+    @JsonProperty
+    String type();
+
+    public interface Builder<SELF> {
+        @JsonProperty(TYPE_FIELD)
+        SELF type(String type);
+    }
+
+    @JsonAutoDetect
+    class Fallback implements InputStateData {
+        @JsonProperty
+        private String type;
+
+        private Map<String, Object> props = Maps.newHashMap();
+
+        @Override
+        public String type() {
+            return type;
+        }
+
+        @JsonAnySetter
+        public void setProperties(String key, Object value) {
+            props.put(key, value);
+        }
+
+        @JsonAnyGetter
+        public Map<String, Object> getProperties() {
+            return props;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            InputStateData.Fallback fallback = (InputStateData.Fallback) o;
+            return Objects.equals(type, fallback.type) &&
+                    Objects.equals(props, fallback.props);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(type, props);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/inputs/persistence/InputStateData.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/persistence/InputStateData.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.inputs.persistence;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;

--- a/graylog2-server/src/main/java/org/graylog2/inputs/persistence/InputStatusRecord.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/persistence/InputStatusRecord.java
@@ -1,0 +1,41 @@
+package org.graylog2.inputs.persistence;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import org.mongojack.Id;
+import org.mongojack.ObjectId;
+
+@AutoValue
+@JsonAutoDetect
+@JsonDeserialize(builder = AutoValue_InputStatusRecord.Builder.class)
+public abstract class InputStatusRecord {
+    private static final String FIELD_ID = "id";
+    public static final String FIELD_INPUT_STATE_DATA = "input_state_data";
+
+    @Id
+    @ObjectId
+    @JsonProperty(FIELD_ID)
+    public abstract String inputId();
+
+    @JsonProperty(FIELD_INPUT_STATE_DATA)
+    public abstract InputStateData inputStateData();
+
+    public static Builder builder() {
+        return new AutoValue_InputStatusRecord.Builder();
+    }
+
+    @AutoValue.Builder
+    public static abstract class Builder {
+        @Id
+        @ObjectId
+        @JsonProperty(FIELD_ID)
+        public abstract Builder inputId(String inputId);
+
+        @JsonProperty(FIELD_INPUT_STATE_DATA)
+        public abstract Builder inputStateData(InputStateData inputStateData);
+
+        public abstract InputStatusRecord build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/inputs/persistence/InputStatusRecord.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/persistence/InputStatusRecord.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.inputs.persistence;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog2/inputs/persistence/InputStatusService.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/persistence/InputStatusService.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 public class InputStatusService {
     private static final Logger LOG = LoggerFactory.getLogger(InputStatusService.class);
 
-    private static final String COLLECTION_NAME = "input_status";
+    public static final String COLLECTION_NAME = "input_status";
 
     private final JacksonDBCollection<InputStatusRecord, ObjectId> statusCollection;
 

--- a/graylog2-server/src/main/java/org/graylog2/inputs/persistence/InputStatusService.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/persistence/InputStatusService.java
@@ -1,0 +1,93 @@
+package org.graylog2.inputs.persistence;
+
+import com.google.common.eventbus.EventBus;
+import com.mongodb.DB;
+import com.mongodb.DBCollection;
+import org.apache.shiro.event.Subscribe;
+import org.bson.types.ObjectId;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.rest.models.system.inputs.responses.InputDeleted;
+import org.mongojack.JacksonDBCollection;
+import org.mongojack.WriteResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.util.Optional;
+
+/**
+ * This is a simple wrapper around MongoDB to allow storage of state data for stateful Inputs.
+ *
+ * Inputs using this service are responsible for defining their own model for InputStatusRecord.inputStateData
+ */
+public class InputStatusService {
+    private static final Logger LOG = LoggerFactory.getLogger(InputStatusService.class);
+
+    private static final String INPUT_STATUS_COLLECTION = "input_status";
+
+    private final JacksonDBCollection<InputStatusRecord, ObjectId> statusCollection;
+
+    @Inject
+    public InputStatusService(MongoConnection mongoConnection,
+                              MongoJackObjectMapperProvider objectMapperProvider,
+                              EventBus eventBus) {
+        DB mongoDatabase = mongoConnection.getDatabase();
+        DBCollection collection = mongoDatabase.getCollection(INPUT_STATUS_COLLECTION);
+
+        eventBus.register(this);
+
+        statusCollection = JacksonDBCollection.wrap(
+                collection,
+                InputStatusRecord.class,
+                ObjectId.class,
+                objectMapperProvider.get());
+    }
+
+    /**
+     * Get the status record for an Input from the DB.
+     *
+     * @param inputId ID of the input whose status you want to get
+     * @return The InputStatusRecord for the given Input ID if it exists; otherwise an empty Optional.
+     */
+    public Optional<InputStatusRecord> get(final String inputId) {
+        return Optional.ofNullable(statusCollection.findOneById(new ObjectId(inputId)));
+    }
+
+    /**
+     * Save the status record for an Input status to the DB.
+     *
+     * @param statusRecord The Input status record to save
+     * @return A copy of the saved object
+     */
+    public InputStatusRecord save(InputStatusRecord statusRecord) {
+        WriteResult save = statusCollection.save(statusRecord);
+        return (InputStatusRecord) save.getSavedObject();
+    }
+
+    /**
+     * Remove the status record from the DB for a given Input
+     *
+     * @param inputId ID of the input whose status you want to delete
+     * @return The count of deleted objects (should be 0 or 1)
+     */
+    public int delete(String inputId) {
+        WriteResult delete = statusCollection.removeById(new ObjectId(inputId));
+        return delete.getN();
+    }
+
+    /**
+     * Clean up MongoDB records when Inputs are deleted
+     *
+     * At the moment, Graylog uses the InputDeleted event both when an Input is stopped
+     * and when it is deleted.
+     *
+     * @param event ID of the input being deleted
+     */
+    @Subscribe
+    public void handleInputDeleted(InputDeleted event) {
+        LOG.debug("Input Deleted event received for Input [{}]", event.id());
+        // TODO: Pending issue #7812
+        // delete(event.id());
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/inputs/persistence/InputStatusService.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/persistence/InputStatusService.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.inputs.persistence;
 
 import com.google.common.eventbus.EventBus;

--- a/graylog2-server/src/main/java/org/graylog2/inputs/persistence/InputStatusService.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/persistence/InputStatusService.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.util.Optional;
 
 /**
@@ -21,10 +22,11 @@ import java.util.Optional;
  *
  * Inputs using this service are responsible for defining their own model for InputStatusRecord.inputStateData
  */
+@Singleton
 public class InputStatusService {
     private static final Logger LOG = LoggerFactory.getLogger(InputStatusService.class);
 
-    private static final String INPUT_STATUS_COLLECTION = "input_status";
+    private static final String COLLECTION_NAME = "input_status";
 
     private final JacksonDBCollection<InputStatusRecord, ObjectId> statusCollection;
 
@@ -33,7 +35,7 @@ public class InputStatusService {
                               MongoJackObjectMapperProvider objectMapperProvider,
                               EventBus eventBus) {
         DB mongoDatabase = mongoConnection.getDatabase();
-        DBCollection collection = mongoDatabase.getCollection(INPUT_STATUS_COLLECTION);
+        DBCollection collection = mongoDatabase.getCollection(COLLECTION_NAME);
 
         eventBus.register(this);
 

--- a/graylog2-server/src/test/java/org/graylog2/inputs/persistence/InputStatusServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/persistence/InputStatusServiceTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.inputs.persistence;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/graylog2-server/src/test/java/org/graylog2/inputs/persistence/InputStatusServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/persistence/InputStatusServiceTest.java
@@ -1,0 +1,189 @@
+package org.graylog2.inputs.persistence;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.eventbus.EventBus;
+import org.bson.types.ObjectId;
+import org.graylog.testing.mongodb.MongoDBFixtures;
+import org.graylog.testing.mongodb.MongoDBInstance;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.rest.models.system.inputs.responses.InputDeleted;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mongojack.JacksonDBCollection;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+public class InputStatusServiceTest {
+    @Rule
+    public final MongoDBInstance mongodb = MongoDBInstance.createForClass();
+
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    // Code Under Test
+    private InputStatusService cut;
+
+    @Mock
+    EventBus mockEventBus;
+
+    private JacksonDBCollection<InputStatusRecord, ObjectId> db;
+
+    @Before
+    public void setUp() {
+        final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+        final MongoJackObjectMapperProvider mapperProvider = new MongoJackObjectMapperProvider(objectMapper);
+
+        cut = new InputStatusService(mongodb.mongoConnection(), mapperProvider, mockEventBus);
+
+        db = JacksonDBCollection.wrap(mongodb.mongoConnection().getDatabase().getCollection(InputStatusService.COLLECTION_NAME),
+                InputStatusRecord.class,
+                ObjectId.class,
+                mapperProvider.get());
+    }
+
+    @Test
+    @MongoDBFixtures("input-status.json")
+    public void get_ReturnsRecord_WhenRecordPresentInDB() {
+        Optional<InputStatusRecord> optDbRecord = cut.get("54e3deadbeefdeadbeef0001");
+
+        assertThat(optDbRecord, notNullValue());
+        assertThat(optDbRecord.isPresent(), is(true));
+        assertThat(optDbRecord.get(), instanceOf(InputStatusRecord.class));
+
+        InputStatusRecord record = optDbRecord.get();
+
+        assertThat(record.inputId(), is("54e3deadbeefdeadbeef0001"));
+        assertThat(record.inputStateData(), instanceOf(InputStateData.class));
+        assertThat(record.inputStateData().type(), is("test_type_1"));
+
+        optDbRecord = cut.get("54e3deadbeefdeadbeef0002");
+
+        assertThat(optDbRecord, notNullValue());
+        assertThat(optDbRecord.isPresent(), is(true));
+        assertThat(optDbRecord.get(), instanceOf(InputStatusRecord.class));
+
+        record = optDbRecord.get();
+
+        assertThat(record.inputId(), is("54e3deadbeefdeadbeef0002"));
+        assertThat(record.inputStateData(), instanceOf(InputStateData.class));
+        assertThat(record.inputStateData().type(), is("test_type_2"));
+
+        optDbRecord = cut.get("54e3deadbeefdeadbeef0003");
+
+        assertThat(optDbRecord, notNullValue());
+        assertThat(optDbRecord.isPresent(), is(true));
+        assertThat(optDbRecord.get(), instanceOf(InputStatusRecord.class));
+
+        record = optDbRecord.get();
+
+        assertThat(record.inputId(), is("54e3deadbeefdeadbeef0003"));
+        assertThat(record.inputStateData(), instanceOf(InputStateData.class));
+        assertThat(record.inputStateData().type(), is("test_type_5"));
+    }
+
+    @Test
+    @MongoDBFixtures("input-status.json")
+    public void get_ReturnsEmptyOptional_WhenNoRecordInDB() {
+        Optional<InputStatusRecord> optDbRecord = cut.get("54e3deadbeefdeadbeef9999");
+
+        assertThat(optDbRecord, notNullValue());
+        assertThat(optDbRecord.isPresent(), is(false));
+    }
+
+    @Test
+    @MongoDBFixtures("input-status.json")
+    public void get_ReturnsRecord_OnlyAfterRecordSaved() {
+        Optional<InputStatusRecord> optDbRecord = cut.get("54e3deadbeefdeadbeef8888");
+
+        assertThat(optDbRecord, notNullValue());
+        assertThat(optDbRecord.isPresent(), is(false));
+
+        InputStatusRecord savedRecord = cut.save(InputStatusRecord.builder()
+                .inputId("54e3deadbeefdeadbeef8888")
+                .inputStateData(new InputStateData() {
+                    public String type() {
+                        return "test_type_8888";
+                    }
+                }).build());
+        assertThat(savedRecord.inputId(), is("54e3deadbeefdeadbeef8888"));
+        assertThat(savedRecord.inputStateData(), instanceOf(InputStateData.class));
+        assertThat(savedRecord.inputStateData().type(), is("test_type_8888"));
+
+        optDbRecord = cut.get("54e3deadbeefdeadbeef8888");
+
+        assertThat(optDbRecord, notNullValue());
+        assertThat(optDbRecord.isPresent(), is(true));
+
+        assertThat(optDbRecord.get(), instanceOf(InputStatusRecord.class));
+
+        InputStatusRecord record = optDbRecord.get();
+
+        assertThat(record.inputId(), is("54e3deadbeefdeadbeef8888"));
+        assertThat(record.inputStateData(), instanceOf(InputStateData.class));
+        assertThat(record.inputStateData().type(), is("test_type_8888"));
+    }
+
+    @Test
+    @MongoDBFixtures("input-status.json")
+    public void get_ReturnsEmptyOptional_OnlyAfterRecordDeleted() {
+        Optional<InputStatusRecord> optDbRecord = cut.get("54e3deadbeefdeadbeef0001");
+
+        assertThat(optDbRecord, notNullValue());
+        assertThat(optDbRecord.isPresent(), is(true));
+        assertThat(optDbRecord.get(), instanceOf(InputStatusRecord.class));
+
+        int deleteCount = cut.delete("54e3deadbeefdeadbeef0001");
+        assertThat(deleteCount, is(1));
+
+        optDbRecord = cut.get("54e3deadbeefdeadbeef0001");
+
+        assertThat(optDbRecord, notNullValue());
+        assertThat(optDbRecord.isPresent(), is(false));
+    }
+
+    @Test
+    @MongoDBFixtures("input-status.json")
+    public void delete_ReturnsZero_WhenDeletingNonExistantRecord() {
+        Optional<InputStatusRecord> optDbRecord = cut.get("54e3deadbeefdeadbeef7777");
+
+        assertThat(optDbRecord, notNullValue());
+        assertThat(optDbRecord.isPresent(), is(false));
+
+        int deleteCount = cut.delete("54e3deadbeefdeadbeef7777");
+        assertThat(deleteCount, is(0));
+    }
+
+    @Test
+    @MongoDBFixtures("input-status.json")
+    public void handleDeleteEvent_DoesNothing() {
+        /*
+        Currently, the InputDeleted event is propagated both when an input is stopped and when an input is deleted. We
+        would like to clean up the DB when an input is deleted, but not when it is stopped.  This method is in place to
+        be used once there are separate events for input deleted and input stopped.  For now, it should do nothing.
+         */
+
+        cut.handleInputDeleted(new InputDeleted(){
+            @Override
+            public String id() {
+                return "54e3deadbeefdeadbeef0001";
+            }
+        });
+
+        // The record should not be removed from the DB
+        Optional<InputStatusRecord> optDbRecord = cut.get("54e3deadbeefdeadbeef0001");
+
+        assertThat(optDbRecord, notNullValue());
+        assertThat(optDbRecord.isPresent(), is(true));
+    }
+}

--- a/graylog2-server/src/test/resources/org/graylog2/inputs/persistence/input-status.json
+++ b/graylog2-server/src/test/resources/org/graylog2/inputs/persistence/input-status.json
@@ -1,0 +1,34 @@
+{
+  "input_status": [
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0001"
+      },
+      "input_state_data": {
+        "type": "test_type_1",
+        "some_timestamp": "3/31/20 11:01:19 PM UTC"
+      }
+    },
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0002"
+      },
+      "input_state_data": {
+        "type": "test_type_2",
+        "some_state_data": "foo",
+        "more_state_data": "bar",
+        "last_state_data": 2
+      }
+    },
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0003"
+      },
+      "input_state_data": {
+        "type": "test_type_5",
+        "some_state_data": "Three, sir.",
+        "more_state_data": "Three!"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Migrating the InputStatusService from the enterprise plugins repo to the main repo.

The InputStatusService was created to support Inputs that need to persist state for the duration of their lifecycle.  It was created to allow the Okta input to checkpoint on seen messages in order to avoid duplicate message processing when the input is restarted.

Original PR: https://github.com/Graylog2/graylog-plugin-enterprise-integrations/issues/136


## Description
Migrating the InputStatusService from the enterprise plugins repo to the main repo.

The InputStatusService was created to support Inputs that need to persist state for the duration of their lifecycle.  It stores Input state in the new `input_status` MongoDB collection. It was created to allow the Okta input to checkpoint on seen messages in order to avoid duplicate message processing when the input is restarted.

## Motivation and Context
Migration to the main graylog2-server repo is needed to allow non-enterprise Inputs to use this service

## How Has This Been Tested?
This feature has been tested locally by multiple Graylog developers.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

