### PR TITLE
Fix LDAP exceptions for local user account

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/DefaultSecurityManagerProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/DefaultSecurityManagerProvider.java
@@ -58,7 +58,9 @@ public class DefaultSecurityManagerProvider implements Provider<DefaultSecurityM
         sm = new DefaultSecurityManager(orderedAuthenticatingRealms);
         final Authenticator authenticator = sm.getAuthenticator();
         if (authenticator instanceof ModularRealmAuthenticator) {
-            ((ModularRealmAuthenticator) authenticator).setAuthenticationStrategy(new FirstSuccessfulStrategy());
+            FirstSuccessfulStrategy strategy = new FirstSuccessfulStrategy();
+            strategy.setStopAfterFirstSuccess(true);
+            ((ModularRealmAuthenticator) authenticator).setAuthenticationStrategy(strategy);
         }
 
         // root account realm might be deactivated and won't be present in that case

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
         <retrofit.version>2.8.1</retrofit.version>
         <scala.version>2.11.8</scala.version>
         <semver4j.version>2.2.0-graylog.1</semver4j.version>
-        <shiro.version>1.5.1</shiro.version>
+        <shiro.version>1.5.2</shiro.version>
         <sigar.version>1.6.4</sigar.version>
         <siv-mode.version>1.3.2</siv-mode.version>
         <slf4j.version>1.7.30</slf4j.version>


### PR DESCRIPTION
Since years we get LDAP exception for logins of local users even if the LDAP realm is in the last position. That is not necessary when the local user authentication is successful.

## Description
This change includes an Apache Shiro bug fix [SHIRO-747](https://issues.apache.org/jira/browse/SHIRO-747) and configures FirstSuccessfulStrategy to do what the name implies, see [SHIRO-669](https://issues.apache.org/jira/browse/SHIRO-669).

## Motivation and Context
This should fix Graylog2/graylog2-server#2267

## How Has This Been Tested?
This has been testen locally
1. create a local user
2. enable and configure ldap against a non existing ldap server (e.g. localhost:389)
3. login with the created user: this results in an LDAP exception in graylog-server.log
4. reorder realms: move ldap to the end
5. login with created user: no more exception in log file

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

