### PR TITLE
Add an end-to-end test for indexing and searching a message 

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/elasticsearch/e2e/ElasticsearchE2E.java
+++ b/full-backend-tests/src/test/java/org/graylog/elasticsearch/e2e/ElasticsearchE2E.java
@@ -1,0 +1,125 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.elasticsearch.e2e;
+
+import io.restassured.specification.RequestSpecification;
+import org.graylog.testing.completebackend.ApiIntegrationTest;
+import org.graylog.testing.completebackend.GraylogBackend;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Locale;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog.testing.backenddriver.SearchDriver.searchAllMessages;
+import static org.graylog.testing.completebackend.Lifecycle.CLASS;
+import static org.junit.Assert.fail;
+
+@ApiIntegrationTest(serverLifecycle = CLASS, extraPorts = {ElasticsearchE2E.GELF_HTTP_PORT})
+public class ElasticsearchE2E {
+    private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchE2E.class);
+
+    static final int GELF_HTTP_PORT = 12201;
+
+    private final GraylogBackend sut;
+    private final RequestSpecification requestSpec;
+
+    public ElasticsearchE2E(GraylogBackend sut, RequestSpecification requestSpec) {
+        this.sut = sut;
+        this.requestSpec = requestSpec;
+    }
+
+    @Test
+    void inputMessageCanBeSearched() {
+        //TODO: dont hardcode port in body
+        // create input
+        String input = "{\"title\":\"KILL ME\",\"type\":\"org.graylog2.inputs.gelf.http.GELFHttpInput\",\"configuration\":{\"bind_address\":\"0.0.0.0\",\"port\":12201,\"recv_buffer_size\":1048576,\"number_worker_threads\":8,\"tls_cert_file\":\"\",\"tls_key_file\":\"\",\"tls_enable\":false,\"tls_key_password\":\"\",\"tls_client_auth\":\"disabled\",\"tls_client_auth_cert_file\":\"\",\"tcp_keepalive\":false,\"enable_cors\":true,\"max_chunk_size\":65536,\"idle_writer_timeout\":60,\"override_source\":null,\"decompress_size_limit\":8388608},\"global\":true}";
+
+        given()
+                .spec(requestSpec)
+                .body(input)
+                .expect().response().statusCode(201)
+                .when()
+                .post("/system/inputs");
+
+        int mappedPort = sut.mappedPortFor(GELF_HTTP_PORT);
+
+        waitForGelfInputListening(mappedPort);
+
+        //post message
+        String message = "{\"short_message\":\"Hello there\", \"host\":\"example.org\", \"facility\":\"test\"}";
+
+        gelfEndpoint(mappedPort)
+                .body(message)
+                .expect().response().statusCode(202)
+                .when()
+                .post();
+
+        //search message
+
+        wait(5000);
+
+        List<String> messages = searchAllMessages(requestSpec);
+
+        assertThat(messages).containsExactly("Hello there");
+    }
+
+    private void waitForGelfInputListening(int port) {
+        int timeOutMs = 5000;
+        int msPassed = 0;
+        int waitMs = 500;
+        while (msPassed <= timeOutMs) {
+            if (gelfInputIsListening(port)) {
+                LOG.info("GELF input listening on port {} after {} ms", port, msPassed);
+                return;
+            }
+            msPassed += waitMs;
+            wait(waitMs);
+        }
+        fail(String.format(Locale.ENGLISH, "Timed out waiting for GELF input listening on port %s after %s ms.", port, msPassed));
+    }
+
+    private void wait(int waitMs) {
+        try {
+            Thread.sleep(waitMs);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private boolean gelfInputIsListening(int mappedPort) {
+        try {
+            gelfEndpoint(mappedPort)
+                    .expect().response().statusCode(200)
+                    .when()
+                    .options();
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private RequestSpecification gelfEndpoint(int mappedPort) {
+        return given()
+                .spec(requestSpec)
+                .basePath("/gelf")
+                .port(mappedPort);
+    }
+}

--- a/full-backend-tests/src/test/java/org/graylog/testing/backenddriver/SearchDriver.java
+++ b/full-backend-tests/src/test/java/org/graylog/testing/backenddriver/SearchDriver.java
@@ -31,10 +31,25 @@ import java.util.List;
 
 import static io.restassured.RestAssured.given;
 
+/**
+ * WIP. This class illustrates how we could reuse common functionality for integration tests.
+ * It might make sense to configure it with @link io.restassured.specification.RequestSpecification
+ * and whatever else it might need in the future and make it injectable into the test class via
+ *
+ * @link org.graylog.testing.completebackend.GraylogBackendExtension
+ * We should do that later, if we find that implementing more functionality here is useful and feasible.
+ */
 public class SearchDriver {
 
+    /**
+     * @param requestSpec @see io.restassured.specification.RequestSpecification
+     * @return all messages' "message" field as List<String>
+     */
     public static List<String> searchAllMessages(RequestSpecification requestSpec) {
-        String body = allMessagesJson();
+        String queryId = "query-id";
+        String messageListId = "message-list-id";
+
+        String body = allMessagesJson(queryId, messageListId);
 
         return given()
                 .spec(requestSpec)
@@ -44,13 +59,13 @@ public class SearchDriver {
                 .then()
                 .statusCode(200)
                 .extract()
-                .jsonPath().getList(allMessagesJsonPath("query-id", "message-list-id"), String.class);
+                .jsonPath().getList(allMessagesJsonPath(queryId, messageListId), String.class);
     }
 
-    private static String allMessagesJson() {
-        MessageList messageList = MessageList.builder().id("message-list-id").build();
+    private static String allMessagesJson(String queryId, String messageListId) {
+        MessageList messageList = MessageList.builder().id(messageListId).build();
         Query q = Query.builder()
-                .id("query-id")
+                .id(queryId)
                 .query(ElasticsearchQueryString.builder().queryString("").build())
                 .timerange(allMessagesTimeRange())
                 .searchTypes(ImmutableSet.of(messageList))

--- a/full-backend-tests/src/test/java/org/graylog/testing/backenddriver/SearchDriver.java
+++ b/full-backend-tests/src/test/java/org/graylog/testing/backenddriver/SearchDriver.java
@@ -1,0 +1,83 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.testing.backenddriver;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.ImmutableSet;
+import io.restassured.specification.RequestSpecification;
+import org.graylog.plugins.views.search.Query;
+import org.graylog.plugins.views.search.Search;
+import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
+import org.graylog.plugins.views.search.searchtypes.MessageList;
+import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
+import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+
+public class SearchDriver {
+
+    public static List<String> searchAllMessages(RequestSpecification requestSpec) {
+        String body = allMessagesJson();
+
+        return given()
+                .spec(requestSpec)
+                .when()
+                .body(body)
+                .post("/views/search/sync")
+                .then()
+                .statusCode(200)
+                .extract()
+                .jsonPath().getList(allMessagesJsonPath("query-id", "message-list-id"), String.class);
+    }
+
+    private static String allMessagesJson() {
+        MessageList messageList = MessageList.builder().id("message-list-id").build();
+        Query q = Query.builder()
+                .id("query-id")
+                .query(ElasticsearchQueryString.builder().queryString("").build())
+                .timerange(allMessagesTimeRange())
+                .searchTypes(ImmutableSet.of(messageList))
+                .build();
+        Search s = Search.builder().queries(ImmutableSet.of(q)).build();
+
+        return toJsonString(s);
+    }
+
+    private static AbsoluteRange allMessagesTimeRange() {
+        try {
+            return AbsoluteRange.create("2010-01-01T00:00:00.0Z", "2050-01-01T00:00:00.0Z");
+        } catch (InvalidRangeParametersException e) {
+            throw new RuntimeException("boo hoo", e);
+        }
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static String allMessagesJsonPath(String queryId, String messageListId) {
+        return "results." + queryId + ".search_types." + messageListId + ".messages.message.message";
+    }
+
+    private static String toJsonString(Search s) {
+        try {
+            return new ObjectMapperProvider().get().writeValueAsString(s);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialize Search", e);
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/ApiIntegrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/ApiIntegrationTest.java
@@ -37,4 +37,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Tag("integration")
 public @interface ApiIntegrationTest {
     Lifecycle serverLifecycle() default Lifecycle.METHOD;
+
+    int[] extraPorts() default {};
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/Lifecycle.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/Lifecycle.java
@@ -16,10 +16,6 @@
  */
 package org.graylog.testing.completebackend;
 
-import org.junit.jupiter.api.extension.ExtensionContext;
-
-import java.util.Optional;
-
 /**
  * Controls the lifecycle of the {@link GraylogBackend} used in tests
  */
@@ -43,14 +39,5 @@ public enum Lifecycle {
     };
 
     void afterEach(GraylogBackend backend) {
-    }
-
-    public static Lifecycle from(ExtensionContext context) {
-        Optional<Class<?>> testClass = context.getTestClass();
-
-        if (!testClass.isPresent())
-            throw new RuntimeException("Error determining test class from ExtensionContext");
-
-        return testClass.get().getAnnotation(ApiIntegrationTest.class).serverLifecycle();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerConfig.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerConfig.java
@@ -23,17 +23,19 @@ public class NodeContainerConfig {
     public final Network network;
     public final String mongoDbUri;
     public final String elasticsearchUri;
+    public final int[] extraPorts;
     public final boolean enableDebugging;
     public final boolean skipPackaging;
 
-    public static NodeContainerConfig create(Network network, String mongoDbUri, String elasticsearchUri) {
-        return new NodeContainerConfig(network, mongoDbUri, elasticsearchUri);
+    public static NodeContainerConfig create(Network network, String mongoDbUri, String elasticsearchUri, int[] extraPorts) {
+        return new NodeContainerConfig(network, mongoDbUri, elasticsearchUri, extraPorts);
     }
 
-    public NodeContainerConfig(Network network, String mongoDbUri, String elasticsearchUri) {
+    public NodeContainerConfig(Network network, String mongoDbUri, String elasticsearchUri, int[] extraPorts) {
         this.network = network;
         this.mongoDbUri = mongoDbUri;
         this.elasticsearchUri = elasticsearchUri;
+        this.extraPorts = extraPorts == null ? new int[0] : extraPorts;
         this.enableDebugging = flagFromEnvVar("GRAYLOG_IT_DEBUG_SERVER");
         this.skipPackaging = flagFromEnvVar("GRAYLOG_IT_SKIP_PACKAGING");
     }

--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerConfig.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerConfig.java
@@ -16,9 +16,15 @@
  */
 package org.graylog.testing.graylognode;
 
+import org.apache.commons.lang.ArrayUtils;
 import org.testcontainers.containers.Network;
 
+import java.util.Arrays;
+
 public class NodeContainerConfig {
+
+    static final int API_PORT = 9000;
+    static final int DEBUG_PORT = 5005;
 
     public final Network network;
     public final String mongoDbUri;
@@ -43,5 +49,15 @@ public class NodeContainerConfig {
     private static boolean flagFromEnvVar(String flagName) {
         String flag = System.getenv(flagName);
         return flag != null && flag.equalsIgnoreCase("true");
+    }
+
+    public Integer[] portsToExpose() {
+        int[] allPorts = ArrayUtils.add(extraPorts, 0, API_PORT);
+
+        if (enableDebugging) {
+            allPorts = ArrayUtils.add(allPorts, 0, DEBUG_PORT);
+        }
+
+        return Arrays.stream(allPorts).boxed().toArray(Integer[]::new);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeInstance.java
@@ -25,7 +25,7 @@ import org.testcontainers.containers.Network;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
-import static org.graylog.testing.graylognode.NodeContainerFactory.API_PORT;
+import static org.graylog.testing.graylognode.NodeContainerConfig.API_PORT;
 
 public class NodeInstance {
 

--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeInstance.java
@@ -25,14 +25,16 @@ import org.testcontainers.containers.Network;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
+import static org.graylog.testing.graylognode.NodeContainerFactory.API_PORT;
+
 public class NodeInstance {
 
     private static final Logger LOG = LoggerFactory.getLogger(NodeInstance.class);
 
     private final GenericContainer<?> container;
 
-    public static NodeInstance createStarted(Network network, String mongoDbUri, String elasticsearchUri) {
-        NodeContainerConfig config = NodeContainerConfig.create(network, mongoDbUri, elasticsearchUri);
+    public static NodeInstance createStarted(Network network, String mongoDbUri, String elasticsearchUri, int[] extraPorts) {
+        NodeContainerConfig config = NodeContainerConfig.create(network, mongoDbUri, elasticsearchUri, extraPorts);
         GenericContainer<?> container = NodeContainerFactory.buildContainer(config);
         return new NodeInstance(container);
     }
@@ -49,12 +51,16 @@ public class NodeInstance {
         LOG.info("Restarted node container in " + sw.elapsed(TimeUnit.SECONDS));
     }
 
-    public String getUri() {
+    public String uri() {
         return String.format(Locale.US, "http://%s", container.getContainerIpAddress());
     }
 
-    public int getApiPort() {
-        return container.getFirstMappedPort();
+    public int apiPort() {
+        return mappedPortFor(API_PORT);
+    }
+
+    public int mappedPortFor(int originalPort) {
+        return container.getMappedPort(originalPort);
     }
 
     public void printLog() {


### PR DESCRIPTION
## Description
This PR creates a new end-to-end test, which
- creates a GELF http input
- posts one message
- searches for that message

## Motivation and Context
We want to support new Elasticsearch versions in the future and need to make sure to not break core functionality.
This test is the first step towards adding more end-to-end test of this kind. 

## How Has This Been Tested?
Execution on local machine

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


