### PR TITLE
Supply position parameter to remaining configuration fields (#7874)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/configuration/fields/AbstractConfigurationField.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/configuration/fields/AbstractConfigurationField.java
@@ -37,7 +37,7 @@ public abstract class AbstractConfigurationField implements ConfigurationField {
         this.position = DEFAULT_POSITION;
     }
     public AbstractConfigurationField(String field_type, String name, String humanName, String description, ConfigurationField.Optional optional1, int position) {
-        this(field_type, name, humanName,description,optional1);
+        this(field_type, name, humanName, description, optional1);
         this.position = position;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/configuration/fields/DropdownField.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/configuration/fields/DropdownField.java
@@ -42,6 +42,11 @@ public class DropdownField extends AbstractConfigurationField {
         this.values = values;
     }
 
+    public DropdownField(String name, String humanName, String defaultValue, Map<String, String> values, String description, Optional isOptional, int position) {
+        this(name, humanName, defaultValue, values, description, isOptional);
+        this.position = position;
+    }
+
     @Override
     public Object getDefaultValue() {
         return defaultValue;
@@ -66,7 +71,7 @@ public class DropdownField extends AbstractConfigurationField {
         public static Map<String, String> timeUnits() {
             Map<String, String> units = Maps.newHashMap();
 
-            for(TimeUnit unit : TimeUnit.values()) {
+            for (TimeUnit unit : TimeUnit.values()) {
                 String human = unit.toString().toLowerCase(Locale.ENGLISH);
                 units.put(unit.toString(), Character.toUpperCase(human.charAt(0)) + human.substring(1));
             }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/configuration/fields/ListField.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/configuration/fields/ListField.java
@@ -47,6 +47,11 @@ public class ListField extends AbstractConfigurationField {
                 .collect(Collectors.toList());
     }
 
+    public ListField(String name, String humanName, List<String> defaultValue, Map<String, String> values, String description, Optional isOptional, int position, Attribute... attributes) {
+        this(name, humanName, defaultValue, values, description, isOptional, attributes);
+        this.position = position;
+    }
+
     @Override
     public Object getDefaultValue() {
         return defaultValue;

--- a/graylog2-server/src/main/java/org/graylog2/plugin/configuration/fields/NumberField.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/configuration/fields/NumberField.java
@@ -52,16 +52,25 @@ public class NumberField extends AbstractConfigurationField {
     }
 
     public NumberField(String name, String humanName, int defaultValue, String description, Optional isOptional, Attribute... attributes) {
-        this(name, humanName, (Number) defaultValue, description, isOptional, attributes);
+        this(name, humanName, (Number) defaultValue, description, isOptional, ConfigurationField.DEFAULT_POSITION, attributes);
     }
 
     public NumberField(String name, String humanName, double defaultValue, String description, Optional isOptional, Attribute... attributes) {
-        this(name, humanName, (Number) defaultValue, description, isOptional, attributes);
+        this(name, humanName, (Number) defaultValue, description, isOptional, ConfigurationField.DEFAULT_POSITION, attributes);
     }
 
-    private NumberField(String name, String humanName, Number defaultValue, String description, Optional isOptional, Attribute... attributes) {
+    public NumberField(String name, String humanName, int defaultValue, String description, Optional isOptional, int position, Attribute... attributes) {
+        this(name, humanName, (Number) defaultValue, description, isOptional, position, attributes);
+    }
+
+    public NumberField(String name, String humanName, double defaultValue, String description, Optional isOptional, int position, Attribute... attributes) {
+        this(name, humanName, (Number) defaultValue, description, isOptional, position, attributes);
+    }
+
+    private NumberField(String name, String humanName, Number defaultValue, String description, Optional isOptional, int position, Attribute... attributes) {
         super(FIELD_TYPE, name, humanName, description, isOptional);
         this.defaultValue = defaultValue;
+        this.position = position;
 
         this.attributes = Lists.newArrayList();
         if (attributes != null) {


### PR DESCRIPTION
* Supply position parameter to remaining configuration fields

PR #7504 added support to specify an explicit position on configuration fields.
This adds constructors to the remaining configuration fields
that were lacking this option: `DropdownField`, `ListField` and `NumberField`.

* Reduce some duplication

Co-authored-by: Bernd Ahlers <bernd@graylog.com>
(cherry picked from commit 1bccb32cd554ddf761899026910ee9ed4cc536af)


