### PR TITLE
Fix search widget grid width when its content results in a scrollbar

### DIFF
--- a/graylog2-web-interface/src/views/components/WidgetGrid.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetGrid.jsx
@@ -4,6 +4,7 @@ import * as Immutable from 'immutable';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import _ from 'lodash';
 import styled, { css } from 'styled-components';
+import { SizeMe } from 'react-sizeme';
 
 import connect from 'stores/connect';
 import { AdditionalContext } from 'views/logic/ActionContext';
@@ -154,11 +155,20 @@ class WidgetGrid extends React.Component {
         {widgets}
       </ReactGridContainer>
     ) : <span />;
+
+    // The SizeMe component is required to update the widget grid
+    // when its content height results in a scrollbar
     return (
-      <DashboardWrap>
-        {grid}
-        {staticWidgets}
-      </DashboardWrap>
+      <SizeMe monitorWidth refreshRate={100}>
+        {({ size }) => {
+          return (
+            <DashboardWrap>
+              {React.cloneElement(grid, { width: size.width })}
+              {staticWidgets}
+            </DashboardWrap>
+          );
+        }}
+      </SizeMe>
     );
   }
 }

--- a/graylog2-web-interface/src/views/components/__snapshots__/WidgetGrid.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/__snapshots__/WidgetGrid.test.jsx.snap
@@ -22,39 +22,48 @@ exports[`<WidgetGrid /> should render with minimal props 1`] = `
     titles={Immutable.Map {}}
     widgets={Object {}}
   >
-    <WidgetGrid__DashboardWrap>
-      <StyledComponent
-        forwardedComponent={
-          Object {
-            "$$typeof": Symbol(react.forward_ref),
-            "attrs": Array [],
-            "componentStyle": ComponentStyle {
-              "componentId": "WidgetGrid__DashboardWrap-sc-1bqopuh-0",
-              "isStatic": false,
-              "lastClassName": "jaucQL",
-              "rules": Array [
-                [Function],
-              ],
-            },
-            "displayName": "WidgetGrid__DashboardWrap",
-            "foldedComponentIds": Array [],
-            "render": [Function],
-            "styledComponentId": "WidgetGrid__DashboardWrap-sc-1bqopuh-0",
-            "target": "div",
-            "toString": [Function],
-            "warnTooManyClasses": [Function],
-            "withComponent": [Function],
-          }
-        }
-        forwardedRef={null}
-      >
-        <div
-          className="WidgetGrid__DashboardWrap-sc-1bqopuh-0 jaucQL"
-        >
-          <span />
-        </div>
-      </StyledComponent>
-    </WidgetGrid__DashboardWrap>
+    <SizeMe
+      monitorWidth={true}
+      refreshRate={100}
+    >
+      <div>
+        <WidgetGrid__DashboardWrap>
+          <StyledComponent
+            forwardedComponent={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "attrs": Array [],
+                "componentStyle": ComponentStyle {
+                  "componentId": "WidgetGrid__DashboardWrap-sc-1bqopuh-0",
+                  "isStatic": false,
+                  "lastClassName": "jaucQL",
+                  "rules": Array [
+                    [Function],
+                  ],
+                },
+                "displayName": "WidgetGrid__DashboardWrap",
+                "foldedComponentIds": Array [],
+                "render": [Function],
+                "styledComponentId": "WidgetGrid__DashboardWrap-sc-1bqopuh-0",
+                "target": "div",
+                "toString": [Function],
+                "warnTooManyClasses": [Function],
+                "withComponent": [Function],
+              }
+            }
+            forwardedRef={null}
+          >
+            <div
+              className="WidgetGrid__DashboardWrap-sc-1bqopuh-0 jaucQL"
+            >
+              <span
+                width={200}
+              />
+            </div>
+          </StyledComponent>
+        </WidgetGrid__DashboardWrap>
+      </div>
+    </SizeMe>
   </WidgetGrid>
 </ConnectStoresWrapper[WidgetGrid] stores=titles>
 `;


### PR DESCRIPTION
There is currently a visual bug, when the widget grid content results in a scrollbar:
![image](https://user-images.githubusercontent.com/46300478/82041959-5a7cf700-96a9-11ea-8f20-16a373d9a01c.png)

This bug is appearing, because the widget grid changes its initially calculated width, when its content results in a scrollbar.

This PR is fixing the problem by reimplementing the `SizeMe` component for the `WidgetGrid`, which got removed with https://github.com/Graylog2/graylog2-server/pull/7833
We removed the `SizeMe` container because it fixed a bug with the worldmap widget viewport, but  we've implemented another solution for this problem in the meantime.

While testing this change I found the following edge case. When opening a dashboard page with a worldmap widget and no scrollbar after being on a page with a scrollbar, the widget has a bigger or smaller (depending on the bowser) white padding on the right side.

## How Has This Been Tested?
Tested with all major browsers, IE11 and different widgets

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

