### PR TITLE
Use containsExactlyInAnyOrder instead of containsExactly for more robust tests

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20161215163900_MoveIndexSetDefaultConfigTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20161215163900_MoveIndexSetDefaultConfigTest.java
@@ -105,7 +105,7 @@ public class V20161215163900_MoveIndexSetDefaultConfigTest {
         assertThat(clusterConfigService.get(DefaultIndexSetConfig.class).defaultIndexSetId()).isEqualTo("57f3d721a43c2d59cb750001");
 
         assertThat(migrationCompleted).isNotNull();
-        assertThat(migrationCompleted.indexSetIds()).containsExactly("57f3d721a43c2d59cb750001", "57f3d721a43c2d59cb750003");
+        assertThat(migrationCompleted.indexSetIds()).containsExactlyInAnyOrder("57f3d721a43c2d59cb750001", "57f3d721a43c2d59cb750003");
     }
 
     @Test


### PR DESCRIPTION
Use containsExactlyInAnyOrder instead of containsExactly
This PR aims for fix #8077
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The fix uses containsExactlyInAnyOrder instead of containsExactly so that the test is more stable.
In this way, the test is no more flaky.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

