### PR TITLE
Extract styles from `ExtendedSearchPage`

### DIFF
--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
@@ -17,6 +17,7 @@ import QueryInput from 'views/components/searchbar/AsyncQueryInput';
 import ViewActionsMenu from 'views/components/ViewActionsMenu';
 import { GlobalOverrideActions, GlobalOverrideStore } from 'views/stores/GlobalOverrideStore';
 import type { QueryString, TimeRange } from 'views/logic/queries/Query';
+import TopRow from 'views/components/searchbar/TopRow';
 import DashboardSearchForm from './DashboardSearchBarForm';
 import TimeRangeInput from './searchbar/TimeRangeInput';
 
@@ -45,7 +46,7 @@ const DashboardSearchBar = ({ config, globalOverride, disableSearch = false, onE
           <DashboardSearchForm initialValues={{ timerange, queryString }} onSubmit={submitForm}>
             {({ dirty, isSubmitting, isValid, handleSubmit }) => (
               <>
-                <Row className="no-bm extended-search-query-metadata">
+                <TopRow>
                   <Col lg={4} md={6} xs={8}>
                     <TimeRangeOverrideTypeSelector />
                     <TimeRangeInput config={config} />
@@ -53,7 +54,7 @@ const DashboardSearchBar = ({ config, globalOverride, disableSearch = false, onE
                   <Col lg={8} md={6} xs={4}>
                     <RefreshControls />
                   </Col>
-                </Row>
+                </TopRow>
 
                 <Row className="no-bm">
                   <Col md={9} xs={8}>

--- a/graylog2-web-interface/src/views/components/SearchBar.jsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.jsx
@@ -11,6 +11,7 @@ import DocsHelper from 'util/DocsHelper';
 import { Spinner, Icon } from 'components/common';
 import { Col, Row } from 'components/graylog';
 
+import TopRow from 'views/components/searchbar/TopRow';
 import SearchButton from 'views/components/searchbar/SearchButton';
 import SavedSearchControls from 'views/components/searchbar/saved-search/SavedSearchControls';
 import TimeRangeInput from 'views/components/searchbar/TimeRangeInput';
@@ -72,7 +73,7 @@ const SearchBar = ({ availableStreams, config, currentQuery, disableSearch = def
                          onSubmit={_onSubmit}>
             {({ dirty, isSubmitting, isValid, handleSubmit }) => (
               <>
-                <Row className="no-bm extended-search-query-metadata">
+                <TopRow>
                   <Col md={4}>
                     <TimeRangeTypeSelector />
                     <TimeRangeInput config={config} />
@@ -95,7 +96,7 @@ const SearchBar = ({ availableStreams, config, currentQuery, disableSearch = def
                   <Col md={3} xs={4}>
                     <RefreshControls />
                   </Col>
-                </Row>
+                </TopRow>
 
                 <Row className="no-bm">
                   <Col md={9} xs={8}>

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.jsx
@@ -10,6 +10,7 @@ import { Icon } from 'components/common';
 import DocumentationLink from 'components/support/DocumentationLink';
 import DocsHelper from 'util/DocsHelper';
 import Button from 'components/graylog/Button';
+import TopRow from 'views/components/searchbar/TopRow';
 
 import Widget from 'views/logic/widgets/Widget';
 import { StreamsStore } from 'views/stores/StreamsStore';
@@ -98,7 +99,7 @@ const WidgetQueryControls = ({ availableStreams, config, globalOverride = {}, wi
                        onSubmit={_onSubmit}>
           {({ dirty, isSubmitting, isValid, handleSubmit }) => (
             <>
-              <Row className="no-bm extended-search-query-metadata">
+              <TopRow>
                 <Col md={4}>
                   <TimeRangeTypeSelector disabled={isGloballyOverridden} />
                   <TimeRangeInput disabled={isGloballyOverridden} config={config} />
@@ -114,7 +115,7 @@ const WidgetQueryControls = ({ availableStreams, config, globalOverride = {}, wi
                     )}
                   </Field>
                 </Col>
-              </Row>
+              </TopRow>
 
               <Row className="no-bm">
                 <Col md={12}>

--- a/graylog2-web-interface/src/views/components/__snapshots__/WidgetQueryControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/__snapshots__/WidgetQueryControls.test.jsx.snap
@@ -6,13 +6,13 @@ exports[`WidgetQueryControls should do something 1`] = `
     action="#"
   >
     <div
-      class="no-bm extended-search-query-metadata row"
+      class="TopRow-sc-1ysyhyx-0 dDogjc row"
     >
       <div
         class="col-md-4"
       >
         <div
-          class="extended-search-timerange-chooser pull-left btn-toolbar"
+          class="pull-left btn-toolbar"
           role="toolbar"
         >
           <div
@@ -21,7 +21,7 @@ exports[`WidgetQueryControls should do something 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="true"
-              class="DropdownButton__StyledDropdownButton-sc-1343dcx-0 cbvLeL dropdown-toggle btn btn-info"
+              class="DropdownButton__StyledDropdownButton-sc-1343dcx-0 cbvLeL TimeRangeDropdownButton__StyledDropdownButton-sc-1rmks06-0 goSdAM dropdown-toggle btn btn-info"
               id="timerange-type"
               role="button"
               type="button"
@@ -196,7 +196,7 @@ exports[`WidgetQueryControls should do something 1`] = `
           </a>
         </div>
         <button
-          class="Button__StyledButton-c9cbmb-0 jVYrA pull-left search-button-execute btn btn-success"
+          class="Button__StyledButton-c9cbmb-0 jVYrA SearchButton__StyledButton-mm3q5z-0 gkhrPg pull-left btn btn-success"
           title="Perform search"
           type="submit"
         >

--- a/graylog2-web-interface/src/views/components/searchbar/SearchButton.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchButton.jsx
@@ -6,7 +6,11 @@ import styled, { type StyledComponent } from 'styled-components';
 import { Button } from 'components/graylog';
 import { Icon } from 'components/common';
 
-const DirtyButton: StyledComponent<{}, void, HTMLButtonElement> = styled(Button)`
+const StyledButton: StyledComponent<{}, void, Button> = styled(Button)`
+  margin-right: 7px;
+`;
+
+const DirtyButton: StyledComponent<{}, void, Button> = styled(StyledButton)`
   position: relative;
 
   ::after {
@@ -28,14 +32,14 @@ type Props = {
 };
 
 const SearchButton = ({ disabled, glyph, dirty }: Props) => {
-  const ButtonComponent = dirty ? DirtyButton : Button;
+  const ButtonComponent = dirty ? DirtyButton : StyledButton;
   const title = dirty ? 'Perform search (changes were made after last search execution)' : 'Perform search';
   return (
     <ButtonComponent type="submit"
                      bsStyle="success"
                      disabled={disabled}
                      title={title}
-                     className="pull-left search-button-execute">
+                     className="pull-left">
       <Icon name={glyph} />
     </ButtonComponent>
   );

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeDropdownButton.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeDropdownButton.jsx
@@ -1,0 +1,33 @@
+// @flow strict
+import * as React from 'react';
+import styled, { type StyledComponent } from 'styled-components';
+import { DropdownButton } from 'components/graylog';
+import { Icon } from 'components/common';
+
+const StyledDropdownButton: StyledComponent<{}, void, DropdownButton> = styled(DropdownButton)`
+  padding: 6px 7px;
+  margin-right: 5px;
+`;
+
+type Props = {
+  onSelect: (newType: string) => void,
+  children: React.Node,
+  disabled?: boolean,
+};
+
+const TimeRangeDropdownButton = ({ onSelect, children, disabled, ...rest }: Props) => (
+  <StyledDropdownButton {...rest}
+                        bsStyle="info"
+                        disabled={disabled}
+                        id="timerange-type"
+                        title={<Icon name="clock" />}
+                        onSelect={onSelect}>
+    {children}
+  </StyledDropdownButton>
+);
+
+TimeRangeDropdownButton.defaultProps = {
+  disabled: false,
+};
+
+export default TimeRangeDropdownButton;

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeOverrideTypeSelector.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeOverrideTypeSelector.jsx
@@ -3,8 +3,8 @@ import * as React from 'react';
 import { useCallback } from 'react';
 import { useField } from 'formik';
 
-import { ButtonToolbar, DropdownButton, MenuItem } from 'components/graylog';
-import { Icon } from 'components/common';
+import { MenuItem, ButtonToolbar } from 'components/graylog';
+import TimeRangeDropdownButton from 'views/components/searchbar/TimeRangeDropdownButton';
 import { migrateTimeRangeToNewType } from '../TimerangeForForm';
 import timeRangeTypeMenuItems from './TimeRangeTypeMenuItems';
 
@@ -18,17 +18,14 @@ const TimeRangeOverrideTypeSelector = () => {
     },
   }), [onChange, value]);
   return (
-    <ButtonToolbar className="extended-search-timerange-chooser pull-left">
-      <DropdownButton bsStyle="info"
-                      title={<Icon name="clock" />}
-                      onSelect={onSelect}
-                      id="dropdown-timerange-selector">
+    <ButtonToolbar className="pull-left">
+      <TimeRangeDropdownButton onSelect={onSelect}>
         <MenuItem eventKey="disabled"
                   active={type === undefined}>
           No Override
         </MenuItem>
         {timeRangeTypeMenuItems(type)}
-      </DropdownButton>
+      </TimeRangeDropdownButton>
     </ButtonToolbar>
   );
 };

--- a/graylog2-web-interface/src/views/components/searchbar/TimeRangeTypeSelector.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TimeRangeTypeSelector.jsx
@@ -3,8 +3,8 @@ import * as React from 'react';
 import { useCallback } from 'react';
 import { useField } from 'formik';
 
-import { ButtonToolbar, DropdownButton } from 'components/graylog';
-import { Icon } from 'components/common';
+import TimeRangeDropdownButton from 'views/components/searchbar/TimeRangeDropdownButton';
+import { ButtonToolbar } from 'components/graylog';
 
 import PropTypes from 'views/components/CustomPropTypes';
 import { migrateTimeRangeToNewType } from '../TimerangeForForm';
@@ -24,14 +24,10 @@ export default function TimeRangeTypeSelector({ disabled }: Props) {
     },
   }), [onChange, value]);
   return (
-    <ButtonToolbar className="extended-search-timerange-chooser pull-left">
-      <DropdownButton bsStyle="info"
-                      id="timerange-type"
-                      disabled={disabled}
-                      title={<Icon name="clock" />}
-                      onSelect={onSelect}>
+    <ButtonToolbar className="pull-left">
+      <TimeRangeDropdownButton disabled={disabled} onSelect={onSelect}>
         {timeRangeTypeMenuItems(currentType)}
-      </DropdownButton>
+      </TimeRangeDropdownButton>
     </ButtonToolbar>
   );
 }

--- a/graylog2-web-interface/src/views/components/searchbar/TopRow.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/TopRow.jsx
@@ -1,0 +1,9 @@
+// @flow strict
+import styled, { type StyledComponent } from 'styled-components';
+import { Row } from 'components/graylog';
+
+const TopRow: StyledComponent<{}, void, Row> = styled(Row)`
+  margin-bottom: 10px;
+`;
+
+export default TopRow;

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.jsx
@@ -83,7 +83,10 @@ class GenericPlot extends React.Component<Props, State> {
     setChartColor: undefined,
   };
 
-  state = {};
+  constructor(props: Props) {
+    super(props);
+    this.state = {};
+  }
 
   componentDidMount() {
     styles.use();

--- a/graylog2-web-interface/src/views/components/visualizations/GenericPlot.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/GenericPlot.jsx
@@ -1,8 +1,11 @@
 // @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import { withTheme } from 'styled-components';
 import { merge } from 'lodash';
 import { Overlay, RootCloseWrapper } from 'react-overlays';
+import { type ThemeInterface } from 'theme';
+
 import { Popover } from 'components/graylog';
 import ColorPicker from 'components/common/ColorPicker';
 import Plot from 'views/components/visualizations/plotly/AsyncPlot';
@@ -42,10 +45,11 @@ export type ChartColor = {
 
 type Props = {
   chartData: Array<*>,
+  getChartColor?: (Array<ChartConfig>, string) => ?string,
   layout: {},
   onZoom: (string, string) => boolean,
-  getChartColor?: (Array<ChartConfig>, string) => ?string,
   setChartColor?: (ChartConfig, ColorMap) => ChartColor,
+  theme: ThemeInterface,
 };
 
 type State = {
@@ -119,7 +123,7 @@ class GenericPlot extends React.Component<Props, State> {
   _onCloseColorPopup = () => this.setState({ legendConfig: undefined });
 
   render() {
-    const { chartData, layout, setChartColor } = this.props;
+    const { chartData, layout, setChartColor, theme } = this.props;
     const defaultLayout = {
       autosize: true,
       showlegend: true,
@@ -138,9 +142,15 @@ class GenericPlot extends React.Component<Props, State> {
       },
       yaxis: {
         automargin: true,
+        tickfont: {
+          color: theme.color.gray[50],
+        },
       },
       xaxis: {
         automargin: true,
+        tickfont: {
+          color: theme.color.gray[50],
+        },
       },
     };
     const plotLayout = merge({}, defaultLayout, layout);
@@ -207,4 +217,4 @@ class GenericPlot extends React.Component<Props, State> {
   }
 }
 
-export default GenericPlot;
+export default withTheme(GenericPlot);

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -17,7 +17,6 @@ import type {
   SearchRefreshConditionArguments,
 } from 'views/logic/hooks/SearchRefreshCondition';
 
-import { type ThemeInterface } from 'theme';
 import { FieldTypesStore, FieldTypesActions } from 'views/stores/FieldTypesStore';
 import { SearchStore, SearchActions } from 'views/stores/SearchStore';
 import { SearchExecutionStateStore } from 'views/stores/SearchExecutionStateStore';
@@ -45,26 +44,6 @@ import bindSearchParamsFromQuery from 'views/hooks/BindSearchParamsFromQuery';
 import { useSyncWithQueryParameters } from 'views/hooks/SyncWithQueryParameters';
 
 import HighlightMessageInQuery from '../components/messagelist/HighlightMessageInQuery';
-
-const ExtendedSearchPageGlobalStyles: StyledComponent<{}, ThemeInterface, HTMLDivElement> = styled.div(({ theme }) => css`
-  .extended-search-timerange-chooser .btn {
-    padding: 6px 7px;
-    margin-right: 5px;
-  }
-
-  .extended-search-query-metadata {
-    margin-bottom: 10px !important;
-  }
-
-  .search-button-execute {
-    margin-right: 7px;
-  }
-
-  .xtick text,
-  .ytick text {
-    fill: ${theme.color.gray[50]} !important;
-  }
-`);
 
 const GridContainer: StyledComponent<{ interactive: boolean }, void, HTMLDivElement> = styled.div`
   ${({ interactive }) => (interactive ? css`
@@ -172,49 +151,47 @@ const ExtendedSearchPage = ({ route, location = { query: {} }, router, searchRef
   useSyncWithQueryParameters(query);
 
   return (
-    <ExtendedSearchPageGlobalStyles>
-      <CurrentViewTypeProvider>
-        <IfInteractive>
-          <IfDashboard>
-            <WindowLeaveMessage route={route} />
-          </IfDashboard>
-        </IfInteractive>
-        <InteractiveContext.Consumer>
-          {(interactive) => (
-            <ViewAdditionalContextProvider>
-              <GridContainer id="main-row" interactive={interactive}>
+    <CurrentViewTypeProvider>
+      <IfInteractive>
+        <IfDashboard>
+          <WindowLeaveMessage route={route} />
+        </IfDashboard>
+      </IfInteractive>
+      <InteractiveContext.Consumer>
+        {(interactive) => (
+          <ViewAdditionalContextProvider>
+            <GridContainer id="main-row" interactive={interactive}>
+              <IfInteractive>
+                <ConnectedSideBar>
+                  <ConnectedFieldList />
+                </ConnectedSideBar>
+              </IfInteractive>
+              <SearchArea>
                 <IfInteractive>
-                  <ConnectedSideBar>
-                    <ConnectedFieldList />
-                  </ConnectedSideBar>
+                  <HeaderElements />
+                  <IfDashboard>
+                    <DashboardSearchBarWithStatus onExecute={refreshIfNotUndeclared} />
+                  </IfDashboard>
+                  <IfSearch>
+                    <SearchBarWithStatus onExecute={refreshIfNotUndeclared} />
+                  </IfSearch>
+
+                  <QueryBarElements />
+
+                  <IfDashboard>
+                    <QueryBar />
+                  </IfDashboard>
                 </IfInteractive>
-                <SearchArea>
-                  <IfInteractive>
-                    <HeaderElements />
-                    <IfDashboard>
-                      <DashboardSearchBarWithStatus onExecute={refreshIfNotUndeclared} />
-                    </IfDashboard>
-                    <IfSearch>
-                      <SearchBarWithStatus onExecute={refreshIfNotUndeclared} />
-                    </IfSearch>
-
-                    <QueryBarElements />
-
-                    <IfDashboard>
-                      <QueryBar />
-                    </IfDashboard>
-                  </IfInteractive>
-                  <HighlightMessageInQuery query={location.query}>
-                    <SearchResult />
-                  </HighlightMessageInQuery>
-                  <Footer />
-                </SearchArea>
-              </GridContainer>
-            </ViewAdditionalContextProvider>
-          )}
-        </InteractiveContext.Consumer>
-      </CurrentViewTypeProvider>
-    </ExtendedSearchPageGlobalStyles>
+                <HighlightMessageInQuery query={location.query}>
+                  <SearchResult />
+                </HighlightMessageInQuery>
+                <Footer />
+              </SearchArea>
+            </GridContainer>
+          </ViewAdditionalContextProvider>
+        )}
+      </InteractiveContext.Consumer>
+    </CurrentViewTypeProvider>
   );
 };
 


### PR DESCRIPTION
With https://github.com/Graylog2/graylog2-server/pull/7914 we've implemented the `ExtendedSearchPage` styled by using styled components instead of a css file.

This changed the styles scope and resulted in the following problem: https://github.com/Graylog2/graylog2-server/issues/7976

This PR is fixing the issue by extract the styles from the `ExtendedSearchPage` by creating own components for the searchbar `TopRow` and `TimeRangeDropdownButton` and adding the specific styles to the `SearchButton` and `GenericPlot`.

Fixes https://github.com/Graylog2/graylog2-server/issues/7976

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

