### PR TITLE
Work around non-existing `Event` constructor in IE11.

### DIFF
--- a/graylog2-web-interface/src/util/CreateEvent.js
+++ b/graylog2-web-interface/src/util/CreateEvent.js
@@ -1,0 +1,13 @@
+// @flow strict
+// Workaround for IE11, see #7670
+const createEvent = (type: string) => {
+  if (typeof (Event) === 'function') {
+    return new Event(type);
+  }
+
+  const event = document.createEvent('Event');
+  event.initEvent(type, true, true);
+  return event;
+};
+
+export default createEvent;

--- a/graylog2-web-interface/src/util/CreateEvent.test.jsx
+++ b/graylog2-web-interface/src/util/CreateEvent.test.jsx
@@ -1,0 +1,20 @@
+// @flow strict
+import createEvent from './CreateEvent';
+
+describe('CreateEvent', () => {
+  it('returns event if `Event` constructor is available', () => {
+    const event = createEvent('submit');
+    expect(event).not.toBeNull();
+    expect(event).toBeInstanceOf(Event);
+  });
+  it('returns event if `Event` constructor is not available', () => {
+    const oldEvent: typeof Event = window.Event;
+    window.Event = null;
+
+    const event = createEvent('submit');
+    expect(event).not.toBeNull();
+    expect(event).toBeInstanceOf(oldEvent);
+
+    window.Event = oldEvent;
+  });
+});

--- a/graylog2-web-interface/src/util/FormsUtils.js
+++ b/graylog2-web-interface/src/util/FormsUtils.js
@@ -16,13 +16,24 @@ const FormUtils = {
   triggerInput(urlInput) {
     const { input } = urlInput;
     const tracker = input._valueTracker;
-    const event = new Event('change', { bubbles: true });
+    const event = this.createEvent('change');
     event.simulated = true;
     if (tracker) {
       tracker.setValue('');
     }
     input.dispatchEvent(event);
   },
+  // Workaround for IE11, see #7670
+  createEvent(type) {
+    if (typeof (Event) === 'function') {
+      return new Event(type);
+    }
+
+    const event = document.createEvent('Event');
+    event.initEvent(type, true, true);
+    return event;
+  },
 };
+
 
 export default FormUtils;

--- a/graylog2-web-interface/src/util/FormsUtils.js
+++ b/graylog2-web-interface/src/util/FormsUtils.js
@@ -1,4 +1,5 @@
 import NumberUtils from 'util/NumberUtils';
+import createEvent from './CreateEvent';
 
 const FormUtils = {
   getValueFromInput(input) {
@@ -16,22 +17,12 @@ const FormUtils = {
   triggerInput(urlInput) {
     const { input } = urlInput;
     const tracker = input._valueTracker;
-    const event = this.createEvent('change');
+    const event = createEvent('change');
     event.simulated = true;
     if (tracker) {
       tracker.setValue('');
     }
     input.dispatchEvent(event);
-  },
-  // Workaround for IE11, see #7670
-  createEvent(type) {
-    if (typeof (Event) === 'function') {
-      return new Event(type);
-    }
-
-    const event = document.createEvent('Event');
-    event.initEvent(type, true, true);
-    return event;
   },
 };
 

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/MapVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/MapVisualization.jsx
@@ -4,8 +4,8 @@ import React from 'react';
 import { CircleMarker, Map, Popup, TileLayer } from 'react-leaflet';
 import chroma from 'chroma-js';
 import { flatten } from 'lodash';
+import createEvent from 'util/CreateEvent';
 
-import FormsUtils from 'util/FormsUtils';
 import style from './MapVisualization.css';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
@@ -73,7 +73,7 @@ class MapVisualization extends React.Component {
   // Workaround to avoid wrong placed markers or empty tiles if the map container size changed.
   _forceMapUpdate = () => {
     if (this._map) {
-      window.dispatchEvent(FormsUtils.createEvent('resize'));
+      window.dispatchEvent(createEvent('resize'));
       const { interactive } = this.props;
       this._map.leafletElement.invalidateSize(interactive);
     }

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/MapVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/MapVisualization.jsx
@@ -5,6 +5,7 @@ import { CircleMarker, Map, Popup, TileLayer } from 'react-leaflet';
 import chroma from 'chroma-js';
 import { flatten } from 'lodash';
 
+import FormsUtils from 'util/FormsUtils';
 import style from './MapVisualization.css';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
@@ -72,7 +73,7 @@ class MapVisualization extends React.Component {
   // Workaround to avoid wrong placed markers or empty tiles if the map container size changed.
   _forceMapUpdate = () => {
     if (this._map) {
-      window.dispatchEvent(new Event('resize'));
+      window.dispatchEvent(FormsUtils.createEvent('resize'));
       const { interactive } = this.props;
       this._map.leafletElement.invalidateSize(interactive);
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In Internet Explorer 11, calling `new Event()` raises an exception.
Instead, a new event needs to be created using
`el.createEvent`/`event.initEvent`, the latter being deprecated on all
other major browsers.

This PR is abstracting the uglyness of this circumstance by offering a
`createEvent` function which returns an event after checking if the
`Event` constructor is available, using the other approach if not.

Fixes #7670.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Running IE11 in a Window VM, testing with Chrome/Safari for the
  regular approach.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.