### PR TITLE
Sanitize Hyperlink String Decorator links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,9 @@ notifications:
 before_script:
   - sudo sysctl -w vm.max_map_count=262144
 script:
-  - mvn -B verify -Dit.ElasticsearchVersion=${GRAYLOG_ELASTICSEARCH_VERSION}
+  - mvn -B package
 after_success:
-  - mvn -B -Dmaven.test.skip=true -Dskip.web.build=true assembly:single
-  - mvn -B -Dmaven.test.skip=true -Dskip.web.build=true --settings config/settings.xml deploy
+  - mvn -B -Dmaven.test.skip=true -DskipITs -Dskip.web.build=true --settings config/settings.xml deploy
 deploy:
   provider: s3
   access_key_id: AKIAIGYGO43W76PZMMVA

--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -364,6 +364,12 @@
             </dependency>
 
             <dependency>
+                <groupId>commons-validator</groupId>
+                <artifactId>commons-validator</artifactId>
+                <version>${commons-validator.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>net.sf.opencsv</groupId>
                 <artifactId>opencsv</artifactId>
                 <version>${opencsv.version}</version>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -211,6 +211,11 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-common</artifactId>
         </dependency>

--- a/graylog2-server/src/main/java/org/graylog2/decorators/LinkFieldDecorator.java
+++ b/graylog2-server/src/main/java/org/graylog2/decorators/LinkFieldDecorator.java
@@ -16,14 +16,11 @@
  */
 package org.graylog2.decorators;
 
-import com.floreysoft.jmte.Engine;
-import com.floreysoft.jmte.template.Template;
-import com.floreysoft.jmte.template.VariableDescription;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.assistedinject.Assisted;
+import org.apache.commons.validator.routines.UrlValidator;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
-import org.graylog2.plugin.configuration.fields.BooleanField;
 import org.graylog2.plugin.configuration.fields.TextField;
 import org.graylog2.plugin.decorators.SearchResponseDecorator;
 import org.graylog2.rest.models.messages.responses.ResultMessageSummary;
@@ -39,7 +36,7 @@ import static java.util.Objects.requireNonNull;
 
 public class LinkFieldDecorator implements SearchResponseDecorator {
 
-    private static final String CK_LINK_FIELD = "link_field";
+    public static final String CK_LINK_FIELD = "link_field";
 
     private final String linkField;
 
@@ -92,14 +89,36 @@ public class LinkFieldDecorator implements SearchResponseDecorator {
                     }
                     final Message message = new Message(ImmutableMap.copyOf(summary.message()));
                     final String href = (String) summary.message().get(linkField);
-                    final Map<String, String> decoratedField = new HashMap<>();
-                    decoratedField.put("type", "a");
-                    decoratedField.put("href", href);
-                    message.addField(linkField, decoratedField);
+                    if (isValidUrl(href)) {
+                        final Map<String, String> decoratedField = new HashMap<>();
+                        decoratedField.put("type", "a");
+                        decoratedField.put("href", href);
+                        message.addField(linkField, decoratedField);
+                    } else {
+                        message.addField(linkField, href);
+                    }
                     return summary.toBuilder().message(message.getFields()).build();
                 })
                 .collect(Collectors.toList());
 
         return searchResponse.toBuilder().messages(summaries).build();
+    }
+
+    /**
+     * @param url a String URL.
+     * @return true if the URL is valid and false if the URL is invalid.
+     *
+     * All URLS that do not start with the protocol "http" or "https" protocol scheme are considered invalid.
+     * All other non-URL text strings will be considered invalid. This includes inline javascript expressions such as:
+     *  - javascript:...
+     *  - alert()
+     *  - or any other javascript expressions.
+     */
+    private boolean isValidUrl(String url) {
+        String[] schemes = {"http", "https"};
+        // UrlValidator.ALLOW_LOCAL_URLS allows local links to be permitted such as http://my-local-server
+        // Some users may reference such local URLs, and there should be no issue with doing so.
+        UrlValidator urlValidator = new UrlValidator(schemes, UrlValidator.ALLOW_LOCAL_URLS + UrlValidator.ALLOW_2_SLASHES);
+        return urlValidator.isValid(url);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/decorators/LinkFieldDecoratorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/decorators/LinkFieldDecoratorTest.java
@@ -1,0 +1,111 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.decorators;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import org.graylog2.plugin.Tools;
+import org.graylog2.rest.models.messages.responses.ResultMessageSummary;
+import org.graylog2.rest.models.system.indexer.responses.IndexRangeSummary;
+import org.graylog2.rest.resources.search.responses.SearchResponse;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
+public class LinkFieldDecoratorTest {
+
+    private static final String TEST_FIELD = "test_field";
+    private LinkFieldDecorator decorator;
+
+    @Before
+    public void setUp() throws Exception {
+        final HashMap<String, Object> config = new HashMap<>();
+        config.put(LinkFieldDecorator.CK_LINK_FIELD, TEST_FIELD);
+        decorator = new LinkFieldDecorator(DecoratorImpl.create("id", "link", config, Optional.empty(), 0));
+    }
+
+    @Test
+    public void verifyUnsafeLinksAreRemoved() {
+
+        // Verify that real, safe URLs are rendered as links.
+        Assert.assertEquals("http://full-local-allowed", getDecoratorUrl("http://full-local-allowed"));
+        Assert.assertEquals("http://full-url-allowed.com", getDecoratorUrl("http://full-url-allowed.com"));
+        Assert.assertEquals("http://full-url-allowed.com/test", getDecoratorUrl("http://full-url-allowed.com/test"));
+        Assert.assertEquals("http://full-url-allowed.com/test?with=param", getDecoratorUrl("http://full-url-allowed.com/test?with=param"));
+        Assert.assertEquals("https://https-is-allowed-too.com", getDecoratorUrl("https://https-is-allowed-too.com"));
+        Assert.assertEquals("HTTPS://upper-case-https-all-good.com", getDecoratorUrl("HTTPS://upper-case-https-all-good.com"));
+
+        // Links with double slashes should be allowed.
+        Assert.assertEquals("https://graylog.com//releases", getDecoratorUrl("https://graylog.com//releases"));
+
+        // Verify that unsafe URLs are rendered as text.
+        Assert.assertEquals("javascript:alert('Javascript is not allowed.')", getDecoratorMessage("javascript:alert('Javascript is not allowed.')"));
+        Assert.assertEquals("alert('Javascript this way is still not allowed", getDecoratorMessage("alert('Javascript this way is still not allowed"));
+        Assert.assertEquals("ntp://other-stuff-is-not-allowed", getDecoratorMessage("ntp://other-stuff-is-not-allowed"));
+    }
+
+    /**
+     * @return Dig out and return the message value directly displayed by the UI.
+     */
+    private Object getDecoratorMessage(String urlFieldValue) {
+
+        return executeDecoratorGetFirstMessage(urlFieldValue).message().get(TEST_FIELD);
+    }
+
+    /**
+     * @return Dig out and return the href link property used by the UI.
+     */
+    private Object getDecoratorUrl(String urlFieldValue) {
+
+        return ((HashMap) executeDecoratorGetFirstMessage(urlFieldValue).message().get(TEST_FIELD)).get("href");
+    }
+
+    private ResultMessageSummary executeDecoratorGetFirstMessage(String urlFieldValue) {
+        return decorator.apply(createSearchResponse(urlFieldValue)).messages().get(0);
+    }
+
+    private SearchResponse createSearchResponse(String urlFieldValue) {
+
+        final List<ResultMessageSummary> messages = ImmutableList.of(
+                ResultMessageSummary.create(ImmutableMultimap.of(), ImmutableMap.of("_id", "a", TEST_FIELD, urlFieldValue), "graylog_0")
+        );
+
+        final IndexRangeSummary indexRangeSummary = IndexRangeSummary.create("graylog_0",
+                                                                             Tools.nowUTC().minusDays(1),
+                                                                             Tools.nowUTC(),
+                                                                             null,
+                                                                             100);
+
+        return SearchResponse.builder()
+                             .query("foo")
+                             .builtQuery("foo")
+                             .usedIndices(ImmutableSet.of(indexRangeSummary))
+                             .messages(messages)
+                             .fields(ImmutableSet.of(TEST_FIELD))
+                             .time(100L)
+                             .totalResults(messages.size())
+                             .from(Tools.nowUTC().minusHours(1))
+                             .to(Tools.nowUTC())
+                             .build();
+    }
+}

--- a/jenkins.groovy
+++ b/jenkins.groovy
@@ -1,0 +1,3 @@
+@Library('ci-pipeline-shared') _
+
+buildSnapshot()

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,7 @@
         <cef-parser.version>0.0.1.10</cef-parser.version>
         <commons-codec.version>1.11</commons-codec.version>
         <commons-email.version>1.5</commons-email.version>
+        <commons-validator.version>1.6</commons-validator.version>
         <commons-io.version>2.6</commons-io.version>
         <disruptor.version>3.4.2</disruptor.version>
         <elasticsearch.version>5.6.12</elasticsearch.version>


### PR DESCRIPTION
Backport of https://github.com/Graylog2/graylog2-server/pull/8073.

This also does:

- Disable integration tests for travis ci, they don't work anymore (we did the same for master)
- Add jenkins.groovy file so we build the project on our new jenkins infrastructure