### PR TITLE
Removing n+1's in `StreamService#loadAll` by consolidating external loads

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetService.java
@@ -61,6 +61,13 @@ public interface IndexSetService {
     List<IndexSetConfig> findAll();
 
     /**
+     * Retrieve all index sets which match one of the specified IDs.
+     *
+     * @return All index sets matching one of the given IDs.
+     */
+    List<IndexSetConfig> findByIds(Set<String> ids);
+
+    /**
      * Retrieve a paginated set of index set.
      *
      * @param indexSetIds List of inde set ids to return

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/MongoIndexSetService.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/MongoIndexSetService.java
@@ -125,6 +125,11 @@ public class MongoIndexSetService implements IndexSetService {
         return ImmutableList.copyOf((Iterator<? extends IndexSetConfig>) collection.find().sort(DBSort.asc("title")));
     }
 
+    @Override
+    public List<IndexSetConfig> findByIds(Set<String> ids) {
+        return collection.find(DBQuery.in("_id", ids)).toArray();
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/streams/StreamServiceImpl.java
@@ -236,8 +236,8 @@ public class StreamServiceImpl extends PersistedServiceImpl implements StreamSer
         return objectIds == null ? Collections.emptyList() : objectIds;
     }
 
-    private Map<String, IndexSet> indexSetsForStreams(List<DBObject> streamsQuery) {
-        final Set<String> indexSetIds = streamsQuery.stream()
+    private Map<String, IndexSet> indexSetsForStreams(List<DBObject> streams) {
+        final Set<String> indexSetIds = streams.stream()
                 .map(stream -> (String)stream.get(StreamImpl.FIELD_INDEX_SET_ID))
                 .filter(s -> !isNullOrEmpty(s))
                 .collect(Collectors.toSet());


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before this change, calling `StreamService#loadAll` triggered loading of associated outputs and index sets, _both_ resulting in n+1 each.

This change is now placing fetching of outputs and index sets outside the loop iterating over each stream, leaving only simple lookups to be done inside the loop, effectively turning this into a call with a _constant_ number of mongodb queries.

Simple tests on my setup showed an improvement of ~270ms -> ~110ms.  While this is already impressive, I expect a much bigger improvement for setups with a high number of outputs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.