### PR TITLE
Create separate module for ES-specific implementations.

### DIFF
--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -23,6 +23,7 @@
         <module>../graylog2-server</module>
         <module>../integration-tests</module>
         <module>../full-backend-tests</module>
+        <module>../graylog-storage-elasticsearch6</module>
     </modules>
 
     <parent>

--- a/graylog-storage-elasticsearch6/pom.xml
+++ b/graylog-storage-elasticsearch6/pom.xml
@@ -9,9 +9,11 @@
         <relativePath>../graylog-project-parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
 
     <artifactId>graylog-storage-elasticsearch6</artifactId>
-    <name>Graylog Storage Module for Elasticsearch 6</name>
+    <name>graylog-storage-elasticsearch6</name>
+    <description>Graylog Storage Module for Elasticsearch 6</description>
 
     <dependencies>
     </dependencies>

--- a/graylog-storage-elasticsearch6/pom.xml
+++ b/graylog-storage-elasticsearch6/pom.xml
@@ -11,6 +11,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>graylog-storage-elasticsearch6</artifactId>
+    <name>Graylog Storage Module for Elasticsearch 6</name>
 
     <dependencies>
     </dependencies>

--- a/graylog-storage-elasticsearch6/pom.xml
+++ b/graylog-storage-elasticsearch6/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.graylog</groupId>
+        <artifactId>graylog-project-parent</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+        <relativePath>../graylog-project-parent</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>graylog-storage-elasticsearch6</artifactId>
+
+    <dependencies>
+    </dependencies>
+</project>

--- a/graylog-storage-elasticsearch6/pom.xml
+++ b/graylog-storage-elasticsearch6/pom.xml
@@ -16,5 +16,17 @@
     <description>Graylog Storage Module for Elasticsearch 6</description>
 
     <dependencies>
+        <dependency>
+            <groupId>org.graylog2</groupId>
+            <artifactId>graylog2-server</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.graylog2</groupId>
+            <artifactId>graylog2-server</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <module>graylog-project-parent</module>
         <module>graylog-plugin-parent</module>
         <module>graylog-plugin-archetype</module>
+        <module>graylog-storage-elasticsearch6</module>
     </modules>
 
     <groupId>org.graylog</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,6 @@
         <module>graylog-project-parent</module>
         <module>graylog-plugin-parent</module>
         <module>graylog-plugin-archetype</module>
-        <module>graylog-storage-elasticsearch6</module>
     </modules>
 
     <groupId>org.graylog</groupId>


### PR DESCRIPTION
This change is the first in a series aiming to separate our
Elasticsearch-specific implementation code from its consumers. It is
creating a separate maven module that is holding our current
implementation for:

  * Indexing Messages
  * Searching/aggregation previously indexed Messages
  * Index Management
  * Cluster health checks and maintenance

The goal of this is to encapsulate and hide version-specific
implementation details, allowing to switch the implementation code in
the future.

Fixes #8154.