### PR TITLE
Remove elasticsearch_request_timeout config option

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchConfiguration.java
@@ -88,9 +88,6 @@ public class ElasticsearchConfiguration {
     @Parameter(value = "index_optimization_max_num_segments", validator = PositiveIntegerValidator.class)
     private int indexOptimizationMaxNumSegments = 1;
 
-    @Parameter(value = "elasticsearch_request_timeout", validator = PositiveDurationValidator.class)
-    private Duration requestTimeout = Duration.minutes(1L);
-
     @Parameter(value = "elasticsearch_index_optimization_timeout", validator = PositiveDurationValidator.class)
     private Duration indexOptimizationTimeout = Duration.hours(1L);
 
@@ -177,10 +174,6 @@ public class ElasticsearchConfiguration {
     @Deprecated // Should be removed in Graylog 3.0
     public boolean isDisableIndexOptimization() {
         return disableIndexOptimization;
-    }
-
-    public Duration getRequestTimeout() {
-        return requestTimeout;
     }
 
     public Duration getIndexOptimizationTimeout() {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
@@ -66,7 +66,7 @@ public class Cluster {
     public Cluster(JestClient jestClient,
                    IndexSetRegistry indexSetRegistry,
                    @Named("daemonScheduler") ScheduledExecutorService scheduler,
-                   @Named("elasticsearch_request_timeout") Duration requestTimeout) {
+                   @Named("elasticsearch_socket_timeout") Duration requestTimeout) {
         this.scheduler = scheduler;
         this.jestClient = jestClient;
         this.indexSetRegistry = indexSetRegistry;

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -193,6 +193,7 @@ plugin_dir = plugin
 #elasticsearch_connect_timeout = 10s
 
 # Maximum amount of time to wait for reading back a response from an Elasticsearch server.
+# (e. g. during search, index creation, or index time-range calculations)
 #
 # Default: 60 seconds
 #elasticsearch_socket_timeout = 60s
@@ -383,11 +384,6 @@ allow_highlighting = false
 #            index related settings can be changed in the Graylog web interface on the 'System / Indices' page.
 #            Also see http://docs.graylog.org/en/2.3/pages/configuration/index_model.html#index-set-configuration.
 elasticsearch_analyzer = standard
-
-# Global request timeout for Elasticsearch requests (e. g. during search, index creation, or index time-range
-# calculations) based on a best-effort to restrict the runtime of Elasticsearch operations.
-# Default: 1m
-#elasticsearch_request_timeout = 1m
 
 # Global timeout for index optimization (force merge) requests.
 # Default: 1h


### PR DESCRIPTION
This option was mostly unused since we started using Jest
to communicate with ES.
Migrate the only remaining usage in the Cluster health checker
to to `elasticsearch_socket_timeout`, which is the effective timeout
used for each Jest request.
