### PR TITLE
Returning effective field name in non-interactive context.

### DIFF
--- a/graylog2-web-interface/src/views/components/Field.jsx
+++ b/graylog2-web-interface/src/views/components/Field.jsx
@@ -30,7 +30,7 @@ const Field = ({ children, disabled = false, menuContainer, name, queryId, type 
           {name} = {type.type}
         </FieldActions>
       )
-      : <span>{name}</span>)}
+      : <span>{children}</span>)}
   </InteractiveContext.Consumer>
 );
 

--- a/graylog2-web-interface/src/views/components/Field.test.jsx
+++ b/graylog2-web-interface/src/views/components/Field.test.jsx
@@ -8,28 +8,38 @@ import InteractiveContext from './contexts/InteractiveContext';
 
 describe('Field', () => {
   describe('handles value action menu depending on interactive context', () => {
-    const component = (interactive) => (props) => (
+    const component = (interactive) => ({ children, ...props }) => (
       <InteractiveContext.Provider value={interactive}>
-        <Field {...props} />
+        <Field {...props}>
+          {children}
+        </Field>
       </InteractiveContext.Provider>
     );
     it('does not show value actions if interactive context is `false`', () => {
       const NoninteractiveComponent = component(false);
-      const wrapper = mount(<NoninteractiveComponent name="foo"
-                                                     queryId="someQueryId"
-                                                     type={FieldType.Unknown} />);
+      const wrapper = mount((
+        <NoninteractiveComponent name="foo"
+                                 queryId="someQueryId"
+                                 type={FieldType.Unknown}>
+          Foo
+        </NoninteractiveComponent>
+      ));
       const fieldActions = wrapper.find('FieldActions');
       expect(fieldActions).not.toExist();
-      expect(wrapper).toHaveText('foo');
+      expect(wrapper).toHaveText('Foo');
     });
     it('shows value actions if interactive context is `true`', () => {
       const InteractiveComponent = component(true);
-      const wrapper = mount(<InteractiveComponent name="foo"
-                                                  queryId="someQueryId"
-                                                  type={FieldType.Unknown} />);
+      const wrapper = mount((
+        <InteractiveComponent name="foo"
+                              queryId="someQueryId"
+                              type={FieldType.Unknown}>
+          Foo
+        </InteractiveComponent>
+      ));
       const fieldActions = wrapper.find('FieldActions');
       expect(fieldActions).toExist();
-      expect(wrapper).toHaveText('foo');
+      expect(wrapper).toHaveText('Foo');
     });
   });
 });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, the `Field` component did return the physical field
name instead of the effective name (which could be overridden by the
user) if the interactive context is `false`.

This change makes `Field` return the effective name as supplied in the
`children` prop instead.

Fixes #7771.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.