### PR TITLE
Display user notification after sharing a view

### DIFF
--- a/graylog2-web-interface/src/views/components/ViewTypeLabel.js
+++ b/graylog2-web-interface/src/views/components/ViewTypeLabel.js
@@ -4,7 +4,7 @@ import type { ViewType } from 'views/logic/views/View';
 
 type Props = {
   type: ViewType,
-  capitalize: boolean,
+  capitalize?: boolean,
 };
 
 const capitalizeLabel = (label) => label[0].toUpperCase() + label.slice(1);

--- a/graylog2-web-interface/src/views/components/views/ShareViewModal.jsx
+++ b/graylog2-web-interface/src/views/components/views/ShareViewModal.jsx
@@ -1,6 +1,7 @@
 // @flow strict
 import * as React from 'react';
 import { get } from 'lodash';
+import UserNotification from 'util/UserNotification';
 
 import { FormGroup, HelpBlock, Radio } from 'components/graylog';
 import BootstrapModalConfirm from 'components/bootstrap/BootstrapModalConfirm';
@@ -79,6 +80,7 @@ class ShareViewModal extends React.Component<Props, State> {
   _onSave = () => {
     const { view } = this.props;
     const { viewSharing } = this.state;
+    const viewTypeLabel = ViewTypeLabel({ type: view.type });
     let promise;
     if (viewSharing) {
       promise = ViewSharingActions.create(view.id, viewSharing);
@@ -86,7 +88,12 @@ class ShareViewModal extends React.Component<Props, State> {
       promise = ViewSharingActions.remove(view.id);
     }
     const { onClose } = this.props;
-    promise.then(() => onClose(viewSharing));
+    promise.then(() => {
+      onClose(viewSharing);
+      UserNotification.success(`Sharing ${viewTypeLabel} "${view.title}" was successful!`, 'Success!');
+    }).catch((error) => {
+      UserNotification.error(`Sharing ${viewTypeLabel} failed: ${error?.additional?.body?.message ?? error}`, 'Error!');
+    });
   };
 
   // eslint-disable-next-line react/destructuring-assignment


### PR DESCRIPTION
Currently a user does not receive any kind of feedback after sharing a view. This PR implements the common `UserNotification` for the success and error case.

Fixes: #7218

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

