### PR TITLE
standardize graylog schema field names

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/schema/GraylogSchemaFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/GraylogSchemaFields.java
@@ -19,7 +19,11 @@ package org.graylog.schema;
 /**
  * Field names used in the standard Graylog Schema.
  */
+
+
+
 public class GraylogSchemaFields {
+
     public static final String FIELD_USER_ID = "user_id";
     public static final String FIELD_USER_TYPE = "user_type";
     public static final String FIELD_ASSOCIATED_USER_REFERENCE = "associated_user_reference";
@@ -33,20 +37,35 @@ public class GraylogSchemaFields {
     public static final String FIELD_SOURCE_GEO_COUNTRY_NAME = "source_geo_country_name";
     public static final String FIELD_SOURCE_GEO_COORDINATES = "source_geo_coordinates";
     public static final String FIELD_SESSION_ID = "session_id";
-    public static final String FIELD_EVENT_VENDOR_DESCRIPTION = "event_vendor_description";
-    public static final String FIELD_EVENT_VENDOR_ACTION = "event_vendor_action";
     public static final String FIELD_EVENT_ERROR_DESCRIPTION = "event_error_description";
     public static final String FIELD_TIMESTAMP = "timestamp";
     public static final String FIELD_SOURCE_AS_NUMBER = "source_as_number";
     public static final String FIELD_SOURCE_AS_ORGANIZATION_NAME = "source_as_organization_name";
     public static final String FIELD_SOURCE_AS_IP = "source_as_ip";
     public static final String FIELD_SOURCE_AS_DOMAIN = "source_as_domain";
-    public static final String FIELD_EVENT_VENDOR_SEVERITY_DESCRIPTION = "event_vendor_severity_description";
     public static final String FIELD_THREAT_DETECTED = "threat_detected";
-    public static final String FIELD_EVENT_UID = "event_uid";
     public static final String FIELD_SERVICE_VERSION = "service_version";
     public static final String FIELD_TARGET_USER_NAME = "target_user_name";
     public static final String FIELD_TARGET_USER_ID = "target_user_id";
     public static final String FIELD_ASSOCIATED_USER_NAME = "associated_user_name";
     public static final String FIELD_ASSOCIATED_USER_ID = "associated_user_id";
+    public static final String FIELD_EVENT_UID = "event_uid";
+    public static final String FIELD_EVENT_SOURCE_PRODUCT = "event_source_product";
+
+    public static final String FIELD_APPLICATION_SSO_SIGNONMODE  = "application_sso_signonmode";
+    public static final String FIELD_APPLICATION_SSO_TARGET_NAME = "application_sso_target_name";
+
+    public static final String FIELD_VENDOR_EVENT_ACTION = "vendor_event_action";
+    public static final String FIELD_VENDOR_EVENT_DESCRIPTION = "vendor_event_description";
+    public static final String FIELD_VENDOR_EVENT_SEVERITY = "vendor_event_severity";
+    public static final String FIELD_VENDOR_EVENT_OUTCOME  = "vendor_event_outcome";
+    public static final String FIELD_VENDOR_EVENT_OUTCOME_REASON = "vendor_event_outcome_reason";
+    public static final String FIELD_VENDOR_SEVERITY_DESCRIPTION = "vendor_severity_description";
+    public static final String FIELD_VENDOR_THREAT_SUSPECTED = "vendor_threat_suspected";
+    public static final String FIELD_VENDOR_TRANSACTION_TYPE = "vendor_transaction_type";
+    public static final String FIELD_VENDOR_TRANSACTION_ID   = "vendor_transaction_id";
+    public static final String FIELD_VENDOR_USER_TYPE        = "vendor_user_type";
+
+
+
 }

--- a/graylog2-server/src/main/java/org/graylog/schema/GraylogSchemaFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/GraylogSchemaFields.java
@@ -25,7 +25,6 @@ package org.graylog.schema;
 public class GraylogSchemaFields {
 
     public static final String FIELD_USER_ID = "user_id";
-    public static final String FIELD_USER_TYPE = "user_type";
     public static final String FIELD_ASSOCIATED_USER_REFERENCE = "associated_user_reference";
     public static final String FIELD_USER_NAME = "user_name";
     public static final String FIELD_HTTP_USER_AGENT = "http_user_agent";


### PR DESCRIPTION
standardize field names in graylog common schema,  will be used in codecs to map vendor specific fields.

## Description
* add a constant field `event_source_product`.
* add 2 new fields `application_sso_signonmode` and `application_sso_target_name`
* there are 5 vendor events.`action`, `description`, `severity`, `outcome`, `outcome_reason`
* there are 5 non-vendor events , `severity description`, `threat suspected`, `transaction type`,`transaction id`, `user type`

## Pending and needs clarification
Add: Where target.type = "AppInstance": 

## Motivation and Context
https://github.com/Graylog2/graylog-plugin-enterprise-integrations/issues/214

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

