### PR TITLE
Replacing usage of `Object.fromEntries` with `reduce`.

### DIFF
--- a/graylog2-web-interface/src/stores/nodes/NodesStore.js
+++ b/graylog2-web-interface/src/stores/nodes/NodesStore.js
@@ -59,7 +59,9 @@ const NodesStore = Reflux.createStore({
       .then((response: NodesListResponse) => {
         this.nodes = {};
         if (response.nodes) {
-          this.nodes = Object.fromEntries(response.nodes.map((node) => [node.node_id, node]));
+          this.nodes = response.nodes
+            .map((node) => [node.node_id, node])
+            .reduce((prev, [key, value]) => ({ ...prev, [key]: value }), {});
           this.clusterId = this._clusterId();
           this.nodeCount = this._nodeCount();
           this._propagateState();


### PR DESCRIPTION
In #7864 a usage of `Object.fromEntries` was introduced. Unfortunately
this causes tests to fail on node v10. Luckily this was caught by
@linuspahl. My attempts to configure babel to include the required
transforms for this (by setting `{ targets: { node: true } }`) did not
succeed, but cause other errors. Therefore I decided to replace the
usage with a call to `reduce`, which is less readable, but has the same
outcome.