### PR TITLE
Enforce Unix newlines for Ace editor (#7893)

### DIFF
--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -224,6 +224,8 @@ class SourceCodeEditor extends React.Component {
             <AceEditor ref={(c) => { this.reactAce = c; }}
                        annotations={annotations}
                        editorProps={{ $blockScrolling: 'Infinity' }}
+                       // Convert Windows line breaks to Unix. See issue #7889
+                       setOptions={{ newLineMode: 'unix' }}
                        focus={focus}
                        fontSize={fontSize}
                        mode={mode}


### PR DESCRIPTION
* Enforce Unix newlines for Ace editor

If documents in the Ace editor are modified on a Windows browser,
it would result in windows style newlines, which Graylog doesn't handle
correctly.

The Ace editor defaults to 'auto' mode, which switches to
windows mode, if the content is pasted on Windows.

It's better to uniformly have unix style newlines everywhere,
thus enforce unix mode as a default for Ace.

Fixes #7889
Fixes https://github.com/Graylog2/collector-sidecar/issues/389

* Add comment

(cherry picked from commit 208a5bc0a01f980ad7811b6fb4fd1a85d118bce7)
