### PR TITLE
Remove sort and sort direction select from CSV export modal

### DIFF
--- a/graylog2-web-interface/src/util/MessagesExportUtils.js
+++ b/graylog2-web-interface/src/util/MessagesExportUtils.js
@@ -7,14 +7,12 @@ import UserNotification from 'util/UserNotification';
 import ApiRoutes from 'routing/ApiRoutes';
 
 import { type QueryString, type TimeRange } from 'views/logic/queries/Query';
-import MessageSortConfig from 'views/logic/searchtypes/messages/MessageSortConfig';
 
 export type ExportPayload = {
   timerange?: ?TimeRange,
   query_string?: QueryString,
   streams?: string[],
   fields_in_order: ?string[],
-  sort: MessageSortConfig[],
 };
 
 const downloadCSV = (fileContent: string, filename: string = 'search-result') => {

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.jsx
@@ -8,9 +8,7 @@ import connect from 'stores/connect';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
 import { SearchExecutionStateStore } from 'views/stores/SearchExecutionStateStore';
 import { FieldTypesStore } from 'views/stores/FieldTypesStore';
-import { defaultSort } from 'views/logic/widgets/MessagesWidgetConfig';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
-import SortConfig from 'views/logic/aggregationbuilder/SortConfig';
 import MessagesWidget from 'views/logic/widgets/MessagesWidget';
 import View from 'views/logic/views/View';
 import Widget from 'views/logic/widgets/Widget';
@@ -55,19 +53,18 @@ const _getInitialFields = (selectedWidget) => {
   return initialFields.map((field) => ({ field }));
 };
 
-const _onSelectWidget = ({ value: newWidget }, setSelectedWidget, setSelectedFields, setSelectedSort) => {
+const _onSelectWidget = ({ value: newWidget }, setSelectedWidget, setSelectedFields) => {
   setSelectedWidget(newWidget);
   setSelectedFields(_getInitialFields(newWidget));
-  setSelectedSort(newWidget.config.sort);
 };
 
 const _onFieldSelect = (newFields, setSelectedFields) => {
   setSelectedFields(newFields.map((field) => ({ field: field.value })));
 };
 
-const _onStartDownload = (downloadFile, view, executionState, selectedWidget, selectedFields, selectedSort, limit, setLoading, closeModal) => {
+const _onStartDownload = (downloadFile, view, executionState, selectedWidget, selectedFields, limit, setLoading, closeModal) => {
   setLoading(true);
-  startDownload(downloadFile, view, executionState, selectedWidget, selectedFields, selectedSort, limit).then(closeModal);
+  startDownload(downloadFile, view, executionState, selectedWidget, selectedFields, limit).then(closeModal);
 };
 
 const CSVExportModal = ({ closeModal, fields, view, directExportWidgetId, executionState }: Props) => {
@@ -78,15 +75,13 @@ const CSVExportModal = ({ closeModal, fields, view, directExportWidgetId, execut
   const [loading, setLoading] = useState(false);
   const [selectedWidget, setSelectedWidget] = useState<?Widget>(initialWidget(messagesWidgets, directExportWidgetId));
   const [selectedFields, setSelectedFields] = useState<{ field: string }[]>(_getInitialFields(selectedWidget));
-  const [selectedSort, setSelectedSort] = useState<SortConfig[]>(selectedWidget ? selectedWidget.config.sort : defaultSort);
-  const [selectedSortDirection] = selectedSort.map((s) => s.direction);
   const [limit, setLimit] = useState<?number>();
 
   const singleWidgetDownload = !!directExportWidgetId;
   const showWidgetSelection = shouldShowWidgetSelection(singleWidgetDownload, selectedWidget, messagesWidgets);
   const allowWidgetSelection = shouldAllowWidgetSelection(singleWidgetDownload, showWidgetSelection, messagesWidgets);
   const enableDownload = shouldEnableDownload(showWidgetSelection, selectedWidget, selectedFields, loading);
-  const _startDownload = () => _onStartDownload(downloadFile, view, executionState, selectedWidget, selectedFields, selectedSort, limit, setLoading, closeModal);
+  const _startDownload = () => _onStartDownload(downloadFile, view, executionState, selectedWidget, selectedFields, limit, setLoading, closeModal);
 
   return (
     <BootstrapModalWrapper showModal onHide={closeModal}>
@@ -96,17 +91,14 @@ const CSVExportModal = ({ closeModal, fields, view, directExportWidgetId, execut
       <Modal.Body>
         <Content>
           {showWidgetSelection && (
-            <CSVExportWidgetSelection selectWidget={(selection) => _onSelectWidget(selection, setSelectedWidget, setSelectedFields, setSelectedSort)}
+            <CSVExportWidgetSelection selectWidget={(selection) => _onSelectWidget(selection, setSelectedWidget, setSelectedFields)}
                                       view={view}
                                       widgets={messagesWidgets} />
           )}
           {!showWidgetSelection && (
             <CSVExportSettings fields={fields}
                                selectedFields={selectedFields}
-                               selectedSort={selectedSort}
-                               selectedSortDirection={selectedSortDirection}
                                selectField={(newFields) => _onFieldSelect(newFields, setSelectedFields)}
-                               setSelectedSort={setSelectedSort}
                                selectedWidget={selectedWidget}
                                setLimit={setLimit}
                                limit={limit}

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.test.jsx
@@ -267,7 +267,7 @@ describe('CSVExportModal', () => {
 
     it('show widget selection if more than one exists', () => {
       const { queryByText } = render(<SearchCSVExportModal view={viewWithMultipleWidgets(View.Type.Search)} />);
-      expect(queryByText(/Please select a message table to adopt its fields and sort./)).not.toBeNull();
+      expect(queryByText(/Please select a message table to adopt its fields./)).not.toBeNull();
     });
 
     it('preselect widget on direct export', () => {

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.test.jsx
@@ -8,7 +8,6 @@ import { exportSearchMessages, exportSearchTypeMessages } from 'util/MessagesExp
 
 import type { ViewStateMap } from 'views/logic/views/View';
 import Direction from 'views/logic/aggregationbuilder/Direction';
-import MessageSortConfig from 'views/logic/searchtypes/messages/MessageSortConfig';
 import MessagesWidget from 'views/logic/widgets/MessagesWidget';
 import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
 import Query from 'views/logic/queries/Query';
@@ -91,12 +90,8 @@ describe('CSVExportModal', () => {
     .state(statesWithMultipleWidgets)
     .build();
   // Prepare expected payload
-  const defaultDirection = Direction.Descending;
-  const messageSortConfig = new MessageSortConfig('level', defaultDirection);
-  const defaultSort = new MessageSortConfig('timestamp', defaultDirection);
   const payload = {
     fields_in_order: ['level', 'http_method', 'message'],
-    sort: [messageSortConfig],
     limit: undefined,
     execution_state: new SearchExecutionState(),
   };
@@ -144,7 +139,6 @@ describe('CSVExportModal', () => {
         'source',
         'message',
       ],
-      sort: [defaultSort],
       execution_state: executionState,
     };
     const { getByTestId } = render(<SimpleCSVExportModal />);
@@ -203,7 +197,6 @@ describe('CSVExportModal', () => {
     expect(exportSearchTypeMessagesAction).toHaveBeenCalledWith(
       {
         ...payload,
-        sort: [defaultSort],
         fields_in_order: [
           'level',
           'http_method',
@@ -224,7 +217,7 @@ describe('CSVExportModal', () => {
     it('should not show widget selection when no widget exists', () => {
       const { queryByText } = render(<SearchCSVExportModal />);
       // should not show widget selection but settings form
-      expect(queryByText(/Define the fields and sorting for your CSV file./)).not.toBeNull();
+      expect(queryByText(/Define the fields for your CSV file./)).not.toBeNull();
       // should not show info about selected widget
       expect(queryByText(/The following settings are based on the message table:/)).toBeNull();
       // should not allow widget selection
@@ -242,7 +235,6 @@ describe('CSVExportModal', () => {
       expect(exportSearchMessagesAction).toHaveBeenCalledWith(
         {
           ...payload,
-          sort: [defaultSort],
           fields_in_order: [
             'timestamp',
             'source',
@@ -257,7 +249,7 @@ describe('CSVExportModal', () => {
     it('preselect messages widget when only one exists', () => {
       const { queryByText } = render(<SearchCSVExportModal view={viewWithOneWidget(View.Type.Search)} />);
       // should not show widget selection but settings form
-      expect(queryByText(/Define the fields and sorting for your CSV file./)).not.toBeNull();
+      expect(queryByText(/Define the fields for your CSV file./)).not.toBeNull();
       // should show info about selected widget
       expect(queryByText(/The following settings are based on the message table:/)).not.toBeNull();
       // should not allow widget selection
@@ -281,7 +273,7 @@ describe('CSVExportModal', () => {
     it('preselect widget on direct export', () => {
       const { queryByText } = render(<SearchCSVExportModal view={viewWithMultipleWidgets(View.Type.Search)} directExportWidgetId="widget-id-1" />);
       // should not show widget selection but settings form
-      expect(queryByText(/Define the fields and sorting for your CSV file./)).not.toBeNull();
+      expect(queryByText(/Define the fields for your CSV file./)).not.toBeNull();
       // should show info about selected widget
       expect(queryByText(/The following settings are based on the message table:/)).not.toBeNull();
       // should not allow widget selection
@@ -321,7 +313,7 @@ describe('CSVExportModal', () => {
     it('preselect widget on direct widget export', () => {
       const { queryByText } = render(<DashboardCSVExportModal view={viewWithMultipleWidgets(View.Type.Dashboard)} directExportWidgetId="widget-id-1" />);
       // should not show widget selection but settings form
-      expect(queryByText(/Define the fields and sorting for your CSV file./)).not.toBeNull();
+      expect(queryByText(/Define the fields for your CSV file./)).not.toBeNull();
       // should show info about selected widget
       expect(queryByText(/You are currently exporting the search results for the message table:/)).not.toBeNull();
       // should not allow widget selection

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportSettings.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportSettings.jsx
@@ -2,19 +2,15 @@
 import * as React from 'react';
 import { List } from 'immutable';
 
-import Direction from 'views/logic/aggregationbuilder/Direction';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
-import SortConfig from 'views/logic/aggregationbuilder/SortConfig';
 import Widget from 'views/logic/widgets/Widget';
 import View from 'views/logic/views/View';
 
 import { Input } from 'components/bootstrap';
 import { Row } from 'components/graylog';
 import FieldSelect from 'views/components/widgets/FieldSelect';
-import FieldSortSelect from 'views/components/widgets/FieldSortSelect';
 import IfDashboard from 'views/components/dashboard/IfDashboard';
 import IfSearch from 'views/components/search/IfSearch';
-import SortDirectionSelect from 'views/components/widgets/SortDirectionSelect';
 
 type CSVExportSettingsType = {
   fields: List<FieldTypeMapping>,
@@ -23,9 +19,6 @@ type CSVExportSettingsType = {
   selectedWidget: ?Widget,
   selectField: ({ label: string, value: string }[]) => void,
   selectedFields: ?{field: string}[],
-  setSelectedSort: (Array<*>) => any,
-  selectedSortDirection: Direction,
-  selectedSort: SortConfig[],
   view: View,
 };
 
@@ -50,23 +43,16 @@ const CSVExportSettings = ({
   selectedWidget,
   selectField,
   selectedFields,
-  selectedSort,
-  setSelectedSort,
-  selectedSortDirection,
   setLimit,
   limit,
   view,
 }: CSVExportSettingsType) => {
-  const onSortDirectionChange = (newDirection) => {
-    const newSort = selectedSort.map((sort) => sort.toBuilder().direction(newDirection).build());
-    setSelectedSort(newSort);
-  };
   return (
     <>
       {selectedWidget && <SelectedWidgetInfo selectedWidget={selectedWidget} view={view} />}
       <Row>
         <p>
-          Define the fields and sorting for your CSV file. You can change the field order with drag and drop.<br />
+          Define the fields for your CSV file. You can change the field order with drag and drop.<br />
         </p>
         {selectedWidget && (
           <p>
@@ -80,16 +66,6 @@ const CSVExportSettings = ({
       <Row>
         <span>Fields to export:</span>
         <FieldSelect fields={fields} onChange={selectField} value={selectedFields} allowOptionCreation={!!selectedWidget} />
-      </Row>
-      <Row>
-        <span>Sort:</span>
-        <FieldSortSelect fields={fields} sort={selectedSort} onChange={setSelectedSort} />
-      </Row>
-      <Row>
-        <span>Sort direction:</span>
-        <SortDirectionSelect disabled={!selectedSort || selectedSort.length === 0}
-                             direction={selectedSortDirection ? selectedSortDirection.direction : null}
-                             onChange={onSortDirectionChange} />
       </Row>
       <Row>
         <span>Messages limit:</span>

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportWidgetSelection.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportWidgetSelection.jsx
@@ -24,10 +24,10 @@ const WidgetSelection = ({ selectWidget, widgets, view }: WidgetSelectionProps) 
       <Row>
         <IfSearch>
           The CSV file will contain all messages for your current search.<br />
-          Please select a message table to adopt its fields and sort. You can adjust all settings in the next step.
+          Please select a message table to adopt its fields. You can adjust all settings in the next step.
         </IfSearch>
         <IfDashboard>
-          Please select the message table you want to export the search results for. You can adjust its fields and sort in the next step.<br />
+          Please select the message table you want to export the search results for. You can adjust its fields in the next step.<br />
           Selecting a message table equals using the option &quot;Export to CSV&quot; in a message table action menu.
         </IfDashboard>
       </Row>

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/startDownload.js
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/startDownload.js
@@ -5,8 +5,6 @@ import { type ExportPayload } from 'util/MessagesExportUtils';
 import StringUtils from 'util/StringUtils';
 
 import Query from 'views/logic/queries/Query';
-import MessageSortConfig from 'views/logic/searchtypes/messages/MessageSortConfig';
-import SortConfig from 'views/logic/aggregationbuilder/SortConfig';
 import View from 'views/logic/views/View';
 import Widget from 'views/logic/widgets/Widget';
 import ViewTypeLabel from 'views/components/ViewTypeLabel';
@@ -30,13 +28,11 @@ const startDownload = (
   executionState: SearchExecutionState,
   selectedWidget: ?Widget,
   selectedFields: { field: string }[],
-  selectedSort: SortConfig[],
   limit: ?number,
 ) => {
   const payload: ExportPayload = {
     execution_state: executionState,
     fields_in_order: selectedFields.map((field) => field.field),
-    sort: selectedSort.map((sortConfig) => new MessageSortConfig(sortConfig.field, sortConfig.direction)),
     limit,
   };
   const searchType = selectedWidget ? view.getSearchTypeByWidgetId(selectedWidget.id) : undefined;


### PR DESCRIPTION
This PR removes the sorting option from the CSV export modal. We've decided to remove this functionality for now, because defining a custom sort will currently result in very slow exports. we We will reimplement the sorting options, once we support [search after](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-search-after.html) beside [Elasticsearch's scroll API](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-scroll.html).
