### PR TITLE
Create flow type definition for search types

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.test.jsx
@@ -42,6 +42,15 @@ describe('CSVExportModal', () => {
   const searchType = {
     id: 'search-type-id-1',
     type: 'messages',
+    streams: [],
+    sort: [],
+    filter: '',
+    name: null,
+    query: null,
+    timerange: null,
+    limit: 150,
+    decorators: [],
+    offset: 0,
   };
   const queries = [
     Query.builder().id('query-id-1').searchTypes([searchType]).build(),

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/ExportStrategy.js
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/ExportStrategy.js
@@ -5,6 +5,7 @@ import View, { type ViewType } from 'views/logic/views/View';
 import Widget from 'views/logic/widgets/Widget';
 import { exportSearchMessages, exportSearchTypeMessages, type ExportPayload } from 'util/MessagesExportUtils';
 import Query from 'views/logic/queries/Query';
+import type { SearchType } from 'views/logic/queries/SearchType';
 
 type ExportStrategy = {
   title: string,
@@ -12,7 +13,7 @@ type ExportStrategy = {
   shouldEnableDownload: (showWidgetSelection: boolean, selectedWidget: ?Widget, selectedFields: { field: string }[], loading: boolean) => boolean,
   shouldShowWidgetSelection: (singleWidgetDownload: boolean, selectedWidget: ?Widget, widgets: List<Widget>) => boolean,
   initialWidget: (widgets: List<Widget>, directExportWidgetId: ?string) => ?Widget,
-  downloadFile: (payload: ExportPayload, searchQueries: Set<Query>, searchType: ?any, searchId: string, filename: string) => Promise<void>,
+  downloadFile: (payload: ExportPayload, searchQueries: Set<Query>, searchType: ?SearchType, searchId: string, filename: string) => Promise<void>,
 };
 
 const _getWidgetById = (widgets, id) => widgets.find((item) => item.id === id);
@@ -27,14 +28,14 @@ const _initialSearchWidget = (widgets, directExportWidgetId) => {
   return null;
 };
 
-const _exportOnDashboard = (payload: ExportPayload, searchType: any, searchId: string, filename: string) => {
+const _exportOnDashboard = (payload: ExportPayload, searchType: ?SearchType, searchId: string, filename: string) => {
   if (!searchType) {
     throw new Error('CSV exports on a dashboard require a selected widget!');
   }
   return exportSearchTypeMessages(payload, searchId, searchType.id, filename);
 };
 
-const _exportOnSearchPage = (payload: ExportPayload, searchQueries: Set<Query>, searchType: ?any, searchId: string, filename: string) => {
+const _exportOnSearchPage = (payload: ExportPayload, searchQueries: Set<Query>, searchType: ?SearchType, searchId: string, filename: string) => {
   if (searchQueries.size !== 1) {
     throw new Error('Searches must only have a single query!');
   }

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/startDownload.js
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/startDownload.js
@@ -9,6 +9,7 @@ import View from 'views/logic/views/View';
 import Widget from 'views/logic/widgets/Widget';
 import ViewTypeLabel from 'views/components/ViewTypeLabel';
 import SearchExecutionState from 'views/logic/search/SearchExecutionState';
+import type { SearchType } from 'views/logic/queries/SearchType';
 
 const getFilename = (view, selectedWidget) => {
   let filename = 'search-result';
@@ -23,7 +24,7 @@ const getFilename = (view, selectedWidget) => {
 };
 
 const startDownload = (
-  downloadFile: (payload: ExportPayload, searchQueries: Set<Query>, searchType: ?any, searchId: string, filename: string) => Promise<void>,
+  downloadFile: (payload: ExportPayload, searchQueries: Set<Query>, searchType: ?SearchType, searchId: string, filename: string) => Promise<void>,
   view: View,
   executionState: SearchExecutionState,
   selectedWidget: ?Widget,
@@ -35,7 +36,7 @@ const startDownload = (
     fields_in_order: selectedFields.map((field) => field.field),
     limit,
   };
-  const searchType = selectedWidget ? view.getSearchTypeByWidgetId(selectedWidget.id) : undefined;
+  const searchType: ?SearchType = selectedWidget ? view.getSearchTypeByWidgetId(selectedWidget.id) : undefined;
   const filename = getFilename(view, selectedWidget);
 
   return downloadFile(payload, view.search.queries, searchType, view.search.id, filename);

--- a/graylog2-web-interface/src/views/logic/queries/Query.js
+++ b/graylog2-web-interface/src/views/logic/queries/Query.js
@@ -1,13 +1,38 @@
 // @flow strict
 import * as Immutable from 'immutable';
 import uuid from 'uuid/v4';
-
 import isDeepEqual from 'stores/isDeepEqual';
+
+import type { SearchType } from './SearchType';
 
 export type QueryId = string;
 
 export type FilterType = Immutable.Map<string, any>;
-type SearchTypeList = Array<any>;
+
+export type ElasticsearchQueryString = {
+  type: 'elasticsearch',
+  query_string: string,
+};
+
+export type RelativeTimeRange = {|
+  type: 'relative',
+  range: number,
+|};
+
+export type AbsoluteTimeRange = {|
+  type: 'absolute',
+  from: string,
+  to: string,
+|};
+
+export type KeywordTimeRange = {|
+  type: 'keyword',
+  keyword: string,
+|};
+
+export type TimeRange = RelativeTimeRange | AbsoluteTimeRange | KeywordTimeRange;
+
+type SearchTypeList = Array<SearchType>;
 type InternalBuilderState = Immutable.Map<string, any>;
 
 type InternalState = {
@@ -24,11 +49,6 @@ export type QueryJson = {
   timerange: any,
   filter?: FilterType,
   search_types: any,
-};
-
-export type ElasticsearchQueryString = {
-  type: 'elasticsearch',
-  query_string: string,
 };
 
 export const createElasticsearchQueryString = (query: string = ''): ElasticsearchQueryString => ({ type: 'elasticsearch', query_string: query });
@@ -64,24 +84,6 @@ export type QueryString = ElasticsearchQueryString;
 
 export type TimeRangeTypes = 'relative' | 'absolute' | 'keyword';
 
-export type RelativeTimeRange = {|
-  type: 'relative',
-  range: number,
-|};
-
-export type AbsoluteTimeRange = {|
-  type: 'absolute',
-  from: string,
-  to: string,
-|};
-
-export type KeywordTimeRange = {|
-  type: 'keyword',
-  keyword: string,
-|};
-
-export type TimeRange = RelativeTimeRange | AbsoluteTimeRange | KeywordTimeRange;
-
 export default class Query {
   _value: InternalState;
 
@@ -105,7 +107,7 @@ export default class Query {
     return this._value.filter;
   }
 
-  get searchTypes(): Array<any> {
+  get searchTypes(): SearchTypeList {
     return this._value.searchTypes;
   }
 

--- a/graylog2-web-interface/src/views/logic/queries/Query.js
+++ b/graylog2-web-interface/src/views/logic/queries/Query.js
@@ -9,29 +9,6 @@ export type QueryId = string;
 
 export type FilterType = Immutable.Map<string, any>;
 
-export type ElasticsearchQueryString = {
-  type: 'elasticsearch',
-  query_string: string,
-};
-
-export type RelativeTimeRange = {|
-  type: 'relative',
-  range: number,
-|};
-
-export type AbsoluteTimeRange = {|
-  type: 'absolute',
-  from: string,
-  to: string,
-|};
-
-export type KeywordTimeRange = {|
-  type: 'keyword',
-  keyword: string,
-|};
-
-export type TimeRange = RelativeTimeRange | AbsoluteTimeRange | KeywordTimeRange;
-
 type SearchTypeList = Array<SearchType>;
 type InternalBuilderState = Immutable.Map<string, any>;
 
@@ -49,6 +26,11 @@ export type QueryJson = {
   timerange: any,
   filter?: FilterType,
   search_types: any,
+};
+
+export type ElasticsearchQueryString = {
+  type: 'elasticsearch',
+  query_string: string,
 };
 
 export const createElasticsearchQueryString = (query: string = ''): ElasticsearchQueryString => ({ type: 'elasticsearch', query_string: query });
@@ -83,6 +65,24 @@ export const filtersToStreamSet = (filter: ?Immutable.Map<string, any>): Immutab
 export type QueryString = ElasticsearchQueryString;
 
 export type TimeRangeTypes = 'relative' | 'absolute' | 'keyword';
+
+export type RelativeTimeRange = {|
+  type: 'relative',
+  range: number,
+|};
+
+export type AbsoluteTimeRange = {|
+  type: 'absolute',
+  from: string,
+  to: string,
+|};
+
+export type KeywordTimeRange = {|
+  type: 'keyword',
+  keyword: string,
+|};
+
+export type TimeRange = RelativeTimeRange | AbsoluteTimeRange | KeywordTimeRange;
 
 export default class Query {
   _value: InternalState;

--- a/graylog2-web-interface/src/views/logic/queries/SearchType.js
+++ b/graylog2-web-interface/src/views/logic/queries/SearchType.js
@@ -10,7 +10,7 @@ type SearchTypePivot = {
   field: string,
   limit?: number,
   interval?: Interval,
-  };
+};
 
 type SearchTypeBase = {
   filter: ?string,

--- a/graylog2-web-interface/src/views/logic/queries/SearchType.js
+++ b/graylog2-web-interface/src/views/logic/queries/SearchType.js
@@ -1,0 +1,40 @@
+// @flow strict
+import type MessageSortConfig from 'views/logic/searchtypes/messages/MessageSortConfig';
+import type SortConfig from 'views/logic/aggregationbuilder/SortConfig';
+import type { Decorator } from 'views/components/messagelist/decorators/Types';
+import type { Interval } from 'views/components/aggregationbuilder/pivottypes/Interval';
+import type { ElasticsearchQueryString, TimeRange } from './Query';
+
+type SearchTypePivot = {
+  type: string,
+  field: string,
+  limit?: number,
+  interval?: Interval,
+  };
+
+type SearchTypeBase = {
+  filter: ?string,
+  id: string,
+  name: ?string,
+  query: ?ElasticsearchQueryString,
+  timerange: ?TimeRange,
+  type: string,
+  streams: Array<string>,
+};
+
+export type AggregationSearchType = SearchTypeBase & {
+  sort: Array<SortConfig>,
+  series: Array<{id: string, type: string, field: string}>,
+  column_groups: Array<SearchTypePivot>,
+  row_groups: Array<SearchTypePivot>,
+  rollup: boolean,
+};
+
+export type MessagesSearchType = SearchTypeBase & {
+  sort: Array<MessageSortConfig>,
+  decorators: Array<Decorator>,
+  limit: number,
+  offset: number,
+};
+
+export type SearchType = AggregationSearchType | MessagesSearchType;

--- a/graylog2-web-interface/src/views/logic/searchtypes/messages/MessageSortConfig.js
+++ b/graylog2-web-interface/src/views/logic/searchtypes/messages/MessageSortConfig.js
@@ -1,7 +1,7 @@
 // @flow strict
 import Direction from 'views/logic/aggregationbuilder/Direction';
 
-export type MessageSortConfigJson = {
+type MessageSortConfigJson = {
   field: string,
   order: 'ASC' | 'DESC',
 };

--- a/graylog2-web-interface/src/views/logic/views/View.js
+++ b/graylog2-web-interface/src/views/logic/views/View.js
@@ -8,6 +8,7 @@ import MessagesWidget from 'views/logic/widgets/MessagesWidget';
 import AggregationWidget from 'views/logic/aggregationbuilder/AggregationWidget';
 import ViewState from './ViewState';
 import Search from '../search/Search';
+import type { SearchType as QuerySearchType } from '../queries/SearchType';
 import type { QueryId } from '../queries/Query';
 import type { WidgetMapping } from './types';
 import type { ViewStateJson } from './ViewState';
@@ -140,7 +141,7 @@ export default class View {
     return this._value.requires || {};
   }
 
-  getSearchTypeByWidgetId(widgetId: string) {
+  getSearchTypeByWidgetId(widgetId: string): ?QuerySearchType {
     const widgetMapping = this.state.map((state) => state.widgetMapping).flatten(true);
     const searchTypeId = widgetMapping.get(widgetId).first();
     if (!searchTypeId) {


### PR DESCRIPTION
This PR adds a flow type definition for query search types. There are a few more files were we could use this type definition, but these files are currently not using `// @flow`

## Motivation and Context
I want to remove the `searchType: any` declaration in `views/logic/queries/Query` and the `CSVExportModal`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

