### PR TITLE
Fixing linter hints automatically.

### DIFF
--- a/graylog2-web-interface/src/components/common/PaginatedList.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.jsx
@@ -16,13 +16,13 @@ type Props = {
   pageSize: number,
   pageSizes: Array<number>,
   totalItems: number,
-  showPageSizeSelect: boolean
-}
+  showPageSizeSelect: boolean,
+};
 
 type State = {
   currentPage: number,
-  pageSize: number
-}
+  pageSize: number,
+};
 
 /**
  * Wrapper component around an element that renders pagination

--- a/graylog2-web-interface/src/components/common/Spinner.jsx
+++ b/graylog2-web-interface/src/components/common/Spinner.jsx
@@ -9,7 +9,7 @@ type Props = {
   delay: number,
   name?: string,
   text?: string,
-}
+};
 
 /**
  * Simple spinner to use while waiting for something to load.

--- a/graylog2-web-interface/src/components/common/URLWhiteListFormModal.jsx
+++ b/graylog2-web-interface/src/components/common/URLWhiteListFormModal.jsx
@@ -19,7 +19,7 @@ const URL_WHITELIST_CONFIG = 'org.graylog2.system.urlwhitelist.UrlWhitelist';
 
 type State = {
   config: WhiteListConfig,
-  isValid: boolean
+  isValid: boolean,
 };
 
 type Props = {

--- a/graylog2-web-interface/src/components/common/URLWhiteListInput.jsx
+++ b/graylog2-web-interface/src/components/common/URLWhiteListInput.jsx
@@ -17,8 +17,8 @@ type Props = {
   url: string,
   labelClassName: string,
   wrapperClassName: string,
-  urlType: string
-}
+  urlType: string,
+};
 const URLWhiteListInput = ({ label, onChange, validationMessage, validationState, url, labelClassName, wrapperClassName, urlType }: Props) => {
   const [isWhitelisted, setIsWhitelisted] = useState(false);
   const [currentValidationState, setCurrentValidationState] = useState(validationState);

--- a/graylog2-web-interface/src/components/configurations/UrlWhiteListConfig.jsx
+++ b/graylog2-web-interface/src/components/configurations/UrlWhiteListConfig.jsx
@@ -9,7 +9,7 @@ import type { WhiteListConfig } from 'stores/configurations/ConfigurationsStore'
 
 type State = {
   config: WhiteListConfig,
-  isValid: boolean
+  isValid: boolean,
 };
 
 type Props = {

--- a/graylog2-web-interface/src/components/graylog/ProgressBar.jsx
+++ b/graylog2-web-interface/src/components/graylog/ProgressBar.jsx
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css, keyframes, type StyledComponent } from 'styled-components';

--- a/graylog2-web-interface/src/components/layout/AppContentGrid.jsx
+++ b/graylog2-web-interface/src/components/layout/AppContentGrid.jsx
@@ -6,8 +6,8 @@ import styled, { type StyledComponent } from 'styled-components';
 import { Grid } from 'components/graylog';
 
 type Props = {
-  children: React.Node
-}
+  children: React.Node,
+};
 
 const Container: StyledComponent<Props, {}, HTMLDivElement> = styled.div`
   padding: 15px 10px;

--- a/graylog2-web-interface/src/components/layout/Footer.jsx
+++ b/graylog2-web-interface/src/components/layout/Footer.jsx
@@ -12,7 +12,7 @@ const SystemStore = StoreProvider.getStore('System');
 type Props = {
   system?: {
     version: string,
-    hostname: string
+    hostname: string,
   },
 };
 

--- a/graylog2-web-interface/src/flow/css-useable-modules.js
+++ b/graylog2-web-interface/src/flow/css-useable-modules.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 type CSSModule = {
   [key: string]: string,
   use: () => void,

--- a/graylog2-web-interface/src/routing/AppWithoutSearchBar.jsx
+++ b/graylog2-web-interface/src/routing/AppWithoutSearchBar.jsx
@@ -8,8 +8,8 @@ import Footer from 'components/layout/Footer';
 import AppContentGrid from 'components/layout/AppContentGrid';
 
 type Props = {
-  children: React.Node
-}
+  children: React.Node,
+};
 
 const StyledRow = styled(Row)`
   margin-bottom: 0;

--- a/graylog2-web-interface/src/stores/configurations/ConfigurationsStore.js
+++ b/graylog2-web-interface/src/stores/configurations/ConfigurationsStore.js
@@ -1,4 +1,4 @@
-// @flow
+// @flow strict
 import Reflux from 'reflux';
 import { qualifyUrl } from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
@@ -18,7 +18,7 @@ export type Url = {
 
 export type WhiteListConfig = {
   entries: Array<Url>,
-  disabled: boolean
+  disabled: boolean,
 };
 const ConfigurationsStore = Reflux.createStore({
   listenables: [ConfigurationActions],

--- a/graylog2-web-interface/src/stores/metrics/MetricsStore.js
+++ b/graylog2-web-interface/src/stores/metrics/MetricsStore.js
@@ -57,7 +57,7 @@ export type NodeMetric = {
     | BaseMetric<GaugeMetric>
     | BaseMetric<MeterMetric>
     | BaseMetric<TimerMetric>,
-}
+};
 
 export type ClusterMetric = {
   [nodeId: string]: NodeMetric,

--- a/graylog2-web-interface/src/stores/streams/StreamsStore.js
+++ b/graylog2-web-interface/src/stores/streams/StreamsStore.js
@@ -18,21 +18,21 @@ export type Stream = {
   isDefaultStream: boolean,
   creatorUser: string,
   createdAt: number,
-}
+};
 
 type TestMatchResponse = {
   matches: boolean,
   rules: any,
-}
+};
 
 type Callback = {
   (): void,
-}
+};
 
 type StreamSummaryResponse = {
   total: number,
   streams: Array<Stream>,
-}
+};
 
 const StreamsStore = Reflux.createStore({
   callbacks: [],

--- a/graylog2-web-interface/src/stores/users/RolesStore.js
+++ b/graylog2-web-interface/src/stores/users/RolesStore.js
@@ -12,7 +12,7 @@ type Role = {
   name: string,
   description: string,
   permissions: string[],
-}
+};
 
 type RoleMembership = {
   role: string,

--- a/graylog2-web-interface/src/views/bindings.enterpriseWidgets.test.jsx
+++ b/graylog2-web-interface/src/views/bindings.enterpriseWidgets.test.jsx
@@ -8,8 +8,8 @@ import bindings from './bindings';
 describe('Views bindings enterprise widgets', () => {
   const { enterpriseWidgets } = bindings;
   type WidgetCondig = {
-    needsControlledHeight: (widget?: Widget) => boolean
-  }
+    needsControlledHeight: (widget?: Widget) => boolean,
+  };
   const findWidgetConfig = (type) => enterpriseWidgets.find((widgetConfig) => widgetConfig.type === type);
 
   describe('Aggregations', () => {

--- a/graylog2-web-interface/src/views/components/DebugOverlay.jsx
+++ b/graylog2-web-interface/src/views/components/DebugOverlay.jsx
@@ -17,7 +17,7 @@ type Props = {
   onClose: () => void,
   searches: SearchStoreState,
   show: boolean,
-}
+};
 
 const DebugOverlay = ({ currentView, searches, show, onClose }: Props) => (
   <BootstrapModalWrapper showModal={show} onHide={onClose}>

--- a/graylog2-web-interface/src/views/components/Field.jsx
+++ b/graylog2-web-interface/src/views/components/Field.jsx
@@ -15,7 +15,7 @@ type Props = {|
   menuContainer: ?HTMLElement,
   queryId: string,
   type: FieldType,
-|}
+|};
 
 const Field = ({ children, disabled = false, menuContainer, name, queryId, type }: Props) => (
   <InteractiveContext.Consumer>

--- a/graylog2-web-interface/src/views/components/MigrateFieldCharts.jsx
+++ b/graylog2-web-interface/src/views/components/MigrateFieldCharts.jsx
@@ -28,15 +28,15 @@ const FIELD_CHARTS_MIGRATED_KEY = 'pinned-field-charts-migrated';
 
 type LegacySeries = 'mean' | 'max' | 'min' | 'total' | 'count' | 'cardinality';
 type LegacyInterpolation = 'linear' | 'step-after' | 'basis' | 'bundle' | 'cardinal' | 'monotone';
-type LegacyInterval = 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year'
-type LegacyVisualization = 'bar' | 'area' | 'line' | 'scatterplot'
+type LegacyInterval = 'minute' | 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year';
+type LegacyVisualization = 'bar' | 'area' | 'line' | 'scatterplot';
 type LegacyFieldChart = {
   field: string,
   renderer: LegacyVisualization,
   interpolation: LegacyInterpolation,
   valuetype: LegacySeries,
   interval: LegacyInterval,
-}
+};
 
 const Actions = styled.div`
   margin-top: 10px;

--- a/graylog2-web-interface/src/views/components/QueryTabs.jsx
+++ b/graylog2-web-interface/src/views/components/QueryTabs.jsx
@@ -45,7 +45,7 @@ type Props = {
   queries: Array<QueryIdsStore>,
   selectedQueryId: string,
   titles: Immutable.Map<string, string>,
-}
+};
 
 class QueryTabs extends React.Component<Props> {
   queryTitleEditModal: ?QueryTitleEditModal

--- a/graylog2-web-interface/src/views/components/ViewTypeLabel.js
+++ b/graylog2-web-interface/src/views/components/ViewTypeLabel.js
@@ -4,8 +4,8 @@ import type { ViewType } from 'views/logic/views/View';
 
 type Props = {
   type: ViewType,
-  capitalize: boolean
-}
+  capitalize: boolean,
+};
 
 const capitalizeLabel = (label) => label[0].toUpperCase() + label.slice(1);
 

--- a/graylog2-web-interface/src/views/components/actions/ActionHandler.jsx
+++ b/graylog2-web-interface/src/views/components/actions/ActionHandler.jsx
@@ -15,7 +15,7 @@ export type ActionHandlerArguments = {|
   field: FieldName,
   value?: FieldValue,
   type: FieldType,
-  contexts: ActionContexts
+  contexts: ActionContexts,
 |};
 
 export type ActionHandler = (ActionHandlerArguments) => Promise<mixed>;

--- a/graylog2-web-interface/src/views/components/actions/FieldActions.jsx
+++ b/graylog2-web-interface/src/views/components/actions/FieldActions.jsx
@@ -24,7 +24,7 @@ type Props = {|
 type State = {
   open: boolean,
   overflowingComponents: { [string]: React.Node },
-}
+};
 
 class FieldActions extends React.Component<Props, State> {
   static contextType = ActionContext;

--- a/graylog2-web-interface/src/views/components/actions/ValueActions.jsx
+++ b/graylog2-web-interface/src/views/components/actions/ValueActions.jsx
@@ -21,12 +21,12 @@ type Props = {
   queryId: QueryId,
   type: FieldType,
   value: React.Node,
-}
+};
 
 type State = {
   open: boolean,
   overflowingComponents: { [string]: React.Node },
-}
+};
 
 class ValueActions extends React.Component<Props, State> {
   static propTypes = {

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/BarVisualizationConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/BarVisualizationConfiguration.jsx
@@ -15,7 +15,7 @@ type Props = {
 type BarModeOption = {
   label: string,
   value: BarMode,
-}
+};
 
 class BarVisualizationConfiguration extends React.Component<Props> {
   static propTypes = {

--- a/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeHeader.jsx
+++ b/graylog2-web-interface/src/views/components/dashboard/BigDisplayModeHeader.jsx
@@ -14,7 +14,7 @@ type Props = {
   view: {
     activeQuery: ?QueryId,
     view: ?View,
-  }
+  },
 };
 
 const PositioningWrapper = styled.div`

--- a/graylog2-web-interface/src/views/components/messagelist/NodeName.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/NodeName.jsx
@@ -12,7 +12,7 @@ type NodeId = string;
 type NodeInfo = {
   short_node_id: string,
   hostname: string,
-}
+};
 type Props = {
   nodeId: NodeId,
   nodes: { [NodeId]: NodeInfo },

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
@@ -15,11 +15,11 @@ import type { TitlesMap } from 'views/stores/TitleTypes';
 
 type Props = {
   onTitleChange: (newTitle: string) => Promise<TitlesMap>,
-}
+};
 
 type State = {
   titleDraft: string,
-}
+};
 
 class QueryTitleEditModal extends React.Component<Props, State> {
   modal: BootstrapModalForm = React.createRef();

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.jsx
@@ -19,14 +19,14 @@ type Props = {
   toggleModal: () => void,
   deleteSavedSearch: (View) => Promise<View>,
   views: SavedSearchesState,
-}
+};
 
 type State = {
   selectedSavedSearch?: string,
   query: string,
   page: number,
   perPage: number,
-}
+};
 
 const AlertIcon: StyledComponent<{}, ThemeInterface, *> = styled(Icon)(({ theme }) => css`
   margin-right: 6px;

--- a/graylog2-web-interface/src/views/components/sidebar/NavItem.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/NavItem.jsx
@@ -15,7 +15,7 @@ type Props = {
   icon: string,
   onClick: (string) => void,
   children: React.Element<any>,
-}
+};
 
 const NavItem = ({ isOpen, isSelected, expandRight, text, children, icon, onClick }: Props) => {
   // eslint-disable-next-line no-nested-ternary

--- a/graylog2-web-interface/src/views/components/visualizations/ChartData.js
+++ b/graylog2-web-interface/src/views/components/visualizations/ChartData.js
@@ -13,7 +13,7 @@ export type ChartDefinition = {
   z?: Array<Array<any>>,
 };
 
-export type ChartData = [any, Array<Key>, Array<any>, Array<Array<any>>]
+export type ChartData = [any, Array<Key>, Array<any>, Array<Array<any>>];
 export type ExtractedSeries = Array<ChartData>;
 
 export type KeyJoiner = (Array<any>) => string;

--- a/graylog2-web-interface/src/views/components/widgets/FieldSortIcon.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/FieldSortIcon.jsx
@@ -15,14 +15,14 @@ type Props = {
   fieldName: string,
   onSortChange: (SortConfig[]) => Promise<void>,
   setLoadingState: (loading: boolean) => void,
-}
+};
 
 type DirectionStrategy = {
   handleSortChange: (changeSort: (direction: Direction) => void) => void,
   icon: string,
   sortActive: boolean,
   tooltip: (fieldName: string) => string,
-}
+};
 
 const SortIcon: StyledComponent<{sortActive: boolean}, {}, HTMLButtonElement> = styled.button(({ sortActive }) => {
   const color = sortActive ? '#333' : '#bdbdbd';

--- a/graylog2-web-interface/src/views/components/widgets/FieldSortIcon.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/FieldSortIcon.test.jsx
@@ -1,4 +1,4 @@
-// @flow stric
+// @flow strict
 import React from 'react';
 import { render, fireEvent, cleanup, wait } from 'wrappedTestingLibrary';
 

--- a/graylog2-web-interface/src/views/components/widgets/FieldSortSelect.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/FieldSortSelect.jsx
@@ -19,8 +19,8 @@ type Props = {
 
 type Option = {
   label: string,
-  value: number
-}
+  value: number,
+};
 
 const findOptionByLabel = (options: Immutable.List<Option>, label: string) => options.find((option) => option.label === label);
 

--- a/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageList.jsx
@@ -53,7 +53,7 @@ const Wrapper = styled.div`
 type State = {
   errors: Array<{ description: string }>,
   currentPage: number,
-}
+};
 
 type Props = {
   config: MessagesWidgetConfig,

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
@@ -140,7 +140,7 @@ const TableHead = styled.thead`
 
 type State = {
   expandedMessages: Immutable.Set<string>,
-}
+};
 
 type Props = {
   activeQueryId: string,

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/SeriesConfig.js
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/SeriesConfig.js
@@ -2,7 +2,7 @@
 import * as Immutable from 'immutable';
 
 export type SeriesConfigJson = {
-  name: string
+  name: string,
 };
 
 type InternalState = {

--- a/graylog2-web-interface/src/views/logic/fieldtypes/FieldType.js
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/FieldType.js
@@ -14,7 +14,7 @@ export const Properties: { [string]: Property } = {
 export type FieldTypeJSON = {
   type: string,
   properties: Array<Property>,
-  index_names: Array<string>
+  index_names: Array<string>,
 };
 
 export type FieldName = string;

--- a/graylog2-web-interface/src/views/logic/fieldtypes/FieldTypeMapping.js
+++ b/graylog2-web-interface/src/views/logic/fieldtypes/FieldTypeMapping.js
@@ -5,12 +5,12 @@ import type { FieldTypeJSON } from './FieldType';
 export type FieldTypeMappingJSON = {
   name: string,
   type: FieldTypeJSON,
-}
+};
 
 class FieldTypeMapping {
   value: {
     name: string,
-    type: FieldType
+    type: FieldType,
   };
 
   constructor(name: string, type: FieldType) {

--- a/graylog2-web-interface/src/views/logic/parameters/LookupTableParameter.js
+++ b/graylog2-web-interface/src/views/logic/parameters/LookupTableParameter.js
@@ -10,7 +10,7 @@ type InternalBuilderState = Immutable.Map<string, any>;
 type InternalState = {
   lookupTable: string,
   key: string,
-}
+};
 
 export type LookupTableParameterJson = ParameterJson & {
   lookup_table: string,

--- a/graylog2-web-interface/src/views/logic/parameters/Parameter.js
+++ b/graylog2-web-interface/src/views/logic/parameters/Parameter.js
@@ -13,7 +13,7 @@ type InternalState = {
   dataType: string,
   defaultValue: any,
   optional: boolean,
-  binding: ?ParameterBinding
+  binding: ?ParameterBinding,
 };
 
 export type ParameterJson = {

--- a/graylog2-web-interface/src/views/logic/search/GlobalOverride.js
+++ b/graylog2-web-interface/src/views/logic/search/GlobalOverride.js
@@ -7,20 +7,20 @@ export type MessageListOptions = {
     limit: number;
     offset: number;
   };
-}
+};
 
 type InternalState = {
   timerange?: TimeRange,
   query?: QueryString,
   keepSearchTypes?: string[],
-  searchTypes?: MessageListOptions
+  searchTypes?: MessageListOptions,
 };
 
 type JsonRepresentation = {
   timerange?: TimeRange,
   query?: QueryString,
   keep_search_types?: string[],
-  search_types?: MessageListOptions
+  search_types?: MessageListOptions,
 };
 
 export default class GlobalOverride {

--- a/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotConfigGenerator.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/aggregation/PivotConfigGenerator.js
@@ -26,7 +26,7 @@ type FormattedPivot = {
   interval: {
     timeunit: string,
     type: string,
-  }
+  },
 };
 
 type TimeConfig = {|

--- a/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/events/EventHandler.js
@@ -24,7 +24,7 @@ type Shape = {
   opacity: number,
   line: {
     color: string,
-  }
+  },
 };
 
 export type Shapes = Array<Shape>;

--- a/graylog2-web-interface/src/views/logic/searchtypes/messages/MessageSortConfig.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/messages/MessageSortConfig.js
@@ -9,7 +9,7 @@ export type MessageSortConfigJson = {
 type InternalState = {
   field: string,
   direction: Direction,
-}
+};
 
 export default class MessageSortConfig {
   _value: InternalState

--- a/graylog2-web-interface/src/views/logic/searchtypes/pivot/PivotHandler.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/pivot/PivotHandler.js
@@ -18,21 +18,21 @@ type MultiValue = {|
 |};
 
 export type Leaf = {|
-...{| source: 'leaf' |}, ...Keyed, ...MultiValue
+...{| source: 'leaf' |}, ...Keyed, ...MultiValue,
 |};
 
 export type NonLeaf = {|
-...{| source: 'non-leaf' |}, ...Keyed, ...MultiValue
+...{| source: 'non-leaf' |}, ...Keyed, ...MultiValue,
 |};
 
 export type ColLeaf = {|
-...{| source: 'col-leaf' |}, ...Keyed, ...SingleValue
+...{| source: 'col-leaf' |}, ...Keyed, ...SingleValue,
 |};
 export type RowLeaf = {|
-...{| source: 'row-leaf' |}, ...Keyed, ...SingleValue
+...{| source: 'row-leaf' |}, ...Keyed, ...SingleValue,
 |};
 export type RowInner = {|
-...{| source: 'row-inner' |}, ...Keyed, ...SingleValue
+...{| source: 'row-inner' |}, ...Keyed, ...SingleValue,
 |};
 
 export type Row = Leaf | NonLeaf | ColLeaf | RowLeaf | RowInner;

--- a/graylog2-web-interface/src/views/logic/views/View.js
+++ b/graylog2-web-interface/src/views/logic/views/View.js
@@ -198,7 +198,7 @@ export default class View {
   }
 }
 
-type InternalBuilderState = Immutable.Map<string, any>
+type InternalBuilderState = Immutable.Map<string, any>;
 class Builder {
   value: InternalBuilderState;
 

--- a/graylog2-web-interface/src/views/logic/widgets/WidgetPosition.js
+++ b/graylog2-web-interface/src/views/logic/widgets/WidgetPosition.js
@@ -6,7 +6,7 @@ type State = {
   row: number,
   height: number,
   width: number,
-}
+};
 
 export type WidgetPositionJSON = {
   col: number | 'Infinity',

--- a/graylog2-web-interface/src/views/pages/NewDashboardPage.jsx
+++ b/graylog2-web-interface/src/views/pages/NewDashboardPage.jsx
@@ -19,7 +19,7 @@ type Props = {
     state?: {
       view?: View | ViewJson,
     },
-    query: { [string]: any }
+    query: { [string]: any },
   };
   loadingViewHooks: Array<ViewHook>,
   executingViewHooks: Array<ViewHook>,

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
@@ -16,7 +16,7 @@ import { SearchActions } from 'views/stores/SearchStore';
 import { ExtendedSearchPage } from 'views/pages';
 import { syncWithQueryParameters } from 'views/hooks/SyncWithQueryParameters';
 
-type URLQuery = { [string]: any }
+type URLQuery = { [string]: any };
 
 type Props = {
   route: {},
@@ -25,7 +25,7 @@ type Props = {
   },
   location: {
     query: URLQuery,
-    pathname: string
+    pathname: string,
   },
   executingViewHooks: Array<ViewHook>,
   loadingViewHooks: Array<ViewHook>,

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.jsx
@@ -17,7 +17,7 @@ import type { ViewHook } from 'views/logic/hooks/ViewHook';
 import Spinner from 'components/common/Spinner';
 import { ExtendedSearchPage } from 'views/pages';
 
-type URLQuery = { [string]: any }
+type URLQuery = { [string]: any };
 
 type Props = {
   executingViewHooks: Array<ViewHook>,

--- a/graylog2-web-interface/src/views/stores/TitlesStore.js
+++ b/graylog2-web-interface/src/views/stores/TitlesStore.js
@@ -9,7 +9,7 @@ import { CurrentViewStateActions, CurrentViewStateStore } from './CurrentViewSta
 import type { TitlesMap, TitleType } from './TitleTypes';
 
 type TitlesActionsTypes = RefluxActions<{
-  set: (string, string, string) => Promise<TitlesMap>
+  set: (string, string, string) => Promise<TitlesMap>,
 }>;
 
 export const TitlesActions: TitlesActionsTypes = singletonActions(


### PR DESCRIPTION
This PR is fixing linter hints generated by introducing new rules in
#7923 automatically, by running `yarn run lint --fix`.