### PR TITLE
Remove not needed SizeMe container from WidgetGrid

### DIFF
--- a/graylog2-web-interface/src/views/components/WidgetGrid.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import * as Immutable from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import _ from 'lodash';
-import { SizeMe } from 'react-sizeme';
 import styled, { css } from 'styled-components';
 
 import connect from 'stores/connect';
@@ -157,16 +156,10 @@ class WidgetGrid extends React.Component {
       </ReactGridContainer>
     ) : <span />;
     return (
-      <SizeMe monitorWidth refreshRate={100}>
-        {({ size }) => {
-          return (
-            <DashboardWrap>
-              {React.cloneElement(grid, { width: size.width })}
-              {staticWidgets}
-            </DashboardWrap>
-          );
-        }}
-      </SizeMe>
+      <DashboardWrap>
+        {grid}
+        {staticWidgets}
+      </DashboardWrap>
     );
   }
 }

--- a/graylog2-web-interface/src/views/components/WidgetGrid.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.jsx
@@ -63,7 +63,6 @@ class WidgetGrid extends React.Component {
 
   constructor(props) {
     super(props);
-
     this.state = {
       widgetDimensions: {},
     };

--- a/graylog2-web-interface/src/views/components/__snapshots__/WidgetGrid.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/__snapshots__/WidgetGrid.test.jsx.snap
@@ -22,48 +22,39 @@ exports[`<WidgetGrid /> should render with minimal props 1`] = `
     titles={Immutable.Map {}}
     widgets={Object {}}
   >
-    <SizeMe
-      monitorWidth={true}
-      refreshRate={100}
-    >
-      <div>
-        <WidgetGrid__DashboardWrap>
-          <StyledComponent
-            forwardedComponent={
-              Object {
-                "$$typeof": Symbol(react.forward_ref),
-                "attrs": Array [],
-                "componentStyle": ComponentStyle {
-                  "componentId": "WidgetGrid__DashboardWrap-sc-1bqopuh-0",
-                  "isStatic": false,
-                  "lastClassName": "jaucQL",
-                  "rules": Array [
-                    [Function],
-                  ],
-                },
-                "displayName": "WidgetGrid__DashboardWrap",
-                "foldedComponentIds": Array [],
-                "render": [Function],
-                "styledComponentId": "WidgetGrid__DashboardWrap-sc-1bqopuh-0",
-                "target": "div",
-                "toString": [Function],
-                "warnTooManyClasses": [Function],
-                "withComponent": [Function],
-              }
-            }
-            forwardedRef={null}
-          >
-            <div
-              className="WidgetGrid__DashboardWrap-sc-1bqopuh-0 jaucQL"
-            >
-              <span
-                width={200}
-              />
-            </div>
-          </StyledComponent>
-        </WidgetGrid__DashboardWrap>
-      </div>
-    </SizeMe>
+    <WidgetGrid__DashboardWrap>
+      <StyledComponent
+        forwardedComponent={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "attrs": Array [],
+            "componentStyle": ComponentStyle {
+              "componentId": "WidgetGrid__DashboardWrap-sc-1bqopuh-0",
+              "isStatic": false,
+              "lastClassName": "jaucQL",
+              "rules": Array [
+                [Function],
+              ],
+            },
+            "displayName": "WidgetGrid__DashboardWrap",
+            "foldedComponentIds": Array [],
+            "render": [Function],
+            "styledComponentId": "WidgetGrid__DashboardWrap-sc-1bqopuh-0",
+            "target": "div",
+            "toString": [Function],
+            "warnTooManyClasses": [Function],
+            "withComponent": [Function],
+          }
+        }
+        forwardedRef={null}
+      >
+        <div
+          className="WidgetGrid__DashboardWrap-sc-1bqopuh-0 jaucQL"
+        >
+          <span />
+        </div>
+      </StyledComponent>
+    </WidgetGrid__DashboardWrap>
   </WidgetGrid>
 </ConnectStoresWrapper[WidgetGrid] stores=titles>
 `;


### PR DESCRIPTION
We are currently using the `SizeMe` component inside the `WidgetGrid` to provide the full grid width in px for the `ReactGridContainer`. 

The `ReactGridContainer` is also able to calculate the full width itself by using `WidthProvider` from `react-grid-layout`
(https://github.com/STRML/react-grid-layout/blob/master/lib/components/WidthProvider.jsx),
which means we don't have to use the `SizeMe` component.

Using the `WidthProvider` instead of the `SizeMe` container also fixes a `WorldMap` viewport bug, described here: https://github.com/Graylog2/graylog2-server/issues/7779

Fixes: https://github.com/Graylog2/graylog2-server/issues/7779

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

