### PR TITLE
Added upgrade notes for export (#8167)

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -29,6 +29,16 @@ Please note that the format has changed. You can see the new format for saved se
 
 We are planning to remove the legacy saved searches API and the `/views/savedSearches` redirect in the next major upgrade of Graylog.
 
+CSV Export API
+==============
+
+For 3.3.0 a new endpoint for creating CSV exports has been added under `/views/search/messages`.
+
+We are planning to remove the older export endpoints in the next major upgrade of Graylog:
+- `/search/universal/absolute/export`
+- `/search/universal/keyword/export`
+- `/search/universal/relative/export`
+
 Notes for plugin authors
 ========================
 


### PR DESCRIPTION
## Description
Added upgrade notes for export mentioning that old endpoints will be removed for 4.0

(cherry picked from commit a31736364a51f337ed432e13cba5f9ecdfc1fb87)
