### PR TITLE
Hide export to CSV action in widget action menu for aggregations

### DIFF
--- a/graylog2-web-interface/src/views/components/common/ActionDropdown.jsx
+++ b/graylog2-web-interface/src/views/components/common/ActionDropdown.jsx
@@ -103,7 +103,7 @@ class ActionDropdown extends React.Component<ActionDropdownProps, ActionDropdown
 
     const mappedChildren = React.Children.map(
       children,
-      (child) => React.cloneElement(child, {
+      (child) => child && React.cloneElement(child, {
         ...child.props,
         ...(child.props.onSelect ? {
           onSelect: (eventKey, event) => {

--- a/graylog2-web-interface/src/views/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.jsx
@@ -315,7 +315,7 @@ class Widget extends React.Component<Props, State> {
                   <WidgetActionDropdown>
                     <MenuItem onSelect={this._onToggleEdit}>Edit</MenuItem>
                     <MenuItem onSelect={() => this._onDuplicate(id)}>Duplicate</MenuItem>
-                    <MenuItem onSelect={() => this._onToggleCSVExport()} disabled={type !== MessagesWidget.type}>Export to CSV</MenuItem>
+                    {type === MessagesWidget.type && <MenuItem onSelect={() => this._onToggleCSVExport()}>Export to CSV</MenuItem>}
                     <IfSearch>
                       <MenuItem onSelect={this._onToggleCopyToDashboard}>Copy to Dashboard</MenuItem>
                     </IfSearch>

--- a/graylog2-web-interface/src/views/components/widgets/Widget.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.test.jsx
@@ -22,6 +22,7 @@ import Query from 'views/logic/queries/Query';
 import CopyWidgetToDashboard from 'views/logic/views/CopyWidgetToDashboard';
 import asMock from 'helpers/mocking/AsMock';
 import ViewState from 'views/logic/views/ViewState';
+import MessagesWidget from 'views/logic/widgets/MessagesWidget';
 
 import Widget from './Widget';
 
@@ -253,6 +254,30 @@ describe('<Widget />', () => {
     fireEvent.click(saveButton);
 
     expect(WidgetActions.update).not.toHaveBeenCalledWith('widgetId', { config: { foo: 42 }, id: 'widgetId', type: 'dummy' });
+  });
+
+  it('does not display export to CSV action if widget is not a message table', () => {
+    const dummyWidget = { config: {}, id: 'widgetId', type: 'dummy' };
+    const { getByTestId, queryByText } = render(<DummyWidget title="Dummy Widget" widget={dummyWidget} />);
+
+    const actionToggle = getByTestId('widgetActionDropDown');
+    fireEvent.click(actionToggle);
+
+    expect(queryByText('Export to CSV')).toBeNull();
+  });
+
+  it('allows export to CSV for message tables', () => {
+    ViewStore.getInitialState = jest.fn(() => viewStoreState);
+    const messagesWidget = { config: {}, id: 'widgetId', type: MessagesWidget.type };
+    const { getByTestId, getByText } = render(<DummyWidget title="Dummy Widget" widget={messagesWidget} />);
+
+    const actionToggle = getByTestId('widgetActionDropDown');
+    fireEvent.click(actionToggle);
+
+    const exportButton = getByText('Export to CSV');
+    fireEvent.click(exportButton);
+
+    expect(getByText('Export message table search results to CSV')).not.toBeNull();
   });
 
   describe('copy widget to dashboard', () => {


### PR DESCRIPTION
The CSV export of a widget search result is currently only possible for message tables. With this PR we are hiding the action for all other widget types, instead of disabling the menu item.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.

