### PR TITLE
Allow dashboard creation only permitted users

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
@@ -158,8 +158,6 @@ public class ViewsResource extends RestResource implements PluginRestResource {
     public ViewDTO create(@ApiParam @Valid ViewDTO dto) throws ValidationException {
         if (dto.type().equals(ViewDTO.Type.DASHBOARD)) {
             checkPermission(RestPermissions.DASHBOARDS_CREATE);
-        } else {
-            checkPermission(ViewsRestPermissions.VIEW_EDIT);
         }
         final String username = getCurrentUser() == null ? null : getCurrentUser().getName();
         final ViewDTO savedDto = dbService.save(dto.toBuilder().owner(username).build());

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
@@ -156,6 +156,11 @@ public class ViewsResource extends RestResource implements PluginRestResource {
     @ApiOperation("Create a new view")
     @AuditEvent(type = ViewsAuditEventTypes.VIEW_CREATE)
     public ViewDTO create(@ApiParam @Valid ViewDTO dto) throws ValidationException {
+        if (dto.type().equals(ViewDTO.Type.DASHBOARD)) {
+            checkPermission(RestPermissions.DASHBOARDS_CREATE);
+        } else {
+            checkPermission(ViewsRestPermissions.VIEW_EDIT);
+        }
         final String username = getCurrentUser() == null ? null : getCurrentUser().getName();
         final ViewDTO savedDto = dbService.save(dto.toBuilder().owner(username).build());
         ensureUserPermissions(savedDto);

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewsResourceTest.java
@@ -132,7 +132,6 @@ public class ViewsResourceTest {
 
     @Test
     public void invalidObjectIdReturnsViewNotFoundException() {
-        GuiceInjectorHolder.createInjector(Collections.emptyList());
         expectedException.expect(NotFoundException.class);
         this.viewsResource.get("invalid");
     }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewsResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewsResourceTest.java
@@ -131,16 +131,6 @@ public class ViewsResourceTest {
     }
 
     @Test
-    public void shouldNotCreateASearchWithoutPermission() throws Exception {
-        when(view.type()).thenReturn(ViewDTO.Type.SEARCH);
-
-        when(subject.isPermitted("views:edit")).thenReturn(false);
-
-        assertThatThrownBy(() -> this.viewsResource.create(view))
-                .isInstanceOf(ForbiddenException.class);
-    }
-
-    @Test
     public void invalidObjectIdReturnsViewNotFoundException() {
         GuiceInjectorHolder.createInjector(Collections.emptyList());
         expectedException.expect(NotFoundException.class);

--- a/graylog2-web-interface/src/views/pages/DashboardsPage.jsx
+++ b/graylog2-web-interface/src/views/pages/DashboardsPage.jsx
@@ -5,7 +5,7 @@ import { LinkContainer } from 'react-router-bootstrap';
 
 import { Col, Row, Button } from 'components/graylog';
 import connect from 'stores/connect';
-import { DocumentTitle, PageHeader } from 'components/common/index';
+import { DocumentTitle, PageHeader, IfPermitted } from 'components/common/index';
 import Routes from 'routing/Routes';
 
 import DocumentationLink from 'components/support/DocumentationLink';
@@ -50,11 +50,13 @@ const DashboardsPage = ({ dashboards: { list, pagination } }: Props) => {
             for lots of other useful tips.
           </span>
 
-          <span>
-            <LinkContainer to={Routes.pluginRoute('DASHBOARDS_NEW')}>
-              <Button bsStyle="success" bsSize="lg">Create new dashboard</Button>
-            </LinkContainer>
-          </span>
+          <IfPermitted permissions="dashboards:create">
+            <span>
+              <LinkContainer to={Routes.pluginRoute('DASHBOARDS_NEW')}>
+                <Button bsStyle="success" bsSize="lg">Create new dashboard</Button>
+              </LinkContainer>
+            </span>
+          </IfPermitted>
         </PageHeader>
 
         <Row className="content">

--- a/graylog2-web-interface/src/views/pages/NewDashboardPage.jsx
+++ b/graylog2-web-interface/src/views/pages/NewDashboardPage.jsx
@@ -58,7 +58,7 @@ const NewDashboardPage = ({ route, location, loadingViewHooks, executingViewHook
   }
 
   return loaded
-    ? <IfPermitted permissions="dashboards.create"><ExtendedSearchPage route={route} /></IfPermitted>
+    ? <IfPermitted permissions="dashboards:create"><ExtendedSearchPage route={route} /></IfPermitted>
     : <Spinner />;
 };
 

--- a/graylog2-web-interface/src/views/pages/NewDashboardPage.jsx
+++ b/graylog2-web-interface/src/views/pages/NewDashboardPage.jsx
@@ -11,6 +11,7 @@ import { ViewActions } from 'views/stores/ViewStore';
 import View from 'views/logic/views/View';
 import type { ViewJson } from 'views/logic/views/View';
 import { ExtendedSearchPage } from 'views/pages';
+import { IfPermitted } from 'components/common';
 
 type Props = {
   route: {},
@@ -57,7 +58,7 @@ const NewDashboardPage = ({ route, location, loadingViewHooks, executingViewHook
   }
 
   return loaded
-    ? <ExtendedSearchPage route={route} />
+    ? <IfPermitted permissions="dashboards.create"><ExtendedSearchPage route={route} /></IfPermitted>
     : <Spinner />;
 };
 

--- a/graylog2-web-interface/src/views/pages/NewDashboardPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/NewDashboardPage.test.jsx
@@ -13,6 +13,9 @@ import View from 'views/logic/views/View';
 import NewDashboardPage from './NewDashboardPage';
 
 jest.mock('./ExtendedSearchPage', () => () => <div>Extended search page</div>);
+jest.mock('components/common', () => ({
+  IfPermitted: jest.fn(({ children }) => <>{children}</>),
+}));
 jest.mock('views/stores/ViewStore', () => ({
   ViewActions: { create: jest.fn(() => Promise.resolve()), load: jest.fn(() => Promise.resolve()) },
 }));

--- a/graylog2-web-interface/src/views/spec/CreateNewDashboard.test.jsx
+++ b/graylog2-web-interface/src/views/spec/CreateNewDashboard.test.jsx
@@ -36,7 +36,7 @@ jest.mock('stores/users/CurrentUserStore', () => MockStore(
     currentUser: {
       full_name: 'Betty Holberton',
       username: 'betty',
-      permissions: [],
+      permissions: ['dashboards:create'],
     },
   })],
 ));


### PR DESCRIPTION
## Motivation and Context
Before this PR, a user with only stream reading permissions
was able to create a dashboard by clicking on the displayed
dashboard button.

## Description
With this change, we restrict the creation of dashboards
on the backend and hide the dashboard create button
if the user does not have the needed permissions.
Additionally we only render the dashboards/new page
if the user has the needed permissions.

Fixes #7729 