### PR TITLE
Use StringUtils to capitalize view type label

### DIFF
--- a/graylog2-web-interface/src/views/components/ViewTypeLabel.js
+++ b/graylog2-web-interface/src/views/components/ViewTypeLabel.js
@@ -1,17 +1,16 @@
 // @flow strict
 import PropTypes from 'prop-types';
 import type { ViewType } from 'views/logic/views/View';
+import StringUtils from 'util/StringUtils';
 
 type Props = {
   type: ViewType,
   capitalize?: boolean,
 };
 
-const capitalizeLabel = (label) => label[0].toUpperCase() + label.slice(1);
-
 const ViewTypeLabel = ({ type, capitalize }: Props) => {
   const typeLabel = type.toLowerCase();
-  return capitalize ? capitalizeLabel(typeLabel) : typeLabel;
+  return capitalize ? StringUtils.capitalizeFirstLetter(typeLabel) : typeLabel;
 };
 
 ViewTypeLabel.propTypes = {

--- a/graylog2-web-interface/src/views/components/ViewTypeLabel.js
+++ b/graylog2-web-interface/src/views/components/ViewTypeLabel.js
@@ -1,7 +1,7 @@
 // @flow strict
 import PropTypes from 'prop-types';
-import type { ViewType } from 'views/logic/views/View';
 import StringUtils from 'util/StringUtils';
+import type { ViewType } from 'views/logic/views/View';
 
 type Props = {
   type: ViewType,


### PR DESCRIPTION
The `ViewTypeLabel` currently has its own implementation for capitalization. This implements the `StringUtils` capitalize method instead.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

