### PR TITLE
use consistent spelling for "Content Packs"

### DIFF
--- a/graylog2-web-interface/src/pages/ContentPacksPage.jsx
+++ b/graylog2-web-interface/src/pages/ContentPacksPage.jsx
@@ -32,7 +32,7 @@ const ContentPacksPage = createReactClass({
 
   _deleteContentPack(contentPackId) {
     // eslint-disable-next-line no-alert
-    if (window.confirm('You are about to delete this content pack, are you sure?')) {
+    if (window.confirm('You are about to delete this Content Pack, are you sure?')) {
       ContentPacksActions.delete(contentPackId).then(() => {
         UserNotification.success('Content Pack deleted successfully.', 'Success');
         ContentPacksActions.list();
@@ -54,7 +54,7 @@ const ContentPacksPage = createReactClass({
       UserNotification.success('Content Pack installed successfully.', 'Success');
     }, (error) => {
       UserNotification.error(`Installing content pack failed with status: ${error}.
-         Could not install content pack with ID: ${contentPackId}`);
+         Could not install Content Pack with ID: ${contentPackId}`);
     });
   },
 
@@ -66,22 +66,22 @@ const ContentPacksPage = createReactClass({
     }
 
     return (
-      <DocumentTitle title="Content packs">
+      <DocumentTitle title="Content Packs">
         <span>
-          <PageHeader title="Content packs">
+          <PageHeader title="Content Packs">
             <span>
-              Content packs accelerate the set up process for a specific data source. A content pack can include inputs/extractors, streams, and dashboards.
+              Content Packs accelerate the set up process for a specific data source. A Content Pack can include inputs/extractors, streams, and dashboards.
             </span>
 
             <span>
-              Find more content packs in {' '}
+              Find more Content Packs in {' '}
               <a href="https://marketplace.graylog.org/" target="_blank" rel="noopener noreferrer">the Graylog Marketplace</a>.
             </span>
 
             <ButtonToolbar>
               <ContentPackUploadControls />
               <LinkContainer to={Routes.SYSTEM.CONTENTPACKS.CREATE}>
-                <Button bsStyle="success">Create a content pack</Button>
+                <Button bsStyle="success">Create a Content Pack</Button>
               </LinkContainer>
               <Button bsStyle="info" active>Content Packs</Button>
             </ButtonToolbar>


### PR DESCRIPTION
## Description
Purely cosmetical change for consistent spelling of the term "Content Packs" on this page.

## Motivation and Context

Just looked all wrong, so it triggered me.

## How Has This Been Tested?
N/A text update

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

