### PR TITLE
Allow integration tests for multiple Elasticsearch versions

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/GraylogBackendExtension.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/GraylogBackendExtension.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.TimeUnit;
 
 import static io.restassured.http.ContentType.JSON;
+import static org.graylog.testing.junit5utils.Annotations.annotationFrom;
 import static org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 
 
@@ -48,6 +49,10 @@ public class GraylogBackendExtension implements AfterEachCallback, BeforeAllCall
     public void beforeAll(ExtensionContext context) {
 
         RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+
+        ApiIntegrationTest annotation = annotationFrom(context, ApiIntegrationTest.class);
+
+        lifecycle = annotation.serverLifecycle();
 
         Stopwatch sw = Stopwatch.createStarted();
 

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchInstance.java
@@ -70,6 +70,10 @@ public class ElasticsearchInstance extends ExternalResource {
         return create(Network.newNetwork());
     }
 
+    public static ElasticsearchInstance forVersion(String version) {
+        return create(version, Network.newNetwork());
+    }
+
     public static ElasticsearchInstance create(Network network) {
         String version = PropertyLoader
                 .loadProperties(PROPERTIES_RESOURCE_NAME)

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/multiversion/ElasticsearchVersionOnMethodTest.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/multiversion/ElasticsearchVersionOnMethodTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.testing.elasticsearch.multiversion;
 
 import org.graylog.testing.elasticsearch.Client;

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/multiversion/ElasticsearchVersionOnMethodTest.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/multiversion/ElasticsearchVersionOnMethodTest.java
@@ -1,0 +1,38 @@
+package org.graylog.testing.elasticsearch.multiversion;
+
+import org.graylog.testing.elasticsearch.Client;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ElasticsearchVersionOnMethodTest {
+
+    private Client clientFromSetup;
+
+    @BeforeEach
+    void setUp(Client client) {
+        clientFromSetup = client;
+    }
+
+    @Disabled(value = "This test illustrates that injection in the setup method will fail, "
+            + "if ElasticsearchVersions isn't specified on ALL test methods.")
+    @Test
+    void thisTestWouldFail() {
+        assertThat(1).isEqualTo(1);
+    }
+
+    @ElasticsearchVersions
+    @TestTemplate
+    void clientWasInjectedInSetup() {
+        assertThat(clientFromSetup).as("client should be injectable in setup methods").isNotNull();
+    }
+
+    @ElasticsearchVersions(versions = {"6.8.4"})
+    @TestTemplate
+    void annotationOnMethodWorks(String version) {
+        assertThat(version).isEqualTo("6.8.4");
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/multiversion/ElasticsearchVersions.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/multiversion/ElasticsearchVersions.java
@@ -1,0 +1,33 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.testing.elasticsearch.multiversion;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({METHOD, TYPE})
+@ExtendWith(VersionsContextProvider.class)
+@Retention(RUNTIME)
+public @interface ElasticsearchVersions {
+    String[] versions() default {};
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/multiversion/ElasticsearchVersionsOnClassTest.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/multiversion/ElasticsearchVersionsOnClassTest.java
@@ -1,0 +1,31 @@
+package org.graylog.testing.elasticsearch.multiversion;
+
+import org.graylog.testing.elasticsearch.Client;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog.testing.elasticsearch.multiversion.FetchVersionUtil.fetchVersion;
+
+@ElasticsearchVersions
+public class ElasticsearchVersionsOnClassTest {
+
+    private Client clientFromSetup;
+
+    @BeforeEach
+    void setUp(Client client) {
+        clientFromSetup = client;
+    }
+
+    @TestTemplate
+    void clientWasInjectedInSetup() {
+        assertThat(clientFromSetup).as("client should be injectable in setup methods").isNotNull();
+    }
+
+    @TestTemplate
+    void worksWithAnnotationOnClass(Client client, String version) {
+        String actualVersion = fetchVersion(client);
+
+        assertThat(actualVersion).isEqualTo(version);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/multiversion/ElasticsearchVersionsOnClassTest.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/multiversion/ElasticsearchVersionsOnClassTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.testing.elasticsearch.multiversion;
 
 import org.graylog.testing.elasticsearch.Client;

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/multiversion/ElasticsearchVersionsOnMethodAndClassTest.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/multiversion/ElasticsearchVersionsOnMethodAndClassTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.testing.elasticsearch.multiversion;
 
 import org.graylog.testing.elasticsearch.Client;

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/multiversion/ElasticsearchVersionsOnMethodAndClassTest.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/multiversion/ElasticsearchVersionsOnMethodAndClassTest.java
@@ -1,0 +1,23 @@
+package org.graylog.testing.elasticsearch.multiversion;
+
+import org.graylog.testing.elasticsearch.Client;
+import org.junit.jupiter.api.TestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog.testing.elasticsearch.multiversion.FetchVersionUtil.fetchVersion;
+
+@ElasticsearchVersions
+public class ElasticsearchVersionsOnMethodAndClassTest {
+    @TestTemplate
+    void worksWithAnnotationOnClass(Client client, String version) {
+        String actualVersion = fetchVersion(client);
+
+        assertThat(actualVersion).isEqualTo(version);
+    }
+
+    @ElasticsearchVersions(versions = {"6.8.3"})
+    @TestTemplate
+    void annotationOnMethodTakesPrecedence(String version) {
+        assertThat(version).isEqualTo("6.8.3");
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/multiversion/FetchVersionUtil.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/multiversion/FetchVersionUtil.java
@@ -1,0 +1,24 @@
+package org.graylog.testing.elasticsearch.multiversion;
+
+import io.searchbox.action.GenericResultAbstractAction;
+import io.searchbox.client.JestResult;
+import org.graylog.testing.elasticsearch.Client;
+
+public class FetchVersionUtil {
+    static String fetchVersion(Client client) {
+        JestResult result = client.executeWithExpectedSuccess(new GetStartPage(), "");
+
+        return result.getJsonObject().at("/version/number").asText();
+    }
+
+    private static class GetStartPage extends GenericResultAbstractAction {
+        public GetStartPage() {
+            setURI(buildURI());
+        }
+
+        @Override
+        public String getRestMethodName() {
+            return "GET";
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/multiversion/FetchVersionUtil.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/multiversion/FetchVersionUtil.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.testing.elasticsearch.multiversion;
 
 import io.searchbox.action.GenericResultAbstractAction;

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/multiversion/VersionInvocationContext.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/multiversion/VersionInvocationContext.java
@@ -1,0 +1,80 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.testing.elasticsearch.multiversion;
+
+import com.google.common.collect.ImmutableSet;
+import org.graylog.testing.elasticsearch.Client;
+import org.graylog.testing.elasticsearch.ElasticsearchInstance;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class VersionInvocationContext implements TestTemplateInvocationContext {
+    private static final Map<String, ElasticsearchInstance> instanceByVersion = new HashMap<>();
+    private final String version;
+
+    public static VersionInvocationContext forVersion(String version) {
+        if (!instanceByVersion.containsKey(version)) {
+            instanceByVersion.put(version, ElasticsearchInstance.forVersion(version));
+        }
+        return new VersionInvocationContext(version);
+    }
+
+    private VersionInvocationContext(String version) {
+        this.version = version;
+    }
+
+    @Override
+    public String getDisplayName(int invocationIndex) {
+        return version;
+    }
+
+    @Override
+    public List<Extension> getAdditionalExtensions() {
+        return Collections.singletonList(new ParameterResolver() {
+            @Override
+            public boolean supportsParameter(ParameterContext parameterContext,
+                                             ExtensionContext extensionContext) {
+                return ImmutableSet.of(Client.class, String.class)
+                        .contains(typeFrom(parameterContext));
+            }
+
+            private Class<?> typeFrom(ParameterContext parameterContext) {
+                return parameterContext.getParameter().getType();
+            }
+
+            @Override
+            public Object resolveParameter(ParameterContext parameterContext,
+                                           ExtensionContext extensionContext) {
+                Class<?> type = typeFrom(parameterContext);
+                if (type.equals(String.class)) {
+                    return version;
+                } else if (type.equals(Client.class)) {
+                    return instanceByVersion.get(version).client();
+                }
+                throw new IllegalArgumentException("Unsupported parameter type: " + type);
+            }
+        });
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/multiversion/VersionsContextProvider.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/multiversion/VersionsContextProvider.java
@@ -1,0 +1,45 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.testing.elasticsearch.multiversion;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import static org.graylog.testing.junit5utils.Annotations.annotationFrom;
+
+public class VersionsContextProvider implements TestTemplateInvocationContextProvider {
+    private static final String[] allVersions = {"5.6.12", "6.8.4"};
+
+    @Override
+    public boolean supportsTestTemplate(ExtensionContext context) {
+        return true;
+    }
+
+    @Override
+    public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(ExtensionContext context) {
+
+        ElasticsearchVersions annotation = annotationFrom(context, ElasticsearchVersions.class);
+
+        String[] versions = annotation.versions().length > 0 ? annotation.versions() : allVersions;
+
+        return Arrays.stream(versions).map(VersionInvocationContext::forVersion);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/junit5utils/Annotations.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/junit5utils/Annotations.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.testing.junit5utils;
 
 import org.junit.jupiter.api.extension.ExtensionContext;

--- a/graylog2-server/src/test/java/org/graylog/testing/junit5utils/Annotations.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/junit5utils/Annotations.java
@@ -1,0 +1,41 @@
+package org.graylog.testing.junit5utils;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.lang.annotation.Annotation;
+
+public class Annotations {
+    /**
+     * @return annotation from test method, if present, or from class otherwise
+     * @throws RuntimeException, if annotation wasn't found on either class or method
+     */
+    public static <T extends Annotation> T annotationFrom(ExtensionContext context, Class<T> annotationType) {
+        T fromMethod = fromMethod(context, annotationType);
+
+        if (fromMethod != null) {
+            return fromMethod;
+        }
+
+        T fromClass = fromClass(context, annotationType);
+
+        if (fromClass == null) {
+            throw new RuntimeException("Failed to find annotation " + annotationType);
+        }
+
+        return fromClass;
+    }
+
+    private static <T extends Annotation> T fromClass(ExtensionContext context, Class<T> annotationType) {
+        return context
+                .getTestClass()
+                .map(c -> c.getAnnotation(annotationType))
+                .orElse(null);
+    }
+
+    private static <T extends Annotation> T fromMethod(ExtensionContext context, Class<T> annotationType) {
+        return context
+                .getTestMethod()
+                .map(c -> c.getAnnotation(annotationType))
+                .orElse(null);
+    }
+}


### PR DESCRIPTION
## Description
This PR allows adding integration tests that iterate over multiple Elasticsearch versions with duplicating tests.
It leverages JUnit 5 [`@TestTemplate`s](https://junit.org/junit5/docs/snapshot/user-guide/#extensions-test-templates). The idea is that version-specific dependencies can be injected into the test template. It's not yet clear, what our version-independent interfaces, which we will introduce for 4.0, will look like. So for now only a version string and an instance of a `Client` that is configured with an `ElasticsearchInstance` of the requested version are injected. We should adapt `VersionInvocationContext` as we create new interfaces so that instances can be injected into tests.

## Motivation and Context
1. We are introducing capabilities for Graylog to support multiple Elasticsearch versions and want to cover these capabilities with tests without duplicating too much test code
2. We want to avoid breaking version-dependent functionality in the future. It's too much effort to manually test new features and fixes with multiple Elasticsearch versions. 

## How Has This Been Tested?
Local execution of new tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
