### PR TITLE
Fix assignment of default timerange for export requests

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ExportMessagesCommand.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ExportMessagesCommand.java
@@ -36,17 +36,16 @@ import static org.graylog.plugins.views.search.export.LinkedHashSetUtil.linkedHa
 
 @AutoValue
 public abstract class ExportMessagesCommand {
-    public static final AbsoluteRange DEFAULT_TIME_RANGE = lastFiveMinutes();
     public static final ElasticsearchQueryString DEFAULT_QUERY = ElasticsearchQueryString.empty();
     public static final Set<String> DEFAULT_STREAMS = ImmutableSet.of();
     public static final LinkedHashSet<String> DEFAULT_FIELDS = linkedHashSetOf("timestamp", "source", "message");
     public static final LinkedHashSet<Sort> DEFAULT_SORT = linkedHashSetOf(Sort.create("timestamp", SortOrder.DESC));
     public static final int DEFAULT_CHUNK_SIZE = 1000;
 
-    public static AbsoluteRange lastFiveMinutes() {
+    public static AbsoluteRange defaultTimeRange() {
         try {
-            RelativeRange relativeRange = RelativeRange.create(300);
-            return AbsoluteRange.create(relativeRange.getFrom(), relativeRange.getTo());
+            RelativeRange lastFiveMinutes = RelativeRange.create(300);
+            return AbsoluteRange.create(lastFiveMinutes.getFrom(), lastFiveMinutes.getTo());
         } catch (InvalidRangeParametersException e) {
             throw new RuntimeException("Error creating default time range", e);
         }
@@ -108,7 +107,7 @@ public abstract class ExportMessagesCommand {
 
         public static Builder create() {
             return new AutoValue_ExportMessagesCommand.Builder()
-                    .timeRange(DEFAULT_TIME_RANGE)
+                    .timeRange(defaultTimeRange())
                     .streams(DEFAULT_STREAMS)
                     .queryString(DEFAULT_QUERY)
                     .fieldsInOrder(DEFAULT_FIELDS)

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/MessagesRequest.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/MessagesRequest.java
@@ -35,7 +35,7 @@ import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFA
 import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_QUERY;
 import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_SORT;
 import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_STREAMS;
-import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_TIME_RANGE;
+import static org.graylog.plugins.views.search.export.ExportMessagesCommand.defaultTimeRange;
 import static org.graylog.plugins.views.search.export.LinkedHashSetUtil.linkedHashSetOf;
 
 @AutoValue
@@ -105,7 +105,7 @@ public abstract class MessagesRequest {
         @JsonCreator
         public static Builder create() {
             return new AutoValue_MessagesRequest.Builder()
-                    .timeRange(DEFAULT_TIME_RANGE)
+                    .timeRange(defaultTimeRange())
                     .streams(DEFAULT_STREAMS)
                     .queryString(DEFAULT_QUERY)
                     .fieldsInOrder(DEFAULT_FIELDS)

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/export/CommandFactoryTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/export/CommandFactoryTest.java
@@ -41,7 +41,7 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_FIELDS;
 import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_SORT;
-import static org.graylog.plugins.views.search.export.ExportMessagesCommand.lastFiveMinutes;
+import static org.graylog.plugins.views.search.export.ExportMessagesCommand.defaultTimeRange;
 import static org.graylog.plugins.views.search.export.TestData.relativeRange;
 import static org.graylog.plugins.views.search.export.TestData.validQueryBuilder;
 import static org.graylog.plugins.views.search.export.TestData.validQueryBuilderWith;
@@ -213,7 +213,7 @@ class CommandFactoryTest {
 
     @Test
     void takesTimeRangeFromMessageListIfSpecified() {
-        AbsoluteRange messageListTimeRange = lastFiveMinutes();
+        AbsoluteRange messageListTimeRange = defaultTimeRange();
         MessageList ml = MessageList.builder().id("ml-id").timerange(messageListTimeRange).build();
 
         Query q = validQueryBuilderWith(ml).timerange(timeRange(222)).build();

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/export/MessagesRequestTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/export/MessagesRequestTest.java
@@ -24,7 +24,6 @@ import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFA
 import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_QUERY;
 import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_SORT;
 import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_STREAMS;
-import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_TIME_RANGE;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 class MessagesRequestTest {
@@ -33,7 +32,7 @@ class MessagesRequestTest {
         MessagesRequest defaultRequest = MessagesRequest.builder().build();
 
         assertAll("Should fill every empty field with default",
-                () -> assertThat(defaultRequest.timeRange()).isEqualTo(DEFAULT_TIME_RANGE),
+                () -> assertThat(defaultRequest.timeRange()).isNotNull(),
                 () -> assertThat(defaultRequest.queryString()).isEqualTo(DEFAULT_QUERY),
                 () -> assertThat(defaultRequest.streams()).isEqualTo(DEFAULT_STREAMS),
                 () -> assertThat(defaultRequest.fieldsInOrder()).isEqualTo(DEFAULT_FIELDS),

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/export/TestData.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/export/TestData.java
@@ -30,7 +30,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toCollection;
-import static org.graylog.plugins.views.search.export.ExportMessagesCommand.lastFiveMinutes;
+import static org.graylog.plugins.views.search.export.ExportMessagesCommand.defaultTimeRange;
 
 public class TestData {
 
@@ -40,7 +40,7 @@ public class TestData {
 
     public static Query.Builder validQueryBuilder() {
         return Query.builder().id(UUID.randomUUID().toString())
-                .timerange(lastFiveMinutes())
+                .timerange(defaultTimeRange())
                 .query(new BackendQuery.Fallback());
     }
 


### PR DESCRIPTION
Default time range was originally a `RelativeRange`. When it was converted to an `AbsoluteRange` it should not have been assigned to a static field any more, because the correct absolute time range must be computed dynamically the moment the request is built.
Instead it was computed once and remained statically set to the original "last five minutes" for all subsequent requests. This commit fixes that.
Kudos @kmerz for finding that. :)