### PR TITLE
Do not redirect to `/notfound` when viewing a saved search or dashboard which does not exist.

### DIFF
--- a/graylog2-web-interface/src/components/errors/ReportedErrorBoundary.jsx
+++ b/graylog2-web-interface/src/components/errors/ReportedErrorBoundary.jsx
@@ -3,12 +3,38 @@ import * as React from 'react';
 import { useState, useEffect } from 'react';
 import { withRouter } from 'react-router';
 
+import ErrorPage from 'components/errors/ErrorPage';
 import ErrorsActions from 'actions/errors/ErrorsActions';
-import { type ReportedError, ReactErrorType, UnauthorizedErrorType, StreamPermissionErrorType } from 'logic/errors/ReportedErrors';
+import { type ReportedError, ReactErrorType, NotFoundErrorType, UnauthorizedErrorType, StreamPermissionErrorType } from 'logic/errors/ReportedErrors';
 
 import RuntimeErrorPage from 'pages/RuntimeErrorPage';
+import NotFoundPage from 'pages/NotFoundPage';
 import UnauthorizedErrorPage from 'pages/UnauthorizedErrorPage';
 import StreamPermissionErrorPage from 'pages/StreamPermissionErrorPage';
+
+const FallbackErrorPage = ({ reportedError }: { reportedError: ReportedError }) => (
+  <ErrorPage title="Something went wrong"
+             description={<p>An unkown error has occured. Please have a look at the following message and the graylog server log for more information.</p>}>
+    <pre>
+      {JSON.stringify(reportedError)}
+    </pre>
+  </ErrorPage>
+);
+
+const ReportedErrorPage = ({ reportedError }: { reportedError: ReportedError }) => {
+  switch (reportedError.type) {
+    case ReactErrorType:
+      return <RuntimeErrorPage error={reportedError.error} componentStack={reportedError.info.componentStack} />;
+    case NotFoundErrorType:
+      return <NotFoundPage />;
+    case UnauthorizedErrorType:
+      return <UnauthorizedErrorPage error={reportedError.error} />;
+    case StreamPermissionErrorType:
+      return <StreamPermissionErrorPage error={reportedError.error} />;
+    default:
+      return <FallbackErrorPage reportedError={reportedError} />;
+  }
+};
 
 const ReportedErrorBoundary = ({ children, router }) => {
   const [reportedError, setReportedError] = useState<?ReportedError>();
@@ -29,16 +55,8 @@ const ReportedErrorBoundary = ({ children, router }) => {
     };
   }, [reportedError]);
 
-  if (reportedError && reportedError.type === ReactErrorType) {
-    return <RuntimeErrorPage error={reportedError.error} componentStack={reportedError.info.componentStack} />;
-  }
-
-  if (reportedError && reportedError.type === UnauthorizedErrorType) {
-    return <UnauthorizedErrorPage error={reportedError.error} />;
-  }
-
-  if (reportedError && reportedError.type === StreamPermissionErrorType) {
-    return <StreamPermissionErrorPage error={reportedError.error} />;
+  if (reportedError) {
+    return <ReportedErrorPage reportedError={reportedError} />;
   }
 
   return children;

--- a/graylog2-web-interface/src/components/errors/ReportedErrorBoundary.test.jsx
+++ b/graylog2-web-interface/src/components/errors/ReportedErrorBoundary.test.jsx
@@ -56,8 +56,8 @@ describe('ReportedErrorBoundary', () => {
       ErrorsActions.report(createReactError(new Error('The error message'), { componentStack: 'The component stack' }));
     });
     await wait(() => expect(queryByText('Hello World!')).toBeNull());
-    await wait(() => expect(getByText('Something went wrong.')).not.toBeNull());
-    await wait(() => expect(getByText('The error message')).not.toBeNull());
+    expect(getByText('Something went wrong.')).not.toBeNull();
+    expect(getByText('The error message')).not.toBeNull();
   });
 
   it('displays not found page when not found error got reported', async () => {
@@ -69,8 +69,8 @@ describe('ReportedErrorBoundary', () => {
     });
 
     await wait(() => expect(queryByText('Hello World!')).toBeNull());
-    await wait(() => expect(getByText('Page not found')).not.toBeNull());
-    await wait(() => expect(getByText('The party gorilla was just here, but had another party to rock.')).not.toBeNull());
+    expect(getByText('Page not found')).not.toBeNull();
+    expect(getByText('The party gorilla was just here, but had another party to rock.')).not.toBeNull();
   });
 
   it('displays reported error with an unkown type', async () => {
@@ -82,8 +82,8 @@ describe('ReportedErrorBoundary', () => {
     });
 
     await wait(() => expect(queryByText('Hello World!')).toBeNull());
-    await wait(() => expect(getByText('Something went wrong')).not.toBeNull());
-    await wait(() => expect(getByText(/The error message/)).not.toBeNull());
+    expect(getByText('Something went wrong')).not.toBeNull();
+    expect(getByText(/The error message/)).not.toBeNull();
   });
 
   it('displays unauthorized error page when unauthorized error got reported', async () => {
@@ -95,8 +95,8 @@ describe('ReportedErrorBoundary', () => {
     });
 
     await wait(() => expect(queryByText('Hello World!')).toBeNull());
-    await wait(() => expect(getByText('Missing Permissions')).not.toBeNull());
-    await wait(() => expect(getByText(/The request error message/)).not.toBeNull());
+    expect(getByText('Missing Permissions')).not.toBeNull();
+    expect(getByText(/The request error message/)).not.toBeNull();
   });
 
   it('resets error when navigation changes', async () => {

--- a/graylog2-web-interface/src/components/errors/ReportedErrorBoundary.test.jsx
+++ b/graylog2-web-interface/src/components/errors/ReportedErrorBoundary.test.jsx
@@ -62,9 +62,10 @@ describe('ReportedErrorBoundary', () => {
 
   it('displays unauthorized error page when unauthorized error got reported', async () => {
     const { getByText, queryByText } = render(<ReportedErrorBoundary router={router}>Hello World!</ReportedErrorBoundary>);
+    const response = { status: 403, body: { message: 'The request error message' } };
 
     suppressConsole(() => {
-      ErrorsActions.report(createUnauthorizedError(new FetchError('The request error message', new Error('The request error message'))));
+      ErrorsActions.report(createUnauthorizedError(new FetchError('The request error message', response)));
     });
 
     await wait(() => expect(queryByText('Hello World!')).toBeNull());
@@ -78,11 +79,12 @@ describe('ReportedErrorBoundary', () => {
     };
 
     const { getByText } = render(<ReportedErrorBoundary router={mockRouter}>Hello World!</ReportedErrorBoundary>);
+    const response = { status: 403, body: { message: 'The request error message' } };
 
     expect(getByText('Hello World!')).not.toBeNull();
 
     suppressConsole(() => {
-      ErrorsActions.report(createUnauthorizedError(new FetchError('The request error message', new Error('The request error message'))));
+      ErrorsActions.report(createUnauthorizedError(new FetchError('The request error message', response)));
     });
 
     await wait(() => expect(getByText('Missing Permissions')).not.toBeNull());

--- a/graylog2-web-interface/src/components/errors/ReportedErrorBoundary.test.jsx
+++ b/graylog2-web-interface/src/components/errors/ReportedErrorBoundary.test.jsx
@@ -5,7 +5,7 @@ import { act } from 'react-dom/test-utils';
 
 import suppressConsole from 'helpers/suppressConsole';
 import ErrorsActions from 'actions/errors/ErrorsActions';
-import { createReactError, createUnauthorizedError } from 'logic/errors/ReportedErrors';
+import { createReactError, createUnauthorizedError, createNotFoundError } from 'logic/errors/ReportedErrors';
 import { FetchError } from 'logic/rest/FetchProvider';
 import ReportedErrorBoundary from './ReportedErrorBoundary';
 
@@ -58,6 +58,32 @@ describe('ReportedErrorBoundary', () => {
     await wait(() => expect(queryByText('Hello World!')).toBeNull());
     await wait(() => expect(getByText('Something went wrong.')).not.toBeNull());
     await wait(() => expect(getByText('The error message')).not.toBeNull());
+  });
+
+  it('displays not found page when not found error got reported', async () => {
+    const { getByText, queryByText } = render(<ReportedErrorBoundary router={router}>Hello World!</ReportedErrorBoundary>);
+    const response = { status: 404, body: { message: 'The request error message' } };
+
+    suppressConsole(() => {
+      ErrorsActions.report(createNotFoundError(new FetchError('The request error message', response)));
+    });
+
+    await wait(() => expect(queryByText('Hello World!')).toBeNull());
+    await wait(() => expect(getByText('Page not found')).not.toBeNull());
+    await wait(() => expect(getByText('The party gorilla was just here, but had another party to rock.')).not.toBeNull());
+  });
+
+  it('displays reported error with an unkown type', async () => {
+    const { getByText, queryByText } = render(<ReportedErrorBoundary router={router}>Hello World!</ReportedErrorBoundary>);
+    const response = { status: 404, body: { message: 'The error message' } };
+
+    suppressConsole(() => {
+      ErrorsActions.report({ ...createNotFoundError(new FetchError('The error message', response)), type: 'UnkownReportedError' });
+    });
+
+    await wait(() => expect(queryByText('Hello World!')).toBeNull());
+    await wait(() => expect(getByText('Something went wrong')).not.toBeNull());
+    await wait(() => expect(getByText(/The error message/)).not.toBeNull());
   });
 
   it('displays unauthorized error page when unauthorized error got reported', async () => {

--- a/graylog2-web-interface/src/logic/errors/ReportedErrors.js
+++ b/graylog2-web-interface/src/logic/errors/ReportedErrors.js
@@ -3,6 +3,7 @@
 import { FetchError } from 'logic/rest/FetchProvider';
 
 export const ReactErrorType = 'ReactError';
+export const NotFoundErrorType = 'NotFoundError';
 export const UnauthorizedErrorType = 'UnauthorizedError';
 export const StreamPermissionErrorType = 'StreamPermissionError';
 
@@ -10,6 +11,10 @@ type ReactError = {
   error: Error,
   info: { componentStack: string },
   type: 'ReactError',
+};
+type NotFoundError = {
+  error: FetchError,
+  type: 'NotFoundError',
 };
 type UnauthorizedError = {
   error: FetchError,
@@ -20,12 +25,16 @@ type StreamPermissionError = {
   type: 'StreamPermissionError',
 };
 
-export type ReportedError = ReactError | UnauthorizedError;
+export type ReportedError = ReactError | NotFoundError | UnauthorizedError | StreamPermissionError;
 
 export const createReactError = (error: $PropertyType<ReactError, 'error'>, info: $PropertyType<ReactError, 'info'>): ReactError => ({
   error,
   info,
   type: ReactErrorType,
+});
+export const createNotFoundError = (error: $PropertyType<NotFoundError, 'error'>): NotFoundError => ({
+  error,
+  type: NotFoundErrorType,
 });
 export const createUnauthorizedError = (error: $PropertyType<UnauthorizedError, 'error'>): UnauthorizedError => ({
   error,
@@ -40,6 +49,8 @@ export const createFromFetchError = (error: FetchError) => {
   switch (error.status) {
     case 403:
       return error?.additional?.body?.type === 'MissingStreamPermission' ? createStreamPermissionError(error) : createUnauthorizedError(error);
+    case 404:
+      return createNotFoundError(error);
     default:
       throw Error(`Provided FetchError is not a valid ReportedError because status code ${error.status} is not supported`);
   }

--- a/graylog2-web-interface/src/pages/StreamPermissionErrorPage.test.jsx
+++ b/graylog2-web-interface/src/pages/StreamPermissionErrorPage.test.jsx
@@ -11,8 +11,8 @@ jest.unmock('logic/rest/FetchProvider');
 
 describe('StreamPermissionErrorPage', () => {
   it('displays fetch error', () => {
+    const response = { status: 403, body: { message: 'The request error message', streams: ['stream-1-id', 'stream-2-id'], type: 'MissingStreamPermission' } };
     suppressConsole(async () => {
-      const response = { status: 403, body: { message: 'The request error message', streams: ['stream-1-id', 'stream-2-id'], type: 'MissingStreamPermission' } };
       const { getByText } = render(<StreamPermissionErrorPage error={new FetchError('The request error message', response)} />);
 
       expect(getByText('Missing Stream Permissions')).not.toBeNull();

--- a/graylog2-web-interface/src/pages/UnauthorizedErrorPage.test.jsx
+++ b/graylog2-web-interface/src/pages/UnauthorizedErrorPage.test.jsx
@@ -12,7 +12,8 @@ jest.unmock('logic/rest/FetchProvider');
 describe('UnauthorizedErrorPage', () => {
   it('displays fetch error', () => {
     suppressConsole(async () => {
-      const { getByText } = render(<UnauthorizedErrorPage error={new FetchError('The request error message', new Error('The request error message'))} />);
+      const response = { status: 403, body: { message: 'The request error message' } };
+      const { getByText } = render(<UnauthorizedErrorPage error={new FetchError('The request error message', response)} />);
 
       expect(getByText('Missing Permissions')).not.toBeNull();
       expect(getByText(/The request error message/)).not.toBeNull();

--- a/graylog2-web-interface/src/views/logic/views/ViewLoader.js
+++ b/graylog2-web-interface/src/views/logic/views/ViewLoader.js
@@ -1,9 +1,9 @@
 // @flow strict
-import Routes from 'routing/Routes';
-import history from 'util/History';
-
+import ErrorsActions from 'actions/errors/ErrorsActions';
+import { createFromFetchError } from 'logic/errors/ReportedErrors';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import type { ViewHook, ViewHookArguments } from '../hooks/ViewHook';
+
 import View from './View';
 import ViewDeserializer from './ViewDeserializer';
 
@@ -49,11 +49,11 @@ const ViewLoader = (viewId: string,
   onSuccess: OnSuccess = () => {},
   onError: OnError = () => {}) => {
   const promise = ViewManagementActions.get(viewId)
-    .then(ViewDeserializer, (e) => {
-      if (e.status === 404) {
-        history.replace(Routes.NOTFOUND);
+    .then(ViewDeserializer, (error) => {
+      if (error.status === 404) {
+        ErrorsActions.report(createFromFetchError(error));
       } else {
-        throw e;
+        throw error;
       }
       return View.create();
     });


### PR DESCRIPTION
When a user tries to view a saved search or dashboard which does not exist, he will be redirected to `/notfound`. With this PR the URL will not change when displaying the not found page in the described scenario.

This PR also:
* adds a fallback to display reported errors with an unknown type
* Improves the `FetchError`s we are using in related tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

