### PR TITLE
Give search input focus when saved search list is opening

### DIFF
--- a/graylog2-web-interface/src/components/common/SearchForm.jsx
+++ b/graylog2-web-interface/src/components/common/SearchForm.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import * as React from 'react';
 import Promise from 'bluebird';
 
 import { Button } from 'components/graylog';
@@ -74,6 +74,7 @@ class SearchForm extends React.Component {
       PropTypes.arrayOf(PropTypes.element),
       PropTypes.element,
     ]),
+    focusAfterMount: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -93,12 +94,20 @@ class SearchForm extends React.Component {
     loadingLabel: 'Loading...',
     queryHelpComponent: null,
     children: null,
+    focusAfterMount: false,
   };
 
   state = {
     query: this.props.query,
     isLoading: false,
   };
+
+  componentDidMount(): void {
+    const { focusAfterMount } = this.props;
+    if (focusAfterMount && this.searchInput) {
+      this.searchInput.focus();
+    }
+  }
 
   componentWillReceiveProps(nextProps) {
     // The query might get reset outside of this component so we have to adjust the internal state
@@ -162,6 +171,7 @@ class SearchForm extends React.Component {
           <div className="form-group has-feedback">
             {this.props.label && <label htmlFor="common-search-form-query-input" className="control-label">{this.props.label}</label>}
             <input id="common-search-form-query-input"
+                   ref={(ref) => { this.searchInput = ref; }}
                    onChange={this.handleQueryChange}
                    value={this.state.query}
                    placeholder={this.props.placeholder}

--- a/graylog2-web-interface/src/components/common/SearchForm.jsx
+++ b/graylog2-web-interface/src/components/common/SearchForm.jsx
@@ -102,13 +102,6 @@ class SearchForm extends React.Component {
     isLoading: false,
   };
 
-  componentDidMount(): void {
-    const { focusAfterMount } = this.props;
-    if (focusAfterMount && this.searchInput) {
-      this.searchInput.focus();
-    }
-  }
-
   componentWillReceiveProps(nextProps) {
     // The query might get reset outside of this component so we have to adjust the internal state
     if (this.props.query !== nextProps.query) {
@@ -171,7 +164,8 @@ class SearchForm extends React.Component {
           <div className="form-group has-feedback">
             {this.props.label && <label htmlFor="common-search-form-query-input" className="control-label">{this.props.label}</label>}
             <input id="common-search-form-query-input"
-                   ref={(ref) => { this.searchInput = ref; }}
+                   /* eslint-disable-next-line jsx-a11y/no-autofocus */
+                   autoFocus={this.props.focusAfterMount}
                    onChange={this.handleQueryChange}
                    value={this.state.query}
                    placeholder={this.props.placeholder}

--- a/graylog2-web-interface/src/components/common/SearchForm.jsx
+++ b/graylog2-web-interface/src/components/common/SearchForm.jsx
@@ -134,6 +134,7 @@ class SearchForm extends React.Component {
 
   _onSearch = (e) => {
     e.preventDefault();
+    e.stopPropagation();
 
     if (this.props.useLoadingState) {
       this._setLoadingState().then(() => {

--- a/graylog2-web-interface/src/components/common/SearchForm.jsx
+++ b/graylog2-web-interface/src/components/common/SearchForm.jsx
@@ -97,14 +97,19 @@ class SearchForm extends React.Component {
     focusAfterMount: false,
   };
 
-  state = {
-    query: this.props.query,
-    isLoading: false,
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      query: props.query,
+      isLoading: false,
+    };
+  }
 
+  // eslint-disable-next-line react/no-deprecated
   componentWillReceiveProps(nextProps) {
+    const { query } = this.props;
     // The query might get reset outside of this component so we have to adjust the internal state
-    if (this.props.query !== nextProps.query) {
+    if (query !== nextProps.query) {
       this.setState({ query: nextProps.query });
     }
   }
@@ -117,8 +122,9 @@ class SearchForm extends React.Component {
    * @private
    */
   _setLoadingState = () => {
+    const { useLoadingState } = this.props;
     return new Promise((resolve) => {
-      if (this.props.useLoadingState) {
+      if (useLoadingState) {
         this.setState({ isLoading: true }, resolve);
       } else {
         resolve();
@@ -127,75 +133,98 @@ class SearchForm extends React.Component {
   };
 
   _resetLoadingState = () => {
-    if (this.props.useLoadingState) {
+    const { useLoadingState } = this.props;
+    if (useLoadingState) {
       this.setState({ isLoading: false });
     }
   };
 
   _onSearch = (e) => {
+    const { useLoadingState, onSearch } = this.props;
+    const { query } = this.state;
+
     e.preventDefault();
     e.stopPropagation();
 
-    if (this.props.useLoadingState) {
+    if (useLoadingState) {
       this._setLoadingState().then(() => {
-        this.props.onSearch(this.state.query, this._resetLoadingState);
+        onSearch(query, this._resetLoadingState);
       });
     } else {
-      this.props.onSearch(this.state.query);
+      onSearch(query);
     }
   };
 
   _onReset = () => {
     this._resetLoadingState();
-    this.setState({ query: this.props.query });
-    this.props.onQueryChange(this.props.query);
-    this.props.onReset();
+    const { query, onQueryChange, onReset } = this.props;
+    this.setState({ query: query });
+    onQueryChange(query);
+    onReset();
   };
 
   handleQueryChange = (e) => {
+    const { onQueryChange } = this.props;
     const query = e.target.value;
     this.setState({ query: query });
-    this.props.onQueryChange(query);
+    onQueryChange(query);
   };
 
   render() {
+    const {
+      queryHelpComponent,
+      queryWidth,
+      focusAfterMount,
+      children,
+      placeholder,
+      resetButtonLabel,
+      buttonLeftMargin,
+      label,
+      onReset,
+      wrapperClass,
+      topMargin,
+      searchButtonLabel,
+      loadingLabel,
+      searchBsStyle,
+    } = this.props;
+    const { query, isLoading } = this.state;
     return (
-      <div className={this.props.wrapperClass} style={{ marginTop: this.props.topMargin }}>
+      <div className={wrapperClass} style={{ marginTop: topMargin }}>
         <form className="form-inline" onSubmit={this._onSearch}>
           <div className="form-group has-feedback">
-            {this.props.label && <label htmlFor="common-search-form-query-input" className="control-label">{this.props.label}</label>}
+            {label && <label htmlFor="common-search-form-query-input" className="control-label">{label}</label>}
             <input id="common-search-form-query-input"
                    /* eslint-disable-next-line jsx-a11y/no-autofocus */
-                   autoFocus={this.props.focusAfterMount}
+                   autoFocus={focusAfterMount}
                    onChange={this.handleQueryChange}
-                   value={this.state.query}
-                   placeholder={this.props.placeholder}
+                   value={query}
+                   placeholder={placeholder}
                    type="text"
-                   style={{ width: this.props.queryWidth }}
+                   style={{ width: queryWidth }}
                    className="query form-control"
                    autoComplete="off"
                    spellCheck="false" />
-            {this.props.queryHelpComponent
-              && <span className={`form-control-feedback ${style.helpFeedback}`}>{this.props.queryHelpComponent}</span>}
+            {queryHelpComponent
+              && <span className={`form-control-feedback ${style.helpFeedback}`}>{queryHelpComponent}</span>}
           </div>
 
-          <div className="form-group" style={{ marginLeft: this.props.buttonLeftMargin }}>
-            <Button bsStyle={this.props.searchBsStyle}
+          <div className="form-group" style={{ marginLeft: buttonLeftMargin }}>
+            <Button bsStyle={searchBsStyle}
                     type="submit"
-                    disabled={this.state.isLoading}
+                    disabled={isLoading}
                     className="submit-button">
-              {this.state.isLoading ? <Spinner text={this.props.loadingLabel} /> : this.props.searchButtonLabel}
+              {isLoading ? <Spinner text={loadingLabel} /> : searchButtonLabel}
             </Button>
           </div>
-          {this.props.onReset
+          {onReset
             && (
-            <div className="form-group" style={{ marginLeft: this.props.buttonLeftMargin }}>
+            <div className="form-group" style={{ marginLeft: buttonLeftMargin }}>
               <Button type="reset" className="reset-button" onClick={this._onReset}>
-                {this.props.resetButtonLabel}
+                {resetButtonLabel}
               </Button>
             </div>
             )}
-          {this.props.children}
+          {children}
         </form>
       </div>
     );

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
@@ -1786,6 +1786,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                         >
                           <SearchForm
                             buttonLeftMargin={5}
+                            focusAfterMount={false}
                             id="filter-input"
                             label={null}
                             loadingLabel="Loading..."
@@ -1820,6 +1821,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                                 >
                                   <input
                                     autoComplete="off"
+                                    autoFocus={false}
                                     className="query form-control"
                                     id="common-search-form-query-input"
                                     onChange={[Function]}
@@ -4183,6 +4185,7 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
                         >
                           <SearchForm
                             buttonLeftMargin={5}
+                            focusAfterMount={false}
                             id="filter-input"
                             label={null}
                             loadingLabel="Loading..."
@@ -4217,6 +4220,7 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
                                 >
                                   <input
                                     autoComplete="off"
+                                    autoFocus={false}
                                     className="query form-control"
                                     id="common-search-form-query-input"
                                     onChange={[Function]}

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntitiesList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntitiesList.test.jsx.snap
@@ -19,6 +19,7 @@ exports[`<ContentPackEntitiesList /> should render with empty entities 1`] = `
     <br />
     <SearchForm
       buttonLeftMargin={5}
+      focusAfterMount={false}
       label={null}
       loadingLabel="Loading..."
       onQueryChange={[Function]}
@@ -52,6 +53,7 @@ exports[`<ContentPackEntitiesList /> should render with empty entities 1`] = `
           >
             <input
               autoComplete="off"
+              autoFocus={false}
               className="query form-control"
               id="common-search-form-query-input"
               onChange={[Function]}
@@ -386,6 +388,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
     <br />
     <SearchForm
       buttonLeftMargin={5}
+      focusAfterMount={false}
       label={null}
       loadingLabel="Loading..."
       onQueryChange={[Function]}
@@ -419,6 +422,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
           >
             <input
               autoComplete="off"
+              autoFocus={false}
               className="query form-control"
               id="common-search-form-query-input"
               onChange={[Function]}

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstall.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstall.test.jsx.snap
@@ -572,6 +572,7 @@ exports[`<ContentPackInstall /> should render a install 1`] = `
                 <br />
                 <SearchForm
                   buttonLeftMargin={5}
+                  focusAfterMount={false}
                   label={null}
                   loadingLabel="Loading..."
                   onQueryChange={[Function]}
@@ -605,6 +606,7 @@ exports[`<ContentPackInstall /> should render a install 1`] = `
                       >
                         <input
                           autoComplete="off"
+                          autoFocus={false}
                           className="query form-control"
                           id="common-search-form-query-input"
                           onChange={[Function]}

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameterList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameterList.test.jsx.snap
@@ -28,6 +28,7 @@ exports[`<ContentPackParameterList /> should render with empty parameters with r
     <br />
     <SearchForm
       buttonLeftMargin={5}
+      focusAfterMount={false}
       label={null}
       loadingLabel="Loading..."
       onQueryChange={[Function]}
@@ -61,6 +62,7 @@ exports[`<ContentPackParameterList /> should render with empty parameters with r
           >
             <input
               autoComplete="off"
+              autoFocus={false}
               className="query form-control"
               id="common-search-form-query-input"
               onChange={[Function]}
@@ -522,6 +524,7 @@ exports[`<ContentPackParameterList /> should render with empty parameters withou
     </span>
     <SearchForm
       buttonLeftMargin={5}
+      focusAfterMount={false}
       label={null}
       loadingLabel="Loading..."
       onQueryChange={[Function]}
@@ -555,6 +558,7 @@ exports[`<ContentPackParameterList /> should render with empty parameters withou
           >
             <input
               autoComplete="off"
+              autoFocus={false}
               className="query form-control"
               id="common-search-form-query-input"
               onChange={[Function]}
@@ -828,6 +832,7 @@ exports[`<ContentPackParameterList /> should render with parameters with readOnl
     <br />
     <SearchForm
       buttonLeftMargin={5}
+      focusAfterMount={false}
       label={null}
       loadingLabel="Loading..."
       onQueryChange={[Function]}
@@ -861,6 +866,7 @@ exports[`<ContentPackParameterList /> should render with parameters with readOnl
           >
             <input
               autoComplete="off"
+              autoFocus={false}
               className="query form-control"
               id="common-search-form-query-input"
               onChange={[Function]}
@@ -1508,6 +1514,7 @@ exports[`<ContentPackParameterList /> should render with parameters without read
     </span>
     <SearchForm
       buttonLeftMargin={5}
+      focusAfterMount={false}
       label={null}
       loadingLabel="Loading..."
       onQueryChange={[Function]}
@@ -1541,6 +1548,7 @@ exports[`<ContentPackParameterList /> should render with parameters without read
           >
             <input
               autoComplete="off"
+              autoFocus={false}
               className="query form-control"
               id="common-search-form-query-input"
               onChange={[Function]}

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameters.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameters.test.jsx.snap
@@ -336,6 +336,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                 </span>
                 <SearchForm
                   buttonLeftMargin={5}
+                  focusAfterMount={false}
                   label={null}
                   loadingLabel="Loading..."
                   onQueryChange={[Function]}
@@ -369,6 +370,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                       >
                         <input
                           autoComplete="off"
+                          autoFocus={false}
                           className="query form-control"
                           id="common-search-form-query-input"
                           onChange={[Function]}
@@ -1286,6 +1288,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                 <br />
                 <SearchForm
                   buttonLeftMargin={5}
+                  focusAfterMount={false}
                   label={null}
                   loadingLabel="Loading..."
                   onQueryChange={[Function]}
@@ -1319,6 +1322,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                       >
                         <input
                           autoComplete="off"
+                          autoFocus={false}
                           className="query form-control"
                           id="common-search-form-query-input"
                           onChange={[Function]}
@@ -2373,6 +2377,7 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
                 </span>
                 <SearchForm
                   buttonLeftMargin={5}
+                  focusAfterMount={false}
                   label={null}
                   loadingLabel="Loading..."
                   onQueryChange={[Function]}
@@ -2406,6 +2411,7 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
                       >
                         <input
                           autoComplete="off"
+                          autoFocus={false}
                           className="query form-control"
                           id="common-search-form-query-input"
                           onChange={[Function]}
@@ -2803,6 +2809,7 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
                 <br />
                 <SearchForm
                   buttonLeftMargin={5}
+                  focusAfterMount={false}
                   label={null}
                   loadingLabel="Loading..."
                   onQueryChange={[Function]}
@@ -2836,6 +2843,7 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
                       >
                         <input
                           autoComplete="off"
+                          autoFocus={false}
                           className="query form-control"
                           id="common-search-form-query-input"
                           onChange={[Function]}

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackPreview.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackPreview.test.jsx.snap
@@ -248,6 +248,7 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
                 <br />
                 <SearchForm
                   buttonLeftMargin={5}
+                  focusAfterMount={false}
                   label={null}
                   loadingLabel="Loading..."
                   onQueryChange={[Function]}
@@ -281,6 +282,7 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
                       >
                         <input
                           autoComplete="off"
+                          autoFocus={false}
                           className="query form-control"
                           id="common-search-form-query-input"
                           onChange={[Function]}
@@ -540,6 +542,7 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
                 <br />
                 <SearchForm
                   buttonLeftMargin={5}
+                  focusAfterMount={false}
                   label={null}
                   loadingLabel="Loading..."
                   onQueryChange={[Function]}
@@ -573,6 +576,7 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
                       >
                         <input
                           autoComplete="off"
+                          autoFocus={false}
                           className="query form-control"
                           id="common-search-form-query-input"
                           onChange={[Function]}
@@ -1301,6 +1305,7 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
                 <br />
                 <SearchForm
                   buttonLeftMargin={5}
+                  focusAfterMount={false}
                   label={null}
                   loadingLabel="Loading..."
                   onQueryChange={[Function]}
@@ -1334,6 +1339,7 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
                       >
                         <input
                           autoComplete="off"
+                          autoFocus={false}
                           className="query form-control"
                           id="common-search-form-query-input"
                           onChange={[Function]}
@@ -1593,6 +1599,7 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
                 <br />
                 <SearchForm
                   buttonLeftMargin={5}
+                  focusAfterMount={false}
                   label={null}
                   loadingLabel="Loading..."
                   onQueryChange={[Function]}
@@ -1626,6 +1633,7 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
                       >
                         <input
                           autoComplete="off"
+                          autoFocus={false}
                           className="query form-control"
                           id="common-search-form-query-input"
                           onChange={[Function]}

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
@@ -1255,6 +1255,7 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
           >
             <SearchForm
               buttonLeftMargin={5}
+              focusAfterMount={false}
               id="filter-input"
               label={null}
               loadingLabel="Loading..."
@@ -1289,6 +1290,7 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
                   >
                     <input
                       autoComplete="off"
+                      autoFocus={false}
                       className="query form-control"
                       id="common-search-form-query-input"
                       onChange={[Function]}
@@ -2859,6 +2861,7 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
           >
             <SearchForm
               buttonLeftMargin={5}
+              focusAfterMount={false}
               id="filter-input"
               label={null}
               loadingLabel="Loading..."
@@ -2893,6 +2896,7 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
                   >
                     <input
                       autoComplete="off"
+                      autoFocus={false}
                       className="query form-control"
                       id="common-search-form-query-input"
                       onChange={[Function]}

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.jsx
@@ -40,7 +40,7 @@ const NoSavedSearches: StyledComponent<{}, ThemeInterface, *> = styled(Alert)`
   align-items: center;
 `;
 
-const DeleteButton: StyledComponent<{}, ThemeInterface, *> = styled.span`
+const DeleteButton: StyledComponent<{}, ThemeInterface, HTMLSpanElement> = styled.span`
   position: absolute;
   top: 10px;
   right: 10px;

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { browserHistory } from 'react-router';
+// $FlowFixMe should be there
 import styled, { css, type StyledComponent } from 'styled-components';
 
 import Routes from 'routing/Routes';
@@ -37,6 +38,12 @@ const NoSavedSearches: StyledComponent<{}, ThemeInterface, *> = styled(Alert)`
   clear: right;
   display: flex;
   align-items: center;
+`;
+
+const DeleteButton: StyledComponent<{}, ThemeInterface, *> = styled.span`
+  position: absolute;
+  top: 10px;
+  right: 10px;
 `;
 
 class SavedSearchList extends React.Component<Props, State> {
@@ -93,9 +100,12 @@ class SavedSearchList extends React.Component<Props, State> {
     toggleModal();
   };
 
-  onDelete = (selectedSavedSearch) => {
+  onDelete = (e, selectedSavedSearch) => {
     const { views, deleteSavedSearch } = this.props;
     const { list } = views;
+
+    e.stopPropagation();
+
     if (list) {
       const viewIndex = list.findIndex((v) => v.id === selectedSavedSearch);
       if (viewIndex < 0) {
@@ -117,11 +127,19 @@ class SavedSearchList extends React.Component<Props, State> {
     const { selectedSavedSearch } = this.state;
     const savedSearchList = (views.list || []).map((savedSearch) => {
       return (
-        <ListGroupItem active={selectedSavedSearch === savedSearch.id}
-                       onClick={() => this.setState({ selectedSavedSearch: savedSearch.id })}
-                       key={savedSearch.id}>
-          {savedSearch.title}
-        </ListGroupItem>
+        <ViewLoaderContext.Consumer key={savedSearch.id}>
+          {(loaderFunc) => (
+            <ListGroupItem active={selectedSavedSearch === savedSearch.id}
+                           onClick={() => this.onLoad(savedSearch.id, loaderFunc)}>
+              {savedSearch.title}
+              <span>
+                <DeleteButton bsSize="xsmall" bsStyle="danger" onClick={(e) => this.onDelete(e, savedSearch.id)}>
+                  <Icon name="trash" ttile="Delete" data-testid={`delete-${savedSearch.id}`} />
+                </DeleteButton>
+              </span>
+            </ListGroupItem>
+          )}
+        </ViewLoaderContext.Consumer>
       );
     });
 
@@ -151,19 +169,6 @@ class SavedSearchList extends React.Component<Props, State> {
           {renderResult}
         </Modal.Body>
         <Modal.Footer>
-          <ViewLoaderContext.Consumer>
-            {(loaderFunc) => (
-              <Button disabled={!selectedSavedSearch}
-                      bsStyle="primary"
-                      onClick={() => { this.onLoad(selectedSavedSearch, loaderFunc); }}>
-                Load
-              </Button>
-            )}
-          </ViewLoaderContext.Consumer>
-          <Button disabled={!selectedSavedSearch}
-                  onClick={() => { this.onDelete(selectedSavedSearch); }}>
-            Delete
-          </Button>
           <Button onClick={toggleModal}>Cancel</Button>
         </Modal.Footer>
       </Modal>

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.jsx
@@ -145,7 +145,8 @@ class SavedSearchList extends React.Component<Props, State> {
     return (
       <Modal show>
         <Modal.Body>
-          <SearchForm onSearch={this.handleSearch}
+          <SearchForm focusAfterMount
+                      onSearch={this.handleSearch}
                       onReset={this.handleSearchReset} />
           {renderResult}
         </Modal.Body>

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.test.jsx
@@ -76,13 +76,11 @@ describe('SavedSearchList', () => {
         return new Promise(() => {});
       });
       const views = createViewsResponse(1);
-      const { getByText } = render(<SavedSearchList toggleModal={() => {}}
-                                                    showModal
-                                                    deleteSavedSearch={onDelete}
-                                                    views={views} />);
-      const listItem = getByText('test-0');
-      fireEvent.click(listItem);
-      const deleteBtn = getByText('Delete');
+      const { getByTestId } = render(<SavedSearchList toggleModal={() => {}}
+                                                                 showModal
+                                                                 deleteSavedSearch={onDelete}
+                                                                 views={views} />);
+      const deleteBtn = getByTestId('delete-foo-bar-0');
       fireEvent.click(deleteBtn);
       expect(window.confirm).toBeCalledTimes(1);
       expect(onDelete).toBeCalledTimes(1);
@@ -102,8 +100,6 @@ describe('SavedSearchList', () => {
       );
       const listItem = getByText('test-0');
       fireEvent.click(listItem);
-      const loadBtn = getByText('Load');
-      fireEvent.click(loadBtn);
       expect(onLoad).toBeCalledTimes(1);
     });
   });
@@ -127,8 +123,6 @@ describe('SavedSearchList', () => {
       );
       const listItem = getByText('test-0');
       fireEvent.click(listItem);
-      const loadButton = getByText('Load');
-      fireEvent.click(loadButton);
       await wait(() => {
         expect(browserHistory.push).toBeCalledTimes(1);
         expect(browserHistory.push).toHaveBeenCalledWith('SEARCH_VIEWID:foo-bar-0');

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchList.test.jsx
@@ -77,9 +77,9 @@ describe('SavedSearchList', () => {
       });
       const views = createViewsResponse(1);
       const { getByTestId } = render(<SavedSearchList toggleModal={() => {}}
-                                                                 showModal
-                                                                 deleteSavedSearch={onDelete}
-                                                                 views={views} />);
+                                                      showModal
+                                                      deleteSavedSearch={onDelete}
+                                                      views={views} />);
       const deleteBtn = getByTestId('delete-foo-bar-0');
       fireEvent.click(deleteBtn);
       expect(window.confirm).toBeCalledTimes(1);

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/__snapshots__/SavedSearchList.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/__snapshots__/SavedSearchList.test.jsx.snap
@@ -92,20 +92,6 @@ exports[`SavedSearchList render the SavedSearchList should render empty 1`] = `
             class="modal-footer"
           >
             <button
-              class="Button__StyledButton-c9cbmb-0 jVYrA btn btn-primary"
-              disabled=""
-              type="button"
-            >
-              Load
-            </button>
-            <button
-              class="Button__StyledButton-c9cbmb-0 jVYrA btn btn-default"
-              disabled=""
-              type="button"
-            >
-              Delete
-            </button>
-            <button
               class="Button__StyledButton-c9cbmb-0 jVYrA btn btn-default"
               type="button"
             >
@@ -245,6 +231,16 @@ exports[`SavedSearchList render the SavedSearchList should render with views 1`]
                 type="button"
               >
                 test-0
+                <span>
+                  <span
+                    class="SavedSearchList__DeleteButton-sc-1r3qvm6-2 hOFiKI"
+                  >
+                    <svg
+                      class="svg-inline--fa fa-trash-alt"
+                      data-testid="delete-foo-bar-0"
+                    />
+                  </span>
+                </span>
               </button>
             </div>
             <div
@@ -333,20 +329,6 @@ exports[`SavedSearchList render the SavedSearchList should render with views 1`]
           <div
             class="modal-footer"
           >
-            <button
-              class="Button__StyledButton-c9cbmb-0 jVYrA btn btn-primary"
-              disabled=""
-              type="button"
-            >
-              Load
-            </button>
-            <button
-              class="Button__StyledButton-c9cbmb-0 jVYrA btn btn-default"
-              disabled=""
-              type="button"
-            >
-              Delete
-            </button>
             <button
               class="Button__StyledButton-c9cbmb-0 jVYrA btn btn-default"
               type="button"


### PR DESCRIPTION
## Motivation
Prior to this change, a user needed to click on the search
input after he opened the saved search modal.

## Description
This change will give the search input of the saved search
modal focus, so the user needs one click less.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

