### PR TITLE
Make `FieldSortSelect` use our `Select` wrapper.

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/FieldSortSelect.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/FieldSortSelect.jsx
@@ -1,7 +1,6 @@
 // @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import Select from 'react-select';
 import * as Immutable from 'immutable';
 
 import CustomPropTypes from 'views/components/CustomPropTypes';
@@ -10,6 +9,7 @@ import { defaultCompare } from 'views/logic/DefaultCompare';
 import Direction from 'views/logic/aggregationbuilder/Direction';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import SortConfig from 'views/logic/aggregationbuilder/SortConfig';
+import Select from 'views/components/Select';
 
 type Props = {
   fields: Immutable.List<FieldTypeMapping>,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The `FieldSortSelect` component uses the `Select` component from
`react-select` directly, without reusing our wrapper. This prevents it
from benefitting from the changes we made in #7818, especially resulting
in higher render times if the number of options is high.

<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.