### PR TITLE
Change outputDirectory to non filesystem-root paths

### DIFF
--- a/graylog2-server/src/main/assembly/graylog.xml
+++ b/graylog2-server/src/main/assembly/graylog.xml
@@ -19,7 +19,7 @@
         </fileSet>
         <fileSet>
             <directory>${project.basedir}/../lib/sigar-${sigar.version}</directory>
-            <outputDirectory>/lib/sigar</outputDirectory>
+            <outputDirectory>lib/sigar</outputDirectory>
             <includes>
                 <include>**/*</include>
             </includes>
@@ -28,7 +28,7 @@
         <!-- empty directories -->
         <fileSet>
             <directory>./</directory>
-            <outputDirectory>/log</outputDirectory>
+            <outputDirectory>log</outputDirectory>
             <excludes>
                 <exclude>*/**</exclude>
             </excludes>
@@ -45,7 +45,7 @@
         <file>
             <source>${project.build.directory}/graylog2-server-${project.version}-shaded.jar</source>
             <destName>graylog.jar</destName>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory>.</outputDirectory>
         </file>
         <file>
             <source>${project.basedir}/../bin/graylogctl</source>
@@ -55,7 +55,7 @@
         <file>
             <source>${project.basedir}/../misc/graylog.conf</source>
             <destName>graylog.conf.example</destName>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory>.</outputDirectory>
         </file>
     </files>
 </assembly>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Change to relative paths (to .) instead of / to remove assembly warnings

## Motivation and Context
Fix Graylog2/graylog2-server#7920

## How Has This Been Tested?
mvn package doesn't output any warnings any more

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

