### PR TITLE
Add required id for dashboard pages tabs menu

### DIFF
--- a/graylog2-web-interface/src/views/components/QueryTabs.jsx
+++ b/graylog2-web-interface/src/views/components/QueryTabs.jsx
@@ -108,6 +108,7 @@ class QueryTabs extends React.Component<Props> {
         <Col>
           <StyledQueryTabs activeKey={selectedQueryId}
                            animation={false}
+                           id="dashboard-pages"
                            onSelect={onSelect}>
             {tabs}
           </StyledQueryTabs>


### PR DESCRIPTION
There is currently an error in the console when opening the dashboard:
```
Warning: Failed prop type: The prop `id` is required to make `Tabs` accessible for users of assistive technologies such as screen readers.
```

This PR adds the required id. The id format is inspired by the format used in the `react-bootstrap` docs:
https://react-bootstrap-v3.netlify.com/components/tabs/

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

