### PR TITLE
Show notifications when disk in the Elasticsearch nodes fills up 

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/AbsoluteValueWatermarkSettings.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/AbsoluteValueWatermarkSettings.java
@@ -1,0 +1,62 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.cluster.health;
+
+import com.google.auto.value.AutoValue;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class AbsoluteValueWatermarkSettings implements WatermarkSettings<ByteSizeValue> {
+
+    public abstract SettingsType type();
+
+    public abstract ByteSizeValue low();
+
+    public abstract ByteSizeValue high();
+
+    @Nullable
+    public abstract ByteSizeValue floodStage();
+
+    public static class Builder {
+        private SettingsType type = SettingsType.ABSOLUTE;
+        private ByteSizeValue low;
+        private ByteSizeValue high;
+        private ByteSizeValue floodStage;
+
+        public Builder(){}
+
+        public Builder low(ByteSizeValue low) {
+            this.low = low;
+            return this;
+        }
+
+        public Builder high(ByteSizeValue high) {
+            this.high = high;
+            return this;
+        }
+
+        public Builder floodStage(ByteSizeValue floodStage) {
+            this.floodStage = floodStage;
+            return this;
+        }
+
+        public AbsoluteValueWatermarkSettings build() {
+            return new AutoValue_AbsoluteValueWatermarkSettings(type, low, high, floodStage);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/ClusterAllocationDiskSettings.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/ClusterAllocationDiskSettings.java
@@ -1,0 +1,37 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.cluster.health;
+
+import com.google.auto.value.AutoValue;
+
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class ClusterAllocationDiskSettings {
+
+    public abstract boolean ThresholdEnabled();
+
+    @Nullable
+    public abstract WatermarkSettings<?> watermarkSettings();
+
+    public static ClusterAllocationDiskSettings create(boolean thresholdEnabled, WatermarkSettings<?> watermarkSettings) {
+        return new AutoValue_ClusterAllocationDiskSettings(
+                thresholdEnabled,
+                watermarkSettings
+        );
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/ClusterAllocationDiskSettingsFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/ClusterAllocationDiskSettingsFactory.java
@@ -1,0 +1,65 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.cluster.health;
+
+import org.elasticsearch.common.unit.ByteSizeValue;
+
+import java.util.stream.Stream;
+
+public class ClusterAllocationDiskSettingsFactory {
+
+    public static ClusterAllocationDiskSettings create(boolean enabled, String low, String high, String floodStage) throws Exception {
+        if (!enabled) {
+            return ClusterAllocationDiskSettings.create(enabled, null);
+        }
+        return ClusterAllocationDiskSettings.create(enabled, createWatermarkSettings(low, high, floodStage));
+    }
+
+    private static WatermarkSettings<?> createWatermarkSettings(String low, String high, String floodStage) throws Exception {
+        WatermarkSettings.SettingsType lowType = getType(low);
+        WatermarkSettings.SettingsType highType = getType(high);
+        if (Stream.of(lowType, highType).allMatch(s -> s == WatermarkSettings.SettingsType.ABSOLUTE)) {
+            AbsoluteValueWatermarkSettings.Builder builder = new AbsoluteValueWatermarkSettings.Builder()
+                .low(ByteSizeValue.parseBytesSizeValue(low, "lowWatermark"))
+                .high(ByteSizeValue.parseBytesSizeValue(high, "highWatermark"));
+            if (!floodStage.isEmpty()) {
+                builder.floodStage(ByteSizeValue.parseBytesSizeValue(floodStage, "floodStageWatermark"));
+            }
+            return builder.build();
+        } else if (Stream.of(lowType, highType).allMatch(s -> s == WatermarkSettings.SettingsType.PERCENTAGE)) {
+            PercentageWatermarkSettings.Builder builder = new PercentageWatermarkSettings.Builder()
+                .low(getPercentageValue(low))
+                .high(getPercentageValue(high));
+            if (!floodStage.isEmpty()) {
+                builder.floodStage(getPercentageValue(floodStage));
+            }
+            return builder.build();
+        }
+        throw new Exception("Error creating ClusterAllocationDiskWatermarkSettings. This should never happen.");
+    }
+
+    private static WatermarkSettings.SettingsType getType(String value) {
+        if (value.trim().endsWith("%")) {
+            return WatermarkSettings.SettingsType.PERCENTAGE;
+        }
+        return WatermarkSettings.SettingsType.ABSOLUTE;
+    }
+
+    private static Double getPercentageValue(String value) {
+        return Double.parseDouble(value.trim().replace("%", ""));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/NodeDiskUsageStats.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/NodeDiskUsageStats.java
@@ -1,0 +1,57 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.cluster.health;
+
+import com.google.auto.value.AutoValue;
+import org.elasticsearch.common.unit.ByteSizeValue;
+
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class NodeDiskUsageStats {
+    public static final double DEFAULT_DISK_USED_PERCENT = -1D;
+
+    public abstract String name();
+
+    public abstract String ip();
+
+    @Nullable
+    public abstract String host();
+
+    public abstract ByteSizeValue diskTotal();
+
+    public abstract ByteSizeValue diskUsed();
+
+    public abstract ByteSizeValue diskAvailable();
+
+    public abstract Double diskUsedPercent();
+
+    public static NodeDiskUsageStats create(String name, String ip, @Nullable String host, String diskUsedString, String diskTotalString, Double diskUsedPercent) {
+        ByteSizeValue diskTotal = ByteSizeValue.parseBytesSizeValue(diskTotalString, "diskTotal");
+        ByteSizeValue diskUsed = ByteSizeValue.parseBytesSizeValue(diskUsedString, "diskUsed");
+        ByteSizeValue diskAvailable = new ByteSizeValue(diskTotal.getBytes() - diskUsed.getBytes());
+        return new AutoValue_NodeDiskUsageStats(
+                name,
+                ip,
+                host,
+                diskTotal,
+                diskUsed,
+                diskAvailable,
+                diskUsedPercent
+        );
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/NodeFileDescriptorStats.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/NodeFileDescriptorStats.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.indexer.cluster;
+package org.graylog2.indexer.cluster.health;
 
 import com.google.auto.value.AutoValue;
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/PercentageWatermarkSettings.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/PercentageWatermarkSettings.java
@@ -1,0 +1,62 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.cluster.health;
+
+import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
+
+@AutoValue
+public abstract class PercentageWatermarkSettings implements WatermarkSettings<Double> {
+
+    public abstract SettingsType type();
+
+    public abstract Double low();
+
+    public abstract Double high();
+
+    @Nullable
+    public abstract Double floodStage();
+
+    public static class Builder {
+        private SettingsType type = SettingsType.PERCENTAGE;
+        private Double low;
+        private Double high;
+        private Double floodStage;
+
+        public Builder() {
+        }
+
+        public PercentageWatermarkSettings.Builder low(Double low) {
+            this.low = low;
+            return this;
+        }
+
+        public PercentageWatermarkSettings.Builder high(Double high) {
+            this.high = high;
+            return this;
+        }
+
+        public PercentageWatermarkSettings.Builder floodStage(Double floodStage) {
+            this.floodStage = floodStage;
+            return this;
+        }
+
+        public PercentageWatermarkSettings build() {
+            return new AutoValue_PercentageWatermarkSettings(type, low, high, floodStage);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/WatermarkSettings.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/WatermarkSettings.java
@@ -1,0 +1,33 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.cluster.health;
+
+public interface WatermarkSettings<T> {
+
+    enum SettingsType {
+        ABSOLUTE,
+        PERCENTAGE
+    }
+
+    SettingsType type();
+
+    T low();
+
+    T high();
+
+    T floodStage();
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/GetAllocationDiskSettings.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/jest/GetAllocationDiskSettings.java
@@ -1,0 +1,60 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.cluster.jest;
+
+import io.searchbox.cluster.GetSettings;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+public class GetAllocationDiskSettings extends GetSettings {
+
+    protected GetAllocationDiskSettings(Builder builder) {
+        super(builder);
+    }
+
+    public static class Builder extends GetSettings.Builder {
+        public Builder() {
+            this.configureIncludeDefaults();
+            this.configureSettingsFilter();
+        }
+
+        private void configureIncludeDefaults() {
+            this.parameters.put("include_defaults", true);
+        }
+
+        private void configureSettingsFilter() {
+            this.parameters.put("filter_path", this.getFilterPathValue());
+        }
+
+        private String getFilterPathValue() {
+            List<String> filterPaths = new ArrayList<>();
+            String commonFilterPath = "cluster.routing.allocation.disk";
+            List<String> settingsGroup = Arrays.asList("defaults", "persistent", "transient");
+            for (String settingGroup: settingsGroup) {
+                filterPaths.add(String.join(".", settingGroup, commonFilterPath));
+            }
+            return String.join(",", filterPaths);
+        }
+
+        public GetAllocationDiskSettings build() {
+            return new GetAllocationDiskSettings(this);
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
@@ -62,7 +62,10 @@ public interface Notification extends Persisted {
         JOURNAL_UNCOMMITTED_MESSAGES_DELETED,
         OUTPUT_DISABLED,
         INDEX_RANGES_RECALCULATION,
-        GENERIC
+        GENERIC,
+        ES_NODE_DISK_WATERMARK_LOW,
+        ES_NODE_DISK_WATERMARK_HIGH,
+        ES_NODE_DISK_WATERMARK_FLOOD_STAGE
     }
 
     enum Severity {

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexerClusterCheckerThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexerClusterCheckerThread.java
@@ -16,8 +16,14 @@
  */
 package org.graylog2.periodical;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.graylog2.indexer.cluster.Cluster;
-import org.graylog2.indexer.cluster.NodeFileDescriptorStats;
+import org.graylog2.indexer.cluster.health.AbsoluteValueWatermarkSettings;
+import org.graylog2.indexer.cluster.health.ClusterAllocationDiskSettings;
+import org.graylog2.indexer.cluster.health.NodeDiskUsageStats;
+import org.graylog2.indexer.cluster.health.NodeFileDescriptorStats;
+import org.graylog2.indexer.cluster.health.PercentageWatermarkSettings;
+import org.graylog2.indexer.cluster.health.WatermarkSettings;
 import org.graylog2.notifications.Notification;
 import org.graylog2.notifications.NotificationService;
 import org.graylog2.plugin.periodical.Periodical;
@@ -25,6 +31,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
@@ -45,12 +55,17 @@ public class IndexerClusterCheckerThread extends Periodical {
 
     @Override
     public void doRun() {
-        if (!notificationService.isFirst(Notification.Type.ES_OPEN_FILES)) {
-            return;
-        }
-
         if (!cluster.health().isPresent()) {
             LOG.info("Indexer not fully initialized yet. Skipping periodic cluster check.");
+            return;
+        }
+        checkOpenFiles();
+        checkDiskUsage();
+    }
+
+    @VisibleForTesting
+    void checkOpenFiles() {
+        if (notificationExists(Notification.Type.ES_OPEN_FILES)) {
             return;
         }
 
@@ -86,6 +101,93 @@ public class IndexerClusterCheckerThread extends Periodical {
             Notification notification = notificationService.build().addType(Notification.Type.ES_OPEN_FILES);
             notificationService.fixed(notification);
         }
+    }
+
+    @VisibleForTesting()
+    void checkDiskUsage() {
+        final Map<Notification.Type, List<String>> notificationTypePerNodeIdentifier = new HashMap<>();
+        try {
+            ClusterAllocationDiskSettings settings = cluster.getClusterAllocationDiskSettings();
+            if (settings.ThresholdEnabled()) {
+                final Set<NodeDiskUsageStats> diskUsageStats = cluster.getDiskUsageStats();
+
+                for (NodeDiskUsageStats nodeDiskUsageStats : diskUsageStats) {
+                    Notification.Type currentNodeNotificationType = null;
+                    WatermarkSettings<?> watermarkSettings = settings.watermarkSettings();
+                    if (watermarkSettings instanceof PercentageWatermarkSettings) {
+                        currentNodeNotificationType = getDiskUsageNotificationTypeByPercentage((PercentageWatermarkSettings) watermarkSettings, nodeDiskUsageStats);
+                    } else if (watermarkSettings instanceof AbsoluteValueWatermarkSettings) {
+                        currentNodeNotificationType = getDiskUsageNotificationTypeByAbsoluteValues((AbsoluteValueWatermarkSettings) watermarkSettings, nodeDiskUsageStats);
+                    }
+                    if (currentNodeNotificationType != null) {
+                        String nodeIdentifier = firstNonNull(nodeDiskUsageStats.host(), nodeDiskUsageStats.ip());
+                        if (notificationTypePerNodeIdentifier.containsKey(currentNodeNotificationType)) {
+                            List<String> nodesIdentifier = notificationTypePerNodeIdentifier.get(currentNodeNotificationType);
+                            nodesIdentifier.add(nodeIdentifier);
+                        } else {
+                            notificationTypePerNodeIdentifier.put(currentNodeNotificationType, Arrays.asList(nodeIdentifier));
+                        }
+                    }
+                }
+
+                if (notificationTypePerNodeIdentifier.isEmpty()) {
+                    fixAllDiskUsageNotifications();
+                } else {
+                    publishDiskUsageNotifications(notificationTypePerNodeIdentifier);
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Error while trying to check Elasticsearch disk usage.Details: " + e.getMessage());
+        }
+    }
+
+    private Notification.Type getDiskUsageNotificationTypeByPercentage(PercentageWatermarkSettings settings, NodeDiskUsageStats nodeDiskUsageStats) {
+        if (settings.floodStage() != null && nodeDiskUsageStats.diskUsedPercent() >= settings.floodStage()) {
+            return Notification.Type.ES_NODE_DISK_WATERMARK_FLOOD_STAGE;
+        } else if (nodeDiskUsageStats.diskUsedPercent() >= settings.high()) {
+            return Notification.Type.ES_NODE_DISK_WATERMARK_HIGH;
+        } else if (nodeDiskUsageStats.diskUsedPercent() >= settings.low()) {
+            return Notification.Type.ES_NODE_DISK_WATERMARK_LOW;
+        }
+        return null;
+    }
+
+    private Notification.Type getDiskUsageNotificationTypeByAbsoluteValues(AbsoluteValueWatermarkSettings settings, NodeDiskUsageStats nodeDiskUsageStats) {
+        if (settings.floodStage() != null && nodeDiskUsageStats.diskAvailable().getBytes() <= settings.floodStage().getBytes()) {
+            return Notification.Type.ES_NODE_DISK_WATERMARK_FLOOD_STAGE;
+        } else if (nodeDiskUsageStats.diskAvailable().getBytes() <= settings.high().getBytes()) {
+            return Notification.Type.ES_NODE_DISK_WATERMARK_HIGH;
+        } else if (nodeDiskUsageStats.diskAvailable().getBytes() <= settings.low().getBytes()) {
+            return Notification.Type.ES_NODE_DISK_WATERMARK_LOW;
+        }
+        return null;
+    }
+
+    private void fixAllDiskUsageNotifications() {
+        notificationService.fixed(Notification.Type.ES_NODE_DISK_WATERMARK_FLOOD_STAGE);
+        notificationService.fixed(Notification.Type.ES_NODE_DISK_WATERMARK_HIGH);
+        notificationService.fixed(Notification.Type.ES_NODE_DISK_WATERMARK_LOW);
+    }
+
+    private void publishDiskUsageNotifications(Map<Notification.Type, List<String>> notificationTypePerNodeIdentifier) {
+        for (Map.Entry<Notification.Type, List<String>> entry : notificationTypePerNodeIdentifier.entrySet()) {
+            if (!notificationExists(entry.getKey())) {
+                Notification notification = notificationService.buildNow()
+                        .addType(entry.getKey())
+                        .addSeverity(Notification.Severity.URGENT)
+                        .addDetail("nodes", String.join(", ", entry.getValue()));
+                notificationService.publishIfFirst(notification);
+                for (String node: entry.getValue()) {
+                    LOG.warn("Elasticsearch node [{}] triggered [{}] due to low free disk space",
+                            node,
+                            entry.getKey());
+                }
+            }
+        }
+    }
+
+    private boolean notificationExists(Notification.Type type) {
+        return !notificationService.isFirst(type);
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog2/indexer/cluster/ClusterIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/cluster/ClusterIT.java
@@ -23,6 +23,10 @@ import io.searchbox.core.Cat;
 import io.searchbox.core.CatResult;
 import org.graylog.testing.elasticsearch.ElasticsearchBaseTest;
 import org.graylog2.indexer.IndexSetRegistry;
+import org.graylog2.indexer.cluster.health.ClusterAllocationDiskSettings;
+import org.graylog2.indexer.cluster.health.NodeDiskUsageStats;
+import org.graylog2.indexer.cluster.health.NodeFileDescriptorStats;
+import org.graylog2.indexer.cluster.health.WatermarkSettings;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -66,6 +70,24 @@ public class ClusterIT extends ElasticsearchBaseTest {
     public void getFileDescriptorStats() {
         final Set<NodeFileDescriptorStats> fileDescriptorStats = cluster.getFileDescriptorStats();
         assertThat(fileDescriptorStats).isNotEmpty();
+    }
+
+    @Test
+    public void getDiskUsageStats() {
+        final Set<NodeDiskUsageStats> diskUsageStats = cluster.getDiskUsageStats();
+        assertThat(diskUsageStats).isNotEmpty();
+    }
+
+    @Test
+    public void getClusterAllocationDiskSettings() throws Exception{
+        final ClusterAllocationDiskSettings clusterAllocationDiskSettings = cluster.getClusterAllocationDiskSettings();
+
+        //Default Elasticsearch settings in Elasticsearch 5.6
+        assertThat(clusterAllocationDiskSettings.ThresholdEnabled()).isTrue();
+        assertThat(clusterAllocationDiskSettings.watermarkSettings().type()).isEqualTo(WatermarkSettings.SettingsType.PERCENTAGE);
+        assertThat(clusterAllocationDiskSettings.watermarkSettings().low()).isEqualTo(85D);
+        assertThat(clusterAllocationDiskSettings.watermarkSettings().high()).isEqualTo(90D);
+        assertThat(clusterAllocationDiskSettings.watermarkSettings().floodStage()).isNull();
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/indexer/cluster/health/ClusterAllocationDiskSettingsFactoryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/cluster/health/ClusterAllocationDiskSettingsFactoryTest.java
@@ -1,0 +1,101 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.cluster.health;
+
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ClusterAllocationDiskSettingsFactoryTest {
+
+    @Test
+    public void createPercentageWatermarkSettings() throws Exception {
+        ClusterAllocationDiskSettings settings = ClusterAllocationDiskSettingsFactory.create(true, "75%", "85%", "99%");
+
+        assertThat(settings).isInstanceOf(ClusterAllocationDiskSettings.class);
+        assertThat(settings.ThresholdEnabled()).isTrue();
+        assertThat(settings.watermarkSettings()).isInstanceOf(PercentageWatermarkSettings.class);
+        assertThat(settings.watermarkSettings().type()).isEqualTo(WatermarkSettings.SettingsType.PERCENTAGE);
+        assertThat(settings.watermarkSettings().low()).isEqualTo(75D);
+        assertThat(settings.watermarkSettings().high()).isEqualTo(85D);
+        assertThat(settings.watermarkSettings().floodStage()).isEqualTo(99D);
+    }
+
+    @Test
+    public void createPercentageWatermarkSettingsWithoutFloodStage() throws Exception {
+        ClusterAllocationDiskSettings settings = ClusterAllocationDiskSettingsFactory.create(true, "65%", "75%", "");
+
+        assertThat(settings).isInstanceOf(ClusterAllocationDiskSettings.class);
+        assertThat(settings.ThresholdEnabled()).isTrue();
+        assertThat(settings.watermarkSettings()).isInstanceOf(PercentageWatermarkSettings.class);
+        assertThat(settings.watermarkSettings().type()).isEqualTo(WatermarkSettings.SettingsType.PERCENTAGE);
+        assertThat(settings.watermarkSettings().low()).isEqualTo(65D);
+        assertThat(settings.watermarkSettings().high()).isEqualTo(75D);
+        assertThat(settings.watermarkSettings().floodStage()).isNull();
+    }
+
+    @Test
+    public void createAbsoluteValueWatermarkSettings() throws Exception {
+        ClusterAllocationDiskSettings clusterAllocationDiskSettings = ClusterAllocationDiskSettingsFactory.create(true, "20Gb", "10Gb", "5Gb");
+
+        assertThat(clusterAllocationDiskSettings).isInstanceOf(ClusterAllocationDiskSettings.class);
+        assertThat(clusterAllocationDiskSettings.ThresholdEnabled()).isTrue();
+        assertThat(clusterAllocationDiskSettings.watermarkSettings()).isInstanceOf(AbsoluteValueWatermarkSettings.class);
+
+        AbsoluteValueWatermarkSettings settings = (AbsoluteValueWatermarkSettings) clusterAllocationDiskSettings.watermarkSettings();
+
+        assertThat(settings.type()).isEqualTo(WatermarkSettings.SettingsType.ABSOLUTE);
+        assertThat(settings.low()).isInstanceOf(ByteSizeValue.class);
+        assertThat(settings.low().getBytes()).isEqualTo(21474836480L);
+        assertThat(settings.high()).isInstanceOf(ByteSizeValue.class);
+        assertThat(settings.high().getBytes()).isEqualTo(10737418240L);
+        assertThat(settings.floodStage()).isInstanceOf(ByteSizeValue.class);
+        assertThat(settings.floodStage().getBytes()).isEqualTo(5368709120L);
+    }
+
+    @Test
+    public void createAbsoluteValueWatermarkSettingsWithoutFloodStage() throws Exception {
+        ClusterAllocationDiskSettings clusterAllocationDiskSettings = ClusterAllocationDiskSettingsFactory.create(true, "10Gb", "5Gb", "");
+
+        assertThat(clusterAllocationDiskSettings).isInstanceOf(ClusterAllocationDiskSettings.class);
+        assertThat(clusterAllocationDiskSettings.ThresholdEnabled()).isTrue();
+        assertThat(clusterAllocationDiskSettings.watermarkSettings()).isInstanceOf(AbsoluteValueWatermarkSettings.class);
+
+        AbsoluteValueWatermarkSettings settings = (AbsoluteValueWatermarkSettings) clusterAllocationDiskSettings.watermarkSettings();
+
+        assertThat(settings.type()).isEqualTo(WatermarkSettings.SettingsType.ABSOLUTE);
+        assertThat(settings.low()).isInstanceOf(ByteSizeValue.class);
+        assertThat(settings.low().getBytes()).isEqualTo(10737418240L);
+        assertThat(settings.high()).isInstanceOf(ByteSizeValue.class);
+        assertThat(settings.high().getBytes()).isEqualTo(5368709120L);
+        assertThat(settings.floodStage()).isNull();
+    }
+
+    @Test
+    public void createWithoutSettingsWhenThresholdDisabled() throws Exception {
+        ClusterAllocationDiskSettings settings = ClusterAllocationDiskSettingsFactory.create(false, "", "", "");
+
+        assertThat(settings).isInstanceOf(ClusterAllocationDiskSettings.class);
+        assertThat(settings.ThresholdEnabled()).isFalse();
+    }
+
+    @Test(expected = Exception.class)
+    public void throwExceptionWhenMixedSettings() throws Exception {
+        ClusterAllocationDiskSettingsFactory.create(true, "10Gb", "10%", "");
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/cluster/health/NodeDiskUsageStatsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/cluster/health/NodeDiskUsageStatsTest.java
@@ -1,0 +1,70 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.cluster.health;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NodeDiskUsageStatsTest {
+
+    private NodeDiskUsageStats nodeDiskUsageStats;
+
+    @Test
+    public void createWithValidValues() {
+        nodeDiskUsageStats = NodeDiskUsageStats.create(
+                "name",
+                "0.0.0.0",
+                "myelasticnode.graylog.org",
+                "1gb",
+                "20Gb",
+                30.5D
+        );
+        assertThat(nodeDiskUsageStats.name()).isEqualTo("name");
+        assertThat(nodeDiskUsageStats.ip()).isEqualTo("0.0.0.0");
+        assertThat(nodeDiskUsageStats.host()).isEqualTo("myelasticnode.graylog.org");
+        assertThat(nodeDiskUsageStats.diskUsed().getBytes()).isEqualTo(1073741824L);
+        assertThat(nodeDiskUsageStats.diskTotal().getBytes()).isEqualTo(21474836480L);
+        assertThat(nodeDiskUsageStats.diskUsedPercent()).isEqualTo(30.5D);
+    }
+
+    @Test
+    public void hostCanBeNull() {
+        nodeDiskUsageStats = NodeDiskUsageStats.create(
+                "name",
+                "0.0.0.0",
+                null,
+                "1mb",
+                "2mb",
+                99D
+        );
+        assertThat(nodeDiskUsageStats.host()).isNull();
+    }
+
+    @Test
+    public void diskAvailabileIsCorrect() {
+        nodeDiskUsageStats = NodeDiskUsageStats.create(
+                "name",
+                "0.0.0.0",
+                null,
+                "1gb",
+                "3Gb",
+                33.3D
+        );
+        assertThat(nodeDiskUsageStats.diskAvailable().getBytes()).isEqualTo(2147483648L);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/periodical/IndexerClusterCheckerThreadTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/periodical/IndexerClusterCheckerThreadTest.java
@@ -1,0 +1,256 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.periodical;
+
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.graylog2.indexer.cluster.Cluster;
+import org.graylog2.indexer.cluster.health.*;
+import org.graylog2.notifications.Notification;
+import org.graylog2.notifications.NotificationImpl;
+import org.graylog2.notifications.NotificationService;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class IndexerClusterCheckerThreadTest {
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private Cluster cluster;
+
+    @Mock
+    private NotificationService notificationService;
+
+    private IndexerClusterCheckerThread indexerClusterCheckerThread;
+
+    @Before
+    public void setUp() {
+        indexerClusterCheckerThread = new IndexerClusterCheckerThread(notificationService, cluster);
+    }
+
+    @Test
+    public void preventOpenFilesNotificationFlood() {
+        when(notificationService.isFirst(Notification.Type.ES_OPEN_FILES)).thenReturn(false);
+
+        indexerClusterCheckerThread.checkOpenFiles();
+
+        verify(notificationService, times(1)).isFirst(Notification.Type.ES_OPEN_FILES);
+        verifyNoMoreInteractions(notificationService);
+        verifyZeroInteractions(cluster);
+    }
+
+    @Test
+    public void noChecksWhenDiskAllocationThresholdIsDisabled() throws Exception {
+        ClusterAllocationDiskSettings clusterAllocationDiskSettings = mock(ClusterAllocationDiskSettings.class);
+
+        when(clusterAllocationDiskSettings.ThresholdEnabled()).thenReturn(false);
+        when(cluster.getClusterAllocationDiskSettings()).thenReturn(clusterAllocationDiskSettings);
+
+        indexerClusterCheckerThread.checkDiskUsage();
+
+        verify(clusterAllocationDiskSettings, times(1)).ThresholdEnabled();
+        verifyNoMoreInteractions(clusterAllocationDiskSettings);
+        verify(cluster, times(1)).getClusterAllocationDiskSettings();
+        verifyNoMoreInteractions(cluster);
+    }
+
+    @Test
+    public void fixAllDiskUsageNotificationsAbsolute() throws Exception {
+        Set<NodeDiskUsageStats> nodeDiskUsageStats = mockNodeDiskUsageStats();
+        when(cluster.getDiskUsageStats()).thenReturn(nodeDiskUsageStats);
+        when(cluster.getClusterAllocationDiskSettings()).thenReturn(buildThresholdNotTriggeredClusterAllocationDiskSettings(WatermarkSettings.SettingsType.ABSOLUTE));
+
+        indexerClusterCheckerThread.checkDiskUsage();
+
+        verify(notificationService, never()).publishIfFirst(any());
+        verify(notificationService, times(1)).fixed(Notification.Type.ES_NODE_DISK_WATERMARK_FLOOD_STAGE);
+        verify(notificationService, times(1)).fixed(Notification.Type.ES_NODE_DISK_WATERMARK_HIGH);
+        verify(notificationService, times(1)).fixed(Notification.Type.ES_NODE_DISK_WATERMARK_LOW);
+    }
+
+    @Test
+    public void fixAllDiskUsageNotificationsPercentage() throws Exception {
+        Set<NodeDiskUsageStats> nodeDiskUsageStats = mockNodeDiskUsageStats();
+        when(cluster.getDiskUsageStats()).thenReturn(nodeDiskUsageStats);
+        when(cluster.getClusterAllocationDiskSettings()).thenReturn(buildThresholdNotTriggeredClusterAllocationDiskSettings(WatermarkSettings.SettingsType.PERCENTAGE));
+
+        indexerClusterCheckerThread.checkDiskUsage();
+
+        verify(notificationService, never()).publishIfFirst(any());
+        verify(notificationService, times(1)).fixed(Notification.Type.ES_NODE_DISK_WATERMARK_FLOOD_STAGE);
+        verify(notificationService, times(1)).fixed(Notification.Type.ES_NODE_DISK_WATERMARK_HIGH);
+        verify(notificationService, times(1)).fixed(Notification.Type.ES_NODE_DISK_WATERMARK_LOW);
+    }
+
+    @Test
+    public void notificationCreatesWhenLowThresholdTriggeredAbsolute() throws Exception {
+        notificationCreated(Notification.Type.ES_NODE_DISK_WATERMARK_LOW, WatermarkSettings.SettingsType.ABSOLUTE);
+    }
+
+    @Test
+    public void notificationCreatesWhenLowThresholdTriggeredPercentage() throws Exception {
+        notificationCreated(Notification.Type.ES_NODE_DISK_WATERMARK_LOW, WatermarkSettings.SettingsType.PERCENTAGE);
+    }
+
+    @Test
+    public void notificationCreatesWhenHighThresholdTriggeredAbsolute() throws Exception {
+        notificationCreated(Notification.Type.ES_NODE_DISK_WATERMARK_HIGH, WatermarkSettings.SettingsType.ABSOLUTE);
+    }
+
+    @Test
+    public void notificationCreatesWhenHighThresholdTriggeredPercentage() throws Exception {
+        notificationCreated(Notification.Type.ES_NODE_DISK_WATERMARK_HIGH, WatermarkSettings.SettingsType.PERCENTAGE);
+    }
+
+    @Test
+    public void notificationCreatesWhenFloodStageThresholdTriggeredAbsolute() throws Exception {
+        notificationCreated(Notification.Type.ES_NODE_DISK_WATERMARK_FLOOD_STAGE, WatermarkSettings.SettingsType.ABSOLUTE);
+    }
+
+    @Test
+    public void notificationCreatesWhenFloodStageThresholdTriggeredPercentage() throws Exception {
+        notificationCreated(Notification.Type.ES_NODE_DISK_WATERMARK_FLOOD_STAGE, WatermarkSettings.SettingsType.PERCENTAGE);
+    }
+
+    private void notificationCreated(Notification.Type notificationType, WatermarkSettings.SettingsType watermarkSettingsType) throws Exception {
+        Set<NodeDiskUsageStats> nodeDiskUsageStats = mockNodeDiskUsageStats();
+        when(cluster.getDiskUsageStats()).thenReturn(nodeDiskUsageStats);
+        if (watermarkSettingsType == WatermarkSettings.SettingsType.ABSOLUTE) {
+            when(cluster.getClusterAllocationDiskSettings()).thenReturn(buildThresholdTriggeredClusterAllocationDiskSettings(notificationType, WatermarkSettings.SettingsType.ABSOLUTE));
+        } else {
+            when(cluster.getClusterAllocationDiskSettings()).thenReturn(buildThresholdTriggeredClusterAllocationDiskSettings(notificationType, WatermarkSettings.SettingsType.PERCENTAGE));
+        }
+        when(notificationService.isFirst(notificationType)).thenReturn(true);
+        Notification notification = new NotificationImpl();
+        when(notificationService.buildNow()).thenReturn(notification);
+
+        indexerClusterCheckerThread.checkDiskUsage();
+
+        ArgumentCaptor<Notification> argument = ArgumentCaptor.forClass(Notification.class);
+        verify(notificationService, times(1)).publishIfFirst(argument.capture());
+
+        Notification publishedNotification = argument.getValue();
+        assertThat(publishedNotification.getType()).isEqualTo(notificationType);
+    }
+
+    private Set<NodeDiskUsageStats> mockNodeDiskUsageStats() {
+        Set<NodeDiskUsageStats> nodesDiskUsageStats = new HashSet<>();
+        NodeDiskUsageStats nodeDiskUsageStats = mock(NodeDiskUsageStats.class);
+
+        when(nodeDiskUsageStats.ip()).thenReturn("0.0.0.0");
+        when(nodeDiskUsageStats.diskTotal()).thenReturn(new ByteSizeValue(100L, ByteSizeUnit.GB));
+        when(nodeDiskUsageStats.diskUsed()).thenReturn(new ByteSizeValue(70L, ByteSizeUnit.GB));
+        when(nodeDiskUsageStats.diskAvailable()).thenReturn(new ByteSizeValue(30L, ByteSizeUnit.GB));
+        when(nodeDiskUsageStats.diskUsedPercent()).thenReturn(70D);
+
+        nodesDiskUsageStats.add(nodeDiskUsageStats);
+        return nodesDiskUsageStats;
+    }
+
+    private ClusterAllocationDiskSettings buildThresholdNotTriggeredClusterAllocationDiskSettings(WatermarkSettings.SettingsType type) {
+        if (type == WatermarkSettings.SettingsType.ABSOLUTE) {
+            AbsoluteValueWatermarkSettings absoluteValueWatermarkSettings = new AbsoluteValueWatermarkSettings.Builder()
+                    .low(new ByteSizeValue(15, ByteSizeUnit.GB))
+                    .high(new ByteSizeValue(10, ByteSizeUnit.GB))
+                    .floodStage(new ByteSizeValue(5, ByteSizeUnit.GB))
+                    .build();
+            return ClusterAllocationDiskSettings.create(true, absoluteValueWatermarkSettings);
+        } else {
+            PercentageWatermarkSettings percentageWatermarkSettings = new PercentageWatermarkSettings.Builder()
+                    .low(85D)
+                    .high(90D)
+                    .floodStage(95D)
+                    .build();
+            return ClusterAllocationDiskSettings.create(true, percentageWatermarkSettings);
+        }
+    }
+
+    private ClusterAllocationDiskSettings buildThresholdTriggeredClusterAllocationDiskSettings(Notification.Type expectedNotificationType, WatermarkSettings.SettingsType type) {
+        if (type == WatermarkSettings.SettingsType.ABSOLUTE) {
+            return buildThresholdTriggeredClusterAllocationDiskSettingsAbsolute(expectedNotificationType);
+        } else {
+            return buildThresholdTriggeredClusterAllocationDiskSettingsPercentage(expectedNotificationType);
+        }
+    }
+
+    private ClusterAllocationDiskSettings buildThresholdTriggeredClusterAllocationDiskSettingsAbsolute(Notification.Type expectedNotificationType) {
+        ByteSizeValue low;
+        ByteSizeValue high;
+        ByteSizeValue floodStage;
+        if (expectedNotificationType == Notification.Type.ES_NODE_DISK_WATERMARK_LOW) {
+            low = new ByteSizeValue(35, ByteSizeUnit.GB);
+            high = new ByteSizeValue(10, ByteSizeUnit.GB);
+            floodStage = new ByteSizeValue(5, ByteSizeUnit.GB);
+        } else if (expectedNotificationType == Notification.Type.ES_NODE_DISK_WATERMARK_HIGH) {
+            low = new ByteSizeValue(45, ByteSizeUnit.GB);
+            high = new ByteSizeValue(35, ByteSizeUnit.GB);
+            floodStage = new ByteSizeValue(5, ByteSizeUnit.GB);
+        } else {
+            low = new ByteSizeValue(55, ByteSizeUnit.GB);
+            high = new ByteSizeValue(45, ByteSizeUnit.GB);
+            floodStage = new ByteSizeValue(35, ByteSizeUnit.GB);
+        }
+        return ClusterAllocationDiskSettings.create(true, new AbsoluteValueWatermarkSettings.Builder()
+                .low(low)
+                .high(high)
+                .floodStage(floodStage)
+                .build());
+    }
+
+    public ClusterAllocationDiskSettings buildThresholdTriggeredClusterAllocationDiskSettingsPercentage(Notification.Type expectedNotificationType) {
+        double low;
+        double high;
+        double floodStage;
+        if (expectedNotificationType == Notification.Type.ES_NODE_DISK_WATERMARK_LOW) {
+            low = 25D;
+            high = 90D;
+            floodStage = 95D;
+        } else if (expectedNotificationType == Notification.Type.ES_NODE_DISK_WATERMARK_HIGH) {
+            low = 15D;
+            high = 25D;
+            floodStage = 95D;
+        } else {
+            low = 5D;
+            high = 15D;
+            floodStage = 25D;
+        }
+        return ClusterAllocationDiskSettings.create(true, new PercentageWatermarkSettings.Builder()
+                .low(low)
+                .high(high)
+                .floodStage(floodStage)
+                .build());
+    }
+}

--- a/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
+++ b/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
@@ -221,6 +221,45 @@ class NotificationsFactory {
             </span>
           ),
         };
+      case 'es_node_disk_watermark_low':
+        return {
+          title: 'Elasticsearch nodes disk usage above low watermark',
+          description: (
+            <span>
+              There are Elasticsearch nodes in the cluster running out of disk space, their disk usage is above the low watermark.{' '}
+              For this reason Elasticsearch will not allocate new shards to the affected nodes.{' '}
+              The affected nodes are: [{notification.details.nodes}]{' '}
+              Check <a href="https://www.elastic.co/guide/en/elasticsearch/reference/master/disk-allocator.html" target="_blank">https://www.elastic.co/guide/en/elasticsearch/reference/master/disk-allocator.html</a>{' '}
+              for more details.
+            </span>
+          ),
+        };
+      case 'es_node_disk_watermark_high':
+        return {
+          title: 'Elasticsearch nodes disk usage above high watermark',
+          description: (
+            <span>
+              There are Elasticsearch nodes in the cluster with almost no free disk, their disk usage is above the high watermark.{' '}
+              For this reason Elasticsearch will attempt to relocate shards away from the affected nodes.{' '}
+              The affected nodes are: [{notification.details.nodes}]{' '}
+              Check <a href="https://www.elastic.co/guide/en/elasticsearch/reference/master/disk-allocator.html" target="_blank">https://www.elastic.co/guide/en/elasticsearch/reference/master/disk-allocator.html</a>{' '}
+              for more details.
+            </span>
+          ),
+        };
+      case 'es_node_disk_watermark_flood_stage':
+        return {
+          title: 'Elasticsearch nodes disk usage above flood stage watermark',
+          description: (
+            <span>
+              There are Elasticsearch nodes in the cluster without free disk, their disk usage is above the flood stage watermark.{' '}
+              For this reason Elasticsearch enforces a read-only index block on all indexes having any of their shards in any of the{' '}
+              affected nodes. The affected nodes are: [{notification.details.nodes}]{' '}
+              Check <a href="https://www.elastic.co/guide/en/elasticsearch/reference/master/disk-allocator.html" target="_blank">https://www.elastic.co/guide/en/elasticsearch/reference/master/disk-allocator.html</a>{' '}
+              for more details.
+            </span>
+          ),
+        };
       default:
         return { title: `unknown (${notification.type})`, description: 'unknown' };
     }


### PR DESCRIPTION
## Description

Added a disk usage check of the elasticsearch nodes. If cluster allocation thresholds are enabled, it will monitor those settings against all the elasticsearch nodes of the cluster and send notifications visible in graylog UI.

## Motivation and Context
Backport of https://github.com/Graylog2/graylog2-server/pull/7853 for #7810 
