### PR TITLE
Provide a different IndexHtmlGenerator for development

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/RestApiBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/RestApiBindings.java
@@ -19,6 +19,9 @@ package org.graylog2.shared.bindings;
 import com.google.inject.multibindings.Multibinder;
 import org.graylog2.plugin.inject.Graylog2Module;
 import org.graylog2.shared.security.ShiroSecurityBinding;
+import org.graylog2.web.DevelopmentIndexHtmlGenerator;
+import org.graylog2.web.IndexHtmlGenerator;
+import org.graylog2.web.ProductionIndexHtmlGenerator;
 
 import javax.ws.rs.container.DynamicFeature;
 
@@ -31,6 +34,15 @@ public class RestApiBindings extends Graylog2Module {
         // we don't actually have global REST API bindings for these
         jerseyExceptionMapperBinder();
         jerseyAdditionalComponentsBinder();
+
+        // In development mode we use an external process to provide the web interface.
+        // To avoid errors because of missing production web assets, we use a different implementation for
+        // generating the "index.html" page.
+        if (System.getenv("DEVELOPMENT") == null) {
+            bind(IndexHtmlGenerator.class).to(ProductionIndexHtmlGenerator.class).asEagerSingleton();
+        } else {
+            bind(IndexHtmlGenerator.class).to(DevelopmentIndexHtmlGenerator.class).asEagerSingleton();
+        }
     }
 
     private void bindDynamicFeatures() {

--- a/graylog2-server/src/main/java/org/graylog2/web/DevelopmentIndexHtmlGenerator.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/DevelopmentIndexHtmlGenerator.java
@@ -1,0 +1,70 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.web;
+
+import com.floreysoft.jmte.Engine;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
+import org.graylog2.configuration.HttpConfiguration;
+import org.graylog2.rest.RestTools;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.ws.rs.core.MultivaluedMap;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * Development implementation of the {@link IndexHtmlGenerator} interface that provides a dummy "index.html" page.
+ *
+ * This is used in the development where developers are running the web interface in an external process.
+ */
+@Singleton
+public class DevelopmentIndexHtmlGenerator implements IndexHtmlGenerator {
+    private static final Logger LOG = LoggerFactory.getLogger(DevelopmentIndexHtmlGenerator.class);
+    private static final String TEMPLATE_RESOURCE = "web-interface/index.html.development.template";
+
+    private final Engine templateEngine;
+    private final HttpConfiguration httpConfiguration;
+
+    @Inject
+    public DevelopmentIndexHtmlGenerator(final Engine templateEngine, final HttpConfiguration httpConfiguration) {
+        this.templateEngine = templateEngine;
+        this.httpConfiguration = httpConfiguration;
+    }
+
+    @Override
+    public String get(MultivaluedMap<String, String> headers) {
+        final Map<String, Object> model = ImmutableMap.<String, Object>builder()
+                .put("title", "Graylog DEVELOPMENT Web Interface")
+                .put("appPrefix", RestTools.buildExternalUri(headers, httpConfiguration.getHttpExternalUri()))
+                .build();
+        return templateEngine.transform(getTemplate(), model);
+    }
+
+    private String getTemplate() {
+        try {
+            return Resources.toString(Resources.getResource(TEMPLATE_RESOURCE), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            LOG.error("Couldn't load template resource <{}>", TEMPLATE_RESOURCE, e);
+            return "MISSING TEMPLATE -- THIS IS A BUG!";
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/web/IndexHtmlGenerator.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/IndexHtmlGenerator.java
@@ -16,61 +16,17 @@
  */
 package org.graylog2.web;
 
-import com.floreysoft.jmte.Engine;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.io.Resources;
-import org.graylog2.configuration.HttpConfiguration;
-import org.graylog2.rest.RestTools;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 import javax.ws.rs.core.MultivaluedMap;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Map;
 
-import static java.util.Objects.requireNonNull;
-
-@Singleton
-public class IndexHtmlGenerator {
-    private final String template;
-    private final List<String> cssFiles;
-    private final List<String> sortedJsFiles;
-    private final Engine templateEngine;
-    private final HttpConfiguration httpConfiguration;
-
-    @Inject
-    public IndexHtmlGenerator(final PluginAssets pluginAssets,
-                              final Engine templateEngine,
-                              final HttpConfiguration httpConfiguration) throws IOException {
-        this(
-                Resources.toString(Resources.getResource("web-interface/index.html.template"), StandardCharsets.UTF_8),
-                pluginAssets.cssFiles(),
-                pluginAssets.sortedJsFiles(),
-                templateEngine,
-                httpConfiguration);
-    }
-
-    private IndexHtmlGenerator(final String template,
-                               final List<String> cssFiles,
-                               final List<String> sortedJsFiles,
-                               final Engine templateEngine,
-                               final HttpConfiguration httpConfiguration) throws IOException {
-        this.template = requireNonNull(template, "template");
-        this.cssFiles = requireNonNull(cssFiles, "cssFiles");
-        this.sortedJsFiles = requireNonNull(sortedJsFiles, "sortedJsFiles");
-        this.templateEngine = requireNonNull(templateEngine, "templateEngine");
-        this.httpConfiguration = requireNonNull(httpConfiguration, "httpConfiguration");
-    }
-
-    public String get(MultivaluedMap<String, String> headers) {
-        final Map<String, Object> model = ImmutableMap.<String, Object>builder()
-                .put("title", "Graylog Web Interface")
-                .put("cssFiles", cssFiles)
-                .put("jsFiles", sortedJsFiles)
-                .put("appPrefix", RestTools.buildExternalUri(headers, httpConfiguration.getHttpExternalUri()))
-                .build();
-        return templateEngine.transform(template, model);
-    }
+/**
+ * Implementations provide HTML content for an "index.html" file. This file will be served to browser clients.
+ */
+public interface IndexHtmlGenerator {
+    /**
+     * Get the HTML content.
+     *
+     * @param headers the HTTP request headers of the web request
+     * @return the HTML string
+     */
+    String get(MultivaluedMap<String, String> headers);
 }

--- a/graylog2-server/src/main/java/org/graylog2/web/ProductionIndexHtmlGenerator.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/ProductionIndexHtmlGenerator.java
@@ -1,0 +1,83 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.web;
+
+import com.floreysoft.jmte.Engine;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
+import org.graylog2.configuration.HttpConfiguration;
+import org.graylog2.rest.RestTools;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.ws.rs.core.MultivaluedMap;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Production implementation of the {@link IndexHtmlGenerator} interface that provides an "index.html" page
+ * including the production web interface assets.
+ *
+ * This implementation throws an error when the web interface assets cannot be found in the classpath.
+ */
+@Singleton
+public class ProductionIndexHtmlGenerator implements IndexHtmlGenerator {
+    private final String template;
+    private final List<String> cssFiles;
+    private final List<String> sortedJsFiles;
+    private final Engine templateEngine;
+    private final HttpConfiguration httpConfiguration;
+
+    @Inject
+    public ProductionIndexHtmlGenerator(final PluginAssets pluginAssets,
+                                        final Engine templateEngine,
+                                        final HttpConfiguration httpConfiguration) throws IOException {
+        this(
+                Resources.toString(Resources.getResource("web-interface/index.html.template"), StandardCharsets.UTF_8),
+                pluginAssets.cssFiles(),
+                pluginAssets.sortedJsFiles(),
+                templateEngine,
+                httpConfiguration);
+    }
+
+    private ProductionIndexHtmlGenerator(final String template,
+                                         final List<String> cssFiles,
+                                         final List<String> sortedJsFiles,
+                                         final Engine templateEngine,
+                                         final HttpConfiguration httpConfiguration) throws IOException {
+        this.template = requireNonNull(template, "template");
+        this.cssFiles = requireNonNull(cssFiles, "cssFiles");
+        this.sortedJsFiles = requireNonNull(sortedJsFiles, "sortedJsFiles");
+        this.templateEngine = requireNonNull(templateEngine, "templateEngine");
+        this.httpConfiguration = requireNonNull(httpConfiguration, "httpConfiguration");
+    }
+
+    @Override
+    public String get(MultivaluedMap<String, String> headers) {
+        final Map<String, Object> model = ImmutableMap.<String, Object>builder()
+                .put("title", "Graylog Web Interface")
+                .put("cssFiles", cssFiles)
+                .put("jsFiles", sortedJsFiles)
+                .put("appPrefix", RestTools.buildExternalUri(headers, httpConfiguration.getHttpExternalUri()))
+                .build();
+        return templateEngine.transform(template, model);
+    }
+}

--- a/graylog2-server/src/main/resources/web-interface/index.html.development.template
+++ b/graylog2-server/src/main/resources/web-interface/index.html.development.template
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="robots" content="noindex, nofollow">
+    <meta charset="UTF-8">
+    <title>${title}</title>
+    <link rel="shortcut icon" href="${appPrefix}assets/favicon.png">
+  </head>
+  <body>
+  <h1>${title}</h1>
+  <p>The server is running in development mode and doesn't provide web interface assets.</p>
+  <p>Please use yarn to start the web development server via: <pre>cd /path/to/graylog2-server/graylog2-web-interface && yarn start</pre></p>
+  </body>
+</html>


### PR DESCRIPTION
The production "index.html" generator is throwing an exception when the
production assets cannot be found on server startup. That means
developers need to run a full maven build including the production web
interface before the development server can start successfully in the IDE.

With this PR we can switch to a different IndexHtmlGenerator
implementation that doesn't require the production web assets to be
present on server startup. (it serves a dummy "index.html" page)

Switching to this implementation requires the "DEVELOPMENT" environment
variable to be set.