### PR TITLE
Restore proper error returned by `FetchProvider`.

### DIFF
--- a/graylog2-web-interface/src/logic/rest/FetchProvider.js
+++ b/graylog2-web-interface/src/logic/rest/FetchProvider.js
@@ -13,7 +13,7 @@ import history from 'util/History';
 export class FetchError extends Error {
   constructor(message, additional) {
     super(message);
-    this.message = message || (additional.message || 'Undefined error.');
+    this.message = message ?? additional?.message ?? 'Undefined error.';
     /* eslint-disable no-console */
     try {
       this.responseMessage = additional.body ? additional.body.message : undefined;
@@ -26,7 +26,7 @@ export class FetchError extends Error {
     /* eslint-enable no-console */
 
     this.additional = additional;
-    this.status = additional.status; // Shortcut, as this is often used
+    this.status = additional?.status; // Shortcut, as this is often used
   }
 }
 
@@ -39,7 +39,7 @@ const defaultOnUnauthorizedError = (error) => ErrorsActions.report(createFromFet
 
 const onServerError = (error, onUnauthorized = defaultOnUnauthorizedError) => {
   const SessionStore = StoreProvider.getStore('Session');
-  const fetchError = FetchError(error.statusText, error);
+  const fetchError = new FetchError(error.statusText, error);
   if (SessionStore.isLoggedIn() && error.status === 401) {
     const SessionActions = ActionsProvider.getActions('Session');
     SessionActions.logout(SessionStore.getSessionId());
@@ -55,7 +55,7 @@ const onServerError = (error, onUnauthorized = defaultOnUnauthorizedError) => {
     ServerAvailabilityActions.reportError(fetchError);
   }
 
-  throw new FetchError();
+  throw fetchError;
 };
 
 export class Builder {

--- a/graylog2-web-interface/src/logic/rest/FetchProvider.js
+++ b/graylog2-web-interface/src/logic/rest/FetchProvider.js
@@ -47,7 +47,7 @@ const onServerError = (error, onUnauthorized = defaultOnUnauthorizedError) => {
 
   // Redirect to the start page if a user is logged in but not allowed to access a certain HTTP API.
   if (SessionStore.isLoggedIn() && error.status === 403) {
-    onUnauthorized(error);
+    onUnauthorized(fetchError);
   }
 
   if (error.originalError && !error.originalError.status) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #7709, changes were made to the `FetchProvider`, which prevent a
proper error object being handed down to consumers of it, in case of a
server response that is indicating an error.

This change is restoring the original behavior.

Fixes #7964.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.