### PR TITLE
Only cancel default event action on widget title change if event is defined

### DIFF
--- a/graylog2-web-interface/src/views/components/common/EditableTitle.jsx
+++ b/graylog2-web-interface/src/views/components/common/EditableTitle.jsx
@@ -1,9 +1,21 @@
+// @flow strict
 import React from 'react';
 import PropTypes from 'prop-types';
 
 import styles from './EditableTitle.css';
 
-export default class EditableTitle extends React.Component {
+type Props = {
+  disabled?: boolean,
+  onChange: (newTitle: string) => void,
+  value: string,
+};
+
+type State = {
+  editing: boolean,
+  value: string,
+};
+
+export default class EditableTitle extends React.Component<Props, State> {
   static propTypes = {
     disabled: PropTypes.bool,
     onChange: PropTypes.func,
@@ -15,7 +27,7 @@ export default class EditableTitle extends React.Component {
     onChange: () => {},
   };
 
-  constructor(props) {
+  constructor(props: Props) {
     super(props);
     const { value } = props;
     this.state = {
@@ -36,13 +48,15 @@ export default class EditableTitle extends React.Component {
     this._onSubmit();
   };
 
-  _onChange = (evt) => {
+  _onChange = (evt: SyntheticInputEvent<HTMLInputElement>) => {
     evt.preventDefault();
     this.setState({ value: evt.target.value });
   };
 
-  _onSubmit = (e) => {
-    e.preventDefault();
+  _onSubmit = (e?: SyntheticInputEvent<HTMLInputElement>) => {
+    if (e) {
+      e.preventDefault();
+    }
     const { value } = this.state;
     const { onChange, value: propsValue } = this.props;
     if (value !== '') {

--- a/graylog2-web-interface/src/views/components/common/EditableTitle.jsx
+++ b/graylog2-web-interface/src/views/components/common/EditableTitle.jsx
@@ -45,7 +45,7 @@ export default class EditableTitle extends React.Component<Props, State> {
 
   _onBlur = () => {
     this._toggleEditing();
-    this._onSubmit();
+    this._submitValue();
   };
 
   _onChange = (evt: SyntheticInputEvent<HTMLInputElement>) => {
@@ -53,10 +53,7 @@ export default class EditableTitle extends React.Component<Props, State> {
     this.setState({ value: evt.target.value });
   };
 
-  _onSubmit = (e?: SyntheticInputEvent<HTMLInputElement>) => {
-    if (e) {
-      e.preventDefault();
-    }
+  _submitValue = () => {
     const { value } = this.state;
     const { onChange, value: propsValue } = this.props;
     if (value !== '') {
@@ -64,7 +61,12 @@ export default class EditableTitle extends React.Component<Props, State> {
     } else {
       this.setState({ value: propsValue });
     }
-    this.setState({ editing: false });
+  }
+
+  _onSubmit = (e: SyntheticInputEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    this._toggleEditing();
+    this._submitValue();
   };
 
   render() {


### PR DESCRIPTION
As described in #7998 the widget title is currently sometimes not being saved, when saving a dashboard or saved search. This only happens when a user blurs the widget title input (wit).

This happens because we are not providing an event for the submit handler on blur and `e.preventDefault()`throws an error.

Fixes: #7998

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
