### PR TITLE
Define less strict configuration for ESlint rule `jsx-a11y/label-has-associated-control`

### DIFF
--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -17,7 +17,7 @@ module.exports = {
     'import/extensions': 'off',
     'import/no-extraneous-dependencies': 'off',
     'import/no-unresolved': 'off',
-    'jsx-a11y/label-has-associated-control': [2, { assert: 'either' }],
+    'jsx-a11y/label-has-associated-control': ['error', { assert: 'either' }],
     'max-classes-per-file': 'off',
     'max-len': 'off',
     'new-cap': 'off',

--- a/graylog2-web-interface/packages/eslint-config-graylog/index.js
+++ b/graylog2-web-interface/packages/eslint-config-graylog/index.js
@@ -17,6 +17,7 @@ module.exports = {
     'import/extensions': 'off',
     'import/no-extraneous-dependencies': 'off',
     'import/no-unresolved': 'off',
+    'jsx-a11y/label-has-associated-control': [2, { assert: 'either' }],
     'max-classes-per-file': 'off',
     'max-len': 'off',
     'new-cap': 'off',


### PR DESCRIPTION
The ESLint rule [`jsx-a11y/label-has-associated-control`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/label-has-associated-control.md) requires the following structure for input labels:
```
<label htmlFor="input-id">
  The input label
  <input id="input-id" />
</label>
```

We are usually not using this structure in our project, more common is:
```
<label htmlFor="input-id">The input label</label>
<input id="input-id" />
```

This PR is adjusting the ESLint rule, to allow either the nested format or the sibling structure.
