### PR TITLE
Unify naming for `QueryEditModal` description

### DIFF
--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.jsx
@@ -28,9 +28,12 @@ class QueryTitleEditModal extends React.Component<Props, State> {
     onTitleChange: PropTypes.func.isRequired,
   };
 
-  state = {
-    titleDraft: '',
-  };
+  constructor(props: Props) {
+    super(props);
+    this.state = {
+      titleDraft: '',
+    };
+  }
 
   open = (activeQueryTitle: string) => {
     this.setState({
@@ -54,12 +57,12 @@ class QueryTitleEditModal extends React.Component<Props, State> {
     const { titleDraft } = this.state;
     return (
       <BootstrapModalForm ref={(modal) => { this.modal = modal; }}
-                          title="Editing query title"
+                          title="Editing dashboard page title"
                           onSubmitForm={this._onDraftSave}
                           submitButtonText="Save"
                           bsSize="large">
         <Input autoFocus
-               help="The title of the query tab. It has a maximum length of 40 characters."
+               help="Enter a helpful dashboard page title. It has a maximum length of 40 characters."
                id="title"
                label="Title"
                name="title"

--- a/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.jsx
+++ b/graylog2-web-interface/src/views/components/queries/QueryTitleEditModal.test.jsx
@@ -7,7 +7,7 @@ import QueryTitleEditModal from './QueryTitleEditModal';
 
 describe('QueryTitleEditModal', () => {
   afterEach(cleanup);
-  const modalHeadline = 'Editing query title';
+  const modalHeadline = 'Editing dashboard page title';
   const openModal = (modalRef, currentTitle = 'CurrentTitle') => {
     if (modalRef) {
       modalRef.open(currentTitle);


### PR DESCRIPTION
**This PR needs a backport for 3.3**

With https://github.com/Graylog2/graylog2-server/pull/7748 we've changed the naming for dashboard tabs from "tabs" to "pages". This PR adapts the change for the `QueryEditModal`.
