### PR TITLE
Show view type specific description for dashboard and saved searches share modal.

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/BootstrapModalConfirm.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/BootstrapModalConfirm.jsx
@@ -13,7 +13,10 @@ class BootstrapModalConfirm extends React.Component {
     /** Indicates whether the modal should be shown by default or not. */
     showModal: PropTypes.bool,
     /** Title to use in the modal. */
-    title: PropTypes.string.isRequired,
+    title: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.element,
+    ]).isRequired,
     /** Text to use in the cancel button. */
     cancelButtonText: PropTypes.string,
     /** Text to use in the confirmation button. */

--- a/graylog2-web-interface/src/views/components/ViewTypeLabel.js
+++ b/graylog2-web-interface/src/views/components/ViewTypeLabel.js
@@ -1,0 +1,26 @@
+// @flow strict
+import PropTypes from 'prop-types';
+import type { ViewType } from 'views/logic/views/View';
+
+type Props = {
+  type: ViewType,
+  capitalize: boolean
+}
+
+const capitalizeLabel = (label) => label[0].toUpperCase() + label.slice(1);
+
+const ViewTypeLabel = ({ type, capitalize }: Props) => {
+  const typeLabel = type.toLowerCase();
+  return capitalize ? capitalizeLabel(typeLabel) : typeLabel;
+};
+
+ViewTypeLabel.propTypes = {
+  type: PropTypes.string.isRequired,
+  capitalize: PropTypes.bool,
+};
+
+ViewTypeLabel.defaultProps = {
+  capitalize: false,
+};
+
+export default ViewTypeLabel;

--- a/graylog2-web-interface/src/views/components/ViewTypeLabel.test.jsx
+++ b/graylog2-web-interface/src/views/components/ViewTypeLabel.test.jsx
@@ -1,0 +1,22 @@
+// @flow strict
+import React from 'react';
+import { cleanup, render } from 'wrappedTestingLibrary';
+import View from 'views/logic/views/View';
+import ViewTypeLabel from './ViewTypeLabel';
+
+describe('ViewTypeLabel', () => {
+  afterEach(cleanup);
+  it('should create correct label for view type search', () => {
+    const { getByText } = render(<ViewTypeLabel type={View.Type.Search} />);
+    expect(getByText('search')).not.toBe(null);
+  });
+  afterEach(cleanup);
+  it('should create correct label for view type dasboard', () => {
+    const { getByText } = render(<ViewTypeLabel type={View.Type.Dashboard} />);
+    expect(getByText('dashboard')).not.toBe(null);
+  });
+  it('should create capitalized label', () => {
+    const { getByText } = render(<ViewTypeLabel type={View.Type.Search} capitalize />);
+    expect(getByText('Search')).not.toBe(null);
+  });
+});

--- a/graylog2-web-interface/src/views/components/views/ShareViewModal.jsx
+++ b/graylog2-web-interface/src/views/components/views/ShareViewModal.jsx
@@ -6,6 +6,7 @@ import { FormGroup, HelpBlock, Radio } from 'components/graylog';
 import BootstrapModalConfirm from 'components/bootstrap/BootstrapModalConfirm';
 import Select from 'views/components/Select';
 import Spinner from 'components/common/Spinner';
+import ViewTypeLabel from 'views/components/ViewTypeLabel';
 import StoreProvider from 'injection/StoreProvider';
 import connect from 'stores/connect';
 
@@ -132,13 +133,14 @@ class ShareViewModal extends React.Component<Props, State> {
     const userValue = get(viewSharing, 'users', []).map((user) => (userOptions || []).find((option) => option.value === user));
     const rolesOptions = roles ? roles.map((rolename) => ({ value: rolename, label: rolename })) : null;
     const rolesValue = get(viewSharing, 'roles', []).map((role) => ({ label: role, value: role }));
+    const viewTypeLabel = <ViewTypeLabel type={view.type} />;
     const content = !loaded ? <Spinner /> : (
       <FormGroup style={formStyle}>
         <Radio name={AllUsersOfInstance.Type} checked={type === AllUsersOfInstance.Type} onChange={this._onChange}>
           Any user of this Graylog
         </Radio>{' '}
         <Additional>
-          <HelpBlock>Anyone with an account can access the {view.typeLabel}.</HelpBlock>
+          <HelpBlock>Anyone with an account can access the {viewTypeLabel}.</HelpBlock>
         </Additional>
 
         <Radio name={SpecificRoles.Type} checked={type === SpecificRoles.Type} onChange={this._onChange}>
@@ -151,7 +153,7 @@ class ShareViewModal extends React.Component<Props, State> {
                   placeholder="Select roles"
                   onChange={this._onRolesChange}
                   options={rolesOptions} />
-          <HelpBlock>Only users with these roles can access the {view.typeLabel}.</HelpBlock>
+          <HelpBlock>Only users with these roles can access the {viewTypeLabel}.</HelpBlock>
         </Additional>
 
         <Radio name={SpecificUsers.Type} checked={type === SpecificUsers.Type} onChange={this._onChange}>
@@ -164,21 +166,21 @@ class ShareViewModal extends React.Component<Props, State> {
                   placeholder="Select users"
                   onChange={this._onUsersChange}
                   options={userOptions || []} />
-          <HelpBlock>Only these users can access the {view.typeLabel}.</HelpBlock>
+          <HelpBlock>Only these users can access the {viewTypeLabel}.</HelpBlock>
         </Additional>
 
         <Radio name="none" checked={type === 'none'} onChange={this._onChange}>
           Only me
         </Radio>
         <Additional>
-          <HelpBlock>Noone but you can access the {view.typeLabel}.</HelpBlock>
+          <HelpBlock>Noone but you can access the {viewTypeLabel}.</HelpBlock>
         </Additional>
       </FormGroup>
     );
     return (
       <BootstrapModalConfirm onCancel={() => this._onClose()}
                              onConfirm={() => this._onSave()}
-                             title={`Who is supposed to access the ${view.typeLabel} ${view.title}?`}
+                             title={<>Who is supposed to access the {viewTypeLabel} {view.title}</>}
                              confirmButtonText="Save"
                              showModal={show}>
         {content}

--- a/graylog2-web-interface/src/views/components/views/ShareViewModal.jsx
+++ b/graylog2-web-interface/src/views/components/views/ShareViewModal.jsx
@@ -54,12 +54,15 @@ const Additional = ({ children }: { children: React.Node }) => <div style={{ pad
 const extractValue = ({ value }) => value;
 
 class ShareViewModal extends React.Component<Props, State> {
-  state = {
-    viewSharing: null,
-    loaded: false,
-    users: undefined,
-    roles: undefined,
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      viewSharing: null,
+      loaded: false,
+      users: undefined,
+      roles: undefined,
+    };
+  }
 
   componentDidMount() {
     const { view, currentUser } = this.props;
@@ -135,7 +138,7 @@ class ShareViewModal extends React.Component<Props, State> {
           Any user of this Graylog
         </Radio>{' '}
         <Additional>
-          <HelpBlock>Anyone with an account can access the dashboard.</HelpBlock>
+          <HelpBlock>Anyone with an account can access the {view.typeLabel}.</HelpBlock>
         </Additional>
 
         <Radio name={SpecificRoles.Type} checked={type === SpecificRoles.Type} onChange={this._onChange}>
@@ -148,7 +151,7 @@ class ShareViewModal extends React.Component<Props, State> {
                   placeholder="Select roles"
                   onChange={this._onRolesChange}
                   options={rolesOptions} />
-          <HelpBlock>Only users with these roles can access the dashboard.</HelpBlock>
+          <HelpBlock>Only users with these roles can access the {view.typeLabel}.</HelpBlock>
         </Additional>
 
         <Radio name={SpecificUsers.Type} checked={type === SpecificUsers.Type} onChange={this._onChange}>
@@ -161,21 +164,21 @@ class ShareViewModal extends React.Component<Props, State> {
                   placeholder="Select users"
                   onChange={this._onUsersChange}
                   options={userOptions || []} />
-          <HelpBlock>Only these users can access the dashboard.</HelpBlock>
+          <HelpBlock>Only these users can access the {view.typeLabel}.</HelpBlock>
         </Additional>
 
         <Radio name="none" checked={type === 'none'} onChange={this._onChange}>
           Only me
         </Radio>
         <Additional>
-          <HelpBlock>Noone but you can access the dashboard.</HelpBlock>
+          <HelpBlock>Noone but you can access the {view.typeLabel}.</HelpBlock>
         </Additional>
       </FormGroup>
     );
     return (
       <BootstrapModalConfirm onCancel={() => this._onClose()}
                              onConfirm={() => this._onSave()}
-                             title={`Who is supposed to access the dashboard ${view.title}?`}
+                             title={`Who is supposed to access the ${view.typeLabel} ${view.title}?`}
                              confirmButtonText="Save"
                              showModal={show}>
         {content}

--- a/graylog2-web-interface/src/views/components/views/ShareViewModal.test.jsx
+++ b/graylog2-web-interface/src/views/components/views/ShareViewModal.test.jsx
@@ -125,4 +125,13 @@ describe('ShareViewModal', () => {
       done();
     });
   });
+  it('displays correct description if view is a search', () => {
+    const wrapper = mount(<ShareViewModal show view={view} currentUser={currentUser} onClose={onClose} />);
+    expect(wrapper.contains('Who is supposed to access the search My fabulous view?')).toBe(true);
+  });
+  it('displays correct description if view is a dashboard', () => {
+    const dashboardView = view.toBuilder().type(View.Type.Dashboard).build();
+    const wrapper = mount(<ShareViewModal show view={dashboardView} currentUser={currentUser} onClose={onClose} />);
+    expect(wrapper.contains('Who is supposed to access the dashboard My fabulous view?')).toBe(true);
+  });
 });

--- a/graylog2-web-interface/src/views/components/views/ShareViewModal.test.jsx
+++ b/graylog2-web-interface/src/views/components/views/ShareViewModal.test.jsx
@@ -127,11 +127,11 @@ describe('ShareViewModal', () => {
   });
   it('displays correct description if view is a search', () => {
     const wrapper = mount(<ShareViewModal show view={view} currentUser={currentUser} onClose={onClose} />);
-    expect(wrapper.contains('Who is supposed to access the search My fabulous view?')).toBe(true);
+    expect(wrapper.contains(/'Who is supposed to access the search My fabulous view?'/)).toBe(true);
   });
   it('displays correct description if view is a dashboard', () => {
     const dashboardView = view.toBuilder().type(View.Type.Dashboard).build();
     const wrapper = mount(<ShareViewModal show view={dashboardView} currentUser={currentUser} onClose={onClose} />);
-    expect(wrapper.contains('Who is supposed to access the dashboard My fabulous view?')).toBe(true);
+    expect(wrapper.contains(/'Who is supposed to access the dashboard My fabulous view?'/)).toBe(true);
   });
 });

--- a/graylog2-web-interface/src/views/components/views/ShareViewModal.test.jsx
+++ b/graylog2-web-interface/src/views/components/views/ShareViewModal.test.jsx
@@ -37,7 +37,11 @@ jest.mock('views/stores/ViewSharingStore', () => ({
 }));
 
 describe('ShareViewModal', () => {
-  const view = View.builder().id('deadbeef').title('My fabulous view').build();
+  const view = View.builder()
+    .id('deadbeef')
+    .title('My fabulous view')
+    .type(View.Type.Search)
+    .build();
   const currentUser = { roles: [], permissions: [] };
   const onClose = jest.fn();
 

--- a/graylog2-web-interface/src/views/logic/views/View.js
+++ b/graylog2-web-interface/src/views/logic/views/View.js
@@ -96,10 +96,6 @@ export default class View {
     return this._value.type;
   }
 
-  get typeLabel(): string {
-    return this._value.type.toLowerCase();
-  }
-
   get title(): string {
     return this._value.title;
   }

--- a/graylog2-web-interface/src/views/logic/views/View.js
+++ b/graylog2-web-interface/src/views/logic/views/View.js
@@ -96,6 +96,10 @@ export default class View {
     return this._value.type;
   }
 
+  get typeLabel(): string {
+    return this._value.type.toLowerCase();
+  }
+
   get title(): string {
     return this._value.title;
   }


### PR DESCRIPTION
As described in https://github.com/Graylog2/graylog2-server/issues/7773 the saved search modal displays a dashboard specific description. This PR adds `typeLabel` method for the view class, which can be used wherever we need to display the name of the view type.

Fixes: https://github.com/Graylog2/graylog2-server/issues/7773

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

