### PR TITLE
Handle `query` fields being `null` for all legacy dashboard widgets.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/QuickValuesConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/QuickValuesConfig.java
@@ -172,7 +172,7 @@ public abstract class QuickValuesConfig extends WidgetConfigBase implements Widg
 
     @JsonCreator
     static QuickValuesConfig create(
-            @JsonProperty("query") String query,
+            @JsonProperty("query") @Nullable String query,
             @JsonProperty("timerange") TimeRange timerange,
             @JsonProperty("field") String field,
             @JsonProperty("show_data_table") @Nullable Boolean showDataTable,
@@ -185,7 +185,7 @@ public abstract class QuickValuesConfig extends WidgetConfigBase implements Widg
     ) {
         return new AutoValue_QuickValuesConfig(
                 timerange,
-                query,
+                Strings.nullToEmpty(query),
                 Optional.ofNullable(streamId),
                 field,
                 (showDataTable == null || !showDataTable) && (showPieChart == null || !showPieChart)

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/QuickValuesHistogramConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/QuickValuesHistogramConfig.java
@@ -117,7 +117,7 @@ public abstract class QuickValuesHistogramConfig extends WidgetConfigBase implem
 
     @JsonCreator
     static QuickValuesHistogramConfig create(
-            @JsonProperty("query") String query,
+            @JsonProperty("query") @Nullable String query,
             @JsonProperty("timerange") TimeRange timerange,
             @JsonProperty("field") String field,
             @JsonProperty("limit") Integer limit,
@@ -128,7 +128,7 @@ public abstract class QuickValuesHistogramConfig extends WidgetConfigBase implem
     ) {
         return new AutoValue_QuickValuesHistogramConfig(
                 timerange,
-                query,
+                Strings.nullToEmpty(query),
                 Optional.ofNullable(streamId),
                 field,
                 limit,

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/StackedSeries.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/StackedSeries.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Strings;
 
+import javax.annotation.Nullable;
+
 @AutoValue
 @JsonAutoDetect
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -33,7 +35,7 @@ public abstract class StackedSeries {
 
     @JsonCreator
     public static StackedSeries create(
-            @JsonProperty("query") String query,
+            @JsonProperty("query") @Nullable String query,
             @JsonProperty("field") String field,
             @JsonProperty("statistical_function") String statisticalFunction
     ) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/StatsCountConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/StatsCountConfig.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.RandomUUIDProvider;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.TimeRange;
 import org.graylog.plugins.views.migrations.V20191125144500_MigrateDashboardsToViewsSupport.ViewWidget;
@@ -75,12 +76,12 @@ public abstract class StatsCountConfig extends WidgetConfigBase implements Widge
             @JsonProperty("lower_is_better") Boolean lowerIsBetter,
             @JsonProperty("trend") Boolean trend,
             @JsonProperty("stream_id") @Nullable String streamId,
-            @JsonProperty("query") String query,
+            @JsonProperty("query") @Nullable String query,
             @JsonProperty("timerange") TimeRange timerange
     ) {
         return new AutoValue_StatsCountConfig(
                 timerange,
-                query,
+                Strings.nullToEmpty(query),
                 field,
                 statsFunction,
                 Optional.ofNullable(lowerIsBetter),

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/WorldMapConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboardwidgets/WorldMapConfig.java
@@ -67,7 +67,7 @@ public abstract class WorldMapConfig extends WidgetConfigBase implements WidgetC
     static WorldMapConfig create(
             @JsonProperty("field") String field,
             @JsonProperty("stream_id") @Nullable String streamId,
-            @JsonProperty("query") String query,
+            @JsonProperty("query") @Nullable String query,
             @JsonProperty("timerange") TimeRange timerange
     ) {
         return new AutoValue_WorldMapConfig(

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/V20191125144500_MigrateDashboardsToViewsTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/V20191125144500_MigrateDashboardsToViewsTest.java
@@ -421,6 +421,36 @@ public class V20191125144500_MigrateDashboardsToViewsTest {
         assertSearchesWritten(1, resourceFile("quickvalues_widget_with_sort_order-expected_searches.json"));
     }
 
+    @Test
+    @MongoDBFixtures("dashboard_with_widgets_missing_query_attributes.json")
+    public void migrateDashboardWithWidgetsMissingQueryAttributes() throws Exception {
+        this.migration.upgrade();
+
+        final MigrationCompleted migrationCompleted = captureMigrationCompleted();
+        assertThat(migrationCompleted.migratedDashboardIds()).containsExactly("5c7fc3f9f38ed741ac154697");
+        assertThat(migrationCompleted.widgetMigrationIds()).containsAllEntriesOf(
+                ImmutableMap.<String, Set<String>>builder()
+                        .put("05b03c7b-fe23-4789-a1c8-a38a583d3ba6", ImmutableSet.of("0000016e-b690-426f-0000-016eb690426f"))
+                        .put("10c1b3f9-6b34-4b34-9457-892d12b84151", ImmutableSet.of("0000016e-b690-4270-0000-016eb690426f"))
+                        .put("2afb1838-24ee-489f-929f-ef7d47485021", ImmutableSet.of("0000016e-b690-4271-0000-016eb690426f"))
+                        .put("40c9cf4e-0956-4dc1-9ccd-83868fa83277", ImmutableSet.of("0000016e-b690-4272-0000-016eb690426f"))
+                        .put("4a192616-51d3-474e-9e18-a680f2577769", ImmutableSet.of("0000016e-b690-4273-0000-016eb690426f"))
+                        .put("5020d62d-24a0-4b0c-8819-78e668cc2428", ImmutableSet.of("0000016e-b690-4274-0000-016eb690426f"))
+                        .put("6f2cc355-bcbb-4b3f-be01-bfba299aa51a", ImmutableSet.of("0000016e-b690-4275-0000-016eb690426f", "0000016e-b690-4276-0000-016eb690426f"))
+                        .put("76b7f7e1-76ac-486b-894b-bc31bf4808f1", ImmutableSet.of("0000016e-b690-4277-0000-016eb690426f"))
+                        .put("91b37752-e3a8-4274-910f-3d66d19f1028", ImmutableSet.of("0000016e-b690-4278-0000-016eb690426f"))
+                        .put("9b55d975-a5d4-4df6-8b2e-6fc7b48d52c3", ImmutableSet.of("0000016e-b690-4279-0000-016eb690426f"))
+                        .put("a8eadf94-6494-4271-8c0e-3c8d08e65623", ImmutableSet.of("0000016e-b690-427a-0000-016eb690426f"))
+                        .put("d9be20a1-82d7-427b-8a2d-c7ea9cd114de", ImmutableSet.of("0000016e-b690-427b-0000-016eb690426f"))
+                        .put("da111daa-0d0a-47b9-98ed-8b8aa8a4f575", ImmutableSet.of("0000016e-b690-427c-0000-016eb690426f"))
+                        .put("e9efdfaf-f7be-47ca-97fe-871c05a24d3c", ImmutableSet.of("0000016e-b690-427d-0000-016eb690426f"))
+                        .put("f6e9d960-9cc8-4d16-b3c8-770501b2709f", ImmutableSet.of("0000016e-b690-427e-0000-016eb690426f"))
+                        .build()
+        );
+
+        assertViewsWritten(1,resourceFile("dashboard_with_widgets_missing_query_attributes-expected_views.json"));
+        assertSearchesWritten(1, resourceFile("dashboard_with_widgets_missing_query_attributes-expected_searches.json"));
+    }
 
     private void assertSearchesWritten(int count, String expectedEntities) throws Exception {
         final ArgumentCaptor<Search> newSearchesCaptor = ArgumentCaptor.forClass(Search.class);

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_widgets_missing_query_attributes-expected_searches.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_widgets_missing_query_attributes-expected_searches.json
@@ -1,0 +1,544 @@
+[ {
+  "id" : "5de0e98900002a0017000001",
+  "queries" : [ {
+    "id" : "0000016e-b690-4291-0000-016eb690426f",
+    "timerange" : {
+      "type" : "relative",
+      "range" : 300
+    },
+    "query" : {
+      "type" : "elasticsearch",
+      "query_string" : ""
+    },
+    "search_types" : [ {
+      "id" : "0000016e-b690-4281-0000-016eb690426f",
+      "timerange" : {
+        "type" : "relative",
+        "range" : 300
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : ""
+      },
+      "streams" : [ ],
+      "name" : "chart",
+      "series" : [ {
+        "type" : "card",
+        "id" : "card(nf_src_address_geolocation)",
+        "field" : "nf_src_address_geolocation"
+      } ],
+      "sort" : [ ],
+      "rollup" : true,
+      "type" : "pivot",
+      "filter" : null,
+      "row_groups" : [ ],
+      "column_groups" : [ ]
+    }, {
+      "id" : "0000016e-b690-428d-0000-016eb690426f",
+      "timerange" : {
+        "type" : "relative",
+        "range" : 300
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : ""
+      },
+      "streams" : [ "5c2e07eeba33a9681ad6070a" ],
+      "name" : "chart",
+      "series" : [ {
+        "type" : "card",
+        "id" : "card(nf_proto)",
+        "field" : "nf_proto"
+      } ],
+      "sort" : [ ],
+      "rollup" : true,
+      "type" : "pivot",
+      "filter" : null,
+      "row_groups" : [ ],
+      "column_groups" : [ ]
+    }, {
+      "id" : "0000016e-b690-4288-0000-016eb690426f",
+      "timerange" : {
+        "type" : "relative",
+        "range" : 300
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : ""
+      },
+      "streams" : [ "5c2e07eeba33a9681ad6070a" ],
+      "name" : "chart",
+      "series" : [ {
+        "type" : "count",
+        "id" : "count()",
+        "field" : null
+      } ],
+      "sort" : [ ],
+      "rollup" : true,
+      "type" : "pivot",
+      "filter" : null,
+      "row_groups" : [ {
+        "field" : "nf_dst_address_geolocation",
+        "limit" : 15,
+        "type" : "values"
+      } ],
+      "column_groups" : [ ]
+    }, {
+      "id" : "0000016e-b690-4284-0000-016eb690426f",
+      "timerange" : {
+        "type" : "relative",
+        "range" : 300
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : ""
+      },
+      "streams" : [ ],
+      "name" : "chart",
+      "series" : [ {
+        "type" : "count",
+        "id" : "count()",
+        "field" : null
+      } ],
+      "sort" : [ {
+        "type" : "series",
+        "field" : "facility",
+        "direction" : "Descending"
+      } ],
+      "rollup" : true,
+      "type" : "pivot",
+      "filter" : null,
+      "row_groups" : [ {
+        "field" : "timestamp",
+        "interval" : {
+          "timeunit" : "1h",
+          "type" : "timeunit"
+        },
+        "type" : "time"
+      } ],
+      "column_groups" : [ {
+        "field" : "facility",
+        "limit" : 5,
+        "type" : "values"
+      } ]
+    }, {
+      "id" : "0000016e-b690-4285-0000-016eb690426f",
+      "timerange" : {
+        "type" : "relative",
+        "range" : 28800
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : ""
+      },
+      "streams" : [ ],
+      "name" : "chart",
+      "series" : [ {
+        "type" : "sum",
+        "id" : "sum(nf_bytes)",
+        "field" : "nf_bytes"
+      } ],
+      "sort" : [ ],
+      "rollup" : true,
+      "type" : "pivot",
+      "filter" : null,
+      "row_groups" : [ {
+        "field" : "timestamp",
+        "interval" : {
+          "timeunit" : "1m",
+          "type" : "timeunit"
+        },
+        "type" : "time"
+      } ],
+      "column_groups" : [ ]
+    }, {
+      "id" : "0000016e-b690-4280-0000-016eb690426f",
+      "timerange" : {
+        "type" : "offset",
+        "source" : "search_type",
+        "id" : "0000016e-b690-427f-0000-016eb690426f",
+        "offset" : "1i"
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : ""
+      },
+      "streams" : [ ],
+      "name" : "trend",
+      "series" : [ {
+        "type" : "count",
+        "id" : "count()",
+        "field" : null
+      } ],
+      "sort" : [ ],
+      "rollup" : true,
+      "type" : "pivot",
+      "filter" : null,
+      "row_groups" : [ ],
+      "column_groups" : [ ]
+    }, {
+      "id" : "0000016e-b690-428c-0000-016eb690426f",
+      "timerange" : {
+        "type" : "relative",
+        "range" : 7200
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : "*"
+      },
+      "streams" : [ ],
+      "name" : "chart",
+      "series" : [ {
+        "type" : "count",
+        "id" : "count(dns_client)",
+        "field" : "dns_client"
+      }, {
+        "type" : "count",
+        "id" : "count(nf_bytes)",
+        "field" : "nf_bytes"
+      } ],
+      "sort" : [ ],
+      "rollup" : true,
+      "type" : "pivot",
+      "filter" : null,
+      "row_groups" : [ {
+        "field" : "timestamp",
+        "interval" : {
+          "scaling" : 1.0,
+          "type" : "auto"
+        },
+        "type" : "time"
+      } ],
+      "column_groups" : [ ]
+    }, {
+      "id" : "0000016e-b690-4283-0000-016eb690426f",
+      "timerange" : {
+        "type" : "relative",
+        "range" : 300
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : ""
+      },
+      "streams" : [ ],
+      "name" : "chart",
+      "series" : [ {
+        "type" : "sum",
+        "id" : "sum(nf_bytes)",
+        "field" : "nf_bytes"
+      } ],
+      "sort" : [ ],
+      "rollup" : true,
+      "type" : "pivot",
+      "filter" : null,
+      "row_groups" : [ {
+        "field" : "timestamp",
+        "interval" : {
+          "timeunit" : "1m",
+          "type" : "timeunit"
+        },
+        "type" : "time"
+      } ],
+      "column_groups" : [ ]
+    }, {
+      "id" : "0000016e-b690-4282-0000-016eb690426f",
+      "timerange" : {
+        "type" : "relative",
+        "range" : 300
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : ""
+      },
+      "streams" : [ ],
+      "name" : "chart",
+      "series" : [ {
+        "type" : "count",
+        "id" : "count()",
+        "field" : null
+      } ],
+      "sort" : [ ],
+      "rollup" : true,
+      "type" : "pivot",
+      "filter" : null,
+      "row_groups" : [ {
+        "field" : "timestamp",
+        "interval" : {
+          "timeunit" : "1m",
+          "type" : "timeunit"
+        },
+        "type" : "time"
+      } ],
+      "column_groups" : [ ]
+    }, {
+      "id" : "0000016e-b690-4290-0000-016eb690426f",
+      "timerange" : {
+        "type" : "relative",
+        "range" : 300
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : "*"
+      },
+      "streams" : [ ],
+      "name" : "chart",
+      "series" : [ {
+        "type" : "count",
+        "id" : "count(dns_client)",
+        "field" : "dns_client"
+      }, {
+        "type" : "count",
+        "id" : "count(nf_bytes)",
+        "field" : "nf_bytes"
+      } ],
+      "sort" : [ ],
+      "rollup" : true,
+      "type" : "pivot",
+      "filter" : null,
+      "row_groups" : [ {
+        "field" : "timestamp",
+        "interval" : {
+          "timeunit" : "1m",
+          "type" : "timeunit"
+        },
+        "type" : "time"
+      } ],
+      "column_groups" : [ ]
+    }, {
+      "id" : "0000016e-b690-428a-0000-016eb690426f",
+      "timerange" : {
+        "type" : "absolute",
+        "from" : "2019-11-25T00:00:00.000Z",
+        "to" : "2019-11-26T00:00:00.000Z"
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : ""
+      },
+      "streams" : [ ],
+      "name" : "chart",
+      "series" : [ {
+        "type" : "count",
+        "id" : "count(nf_bytes)",
+        "field" : "nf_bytes"
+      } ],
+      "sort" : [ ],
+      "rollup" : true,
+      "type" : "pivot",
+      "filter" : null,
+      "row_groups" : [ {
+        "field" : "timestamp",
+        "interval" : {
+          "timeunit" : "1m",
+          "type" : "timeunit"
+        },
+        "type" : "time"
+      } ],
+      "column_groups" : [ ]
+    }, {
+      "id" : "0000016e-b690-428f-0000-016eb690426f",
+      "timerange" : {
+        "type" : "relative",
+        "range" : 28800
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : ""
+      },
+      "streams" : [ ],
+      "name" : "chart",
+      "series" : [ {
+        "type" : "count",
+        "id" : "count()",
+        "field" : null
+      } ],
+      "sort" : [ ],
+      "rollup" : true,
+      "type" : "pivot",
+      "filter" : null,
+      "row_groups" : [ {
+        "field" : "timestamp",
+        "interval" : {
+          "timeunit" : "1m",
+          "type" : "timeunit"
+        },
+        "type" : "time"
+      } ],
+      "column_groups" : [ ]
+    }, {
+      "id" : "0000016e-b690-427f-0000-016eb690426f",
+      "timerange" : {
+        "type" : "relative",
+        "range" : 300
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : ""
+      },
+      "streams" : [ ],
+      "name" : "chart",
+      "series" : [ {
+        "type" : "count",
+        "id" : "count()",
+        "field" : null
+      } ],
+      "sort" : [ ],
+      "rollup" : true,
+      "type" : "pivot",
+      "filter" : null,
+      "row_groups" : [ ],
+      "column_groups" : [ ]
+    }, {
+      "id" : "0000016e-b690-428e-0000-016eb690426f",
+      "timerange" : {
+        "type" : "offset",
+        "source" : "search_type",
+        "id" : "0000016e-b690-428d-0000-016eb690426f",
+        "offset" : "1i"
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : ""
+      },
+      "streams" : [ "5c2e07eeba33a9681ad6070a" ],
+      "name" : "trend",
+      "series" : [ {
+        "type" : "card",
+        "id" : "card(nf_proto)",
+        "field" : "nf_proto"
+      } ],
+      "sort" : [ ],
+      "rollup" : true,
+      "type" : "pivot",
+      "filter" : null,
+      "row_groups" : [ ],
+      "column_groups" : [ ]
+    }, {
+      "id" : "0000016e-b690-4286-0000-016eb690426f",
+      "timerange" : {
+        "type" : "relative",
+        "range" : 300
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : ""
+      },
+      "streams" : [ ],
+      "name" : "chart",
+      "series" : [ {
+        "type" : "count",
+        "id" : "count()",
+        "field" : null
+      } ],
+      "sort" : [ {
+        "type" : "series",
+        "field" : "count()",
+        "direction" : "Descending"
+      } ],
+      "rollup" : true,
+      "type" : "pivot",
+      "filter" : null,
+      "row_groups" : [ {
+        "field" : "facility",
+        "limit" : 5,
+        "type" : "values"
+      } ],
+      "column_groups" : [ ]
+    }, {
+      "id" : "0000016e-b690-4287-0000-016eb690426f",
+      "timerange" : {
+        "type" : "relative",
+        "range" : 300
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : ""
+      },
+      "streams" : [ ],
+      "name" : "chart",
+      "series" : [ {
+        "type" : "count",
+        "id" : "count()",
+        "field" : null
+      } ],
+      "sort" : [ {
+        "type" : "series",
+        "field" : "count()",
+        "direction" : "Descending"
+      } ],
+      "rollup" : true,
+      "type" : "pivot",
+      "filter" : null,
+      "row_groups" : [ {
+        "field" : "facility",
+        "limit" : 50,
+        "type" : "values"
+      } ],
+      "column_groups" : [ ]
+    }, {
+      "id" : "0000016e-b690-4289-0000-016eb690426f",
+      "timerange" : {
+        "type" : "keyword",
+        "keyword" : "yesterday"
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : ""
+      },
+      "streams" : [ ],
+      "name" : "chart",
+      "series" : [ {
+        "type" : "count",
+        "id" : "count(nf_bytes)",
+        "field" : "nf_bytes"
+      } ],
+      "sort" : [ ],
+      "rollup" : true,
+      "type" : "pivot",
+      "filter" : null,
+      "row_groups" : [ {
+        "field" : "timestamp",
+        "interval" : {
+          "timeunit" : "1m",
+          "type" : "timeunit"
+        },
+        "type" : "time"
+      } ],
+      "column_groups" : [ ]
+    }, {
+      "id" : "0000016e-b690-428b-0000-016eb690426f",
+      "timerange" : {
+        "type" : "relative",
+        "range" : 300
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : ""
+      },
+      "streams" : [ ],
+      "name" : "chart",
+      "series" : [ {
+        "type" : "sum",
+        "id" : "sum(nf_bytes)",
+        "field" : "nf_bytes"
+      } ],
+      "sort" : [ ],
+      "rollup" : true,
+      "type" : "pivot",
+      "filter" : null,
+      "row_groups" : [ {
+        "field" : "timestamp",
+        "interval" : {
+          "timeunit" : "1m",
+          "type" : "timeunit"
+        },
+        "type" : "time"
+      } ],
+      "column_groups" : [ ]
+    } ]
+  } ],
+  "parameters" : [ ],
+  "owner" : "admin",
+  "created_at" : "2019-03-06T12:58:33.610Z",
+  "requires" : { }
+} ]

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_widgets_missing_query_attributes-expected_views.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_widgets_missing_query_attributes-expected_views.json
@@ -1,0 +1,760 @@
+[ {
+  "id" : "5c7fc3f9f38ed741ac154697",
+  "type" : "DASHBOARD",
+  "title" : "Sample Dashboard",
+  "summary" : "This dashboard was migrated automatically.",
+  "description" : "Hey!",
+  "search_id" : "5de0e98900002a0017000001",
+  "state" : {
+    "0000016e-b690-4291-0000-016eb690426f" : {
+      "titles" : {
+        "widget" : {
+          "0000016e-b690-427c-0000-016eb690426f" : "Some Statistical values",
+          "0000016e-b690-4270-0000-016eb690426f" : "Statistical value",
+          "0000016e-b690-4277-0000-016eb690426f" : "World Map Example",
+          "0000016e-b690-426f-0000-016eb690426f" : "Search result count",
+          "0000016e-b690-4279-0000-016eb690426f" : "Field Chart with absolute time range",
+          "0000016e-b690-4273-0000-016eb690426f" : "Quick values Histogram",
+          "0000016e-b690-4276-0000-016eb690426f" : "Quick values",
+          "0000016e-b690-4275-0000-016eb690426f" : "Quick values",
+          "0000016e-b690-427a-0000-016eb690426f" : "KPI",
+          "0000016e-b690-4271-0000-016eb690426f" : "Search result graph",
+          "0000016e-b690-4278-0000-016eb690426f" : "Field chart with keyword time range",
+          "0000016e-b690-427e-0000-016eb690426f" : "Stacked Field graph",
+          "0000016e-b690-4274-0000-016eb690426f" : "Important!",
+          "0000016e-b690-427b-0000-016eb690426f" : "Stacked graph with custom timerange & query",
+          "0000016e-b690-427d-0000-016eb690426f" : "Search result graph",
+          "0000016e-b690-4272-0000-016eb690426f" : "Field graph"
+        },
+        "tab" : {
+          "title" : "Sample Dashboard"
+        }
+      },
+      "widgets" : [ {
+        "id" : "0000016e-b690-426f-0000-016eb690426f",
+        "type" : "aggregation",
+        "filter" : null,
+        "timerange" : {
+          "type" : "relative",
+          "range" : 300
+        },
+        "query" : {
+          "type" : "elasticsearch",
+          "query_string" : ""
+        },
+        "streams" : [ ],
+        "config" : {
+          "row_pivots" : [ ],
+          "column_pivots" : [ ],
+          "series" : [ {
+            "config" : {
+              "name" : null
+            },
+            "function" : "count()"
+          } ],
+          "sort" : [ ],
+          "visualization" : "numeric",
+          "visualization_config" : {
+            "trend" : true,
+            "trend_preference" : "LOWER"
+          },
+          "rollup" : true,
+          "formatting_settings" : null
+        }
+      }, {
+        "id" : "0000016e-b690-4270-0000-016eb690426f",
+        "type" : "aggregation",
+        "filter" : null,
+        "timerange" : {
+          "type" : "relative",
+          "range" : 300
+        },
+        "query" : {
+          "type" : "elasticsearch",
+          "query_string" : ""
+        },
+        "streams" : [ ],
+        "config" : {
+          "row_pivots" : [ ],
+          "column_pivots" : [ ],
+          "series" : [ {
+            "config" : {
+              "name" : null
+            },
+            "function" : "card(nf_src_address_geolocation)"
+          } ],
+          "sort" : [ ],
+          "visualization" : "numeric",
+          "visualization_config" : {
+            "trend" : false,
+            "trend_preference" : "HIGHER"
+          },
+          "rollup" : true,
+          "formatting_settings" : null
+        }
+      }, {
+        "id" : "0000016e-b690-4271-0000-016eb690426f",
+        "type" : "aggregation",
+        "filter" : null,
+        "timerange" : {
+          "type" : "relative",
+          "range" : 300
+        },
+        "query" : {
+          "type" : "elasticsearch",
+          "query_string" : ""
+        },
+        "streams" : [ ],
+        "config" : {
+          "row_pivots" : [ {
+            "field" : "timestamp",
+            "type" : "time",
+            "config" : {
+              "interval" : {
+                "type" : "timeunit",
+                "value" : 1,
+                "unit" : "minutes"
+              }
+            }
+          } ],
+          "column_pivots" : [ ],
+          "series" : [ {
+            "config" : {
+              "name" : "Messages"
+            },
+            "function" : "count()"
+          } ],
+          "sort" : [ ],
+          "visualization" : "bar",
+          "visualization_config" : null,
+          "rollup" : true,
+          "formatting_settings" : null
+        }
+      }, {
+        "id" : "0000016e-b690-4272-0000-016eb690426f",
+        "type" : "aggregation",
+        "filter" : null,
+        "timerange" : {
+          "type" : "relative",
+          "range" : 300
+        },
+        "query" : {
+          "type" : "elasticsearch",
+          "query_string" : ""
+        },
+        "streams" : [ ],
+        "config" : {
+          "row_pivots" : [ {
+            "field" : "timestamp",
+            "type" : "time",
+            "config" : {
+              "interval" : {
+                "type" : "timeunit",
+                "value" : 1,
+                "unit" : "minutes"
+              }
+            }
+          } ],
+          "column_pivots" : [ ],
+          "series" : [ {
+            "config" : {
+              "name" : null
+            },
+            "function" : "sum(nf_bytes)"
+          } ],
+          "sort" : [ ],
+          "visualization" : "line",
+          "visualization_config" : {
+            "interpolation" : "linear"
+          },
+          "rollup" : true,
+          "formatting_settings" : null
+        }
+      }, {
+        "id" : "0000016e-b690-4273-0000-016eb690426f",
+        "type" : "aggregation",
+        "filter" : null,
+        "timerange" : {
+          "type" : "relative",
+          "range" : 300
+        },
+        "query" : {
+          "type" : "elasticsearch",
+          "query_string" : ""
+        },
+        "streams" : [ ],
+        "config" : {
+          "row_pivots" : [ {
+            "field" : "timestamp",
+            "type" : "time",
+            "config" : {
+              "interval" : {
+                "type" : "timeunit",
+                "value" : 1,
+                "unit" : "hours"
+              }
+            }
+          } ],
+          "column_pivots" : [ {
+            "field" : "facility",
+            "type" : "values",
+            "config" : {
+              "limit" : 5
+            }
+          } ],
+          "series" : [ {
+            "config" : {
+              "name" : null
+            },
+            "function" : "count()"
+          } ],
+          "sort" : [ {
+            "type" : "series",
+            "field" : "facility",
+            "direction" : "Descending"
+          } ],
+          "visualization" : "bar",
+          "visualization_config" : {
+            "barmode" : "stack"
+          },
+          "rollup" : true,
+          "formatting_settings" : null
+        }
+      }, {
+        "id" : "0000016e-b690-4274-0000-016eb690426f",
+        "type" : "aggregation",
+        "filter" : null,
+        "timerange" : {
+          "type" : "relative",
+          "range" : 28800
+        },
+        "query" : {
+          "type" : "elasticsearch",
+          "query_string" : ""
+        },
+        "streams" : [ ],
+        "config" : {
+          "row_pivots" : [ {
+            "field" : "timestamp",
+            "type" : "time",
+            "config" : {
+              "interval" : {
+                "type" : "timeunit",
+                "value" : 1,
+                "unit" : "minutes"
+              }
+            }
+          } ],
+          "column_pivots" : [ ],
+          "series" : [ {
+            "config" : {
+              "name" : null
+            },
+            "function" : "sum(nf_bytes)"
+          } ],
+          "sort" : [ ],
+          "visualization" : "line",
+          "visualization_config" : {
+            "interpolation" : "linear"
+          },
+          "rollup" : true,
+          "formatting_settings" : null
+        }
+      }, {
+        "id" : "0000016e-b690-4275-0000-016eb690426f",
+        "type" : "aggregation",
+        "filter" : null,
+        "timerange" : {
+          "type" : "relative",
+          "range" : 300
+        },
+        "query" : {
+          "type" : "elasticsearch",
+          "query_string" : ""
+        },
+        "streams" : [ ],
+        "config" : {
+          "row_pivots" : [ {
+            "field" : "facility",
+            "type" : "values",
+            "config" : {
+              "limit" : 5
+            }
+          } ],
+          "column_pivots" : [ ],
+          "series" : [ {
+            "config" : {
+              "name" : null
+            },
+            "function" : "count()"
+          } ],
+          "sort" : [ {
+            "type" : "series",
+            "field" : "count()",
+            "direction" : "Descending"
+          } ],
+          "visualization" : "pie",
+          "visualization_config" : null,
+          "rollup" : true,
+          "formatting_settings" : null
+        }
+      }, {
+        "id" : "0000016e-b690-4276-0000-016eb690426f",
+        "type" : "aggregation",
+        "filter" : null,
+        "timerange" : {
+          "type" : "relative",
+          "range" : 300
+        },
+        "query" : {
+          "type" : "elasticsearch",
+          "query_string" : ""
+        },
+        "streams" : [ ],
+        "config" : {
+          "row_pivots" : [ {
+            "field" : "facility",
+            "type" : "values",
+            "config" : {
+              "limit" : 50
+            }
+          } ],
+          "column_pivots" : [ ],
+          "series" : [ {
+            "config" : {
+              "name" : null
+            },
+            "function" : "count()"
+          } ],
+          "sort" : [ {
+            "type" : "series",
+            "field" : "count()",
+            "direction" : "Descending"
+          } ],
+          "visualization" : "table",
+          "visualization_config" : null,
+          "rollup" : true,
+          "formatting_settings" : null
+        }
+      }, {
+        "id" : "0000016e-b690-4277-0000-016eb690426f",
+        "type" : "aggregation",
+        "filter" : null,
+        "timerange" : {
+          "type" : "relative",
+          "range" : 300
+        },
+        "query" : {
+          "type" : "elasticsearch",
+          "query_string" : ""
+        },
+        "streams" : [ "5c2e07eeba33a9681ad6070a" ],
+        "config" : {
+          "row_pivots" : [ {
+            "field" : "nf_dst_address_geolocation",
+            "type" : "values",
+            "config" : {
+              "limit" : 15
+            }
+          } ],
+          "column_pivots" : [ ],
+          "series" : [ {
+            "config" : {
+              "name" : null
+            },
+            "function" : "count()"
+          } ],
+          "sort" : [ ],
+          "visualization" : "map",
+          "visualization_config" : null,
+          "rollup" : true,
+          "formatting_settings" : null
+        }
+      }, {
+        "id" : "0000016e-b690-4278-0000-016eb690426f",
+        "type" : "aggregation",
+        "filter" : null,
+        "timerange" : {
+          "type" : "keyword",
+          "keyword" : "yesterday"
+        },
+        "query" : {
+          "type" : "elasticsearch",
+          "query_string" : ""
+        },
+        "streams" : [ ],
+        "config" : {
+          "row_pivots" : [ {
+            "field" : "timestamp",
+            "type" : "time",
+            "config" : {
+              "interval" : {
+                "type" : "timeunit",
+                "value" : 1,
+                "unit" : "minutes"
+              }
+            }
+          } ],
+          "column_pivots" : [ ],
+          "series" : [ {
+            "config" : {
+              "name" : null
+            },
+            "function" : "count(nf_bytes)"
+          } ],
+          "sort" : [ ],
+          "visualization" : "bar",
+          "visualization_config" : null,
+          "rollup" : true,
+          "formatting_settings" : null
+        }
+      }, {
+        "id" : "0000016e-b690-4279-0000-016eb690426f",
+        "type" : "aggregation",
+        "filter" : null,
+        "timerange" : {
+          "type" : "absolute",
+          "from" : "2019-11-25T00:00:00.000Z",
+          "to" : "2019-11-26T00:00:00.000Z"
+        },
+        "query" : {
+          "type" : "elasticsearch",
+          "query_string" : ""
+        },
+        "streams" : [ ],
+        "config" : {
+          "row_pivots" : [ {
+            "field" : "timestamp",
+            "type" : "time",
+            "config" : {
+              "interval" : {
+                "type" : "timeunit",
+                "value" : 1,
+                "unit" : "minutes"
+              }
+            }
+          } ],
+          "column_pivots" : [ ],
+          "series" : [ {
+            "config" : {
+              "name" : null
+            },
+            "function" : "count(nf_bytes)"
+          } ],
+          "sort" : [ ],
+          "visualization" : "bar",
+          "visualization_config" : null,
+          "rollup" : true,
+          "formatting_settings" : null
+        }
+      }, {
+        "id" : "0000016e-b690-427a-0000-016eb690426f",
+        "type" : "aggregation",
+        "filter" : null,
+        "timerange" : {
+          "type" : "relative",
+          "range" : 300
+        },
+        "query" : {
+          "type" : "elasticsearch",
+          "query_string" : ""
+        },
+        "streams" : [ ],
+        "config" : {
+          "row_pivots" : [ {
+            "field" : "timestamp",
+            "type" : "time",
+            "config" : {
+              "interval" : {
+                "type" : "timeunit",
+                "value" : 1,
+                "unit" : "minutes"
+              }
+            }
+          } ],
+          "column_pivots" : [ ],
+          "series" : [ {
+            "config" : {
+              "name" : null
+            },
+            "function" : "sum(nf_bytes)"
+          } ],
+          "sort" : [ ],
+          "visualization" : "line",
+          "visualization_config" : {
+            "interpolation" : "linear"
+          },
+          "rollup" : true,
+          "formatting_settings" : null
+        }
+      }, {
+        "id" : "0000016e-b690-427b-0000-016eb690426f",
+        "type" : "aggregation",
+        "filter" : null,
+        "timerange" : {
+          "type" : "relative",
+          "range" : 7200
+        },
+        "query" : {
+          "type" : "elasticsearch",
+          "query_string" : "*"
+        },
+        "streams" : [ ],
+        "config" : {
+          "row_pivots" : [ {
+            "field" : "timestamp",
+            "type" : "time",
+            "config" : {
+              "interval" : {
+                "type" : "auto",
+                "scaling" : 2.0
+              }
+            }
+          } ],
+          "column_pivots" : [ ],
+          "series" : [ {
+            "config" : {
+              "name" : null
+            },
+            "function" : "count(dns_client)"
+          }, {
+            "config" : {
+              "name" : null
+            },
+            "function" : "count(nf_bytes)"
+          } ],
+          "sort" : [ ],
+          "visualization" : "bar",
+          "visualization_config" : null,
+          "rollup" : true,
+          "formatting_settings" : null
+        }
+      }, {
+        "id" : "0000016e-b690-427c-0000-016eb690426f",
+        "type" : "aggregation",
+        "filter" : null,
+        "timerange" : {
+          "type" : "relative",
+          "range" : 300
+        },
+        "query" : {
+          "type" : "elasticsearch",
+          "query_string" : ""
+        },
+        "streams" : [ "5c2e07eeba33a9681ad6070a" ],
+        "config" : {
+          "row_pivots" : [ ],
+          "column_pivots" : [ ],
+          "series" : [ {
+            "config" : {
+              "name" : null
+            },
+            "function" : "card(nf_proto)"
+          } ],
+          "sort" : [ ],
+          "visualization" : "numeric",
+          "visualization_config" : {
+            "trend" : true,
+            "trend_preference" : "LOWER"
+          },
+          "rollup" : true,
+          "formatting_settings" : null
+        }
+      }, {
+        "id" : "0000016e-b690-427d-0000-016eb690426f",
+        "type" : "aggregation",
+        "filter" : null,
+        "timerange" : {
+          "type" : "relative",
+          "range" : 28800
+        },
+        "query" : {
+          "type" : "elasticsearch",
+          "query_string" : ""
+        },
+        "streams" : [ ],
+        "config" : {
+          "row_pivots" : [ {
+            "field" : "timestamp",
+            "type" : "time",
+            "config" : {
+              "interval" : {
+                "type" : "timeunit",
+                "value" : 1,
+                "unit" : "minutes"
+              }
+            }
+          } ],
+          "column_pivots" : [ ],
+          "series" : [ {
+            "config" : {
+              "name" : "Messages"
+            },
+            "function" : "count()"
+          } ],
+          "sort" : [ ],
+          "visualization" : "bar",
+          "visualization_config" : null,
+          "rollup" : true,
+          "formatting_settings" : null
+        }
+      }, {
+        "id" : "0000016e-b690-427e-0000-016eb690426f",
+        "type" : "aggregation",
+        "filter" : null,
+        "timerange" : {
+          "type" : "relative",
+          "range" : 300
+        },
+        "query" : {
+          "type" : "elasticsearch",
+          "query_string" : "*"
+        },
+        "streams" : [ ],
+        "config" : {
+          "row_pivots" : [ {
+            "field" : "timestamp",
+            "type" : "time",
+            "config" : {
+              "interval" : {
+                "type" : "timeunit",
+                "value" : 1,
+                "unit" : "minutes"
+              }
+            }
+          } ],
+          "column_pivots" : [ ],
+          "series" : [ {
+            "config" : {
+              "name" : null
+            },
+            "function" : "count(dns_client)"
+          }, {
+            "config" : {
+              "name" : null
+            },
+            "function" : "count(nf_bytes)"
+          } ],
+          "sort" : [ ],
+          "visualization" : "bar",
+          "visualization_config" : null,
+          "rollup" : true,
+          "formatting_settings" : null
+        }
+      } ],
+      "widget_mapping" : {
+        "0000016e-b690-427c-0000-016eb690426f" : [ "0000016e-b690-428d-0000-016eb690426f", "0000016e-b690-428e-0000-016eb690426f" ],
+        "0000016e-b690-4277-0000-016eb690426f" : [ "0000016e-b690-4288-0000-016eb690426f" ],
+        "0000016e-b690-4270-0000-016eb690426f" : [ "0000016e-b690-4281-0000-016eb690426f" ],
+        "0000016e-b690-426f-0000-016eb690426f" : [ "0000016e-b690-427f-0000-016eb690426f", "0000016e-b690-4280-0000-016eb690426f" ],
+        "0000016e-b690-4279-0000-016eb690426f" : [ "0000016e-b690-428a-0000-016eb690426f" ],
+        "0000016e-b690-4276-0000-016eb690426f" : [ "0000016e-b690-4287-0000-016eb690426f" ],
+        "0000016e-b690-4273-0000-016eb690426f" : [ "0000016e-b690-4284-0000-016eb690426f" ],
+        "0000016e-b690-4275-0000-016eb690426f" : [ "0000016e-b690-4286-0000-016eb690426f" ],
+        "0000016e-b690-427a-0000-016eb690426f" : [ "0000016e-b690-428b-0000-016eb690426f" ],
+        "0000016e-b690-427e-0000-016eb690426f" : [ "0000016e-b690-4290-0000-016eb690426f" ],
+        "0000016e-b690-4278-0000-016eb690426f" : [ "0000016e-b690-4289-0000-016eb690426f" ],
+        "0000016e-b690-4271-0000-016eb690426f" : [ "0000016e-b690-4282-0000-016eb690426f" ],
+        "0000016e-b690-427b-0000-016eb690426f" : [ "0000016e-b690-428c-0000-016eb690426f" ],
+        "0000016e-b690-4274-0000-016eb690426f" : [ "0000016e-b690-4285-0000-016eb690426f" ],
+        "0000016e-b690-427d-0000-016eb690426f" : [ "0000016e-b690-428f-0000-016eb690426f" ],
+        "0000016e-b690-4272-0000-016eb690426f" : [ "0000016e-b690-4283-0000-016eb690426f" ]
+      },
+      "positions" : {
+        "0000016e-b690-427c-0000-016eb690426f" : {
+          "col" : 5,
+          "row" : 5,
+          "height" : 2,
+          "width" : 2
+        },
+        "0000016e-b690-4270-0000-016eb690426f" : {
+          "col" : 5,
+          "row" : 3,
+          "height" : 2,
+          "width" : 2
+        },
+        "0000016e-b690-4277-0000-016eb690426f" : {
+          "col" : 4,
+          "row" : 7,
+          "height" : 5,
+          "width" : 3
+        },
+        "0000016e-b690-426f-0000-016eb690426f" : {
+          "col" : 5,
+          "row" : 1,
+          "height" : 2,
+          "width" : 2
+        },
+        "0000016e-b690-4279-0000-016eb690426f" : {
+          "col" : 1,
+          "row" : 14,
+          "height" : 2,
+          "width" : 4
+        },
+        "0000016e-b690-4273-0000-016eb690426f" : {
+          "col" : 1,
+          "row" : 5,
+          "height" : 2,
+          "width" : 4
+        },
+        "0000016e-b690-4276-0000-016eb690426f" : {
+          "col" : 1,
+          "row" : 10,
+          "height" : 2,
+          "width" : 3
+        },
+        "0000016e-b690-4275-0000-016eb690426f" : {
+          "col" : 1,
+          "row" : 7,
+          "height" : 3,
+          "width" : 3
+        },
+        "0000016e-b690-427a-0000-016eb690426f" : {
+          "col" : 7,
+          "row" : 7,
+          "height" : 5,
+          "width" : 6
+        },
+        "0000016e-b690-4271-0000-016eb690426f" : {
+          "col" : 7,
+          "row" : 1,
+          "height" : 3,
+          "width" : 6
+        },
+        "0000016e-b690-4278-0000-016eb690426f" : {
+          "col" : 1,
+          "row" : 12,
+          "height" : 2,
+          "width" : 4
+        },
+        "0000016e-b690-4274-0000-016eb690426f" : {
+          "col" : 1,
+          "row" : 1,
+          "height" : 2,
+          "width" : 4
+        },
+        "0000016e-b690-427d-0000-016eb690426f" : {
+          "col" : 1,
+          "row" : 3,
+          "height" : 2,
+          "width" : 4
+        },
+        "0000016e-b690-4272-0000-016eb690426f" : {
+          "col" : 7,
+          "row" : 4,
+          "height" : 3,
+          "width" : 6
+        }
+      },
+      "selected_fields" : null,
+      "static_message_list_id" : null,
+      "display_mode_settings" : {
+        "positions" : { }
+      }
+    }
+  },
+  "owner" : "admin",
+  "created_at" : "2019-03-06T12:58:33.610Z",
+  "requires" : { },
+  "properties" : [ ]
+} ]

--- a/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_widgets_missing_query_attributes.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/views/migrations/V20191125144500_MigrateDashboardsToViewsSupport/dashboard_with_widgets_missing_query_attributes.json
@@ -1,0 +1,384 @@
+{
+  "dashboards": [
+    {
+      "_id": { "$oid": "5c7fc3f9f38ed741ac154697" },
+      "creator_user_id": "admin",
+      "description": "Hey!",
+      "created_at": { "$date": "2019-03-06T12:58:33.610Z" },
+      "positions": {
+        "da111daa-0d0a-47b9-98ed-8b8aa8a4f575": {
+          "width": 2,
+          "col": 5,
+          "row": 5,
+          "height": 2
+        },
+        "40c9cf4e-0956-4dc1-9ccd-83868fa83277": {
+          "width": 6,
+          "col": 7,
+          "row": 4,
+          "height": 3
+        },
+        "a8eadf94-6494-4271-8c0e-3c8d08e65623": {
+          "width": 6,
+          "col": 7,
+          "row": 7,
+          "height": 5
+        },
+        "6f2cc355-bcbb-4b3f-be01-bfba299aa51a": {
+          "width": 3,
+          "col": 1,
+          "row": 7,
+          "height": 5
+        },
+        "9b55d975-a5d4-4df6-8b2e-6fc7b48d52c3": {
+          "width": 4,
+          "col": 1,
+          "row": 14,
+          "height": 2
+        },
+        "5020d62d-24a0-4b0c-8819-78e668cc2428": {
+          "width": 4,
+          "col": 1,
+          "row": 1,
+          "height": 2
+        },
+        "91b37752-e3a8-4274-910f-3d66d19f1028": {
+          "width": 4,
+          "col": 1,
+          "row": 12,
+          "height": 2
+        },
+        "05b03c7b-fe23-4789-a1c8-a38a583d3ba6": {
+          "width": 2,
+          "col": 5,
+          "row": 1,
+          "height": 2
+        },
+        "76b7f7e1-76ac-486b-894b-bc31bf4808f1": {
+          "width": 3,
+          "col": 4,
+          "row": 7,
+          "height": 5
+        },
+        "10c1b3f9-6b34-4b34-9457-892d12b84151": {
+          "width": 2,
+          "col": 5,
+          "row": 3,
+          "height": 2
+        },
+        "4a192616-51d3-474e-9e18-a680f2577769": {
+          "width": 4,
+          "col": 1,
+          "row": 5,
+          "height": 2
+        },
+        "e9efdfaf-f7be-47ca-97fe-871c05a24d3c": {
+          "width": 4,
+          "col": 1,
+          "row": 3,
+          "height": 2
+        },
+        "2afb1838-24ee-489f-929f-ef7d47485021": {
+          "width": 6,
+          "col": 7,
+          "row": 1,
+          "height": 3
+        },
+        "f2e76256-0379-483e-8622-8efd661ca939": {
+          "width": 23,
+          "col": 8,
+          "row": 8,
+          "height": 42
+        }
+      },
+      "title": "Sample Dashboard",
+      "widgets": [
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "KPI",
+          "id": "a8eadf94-6494-4271-8c0e-3c8d08e65623",
+          "type": "FIELD_CHART",
+          "config": {
+            "valuetype": "total",
+            "renderer": "line",
+            "interpolation": "linear",
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "rangeType": "relative",
+            "field": "nf_bytes",
+            "interval": "minute",
+            "relative": 300
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Field graph",
+          "id": "40c9cf4e-0956-4dc1-9ccd-83868fa83277",
+          "type": "FIELD_CHART",
+          "config": {
+            "valuetype": "total",
+            "renderer": "line",
+            "interpolation": "linear",
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "rangeType": "relative",
+            "field": "nf_bytes",
+            "interval": "minute",
+            "relative": 300
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Search result graph",
+          "id": "e9efdfaf-f7be-47ca-97fe-871c05a24d3c",
+          "type": "SEARCH_RESULT_CHART",
+          "config": {
+            "interval": "minute",
+            "timerange": {
+              "type": "relative",
+              "range": 28800
+            },
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Important!",
+          "id": "5020d62d-24a0-4b0c-8819-78e668cc2428",
+          "type": "FIELD_CHART",
+          "config": {
+            "valuetype": "total",
+            "renderer": "line",
+            "interpolation": "linear",
+            "timerange": {
+              "type": "relative",
+              "range": 28800
+            },
+            "rangeType": "relative",
+            "field": "nf_bytes",
+            "interval": "minute",
+            "relative": 28800
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Search result count",
+          "id": "05b03c7b-fe23-4789-a1c8-a38a583d3ba6",
+          "type": "SEARCH_RESULT_COUNT",
+          "config": {
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "lower_is_better": true,
+            "trend": true,
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Quick values",
+          "id": "6f2cc355-bcbb-4b3f-be01-bfba299aa51a",
+          "type": "QUICKVALUES",
+          "config": {
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "field": "facility",
+            "show_data_table": true,
+            "limit": 5,
+            "show_pie_chart": true,
+            "sort_order": "desc",
+            "stacked_fields": "",
+            "data_table_limit": 50
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Statistical value",
+          "id": "10c1b3f9-6b34-4b34-9457-892d12b84151",
+          "type": "STATS_COUNT",
+          "config": {
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "field": "nf_src_address_geolocation",
+            "trend": false,
+            "stats_function": "cardinality",
+            "lower_is_better": false
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Search result graph",
+          "id": "2afb1838-24ee-489f-929f-ef7d47485021",
+          "type": "SEARCH_RESULT_CHART",
+          "config": {
+            "interval": "minute",
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "World Map Example",
+          "id": "76b7f7e1-76ac-486b-894b-bc31bf4808f1",
+          "type": "org.graylog.plugins.map.widget.strategy.MapWidgetStrategy",
+          "config": {
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "field": "nf_dst_address_geolocation",
+            "stream_id": "5c2e07eeba33a9681ad6070a",
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Some Statistical values",
+          "id": "da111daa-0d0a-47b9-98ed-8b8aa8a4f575",
+          "type": "STATS_COUNT",
+          "config": {
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "field": "nf_proto",
+            "stream_id": "5c2e07eeba33a9681ad6070a",
+            "trend": true,
+            "stats_function": "cardinality",
+            "lower_is_better": true
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Field Chart with absolute time range",
+          "id": "9b55d975-a5d4-4df6-8b2e-6fc7b48d52c3",
+          "type": "FIELD_CHART",
+          "config": {
+            "valuetype": "count",
+            "renderer": "bar",
+            "interpolation": "linear",
+            "timerange": {
+              "from": { "$date": "2019-11-25T00:00:00.000Z" },
+              "to": { "$date": "2019-11-26T00:00:00.000Z" },
+              "type": "absolute"
+            },
+            "rangeType": "absolute",
+            "field": "nf_bytes",
+            "interval": "minute",
+            "from": "2019-11-25T00:00:00.000Z",
+            "to": "2019-11-26T00:00:00.000Z"
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Field chart with keyword time range",
+          "id": "91b37752-e3a8-4274-910f-3d66d19f1028",
+          "type": "FIELD_CHART",
+          "config": {
+            "valuetype": "count",
+            "renderer": "bar",
+            "interpolation": "linear",
+            "timerange": {
+              "type": "keyword",
+              "keyword": "yesterday"
+            },
+            "rangeType": "keyword",
+            "field": "nf_bytes",
+            "interval": "minute",
+            "keyword": "yesterday"
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Quick values Histogram",
+          "id": "4a192616-51d3-474e-9e18-a680f2577769",
+          "type": "QUICKVALUES_HISTOGRAM",
+          "config": {
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "field": "facility",
+            "limit": 5,
+            "interval": "hour",
+            "sort_order": "desc",
+            "stacked_fields": ""
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Stacked Field graph",
+          "id": "f6e9d960-9cc8-4d16-b3c8-770501b2709f",
+          "type": "STACKED_CHART",
+          "config": {
+            "interval": "minute",
+            "timerange": {
+              "type": "relative",
+              "range": 300
+            },
+            "renderer": "bar",
+            "interpolation": "linear",
+            "series": [
+              {
+                "field": "dns_client",
+                "statistical_function": "count"
+              },
+              {
+                "field": "nf_bytes",
+                "statistical_function": "count"
+              }
+            ]
+          }
+        },
+        {
+          "creator_user_id": "admin",
+          "cache_time": 10,
+          "description": "Stacked graph with custom timerange & query",
+          "id": "d9be20a1-82d7-427b-8a2d-c7ea9cd114de",
+          "type": "STACKED_CHART",
+          "config": {
+            "interval": "minute",
+            "timerange": {
+              "type": "relative",
+              "range": 7200
+            },
+            "renderer": "bar",
+            "interpolation": "linear",
+            "series": [
+              {
+                "field": "dns_client",
+                "statistical_function": "count"
+              },
+              {
+                "field": "nf_bytes",
+                "statistical_function": "count"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note: This requires a backport to `3.2`.**

This PR is changing the legacy dashboards migration to handle the
`query` field being potentially `null` in more legacy widget types than
expected, by adding a `Nullable` annotation where it was missing and
turning a `null` query into an empty one.

Fixes #7781.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.