### PR TITLE
Replace mutating state inline in stores with new object creation.

### DIFF
--- a/graylog2-web-interface/src/stores/indices/IndicesStore.js
+++ b/graylog2-web-interface/src/stores/indices/IndicesStore.js
@@ -47,13 +47,7 @@ const IndicesStore = Reflux.createStore({
     const urlList = URLUtils.qualifyUrl(ApiRoutes.IndicesApiController.multiple().url);
     const request = { indices: indexNames };
     const promise = fetch('POST', urlList, request).then((response) => {
-      if (!this.indices) {
-        this.indices = response;
-      } else {
-        Object.keys(response).forEach((indexName) => {
-          this.indices[indexName] = response[indexName];
-        });
-      }
+      this.indices = { ...this.indices, ...response };
       this.trigger({ indices: this.indices, closedIndices: this.closedIndices });
       return { indices: this.indices, closedIndices: this.closedIndices };
     });

--- a/graylog2-web-interface/src/stores/nodes/NodesStore.js
+++ b/graylog2-web-interface/src/stores/nodes/NodesStore.js
@@ -1,5 +1,6 @@
+// @flow strict
 import Reflux from 'reflux';
-import URLUtils from 'util/URLUtils';
+import { qualifyUrl } from 'util/URLUtils';
 import { fetchPeriodically } from 'logic/rest/FetchProvider';
 
 import ApiRoutes from 'routing/ApiRoutes';
@@ -7,6 +8,22 @@ import CombinedProvider from 'injection/CombinedProvider';
 
 const { NodesActions } = CombinedProvider.get('Nodes');
 const { SessionStore } = CombinedProvider.get('Session');
+
+type NodeInfo = {
+  cluster_id: string,
+  hostname: string,
+  is_master: boolean,
+  last_seen: string,
+  node_id: string,
+  short_node_id: string,
+  transport_address: string,
+  type: 'server',
+};
+
+type NodesListResponse = {
+  nodes: ?Array<NodeInfo>,
+  total: number,
+};
 
 const NodesStore = Reflux.createStore({
   listenables: [NodesActions],
@@ -38,13 +55,11 @@ const NodesStore = Reflux.createStore({
   },
 
   list() {
-    const promise = this.promises.list || fetchPeriodically('GET', URLUtils.qualifyUrl(ApiRoutes.ClusterApiResource.list().url))
-      .then((response) => {
+    const promise = this.promises.list || fetchPeriodically('GET', qualifyUrl(ApiRoutes.ClusterApiResource.list().url))
+      .then((response: NodesListResponse) => {
         this.nodes = {};
         if (response.nodes) {
-          response.nodes.forEach((node) => {
-            this.nodes[node.node_id] = node;
-          });
+          this.nodes = Object.fromEntries(response.nodes.map((node) => [node.node_id, node]));
           this.clusterId = this._clusterId();
           this.nodeCount = this._nodeCount();
           this._propagateState();

--- a/graylog2-web-interface/src/stores/systemjobs/SystemJobsStore.js
+++ b/graylog2-web-interface/src/stores/systemjobs/SystemJobsStore.js
@@ -29,13 +29,14 @@ const SystemJobsStore = Reflux.createStore({
   getJob(jobId) {
     const url = URLUtils.qualifyUrl(ApiRoutes.SystemJobsApiController.getJob(jobId).url);
     const promise = fetch('GET', url).then((response) => {
-      this.jobsById[response.id] = response;
+      this.jobsById = { ...this.jobsById, [response.id]: response };
       this.trigger({ jobsById: this.jobsById });
 
       return response;
     }, () => {
       // If we get an error (probably 404 because the job is gone), remove the job from the cache and trigger an update.
-      delete (this.jobsById[jobId]);
+      const { [jobId]: currentJob, ...rest } = this.jobsById;
+      this.jobsById = rest;
       this.trigger({ jobsById: this.jobsById });
     });
     SystemJobsActions.getJob.promise(promise);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #7671, a `shouldComponentUpdate` function for `connect` was
implemented, that prevents a rerendering of its children when the state
supplied by a store did not change. The implication of this is that a
store should always propagate a new object when its state has changed,
instead of mutating its state inline. In the latter case, the consumer
of the state will hold a reference to the previous state that is the
same as the new state, so it will appear to be equal. When implementing
that PR, a search was performed for patterns where a store was assigning
a new value to an instance variable (anything that looks like
`this(\.\w+)+ = .+;`) and patterns like this were changed to create a
new object that is assigned to the instance variable.

Unfortunately patterns where the bracket notation (e.g. `this.foo[bar] =
42`) were left out, leading to some inline mutations being left in
stores. This PR is addressing these. To find code positions where this
is necessary, a regex search for `this(\.\w+)+\[.+\] =` was performed
and the affected code parts where fixed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.