### PR TITLE
Extract method to generate new salt for encryption. (3.2)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/security/AESTools.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/AESTools.java
@@ -24,6 +24,7 @@ import javax.annotation.Nullable;
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
+import java.security.SecureRandom;
 
 public class AESTools {
     private static final Logger LOG = LoggerFactory.getLogger(AESTools.class);
@@ -54,5 +55,17 @@ public class AESTools {
             LOG.error("Could not decrypt value.", e);
         }
         return null;
+    }
+
+    /**
+     * Generates a new random salt
+     *
+     * @return the generated random salt as a string of hexadecimal digits.
+     */
+    public static String generateNewSalt() {
+        final SecureRandom random = new SecureRandom();
+        byte[] saltBytes = new byte[8];
+        random.nextBytes(saltBytes);
+        return Hex.encodeToString(saltBytes);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapSettingsImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapSettingsImpl.java
@@ -25,7 +25,6 @@ import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
 import com.mongodb.BasicDBList;
 import com.mongodb.DBObject;
-import org.apache.shiro.codec.Hex;
 import org.bson.types.ObjectId;
 import org.graylog2.Configuration;
 import org.graylog2.database.CollectionName;
@@ -43,7 +42,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.net.URI;
-import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -154,10 +152,7 @@ public class LdapSettingsImpl extends PersistedImpl implements LdapSettings {
         // set new salt value, if we didn't have any.
         if (getSystemPasswordSalt().isEmpty()) {
             LOG.debug("Generating new salt for LDAP system password.");
-            final SecureRandom random = new SecureRandom();
-            byte[] saltBytes = new byte[8];
-            random.nextBytes(saltBytes);
-            setSystemPasswordSalt(Hex.encodeToString(saltBytes));
+            setSystemPasswordSalt(AESTools.generateNewSalt());
         }
         final String encrypted = AESTools.encrypt(
                 systemPassword,


### PR DESCRIPTION
This change is adding a new static method to our `AESTools` utility class, which generates a new random salt. This method is reused in `LdapLdapSettingsImpl`. It will also be reused in future code changes where the generation of a new salt for encryption is desired.