### PR TITLE
Workarounds to allow exporting events with Search After

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ExportMessagesCommand.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ExportMessagesCommand.java
@@ -78,6 +78,10 @@ public abstract class ExportMessagesCommand {
 
         public abstract Builder streams(Set<String> streams);
 
+        public Builder streams(String... streams) {
+            return streams(ImmutableSet.copyOf(streams));
+        }
+
         public abstract Builder queryString(ElasticsearchQueryString queryString);
 
         public abstract Builder fieldsInOrder(LinkedHashSet<String> fieldsInOrder);

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/es/ElasticsearchExportBackend.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/es/ElasticsearchExportBackend.java
@@ -139,7 +139,8 @@ public class ElasticsearchExportBackend implements ExportBackend {
     }
 
     private TermsQueryBuilder streamsFilter(ExportMessagesCommand command) {
-        return termsQuery(Message.FIELD_STREAMS, command.streams());
+        Set<String> streams = requestStrategy.removeUnsupportedStreams(command.streams());
+        return termsQuery(Message.FIELD_STREAMS, streams);
     }
 
     private Set<String> indicesFor(ExportMessagesCommand command) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/es/ElasticsearchExportBackend.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/es/ElasticsearchExportBackend.java
@@ -67,25 +67,25 @@ public class ElasticsearchExportBackend implements ExportBackend {
     }
 
     @Override
-    public void run(ExportMessagesCommand request, Consumer<SimpleMessageChunk> chunkCollector) {
+    public void run(ExportMessagesCommand command, Consumer<SimpleMessageChunk> chunkCollector) {
         boolean isFirstChunk = true;
         int totalCount = 0;
 
         while (true) {
-            List<SearchResult.Hit<Map, Void>> hits = search(request);
+            List<SearchResult.Hit<Map, Void>> hits = search(command);
 
             if (hits.isEmpty()) {
                 return;
             }
 
-            boolean success = publishChunk(chunkCollector, hits, request.fieldsInOrder(), isFirstChunk);
+            boolean success = publishChunk(chunkCollector, hits, command.fieldsInOrder(), isFirstChunk);
             if (!success) {
                 return;
             }
 
             totalCount += hits.size();
-            if (request.limit().isPresent() && totalCount >= request.limit().getAsInt()) {
-                LOG.info("Limit of {} reached. Stopping message retrieval.", request.limit().getAsInt());
+            if (command.limit().isPresent() && totalCount >= command.limit().getAsInt()) {
+                LOG.info("Limit of {} reached. Stopping message retrieval.", command.limit().getAsInt());
                 return;
             }
 
@@ -93,16 +93,16 @@ public class ElasticsearchExportBackend implements ExportBackend {
         }
     }
 
-    private List<SearchResult.Hit<Map, Void>> search(ExportMessagesCommand request) {
-        Search.Builder search = prepareSearchRequest(request);
+    private List<SearchResult.Hit<Map, Void>> search(ExportMessagesCommand command) {
+        Search.Builder search = prepareSearchRequest(command);
 
-        return requestStrategy.nextChunk(search, request);
+        return requestStrategy.nextChunk(search, command);
     }
 
-    private Search.Builder prepareSearchRequest(ExportMessagesCommand request) {
-        SearchSourceBuilder ssb = searchSourceBuilderFrom(request);
+    private Search.Builder prepareSearchRequest(ExportMessagesCommand command) {
+        SearchSourceBuilder ssb = searchSourceBuilderFrom(command);
 
-        Set<String> indices = indicesFor(request);
+        Set<String> indices = indicesFor(command);
         return new Search.Builder(ssb.toString())
                 .addType(IndexMapping.TYPE_MESSAGE)
                 .allowNoIndices(false)
@@ -110,51 +110,47 @@ public class ElasticsearchExportBackend implements ExportBackend {
                 .addIndex(indices);
     }
 
-    private SearchSourceBuilder searchSourceBuilderFrom(ExportMessagesCommand request) {
-        QueryBuilder query = queryFrom(request);
+    private SearchSourceBuilder searchSourceBuilderFrom(ExportMessagesCommand command) {
+        QueryBuilder query = queryFrom(command);
 
         SearchSourceBuilder ssb = new SearchSourceBuilder()
                 .query(query)
-                .size(request.chunkSize());
+                .size(command.chunkSize());
 
         return requestStrategy.configure(ssb);
     }
 
-    private QueryBuilder queryFrom(ExportMessagesCommand request) {
+    private QueryBuilder queryFrom(ExportMessagesCommand command) {
         return boolQuery()
-                .filter(queryStringFilter(request))
-                .filter(timestampFilter(request))
-                .filter(streamsFilter(request));
+                .filter(queryStringFilter(command))
+                .filter(timestampFilter(command))
+                .filter(streamsFilter(command));
     }
 
-    private QueryBuilder queryStringFilter(ExportMessagesCommand request) {
-        ElasticsearchQueryString backendQuery = request.queryString();
+    private QueryBuilder queryStringFilter(ExportMessagesCommand command) {
+        ElasticsearchQueryString backendQuery = command.queryString();
         return backendQuery.isEmpty() ?
                 matchAllQuery() :
                 queryStringQuery(backendQuery.queryString()).allowLeadingWildcard(allowLeadingWildcard);
     }
 
-    private QueryBuilder timestampFilter(ExportMessagesCommand request) {
-        return requireNonNull(IndexHelper.getTimestampRangeFilter(request.timeRange()));
+    private QueryBuilder timestampFilter(ExportMessagesCommand command) {
+        return requireNonNull(IndexHelper.getTimestampRangeFilter(command.timeRange()));
     }
 
-    private TermsQueryBuilder streamsFilter(ExportMessagesCommand request) {
-        return termsQuery(Message.FIELD_STREAMS, request.streams());
+    private TermsQueryBuilder streamsFilter(ExportMessagesCommand command) {
+        return termsQuery(Message.FIELD_STREAMS, command.streams());
     }
 
-    private Set<String> indicesFor(ExportMessagesCommand request) {
-        return indexLookup.indexNamesForStreamsInTimeRange(request.streams(), request.timeRange());
+    private Set<String> indicesFor(ExportMessagesCommand command) {
+        return indexLookup.indexNamesForStreamsInTimeRange(command.streams(), command.timeRange());
     }
 
     private boolean publishChunk(Consumer<SimpleMessageChunk> chunkCollector, List<SearchResult.Hit<Map, Void>> hits, LinkedHashSet<String> desiredFieldsInOrder, boolean isFirstChunk) {
-        SimpleMessageChunk hitsWithOnlyRelevantFields = buildHitsWithRelevantFields(hits, desiredFieldsInOrder);
-
-        if (isFirstChunk) {
-            hitsWithOnlyRelevantFields = hitsWithOnlyRelevantFields.toBuilder().isFirstChunk(true).build();
-        }
+        SimpleMessageChunk chunk = chunkFrom(hits, desiredFieldsInOrder, isFirstChunk);
 
         try {
-            chunkCollector.accept(hitsWithOnlyRelevantFields);
+            chunkCollector.accept(chunk);
             return true;
         } catch (Exception e) {
             LOG.warn("Chunk publishing threw exception. Stopping search after queries", e);
@@ -162,11 +158,20 @@ public class ElasticsearchExportBackend implements ExportBackend {
         }
     }
 
-    private SimpleMessageChunk buildHitsWithRelevantFields(List<SearchResult.Hit<Map, Void>> hits, LinkedHashSet<String> desiredFieldsInOrder) {
-        LinkedHashSet<SimpleMessage> set = hits.stream()
+    private SimpleMessageChunk chunkFrom(List<SearchResult.Hit<Map, Void>> hits, LinkedHashSet<String> desiredFieldsInOrder, boolean isFirstChunk) {
+        LinkedHashSet<SimpleMessage> messages = messagesFrom(hits);
+
+        return SimpleMessageChunk.builder()
+                .fieldsInOrder(desiredFieldsInOrder)
+                .messages(messages)
+                .isFirstChunk(isFirstChunk)
+                .build();
+    }
+
+    private LinkedHashSet<SimpleMessage> messagesFrom(List<SearchResult.Hit<Map, Void>> hits) {
+        return hits.stream()
                 .map(h -> buildHitWithAllFields(h.source, h.index))
                 .collect(toCollection(LinkedHashSet::new));
-        return SimpleMessageChunk.from(desiredFieldsInOrder, set);
     }
 
     private SimpleMessage buildHitWithAllFields(Map source, String index) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/es/RequestStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/es/RequestStrategy.java
@@ -23,6 +23,7 @@ import org.graylog.plugins.views.search.export.ExportMessagesCommand;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface RequestStrategy {
     @SuppressWarnings("rawtypes")
@@ -36,5 +37,16 @@ public interface RequestStrategy {
      */
     default SearchSourceBuilder configure(SearchSourceBuilder ssb) {
         return ssb;
+    }
+
+    /**
+     * Overriding this allows implementers to remove streams containing messages that would can't be processed.
+     * Most prominently those that are lacking the required tie breaker field for search-after.
+     *
+     * @param streams Streams the user wants to export
+     * @return Streams that can be exported using the implementing RequestStrategy
+     */
+    default Set<String> removeUnsupportedStreams(Set<String> streams) {
+        return streams;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/es/SearchAfter.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/es/SearchAfter.java
@@ -16,23 +16,31 @@
  */
 package org.graylog.plugins.views.search.export.es;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import io.searchbox.core.Search;
 import io.searchbox.core.SearchResult;
 import io.searchbox.core.search.sort.Sort;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.graylog.plugins.views.search.export.ExportMessagesCommand;
 import org.graylog2.plugin.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static jersey.repackaged.com.google.common.collect.Lists.newArrayList;
+import static org.graylog2.plugin.streams.Stream.DEFAULT_EVENT_STREAM_IDS;
 
 public class SearchAfter implements RequestStrategy {
+    private static final Logger LOG = LoggerFactory.getLogger(SearchAfter.class);
 
-    private static final String TIEBREAKER_FIELD = Message.FIELD_GL2_MESSAGE_ID;
+    static final String DEFAULT_TIEBREAKER_FIELD = Message.FIELD_GL2_MESSAGE_ID;
+    static final String EVENTS_TIEBREAKER_FIELD = Message.FIELD_ID;
 
     private final JestWrapper jestWrapper;
 
@@ -46,23 +54,29 @@ public class SearchAfter implements RequestStrategy {
     @SuppressWarnings("rawtypes")
     @Override
     public List<SearchResult.Hit<Map, Void>> nextChunk(Search.Builder search, ExportMessagesCommand command) {
-        SearchResult result = search(search);
+
+        SearchResult result = search(search, command);
         List<SearchResult.Hit<Map, Void>> hits = result.getHits(Map.class, false);
         searchAfterValues = lastHitSortFrom(hits);
         return hits;
     }
 
-    private SearchResult search(Search.Builder search) {
-        Search.Builder modified = search.addSort(timestampDescending());
+    private SearchResult search(Search.Builder search, ExportMessagesCommand command) {
+        Search.Builder modified = search.addSort(configureSort(command));
 
         return jestWrapper.execute(modified.build(), () -> "Failed to execute Search After request");
     }
 
-    private ArrayList<Sort> timestampDescending() {
+    private ArrayList<Sort> configureSort(ExportMessagesCommand command) {
         return newArrayList(
                 new Sort("timestamp", Sort.Sorting.DESC),
-                new Sort(TIEBREAKER_FIELD, Sort.Sorting.DESC)
+                new Sort(tieBreakerFrom(command.streams()), Sort.Sorting.DESC)
         );
+    }
+
+    private String tieBreakerFrom(Set<String> streams) {
+        boolean hasOnlyEventStreams = Sets.difference(streams, DEFAULT_EVENT_STREAM_IDS).size() == 0;
+        return hasOnlyEventStreams ? EVENTS_TIEBREAKER_FIELD : DEFAULT_TIEBREAKER_FIELD;
     }
 
     @SuppressWarnings("rawtypes")
@@ -78,5 +92,19 @@ public class SearchAfter implements RequestStrategy {
     @Override
     public SearchSourceBuilder configure(SearchSourceBuilder ssb) {
         return searchAfterValues == null ? ssb : ssb.searchAfter(searchAfterValues);
+    }
+
+    @Override
+    public Set<String> removeUnsupportedStreams(Set<String> streams) {
+        boolean hasEventStreams = Sets.intersection(streams, DEFAULT_EVENT_STREAM_IDS).size() > 0;
+        Sets.SetView<String> others = Sets.difference(streams, DEFAULT_EVENT_STREAM_IDS);
+        boolean hasOthers = others.size() > 0;
+
+        if (hasEventStreams && hasOthers) {
+            LOG.warn("Search After requests for a mix of event streams and others are not supported. Removing event streams.");
+            return ImmutableSet.copyOf(others);
+        }
+
+        return streams;
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/export/es/ElasticsearchExportBackendTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/export/es/ElasticsearchExportBackendTest.java
@@ -1,0 +1,75 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.views.search.export.es;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.searchbox.core.Search;
+import org.graylog.plugins.views.search.elasticsearch.IndexLookup;
+import org.graylog.plugins.views.search.export.ExportMessagesCommand;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableSet;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ElasticsearchExportBackendTest {
+
+    private RequestStrategy requestStrategy;
+    private ElasticsearchExportBackend sut;
+
+    @BeforeEach
+    void setUp() {
+        requestStrategy = mock(RequestStrategy.class);
+        when(requestStrategy.configure(any())).then(returnsFirstArg());
+        sut = new ElasticsearchExportBackend(mock(IndexLookup.class), requestStrategy, false);
+    }
+
+    @Test
+    void appliesRequestStrategyStreamFilter() {
+        ExportMessagesCommand command = ExportMessagesCommand.withDefaults().toBuilder()
+                .streams("stream-1", "stream-2").build();
+
+        when(requestStrategy.removeUnsupportedStreams(command.streams()))
+                .thenReturn(ImmutableSet.of("stream-1"));
+
+        sut.run(command, chunk -> {
+        });
+
+        String searchPayload = captureSearchPayload(command);
+        assertThat(searchPayload).doesNotContain("stream-2");
+    }
+
+    private String captureSearchPayload(ExportMessagesCommand command) {
+        ArgumentCaptor<Search.Builder> captor = ArgumentCaptor.forClass(Search.Builder.class);
+        verify(requestStrategy).nextChunk(captor.capture(), eq(command));
+
+        try {
+            return captor.getValue().build().getData(new ObjectMapper());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/export/es/SearchAfterTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/export/es/SearchAfterTest.java
@@ -1,0 +1,135 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.views.search.export.es;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
+import io.searchbox.action.Action;
+import io.searchbox.client.JestResult;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import net.minidev.json.JSONArray;
+import org.elasticsearch.common.util.set.Sets;
+import org.graylog.plugins.views.search.export.ExportMessagesCommand;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.testcontainers.shaded.com.google.common.collect.ImmutableSet;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog.plugins.views.search.export.es.SearchAfter.DEFAULT_TIEBREAKER_FIELD;
+import static org.graylog.plugins.views.search.export.es.SearchAfter.EVENTS_TIEBREAKER_FIELD;
+import static org.graylog2.plugin.Message.FIELD_TIMESTAMP;
+import static org.graylog2.plugin.streams.Stream.DEFAULT_EVENT_STREAM_IDS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class SearchAfterTest {
+    private SearchAfter sut;
+    private JestWrapper jestWrapper;
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+
+    @BeforeEach
+    void setUp() {
+        jestWrapper = mock(JestWrapper.class);
+        SearchResult emptyResult = new SearchResult(new ObjectMapper());
+
+        doReturn(emptyResult).when(jestWrapper).execute(any(), any());
+        sut = new SearchAfter(jestWrapper);
+    }
+
+    @Test
+    void ignoresEventsStreamsForAMixOfEventStreamsAndOthers() {
+        ImmutableSet<String> eventStreams = ImmutableSet.copyOf(DEFAULT_EVENT_STREAM_IDS);
+        ImmutableSet<String> allowedStream = ImmutableSet.of("allowed-stream");
+        Set<String> requestedStreams = Sets.union(eventStreams, allowedStream);
+
+        Set<String> supportedStreams = sut.removeUnsupportedStreams(requestedStreams);
+
+        assertThat(supportedStreams).containsOnly("allowed-stream");
+    }
+
+    @Test
+    void supportsEventsStreamsOnly() {
+        ImmutableSet<String> eventStreams = ImmutableSet.copyOf(DEFAULT_EVENT_STREAM_IDS);
+
+        Set<String> supportedStreams = sut.removeUnsupportedStreams(eventStreams);
+
+        assertThat(supportedStreams).containsOnlyElementsOf(DEFAULT_EVENT_STREAM_IDS);
+    }
+
+    @Test
+    void usesIDAsTieBreakerForEventStreams() {
+        ExportMessagesCommand command = ExportMessagesCommand.withDefaults().toBuilder()
+                .streams(DEFAULT_EVENT_STREAM_IDS.asList().get(0)).build();
+
+        sut.nextChunk(new Search.Builder(""), command);
+
+        List<String> sortKeys = captureSortKeys();
+
+        assertThat(sortKeys).containsExactly(FIELD_TIMESTAMP, EVENTS_TIEBREAKER_FIELD);
+    }
+
+    @Test
+    void usesDefaultTieBreakerForNonEventStreams() {
+        ExportMessagesCommand command = ExportMessagesCommand.withDefaults().toBuilder()
+                .streams("stream-1", "stream-2").build();
+
+        sut.nextChunk(new Search.Builder(""), command);
+
+        List<String> sortKeys = captureSortKeys();
+
+        assertThat(sortKeys).containsExactly(FIELD_TIMESTAMP, DEFAULT_TIEBREAKER_FIELD);
+    }
+
+    private List<String> captureSortKeys() {
+        //noinspection unchecked
+        ArgumentCaptor<Action<? extends JestResult>> captor = ArgumentCaptor.forClass(Action.class);
+
+        verify(jestWrapper).execute(captor.capture(), any());
+
+        return sortKeysFrom(captor.getValue());
+    }
+
+    private List<String> sortKeysFrom(Action<? extends JestResult> searchAction) {
+        String rawJson = dataFrom(searchAction);
+        JSONArray sorts = JsonPath.parse(rawJson).read("$.sort.*");
+        return sorts.stream().map(this::singleKeyFrom).collect(Collectors.toList());
+    }
+
+    private String singleKeyFrom(Object jsonMap) {
+        //noinspection unchecked
+        return ((Map<String, Object>) jsonMap).keySet().iterator().next();
+    }
+
+    private String dataFrom(Action<? extends JestResult> searchAction) {
+        try {
+            return searchAction.getData(objectMapper);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
#  Description
This PR allows exporting events using Search After. 
If only events should be exported, a different tie breaker field will be used (`_id` instead of `gl2_message_id`). If a mix of events and other messages should be exported, events will be ignored and a warning logged.

## Motivation and Context
See #7985
While these workarounds don't immediately solve the problem, they open up possibilities for later:
- We could create a version of the server that uses search after for ourselves or for customers who understand the limitations and still want to use it (e.g., because scrolling takes too long or creates unacceptable load on their ES cluster.
- SearchAfter now can select an appropriate tie breaker based on the streams to be exported. In theory, it should be possible to add in support for old indices that don't contain `gl2_message_id` yet. (Mixing them with new indices would still be impossible.)

## How Has This Been Tested?
- New unit tests
- Export events using both `RequestStrategy`s and compare with `comm -3  <(sort -u events_scroll.csv) <(sort -u events_search_after.csv) `

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


