### PR TITLE
Preselect node if only one node exists

### DIFF
--- a/graylog2-web-interface/src/components/inputs/NodeOrGlobalSelect.jsx
+++ b/graylog2-web-interface/src/components/inputs/NodeOrGlobalSelect.jsx
@@ -1,7 +1,7 @@
+// @flow strict
 import PropTypes from 'prop-types';
-import React from 'react';
-import createReactClass from 'create-react-class';
-import Reflux from 'reflux';
+import React, { useCallback, useState, useEffect } from 'react';
+import { useStore } from 'stores/connect';
 import { Input } from 'components/bootstrap';
 
 import StoreProvider from 'injection/StoreProvider';
@@ -10,77 +10,88 @@ import { Spinner } from 'components/common';
 
 const NodesStore = StoreProvider.getStore('Nodes');
 
-const NodeOrGlobalSelect = createReactClass({
-  displayName: 'NodeOrGlobalSelect',
+type Props = {
+  global: boolean,
+  node: string,
+  onChange: (string, boolean | string) => void,
+};
 
-  propTypes: {
-    global: PropTypes.bool,
-    onChange: PropTypes.func.isRequired,
-    node: PropTypes.string,
-  },
+const NodeOrGlobalSelect = ({ global = false, node, onChange }: Props) => {
+  const { nodes } = useStore(NodesStore);
+  const [globalState, setGlobal] = useState(global);
+  const [nodeState, setNode] = useState(node);
 
-  mixins: [Reflux.connect(NodesStore)],
+  useEffect(() => {
+    if (!node && nodes) {
+      const nodeIds = Object.keys(nodes);
+      if (nodeIds.length === 1) {
+        onChange('node', nodeIds[0]);
+        setNode(nodeIds[0]);
+      }
+    }
+  }, [nodes]);
 
-  getInitialState() {
-    return {
-      global: this.props.global !== undefined ? this.props.global : false,
-      node: this.props.node,
-    };
-  },
-
-  _onChangeGlobal(evt) {
-    const global = evt.target.checked;
-    this.setState({ global: global });
-    if (global) {
-      this.setState({ node: 'placeholder' });
-      this.props.onChange('node', undefined);
+  const _onChangeGlobal = useCallback((evt) => {
+    const isGlobal = evt.target.checked;
+    setGlobal(isGlobal);
+    if (isGlobal) {
+      setNode('placeholder');
+      onChange('node', undefined);
     } else {
-      this.props.onChange('node', this.state.node);
+      onChange('node', nodeState);
     }
-    this.props.onChange('global', global);
-  },
+    onChange('global', isGlobal);
+  }, [onChange, nodeState, setNode, setGlobal]);
 
-  _onChangeNode(evt) {
-    this.setState({ node: evt.target.value });
-    this.props.onChange('node', evt.target.value);
-  },
+  const _onChangeNode = useCallback((evt) => {
+    setNode(evt.target.value);
+    onChange('node', evt.target.value);
+  }, [setNode, onChange]);
 
-  render() {
-    if (!this.state.nodes) {
-      return <Spinner />;
-    }
+  if (!nodes) {
+    return <Spinner />;
+  }
+  const options = Object.keys(nodes)
+    .map((nodeId) => {
+      return <option key={nodeId} value={nodeId}>{nodes[nodeId].short_node_id} / {nodes[nodeId].hostname}</option>;
+    });
 
-    const options = Object.keys(this.state.nodes)
-      .map((nodeId) => {
-        return <option key={nodeId} value={nodeId}>{this.state.nodes[nodeId].short_node_id} / {this.state.nodes[nodeId].hostname}</option>;
-      });
+  const nodeSelect = !globalState ? (
+    <Input id="node-select"
+           type="select"
+           label="Node"
+           placeholder="placeholder"
+           value={node}
+           help="On which node should this input start"
+           onChange={_onChangeNode}
+           required>
+      <option key="placeholder" value="">Select Node</option>
+      {options}
+    </Input>
+  ) : null;
 
-    const nodeSelect = !this.state.global ? (
-      <Input id="node-select"
-             type="select"
-             label="Node"
-             placeholder="placeholder"
-             value={this.state.node}
-             help="On which node should this input start"
-             onChange={this._onChangeNode}
-             required>
-        <option key="placeholder" value="">Select Node</option>
-        {options}
-      </Input>
-    ) : null;
+  return (
+    <span>
+      <Input id="global-checkbox"
+             type="checkbox"
+             label="Global"
+             help="Should this input start on all nodes"
+             checked={globalState}
+             onChange={_onChangeGlobal} />
+      {nodeSelect}
+    </span>
+  );
+};
 
-    return (
-      <span>
-        <Input id="global-checkbox"
-               type="checkbox"
-               label="Global"
-               help="Should this input start on all nodes"
-               checked={this.state.global}
-               onChange={this._onChangeGlobal} />
-        {nodeSelect}
-      </span>
-    );
-  },
-});
+NodeOrGlobalSelect.propTypes = {
+  global: PropTypes.bool,
+  onChange: PropTypes.func.isRequired,
+  node: PropTypes.string,
+};
+
+NodeOrGlobalSelect.defaultProps = {
+  global: false,
+  node: undefined,
+};
 
 export default NodeOrGlobalSelect;

--- a/graylog2-web-interface/src/components/inputs/NodeOrGlobalSelect.jsx
+++ b/graylog2-web-interface/src/components/inputs/NodeOrGlobalSelect.jsx
@@ -13,7 +13,7 @@ const NodesStore = StoreProvider.getStore('Nodes');
 type Props = {
   global: boolean,
   node: string,
-  onChange: (string, boolean | string) => void,
+  onChange: ('node' | 'global', boolean | ?string) => void,
 };
 
 const NodeOrGlobalSelect = ({ global = false, node, onChange }: Props) => {


### PR DESCRIPTION
## Motivation
Prior to this change, the user must select the only existing node when
creating a new input.

## Description
This change will refactor the NodeOrGlobalSelect and preselect a node
when only one node is in the cluster.

## How Has This Been Tested?
- Created a  input with only a single node in the cluster
- **NOT TESTED YET** with multiple nodes in the cluster

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

