### PR TITLE
Sanitize Hyperlink String Decorator links

### DIFF
--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -376,6 +376,12 @@
             </dependency>
 
             <dependency>
+                <groupId>commons-validator</groupId>
+                <artifactId>commons-validator</artifactId>
+                <version>${commons-validator.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>net.sf.opencsv</groupId>
                 <artifactId>opencsv</artifactId>
                 <version>${opencsv.version}</version>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -221,6 +221,11 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-common</artifactId>
         </dependency>

--- a/graylog2-server/src/main/java/org/graylog2/decorators/LinkFieldDecorator.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/LinkFieldDecorator.java
@@ -118,7 +118,7 @@ public class LinkFieldDecorator implements SearchResponseDecorator {
         String[] schemes = {"http", "https"};
         // UrlValidator.ALLOW_LOCAL_URLS allows local links to be permitted such as http://my-local-server
         // Some users may reference such local URLs, and there should be no issue with doing so.
-        UrlValidator urlValidator = new UrlValidator(schemes, UrlValidator.ALLOW_LOCAL_URLS);
+        UrlValidator urlValidator = new UrlValidator(schemes, UrlValidator.ALLOW_LOCAL_URLS + UrlValidator.ALLOW_2_SLASHES);
         return urlValidator.isValid(url);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/decorators/LinkFieldDecorator.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/LinkFieldDecorator.java
@@ -16,14 +16,11 @@
  */
 package org.graylog2.decorators;
 
-import com.floreysoft.jmte.Engine;
-import com.floreysoft.jmte.template.Template;
-import com.floreysoft.jmte.template.VariableDescription;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.assistedinject.Assisted;
+import org.apache.commons.validator.routines.UrlValidator;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
-import org.graylog2.plugin.configuration.fields.BooleanField;
 import org.graylog2.plugin.configuration.fields.TextField;
 import org.graylog2.plugin.decorators.SearchResponseDecorator;
 import org.graylog2.rest.models.messages.responses.ResultMessageSummary;
@@ -39,7 +36,7 @@ import static java.util.Objects.requireNonNull;
 
 public class LinkFieldDecorator implements SearchResponseDecorator {
 
-    private static final String CK_LINK_FIELD = "link_field";
+    public static final String CK_LINK_FIELD = "link_field";
 
     private final String linkField;
 
@@ -92,14 +89,36 @@ public class LinkFieldDecorator implements SearchResponseDecorator {
                     }
                     final Message message = new Message(ImmutableMap.copyOf(summary.message()));
                     final String href = (String) summary.message().get(linkField);
-                    final Map<String, String> decoratedField = new HashMap<>();
-                    decoratedField.put("type", "a");
-                    decoratedField.put("href", href);
-                    message.addField(linkField, decoratedField);
+                    if (isValidUrl(href)) {
+                        final Map<String, String> decoratedField = new HashMap<>();
+                        decoratedField.put("type", "a");
+                        decoratedField.put("href", href);
+                        message.addField(linkField, decoratedField);
+                    } else {
+                        message.addField(linkField, href);
+                    }
                     return summary.toBuilder().message(message.getFields()).build();
                 })
                 .collect(Collectors.toList());
 
         return searchResponse.toBuilder().messages(summaries).build();
+    }
+
+    /**
+     * @param url a String URL.
+     * @return true if the URL is valid and false if the URL is invalid.
+     *
+     * All URLS that do not start with the protocol "http" or "https" protocol scheme are considered invalid.
+     * All other non-URL text strings will be considered invalid. This includes inline javascript expressions such as:
+     *  - javascript:...
+     *  - alert()
+     *  - or any other javascript expressions.
+     */
+    private boolean isValidUrl(String url) {
+        String[] schemes = {"http", "https"};
+        // UrlValidator.ALLOW_LOCAL_URLS allows local links to be permitted such as http://my-local-server
+        // Some users may reference such local URLs, and there should be no issue with doing so.
+        UrlValidator urlValidator = new UrlValidator(schemes, UrlValidator.ALLOW_LOCAL_URLS);
+        return urlValidator.isValid(url);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/decorators/LinkFieldDecoratorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/decorators/LinkFieldDecoratorTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.decorators;
 
 import com.google.common.collect.ImmutableList;

--- a/graylog2-server/src/test/java/org/graylog2/decorators/LinkFieldDecoratorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/decorators/LinkFieldDecoratorTest.java
@@ -55,6 +55,9 @@ public class LinkFieldDecoratorTest {
         Assert.assertEquals("https://https-is-allowed-too.com", getDecoratorUrl("https://https-is-allowed-too.com"));
         Assert.assertEquals("HTTPS://upper-case-https-all-good.com", getDecoratorUrl("HTTPS://upper-case-https-all-good.com"));
 
+        // Links with double slashes should be allowed.
+        Assert.assertEquals("https://graylog.com//releases", getDecoratorUrl("https://graylog.com//releases"));
+
         // Verify that unsafe URLs are rendered as text.
         Assert.assertEquals("javascript:alert('Javascript is not allowed.')", getDecoratorMessage("javascript:alert('Javascript is not allowed.')"));
         Assert.assertEquals("alert('Javascript this way is still not allowed", getDecoratorMessage("alert('Javascript this way is still not allowed"));

--- a/graylog2-server/src/test/java/org/graylog2/decorators/LinkFieldDecoratorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/decorators/LinkFieldDecoratorTest.java
@@ -1,0 +1,86 @@
+package org.graylog2.decorators;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import org.graylog2.plugin.Tools;
+import org.graylog2.rest.models.messages.responses.ResultMessageSummary;
+import org.graylog2.rest.models.system.indexer.responses.IndexRangeSummary;
+import org.graylog2.rest.resources.search.responses.SearchResponse;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+public class LinkFieldDecoratorTest {
+
+    private static final String TEST_FIELD = "test_field";
+    private LinkFieldDecorator decorator;
+
+    @Before
+    public void setUp() throws Exception {
+        final HashMap<String, Object> config = new HashMap<>();
+        config.put(LinkFieldDecorator.CK_LINK_FIELD, TEST_FIELD);
+        decorator = new LinkFieldDecorator(DecoratorImpl.create("id", "link", config, Optional.empty(), 0));
+    }
+
+    @Test
+    public void verifyUnsafeLinksAreRemoved() {
+
+        // Verify that real, safe URLs are rendered as links.
+        Assert.assertEquals("http://full-local-should-match", getDecoratorUrl("http://full-local-should-match"));
+        Assert.assertEquals("http://full-url-should-match.com", getDecoratorUrl("http://full-url-should-match.com"));
+        Assert.assertEquals("http://full-url-should-match.com/test", getDecoratorUrl("http://full-url-should-match.com/test"));
+        Assert.assertEquals("http://full-url-should-match.com/test?with=param", getDecoratorUrl("http://full-url-should-match.com/test?with=param"));
+        Assert.assertEquals("https://https-is-allowed-too.com", getDecoratorUrl("https://https-is-allowed-too.com"));
+        Assert.assertEquals("HTTPS://upper-case-https-all-good.com", getDecoratorUrl("HTTPS://upper-case-https-all-good.com"));
+
+        // Verify that unsafe URLs are rendered as text.
+        Assert.assertEquals("javascript:alert('Javascript is not allowed.')", getDecoratorMessage("javascript:alert('Javascript is not allowed.')"));
+        Assert.assertEquals("alert('Javascript this way is still not allowed", getDecoratorMessage("alert('Javascript this way is still not allowed"));
+        Assert.assertEquals("ntp://other-stuff-is-not-allowed", getDecoratorMessage("ntp://other-stuff-is-not-allowed"));
+    }
+
+    private Object getDecoratorMessage(String urlFieldValue) {
+
+        return executeDecoratorGetFirstMessage(urlFieldValue).message().get(TEST_FIELD);
+    }
+
+    private Object getDecoratorUrl(String urlFieldValue) {
+
+        return ((HashMap) executeDecoratorGetFirstMessage(urlFieldValue).message().get(TEST_FIELD)).get("href");
+    }
+
+    private ResultMessageSummary executeDecoratorGetFirstMessage(String urlFieldValue) {
+        return decorator.apply(createSearchResponse(urlFieldValue)).messages().get(0);
+    }
+
+    private SearchResponse createSearchResponse(String urlFieldValue) {
+
+        final List<ResultMessageSummary> messages = ImmutableList.of(
+                ResultMessageSummary.create(ImmutableMultimap.of(), ImmutableMap.of("_id", "a", TEST_FIELD, urlFieldValue), "graylog_0")
+        );
+
+        final IndexRangeSummary indexRangeSummary = IndexRangeSummary.create("graylog_0",
+                                                                             Tools.nowUTC().minusDays(1),
+                                                                             Tools.nowUTC(),
+                                                                             null,
+                                                                             100);
+
+        return SearchResponse.builder()
+                             .query("foo")
+                             .builtQuery("foo")
+                             .usedIndices(ImmutableSet.of(indexRangeSummary))
+                             .messages(messages)
+                             .fields(ImmutableSet.of(TEST_FIELD))
+                             .time(100L)
+                             .totalResults(messages.size())
+                             .from(Tools.nowUTC().minusHours(1))
+                             .to(Tools.nowUTC())
+                             .build();
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/decorators/LinkFieldDecoratorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/decorators/LinkFieldDecoratorTest.java
@@ -32,10 +32,10 @@ public class LinkFieldDecoratorTest {
     public void verifyUnsafeLinksAreRemoved() {
 
         // Verify that real, safe URLs are rendered as links.
-        Assert.assertEquals("http://full-local-should-match", getDecoratorUrl("http://full-local-should-match"));
-        Assert.assertEquals("http://full-url-should-match.com", getDecoratorUrl("http://full-url-should-match.com"));
-        Assert.assertEquals("http://full-url-should-match.com/test", getDecoratorUrl("http://full-url-should-match.com/test"));
-        Assert.assertEquals("http://full-url-should-match.com/test?with=param", getDecoratorUrl("http://full-url-should-match.com/test?with=param"));
+        Assert.assertEquals("http://full-local-allowed", getDecoratorUrl("http://full-local-allowed"));
+        Assert.assertEquals("http://full-url-allowed.com", getDecoratorUrl("http://full-url-allowed.com"));
+        Assert.assertEquals("http://full-url-allowed.com/test", getDecoratorUrl("http://full-url-allowed.com/test"));
+        Assert.assertEquals("http://full-url-allowed.com/test?with=param", getDecoratorUrl("http://full-url-allowed.com/test?with=param"));
         Assert.assertEquals("https://https-is-allowed-too.com", getDecoratorUrl("https://https-is-allowed-too.com"));
         Assert.assertEquals("HTTPS://upper-case-https-all-good.com", getDecoratorUrl("HTTPS://upper-case-https-all-good.com"));
 
@@ -45,11 +45,17 @@ public class LinkFieldDecoratorTest {
         Assert.assertEquals("ntp://other-stuff-is-not-allowed", getDecoratorMessage("ntp://other-stuff-is-not-allowed"));
     }
 
+    /**
+     * @return Dig out and return the message value directly displayed by the UI.
+     */
     private Object getDecoratorMessage(String urlFieldValue) {
 
         return executeDecoratorGetFirstMessage(urlFieldValue).message().get(TEST_FIELD);
     }
 
+    /**
+     * @return Dig out and return the href link property used by the UI.
+     */
     private Object getDecoratorUrl(String urlFieldValue) {
 
         return ((HashMap) executeDecoratorGetFirstMessage(urlFieldValue).message().get(TEST_FIELD)).get("href");

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,7 @@
         <cef-parser.version>0.0.1.10</cef-parser.version>
         <commons-codec.version>1.14</commons-codec.version>
         <commons-email.version>1.5</commons-email.version>
+        <commons-validator.version>1.6</commons-validator.version>
         <commons-io.version>2.6</commons-io.version>
         <disruptor.version>3.4.2</disruptor.version>
         <elasticsearch.version>5.6.12</elasticsearch.version>


### PR DESCRIPTION
## Overview
This PR fixes an issue with [Hyperlink String Field Decorators](https://docs.graylog.org/en/3.1/pages/queries.html#decorators). When a non-link string is included in the message field for a Hyperlink Decorator field, the link is still clickable in stream-specific message tables on the Graylog Search page.

Now, the link is only clickable if the field contains a valid url starting with the protocol scheme `http://` or `https://`.

This change adds the `commons-validator` Java dependency. This allows effective URL validation without the need for reinventing custom regex patters for handle all cases.

## Testing

Verify that Hyperlink String decorated fields only render a clickable link for real URLs that start with `http://` or `https://` and also that other non-link string are still displayed, but are not clickable.

