### PR TITLE
Improving eslint rules for flow.

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -43,5 +43,22 @@ module.exports = {
     'react/prefer-es6-class': 'off',
     'react/prefer-stateless-function': 'warn',
     'react/static-property-placement': 'off',
+
+    // eslint-plugin-flowtype configs, `recommended` is too weak in a couple of places:
+    'flowtype/delimiter-dangle': [1, 'always-multiline'],
+    'flowtype/no-weak-types': [
+      2,
+      {
+        any: false,
+      },
+    ],
+    'flowtype/require-valid-file-annotation': [
+      2,
+      'always', {
+        annotationStyle: 'line',
+        strict: true,
+      },
+    ],
+    'flowtype/semi': [2, 'always'],
   },
 };

--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -54,7 +54,7 @@ module.exports = {
     ],
     'flowtype/require-valid-file-annotation': [
       2,
-      'always', {
+      'never', {
         annotationStyle: 'line',
         strict: true,
       },


### PR DESCRIPTION
When the `eslint-plugin-flowtype` was introduced, it was not considered
that its `recommended` config actually does not activate all rules. This
PR is activating the relevant rules for us. These are:

  * [`delimiter-dangle`](https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype-rules-delimiter-dangle): making rules for dangling commas consistent (enforce for multilines)
  * [`no-weak-types`](https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype-rules-no-weak-types): not allowing `Object` or `Function` types, because they are too generic
  * [`require-valid-file-annotation`](https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype-rules-require-valid-file-annotation): flow header should always be a line comment and `strict` should be true
  * [`semi`](https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype-rules-semi): enforcing semicolon for line endings