### PR TITLE
Refactor index mapping templates for ES5 & 6.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
@@ -53,14 +53,14 @@ public abstract class IndexMapping implements IndexMappingTemplate {
         );
     }
 
-    protected Map<String, Object> messageMapping(final String analyzer) {
+    private Map<String, Object> messageMapping(final String analyzer) {
         return ImmutableMap.of(
                 "properties", fieldProperties(analyzer),
                 "dynamic_templates", dynamicTemplate(),
                 "_source", enabled());
     }
 
-    protected Map<String, Map<String, Object>> internalFieldsMapping() {
+    private Map<String, Map<String, Object>> internalFieldsMapping() {
         return ImmutableMap.of("internal_fields",
                 ImmutableMap.of(
                         "match", "gl2_*",
@@ -69,7 +69,7 @@ public abstract class IndexMapping implements IndexMappingTemplate {
         );
     }
 
-    protected List<Map<String, Map<String, Object>>> dynamicTemplate() {
+    private List<Map<String, Map<String, Object>>> dynamicTemplate() {
         final Map<String, Map<String, Object>> templateInternal = internalFieldsMapping();
 
         final Map<String, Map<String, Object>> templateAll = ImmutableMap.of("store_generic", dynamicStrings());
@@ -85,7 +85,7 @@ public abstract class IndexMapping implements IndexMappingTemplate {
                     "mapping", ImmutableMap.of("index", "not_analyzed"));
     }
 
-    protected Map<String, Map<String, Object>> fieldProperties(String analyzer) {
+    private Map<String, Map<String, Object>> fieldProperties(String analyzer) {
         return ImmutableMap.<String, Map<String, Object>>builder()
                 .put("message", analyzedString(analyzer, false))
                 .put("full_message", analyzedString(analyzer, false))
@@ -111,17 +111,17 @@ public abstract class IndexMapping implements IndexMappingTemplate {
                 "fielddata", fieldData);
     }
 
-    protected Map<String, Object> typeTimeWithMillis() {
+    private Map<String, Object> typeTimeWithMillis() {
         return ImmutableMap.of(
                 "type", "date",
                 "format", Tools.ES_DATE_FORMAT);
     }
 
-    protected Map<String, Object> typeLong() {
+    private Map<String, Object> typeLong() {
         return ImmutableMap.of("type", "long");
     }
 
-    protected Map<String, Boolean> enabled() {
+    private Map<String, Boolean> enabled() {
         return ImmutableMap.of("enabled", true);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
@@ -77,13 +77,7 @@ public abstract class IndexMapping implements IndexMappingTemplate {
         return ImmutableList.of(templateInternal, templateAll);
     }
 
-    protected Map<String, Object> dynamicStrings() {
-        return ImmutableMap.of(
-                    // Match all
-                    "match", "*",
-                    // Analyze nothing by default
-                    "mapping", ImmutableMap.of("index", "not_analyzed"));
-    }
+    abstract Map<String, Object> dynamicStrings();
 
     private Map<String, Map<String, Object>> fieldProperties(String analyzer) {
         return ImmutableMap.<String, Map<String, Object>>builder()
@@ -101,10 +95,10 @@ public abstract class IndexMapping implements IndexMappingTemplate {
                 .build();
     }
 
-    protected Map<String, Object> notAnalyzedString() {
+    Map<String, Object> notAnalyzedString() {
         return ImmutableMap.of("type", "keyword");
     }
-    protected Map<String, Object> analyzedString(String analyzer, boolean fieldData) {
+    Map<String, Object> analyzedString(String analyzer, boolean fieldData) {
         return ImmutableMap.of(
                 "type", "text",
                 "analyzer", analyzer,

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping5.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping5.java
@@ -22,4 +22,4 @@ package org.graylog2.indexer;
  *
  * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/5.4/mapping.html">Elasticsearch Reference / Mapping</a>
  */
-public class IndexMapping5 extends IndexMapping {}
+class IndexMapping5 extends IndexMapping {}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping5.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping5.java
@@ -16,10 +16,23 @@
  */
 package org.graylog2.indexer;
 
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
 /**
  * Representing the message type mapping in Elasticsearch 5.x. This is giving ES more
  * information about what the fields look like and how it should analyze them.
  *
  * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/5.4/mapping.html">Elasticsearch Reference / Mapping</a>
  */
-class IndexMapping5 extends IndexMapping {}
+class IndexMapping5 extends IndexMapping {
+    @Override
+    Map<String, Object> dynamicStrings() {
+        return ImmutableMap.of(
+                // Match all
+                "match", "*",
+                // Analyze nothing by default
+                "mapping", ImmutableMap.of("index", "not_analyzed"));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping5.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping5.java
@@ -16,44 +16,10 @@
  */
 package org.graylog2.indexer;
 
-import com.google.common.collect.ImmutableMap;
-import org.graylog2.plugin.Message;
-
-import java.util.Map;
-
 /**
  * Representing the message type mapping in Elasticsearch 5.x. This is giving ES more
  * information about what the fields look like and how it should analyze them.
  *
  * @see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/5.4/mapping.html">Elasticsearch Reference / Mapping</a>
  */
-public class IndexMapping5 extends IndexMapping {
-    @Override
-    protected Map<String, Map<String, Object>> fieldProperties(String analyzer) {
-        return ImmutableMap.<String, Map<String, Object>>builder()
-                .put("message", analyzedString(analyzer, false))
-                .put("full_message", analyzedString(analyzer, false))
-                // http://joda-time.sourceforge.net/api-release/org/joda/time/format/DateTimeFormat.html
-                // http://www.elasticsearch.org/guide/reference/mapping/date-format.html
-                .put("timestamp", typeTimeWithMillis())
-                .put(Message.FIELD_GL2_ACCOUNTED_MESSAGE_SIZE, typeLong())
-                .put(Message.FIELD_GL2_RECEIVE_TIMESTAMP, typeTimeWithMillis())
-                .put(Message.FIELD_GL2_PROCESSING_TIMESTAMP, typeTimeWithMillis())
-                // to support wildcard searches in source we need to lowercase the content (wildcard search lowercases search term)
-                .put("source", analyzedString("analyzer_keyword", true))
-                .put("streams", notAnalyzedString())
-                .build();
-    }
-
-    @Override
-    protected Map<String, Object> notAnalyzedString() {
-        return ImmutableMap.of("type", "keyword");
-    }
-
-    private Map<String, Object> analyzedString(String analyzer, boolean fieldData) {
-        return ImmutableMap.of(
-                "type", "text",
-                "analyzer", analyzer,
-                "fielddata", fieldData);
-    }
-}
+public class IndexMapping5 extends IndexMapping {}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping6.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping6.java
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 
-public class IndexMapping6 extends IndexMapping {
+class IndexMapping6 extends IndexMapping {
     @Override
     protected Map<String, Object> dynamicStrings() {
         return ImmutableMap.of(

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping6.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping6.java
@@ -22,10 +22,10 @@ import java.util.Map;
 
 class IndexMapping6 extends IndexMapping {
     @Override
-    protected Map<String, Object> dynamicStrings() {
+    Map<String, Object> dynamicStrings() {
         return ImmutableMap.of(
                 "match_mapping_type", "string",
                 "mapping", notAnalyzedString()
-            );
+        );
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping6.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping6.java
@@ -16,76 +16,16 @@
  */
 package org.graylog2.indexer;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import org.graylog2.plugin.Message;
 
-import java.util.List;
 import java.util.Map;
 
 public class IndexMapping6 extends IndexMapping {
-
     @Override
-    public Map<String, Object> messageTemplate(final String template, final String analyzer,
-        final int order) {
-        final Map<String, Object> analyzerKeyword = ImmutableMap
-            .of("analyzer_keyword", ImmutableMap.of(
-                "tokenizer", "keyword",
-                "filter", "lowercase"));
-        final Map<String, Object> analysis = ImmutableMap.of("analyzer", analyzerKeyword);
-        final Map<String, Object> settings = ImmutableMap.of("analysis", analysis);
-        final Map<String, Object> mappings = ImmutableMap.of(IndexMapping.TYPE_MESSAGE, messageMapping(analyzer));
-
+    protected Map<String, Object> dynamicStrings() {
         return ImmutableMap.of(
-            "template", template,
-            "order", order,
-            "settings", settings,
-            "mappings", mappings
-        );
-    }
-
-    protected List<Map<String, Map<String, Object>>> dynamicTemplate() {
-        final Map<String, Map<String, Object>> templateInternal =
-            ImmutableMap.of("internal_fields", ImmutableMap.of(
-                "match", "gl2_*",
                 "match_mapping_type", "string",
-                "mapping", notAnalyzedString()));
-
-        final Map<String, Object> dynamicStrings = ImmutableMap.of(
-            "match_mapping_type", "string",
-            "mapping", notAnalyzedString()
-        );
-        final Map<String, Map<String, Object>> templateAll = ImmutableMap.of("store_generic", dynamicStrings);
-
-        return ImmutableList.of(templateInternal, templateAll);
-    }
-
-    @Override
-    protected Map<String, Map<String, Object>> fieldProperties(String analyzer) {
-        return ImmutableMap.<String, Map<String, Object>>builder()
-                .put("message", analyzedString(analyzer, false))
-                .put("full_message", analyzedString(analyzer, false))
-                // http://joda-time.sourceforge.net/api-release/org/joda/time/format/DateTimeFormat.html
-                // http://www.elasticsearch.org/guide/reference/mapping/date-format.html
-                .put("timestamp", typeTimeWithMillis())
-                .put(Message.FIELD_GL2_ACCOUNTED_MESSAGE_SIZE, typeLong())
-                .put(Message.FIELD_GL2_RECEIVE_TIMESTAMP, typeTimeWithMillis())
-                .put(Message.FIELD_GL2_PROCESSING_TIMESTAMP, typeTimeWithMillis())
-                // to support wildcard searches in source we need to lowercase the content (wildcard search lowercases search term)
-                .put("source", analyzedString("analyzer_keyword", true))
-                .put("streams", notAnalyzedString())
-                .build();
-    }
-
-    private Map<String, Object> analyzedString(String analyzer, boolean fieldData) {
-        return ImmutableMap.of(
-            "type", "text",
-            "analyzer", analyzer,
-            "fielddata", fieldData);
-    }
-
-    @Override
-    protected Map<String, Object> notAnalyzedString() {
-        return ImmutableMap.of("type", "keyword");
+                "mapping", notAnalyzedString()
+            );
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexMapping5Test.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexMapping5Test.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.indexer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexMapping5Test.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexMapping5Test.java
@@ -1,0 +1,53 @@
+package org.graylog2.indexer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class IndexMapping5Test {
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+    private final IndexMapping5 indexMapping = new IndexMapping5();
+
+    @Test
+    void generateDefaultTemplate() throws Exception {
+        final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
+        when(indexSetConfig.indexAnalyzer()).thenReturn("standard");
+        final Map<String, Object> sampleIndexTemplate = indexMapping.toTemplate(indexSetConfig, "sampleIndexTemplate");
+
+        JSONAssert.assertEquals(json(sampleIndexTemplate), resourceFile("expected_template5.json"), true);
+    }
+
+    private String json(Object value) throws JsonProcessingException {
+        return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(value);
+    }
+
+    private String resourceFile(String filename) {
+        try {
+            final URL resource = this.getClass().getResource(filename);
+            if (resource == null) {
+                Assert.fail("Unable to find resource file for test: " + filename);
+            }
+            final Path path = Paths.get(resource.toURI());
+            final byte[] bytes = Files.readAllBytes(path);
+            return new String(bytes, StandardCharsets.UTF_8);
+        } catch (IOException | URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexMapping5Test.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexMapping5Test.java
@@ -16,28 +16,16 @@
  */
 package org.graylog2.indexer;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.graylog2.indexer.indexset.IndexSetConfig;
-import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-class IndexMapping5Test {
-    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+class IndexMapping5Test extends IndexMappingTestBase {
     private final IndexMapping5 indexMapping = new IndexMapping5();
 
     @Test
@@ -47,23 +35,5 @@ class IndexMapping5Test {
         final Map<String, Object> sampleIndexTemplate = indexMapping.toTemplate(indexSetConfig, "sampleIndexTemplate");
 
         JSONAssert.assertEquals(json(sampleIndexTemplate), resourceFile("expected_template5.json"), true);
-    }
-
-    private String json(Object value) throws JsonProcessingException {
-        return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(value);
-    }
-
-    private String resourceFile(String filename) {
-        try {
-            final URL resource = this.getClass().getResource(filename);
-            if (resource == null) {
-                Assert.fail("Unable to find resource file for test: " + filename);
-            }
-            final Path path = Paths.get(resource.toURI());
-            final byte[] bytes = Files.readAllBytes(path);
-            return new String(bytes, StandardCharsets.UTF_8);
-        } catch (IOException | URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexMapping6Test.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexMapping6Test.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.indexer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexMapping6Test.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexMapping6Test.java
@@ -16,28 +16,16 @@
  */
 package org.graylog2.indexer;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.graylog2.indexer.indexset.IndexSetConfig;
-import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-class IndexMapping6Test {
-    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+class IndexMapping6Test extends IndexMappingTestBase {
     private final IndexMapping6 indexMapping = new IndexMapping6();
 
     @Test
@@ -47,23 +35,5 @@ class IndexMapping6Test {
         final Map<String, Object> sampleIndexTemplate = indexMapping.toTemplate(indexSetConfig, "sampleIndexTemplate");
 
         JSONAssert.assertEquals(json(sampleIndexTemplate), resourceFile("expected_template6.json"), true);
-    }
-
-    private String json(Object value) throws JsonProcessingException {
-        return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(value);
-    }
-
-    private String resourceFile(String filename) {
-        try {
-            final URL resource = this.getClass().getResource(filename);
-            if (resource == null) {
-                Assert.fail("Unable to find resource file for test: " + filename);
-            }
-            final Path path = Paths.get(resource.toURI());
-            final byte[] bytes = Files.readAllBytes(path);
-            return new String(bytes, StandardCharsets.UTF_8);
-        } catch (IOException | URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexMapping6Test.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexMapping6Test.java
@@ -1,0 +1,53 @@
+package org.graylog2.indexer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class IndexMapping6Test {
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+    private final IndexMapping6 indexMapping = new IndexMapping6();
+
+    @Test
+    void generateDefaultTemplate() throws Exception {
+        final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
+        when(indexSetConfig.indexAnalyzer()).thenReturn("standard");
+        final Map<String, Object> sampleIndexTemplate = indexMapping.toTemplate(indexSetConfig, "sampleIndexTemplate");
+
+        JSONAssert.assertEquals(json(sampleIndexTemplate), resourceFile("expected_template6.json"), true);
+    }
+
+    private String json(Object value) throws JsonProcessingException {
+        return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(value);
+    }
+
+    private String resourceFile(String filename) {
+        try {
+            final URL resource = this.getClass().getResource(filename);
+            if (resource == null) {
+                Assert.fail("Unable to find resource file for test: " + filename);
+            }
+            final Path path = Paths.get(resource.toURI());
+            final byte[] bytes = Files.readAllBytes(path);
+            return new String(bytes, StandardCharsets.UTF_8);
+        } catch (IOException | URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingTestBase.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingTestBase.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.indexer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingTestBase.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/IndexMappingTestBase.java
@@ -1,0 +1,36 @@
+package org.graylog2.indexer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.junit.Assert;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+class IndexMappingTestBase {
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+
+    String json(Object value) throws JsonProcessingException {
+        return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(value);
+    }
+
+    String resourceFile(String filename) {
+        try {
+            final URL resource = this.getClass().getResource(filename);
+            if (resource == null) {
+                Assert.fail("Unable to find resource file for test: " + filename);
+            }
+            final Path path = Paths.get(resource.toURI());
+            final byte[] bytes = Files.readAllBytes(path);
+            return new String(bytes, StandardCharsets.UTF_8);
+        } catch (IOException | URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/expected_template5.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/expected_template5.json
@@ -1,0 +1,72 @@
+{
+  "template" : "sampleIndexTemplate",
+  "order" : -1,
+  "settings" : {
+    "analysis" : {
+      "analyzer" : {
+        "analyzer_keyword" : {
+          "tokenizer" : "keyword",
+          "filter" : "lowercase"
+        }
+      }
+    }
+  },
+  "mappings" : {
+    "message" : {
+      "properties" : {
+        "message" : {
+          "type" : "text",
+          "analyzer" : "standard",
+          "fielddata" : false
+        },
+        "full_message" : {
+          "type" : "text",
+          "analyzer" : "standard",
+          "fielddata" : false
+        },
+        "timestamp" : {
+          "type" : "date",
+          "format" : "yyyy-MM-dd HH:mm:ss.SSS"
+        },
+        "gl2_accounted_message_size" : {
+          "type" : "long"
+        },
+        "gl2_receive_timestamp" : {
+          "type" : "date",
+          "format" : "yyyy-MM-dd HH:mm:ss.SSS"
+        },
+        "gl2_processing_timestamp" : {
+          "type" : "date",
+          "format" : "yyyy-MM-dd HH:mm:ss.SSS"
+        },
+        "source" : {
+          "type" : "text",
+          "analyzer" : "analyzer_keyword",
+          "fielddata" : true
+        },
+        "streams" : {
+          "type" : "keyword"
+        }
+      },
+      "dynamic_templates" : [ {
+        "internal_fields" : {
+          "match" : "gl2_*",
+          "match_mapping_type" : "string",
+          "mapping" : {
+            "type" : "keyword"
+          }
+        }
+      }, {
+        "store_generic" : {
+          "match" : "*",
+          "mapping" : {
+            "index" : "not_analyzed"
+          }
+        }
+      } ],
+      "_source" : {
+        "enabled" : true
+      }
+    }
+  }
+}

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/expected_template6.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/expected_template6.json
@@ -1,0 +1,72 @@
+{
+  "template" : "sampleIndexTemplate",
+  "order" : -1,
+  "settings" : {
+    "analysis" : {
+      "analyzer" : {
+        "analyzer_keyword" : {
+          "tokenizer" : "keyword",
+          "filter" : "lowercase"
+        }
+      }
+    }
+  },
+  "mappings" : {
+    "message" : {
+      "properties" : {
+        "message" : {
+          "type" : "text",
+          "analyzer" : "standard",
+          "fielddata" : false
+        },
+        "full_message" : {
+          "type" : "text",
+          "analyzer" : "standard",
+          "fielddata" : false
+        },
+        "timestamp" : {
+          "type" : "date",
+          "format" : "yyyy-MM-dd HH:mm:ss.SSS"
+        },
+        "gl2_accounted_message_size" : {
+          "type" : "long"
+        },
+        "gl2_receive_timestamp" : {
+          "type" : "date",
+          "format" : "yyyy-MM-dd HH:mm:ss.SSS"
+        },
+        "gl2_processing_timestamp" : {
+          "type" : "date",
+          "format" : "yyyy-MM-dd HH:mm:ss.SSS"
+        },
+        "source" : {
+          "type" : "text",
+          "analyzer" : "analyzer_keyword",
+          "fielddata" : true
+        },
+        "streams" : {
+          "type" : "keyword"
+        }
+      },
+      "dynamic_templates" : [ {
+        "internal_fields" : {
+          "match" : "gl2_*",
+          "match_mapping_type" : "string",
+          "mapping" : {
+            "type" : "keyword"
+          }
+        }
+      }, {
+        "store_generic" : {
+          "match_mapping_type" : "string",
+          "mapping" : {
+            "type" : "keyword"
+          }
+        }
+      } ],
+      "_source" : {
+        "enabled" : true
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In order to clean up the code and research relevant differences between
different supported Elasticsearch versions, the two classes generating index
mapping templates for ES5 & 6 were refactored and most code was moved
into the abstract base class. Tests were added before to make sure that
the refactoring does not change the logic.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.