### PR TITLE
Extract interface of input status service

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/PersistenceServicesBindings.java
@@ -31,16 +31,17 @@ import org.graylog2.indexer.ranges.MongoIndexRangeService;
 import org.graylog2.inputs.InputService;
 import org.graylog2.inputs.InputServiceImpl;
 import org.graylog2.inputs.persistence.InputStatusService;
+import org.graylog2.inputs.persistence.MongoInputStatusService;
 import org.graylog2.notifications.NotificationService;
 import org.graylog2.notifications.NotificationServiceImpl;
 import org.graylog2.savedsearches.SavedSearchService;
 import org.graylog2.savedsearches.SavedSearchServiceImpl;
 import org.graylog2.security.AccessTokenService;
+import org.graylog2.security.AccessTokenServiceImpl;
 import org.graylog2.security.MongoDBSessionService;
 import org.graylog2.security.MongoDBSessionServiceImpl;
 import org.graylog2.security.ldap.LdapSettingsService;
 import org.graylog2.security.ldap.LdapSettingsServiceImpl;
-import org.graylog2.security.AccessTokenServiceImpl;
 import org.graylog2.shared.users.UserService;
 import org.graylog2.streams.StreamRuleService;
 import org.graylog2.streams.StreamRuleServiceImpl;
@@ -69,6 +70,6 @@ public class PersistenceServicesBindings extends AbstractModule {
         bind(SavedSearchService.class).to(SavedSearchServiceImpl.class);
         bind(LdapSettingsService.class).to(LdapSettingsServiceImpl.class);
         bind(MongoDBSessionService.class).to(MongoDBSessionServiceImpl.class);
-        bind(InputStatusService.class).asEagerSingleton();
+        bind(InputStatusService.class).to(MongoInputStatusService.class).asEagerSingleton();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/persistence/InputStatusService.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/persistence/InputStatusService.java
@@ -1,111 +1,32 @@
-/**
- * This file is part of Graylog.
- *
- * Graylog is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * Graylog is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
- */
 package org.graylog2.inputs.persistence;
 
-import com.google.common.eventbus.EventBus;
-import com.mongodb.DB;
-import com.mongodb.DBCollection;
-import org.apache.shiro.event.Subscribe;
-import org.bson.types.ObjectId;
-import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
-import org.graylog2.database.MongoConnection;
-import org.graylog2.rest.models.system.inputs.responses.InputDeleted;
-import org.mongojack.JacksonDBCollection;
-import org.mongojack.WriteResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import java.util.Optional;
 
 /**
- * This is a simple wrapper around MongoDB to allow storage of state data for stateful Inputs.
- *
- * Inputs using this service are responsible for defining their own model for InputStatusRecord.inputStateData
+ * Provides CRUD operations for input status records.
  */
-@Singleton
-public class InputStatusService {
-    private static final Logger LOG = LoggerFactory.getLogger(InputStatusService.class);
-
-    public static final String COLLECTION_NAME = "input_status";
-
-    private final JacksonDBCollection<InputStatusRecord, ObjectId> statusCollection;
-
-    @Inject
-    public InputStatusService(MongoConnection mongoConnection,
-                              MongoJackObjectMapperProvider objectMapperProvider,
-                              EventBus eventBus) {
-        DB mongoDatabase = mongoConnection.getDatabase();
-        DBCollection collection = mongoDatabase.getCollection(COLLECTION_NAME);
-
-        eventBus.register(this);
-
-        statusCollection = JacksonDBCollection.wrap(
-                collection,
-                InputStatusRecord.class,
-                ObjectId.class,
-                objectMapperProvider.get());
-    }
-
+public interface InputStatusService {
     /**
-     * Get the status record for an Input from the DB.
+     * Get the saved status record for an Input.
      *
      * @param inputId ID of the input whose status you want to get
      * @return The InputStatusRecord for the given Input ID if it exists; otherwise an empty Optional.
      */
-    public Optional<InputStatusRecord> get(final String inputId) {
-        return Optional.ofNullable(statusCollection.findOneById(new ObjectId(inputId)));
-    }
+    Optional<InputStatusRecord> get(String inputId);
 
     /**
-     * Save the status record for an Input status to the DB.
+     * Save the status record for an Input.
      *
      * @param statusRecord The Input status record to save
      * @return A copy of the saved object
      */
-    public InputStatusRecord save(InputStatusRecord statusRecord) {
-        WriteResult save = statusCollection.save(statusRecord);
-        return (InputStatusRecord) save.getSavedObject();
-    }
+    InputStatusRecord save(InputStatusRecord statusRecord);
 
     /**
-     * Remove the status record from the DB for a given Input
+     * Remove the status record for a given Input
      *
      * @param inputId ID of the input whose status you want to delete
      * @return The count of deleted objects (should be 0 or 1)
      */
-    public int delete(String inputId) {
-        WriteResult delete = statusCollection.removeById(new ObjectId(inputId));
-        return delete.getN();
-    }
-
-    /**
-     * Clean up MongoDB records when Inputs are deleted
-     *
-     * At the moment, Graylog uses the InputDeleted event both when an Input is stopped
-     * and when it is deleted.
-     *
-     * @param event ID of the input being deleted
-     */
-    @Subscribe
-    public void handleInputDeleted(InputDeleted event) {
-        LOG.debug("Input Deleted event received for Input [{}]", event.id());
-        // TODO: Pending issue #7812
-        // delete(event.id());
-    }
+    int delete(String inputId);
 }

--- a/graylog2-server/src/main/java/org/graylog2/inputs/persistence/InputStatusService.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/persistence/InputStatusService.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.inputs.persistence;
 
 import java.util.Optional;

--- a/graylog2-server/src/main/java/org/graylog2/inputs/persistence/MongoInputStatusService.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/persistence/MongoInputStatusService.java
@@ -1,0 +1,96 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.inputs.persistence;
+
+import com.google.common.eventbus.EventBus;
+import com.mongodb.DB;
+import com.mongodb.DBCollection;
+import org.apache.shiro.event.Subscribe;
+import org.bson.types.ObjectId;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.rest.models.system.inputs.responses.InputDeleted;
+import org.mongojack.JacksonDBCollection;
+import org.mongojack.WriteResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.util.Optional;
+
+/**
+ * This is a simple wrapper around MongoDB to allow storage of state data for stateful Inputs.
+ *
+ * Inputs using this service are responsible for defining their own model for InputStatusRecord.inputStateData
+ */
+@Singleton
+public class MongoInputStatusService implements InputStatusService {
+    private static final Logger LOG = LoggerFactory.getLogger(MongoInputStatusService.class);
+
+    public static final String COLLECTION_NAME = "input_status";
+
+    private final JacksonDBCollection<InputStatusRecord, ObjectId> statusCollection;
+
+    @Inject
+    public MongoInputStatusService(MongoConnection mongoConnection,
+                              MongoJackObjectMapperProvider objectMapperProvider,
+                              EventBus eventBus) {
+        DB mongoDatabase = mongoConnection.getDatabase();
+        DBCollection collection = mongoDatabase.getCollection(COLLECTION_NAME);
+
+        eventBus.register(this);
+
+        statusCollection = JacksonDBCollection.wrap(
+                collection,
+                InputStatusRecord.class,
+                ObjectId.class,
+                objectMapperProvider.get());
+    }
+
+    @Override
+    public Optional<InputStatusRecord> get(final String inputId) {
+        return Optional.ofNullable(statusCollection.findOneById(new ObjectId(inputId)));
+    }
+
+    @Override
+    public InputStatusRecord save(InputStatusRecord statusRecord) {
+        WriteResult save = statusCollection.save(statusRecord);
+        return (InputStatusRecord) save.getSavedObject();
+    }
+
+    @Override
+    public int delete(String inputId) {
+        WriteResult delete = statusCollection.removeById(new ObjectId(inputId));
+        return delete.getN();
+    }
+
+    /**
+     * Clean up MongoDB records when Inputs are deleted
+     *
+     * At the moment, Graylog uses the InputDeleted event both when an Input is stopped
+     * and when it is deleted.
+     *
+     * @param event ID of the input being deleted
+     */
+    @Subscribe
+    public void handleInputDeleted(InputDeleted event) {
+        LOG.debug("Input Deleted event received for Input [{}]", event.id());
+        // TODO: Pending issue #7812
+        // delete(event.id());
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/inputs/persistence/MongoInputStatusServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/persistence/MongoInputStatusServiceTest.java
@@ -40,7 +40,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 
-public class InputStatusServiceTest {
+public class MongoInputStatusServiceTest {
     @Rule
     public final MongoDBInstance mongodb = MongoDBInstance.createForClass();
 
@@ -48,7 +48,7 @@ public class InputStatusServiceTest {
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
     // Code Under Test
-    private InputStatusService cut;
+    private MongoInputStatusService cut;
 
     @Mock
     EventBus mockEventBus;
@@ -60,9 +60,9 @@ public class InputStatusServiceTest {
         final ObjectMapper objectMapper = new ObjectMapperProvider().get();
         final MongoJackObjectMapperProvider mapperProvider = new MongoJackObjectMapperProvider(objectMapper);
 
-        cut = new InputStatusService(mongodb.mongoConnection(), mapperProvider, mockEventBus);
+        cut = new MongoInputStatusService(mongodb.mongoConnection(), mapperProvider, mockEventBus);
 
-        db = JacksonDBCollection.wrap(mongodb.mongoConnection().getDatabase().getCollection(InputStatusService.COLLECTION_NAME),
+        db = JacksonDBCollection.wrap(mongodb.mongoConnection().getDatabase().getCollection(MongoInputStatusService.COLLECTION_NAME),
                 InputStatusRecord.class,
                 ObjectId.class,
                 mapperProvider.get());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Extracted `InputStatusService` as an interface and renamed the implementation to `MongoInputStatusService`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
By extracting the interface of the input status service, we can bind a default implementation but provide the possibility to bind an alternative implementation in a different context.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The service is not used yet. Temporarily modified another service to have the InputStatusService injected and made sure that the server did still start.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

