### PR TITLE
Reset pagination on page size change

### DIFF
--- a/graylog2-web-interface/src/components/common/PaginatedList.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.jsx
@@ -6,7 +6,8 @@ import { Pagination } from 'components/graylog';
 import { Input } from 'components/bootstrap';
 import IfInteractive from 'views/components/dashboard/IfInteractive';
 
-const defaultPageSizes = [10, 50, 100];
+const DEFAULT_PAGE_SIZES = [10, 50, 100];
+const INITIAL_PAGE = 1;
 
 type Props = {
   children: React.Node,
@@ -53,8 +54,8 @@ class PaginatedList extends React.Component<Props, State> {
 
   static defaultProps = {
     activePage: 0,
-    pageSizes: defaultPageSizes,
-    pageSize: defaultPageSizes[0],
+    pageSizes: DEFAULT_PAGE_SIZES,
+    pageSize: DEFAULT_PAGE_SIZES[0],
     showPageSizeSelect: true,
   };
 
@@ -62,7 +63,7 @@ class PaginatedList extends React.Component<Props, State> {
     super(props);
     const { activePage, pageSize } = props;
     this.state = {
-      currentPage: activePage > 0 ? activePage : 1,
+      currentPage: activePage > 0 ? activePage : INITIAL_PAGE,
       pageSize: pageSize,
     };
   }
@@ -80,11 +81,10 @@ class PaginatedList extends React.Component<Props, State> {
 
   _onChangePageSize = (event: SyntheticInputEvent<HTMLLinkElement>) => {
     const { onChange } = this.props;
-    const { currentPage } = this.state;
     event.preventDefault();
     const pageSize = Number(event.target.value);
-    this.setState({ pageSize: pageSize });
-    onChange(currentPage, pageSize);
+    this.setState({ currentPage: INITIAL_PAGE, pageSize: pageSize });
+    onChange(INITIAL_PAGE, pageSize);
   };
 
   _onChangePage = (pageNo: number, event: MouseEvent) => {

--- a/graylog2-web-interface/src/components/common/PaginatedList.test.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.test.jsx
@@ -1,6 +1,6 @@
 // @flow strict
 import React from 'react';
-import { render, cleanup } from 'wrappedTestingLibrary';
+import { render, cleanup, fireEvent } from 'wrappedTestingLibrary';
 
 import InteractiveContext from 'views/components/contexts/InteractiveContext';
 import PaginatedList from './PaginatedList';
@@ -9,15 +9,29 @@ describe('PaginatedList', () => {
   afterEach(cleanup);
 
   it('should display Pagination', () => {
-    const { getByText } = render(<PaginatedList totalItems={100} onChange={() => {}} pageSize={10}>List</PaginatedList>);
+    const { getByText } = render(<PaginatedList totalItems={100} onChange={() => {}}>The list</PaginatedList>);
+    expect(getByText('The list')).not.toBeNull();
     expect(getByText('1')).not.toBeNull();
   });
+
   it('should not display Pagination, when context is not interactive', () => {
     const { queryByText } = render(
       <InteractiveContext.Provider value={false}>
-        <PaginatedList totalItems={100} onChange={() => {}} pageSize={10}>List</PaginatedList>,
+        <PaginatedList totalItems={100} onChange={() => {}}>The list</PaginatedList>,
       </InteractiveContext.Provider>,
     );
+    expect(queryByText('The list')).toBeNull();
     expect(queryByText('1')).toBeNull();
+  });
+
+  it('should reset current page on page size change', () => {
+    const onChangeStub = jest.fn();
+    const { getByLabelText } = render(<PaginatedList totalItems={200} onChange={onChangeStub} activePage={3}>The list</PaginatedList>);
+
+    const pageSizeInput = getByLabelText('Show:');
+    fireEvent.change(pageSizeInput, { target: { value: 100 } });
+
+    expect(onChangeStub).toHaveBeenCalledTimes(1);
+    expect(onChangeStub).toHaveBeenCalledWith(1, 100);
   });
 });


### PR DESCRIPTION
We are currently not reseting the pagination / active page, when changing the page size. This can lead to a problem described here: https://github.com/Graylog2/graylog2-server/issues/7825

This PR is fixing the problem, by resetting the active page on a page size change.

Fixes: https://github.com/Graylog2/graylog2-server/issues/7825

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

