### PR TITLE
Improve field name completion performance by caching field names.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.js
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.js
@@ -53,14 +53,14 @@ class FieldNameCompletion implements Completer {
 
   constructor(staticSuggestions: Array<Suggestion> = [existsOperator]) {
     this.staticSuggestions = staticSuggestions;
-    this._newFields(FieldTypesStore.getInitialState());
-    FieldTypesStore.listen((newState) => this._newFields(newState));
-
     this.onViewMetadataStoreUpdate(ViewMetadataStore.getInitialState());
     ViewMetadataStore.listen(this.onViewMetadataStoreUpdate);
+
+    this._newFields(FieldTypesStore.getInitialState());
+    FieldTypesStore.listen((newState) => this._newFields(newState));
   }
 
-  _newFields = (fields) => {
+  _newFields = (fields: FieldTypesStoreState) => {
     this.fields = fields;
     const { queryFields } = this.fields;
     if (this.activeQuery) {

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.js
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.js
@@ -47,22 +47,35 @@ class FieldNameCompletion implements Completer {
 
   fields: FieldTypesStoreState;
 
+  currentQueryFieldNames: { [string]: string };
+
   staticSuggestions: Array<Suggestion>;
 
   constructor(staticSuggestions: Array<Suggestion> = [existsOperator]) {
     this.staticSuggestions = staticSuggestions;
-    this.fields = FieldTypesStore.getInitialState();
-    FieldTypesStore.listen((newState) => {
-      this.fields = newState;
-    });
+    this._newFields(FieldTypesStore.getInitialState());
+    FieldTypesStore.listen((newState) => this._newFields(newState));
 
     this.onViewMetadataStoreUpdate(ViewMetadataStore.getInitialState());
     ViewMetadataStore.listen(this.onViewMetadataStoreUpdate);
   }
 
+  _newFields = (fields) => {
+    this.fields = fields;
+    const { queryFields } = this.fields;
+    if (this.activeQuery) {
+      const currentQueryFields: FieldTypeMappingsList = queryFields.get(this.activeQuery, Immutable.List());
+      this.currentQueryFieldNames = currentQueryFields.map((fieldMapping) => fieldMapping.name)
+        .reduce((prev, cur) => ({ ...prev, [cur]: cur }), {});
+    }
+  };
+
   onViewMetadataStoreUpdate = (newState: { activeQuery: string }) => {
     const { activeQuery } = newState;
     this.activeQuery = activeQuery;
+    if (this.fields) {
+      this._newFields(this.fields);
+    }
   };
 
   _isFollowingExistsOperator = (lastToken: ?Token) => ((lastToken && lastToken.value === `${existsOperator.name}:`) === true);
@@ -82,8 +95,7 @@ class FieldNameCompletion implements Completer {
 
     const valuePosition = this._isFollowingExistsOperator(lastToken);
 
-    const currentQueryFieldNames = currentQueryFields.map((fieldMapping) => fieldMapping.name);
-    const allButInCurrent = all.filter((field) => !currentQueryFieldNames.includes(field.name));
+    const allButInCurrent = all.filter((field) => !this.currentQueryFieldNames[field.name]);
     const fieldsToMatchIn = valuePosition
       ? [...currentQueryFields]
       : [...this.staticSuggestions, ...currentQueryFields];

--- a/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/completions/FieldNameCompletion.test.jsx
@@ -1,14 +1,21 @@
 // @flow strict
 import { StoreMock as MockStore } from 'helpers/mocking';
 import asMock from 'helpers/mocking/AsMock';
-import { FieldTypesStore } from 'views/stores/FieldTypesStore';
 
+import { ViewMetadataStore } from 'views/stores/ViewMetadataStore';
+import { FieldTypesStore } from 'views/stores/FieldTypesStore';
 import FieldNameCompletion from './FieldNameCompletion';
 
 jest.mock('views/stores/FieldTypesStore', () => ({
   FieldTypesStore: MockStore(
     'listen',
     ['getInitialState', jest.fn(() => ({ all: [], queryFields: { get: () => [] } }))],
+  ),
+}));
+
+jest.mock('views/stores/ViewMetadataStore', () => ({
+  ViewMetadataStore: MockStore(
+    ['getInitialState', jest.fn(() => ({ activeQuery: 'query1' }))],
   ),
 }));
 
@@ -20,6 +27,7 @@ const _createFieldTypesStoreState = (fields) => ({ all: fields, queryFields: _cr
 
 describe('FieldNameCompletion', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     asMock(FieldTypesStore.getInitialState).mockReturnValue(_createFieldTypesStoreState(dummyFields));
   });
   it('returns empty list if inputs are empty', () => {
@@ -64,5 +72,61 @@ describe('FieldNameCompletion', () => {
     const completer = new FieldNameCompletion();
     expect(completer.getCompletions(null, null, 'e').map((result) => result.name))
       .toEqual(['_exists_', 'source', 'message', 'timestamp']);
+  });
+
+  it('updates its types when `FieldTypesStore` updates', () => {
+    const completer = new FieldNameCompletion([]);
+    const newFields = ['nf_version', 'nf_proto_name'];
+    const callback = asMock(FieldTypesStore.listen).mock.calls[0][0];
+
+    callback(_createFieldTypesStoreState(newFields.map(_createField)));
+
+    expect(completer.getCompletions(null, null, '').map((result) => result.name))
+      .toEqual(['nf_version', 'nf_proto_name']);
+  });
+
+  describe('considers current query', () => {
+    const completionByName = (fieldName, completions) => completions.find(({ name }) => (name === fieldName));
+
+    const queryFields = {
+      get: (queryId, _default) => ({
+        query1: ['foo'].map(_createField),
+        query2: ['bar'].map(_createField),
+      }[queryId] || _default),
+    };
+
+    const all = ['foo', 'bar'].map(_createField);
+
+    beforeEach(() => {
+      asMock(FieldTypesStore.getInitialState).mockReturnValue({ all, queryFields });
+    });
+
+    it('scores fields of current query higher', () => {
+      const completer = new FieldNameCompletion([]);
+
+      const completions = completer.getCompletions(null, null, '');
+
+      const completion = (fieldName) => completionByName(fieldName, completions);
+      expect(completion('foo')?.score).toEqual(12);
+      expect(completion('foo')?.meta).not.toMatch('(not in streams)');
+
+      expect(completion('bar')?.score).toEqual(3);
+      expect(completion('bar')?.meta).toMatch('(not in streams)');
+    });
+
+    it('scores fields of current query higher', () => {
+      const completer = new FieldNameCompletion([]);
+      const callback = asMock(ViewMetadataStore.listen).mock.calls[0][0];
+
+      callback({ activeQuery: 'query2' });
+
+      const completions = completer.getCompletions(null, null, '');
+      const completion = (fieldName) => completionByName(fieldName, completions);
+      expect(completion('foo')?.score).toEqual(3);
+      expect(completion('foo')?.meta).toMatch('(not in streams)');
+
+      expect(completion('bar')?.score).toEqual(12);
+      expect(completion('bar')?.meta).not.toMatch('(not in streams)');
+    });
   });
 });

--- a/graylog2-web-interface/src/views/logic/fieldactions/ChartActionHandler.test.js
+++ b/graylog2-web-interface/src/views/logic/fieldactions/ChartActionHandler.test.js
@@ -51,14 +51,14 @@ describe('ChartActionHandler', () => {
       pivotForField.mockReturnValue('PIVOT');
     });
     it('uses Unknown if FieldTypeStore returns nothing', () => {
-      FieldTypesStore.getInitialState.mockReturnValue(undefined);
+      asMock(FieldTypesStore.getInitialState).mockReturnValue(undefined);
 
       ChartActionHandler({ queryId: 'queryId', field: 'somefield', type: emptyFieldType, contexts: {} });
 
       expect(pivotForField).toHaveBeenCalledWith('timestamp', FieldType.Unknown);
     });
     it('uses Unknown if FieldTypeStore returns neither all nor query fields', () => {
-      FieldTypesStore.getInitialState.mockReturnValue({
+      asMock(FieldTypesStore.getInitialState).mockReturnValue({
         all: Immutable.List([]),
         queryFields: Immutable.Map({}),
       });
@@ -69,7 +69,7 @@ describe('ChartActionHandler', () => {
     });
     it('from query field types if present', () => {
       const timestampFieldType = new FieldType('date', [], []);
-      FieldTypesStore.getInitialState.mockReturnValue({
+      asMock(FieldTypesStore.getInitialState).mockReturnValue({
         all: Immutable.List([]),
         queryFields: Immutable.fromJS({
           queryId: [
@@ -86,7 +86,7 @@ describe('ChartActionHandler', () => {
     });
     it('from all field types if present', () => {
       const timestampFieldType = new FieldType('date', [], []);
-      FieldTypesStore.getInitialState.mockReturnValue({
+      asMock(FieldTypesStore.getInitialState).mockReturnValue({
         all: Immutable.List([
           new FieldTypeMapping('otherfield', new FieldType('sometype', [], [])),
           new FieldTypeMapping('somefield', new FieldType('othertype', [], [])),
@@ -100,7 +100,7 @@ describe('ChartActionHandler', () => {
       expect(pivotForField).toHaveBeenCalledWith('timestamp', timestampFieldType);
     });
     it('uses unknown if not in query field types', () => {
-      FieldTypesStore.getInitialState.mockReturnValue({
+      asMock(FieldTypesStore.getInitialState).mockReturnValue({
         all: Immutable.List([]),
         queryFields: Immutable.fromJS({
           queryId: [
@@ -115,7 +115,7 @@ describe('ChartActionHandler', () => {
       expect(pivotForField).toHaveBeenCalledWith('timestamp', FieldType.Unknown);
     });
     it('uses Unknown if not in all field types', () => {
-      FieldTypesStore.getInitialState.mockReturnValue({
+      asMock(FieldTypesStore.getInitialState).mockReturnValue({
         all: Immutable.List([
           new FieldTypeMapping('otherfield', new FieldType('sometype', [], [])),
           new FieldTypeMapping('somefield', new FieldType('othertype', [], [])),
@@ -136,7 +136,7 @@ describe('ChartActionHandler', () => {
       const filter = "author: 'Vanth'";
       const origWidget = Widget.builder().filter(filter).build();
       const timestampFieldType = new FieldType('date', [], []);
-      FieldTypesStore.getInitialState.mockReturnValue({
+      asMock(FieldTypesStore.getInitialState).mockReturnValue({
         all: Immutable.List([]),
         queryFields: Immutable.fromJS({
           queryId: [

--- a/graylog2-web-interface/src/views/stores/FieldTypesStore.js
+++ b/graylog2-web-interface/src/views/stores/FieldTypesStore.js
@@ -3,15 +3,14 @@ import Reflux from 'reflux';
 import * as Immutable from 'immutable';
 
 import fetch from 'logic/rest/FetchProvider';
-import URLUtils from 'util/URLUtils';
+import { qualifyUrl } from 'util/URLUtils';
 
-import type { Store } from 'stores/StoreTypes';
-import type { RefluxActions } from 'stores/StoreTypes';
+import type { RefluxActions, Store } from 'stores/StoreTypes';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
 import { QueryFiltersStore } from './QueryFiltersStore';
 
-const fieldTypesUrl = URLUtils.qualifyUrl('/views/fields');
+const fieldTypesUrl = qualifyUrl('/views/fields');
 
 type FieldTypesActionsType = RefluxActions<{
   all: () => Promise<void>,

--- a/graylog2-web-interface/src/views/stores/FieldTypesStore.js
+++ b/graylog2-web-interface/src/views/stores/FieldTypesStore.js
@@ -5,6 +5,7 @@ import * as Immutable from 'immutable';
 import fetch from 'logic/rest/FetchProvider';
 import URLUtils from 'util/URLUtils';
 
+import type { Store } from 'stores/StoreTypes';
 import type { RefluxActions } from 'stores/StoreTypes';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
@@ -29,7 +30,9 @@ export type FieldTypesStoreState = {
   queryFields: Immutable.Map<string, FieldTypeMappingsList>,
 };
 
-export const FieldTypesStore = singletonStore(
+export type FieldTypesStoreType = Store<FieldTypesStoreState>;
+
+export const FieldTypesStore: FieldTypesStoreType = singletonStore(
   'views.FieldTypes',
   () => Reflux.createStore({
     listenables: [FieldTypesActions],

--- a/graylog2-web-interface/src/views/stores/ViewMetadataStore.js
+++ b/graylog2-web-interface/src/views/stores/ViewMetadataStore.js
@@ -2,6 +2,7 @@
 import Reflux from 'reflux';
 import { isEqual } from 'lodash';
 
+import type { Store } from 'stores/StoreTypes';
 import { singletonStore } from 'views/logic/singleton';
 import { ViewStore } from './ViewStore';
 
@@ -13,8 +14,10 @@ export type ViewMetaData = {
   title: string,
 };
 
+export type ViewMetadataStoreType = Store<ViewMetaData>;
+
 // eslint-disable-next-line import/prefer-default-export
-export const ViewMetadataStore = singletonStore(
+export const ViewMetadataStore: ViewMetadataStoreType = singletonStore(
   'views.ViewMetadata',
   () => Reflux.createStore({
     state: {},


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The field name completer of the query input is returning different scores depending on if
 the current query's stream set or not. For this, it retrieved an array of field names for the current query and iterated over all field names and checked for each field if it is included in that array. This leads to a complexity of `n*m` (where n is the number of total fields, while m is the number of fields in the current query). This lead to performance degrading for a high number of fields.

This PR is changing the code so that whenever the field types set is updated, it creates a map for the field names of the current query. This reduces the check if the field is part of the current query from `n*m` to constant effort (a plain hash lookup).

Refs #7809.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.