### PR TITLE
Add HTTP method and body to HTTPJsonPath Lookup Data Adapter

### DIFF
--- a/graylog2-web-interface/src/components/lookup-tables/adapters/HTTPJSONPathAdapterDocumentation.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/HTTPJSONPathAdapterDocumentation.jsx
@@ -108,6 +108,18 @@ end`;
         contact details so owners of the services you query know whom to contact if issues arise.
         (like excessive API requests from your Graylog cluster)
       </p>
+      <h5 style={{ marginBottom: 10}}>HTTP Method</h5>
+      <p style={{ marginBottom: 10, padding: 0 }}>
+        This is the <em>HTTP Method</em> used to send the HTTP requests. When using <em>POST</em> you can optionally
+        send a body.
+      </p>
+
+      <h5 style={{ marginBottom: 10}}>HTTP Body</h5>
+      <p style={{ marginBottom: 10, padding: 0 }}>
+        When using <em>POST</em> HTTP Method, this will be the body in the HTTP requests. Like in the <em>URL</em>
+        you can use <code>{'${key}'}</code> to replace it with by the actual key that is passed to a
+        lookup function.
+      </p>
 
       <hr />
 

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/HTTPJSONPathAdapterFieldSet.tsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/HTTPJSONPathAdapterFieldSet.tsx
@@ -51,7 +51,6 @@ class HTTPJSONPathAdapterFieldSet extends React.Component<Props> {
   onHTTPHeaderUpdate = (headers: Headers) => {
     const { config, updateConfig } = this.props;
     const configChange = ObjectUtils.clone(config);
-
     configChange.headers = headers;
     updateConfig(configChange);
   };
@@ -107,7 +106,36 @@ class HTTPJSONPathAdapterFieldSet extends React.Component<Props> {
                wrapperClassName="col-sm-9">
           <KeyValueTable pairs={config.headers || {}} editable onChange={this.onHTTPHeaderUpdate} />
         </Input>
-
+        <div className="form-group">
+          <label className="col-sm-3 control-label">HTTP Method</label>
+          <div className="col-sm9">
+            <label className="radio-inline">
+              <input type="radio"
+                     id="method"
+                     name="method"
+                     value="GET"
+                     checked={!config.method || config.method === "GET"}
+                     onChange={handleFormEvent} />
+              GET</label>
+            <label className="radio-inline">
+              <input type="radio"
+                   id="method"
+                   name="method"
+                   value="POST"
+                   checked={config.method === "POST"}
+                   onChange={handleFormEvent} />
+              POST</label>
+           </div>
+        </div>
+        <Input type="textarea"
+               id="body"
+               name="body"
+               label="HTTP Body"
+               onChange={handleFormEvent}
+               help="The HTTP body to send in the request (only when using POST method)."
+               value={config.body}
+               labelClassName="col-sm-3"
+               wrapperClassName="col-sm-9" />
       </fieldset>
     );
   }

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/HTTPJSONPathAdapterSummary.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/HTTPJSONPathAdapterSummary.jsx
@@ -34,6 +34,10 @@ const HTTPJSONPathAdapterSummary = ({ dataAdapter }) => {
       <dd>{config.user_agent}</dd>
       <dt>HTTP Headers</dt>
       <dd><KeyValueTable pairs={config.headers || {}} /></dd>
+      <dt>HTTP Method</dt>
+      <dd>{config.method}</dd>
+      <dt>HTTP Request body</dt>
+      <dd>{config.body}</dd>
     </dl>
   );
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds new HTTP method and body options to the HTTPJsonPath Lookup Data Adapter to allow POST requests with body.

## Motivation and Context
Implements #6493 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

