### PR TITLE
Add missing mapping for chunk size

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/CommandFactory.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/CommandFactory.java
@@ -41,7 +41,8 @@ public class CommandFactory {
                 .queryString(request.queryString())
                 .streams(request.streams())
                 .fieldsInOrder(request.fieldsInOrder())
-                .sort(request.sort());
+                .sort(request.sort())
+                .chunkSize(request.chunkSize());
 
         if (request.limit().isPresent()) {
             builder.limit(request.limit().getAsInt());

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/export/CommandFactoryTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/export/CommandFactoryTest.java
@@ -73,7 +73,8 @@ class CommandFactoryTest {
                 () -> assertThat(command.streams()).isEqualTo(request.streams()),
                 () -> assertThat(command.fieldsInOrder()).isEqualTo(request.fieldsInOrder()),
                 () -> assertThat(command.sort()).isEqualTo(request.sort()),
-                () -> assertThat(command.limit()).isEqualTo(request.limit())
+                () -> assertThat(command.limit()).isEqualTo(request.limit()),
+                () -> assertThat(command.chunkSize()).isEqualTo(request.chunkSize())
         );
     }
 


### PR DESCRIPTION
...from MessagesRequest to ExportMessagesCommand

This allows overriding the default chunk size for api requests, which is useful for testing.

This should be easy to verify with a simple curl:
`curl -X POST -H "X-Requested-By: peterchen" -H "Content-Type: application/json"  -u admin:admin -d '{"chunk_size": 1}' localhost:9000/api/views/search/messages`

With a bigger chunk size many (all) messages will appear at once. With a chunk size of 1 you can see single messages popping up in the terminal.