### PR TITLE
List all message lists from all dashboard pages in CSV export widget select

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.jsx
@@ -70,7 +70,7 @@ const _onStartDownload = (downloadFile, view, executionState, selectedWidget, se
 const CSVExportModal = ({ closeModal, fields, view, directExportWidgetId, executionState }: Props) => {
   const { state: viewStates } = view;
   const { shouldEnableDownload, title, initialWidget, shouldShowWidgetSelection, shouldAllowWidgetSelection, downloadFile } = ExportStrategy.createExportStrategy(view.type);
-  const messagesWidgets = viewStates.map((state) => state.widgets.filter((widget) => widget.type === MessagesWidget.type)).flatten(true);
+  const messagesWidgets = viewStates.map((state) => state.widgets.filter((widget) => widget.type === MessagesWidget.type)).toList().flatten();
 
   const [loading, setLoading] = useState(false);
   const [selectedWidget, setSelectedWidget] = useState<?Widget>(initialWidget(messagesWidgets, directExportWidgetId));

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.test.jsx
@@ -263,7 +263,7 @@ describe('CSVExportModal', () => {
     it('show widget selection if more than one exists', async () => {
       const { getByLabelText, queryByText } = render(<SearchCSVExportModal view={viewWithMultipleWidgets(View.Type.Search)} />);
 
-      const select = getByLabelText('Select message table:');
+      const select = getByLabelText('Select message table');
 
       expect(queryByText(/Please select a message table to adopt its fields./)).not.toBeNull();
 
@@ -310,7 +310,7 @@ describe('CSVExportModal', () => {
 
     it('show widget selection if more than one exists', async () => {
       const { queryByText, getByLabelText } = render(<DashboardCSVExportModal view={viewWithMultipleWidgets(View.Type.Dashboard)} />);
-      const select = getByLabelText('Select message table:');
+      const select = getByLabelText('Select message table');
 
       expect(queryByText(/Please select the message table you want to export the search results for./)).not.toBeNull();
 
@@ -333,7 +333,7 @@ describe('CSVExportModal', () => {
         .build();
 
       const { queryByText, getByLabelText } = render(<DashboardCSVExportModal view={complexView} />);
-      const select = getByLabelText('Select message table:');
+      const select = getByLabelText('Select message table');
 
       await selectEvent.openMenu(select);
 

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.test.jsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { cleanup, render, fireEvent, wait } from 'wrappedTestingLibrary';
 import * as Immutable from 'immutable';
 import asMock from 'helpers/mocking/AsMock';
+import selectEvent from 'react-select-event';
 
 import { exportSearchMessages, exportSearchTypeMessages } from 'util/MessagesExportUtils';
 
@@ -66,28 +67,24 @@ describe('CSVExportModal', () => {
     .state(states)
     .build();
   // Prepare view with one widget
-  const statesWithOneWidget: ViewStateMap = Immutable.Map({
-    'query-id-1': ViewState.builder()
-      .widgets(Immutable.List([widget1]))
-      .widgetMapping(Immutable.Map({ 'widget-id-1': Immutable.Set(['search-type-id-1']) }))
-      .titles(Immutable.Map())
-      .build(),
-  });
+  const stateWithOneWidget: ViewState = ViewState.builder()
+    .widgets(Immutable.List([widget1]))
+    .widgetMapping(Immutable.Map({ 'widget-id-1': Immutable.Set(['search-type-id-1']) }))
+    .titles(Immutable.Map({ widget: Immutable.Map({ 'widget-id-1': 'Widget 1' }) }))
+    .build();
   const viewWithOneWidget = (viewType) => viewWithoutWidget(viewType)
     .toBuilder()
-    .state(statesWithOneWidget)
+    .state(Immutable.Map({ 'query-id-1': stateWithOneWidget }))
     .build();
   // Prepare view with mulitple widgets
-  const statesWithMultipleWidgets: ViewStateMap = Immutable.Map({
-    'query-id-1': ViewState.builder()
-      .widgets(Immutable.List([widget1, widget2]))
-      .widgetMapping(Immutable.Map({ 'widget-id-1': Immutable.Set(['search-type-id-1']) }))
-      .titles(Immutable.Map())
-      .build(),
-  });
+  const stateWithMultipleWidgets: ViewState = ViewState.builder()
+    .widgets(Immutable.List([widget1, widget2]))
+    .widgetMapping(Immutable.Map({ 'widget-id-1': Immutable.Set(['search-type-id-1']) }))
+    .titles(Immutable.Map({ widget: Immutable.Map({ 'widget-id-1': 'Widget 1', 'widget-id-2': 'Widget 2' }) }))
+    .build();
   const viewWithMultipleWidgets = (viewType) => viewWithoutWidget(viewType)
     .toBuilder()
-    .state(statesWithMultipleWidgets)
+    .state(Immutable.Map({ 'query-id-1': stateWithMultipleWidgets }))
     .build();
   // Prepare expected payload
   const payload = {
@@ -178,10 +175,8 @@ describe('CSVExportModal', () => {
     const widgetConfig = new MessagesWidgetConfig(['level', 'http_method'], false, [], []);
     const widgetWithoutMessageRow = widget1.toBuilder().config(widgetConfig).build();
     const viewStateMap: ViewStateMap = Immutable.Map({
-      'query-id-1': ViewState.builder()
+      'query-id-1': stateWithOneWidget.toBuilder()
         .widgets(Immutable.List([widgetWithoutMessageRow]))
-        .widgetMapping(Immutable.Map({ 'widget-id-1': Immutable.Set(['search-type-id-1']) }))
-        .titles(Immutable.Map())
         .build(),
     });
     const view = viewWithoutWidget(View.Type.Search)
@@ -204,7 +199,7 @@ describe('CSVExportModal', () => {
       },
       'search-id',
       'search-type-id-1',
-      'Untitled-Message-Table-search-result',
+      'Widget-1-search-result',
     );
   });
 
@@ -262,12 +257,20 @@ describe('CSVExportModal', () => {
       const submitButton = getByTestId('csv-download-button');
       fireEvent.click(submitButton);
       await wait(() => expect(exportSearchTypeMessages).toHaveBeenCalledTimes(1));
-      expect(exportSearchTypeMessages).toHaveBeenCalledWith(payload, 'search-id', 'search-type-id-1', 'Untitled-Message-Table-search-result');
+      expect(exportSearchTypeMessages).toHaveBeenCalledWith(payload, 'search-id', 'search-type-id-1', 'Widget-1-search-result');
     });
 
-    it('show widget selection if more than one exists', () => {
-      const { queryByText } = render(<SearchCSVExportModal view={viewWithMultipleWidgets(View.Type.Search)} />);
+    it('show widget selection if more than one exists', async () => {
+      const { getByLabelText, queryByText } = render(<SearchCSVExportModal view={viewWithMultipleWidgets(View.Type.Search)} />);
+
+      const select = getByLabelText('Select message table:');
+
       expect(queryByText(/Please select a message table to adopt its fields./)).not.toBeNull();
+
+      await selectEvent.openMenu(select);
+
+      expect(queryByText('Widget 1')).not.toBeNull();
+      expect(queryByText('Widget 2')).not.toBeNull();
     });
 
     it('preselect widget on direct export', () => {
@@ -286,7 +289,7 @@ describe('CSVExportModal', () => {
       const submitButton = getByTestId('csv-download-button');
       fireEvent.click(submitButton);
       await wait(() => expect(exportSearchTypeMessages).toHaveBeenCalledTimes(1));
-      expect(exportSearchTypeMessages).toHaveBeenCalledWith(payload, 'search-id', 'search-type-id-1', 'Untitled-Message-Table-search-result');
+      expect(exportSearchTypeMessages).toHaveBeenCalledWith(payload, 'search-id', 'search-type-id-1', 'Widget-1-search-result');
     });
   });
 
@@ -305,9 +308,37 @@ describe('CSVExportModal', () => {
       expect(queryByText(/Please select the message table you want to export the search results for./)).not.toBeNull();
     });
 
-    it('show widget selection if more than one exists', () => {
-      const { queryByText } = render(<DashboardCSVExportModal view={viewWithMultipleWidgets(View.Type.Dashboard)} />);
+    it('show widget selection if more than one exists', async () => {
+      const { queryByText, getByLabelText } = render(<DashboardCSVExportModal view={viewWithMultipleWidgets(View.Type.Dashboard)} />);
+      const select = getByLabelText('Select message table:');
+
       expect(queryByText(/Please select the message table you want to export the search results for./)).not.toBeNull();
+
+      await selectEvent.openMenu(select);
+
+      expect(queryByText('Widget 1')).not.toBeNull();
+      expect(queryByText('Widget 2')).not.toBeNull();
+    });
+
+    it('show widget selection with widgets from all dashboard pages', async () => {
+      const secondViewState: ViewState = ViewState.builder()
+        .widgets(Immutable.List([widget2]))
+        .widgetMapping(Immutable.Map({ 'widget-id-2': Immutable.Set(['search-type-id-2']) }))
+        .titles(Immutable.Map({ widget: Immutable.Map({ 'widget-id-2': 'Widget 2' }) }))
+        .build();
+
+      const complexView = viewWithoutWidget(View.Type.Dashboard)
+        .toBuilder()
+        .state(Immutable.Map({ 'query-id-1': stateWithOneWidget, 'query-id-2': secondViewState }))
+        .build();
+
+      const { queryByText, getByLabelText } = render(<DashboardCSVExportModal view={complexView} />);
+      const select = getByLabelText('Select message table:');
+
+      await selectEvent.openMenu(select);
+
+      expect(queryByText('Widget 1')).not.toBeNull();
+      expect(queryByText('Widget 2')).not.toBeNull();
     });
 
     it('preselect widget on direct widget export', () => {
@@ -326,7 +357,7 @@ describe('CSVExportModal', () => {
       const submitButton = getByTestId('csv-download-button');
       fireEvent.click(submitButton);
       await wait(() => expect(exportSearchTypeMessages).toHaveBeenCalledTimes(1));
-      expect(exportSearchTypeMessages).toHaveBeenCalledWith(payload, 'search-id', 'search-type-id-1', 'Untitled-Message-Table-search-result');
+      expect(exportSearchTypeMessages).toHaveBeenCalledWith(payload, 'search-id', 'search-type-id-1', 'Widget-1-search-result');
     });
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportSettings.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportSettings.jsx
@@ -26,14 +26,14 @@ const SelectedWidgetInfo = ({ selectedWidget, view }: {selectedWidget: Widget, v
   const selectedWidgetTitle = view.getWidgetTitleByWidget(selectedWidget);
   return (
     <Row>
-      <b>
+      <i>
         <IfSearch>
           {selectedWidget && `The following settings are based on the message table: ${selectedWidgetTitle}`}<br />
         </IfSearch>
         <IfDashboard>
           {selectedWidget && `You are currently exporting the search results for the message table: ${selectedWidgetTitle}`}<br />
         </IfDashboard>
-      </b>
+      </i>
     </Row>
   );
 };
@@ -60,17 +60,17 @@ const CSVExportSettings = ({
           </p>
         )}
         <p>
-          When you&apos;ve finished the configuration, click on <i>Start Download</i>.
+          When you&apos;ve finished the configuration, click on <q>Start Download</q>.
         </p>
       </Row>
       <Row>
-        <span>Fields to export:</span>
-        <FieldSelect fields={fields} onChange={selectField} value={selectedFields} allowOptionCreation={!!selectedWidget} />
+        <label htmlFor="export-fields">Fields to export:</label>
+        <FieldSelect fields={fields} onChange={selectField} value={selectedFields} allowOptionCreation={!!selectedWidget} inputId="export-fields" />
       </Row>
       <Row>
-        <span>Messages limit:</span>
+        <label htmlFor="export-limit">Messages limit:</label>
         <Input type="number"
-               id="export-message-limit"
+               id="export-limit"
                onChange={({ target: { value } }) => setLimit(Number(value))}
                min={1}
                step={1}

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportSettings.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportSettings.jsx
@@ -64,11 +64,11 @@ const CSVExportSettings = ({
         </p>
       </Row>
       <Row>
-        <label htmlFor="export-fields">Fields to export:</label>
+        <label htmlFor="export-fields">Fields to export</label>
         <FieldSelect fields={fields} onChange={selectField} value={selectedFields} allowOptionCreation={!!selectedWidget} inputId="export-fields" />
       </Row>
       <Row>
-        <label htmlFor="export-limit">Messages limit:</label>
+        <label htmlFor="export-limit">Messages limit</label>
         <Input type="number"
                id="export-limit"
                onChange={({ target: { value } }) => setLimit(Number(value))}

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportWidgetSelection.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportWidgetSelection.jsx
@@ -1,6 +1,6 @@
 // @flow strict
 import * as React from 'react';
-import { Map } from 'immutable';
+import { List } from 'immutable';
 
 import Widget from 'views/logic/widgets/Widget';
 import View from 'views/logic/views/View';
@@ -12,7 +12,7 @@ import Select from 'views/components/Select';
 
 type WidgetSelectionProps = {
   selectWidget: {label: string, value: Widget} => void,
-  widgets: Map<string, Widget>,
+  widgets: List<Widget>,
   view: View,
 };
 

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportWidgetSelection.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportWidgetSelection.jsx
@@ -33,10 +33,12 @@ const WidgetSelection = ({ selectWidget, widgets, view }: WidgetSelectionProps) 
       </Row>
       {widgets.size !== 0 ? (
         <Row>
-          <span>Select message table:</span>
+          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+          <label htmlFor="widget-selection">Select message table:</label>
           <Select placeholder="Select message table"
                   onChange={selectWidget}
-                  options={widgetOptions} />
+                  options={widgetOptions}
+                  inputId="widget-selection" />
         </Row>
       ) : (
         <Row>

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportWidgetSelection.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportWidgetSelection.jsx
@@ -33,7 +33,6 @@ const WidgetSelection = ({ selectWidget, widgets, view }: WidgetSelectionProps) 
       </Row>
       {widgets.size !== 0 ? (
         <Row>
-          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
           <label htmlFor="widget-selection">Select message table:</label>
           <Select placeholder="Select message table"
                   onChange={selectWidget}

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportWidgetSelection.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportWidgetSelection.jsx
@@ -33,7 +33,7 @@ const WidgetSelection = ({ selectWidget, widgets, view }: WidgetSelectionProps) 
       </Row>
       {widgets.size !== 0 ? (
         <Row>
-          <label htmlFor="widget-selection">Select message table:</label>
+          <label htmlFor="widget-selection">Select message table</label>
           <Select placeholder="Select message table"
                   onChange={selectWidget}
                   options={widgetOptions}

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/ExportStrategy.js
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/ExportStrategy.js
@@ -1,5 +1,5 @@
 // @flow strict
-import { Map, Set } from 'immutable';
+import { Set, List } from 'immutable';
 
 import View, { type ViewType } from 'views/logic/views/View';
 import Widget from 'views/logic/widgets/Widget';
@@ -8,10 +8,10 @@ import Query from 'views/logic/queries/Query';
 
 type ExportStrategy = {
   title: string,
-  shouldAllowWidgetSelection: (singleWidgetDownload: boolean, showWidgetSelection: boolean, widgets: Map<string, Widget>) => boolean,
+  shouldAllowWidgetSelection: (singleWidgetDownload: boolean, showWidgetSelection: boolean, widgets: List<Widget>) => boolean,
   shouldEnableDownload: (showWidgetSelection: boolean, selectedWidget: ?Widget, selectedFields: { field: string }[], loading: boolean) => boolean,
-  shouldShowWidgetSelection: (singleWidgetDownload: boolean, selectedWidget: ?Widget, widgets: Map<string, Widget>) => boolean,
-  initialWidget: (widgets: Map<string, Widget>, directExportWidgetId: ?string) => ?Widget,
+  shouldShowWidgetSelection: (singleWidgetDownload: boolean, selectedWidget: ?Widget, widgets: List<Widget>) => boolean,
+  initialWidget: (widgets: List<Widget>, directExportWidgetId: ?string) => ?Widget,
   downloadFile: (payload: ExportPayload, searchQueries: Set<Query>, searchType: ?any, searchId: string, filename: string) => Promise<void>,
 };
 


### PR DESCRIPTION
This PR is fixing the bug described in #8035 (CSV export modal does not list every message table configured for a dashboard.) It also adds tests for the described case and implements correct markup for the CSV export form labels. This is a good practice in general and necessary to test the widget select component.

We need to merge https://github.com/Graylog2/graylog2-server/pull/8041 before this PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

