### PR TITLE
Reactivate module that turns console.error/warn to test failures.

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -33,7 +33,8 @@
       "jest-localstorage-mock",
       "<rootDir>/test/setup-jest.js",
       "<rootDir>/test/mock-FetchProvider.js",
-      "<rootDir>/test/mock-Version.js"
+      "<rootDir>/test/mock-Version.js",
+      "<rootDir>/test/console-warnings-fail-tests.js"
     ],
     "setupFilesAfterEnv": [
       "jest-enzyme"

--- a/graylog2-web-interface/src/routing/AppRouter.test.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.test.jsx
@@ -20,7 +20,7 @@ jest.mock('injection/CombinedProvider', () => {
   })]);
   return new MockCombinedProvider({
     CurrentUser: { CurrentUserStore: mockCurrentUserStoretore },
-    Notifications: { NotificationsActions: { list: jest.fn() } },
+    Notifications: { NotificationsActions: { list: jest.fn() }, NotificationsStore: MockStore() },
   });
 });
 

--- a/graylog2-web-interface/src/views/components/SearchBar.test.jsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.test.jsx
@@ -9,8 +9,9 @@ import { QueriesActions } from 'views/stores/QueriesStore';
 import mockAction from 'helpers/mocking/MockAction';
 import SearchBar from './SearchBar';
 
+const mockCurrentUser = { currentUser: { fullname: 'Ada Lovelace', username: 'ada' } };
 jest.mock('stores/sessions/SessionStore', () => MockStore(['isLoggedIn', () => { return true; }], 'getSessionId'));
-jest.mock('stores/users/CurrentUserStore', () => MockStore('listen', 'get'));
+jest.mock('stores/users/CurrentUserStore', () => MockStore('listen', ['getInitialState', () => mockCurrentUser], ['get', () => mockCurrentUser]));
 jest.mock('actions/sessions/SessionActions', () => ({
   logout: {
     completed: {

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.test.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.test.jsx
@@ -10,7 +10,6 @@ import WrappingContainer from 'WrappingContainer';
 import WidgetQueryControls from './WidgetQueryControls';
 import { WidgetActions } from '../stores/WidgetStore';
 
-
 jest.mock('views/stores/WidgetStore', () => ({
   WidgetActions: {
     timerange: jest.fn(),
@@ -31,6 +30,8 @@ jest.mock('moment', () => {
   const mockMoment = jest.requireActual('moment');
   return Object.assign(() => mockMoment('2019-10-10T12:26:31.146Z'), mockMoment);
 });
+
+jest.mock('views/components/searchbar/QueryInput', () => () => <span>Query Editor</span>);
 
 describe('WidgetQueryControls', () => {
   afterEach(cleanup);

--- a/graylog2-web-interface/src/views/components/searchbar/QueryInput.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/QueryInput.test.jsx
@@ -20,8 +20,10 @@ class Completer {
 
 describe('QueryInput', () => {
   beforeAll(() => {
-    // eslint-disable-next-line no-undef
+    /* eslint-disable no-undef */
+    // $FlowFixMe: `ace` is defined by external import
     ace.config.set('basePath', 'path');
+    /* eslint-enable no-undef */
   });
   const SimpleQueryInput = (props) => (
     <QueryInput value="*"

--- a/graylog2-web-interface/src/views/components/searchbar/QueryInput.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/QueryInput.test.jsx
@@ -19,6 +19,10 @@ class Completer {
 }
 
 describe('QueryInput', () => {
+  beforeAll(() => {
+    // eslint-disable-next-line no-undef
+    ace.config.set('basePath', 'path');
+  });
   const SimpleQueryInput = (props) => (
     <QueryInput value="*"
                 onChange={(s) => Promise.resolve(s)}

--- a/graylog2-web-interface/src/views/spec/CreateNewDashboard.test.jsx
+++ b/graylog2-web-interface/src/views/spec/CreateNewDashboard.test.jsx
@@ -51,6 +51,7 @@ jest.mock('stores/sessions/SessionStore', () => ({
   isLoggedIn: jest.fn(() => true),
   getSessionId: jest.fn(() => 'foobar'),
 }));
+jest.mock('views/components/searchbar/QueryInput', () => () => <span>Query Editor</span>);
 
 jest.unmock('logic/rest/FetchProvider');
 

--- a/graylog2-web-interface/test/console-warnings-fail-tests.js
+++ b/graylog2-web-interface/test/console-warnings-fail-tests.js
@@ -2,8 +2,8 @@
 import { format } from 'util';
 import { DEPRECATION_NOTICE } from 'util/deprecationNotice';
 
-const oldConsoleWarn = console.warn;
-const oldConsoleError = console.error;
+console.origWarn = console.warn;
+console.origError = console.error;
 
 const ignoredWarnings = [
   'react-async-component-lifecycle-hooks',
@@ -11,18 +11,18 @@ const ignoredWarnings = [
   DEPRECATION_NOTICE,
 ];
 
-const ignoreWarning = args => (!args[0] || ignoredWarnings.filter(warning => args[0].includes(warning)).length > 0);
+const ignoreWarning = (args) => (!args[0] || ignoredWarnings.filter((warning) => args[0].includes(warning)).length > 0);
 
 console.warn = jest.fn((...args) => {
   if (!ignoreWarning(args)) {
     throw new Error(format(...args));
   }
-  oldConsoleWarn(...args);
+  console.origWarn(...args);
 });
 
 console.error = jest.fn((...args) => {
   if (!ignoreWarning(args)) {
     throw new Error(format(...args));
   }
-  oldConsoleError(...args);
+  console.origError(...args);
 });

--- a/graylog2-web-interface/test/console-warnings-fail-tests.test.js
+++ b/graylog2-web-interface/test/console-warnings-fail-tests.test.js
@@ -9,17 +9,15 @@ describe('console-warnings-fail-tests', () => {
   let oldConsoleWarn;
   let oldConsoleError;
   beforeAll(() => {
-    oldConsoleWarn = console.warn;
-    oldConsoleError = console.error;
-    console.warn = () => {};
-    console.error = () => {};
-    // eslint-disable-next-line no-unused-vars, global-require
-    const unused = require('./console-warnings-fail-tests');
+    oldConsoleWarn = console.origWarn;
+    oldConsoleError = console.origError;
+    console.origWarn = () => {};
+    console.origError = () => {};
   });
 
   afterAll(() => {
-    console.warn = oldConsoleWarn;
-    console.error = oldConsoleError;
+    console.origWarn = oldConsoleWarn;
+    console.origError = oldConsoleError;
   });
   describe('console.error', () => {
     it('throws error if used', () => {

--- a/graylog2-web-interface/test/setup-jest.js
+++ b/graylog2-web-interface/test/setup-jest.js
@@ -1,5 +1,6 @@
 import jQuery from 'jquery';
 import registerBuiltinStores from 'injection/registerBuiltinStores';
+import './console-warnings-fail-tests';
 
 global.$ = jQuery;
 global.jQuery = jQuery;

--- a/graylog2-web-interface/test/setup-jest.js
+++ b/graylog2-web-interface/test/setup-jest.js
@@ -1,6 +1,5 @@
 import jQuery from 'jquery';
 import registerBuiltinStores from 'injection/registerBuiltinStores';
-import './console-warnings-fail-tests';
 
 global.$ = jQuery;
 global.jQuery = jQuery;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #7524 the logic that manages `console.error/warn` functions and wraps
them in functions turning non-ignored logs into test failures was
extracted into a module, but unfortunately not wired for testing, so it
was ineffective.

This PR is turning this back on and fixes the causes for test failures
related to this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.