### PR TITLE
Export API Docs

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/MessagesRequest.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/MessagesRequest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.plugins.views.search.export;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -36,21 +37,32 @@ import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFA
 import static org.graylog.plugins.views.search.export.ExportMessagesCommand.defaultTimeRange;
 import static org.graylog.plugins.views.search.export.LinkedHashSetUtil.linkedHashSetOf;
 
+@JsonAutoDetect
 @AutoValue
 @JsonDeserialize(builder = MessagesRequest.Builder.class)
 public abstract class MessagesRequest {
+    private static final String FIELD_TIMERANGE = "timerange";
+    private static final String FIELD_QUERY_STRING = "query_string";
+    private static final String FIELD_FIELDS = "fields_in_order";
+    private static final String FIELD_CHUNK_SIZE = "chunk_size";
 
+    @JsonProperty(FIELD_TIMERANGE)
     public abstract TimeRange timeRange();
 
+    @JsonProperty(FIELD_QUERY_STRING)
     public abstract ElasticsearchQueryString queryString();
 
+    @JsonProperty
     public abstract Set<String> streams();
 
+    @JsonProperty(FIELD_FIELDS)
     @NotEmpty
     public abstract LinkedHashSet<String> fieldsInOrder();
 
+    @JsonProperty(FIELD_CHUNK_SIZE)
     public abstract int chunkSize();
 
+    @JsonProperty
     @Positive
     public abstract OptionalInt limit();
 
@@ -66,23 +78,23 @@ public abstract class MessagesRequest {
 
     @AutoValue.Builder
     public abstract static class Builder {
-        @JsonProperty("timerange")
+        @JsonProperty(FIELD_TIMERANGE)
         public abstract Builder timeRange(TimeRange timeRange);
 
         @JsonProperty
         public abstract Builder streams(Set<String> streams);
 
-        @JsonProperty("query_string")
+        @JsonProperty(FIELD_QUERY_STRING)
         public abstract Builder queryString(ElasticsearchQueryString queryString);
 
-        @JsonProperty("fields_in_order")
+        @JsonProperty(FIELD_FIELDS)
         public abstract Builder fieldsInOrder(LinkedHashSet<String> fieldsInOrder);
 
         public Builder fieldsInOrder(String... fieldsInOrder) {
             return fieldsInOrder(linkedHashSetOf(fieldsInOrder));
         }
 
-        @JsonProperty("chunk_size")
+        @JsonProperty(FIELD_CHUNK_SIZE)
         public abstract Builder chunkSize(int chunkSize);
 
         @JsonProperty

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ResultFormat.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/export/ResultFormat.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.plugins.views.search.export;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -31,15 +32,21 @@ import java.util.OptionalInt;
 import static org.graylog.plugins.views.search.export.ExportMessagesCommand.DEFAULT_FIELDS;
 import static org.graylog.plugins.views.search.export.LinkedHashSetUtil.linkedHashSetOf;
 
+@JsonAutoDetect
 @AutoValue
 @JsonDeserialize(builder = ResultFormat.Builder.class)
 public abstract class ResultFormat {
+    private static final String FIELD_FIELDS = "fields_in_order";
+
+    @JsonProperty(FIELD_FIELDS)
     @NotEmpty
     public abstract LinkedHashSet<String> fieldsInOrder();
 
-   @Positive
+    @JsonProperty
+    @Positive
     public abstract OptionalInt limit();
 
+    @JsonProperty
     public abstract Map<String, Object> executionState();
 
     public static ResultFormat.Builder builder() {
@@ -52,7 +59,7 @@ public abstract class ResultFormat {
 
     @AutoValue.Builder
     public abstract static class Builder {
-        @JsonProperty("fields_in_order")
+        @JsonProperty(FIELD_FIELDS)
         public abstract Builder fieldsInOrder(LinkedHashSet<String> fieldsInOrder);
 
         public Builder fieldsInOrder(String... fields) {


### PR DESCRIPTION
## Description
- Properly annotated MessagesRequest and ResultFormat
- Annotated MessagesResource

Unfortunately it seems impossible to get proper docs for nested json objects working with our current swagger solution. So as for all our other endpoints, the user can see, that a "timerange" parameter can be specified, but not what fields it must have. :/ See #8087

## Motivation and Context
Provide guidance for exports via the API

## How Has This Been Tested?
Verified in local API browser
