### PR TITLE
Add API description on MessagesResource

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/MessagesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/MessagesResource.java
@@ -55,7 +55,7 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-@Api(value = "Search/Messages")
+@Api(value = "Search/Messages", description = "Simple search returning (matching) messages only, as CSV.")
 @Path("/views/search/messages")
 @RequiresAuthentication
 public class MessagesResource extends RestResource implements PluginRestResource {


### PR DESCRIPTION
Although it's deprecated, our API browser supports it, and we don't have anything better. :/
