### PR TITLE
Export `ChartColorContext` as singleton.

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/ChartColorContext.js
+++ b/graylog2-web-interface/src/views/components/visualizations/ChartColorContext.js
@@ -1,5 +1,6 @@
 // @flow strict
 import * as React from 'react';
+import { singleton } from 'views/logic/singleton';
 
 export type ChartColorMap = { [string]: string };
 export type ChangeColorFunction = (string, string) => Promise<*>;
@@ -8,4 +9,4 @@ const ChartColorContext = React.createContext<{ colors: ChartColorMap, setColor:
   colors: {},
   setColor: () => Promise.resolve([]),
 });
-export default ChartColorContext;
+export default singleton('views.components.visualizations.ChartColorContext', () => ChartColorContext);


### PR DESCRIPTION
This PR is ensuring that `ChartColorContext` is exported as singleton,
meaning that plugins and core are always importing the same instance.