### PR TITLE
Allow arbitrary key sizes for AESTools.encrypt/decrypt. (3.2)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/security/AESTools.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/AESTools.java
@@ -25,6 +25,7 @@ import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.security.SecureRandom;
+import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -100,8 +101,8 @@ public class AESTools {
         return Hex.encodeToString(saltBytes);
     }
 
-    private static int desiredKeyLength(String input) {
-        final int length = input.length();
+    private static int desiredKeyLength(byte[] input) {
+        final int length = input.length;
 
         if (length == 16 || length == 24 || length == 32) {
             return length;

--- a/graylog2-server/src/main/java/org/graylog2/security/AESTools.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/AESTools.java
@@ -34,8 +34,21 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class AESTools {
     private static final Logger LOG = LoggerFactory.getLogger(AESTools.class);
 
+    /**
+     * Encrypt the given plain text value with the given encryption key and salt using AES CBC.
+     * If the supplied encryption key is not of 16, 24 or 32 bytes length, it will be truncated or padded to the next
+     * largest key size before encryption.
+     *
+     * @param plainText     the plain text value to encrypt
+     * @param encryptionKey the encryption key
+     * @param salt          the salt
+     * @return the encrypted hexadecimal cipher text or null if encryption failed
+     */
     @Nullable
     public static String encrypt(String plainText, String encryptionKey, String salt) {
+        checkNotNull(plainText, "Plain text must not be null.");
+        checkNotNull(encryptionKey, "Encryption key must not be null.");
+        checkNotNull(salt, "Salt must not be null.");
         try {
             @SuppressWarnings("CIPHER_INTEGRITY")
             Cipher cipher = Cipher.getInstance("AES/CBC/ISO10126Padding", "SunJCE");
@@ -48,8 +61,22 @@ public class AESTools {
         return null;
     }
 
+    /**
+     * Decrypt the given cipher text value with the given encryption key and the same salt used for encryption using AES
+     * CBC.
+     * If the supplied encryption key is not of 16, 24 or 32 bytes length, it will be truncated or padded to the next
+     * largest key size before encryption.
+     *
+     * @param cipherText    the hexadecimal cipher text value to decrypt
+     * @param encryptionKey the encryption key
+     * @param salt          the salt used for encrypting this cipherText
+     * @return the decrypted cipher text or null if decryption failed
+     */
     @Nullable
     public static String decrypt(String cipherText, String encryptionKey, String salt) {
+        checkNotNull(cipherText, "Cipher text must not be null.");
+        checkNotNull(encryptionKey, "Encryption key must not be null.");
+        checkNotNull(salt, "Salt must not be null.");
         try {
             @SuppressWarnings("CIPHER_INTEGRITY")
             Cipher cipher = Cipher.getInstance("AES/CBC/ISO10126Padding", "SunJCE");

--- a/graylog2-server/src/main/java/org/graylog2/security/AESTools.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/AESTools.java
@@ -25,7 +25,6 @@ import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.security.SecureRandom;
-import java.util.Arrays;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -119,32 +118,33 @@ public class AESTools {
         return (length / 8 + 1) * 8;
     }
 
-    private static byte[] cutToLength(String input, int length) {
-        checkArgument(input.length() >= length, "Input string must be greater or of desired length");
-        return (input.length() > length ? input.substring(0, length) : input).getBytes(UTF_8);
+    private static byte[] cutToLength(byte[] input, int length) {
+        checkArgument(input.length >= length, "Input string must be greater or of desired length");
+        return input.length > length ? Arrays.copyOfRange(input, 0, length) : input;
     }
 
-    private static byte[] padToLength(String input, int length) {
-        checkArgument(input.length() < length, "Input string must be smaller than desired length");
+    private static byte[] padToLength(byte[] input, int length) {
+        checkArgument(input.length < length, "Input string must be smaller than desired length");
         final byte[] result = new byte[length];
-        System.arraycopy(input.getBytes(UTF_8), 0, result, 0, input.length());
+        System.arraycopy(input, 0, result, 0, input.length);
 
         return result;
     }
 
-    private static byte[] cutOrPadToLength(String input, int length) {
-        if (input.length() == length) {
-            return input.getBytes(UTF_8);
+    private static byte[] cutOrPadToLength(byte[] input, int length) {
+        if (input.length == length) {
+            return input;
         }
 
-        return input.length() > length
+        return input.length > length
                 ? cutToLength(input, length)
                 : padToLength(input, length);
     }
 
     private static byte[] adjustToIdealKeyLength(String input) {
         checkNotNull(input);
-        final int desiredLength = desiredKeyLength(input);
-        return cutOrPadToLength(input, desiredLength);
+        final byte[] inputAsBytes = input.getBytes(UTF_8);
+        final int desiredLength = desiredKeyLength(inputAsBytes);
+        return cutOrPadToLength(inputAsBytes, desiredLength);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/security/AESTools.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/AESTools.java
@@ -25,16 +25,64 @@ import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.security.SecureRandom;
+import java.util.Arrays;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class AESTools {
     private static final Logger LOG = LoggerFactory.getLogger(AESTools.class);
+
+    private static int desiredKeyLength(String input) {
+        final int length = input.length();
+
+        if (length == 16 || length == 24 || length == 32) {
+            return length;
+        }
+
+        if (length < 16) {
+            return 16;
+        }
+
+        if (length > 32) {
+            return 32;
+        }
+
+        return (length / 8 + 1) * 8;
+    }
+
+    private static byte[] cutToLength(String input, int length) {
+        checkArgument(input.length() >= length, "Input string must be greater or of desired length");
+        return (input.length() > length ? input.substring(0, length) : input).getBytes(UTF_8);
+    }
+
+    private static byte[] padToLength(String input, int length) {
+        checkArgument(input.length() < length, "Input string must be smaller than desired length");
+        final byte[] result = new byte[length];
+        System.arraycopy(input.getBytes(UTF_8), 0, result, 0, input.length());
+
+        return result;
+    }
+
+    private static byte[] cutOrPadToLength(String input, int length) {
+        checkNotNull(input);
+        if (input.length() == length) {
+            return input.getBytes(UTF_8);
+        }
+
+        return input.length() > length
+                ? cutToLength(input, length)
+                : padToLength(input, length);
+    }
 
     @Nullable
     public static String encrypt(String plainText, String encryptionKey, String salt) {
         try {
             @SuppressWarnings("CIPHER_INTEGRITY")
             Cipher cipher = Cipher.getInstance("AES/CBC/ISO10126Padding", "SunJCE");
-            SecretKeySpec key = new SecretKeySpec(encryptionKey.getBytes("UTF-8"), "AES");
+            final int desiredLength = desiredKeyLength(encryptionKey);
+            SecretKeySpec key = new SecretKeySpec(cutOrPadToLength(encryptionKey, desiredLength), "AES");
             cipher.init(Cipher.ENCRYPT_MODE, key, new IvParameterSpec(salt.getBytes("UTF-8")));
             return Hex.encodeToString(cipher.doFinal(plainText.getBytes("UTF-8")));
         } catch (Exception e) {
@@ -48,7 +96,8 @@ public class AESTools {
         try {
             @SuppressWarnings("CIPHER_INTEGRITY")
             Cipher cipher = Cipher.getInstance("AES/CBC/ISO10126Padding", "SunJCE");
-            SecretKeySpec key = new SecretKeySpec(encryptionKey.getBytes("UTF-8"), "AES");
+            final int desiredLength = desiredKeyLength(encryptionKey);
+            SecretKeySpec key = new SecretKeySpec(cutOrPadToLength(encryptionKey, desiredLength), "AES");
             cipher.init(Cipher.DECRYPT_MODE, key, new IvParameterSpec(salt.getBytes("UTF-8")));
             return new String(cipher.doFinal(Hex.decode(cipherText)), "UTF-8");
         } catch (Exception e) {

--- a/graylog2-server/src/test/java/org/graylog2/security/AESToolsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/AESToolsTest.java
@@ -34,7 +34,7 @@ public class AESToolsTest {
     }
 
     @Test
-    public void testEncryptWithKeyBeingLargerThan32() {
+    public void testEncryptDecryptWithKeyBeingLargerThan32Bytes() {
         byte[] iv = new byte[8];
         new SecureRandom().nextBytes(iv);
         final String encrypt = AESTools.encrypt("I am secret", "1234567890123456789012345678901234567", Hex.encodeHexString(iv));
@@ -43,7 +43,7 @@ public class AESToolsTest {
     }
 
     @Test
-    public void testEncryptWithKeyBeingSmallerThan32() {
+    public void testEncryptDecryptWith18BytesKey() {
         byte[] iv = new byte[8];
         new SecureRandom().nextBytes(iv);
         final String encrypt = AESTools.encrypt("I am secret", "123456789012345678", Hex.encodeHexString(iv));

--- a/graylog2-server/src/test/java/org/graylog2/security/AESToolsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/AESToolsTest.java
@@ -50,4 +50,13 @@ public class AESToolsTest {
         final String decrypt = AESTools.decrypt(encrypt, "123456789012345678", Hex.encodeHexString(iv));
         Assert.assertEquals("I am secret", decrypt);
     }
+
+    @Test
+    public void testEncryptDecryptWith16Characters17BytesKey() {
+        byte[] iv = new byte[8];
+        new SecureRandom().nextBytes(iv);
+        final String encrypt = AESTools.encrypt("I am secret", "123456789012345\u00E4", Hex.encodeHexString(iv));
+        final String decrypt = AESTools.decrypt(encrypt, "123456789012345\u00E4", Hex.encodeHexString(iv));
+        Assert.assertEquals("I am secret", decrypt);
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog2/security/AESToolsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/AESToolsTest.java
@@ -33,4 +33,21 @@ public class AESToolsTest {
         Assert.assertEquals("I am secret", decrypt);
     }
 
+    @Test
+    public void testEncryptWithKeyBeingLargerThan32() {
+        byte[] iv = new byte[8];
+        new SecureRandom().nextBytes(iv);
+        final String encrypt = AESTools.encrypt("I am secret", "1234567890123456789012345678901234567", Hex.encodeHexString(iv));
+        final String decrypt = AESTools.decrypt(encrypt, "1234567890123456789012345678901234567", Hex.encodeHexString(iv));
+        Assert.assertEquals("I am secret", decrypt);
+    }
+
+    @Test
+    public void testEncryptWithKeyBeingSmallerThan32() {
+        byte[] iv = new byte[8];
+        new SecureRandom().nextBytes(iv);
+        final String encrypt = AESTools.encrypt("I am secret", "123456789012345678", Hex.encodeHexString(iv));
+        final String decrypt = AESTools.decrypt(encrypt, "123456789012345678", Hex.encodeHexString(iv));
+        Assert.assertEquals("I am secret", decrypt);
+    }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In the current state, the `AESTools.encrypt/decrypt` methods rely on key
sizes being 16, 24 or 32 bytes. This makes functionality using it with
user-supplied keys fail if their lengths are not exactly that size.

In order to allow arbitrary key sizes, this change is cutting keys if
they are longer than 32 bytes or pads them if they are shorter than the
desired key size. Also, it uses the first of the three key sizes which
can hold as most of the supplied key as possible.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.