### PR TITLE
Include message field as initial field when using CSV export modal widget select.

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.jsx
@@ -40,15 +40,20 @@ export type Props = {
   view: View,
 };
 
+const _getInitialWidgetFields = (selectedWidget) => {
+  if (selectedWidget.config.showMessageRow) {
+    return [...new Set([...selectedWidget.config.fields, 'message'])];
+  }
+  return selectedWidget.config.fields;
+};
+
 const _getInitialFields = (selectedWidget) => {
   let initialFields = DEFAULT_FIELDS;
   if (selectedWidget) {
-    // Because the message table always displays the message, we need to add it as an initial field.
-    initialFields = [...new Set([...selectedWidget.config.fields, 'message'])];
+    initialFields = _getInitialWidgetFields(selectedWidget);
   }
   return initialFields.map((field) => ({ field }));
 };
-
 
 const _onSelectWidget = ({ value: newWidget }, setSelectedWidget, setSelectedFields, setSelectedSort) => {
   setSelectedWidget(newWidget);

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.jsx
@@ -40,9 +40,19 @@ export type Props = {
   view: View,
 };
 
+const _getInitialFields = (selectedWidget) => {
+  let initialFields = DEFAULT_FIELDS;
+  if (selectedWidget) {
+    // Because the message table always displays the message, we need to add it as an initial field.
+    initialFields = [...new Set([...selectedWidget.config.fields, 'message'])];
+  }
+  return initialFields.map((field) => ({ field }));
+};
+
+
 const _onSelectWidget = ({ value: newWidget }, setSelectedWidget, setSelectedFields, setSelectedSort) => {
   setSelectedWidget(newWidget);
-  setSelectedFields(newWidget.config.fields.map((fieldName) => ({ field: fieldName })));
+  setSelectedFields(_getInitialFields(newWidget));
   setSelectedSort(newWidget.config.sort);
 };
 
@@ -53,15 +63,6 @@ const _onFieldSelect = (newFields, setSelectedFields) => {
 const _onStartDownload = (downloadFile, view, executionState, selectedWidget, selectedFields, selectedSort, limit, setLoading, closeModal) => {
   setLoading(true);
   startDownload(downloadFile, view, executionState, selectedWidget, selectedFields, selectedSort, limit).then(closeModal);
-};
-
-const _getInitialFields = (selectedWidget) => {
-  let initialFields = DEFAULT_FIELDS;
-  if (selectedWidget) {
-    // Because the message table always displays the message, we need to add it as an initial field.
-    initialFields = [...new Set([...selectedWidget.config.fields, 'message'])];
-  }
-  return initialFields.map((field) => ({ field }));
 };
 
 const CSVExportModal = ({ closeModal, fields, view, directExportWidgetId, executionState }: Props) => {

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.test.jsx
@@ -178,6 +178,44 @@ describe('CSVExportModal', () => {
     await wait(() => expect(closeModalStub).toHaveBeenCalledTimes(1));
   });
 
+
+  it('initial fields should not contain the message field if message list config showMessageRow is false', async () => {
+    const exportSearchTypeMessagesAction = asMock(exportSearchTypeMessages);
+    const widgetConfig = new MessagesWidgetConfig(['level', 'http_method'], false, [], []);
+    const widgetWithoutMessageRow = widget1.toBuilder().config(widgetConfig).build();
+    const viewStateMap: ViewStateMap = Immutable.Map({
+      'query-id-1': ViewState.builder()
+        .widgets(Immutable.List([widgetWithoutMessageRow]))
+        .widgetMapping(Immutable.Map({ 'widget-id-1': Immutable.Set(['search-type-id-1']) }))
+        .titles(Immutable.Map())
+        .build(),
+    });
+    const view = viewWithoutWidget(View.Type.Search)
+      .toBuilder()
+      .state(viewStateMap)
+      .build();
+    const { getByTestId } = render(<SimpleCSVExportModal view={view} />);
+
+    const submitButton = getByTestId('csv-download-button');
+    fireEvent.click(submitButton);
+
+    await wait(() => expect(exportSearchTypeMessagesAction).toHaveBeenCalledTimes(1));
+    expect(exportSearchTypeMessagesAction).toHaveBeenCalledWith(
+      {
+        ...payload,
+        sort: [defaultSort],
+        fields_in_order: [
+          'level',
+          'http_method',
+        ],
+      },
+      'search-id',
+      'search-type-id-1',
+      'Untitled-Message-Table-search-result',
+    );
+  });
+
+
   describe('on search page', () => {
     const SearchCSVExportModal = (props) => (
       <SimpleCSVExportModal viewType={View.Type.Search} {...props} />

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportWidgetSelection.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportWidgetSelection.jsx
@@ -27,7 +27,7 @@ const WidgetSelection = ({ selectWidget, widgets, view }: WidgetSelectionProps) 
           Please select a message table to adopt its fields and sort. You can adjust all settings in the next step.
         </IfSearch>
         <IfDashboard>
-          Please select the message table you want to export the search results for. You can adjust it&apos;s fields and sort in the next step.<br />
+          Please select the message table you want to export the search results for. You can adjust its fields and sort in the next step.<br />
           Selecting a message table equals using the option &quot;Export to CSV&quot; in a message table action menu.
         </IfDashboard>
       </Row>


### PR DESCRIPTION
The message field is not a common message list field. When exporting a message list to CSV the message field needs to be added. We are already doing this when exporting a search, but this is currently not working when using the message list selection which is part of the CSV export modal. This PR is fixing the described problem.

Fixes #8001
