### PR TITLE
Migrate PaginatedList from class to functional component

### DIFF
--- a/graylog2-web-interface/src/components/common/PaginatedList.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.jsx
@@ -1,6 +1,7 @@
 // @flow strict
 import PropTypes from 'prop-types';
 import * as React from 'react';
+import { useState, useEffect } from 'react';
 
 import { Pagination } from 'components/graylog';
 import { Input } from 'components/bootstrap';
@@ -8,6 +9,20 @@ import IfInteractive from 'views/components/dashboard/IfInteractive';
 
 const DEFAULT_PAGE_SIZES = [10, 50, 100];
 const INITIAL_PAGE = 1;
+
+type PageSizeSelectProps = {
+  pageSize: number,
+  pageSizes: Array<number>,
+  onChange: (event: SyntheticInputEvent<HTMLLinkElement>) => void,
+};
+
+const PageSizeSelect = ({ pageSizes, pageSize, onChange }: PageSizeSelectProps) => (
+  <div className="form-inline page-size" style={{ float: 'right' }}>
+    <Input id="page-size" type="select" bsSize="small" label="Show:" value={pageSize} onChange={onChange}>
+      {pageSizes.map((size) => <option key={`option-${size}`} value={size}>{size}</option>)}
+    </Input>
+  </div>
+);
 
 type Props = {
   children: React.Node,
@@ -19,124 +34,97 @@ type Props = {
   showPageSizeSelect: boolean,
 };
 
-type State = {
-  currentPage: number,
-  pageSize: number,
-};
-
 /**
  * Wrapper component around an element that renders pagination
  * controls and provides a callback when the page or page size change.
  * You still need to fetch or filter the data yourself to ensure that
  * the selected page is displayed on screen.
  */
-class PaginatedList extends React.Component<Props, State> {
-  static propTypes = {
-    /** React element containing items of the current selected page. */
-    children: PropTypes.node.isRequired,
-    /**
-     * Function that will be called when the page changes.
-     * It receives the current page and the page size as arguments.
-     */
-    onChange: PropTypes.func.isRequired,
-    /** The active page number. If not specified the active page number will be tracked internally. */
-    activePage: PropTypes.number,
-    /** Number of items per page. */
-    pageSize: PropTypes.number,
-    /** Array of different items per page that are allowed. */
-    pageSizes: PropTypes.arrayOf(PropTypes.number),
-    /** Total amount of items in all pages. */
-    totalItems: PropTypes.number.isRequired,
-    /** Whether to show the page size selector or not. */
-    showPageSizeSelect: PropTypes.bool,
-  };
+const PaginatedList = ({
+  activePage,
+  children,
+  onChange,
+  pageSize: propsPageSize,
+  pageSizes,
+  showPageSizeSelect,
+  totalItems,
+}: Props) => {
+  const initialPage = activePage > 0 ? activePage : INITIAL_PAGE;
+  const [pageSize, setPageSize] = useState(propsPageSize);
+  const [currentPage, setCurrentPage] = useState(initialPage);
+  const numberPages = Math.ceil(totalItems / pageSize);
 
+  useEffect(() => {
+    setCurrentPage(activePage);
+  }, [activePage]);
+  useEffect(() => {
+    setPageSize(propsPageSize);
+  }, [propsPageSize]);
 
-  static defaultProps = {
-    activePage: 0,
-    pageSizes: DEFAULT_PAGE_SIZES,
-    pageSize: DEFAULT_PAGE_SIZES[0],
-    showPageSizeSelect: true,
-  };
-
-  constructor(props: Props) {
-    super(props);
-    const { activePage, pageSize } = props;
-    this.state = {
-      currentPage: activePage > 0 ? activePage : INITIAL_PAGE,
-      pageSize: pageSize,
-    };
-  }
-
-  componentWillReceiveProps(nextProps: Props) {
-    const { pageSize, activePage } = this.props;
-
-    if (activePage !== nextProps.activePage) {
-      this.setState({ currentPage: nextProps.activePage });
-    }
-    if (pageSize !== nextProps.pageSize) {
-      this.setState({ pageSize: nextProps.pageSize });
-    }
-  }
-
-  _onChangePageSize = (event: SyntheticInputEvent<HTMLLinkElement>) => {
-    const { onChange } = this.props;
+  const _onChangePageSize = (event: SyntheticInputEvent<HTMLLinkElement>) => {
     event.preventDefault();
-    const pageSize = Number(event.target.value);
-    this.setState({ currentPage: INITIAL_PAGE, pageSize: pageSize });
-    onChange(INITIAL_PAGE, pageSize);
+    const newPageSize = Number(event.target.value);
+    setCurrentPage(INITIAL_PAGE);
+    setPageSize(newPageSize);
+    onChange(INITIAL_PAGE, newPageSize);
   };
 
-  _onChangePage = (pageNo: number, event: MouseEvent) => {
-    const { onChange } = this.props;
-    const { pageSize } = this.state;
+  const _onChangePage = (pageNo: number, event: MouseEvent) => {
     event.preventDefault();
-    this.setState({ currentPage: pageNo });
+    setCurrentPage(pageNo);
     onChange(pageNo, pageSize);
   };
 
-  _pageSizeSelect = () => {
-    const { showPageSizeSelect, pageSizes } = this.props;
-    const { pageSize } = this.state;
-    if (!showPageSizeSelect) {
-      return null;
-    }
-    return (
-      <div className="form-inline page-size" style={{ float: 'right' }}>
-        <Input id="page-size" type="select" bsSize="small" label="Show:" value={pageSize} onChange={this._onChangePageSize}>
-          {pageSizes.map((size) => <option key={`option-${size}`} value={size}>{size}</option>)}
-        </Input>
-      </div>
-    );
-  };
+  return (
+    <>
+      {showPageSizeSelect && (
+        <PageSizeSelect pageSizes={pageSizes} pageSize={pageSize} onChange={_onChangePageSize} />
+      )}
 
-  render() {
-    const { totalItems, children } = this.props;
-    const { pageSize, currentPage } = this.state;
-    const numberPages = Math.ceil(totalItems / pageSize);
+      {children}
 
-    return (
-      <>
-        {this._pageSizeSelect()}
+      <IfInteractive>
+        <div className="text-center pagination-wrapper">
+          <Pagination bsSize="small"
+                      items={numberPages}
+                      maxButtons={10}
+                      activePage={currentPage}
+                      onSelect={_onChangePage}
+                      prev
+                      next
+                      first
+                      last />
+        </div>
+      </IfInteractive>
+    </>
+  );
+};
 
-        {children}
+PaginatedList.propTypes = {
+  /** React element containing items of the current selected page. */
+  children: PropTypes.node.isRequired,
+  /**
+   * Function that will be called when the page changes.
+   * It receives the current page and the page size as arguments.
+   */
+  onChange: PropTypes.func.isRequired,
+  /** The active page number. If not specified the active page number will be tracked internally. */
+  activePage: PropTypes.number,
+  /** Number of items per page. */
+  pageSize: PropTypes.number,
+  /** Array of different items per page that are allowed. */
+  pageSizes: PropTypes.arrayOf(PropTypes.number),
+  /** Total amount of items in all pages. */
+  totalItems: PropTypes.number.isRequired,
+  /** Whether to show the page size selector or not. */
+  showPageSizeSelect: PropTypes.bool,
+};
 
-        <IfInteractive>
-          <div className="text-center pagination-wrapper">
-            <Pagination bsSize="small"
-                        items={numberPages}
-                        maxButtons={10}
-                        activePage={currentPage}
-                        onSelect={this._onChangePage}
-                        prev
-                        next
-                        first
-                        last />
-          </div>
-        </IfInteractive>
-      </>
-    );
-  }
-}
+PaginatedList.defaultProps = {
+  activePage: 0,
+  pageSizes: DEFAULT_PAGE_SIZES,
+  pageSize: DEFAULT_PAGE_SIZES[0],
+  showPageSizeSelect: true,
+};
 
 export default PaginatedList;


### PR DESCRIPTION
The `PaginatedList` is currently still using the unsafe method `componentWIllReceiveProps`.

We've discussed this circumstance here: https://github.com/Graylog2/graylog2-server/pull/7826#issuecomment-612827854 and decided to refactor this part in a separate PR.

There are different ways to remove `componentWIllReceiveProps`, I've decided to migrate the class component to a functional component and use the `useEffect` hook.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

