### PR TITLE
Allow arbitrary key sizes for AESTools.encrypt/decrypt.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/security/AESTools.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/AESTools.java
@@ -37,8 +37,21 @@ public class AESTools {
 
     private static final SivMode SIV_MODE = new SivMode();
 
+    /**
+     * Encrypt the given plain text value with the given encryption key and salt using AES CBC.
+     * If the supplied encryption key is not of 16, 24 or 32 bytes length, it will be truncated or padded to the next
+     * largest key size before encryption.
+     *
+     * @param plainText     the plain text value to encrypt
+     * @param encryptionKey the encryption key
+     * @param salt          the salt
+     * @return the encrypted hexadecimal cipher text or null if encryption failed
+     */
     @Nullable
     public static String encrypt(String plainText, String encryptionKey, String salt) {
+        checkNotNull(plainText, "Plain text must not be null.");
+        checkNotNull(encryptionKey, "Encryption key must not be null.");
+        checkNotNull(salt, "Salt must not be null.");
         try {
             @SuppressWarnings("CIPHER_INTEGRITY")
             Cipher cipher = Cipher.getInstance("AES/CBC/ISO10126Padding", "SunJCE");
@@ -51,8 +64,22 @@ public class AESTools {
         return null;
     }
 
+    /**
+     * Decrypt the given cipher text value with the given encryption key and the same salt used for encryption using AES
+     * CBC.
+     * If the supplied encryption key is not of 16, 24 or 32 bytes length, it will be truncated or padded to the next
+     * largest key size before encryption.
+     *
+     * @param cipherText    the hexadecimal cipher text value to decrypt
+     * @param encryptionKey the encryption key
+     * @param salt          the salt used for encrypting this cipherText
+     * @return the decrypted cipher text or null if decryption failed
+     */
     @Nullable
     public static String decrypt(String cipherText, String encryptionKey, String salt) {
+        checkNotNull(cipherText, "Cipher text must not be null.");
+        checkNotNull(encryptionKey, "Encryption key must not be null.");
+        checkNotNull(salt, "Salt must not be null.");
         try {
             @SuppressWarnings("CIPHER_INTEGRITY")
             Cipher cipher = Cipher.getInstance("AES/CBC/ISO10126Padding", "SunJCE");

--- a/graylog2-server/src/main/java/org/graylog2/security/AESTools.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/AESTools.java
@@ -161,8 +161,8 @@ public class AESTools {
         }
     }
 
-    private static int desiredKeyLength(String input) {
-        final int length = input.length();
+    private static int desiredKeyLength(byte[] input) {
+        final int length = input.length;
 
         if (length == 16 || length == 24 || length == 32) {
             return length;
@@ -179,32 +179,33 @@ public class AESTools {
         return (length / 8 + 1) * 8;
     }
 
-    private static byte[] cutToLength(String input, int length) {
-        checkArgument(input.length() >= length, "Input string must be greater or of desired length");
-        return (input.length() > length ? input.substring(0, length) : input).getBytes(UTF_8);
+    private static byte[] cutToLength(byte[] input, int length) {
+        checkArgument(input.length >= length, "Input string must be greater or of desired length");
+        return input.length > length ? Arrays.copyOfRange(input, 0, length) : input;
     }
 
-    private static byte[] padToLength(String input, int length) {
-        checkArgument(input.length() < length, "Input string must be smaller than desired length");
+    private static byte[] padToLength(byte[] input, int length) {
+        checkArgument(input.length < length, "Input string must be smaller than desired length");
         final byte[] result = new byte[length];
-        System.arraycopy(input.getBytes(UTF_8), 0, result, 0, input.length());
+        System.arraycopy(input, 0, result, 0, input.length);
 
         return result;
     }
 
-    private static byte[] cutOrPadToLength(String input, int length) {
-        if (input.length() == length) {
-            return input.getBytes(UTF_8);
+    private static byte[] cutOrPadToLength(byte[] input, int length) {
+        if (input.length == length) {
+            return input;
         }
 
-        return input.length() > length
+        return input.length > length
                 ? cutToLength(input, length)
                 : padToLength(input, length);
     }
 
     private static byte[] adjustToIdealKeyLength(String input) {
         checkNotNull(input);
-        final int desiredLength = desiredKeyLength(input);
-        return cutOrPadToLength(input, desiredLength);
+        final byte[] inputAsBytes = input.getBytes(UTF_8);
+        final int desiredLength = desiredKeyLength(inputAsBytes);
+        return cutOrPadToLength(inputAsBytes, desiredLength);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/security/AESToolsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/AESToolsTest.java
@@ -57,6 +57,15 @@ public class AESToolsTest {
     }
 
     @Test
+    public void testEncryptDecryptWith16Characters17BytesKey() {
+        byte[] iv = new byte[8];
+        new SecureRandom().nextBytes(iv);
+        final String encrypt = AESTools.encrypt("I am secret", "123456789012345\u00E4", Hex.encodeHexString(iv));
+        final String decrypt = AESTools.decrypt(encrypt, "123456789012345\u00E4", Hex.encodeHexString(iv));
+        Assert.assertEquals("I am secret", decrypt);
+    }
+
+    @Test
     public void sivEncryptAndDecrypt() throws Exception {
         final byte[] encryptionKey = DigestUtils.sha256("encryptionKey");
         final String secret = "secret";

--- a/graylog2-server/src/test/java/org/graylog2/security/AESToolsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/AESToolsTest.java
@@ -39,7 +39,7 @@ public class AESToolsTest {
     }
 
     @Test
-    public void testEncryptWithKeyBeingLargerThan32() {
+    public void testEncryptDecryptWithKeyBeingLargerThan32Bytes() {
         byte[] iv = new byte[8];
         new SecureRandom().nextBytes(iv);
         final String encrypt = AESTools.encrypt("I am secret", "1234567890123456789012345678901234567", Hex.encodeHexString(iv));
@@ -48,7 +48,7 @@ public class AESToolsTest {
     }
 
     @Test
-    public void testEncryptWithKeyBeingSmallerThan32() {
+    public void testEncryptDecryptWith18BytesKey() {
         byte[] iv = new byte[8];
         new SecureRandom().nextBytes(iv);
         final String encrypt = AESTools.encrypt("I am secret", "123456789012345678", Hex.encodeHexString(iv));

--- a/graylog2-server/src/test/java/org/graylog2/security/AESToolsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/AESToolsTest.java
@@ -39,6 +39,24 @@ public class AESToolsTest {
     }
 
     @Test
+    public void testEncryptWithKeyBeingLargerThan32() {
+        byte[] iv = new byte[8];
+        new SecureRandom().nextBytes(iv);
+        final String encrypt = AESTools.encrypt("I am secret", "1234567890123456789012345678901234567", Hex.encodeHexString(iv));
+        final String decrypt = AESTools.decrypt(encrypt, "1234567890123456789012345678901234567", Hex.encodeHexString(iv));
+        Assert.assertEquals("I am secret", decrypt);
+    }
+
+    @Test
+    public void testEncryptWithKeyBeingSmallerThan32() {
+        byte[] iv = new byte[8];
+        new SecureRandom().nextBytes(iv);
+        final String encrypt = AESTools.encrypt("I am secret", "123456789012345678", Hex.encodeHexString(iv));
+        final String decrypt = AESTools.decrypt(encrypt, "123456789012345678", Hex.encodeHexString(iv));
+        Assert.assertEquals("I am secret", decrypt);
+    }
+
+    @Test
     public void sivEncryptAndDecrypt() throws Exception {
         final byte[] encryptionKey = DigestUtils.sha256("encryptionKey");
         final String secret = "secret";


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In the current state, the `AESTools.encrypt/decrypt` methods rely on key
sizes being 16, 24 or 32 bytes. This makes functionality using it with
user-supplied keys fail if their lengths are not exactly that size.

In order to allow arbitrary key sizes, this change is cutting keys if
they are longer than 32 bytes or pads them if they are shorter than the
desired key size. Also, it uses the first of the three key sizes which
can hold as most of the supplied key as possible.


<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.