### PR TITLE
use JsonUnit to ignore the order of fields in expected JSON string

### DIFF
--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -667,6 +667,12 @@
             <version>1.5.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
+            <version>2.6.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/model/ContentPackTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/model/ContentPackTest.java
@@ -50,6 +50,7 @@ import java.util.Collections;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 
 public class ContentPackTest {
 
@@ -145,7 +146,7 @@ public class ContentPackTest {
         String expectedJSON = String.join("", Files.readAllLines(path)).replace("\n", "").replace("\r", "");
 
         final String jsonTxt = objectMapper.writeValueAsString(contentPack);
-        assertThat(jsonTxt).isEqualTo(expectedJSON);
+        assertThatJson(jsonTxt).isEqualTo(expectedJSON);
 
         final ContentPack readContentPack = objectMapper.readValue(jsonTxt, ContentPack.class);
         assertThat(readContentPack.id()).isEqualTo(contentPack.id());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR fixes #7445
## Description
<!--- Describe your changes in detail -->
It uses `JsonUnit` to make the test is more stable.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The test method uses `jackson`to serialize objects into JSON and assert the serialized results with JSON string. However, the order of serialized JSON is not guaranteed so test

This PR proposes to use `JsonUnit` to compare JSON string without taking the order into consideration.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
