### PR TITLE
Support editing title, description and summary of a saved search

### DIFF
--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
@@ -63,7 +63,7 @@ const ViewActionsMenu = ({ view, isNewView, metadata, currentUser, router }) => 
       </Button>
       <DropdownButton title={<Icon name="ellipsis-h" />} id="query-tab-actions-dropdown" pullRight noCaret>
         <MenuItem onSelect={() => setEditViewOpen(true)} disabled={isNewView || !allowedToEdit}>
-          <Icon name="edit" /> Edit
+          <Icon name="edit" /> Edit metadata
         </MenuItem>
         <MenuItem onSelect={() => setShareViewOpen(true)} disabled={isNewView || !allowedToEdit}>
           <Icon name="share-alt" /> Share
@@ -88,7 +88,7 @@ const ViewActionsMenu = ({ view, isNewView, metadata, currentUser, router }) => 
                              view={view}
                              title="Editing dashboard"
                              onClose={() => setEditViewOpen(false)}
-                             onSave={(updatedView) => onSaveView(updatedView, router)} />
+                             onSave={onSaveView} />
       )}
       {shareViewOpen && <ShareViewModal show view={view} onClose={() => setShareViewOpen(false)} />}
       {csvExportOpen && <CSVExportModal view={view} closeModal={() => setCsvExportOpen(false)} />}

--- a/graylog2-web-interface/src/views/components/sidebar/SideBar.test.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/SideBar.test.jsx
@@ -130,7 +130,7 @@ describe('<Sidebar />', () => {
     expect(wrapper.find('h3').text()).toBe('Untitled Dashboard');
   });
 
-  it('should render a summary and descirption, for dashboard view', () => {
+  it('should render summary and description of a view', () => {
     const wrapper = mount(
       <ViewTypeContext.Provider value={View.Type.Dashboard}>
         <SideBar viewMetadata={viewMetaData}
@@ -148,9 +148,63 @@ describe('<Sidebar />', () => {
     expect(wrapper.find('ViewDescription').text()).toContain(viewMetaData.description);
   });
 
-  it('should not render a summary and descirption, if the view is not a dashboard', () => {
+  it('should render placeholder if dashboard has no summary or description ', () => {
     const wrapper = mount(
-      <SideBar viewMetadata={viewMetaData}
+      <ViewTypeContext.Provider value={View.Type.Dashboard}>
+        <SideBar viewMetadata={{ ...viewMetaData, description: undefined, summary: undefined }}
+                 toggleOpen={jest.fn}
+                 queryId={query.id}
+                 results={queryResult}>
+          <TestComponent />
+        </SideBar>
+      </ViewTypeContext.Provider>,
+    );
+
+    wrapper.find('Sidebarstyles__SidebarHeader').simulate('click');
+    wrapper.find('div[children="Description"]').simulate('click');
+    expect(wrapper.find('ViewDescription').text()).toContain('No dashboard description');
+    expect(wrapper.find('ViewDescription').text()).toContain('No dashboard summary');
+  });
+
+  it('should render placeholder if saved search has no summary or description ', () => {
+    const wrapper = mount(
+      <ViewTypeContext.Provider value={View.Type.Search}>
+        <SideBar viewMetadata={{ ...viewMetaData, description: undefined, summary: undefined }}
+                 toggleOpen={jest.fn}
+                 queryId={query.id}
+                 results={queryResult}>
+          <TestComponent />
+        </SideBar>
+      </ViewTypeContext.Provider>,
+    );
+
+    wrapper.find('Sidebarstyles__SidebarHeader').simulate('click');
+    wrapper.find('div[children="Description"]').simulate('click');
+    expect(wrapper.find('ViewDescription').text()).toContain('No search description');
+    expect(wrapper.find('ViewDescription').text()).toContain('No search summary');
+  });
+
+  it('should render a summary and description, for a saved search', () => {
+    const wrapper = mount(
+      <ViewTypeContext.Provider value={View.Type.Search}>
+        <SideBar viewMetadata={viewMetaData}
+                 toggleOpen={jest.fn}
+                 queryId={query.id}
+                 results={queryResult}>
+          <TestComponent />
+        </SideBar>
+      </ViewTypeContext.Provider>,
+    );
+
+    wrapper.find('Sidebarstyles__SidebarHeader').simulate('click');
+    wrapper.find('div[children="Description"]').simulate('click');
+    expect(wrapper.find('ViewDescription').text()).toContain(viewMetaData.summary);
+    expect(wrapper.find('ViewDescription').text()).toContain(viewMetaData.description);
+  });
+
+  it('should not render a summary and description, if the view is an ad hoc search', () => {
+    const wrapper = mount(
+      <SideBar viewMetadata={{ ...viewMetaData, id: undefined }}
                toggleOpen={jest.fn}
                queryId={query.id}
                results={queryResult}>
@@ -162,6 +216,7 @@ describe('<Sidebar />', () => {
     wrapper.find('div[children="Description"]').simulate('click');
     expect(wrapper.find('ViewDescription').text()).not.toContain(viewMetaData.summary);
     expect(wrapper.find('ViewDescription').text()).not.toContain(viewMetaData.description);
+    expect(wrapper.find('ViewDescription').text()).toContain('Save the search or export it to a dashboard to add a custom description.');
   });
 
   it('should render widget create options', () => {

--- a/graylog2-web-interface/src/views/components/sidebar/ViewDescription.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/ViewDescription.jsx
@@ -43,10 +43,10 @@ const ViewDescription = ({ results, viewMetadata }: Props) => {
 
   return (
     <>
+      {resultsSection}
       <Section>
         {viewMetadata.summary || <i>No {viewTypeLabel} summary.</i>}
       </Section>
-      {resultsSection}
       <Section>
         {viewMetadata.description || <i>No {viewTypeLabel} description.</i>}
       </Section>

--- a/graylog2-web-interface/src/views/components/sidebar/ViewDescription.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/ViewDescription.jsx
@@ -1,46 +1,55 @@
 // @flow strict
-import React from 'react';
+import * as React from 'react';
+import { useContext } from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 
 import type { ViewMetaData } from 'views/stores/ViewMetadataStore';
+import QueryResult from 'views/logic/QueryResult';
 
-import IfDashboard from 'views/components/dashboard/IfDashboard';
+import ViewTypeLabel from 'views/components/ViewTypeLabel';
+import ViewTypeContext from 'views/components/contexts/ViewTypeContext';
 import { SearchResultOverview } from 'views/components/sidebar';
 
 const Section = styled.div`
   margin-bottom: 8px;
 `;
 
-const defaultNewDashboardSummary = 'No dashboard summary.';
-
 type Props = {
-  results: Object,
+  results: QueryResult,
   viewMetadata: ViewMetaData,
 };
 
 const ViewDescription = ({ results, viewMetadata }: Props) => {
-  const formatDashboardDescription = (view: ViewMetaData) => {
-    const { description } = view;
-    if (description) {
-      return <span>{description}</span>;
-    }
-    return <i>No dashboard description.</i>;
-  };
+  const isAdHocSearch = !viewMetadata.id;
+  const viewType = useContext(ViewTypeContext);
+  const viewTypeLabel = viewType ? <ViewTypeLabel type={viewType} /> : '';
+  const resultsSection = (
+    <Section>
+      <SearchResultOverview results={results} />
+    </Section>
+  );
+
+  if (isAdHocSearch) {
+    return (
+      <>
+        {resultsSection}
+        <Section>
+          <i>Save the search or export it to a dashboard to add a custom description.</i>
+        </Section>
+      </>
+    );
+  }
 
   return (
     <>
-      <IfDashboard>
-        <Section>
-          {viewMetadata.summary || defaultNewDashboardSummary}
-        </Section>
-      </IfDashboard>
       <Section>
-        <SearchResultOverview results={results} />
+        {viewMetadata.summary || <i>No {viewTypeLabel} summary.</i>}
       </Section>
-      <IfDashboard>
-        {formatDashboardDescription(viewMetadata)}
-      </IfDashboard>
+      {resultsSection}
+      <Section>
+        {viewMetadata.description || <i>No {viewTypeLabel} description.</i>}
+      </Section>
     </>
   );
 };

--- a/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.jsx
+++ b/graylog2-web-interface/src/views/components/views/ViewPropertiesModal.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { isEqual } from 'lodash';
 import FormsUtils from 'util/FormsUtils';
 
+import ViewTypeLabel from 'views/components/ViewTypeLabel';
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import Input from 'components/bootstrap/Input';
 
@@ -23,7 +24,8 @@ export default class ViewPropertiesModal extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { title } = this.props;
     const { view } = this.state;
     if (title !== nextProps.title || !isEqual(view, nextProps.view)) {
@@ -57,7 +59,8 @@ export default class ViewPropertiesModal extends React.Component {
 
   render() {
     const { view: { title = '', summary = '', description = '' }, title: modalTitle } = this.state;
-    const { onClose, show } = this.props;
+    const { onClose, show, view } = this.props;
+    const viewType = ViewTypeLabel({ type: view.type });
     return (
       <BootstrapModalForm show={show}
                           title={modalTitle}
@@ -69,7 +72,7 @@ export default class ViewPropertiesModal extends React.Component {
                type="text"
                name="title"
                label="Title"
-               help="The title of the dashboard."
+               help={`The title of the ${viewType}.`}
                required
                onChange={this._onChange}
                value={title} />
@@ -77,14 +80,14 @@ export default class ViewPropertiesModal extends React.Component {
                type="text"
                name="summary"
                label="Summary"
-               help="A helpful summary of the dashboard."
+               help={`A helpful summary of the ${viewType}.`}
                onChange={this._onChange}
                value={summary} />
         <Input id="description"
                type="textarea"
                name="description"
                label="Description"
-               help="A longer, helpful description of the dashboard and its functionality."
+               help={`A longer, helpful description of the ${viewType} and its functionality.`}
                onChange={this._onChange}
                value={description} />
       </BootstrapModalForm>


### PR DESCRIPTION
This PR implements the "Edit metadata" action for the saved searches search bar menu, which opens a modal to edit the title, description and summary.

It also:
* renames the "Edit" dashboard search bar action to "Edit metadata"
I think "Edit" is too generic. From a user's perspective: What is going to happen, will a click on the button display the search / widgets in an edit mode?
* adjusts the sidebar view description.
For an ad hoc search, an info will be displayed to save the search as a saved search / dashboard, to add a description / summary. On a dashboard / saved search the view description will include a view type specific placeholder, if a summary or description is not defined.

Regarding the tests for `SavedSearchControls`, I've tried to test if the edit modal opens, when clicking on "Edit Metadata", but I could not easily test this case with `enzyme`. Out of Interest I would like to have another look with someone else.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

