### PR TITLE
Improving runtime for field type retrieval endpoint.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypesService.java
@@ -61,6 +61,7 @@ public class IndexFieldTypesService {
         )), new BasicDBObject("unique", true));
         this.db.createIndex(new BasicDBObject(IndexFieldTypesDTO.FIELD_INDEX_NAME, 1), new BasicDBObject("unique", true));
         this.db.createIndex(new BasicDBObject(FIELDS_FIELD_NAMES, 1));
+        this.db.createIndex(new BasicDBObject(IndexFieldTypesDTO.FIELD_INDEX_SET_ID, 1));
     }
 
     public Optional<IndexFieldTypesDTO> get(String idOrIndexName) {
@@ -110,11 +111,10 @@ public class IndexFieldTypesService {
         return findByQuery(DBQuery.is(IndexFieldTypesDTO.FIELD_INDEX_SET_ID, indexSetId));
     }
 
-    private Collection<IndexFieldTypesDTO> findForIndexSets(Collection<String> indexSetIds) {
-        return findByQuery(DBQuery.or(
-                indexSetIds.stream().map(indexSetId -> DBQuery.is(IndexFieldTypesDTO.FIELD_INDEX_SET_ID, indexSetId))
-                .toArray(DBQuery.Query[]::new)
-        ));
+    public Collection<IndexFieldTypesDTO> findForIndexSets(Collection<String> indexSetIds) {
+        return findByQuery(
+                DBQuery.in(IndexFieldTypesDTO.FIELD_INDEX_SET_ID, indexSetIds)
+        );
     }
 
     public Collection<IndexFieldTypesDTO> findForFieldNames(Collection<String> fieldNames) {

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamService.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamService.java
@@ -48,6 +48,8 @@ public interface StreamService extends PersistedService {
 
     Set<Stream> loadByIds(Collection<String> streamIds);
 
+    Set<String> indexSetIdsByIds(Collection<String> streamIds);
+
     List<Stream> loadAllEnabled();
 
     /**

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
@@ -52,6 +52,7 @@ import org.graylog2.plugin.streams.StreamRule;
 import org.graylog2.rest.resources.streams.requests.CreateStreamRequest;
 import org.graylog2.streams.events.StreamDeletedEvent;
 import org.graylog2.streams.events.StreamsChangedEvent;
+import org.mongojack.DBProjection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -219,6 +220,18 @@ public class StreamServiceImpl extends PersistedServiceImpl implements StreamSer
         final DBObject query = QueryBuilder.start("_id").in(objectIds).get();
 
         return ImmutableSet.copyOf(loadAll(query));
+    }
+
+    @Override
+    public Set<String> indexSetIdsByIds(Collection<String> streamIds) {
+        final Set<ObjectId> objectIds = streamIds.stream()
+                .map(ObjectId::new)
+                .collect(Collectors.toSet());
+        final DBObject query = QueryBuilder.start("_id").in(objectIds).get();
+        final DBObject onlyIndexSetIdField = DBProjection.include(StreamImpl.FIELD_INDEX_SET_ID);
+        return StreamSupport.stream(collection(StreamImpl.class).find(query, onlyIndexSetIdField).spliterator(), false)
+                .map(s -> s.get(StreamImpl.FIELD_INDEX_SET_ID).toString())
+                .collect(Collectors.toSet());
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdaterTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/pipelineprocessor/processors/ConfigurationStateUpdaterTest.java
@@ -323,5 +323,11 @@ public class ConfigurationStateUpdaterTest {
                                                             Map<String, Object> fields) {
             throw new IllegalStateException("no implemented");
         }
+
+
+        @Override
+        public Set<String> indexSetIdsByIds(Collection<String> streamIds) {
+            throw new IllegalStateException("not implemented");
+        }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/MappedFieldTypesServiceTest.java
@@ -19,12 +19,10 @@ package org.graylog2.indexer.fieldtypes;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.graylog.plugins.views.search.rest.MappedFieldTypeDTO;
-import org.graylog2.plugin.streams.Stream;
 import org.graylog2.streams.StreamService;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -35,7 +33,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class MappedFieldTypesServiceTest {
@@ -53,10 +50,7 @@ public class MappedFieldTypesServiceTest {
     @Before
     public void setUp() throws Exception {
         this.mappedFieldTypesService = new MappedFieldTypesService(streamService, indexFieldTypesService, new FieldTypeMapper());
-        final Stream stream = mock(Stream.class, Answers.RETURNS_DEEP_STUBS);
-        when(stream.getIndexSet().getConfig().id()).thenReturn("indexSetId");
-        final Set<Stream> streams = Collections.singleton(stream);
-        when(streamService.loadByIds(Collections.singleton("stream1"))).thenReturn(streams);
+        when(streamService.indexSetIdsByIds(Collections.singleton("stream1"))).thenReturn(Collections.singleton("indexSetId"));
     }
 
     @Test
@@ -75,7 +69,7 @@ public class MappedFieldTypesServiceTest {
                         FieldTypeDTO.create("field2", "long")
                 )
         );
-        when(indexFieldTypesService.findForIndexSet("indexSetId")).thenReturn(fieldTypes);
+        when(indexFieldTypesService.findForIndexSets(Collections.singleton("indexSetId"))).thenReturn(fieldTypes);
 
         final Set<MappedFieldTypeDTO> result = this.mappedFieldTypesService.fieldTypesByStreamIds(Collections.singleton("stream1"));
         assertThat(result).containsExactlyInAnyOrder(
@@ -100,7 +94,7 @@ public class MappedFieldTypesServiceTest {
                         FieldTypeDTO.create("field2", "long")
                 )
         );
-        when(indexFieldTypesService.findForIndexSet("indexSetId")).thenReturn(fieldTypes);
+        when(indexFieldTypesService.findForIndexSets(Collections.singleton("indexSetId"))).thenReturn(fieldTypes);
 
         final Set<MappedFieldTypeDTO> result = this.mappedFieldTypesService.fieldTypesByStreamIds(Collections.singleton("stream1"));
         assertThat(result).containsExactlyInAnyOrder(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, the performance of the API endpoint allowing to
retrieve field types for a given set of stream IDs was not ideal. The
reason for this is that it reuses the `StreamService#loadByIds` method,
which always loads the complete streams from Mongo, as well as their
associated stream rules, outputs and index sets. The last two are
fetched using inefficient method chains producing n+1 for both, so the
overall complexity of the call is non-linear.

This PR implements a method on the `StreamService` interface, that
returns a set of index set ids for a given set of stream ids. Fetching
these is done by using an `$in` query returning only the index set id
field, so the query performance should be optimal.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.