### PR TITLE
Don't throw error in event wizard when query has no result

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterPreview.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterPreview.jsx
@@ -33,8 +33,8 @@ class FilterPreview extends React.Component {
     });
   };
 
-  renderSearchResult = (searchResult) => {
-    if (searchResult.messages.length === 0) {
+  renderSearchResult = (searchResult = {}) => {
+    if (!searchResult.messages || searchResult.messages.length === 0) {
       return <p>Could not find any messages with the current search criteria.</p>;
     }
 


### PR DESCRIPTION
There is currently a bug when the search query in the event wizard does not return any result.

![event-bug](https://user-images.githubusercontent.com/46300478/81668487-0a055f80-9445-11ea-8dd6-1bbf4c58b609.gif)

This PR is fixing the `cannot read property .length of undefined` error, but I am not sure why this error did not occurred before. This bug does not exist in 3.3.0-beta.1.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

