### PR TITLE
Add calculated height for search area to fix scrolling with safari

### DIFF
--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -58,7 +58,7 @@ const GridContainer: StyledComponent<{ interactive: boolean }, void, HTMLDivElem
 `;
 
 const SearchArea: StyledComponent<{}, void, *> = styled(AppContentGrid)`
-  height: 100%;
+  height: calc(100vh - 50px);
   grid-column: 2;
   -ms-grid-column: 2;
   grid-row: 1;


### PR DESCRIPTION
This PR is fixing the search area scroll issue described here #8003, by adding a calculated height. As discussed this is only a workaround and we will adjust the page layout with the next sidebar layout change. Right now we are defining the height multiple times, with a dynamic layout we don't need to calculate the height manually.

Fixes #8003 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

