### PR TITLE
Do not filter querys with empty search types

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Query.java
@@ -209,10 +209,6 @@ public abstract class Query implements ContentPackable<QueryEntity> {
         return AndFilter.and(streamIdFilter, filter);
     }
 
-    boolean hasSearchTypes() {
-        return !searchTypes().isEmpty();
-    }
-
     @AutoValue.Builder
     @JsonPOJOBuilder(withPrefix = "")
     public abstract static class Builder {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/Search.java
@@ -116,7 +116,6 @@ public abstract class Search implements ContentPackable<SearchEntity> {
                                 : state.path("queries").path(query.id());
                         return query.applyExecutionState(objectMapper, queryOverride);
                     })
-                    .filter(Query::hasSearchTypes)
                     .collect(toImmutableSet());
             builder.queries(queries);
         }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/SearchTest.java
@@ -128,19 +128,6 @@ public class SearchTest {
         assertThat(searchTypeIdsFrom(after)).containsExactlyInAnyOrder("oans", "gsuffa");
     }
 
-    @Test
-    public void removesQueryIfNoneOfItsSearchTypesIsRequired() {
-        Search before = Search.builder().queries(queriesWithSearchTypes("oans,zwoa", "gsuffa")).build();
-
-        Map<String, Object> executionState = partialResultsMapWithSearchTypes("oans");
-
-        Search after = before.applyExecutionState(objectMapperProvider.get(), executionState);
-
-        String expected = idOfQueryWithSearchType(before.queries(), "oans");
-
-        assertThat(after.queries()).extracting(Query::id).containsExactly(expected);
-    }
-
     private Set<String> searchTypeIdsFrom(Search search) {
         return search.queries().stream()
                 .flatMap(q -> q.searchTypes().stream().map(SearchType::id))


### PR DESCRIPTION
## Motivation and Context
Prior to this change, we filtered the queries with
empty search types. Without this any queries
(which can happen on an completely new dashboard)
the resulting response to the front-end is empty.
Which leads to an loading spinner.

## Description
This change will remove the filtering of the queries.
So a search from a search and from a dashboard
are producing the same result.

This is far from ideal since we now produce a
empty result set which is not needed. But this
is the safest option for now.

Fixes #7807

## How Has This Been Tested?
1. Created a empty Dashboard typed in a global query and saw no spinner
2. Same for the search
3. Created a Dashboard with a Message Table and stepped through the pages
4. Add a another widget an did again stepped through the Message Table

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

