### PR TITLE
Log warn/error before throwing an error in console-warnings-fail-tests.js

### DIFF
--- a/graylog2-web-interface/test/console-warnings-fail-tests.js
+++ b/graylog2-web-interface/test/console-warnings-fail-tests.js
@@ -14,15 +14,15 @@ const ignoredWarnings = [
 const ignoreWarning = (args) => (!args[0] || ignoredWarnings.filter((warning) => args[0].includes(warning)).length > 0);
 
 console.warn = jest.fn((...args) => {
+  console.origWarn(...args);
   if (!ignoreWarning(args)) {
     throw new Error(format(...args));
   }
-  console.origWarn(...args);
 });
 
 console.error = jest.fn((...args) => {
+  console.origError(...args);
   if (!ignoreWarning(args)) {
     throw new Error(format(...args));
   }
-  console.origError(...args);
 });


### PR DESCRIPTION
Without logging the message it's really hard to find out the actual
error because the Error message doesn't get logged properly.