### PR TITLE
Fix getting started guide page scroll behaviour

### DIFF
--- a/graylog2-web-interface/src/components/gettingstarted/GettingStarted.jsx
+++ b/graylog2-web-interface/src/components/gettingstarted/GettingStarted.jsx
@@ -3,29 +3,47 @@ import PropTypes from 'prop-types';
 import Qs from 'qs';
 import styled, { css } from 'styled-components';
 
-import { Grid, Row, Col, Button } from 'components/graylog';
+import { Grid, Col, Button } from 'components/graylog';
 import { ContentHeadRow, Spinner, Icon } from 'components/common';
 import ActionsProvider from 'injection/ActionsProvider';
 
 const GettingStartedActions = ActionsProvider.getActions('GettingStarted');
 
-const FullHeightContainer = styled.div`
-  height: calc(100vh - 100px);
-  margin-left: -15px;
-  margin-right: -15px;
+const Container = styled.div`
+  height: calc(100vh - 130px);
+  display: grid;
+  display: -ms-grid;
+  grid-template-rows: max-content 1fr;
+  -ms-grid-rows: max-content 1fr;
+  grid-template-columns: 1fr;
+  -ms-grid-columns: 1fr;
 `;
 
-const GettingStartedIframe = styled.iframe(({ hidden }) => css`
-  width: 100%;
-  display: ${hidden ? 'none' : 'block'};
-  min-height: calc(100vh - 100px);
-`);
+const DismissButtonSection = styled.div`
+  grid-colum: 1;
+  -ms-grid-column: 1;
+  grid-row: 1;
+  -ms-grid-row: 1;
+`;
 
 const DismissButton = styled(Button)`
   margin-right: 5px;
   top: -4px;
   position: relative;
 `;
+
+const ContentSection = styled.div`
+  grid-row: 2;
+  -ms-grid-row: 2;
+  grid-colum: 1;
+  -ms-grid-column: 1;
+`;
+
+const GettingStartedIframe = styled.iframe(({ hidden }) => `
+  display: ${hidden ? 'none' : 'block'};
+  width: 100%;
+  height: 100%;
+`);
 
 class GettingStarted extends React.Component {
   timeoutId = null;
@@ -44,11 +62,14 @@ class GettingStarted extends React.Component {
     onDismiss: () => {},
   }
 
-  state = {
-    guideLoaded: false,
-    guideUrl: '',
-    showStaticContent: false,
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      guideLoaded: false,
+      guideUrl: '',
+      showStaticContent: false,
+    };
+  }
 
   componentDidMount() {
     if (window.addEventListener) {
@@ -159,10 +180,14 @@ class GettingStarted extends React.Component {
       );
     }
     return (
-      <FullHeightContainer>
-        <div className="pull-right">{dismissButton}</div>
-        {gettingStartedContent}
-      </FullHeightContainer>
+      <Container>
+        <DismissButtonSection>
+          <div className="pull-right">{dismissButton}</div>
+        </DismissButtonSection>
+        <ContentSection>
+          {gettingStartedContent}
+        </ContentSection>
+      </Container>
     );
   }
 }

--- a/graylog2-web-interface/src/components/gettingstarted/GettingStarted.jsx
+++ b/graylog2-web-interface/src/components/gettingstarted/GettingStarted.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Qs from 'qs';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 
 import { Grid, Col, Button } from 'components/graylog';
 import { ContentHeadRow, Spinner, Icon } from 'components/common';
@@ -20,7 +20,7 @@ const Container = styled.div`
 `;
 
 const DismissButtonSection = styled.div`
-  grid-colum: 1;
+  grid-column: 1;
   -ms-grid-column: 1;
   grid-row: 1;
   -ms-grid-row: 1;
@@ -35,7 +35,7 @@ const DismissButton = styled(Button)`
 const ContentSection = styled.div`
   grid-row: 2;
   -ms-grid-row: 2;
-  grid-colum: 1;
+  grid-column: 1;
   -ms-grid-column: 1;
 `;
 

--- a/graylog2-web-interface/src/pages/GettingStartedPage.jsx
+++ b/graylog2-web-interface/src/pages/GettingStartedPage.jsx
@@ -4,6 +4,7 @@ import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import { DocumentTitle, Spinner } from 'components/common';
+import { Row } from 'components/graylog';
 import GettingStarted from 'components/gettingstarted/GettingStarted';
 
 import Routes from 'routing/Routes';
@@ -38,14 +39,14 @@ const GettingStartedPage = createReactClass({
 
     return (
       <DocumentTitle title="Getting started">
-        <div>
+        <Row>
           <GettingStarted clusterId={this.state.system.cluster_id}
                           masterOs={this.state.system.operating_system}
                           masterVersion={this.state.system.version}
                           gettingStartedUrl={GETTING_STARTED_URL}
                           noDismissButton={Boolean(this.props.location.query.menu)}
                           onDismiss={this._onDismiss} />
-        </div>
+        </Row>
       </DocumentTitle>
     );
   },

--- a/graylog2-web-interface/src/pages/GettingStartedPage.jsx
+++ b/graylog2-web-interface/src/pages/GettingStartedPage.jsx
@@ -1,7 +1,7 @@
+// @flow strict
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
-import Reflux from 'reflux';
+import connect from 'stores/connect';
 
 import { DocumentTitle, Spinner } from 'components/common';
 import { Row } from 'components/graylog';
@@ -15,41 +15,49 @@ import StoreProvider from 'injection/StoreProvider';
 const SystemStore = StoreProvider.getStore('System');
 
 const GETTING_STARTED_URL = 'https://gettingstarted.graylog.org/';
-const GettingStartedPage = createReactClass({
-  displayName: 'GettingStartedPage',
 
-  propTypes: {
-    location: PropTypes.object.isRequired,
+type Props = {
+  system: {
+    cluster_id: string,
+    operating_system: string,
+    version: string,
   },
-
-  mixins: [Reflux.connect(SystemStore)],
-
-  _isLoading() {
-    return !this.state.system;
+  location: {
+    query: { [string]: any },
   },
+};
 
-  _onDismiss() {
-    history.push(Routes.STARTPAGE);
-  },
+const GettingStartedPage = ({ system, location }: Props) => {
+  if (!system) {
+    return <Spinner />;
+  }
+  const { cluster_id: clusterId, operating_system: operatingSystem, version } = system;
+  const _onDismiss = () => history.push(Routes.STARTPAGE);
+  return (
+    <DocumentTitle title="Getting started">
+      <Row>
+        <GettingStarted clusterId={clusterId}
+                        masterOs={operatingSystem}
+                        masterVersion={version}
+                        gettingStartedUrl={GETTING_STARTED_URL}
+                        noDismissButton={Boolean(location.query.menu)}
+                        onDismiss={_onDismiss} />
+      </Row>
+    </DocumentTitle>
+  );
+};
 
-  render() {
-    if (this._isLoading()) {
-      return <Spinner />;
-    }
+GettingStartedPage.displayName = 'GettingStartedPage';
 
-    return (
-      <DocumentTitle title="Getting started">
-        <Row>
-          <GettingStarted clusterId={this.state.system.cluster_id}
-                          masterOs={this.state.system.operating_system}
-                          masterVersion={this.state.system.version}
-                          gettingStartedUrl={GETTING_STARTED_URL}
-                          noDismissButton={Boolean(this.props.location.query.menu)}
-                          onDismiss={this._onDismiss} />
-        </Row>
-      </DocumentTitle>
-    );
-  },
-});
+GettingStartedPage.propTypes = {
+  location: PropTypes.object.isRequired,
+};
 
-export default GettingStartedPage;
+export default connect(
+  GettingStartedPage,
+  { systemStore: SystemStore },
+  (props) => ({
+    ...props,
+    system: props.systemStore.system,
+  }),
+);


### PR DESCRIPTION
The getting stared guide currently has two scrollbars, which are always visible. This PR is fixing the problem by implementing a grid layout.

![image](https://user-images.githubusercontent.com/46300478/82025282-61980b00-9691-11ea-9e6a-11f70e8f94ae.png)

## How Has This Been Tested?
Tested with all mayor browsers and IE11
