### PR TITLE
Define key prop for `MapVisualization` to update map on dimension change

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/MapVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/MapVisualization.jsx
@@ -147,7 +147,7 @@ class MapVisualization extends React.Component {
         <Map animate={interactive}
              className={style.map}
              fadeAnimation={interactive}
-             key={`map-${width}-${height}`}
+             key={`visualization-${id}-${width}-${height}`}
              id={`visualization-${id}`}
              markerZoomAnimation={interactive}
              onViewportChanged={onChange}

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/MapVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/MapVisualization.jsx
@@ -55,28 +55,11 @@ class MapVisualization extends React.Component {
   }
 
   componentDidMount() {
-    this._forceMapUpdate();
     leafletStyles.use();
-  }
-
-  componentDidUpdate(prevProps) {
-    const { height, width } = this.props;
-    if (height !== prevProps.height || width !== prevProps.width) {
-      this._forceMapUpdate();
-    }
   }
 
   componentWillUnmount() {
     leafletStyles.unuse();
-  }
-
-  // Workaround to avoid wrong placed markers or empty tiles if the map container size changed.
-  _forceMapUpdate = () => {
-    if (this._map) {
-      window.dispatchEvent(createEvent('resize'));
-      const { interactive } = this.props;
-      this._map.leafletElement.invalidateSize(interactive);
-    }
   }
 
   // Coordinates are given as "lat,long"
@@ -161,18 +144,19 @@ class MapVisualization extends React.Component {
     return (
       <div className={locked ? style.mapLocked : ''} style={{ position: 'relative', zIndex: 0 }}>
         {locked && <div className={style.overlay} style={{ height, width }} />}
-        <Map ref={(c) => { this._map = c; }}
-             id={`visualization-${id}`}
-             viewport={viewport}
-             onViewportChanged={onChange}
+        <Map animate={interactive}
              className={style.map}
-             style={{ height, width }}
-             scrollWheelZoom
-             animate={interactive}
-             zoomAnimation={interactive}
              fadeAnimation={interactive}
+             key={`map-${width}-${height}`}
+             id={`visualization-${id}`}
              markerZoomAnimation={interactive}
-             whenReady={this._handleMapReady}>
+             onViewportChanged={onChange}
+             scrollWheelZoom
+             style={{ height, width }}
+             viewport={viewport}
+             whenReady={this._handleMapReady}
+             zoomAnimation={interactive}
+             ref={(c) => { this._map = c; }}>
           <TileLayer url={url} maxZoom={19} attribution={attribution} onLoad={this._handleTilesReady} />
           {markers}
         </Map>

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/MapVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/MapVisualization.jsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { CircleMarker, Map, Popup, TileLayer } from 'react-leaflet';
 import chroma from 'chroma-js';
 import { flatten } from 'lodash';
-import createEvent from 'util/CreateEvent';
 
 import style from './MapVisualization.css';
 


### PR DESCRIPTION
As described in #7997 a worldmap viewport can change when switching dashboard pages. With this PR we are defining a `key` prop for the `Map` component, which includes the provided height and width. This way we can ensure the map is rerendering on a dimension change.

Fixes #7997

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
