### PR TITLE
Sort CSV export widget select options alphabetically

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportWidgetSelection.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportWidgetSelection.jsx
@@ -4,21 +4,26 @@ import { Map } from 'immutable';
 
 import Widget from 'views/logic/widgets/Widget';
 import View from 'views/logic/views/View';
+import { defaultCompare } from 'views/logic/DefaultCompare';
 
 import { Row, Alert } from 'components/graylog';
 import IfDashboard from 'views/components/dashboard/IfDashboard';
 import IfSearch from 'views/components/search/IfSearch';
 import Select from 'views/components/Select';
 
-type WidgetSelectionProps = {
+const sortOptions = (options) => options.sort(
+  (option1, option2) => defaultCompare(option1.label, option2.label),
+);
+
+type Props = {
   selectWidget: {label: string, value: Widget} => void,
   widgets: Map<string, Widget>,
   view: View,
 };
 
-const WidgetSelection = ({ selectWidget, widgets, view }: WidgetSelectionProps) => {
+const WidgetSelection = ({ selectWidget, widgets, view }: Props) => {
   const widgetOption = (widget) => ({ label: view.getWidgetTitleByWidget(widget), value: widget });
-  const widgetOptions = widgets.map((widget) => (widgetOption(widget))).toArray();
+  const widgetOptions = sortOptions(widgets.map((widget) => (widgetOption(widget))).toArray());
   return (
     <>
       <Row>


### PR DESCRIPTION
While testing the CSV export I saw the benefits in sorting the widget select options. With this PR we are sorting them alphabetically.

Ideally we should implement a `sortSelectOption` utility function for every comparable case or just sort the select options inside the `Select` component, but these solutions are not suitable right now, concerning the upcoming release.