### PR TITLE
Allow writing cluster config object with custom key.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/plugin/cluster/ClusterConfigService.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/cluster/ClusterConfigService.java
@@ -53,6 +53,14 @@ public interface ClusterConfigService {
     <T> T getOrDefault(Class<T> type, T defaultValue);
 
     /**
+     * Write a configuration bean to the cluster configuration with the specified key.
+     * @param key     The key that is used to write the cluster config object to the database.
+     * @param payload The object to write to the cluster configuration. Must be serializable by Jackson!
+     * @param <T>     The type of the Java configuration bean.
+     */
+    <T> void write(String key, T payload);
+
+    /**
      * Write a configuration bean to the cluster configuration.
      *
      * @param payload The object to write to the cluster configuration. Must be serializable by Jackson!

--- a/graylog2-server/src/test/java/org/graylog2/cluster/ClusterConfigServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/ClusterConfigServiceImplTest.java
@@ -45,7 +45,6 @@ import org.mockito.junit.MockitoRule;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -244,6 +243,24 @@ public class ClusterConfigServiceImplTest {
 
         DBObject dbObject = collection.findOne();
         assertThat((String) dbObject.get("type")).isEqualTo(CustomConfig.class.getCanonicalName());
+        assertThat((String) dbObject.get("last_updated_by")).isEqualTo("ID");
+    }
+
+    @Test
+    public void writeWithCustomKeyPersistsClusterConfig() throws Exception {
+        CustomConfig customConfig = new CustomConfig();
+        customConfig.text = "TEST";
+
+        @SuppressWarnings("deprecation")
+        final DBCollection collection = mongoConnection.getDatabase().getCollection(COLLECTION_NAME);
+        assertThat(collection.count()).isEqualTo(0L);
+
+        clusterConfigService.write("foobar", customConfig);
+
+        assertThat(collection.count()).isEqualTo(1L);
+
+        DBObject dbObject = collection.findOne();
+        assertThat((String) dbObject.get("type")).isEqualTo("foobar");
         assertThat((String) dbObject.get("last_updated_by")).isEqualTo("ID");
     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Requires Graylog2/graylog-plugin-threatintel#162 to be merged before.**

Previously, the `ClusterConfigService` interface allowed writing a
cluster config object by passing it and extracting the key/type it is
stored as from its class name. This is fine for most use cases, but
makes writing migrations that migrate the structure of a pre-existing
cluster config object non-trivial if separate classes are used for
stability. Those result in different class names, therefore being
persisted with different types than the cluster config object that
should be migrated.

This change is adding a `write(String key, Class<T> payload)` method to
the interface, which allows specifying a custom key for the payload,
therefore making it independent of the class implementing it.


<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.