### PR TITLE
Add minimal support for Beats > 7.0 (#7879)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/Beats2Codec.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/Beats2Codec.java
@@ -88,8 +88,12 @@ public class Beats2Codec extends AbstractCodec {
         final String timestampField = event.path("@timestamp").asText();
         final DateTime timestamp = Tools.dateTimeFromString(timestampField);
 
-        final JsonNode beat = event.path("beat");
-        final String hostname = beat.path("hostname").asText(BEATS_UNKNOWN);
+        JsonNode agentOrBeat = event.path("agent");
+        // backwards compatibility for beats < 7.0
+        if (agentOrBeat.isMissingNode()) {
+            agentOrBeat = event.path("beat");
+        }
+        final String hostname = agentOrBeat.path("hostname").asText(BEATS_UNKNOWN);
 
         final Message gelfMessage = new Message(message, hostname, timestamp);
         gelfMessage.addField("beats_type", beatsType);

--- a/graylog2-server/src/test/java/org/graylog/plugins/beats/Beats2CodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/beats/Beats2CodecTest.java
@@ -134,6 +134,19 @@ public class Beats2CodecTest {
     }
 
     @Test
+    public void decodeMessagesHandlesWinlogbeatv7Messages() throws Exception {
+        final Message message = codec.decode(messageFromJson("winlogbeat-v7.json"));
+        assertThat(message).isNotNull();
+        assertThat(message.getSource()).isEqualTo("example.local");
+        assertThat(message.getTimestamp()).isEqualTo(new DateTime(2016, 11, 24, 12, 13, DateTimeZone.UTC));
+        assertThat(message.getField("beats_type")).isEqualTo("winlogbeat");
+        assertThat(message.getField("winlogbeat_winlog_level")).isEqualTo("Information");
+        assertThat(message.getField("winlogbeat_winlog_event_id")).isEqualTo(5024);
+        assertThat(message.getField("winlogbeat_winlog_process_id")).isEqualTo(500);
+        assertThat(message.getField("winlogbeat_winlog_log_name")).isEqualTo("Security");
+    }
+
+    @Test
     public void decodeMessagesHandleGenericBeatMessages() throws Exception {
         final Message message = codec.decode(messageFromJson("generic.json"));
         assertThat(message).isNotNull();

--- a/graylog2-server/src/test/resources/org/graylog/plugins/beats/winlogbeat-v7.json
+++ b/graylog2-server/src/test/resources/org/graylog/plugins/beats/winlogbeat-v7.json
@@ -1,0 +1,31 @@
+{
+  "@metadata": {
+    "beat": "winlogbeat"
+  },
+  "@timestamp": "2016-11-24T12:13:00.000Z",
+  "agent": {
+    "hostname": "example.local",
+    "version": "7.6.2"
+  },
+  "gl2_source_collector": "5a4b9161-2f6a-48f6-b121-109dc85c8481",
+  "winlog": {
+    "computer_name": "windows",
+    "event_id": 5024,
+    "keywords": [
+      "Audit Success"
+    ],
+    "level": "Information",
+    "log_name": "Security",
+    "message": "The Windows Firewall service started successfully.",
+    "opcode": "Info",
+    "process_id": 500,
+    "provider_guid": "{54849625-5478-4994-A5BA-3E3B0328C30D}",
+    "record_number": "2126",
+    "source_name": "Microsoft-Windows-Security-Auditing",
+    "tags": [
+      "windows",
+      "iis"
+    ],
+    "task": "Other System Events"
+  }
+}


### PR DESCRIPTION
Beats 7.0 changed a lot of their field name schema.

  https://www.elastic.co/guide/en/beats/libbeat/7.x/breaking-changes-7.0.html#_field_name_changes

This is a minimal change to extract the hostname from pre-7 and post-7
type beats messages.

Fixes #6501

(cherry picked from commit 5061d81ae01c96e74267b40510ff5fd7be88ffd2)
