### PR TITLE
Enable/disable auto-completion in query input based on user preference.

### DIFF
--- a/graylog2-web-interface/src/views/components/SearchBar.jsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.jsx
@@ -47,7 +47,12 @@ const defaultOnSubmit = ({ timerange, streams, queryString }, currentQuery: Quer
   return QueriesActions.update(newQuery.id, newQuery);
 };
 
-const SearchBar = ({ availableStreams, config, currentQuery, disableSearch = false, queryFilters, onSubmit = defaultOnSubmit }: Props) => {
+const defaultProps = {
+  disableSearch: false,
+  onSubmit: defaultOnSubmit,
+};
+
+const SearchBar = ({ availableStreams, config, currentQuery, disableSearch = defaultProps.disableSearch, queryFilters, onSubmit = defaultProps.onSubmit }: Props) => {
   if (!currentQuery || !config) {
     return <Spinner />;
   }
@@ -131,10 +136,7 @@ SearchBar.propTypes = {
   onSubmit: PropTypes.func,
 };
 
-SearchBar.defaultProps = {
-  disableSearch: false,
-  onSubmit: defaultOnSubmit,
-};
+SearchBar.defaultProps = defaultProps;
 
 export default connect(
   SearchBar,

--- a/graylog2-web-interface/src/views/components/__snapshots__/WidgetQueryControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/__snapshots__/WidgetQueryControls.test.jsx.snap
@@ -21,21 +21,19 @@ exports[`WidgetQueryControls should do something 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="true"
-              class="DropdownButton__StyledDropdownButton-sc-1343dcx-0 ZNXPm dropdown-toggle btn btn-info"
-              id="timerange-type"
+              class="DropdownButton__StyledDropdownButton-sc-1343dcx-0 hNEGNs dropdown-toggle btn btn-info"
               role="button"
               type="button"
             >
               <svg
                 class="svg-inline--fa fa-clock"
               />
-               
+
               <span
                 class="caret"
               />
             </button>
             <ul
-              aria-labelledby="timerange-type"
               class="dropdown-menu"
               role="menu"
             >
@@ -85,7 +83,7 @@ exports[`WidgetQueryControls should do something 1`] = `
           <div
             class="FormGroup__StyledFormGroup-sc-1wv4cm9-0 ekazNr form-group"
           >
-            
+
             <span>
               <select
                 class="FormControl-sc-1amoaox-0 fcGLmv relative form-control"
@@ -93,11 +91,10 @@ exports[`WidgetQueryControls should do something 1`] = `
                 label=""
                 name="timerange.range"
                 placeholder=""
-                title="Select a relative time range"
                 type="select"
               >
                 <option
-                  value="86400"
+                  value="0"
                 >
                   Search in last day
                 </option>
@@ -107,7 +104,7 @@ exports[`WidgetQueryControls should do something 1`] = `
                   Search in all messages
                 </option>
               </select>
-              
+
             </span>
           </div>
         </div>
@@ -196,7 +193,7 @@ exports[`WidgetQueryControls should do something 1`] = `
           </a>
         </div>
         <button
-          class="Button__StyledButton-c9cbmb-0 jVYrA pull-left search-button-execute btn btn-success"
+          class="Button__StyledButton-c9cbmb-0 gxhWww pull-left search-button-execute btn btn-success"
           title="Perform search"
           type="submit"
         >

--- a/graylog2-web-interface/src/views/components/__snapshots__/WidgetQueryControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/__snapshots__/WidgetQueryControls.test.jsx.snap
@@ -21,19 +21,21 @@ exports[`WidgetQueryControls should do something 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="true"
-              class="DropdownButton__StyledDropdownButton-sc-1343dcx-0 hNEGNs dropdown-toggle btn btn-info"
+              class="DropdownButton__StyledDropdownButton-sc-1343dcx-0 ZNXPm dropdown-toggle btn btn-info"
+              id="timerange-type"
               role="button"
               type="button"
             >
               <svg
                 class="svg-inline--fa fa-clock"
               />
-
+               
               <span
                 class="caret"
               />
             </button>
             <ul
+              aria-labelledby="timerange-type"
               class="dropdown-menu"
               role="menu"
             >
@@ -83,7 +85,7 @@ exports[`WidgetQueryControls should do something 1`] = `
           <div
             class="FormGroup__StyledFormGroup-sc-1wv4cm9-0 ekazNr form-group"
           >
-
+            
             <span>
               <select
                 class="FormControl-sc-1amoaox-0 fcGLmv relative form-control"
@@ -91,10 +93,11 @@ exports[`WidgetQueryControls should do something 1`] = `
                 label=""
                 name="timerange.range"
                 placeholder=""
+                title="Select a relative time range"
                 type="select"
               >
                 <option
-                  value="0"
+                  value="86400"
                 >
                   Search in last day
                 </option>
@@ -104,7 +107,7 @@ exports[`WidgetQueryControls should do something 1`] = `
                   Search in all messages
                 </option>
               </select>
-
+              
             </span>
           </div>
         </div>
@@ -193,7 +196,7 @@ exports[`WidgetQueryControls should do something 1`] = `
           </a>
         </div>
         <button
-          class="Button__StyledButton-c9cbmb-0 gxhWww pull-left search-button-execute btn btn-success"
+          class="Button__StyledButton-c9cbmb-0 jVYrA pull-left search-button-execute btn btn-success"
           title="Perform search"
           type="submit"
         >

--- a/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
@@ -8,15 +8,6 @@ import AceEditor from './queryinput/ace';
 import type { Completer } from './SearchBarAutocompletions';
 import SearchBarAutoCompletions from './SearchBarAutocompletions';
 
-const _placeholderNode = (placeholder) => {
-  const node = document.createElement('div');
-  node.textContent = placeholder;
-  node.className = 'ace_invisible ace_emptyMessage';
-  node.style.padding = '0 9px';
-  node.style.color = '#aaa';
-  return node;
-};
-
 type Props = {|
   disabled: boolean,
   value: string,
@@ -29,13 +20,9 @@ type Props = {|
 |};
 
 type State = {
-  value: string,
-  lastValue: string,
 };
 
 class QueryInput extends Component<Props, State> {
-  isFocussed: boolean;
-
   completer: AutoCompleter;
 
   editor: {
@@ -52,10 +39,6 @@ class QueryInput extends Component<Props, State> {
 
   constructor(props: Props) {
     super(props);
-    this.state = {
-      value: props.value,
-      lastValue: props.value,
-    };
     this.editor = undefined;
     const CompleterClass = props.completerClass;
     const { completers = [] } = props;
@@ -77,107 +60,15 @@ class QueryInput extends Component<Props, State> {
       editor.setFontSize(16);
 
       editor.completers = [this.completer];
-
-      const { value } = this.props;
-      if (!value && !this._placeholderExists(editor)) {
-        this._addPlaceholder(editor);
-      }
     }
   }
-
-  componentWillReceiveProps(nextProps: Props) {
-    const { value } = this.state;
-    if (nextProps.value !== value) {
-      this.setState({ value: nextProps.value, lastValue: nextProps.value });
-    }
-    if (this.editor) {
-      const { editor } = this.editor;
-      if (nextProps.value && this._placeholderExists(editor)) {
-        this._removePlaceholder(editor);
-      }
-
-      if (!nextProps.value && !this.isFocussed && !this._placeholderExists(editor)) {
-        this._addPlaceholder(editor);
-      }
-    }
-  }
-
-  _addPlaceholder = (editor: Editor) => {
-    if (!editor.renderer.emptyMessageNode) {
-      const { placeholder } = this.props;
-      const node = _placeholderNode(placeholder);
-      // eslint-disable-next-line no-param-reassign
-      editor.renderer.emptyMessageNode = node;
-      editor.renderer.scroller.appendChild(node);
-    }
-  };
-
-  _removePlaceholder = (editor: Editor) => {
-    if (editor.renderer.emptyMessageNode) {
-      editor.renderer.scroller.removeChild(editor.renderer.emptyMessageNode);
-      // eslint-disable-next-line no-param-reassign
-      editor.renderer.emptyMessageNode = null;
-    }
-  };
-
-  _placeholderExists = (editor: Editor) => {
-    const { emptyMessageNode } = editor.renderer;
-    return emptyMessageNode !== undefined && emptyMessageNode !== null;
-  };
-
-  _addPlaceholderIfEmptyQuery = () => {
-    const editor = this.editor && this.editor.editor;
-    if (editor) {
-      const shouldShow = !editor.session.getValue().length;
-      if (shouldShow && !this._placeholderExists(editor)) {
-        this._addPlaceholder(editor);
-      }
-    }
-  };
-
-  _removePlaceholderOnFocus = () => {
-    const editor = this.editor && this.editor.editor;
-    if (editor && this._placeholderExists(editor)) {
-      this._removePlaceholder(editor);
-    }
-  };
-
-  _onChange = (newValue: string) => {
-    return new Promise((resolve) => this.setState({ value: newValue }, resolve));
-  };
-
-  _onBlur = () => {
-    this.isFocussed = false;
-    this._addPlaceholderIfEmptyQuery();
-
-    const { onBlur, onChange } = this.props;
-    const { value, lastValue } = this.state;
-    const promise = (value !== lastValue)
-      ? new Promise((resolve) => {
-        this.setState({ lastValue: value }, () => onChange(value).then(resolve));
-      })
-      : Promise.resolve(value);
-
-    return promise.then(onBlur);
-  };
-
-  _onFocus = () => {
-    const { disabled } = this.props;
-    if (!disabled) {
-      this.isFocussed = true;
-      this._removePlaceholderOnFocus();
-    }
-  };
 
   _onExecute = (editor: Editor) => {
-    const { onChange, onExecute } = this.props;
+    const { onExecute, value } = this.props;
     if (editor.completer && editor.completer.popup) {
       editor.completer.popup.hide();
     }
-    const { value } = this.state;
-    new Promise((resolve) => this.setState({ lastValue: value }, resolve))
-      .then(() => onChange(value))
-      .then(onExecute);
+    onExecute(value);
   };
 
   _bindEditor(editor: { editor: Editor }) {
@@ -187,17 +78,16 @@ class QueryInput extends Component<Props, State> {
   }
 
   render() {
-    const { disabled, onBlur, onChange, onExecute, placeholder, value: propsValue, ...rest } = this.props;
-    const { value } = this.state;
+    const { disabled, onBlur, onChange, onExecute, placeholder, value } = this.props;
     return (
       <div className="query" style={{ display: 'flex' }} data-testid="query-input">
         <AceEditor mode="lucene"
+                   disabled={disabled}
                    ref={(editor) => editor && this._bindEditor(editor)}
                    readOnly={disabled}
                    theme="ace-queryinput"
-                   onBlur={this._onBlur}
-                   onChange={this._onChange}
-                   onFocus={this._onFocus}
+                   onBlur={onBlur}
+                   onChange={onChange}
                    value={value}
                    name="QueryEditor"
                    showGutter={false}
@@ -217,7 +107,7 @@ class QueryInput extends Component<Props, State> {
                      height: '34px',
                      width: '100%',
                    }}
-                   {...rest} />
+                   placeholder={placeholder} />
       </div>
     );
   }

--- a/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
@@ -79,7 +79,7 @@ const QueryInput = ({ disabled, onBlur, onChange, onExecute, placeholder, value,
                        height: '34px',
                        width: '100%',
                      }}
-                     placeholder={placeholder}/>
+                     placeholder={placeholder} />
         )}
       </UserPreferencesContext.Consumer>
     </div>

--- a/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
@@ -1,127 +1,104 @@
 // @flow strict
+import * as React from 'react';
+import { useCallback, useMemo } from 'react';
 import withPluginEntities from 'views/logic/withPluginEntities';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
 import type { AutoCompleter, Editor } from './ace-types';
 
 import AceEditor from './queryinput/ace';
-import type { Completer } from './SearchBarAutocompletions';
 import SearchBarAutoCompletions from './SearchBarAutocompletions';
+import type { Completer } from './SearchBarAutocompletions';
 
 type Props = {|
   disabled: boolean,
   value: string,
   completers: Array<Completer>,
-  completerClass?: Class<AutoCompleter>,
+  completerFactory: (Array<Completer>) => AutoCompleter,
   onBlur?: (string) => void,
   onChange: (string) => Promise<string>,
   onExecute: (string) => void,
   placeholder: string,
 |};
 
-type State = {
-};
+const defaultCompleterFactory = (completers) => new SearchBarAutoCompletions(completers);
 
-class QueryInput extends Component<Props, State> {
-  completer: AutoCompleter;
-
-  editor: {
-    editor: Editor,
-  } | typeof undefined;
-
-  static defaultProps = {
-    disabled: false,
-    onBlur: () => {},
-    completerClass: SearchBarAutoCompletions,
-    value: '',
-    placeholder: '',
-  };
-
-  constructor(props: Props) {
-    super(props);
-    this.editor = undefined;
-    const CompleterClass = props.completerClass;
-    const { completers = [] } = props;
-    // $FlowFixMe: tailored for this specific one for now
-    this.completer = new CompleterClass(completers);
-  }
-
-  componentDidMount() {
-    const editor = this.editor && this.editor.editor;
-    if (editor) {
-      editor.commands.addCommand({
-        name: 'Execute',
-        bindKey: { win: 'Enter', mac: 'Enter' },
-        exec: this._onExecute,
-      });
-
-      editor.commands.removeCommands(['indent', 'outdent']);
-
-      editor.setFontSize(16);
-
-      editor.completers = [this.completer];
-    }
-  }
-
-  _onExecute = (editor: Editor) => {
-    const { onExecute, value } = this.props;
+const QueryInput = ({ disabled, onBlur, onChange, onExecute, placeholder, value, completers, completerFactory = defaultCompleterFactory }: Props) => {
+  const completer = useMemo(() => completerFactory(completers), [completerFactory, completers]);
+  const _onExecute = (editor: Editor) => {
     if (editor.completer && editor.completer.popup) {
       editor.completer.popup.hide();
     }
     onExecute(value);
   };
 
-  _bindEditor(editor: { editor: Editor }) {
+  const editorRef = useCallback((node) => {
+    const editor = node && node.editor;
     if (editor) {
-      this.editor = editor;
-    }
-  }
+      editor.commands.addCommand({
+        name: 'Execute',
+        bindKey: { win: 'Enter', mac: 'Enter' },
+        exec: _onExecute,
+      });
 
-  render() {
-    const { disabled, onBlur, onChange, onExecute, placeholder, value } = this.props;
-    return (
-      <div className="query" style={{ display: 'flex' }} data-testid="query-input">
-        <AceEditor mode="lucene"
-                   disabled={disabled}
-                   ref={(editor) => editor && this._bindEditor(editor)}
-                   readOnly={disabled}
-                   theme="ace-queryinput"
-                   onBlur={onBlur}
-                   onChange={onChange}
-                   value={value}
-                   name="QueryEditor"
-                   showGutter={false}
-                   showPrintMargin={false}
-                   highlightActiveLine={false}
-                   minLines={1}
-                   maxLines={1}
-                   enableBasicAutocompletion
-                   enableLiveAutocompletion
-                   editorProps={{
-                     $blockScrolling: Infinity,
-                     selectionStyle: 'line',
-                   }}
-                   fontSize={13}
-                   style={{
-                     marginTop: '9px',
-                     height: '34px',
-                     width: '100%',
-                   }}
-                   placeholder={placeholder} />
-      </div>
-    );
-  }
-}
+      editor.commands.removeCommands(['indent', 'outdent']);
+
+      editor.setFontSize(16);
+
+      editor.completers = [completer];
+    }
+  }, [completer]);
+
+  return (
+    <div className="query" style={{ display: 'flex' }} data-testid="query-input">
+      <AceEditor mode="lucene"
+                 disabled={disabled}
+                 ref={editorRef}
+                 readOnly={disabled}
+                 theme="ace-queryinput"
+                 onBlur={onBlur}
+                 onChange={onChange}
+                 value={value}
+                 name="QueryEditor"
+                 showGutter={false}
+                 showPrintMargin={false}
+                 highlightActiveLine={false}
+                 minLines={1}
+                 maxLines={1}
+                 enableBasicAutocompletion
+                 enableLiveAutocompletion
+                 editorProps={{
+                   $blockScrolling: Infinity,
+                   selectionStyle: 'line',
+                 }}
+                 fontSize={13}
+                 style={{
+                   marginTop: '9px',
+                   height: '34px',
+                   width: '100%',
+                 }}
+                 placeholder={placeholder} />
+    </div>
+  );
+};
 
 QueryInput.propTypes = {
-  completers: PropTypes.array.isRequired,
-  completerClass: PropTypes.any,
+  completers: PropTypes.array,
+  completerFactory: PropTypes.func,
   disabled: PropTypes.bool,
   onBlur: PropTypes.func,
   onChange: PropTypes.func.isRequired,
   onExecute: PropTypes.func.isRequired,
   placeholder: PropTypes.string,
   value: PropTypes.string,
+};
+
+QueryInput.defaultProps = {
+  disabled: false,
+  onBlur: () => {},
+  completers: [],
+  completerFactory: defaultCompleterFactory,
+  value: '',
+  placeholder: '',
 };
 
 export default withPluginEntities(QueryInput, { completers: 'views.completers' });

--- a/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
@@ -3,8 +3,9 @@ import * as React from 'react';
 import { useCallback, useMemo } from 'react';
 import withPluginEntities from 'views/logic/withPluginEntities';
 import PropTypes from 'prop-types';
-import type { AutoCompleter, Editor } from './ace-types';
 
+import UserPreferencesContext from 'contexts/UserPreferencesContext';
+import type { AutoCompleter, Editor } from './ace-types';
 import AceEditor from './queryinput/ace';
 import SearchBarAutoCompletions from './SearchBarAutocompletions';
 import type { Completer } from './SearchBarAutocompletions';
@@ -24,12 +25,12 @@ const defaultCompleterFactory = (completers) => new SearchBarAutoCompletions(com
 
 const QueryInput = ({ disabled, onBlur, onChange, onExecute, placeholder, value, completers, completerFactory = defaultCompleterFactory }: Props) => {
   const completer = useMemo(() => completerFactory(completers), [completerFactory, completers]);
-  const _onExecute = (editor: Editor) => {
+  const _onExecute = useCallback((editor: Editor) => {
     if (editor.completer && editor.completer.popup) {
       editor.completer.popup.hide();
     }
     onExecute(value);
-  };
+  }, [onExecute]);
 
   const editorRef = useCallback((node) => {
     const editor = node && node.editor;
@@ -46,37 +47,41 @@ const QueryInput = ({ disabled, onBlur, onChange, onExecute, placeholder, value,
 
       editor.completers = [completer];
     }
-  }, [completer]);
+  }, [completer, _onExecute]);
 
   return (
     <div className="query" style={{ display: 'flex' }} data-testid="query-input">
-      <AceEditor mode="lucene"
-                 disabled={disabled}
-                 ref={editorRef}
-                 readOnly={disabled}
-                 theme="ace-queryinput"
-                 onBlur={onBlur}
-                 onChange={onChange}
-                 value={value}
-                 name="QueryEditor"
-                 showGutter={false}
-                 showPrintMargin={false}
-                 highlightActiveLine={false}
-                 minLines={1}
-                 maxLines={1}
-                 enableBasicAutocompletion
-                 enableLiveAutocompletion
-                 editorProps={{
-                   $blockScrolling: Infinity,
-                   selectionStyle: 'line',
-                 }}
-                 fontSize={13}
-                 style={{
-                   marginTop: '9px',
-                   height: '34px',
-                   width: '100%',
-                 }}
-                 placeholder={placeholder} />
+      <UserPreferencesContext.Consumer>
+        {({ enableSmartSearch = true }) => (
+          <AceEditor mode="lucene"
+                     disabled={disabled}
+                     ref={editorRef}
+                     readOnly={disabled}
+                     theme="ace-queryinput"
+                     onBlur={onBlur}
+                     onChange={onChange}
+                     value={value}
+                     name="QueryEditor"
+                     showGutter={false}
+                     showPrintMargin={false}
+                     highlightActiveLine={false}
+                     minLines={1}
+                     maxLines={1}
+                     enableBasicAutocompletion={enableSmartSearch}
+                     enableLiveAutocompletion={enableSmartSearch}
+                     editorProps={{
+                       $blockScrolling: Infinity,
+                       selectionStyle: 'line',
+                     }}
+                     fontSize={13}
+                     style={{
+                       marginTop: '9px',
+                       height: '34px',
+                       width: '100%',
+                     }}
+                     placeholder={placeholder}/>
+        )}
+      </UserPreferencesContext.Consumer>
     </div>
   );
 };

--- a/graylog2-web-interface/src/views/components/searchbar/QueryInput.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/QueryInput.test.jsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { mount } from 'wrappedEnzyme';
 
 import QueryInput from './QueryInput';
+import UserPreferencesContext, { defaultUserPreferences } from '../../../contexts/UserPreferencesContext';
 
 jest.mock('./SearchBarAutocompletions', () => ({}));
 jest.mock('views/stores/FieldTypesStore', () => ({
@@ -21,69 +22,63 @@ class Completer {
 describe('QueryInput', () => {
   const SimpleQueryInput = (props) => (
     <QueryInput value="*"
-                onChange={(s) => Promise.resolve(s)}
+                onChange={() => {}}
                 onExecute={() => {}}
-                completerClass={Completer}
+                completerFactory={() => new Completer()}
                 {...props} />
   );
 
-  it('should update its state when props change', () => {
+  const _mount = (component) => {
+    const wrapper = mount(component);
+    return wrapper.find('ReactAce');
+  };
+
+  it('renders with minimal props', () => {
     const wrapper = mount(<SimpleQueryInput />);
-    const reactAce = wrapper.find('ReactAce');
-
-    expect(reactAce).toHaveProp('value', '*');
-
-    wrapper.setProps({ value: 'updated' });
-
-    const updatedReactAce = wrapper.find('ReactAce');
-    expect(updatedReactAce).toHaveProp('value', 'updated');
+    expect(wrapper).not.toBeNull();
   });
-  it('does not try to close popup if it does not exist while executing query', (done) => {
-    const onExecute = jest.fn();
-    const wrapper = mount(<SimpleQueryInput onExecute={onExecute} />);
 
-    wrapper.find('QueryInput').instance()._onExecute({});
+  it('triggers onChange when input is changed', () => {
+    const _onChange = jest.fn();
+    const aceEditor = _mount(<SimpleQueryInput onChange={_onChange} />);
+    const { onChange } = aceEditor.props();
 
-    setImmediate(() => {
-      expect(onExecute).toHaveBeenCalledWith('*');
-      done();
-    });
+    onChange('new input');
+
+    expect(_onChange).toHaveBeenCalledWith('new input');
   });
-  it('does not trigger onChange/onExecute if input receives blur without changed value', () => {
-    const onBlur = jest.fn();
-    const onChange = jest.fn();
-    const onExecute = jest.fn();
-    const currentQueryString = 'source:example.com';
-    const wrapper = mount((<SimpleQueryInput onExecute={onExecute}
-                                             onChange={onChange}
-                                             onBlur={onBlur}
-                                             value={currentQueryString} />));
 
-    const { onBlur: _onBlur } = wrapper.find('ReactAce').props();
+  it('triggers onBlur when input is blurred', () => {
+    const _onBlur = jest.fn();
+    const aceEditor = _mount(<SimpleQueryInput onBlur={_onBlur} />);
+    const { onBlur } = aceEditor.props();
 
-    _onBlur().then(() => {
-      expect(onExecute).not.toHaveBeenCalled();
-      expect(onChange).not.toHaveBeenCalled();
-      expect(onBlur).toHaveBeenCalledWith(currentQueryString);
-    });
+    onBlur();
+
+    expect(_onBlur).toHaveBeenCalled();
   });
-  it('does trigger onChange/onExecute if input receives blur with changed value', () => {
-    const onBlur = jest.fn();
-    const onChange = jest.fn((newQuery) => Promise.resolve(newQuery));
-    const onExecute = jest.fn();
-    const currentQueryString = 'source:example.com';
-    const wrapper = mount((<SimpleQueryInput onExecute={onExecute}
-                                             onChange={onChange}
-                                             onBlur={onBlur}
-                                             value={currentQueryString} />));
 
-    const { onBlur: _onBlur, onChange: _onChange } = wrapper.find('ReactAce').props();
+  it('disables auto completion if `enableSmartSearch` is false', () => {
+    const aceEditor = _mount((
+      <UserPreferencesContext.Provider value={{ ...defaultUserPreferences, enableSmartSearch: false }}>
+        <SimpleQueryInput />
+      </UserPreferencesContext.Provider>
+    ));
+    const { enableBasicAutocompletion, enableLiveAutocompletion } = aceEditor.props();
 
-    return _onChange('source:foobar')
-      .then(_onBlur)
-      .then(() => {
-        expect(onChange).toHaveBeenCalledWith('source:foobar');
-        expect(onBlur).toHaveBeenCalledWith('source:foobar');
-      });
+    expect(enableBasicAutocompletion).toBe(false);
+    expect(enableLiveAutocompletion).toBe(false);
+  });
+
+  it('enables auto completion if `enableSmartSearch` is true', () => {
+    const aceEditor = _mount((
+      <UserPreferencesContext.Provider value={{ ...defaultUserPreferences, enableSmartSearch: true }}>
+        <SimpleQueryInput />
+      </UserPreferencesContext.Provider>
+    ));
+    const { enableBasicAutocompletion, enableLiveAutocompletion } = aceEditor.props();
+
+    expect(enableBasicAutocompletion).toBe(true);
+    expect(enableLiveAutocompletion).toBe(true);
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/ace-queryinput.css
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/ace-queryinput.css
@@ -101,6 +101,12 @@
     color: #8E908C
 }
 
+.ace_placeholder {
+    font-size: 16px;
+    padding: 0 !important;
+    font-family: inherit !important;
+}
+
 .ace-queryinput .ace_indent-guide {
     background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAACCAYAAACZgbYnAAAAE0lEQVQImWP4////f4bdu3f/BwAlfgctduB85QAAAABJRU5ErkJggg==) right repeat-y
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note: This needs #7829 to be merged before.**

This PR is adding back functionality which enables/disables the field
name autocompletion in the query input on the search/dashboards pages if
the user has a user preference for `enableSmartSearch` set which is
`false`.

Fixes #7809.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.