### PR TITLE
Fix summing up individual node throughput metrics. (3.3)

### DIFF
--- a/graylog2-web-interface/src/stores/metrics/GlobalThroughputStore.js
+++ b/graylog2-web-interface/src/stores/metrics/GlobalThroughputStore.js
@@ -35,16 +35,13 @@ const GlobalThroughputStore = Reflux.createStore({
     if (!update.metrics) {
       return;
     }
-    Object.keys(update.metrics).forEach((nodeId) => {
-      const inputMetric = update.metrics[nodeId][this.metrics.input];
-      const outputMetric = update.metrics[nodeId][this.metrics.output];
-      if (inputMetric) {
-        this.throughput = { ...this.throughput, input: inputMetric.metric.value };
-      }
-      if (outputMetric) {
-        this.throughput = { ...this.throughput, output: outputMetric.metric.value };
-      }
-    });
+    const input = Object.keys(update.metrics)
+      .map((nodeId) => update.metrics[nodeId][this.metrics.input]?.metric?.value ?? 0)
+      .reduce((prev, cur) => prev + cur, 0);
+    const output = Object.keys(update.metrics)
+      .map((nodeId) => update.metrics[nodeId][this.metrics.output]?.metric?.value ?? 0)
+      .reduce((prev, cur) => prev + cur, 0);
+    this.throughput = { input, output, loading: false };
 
     this.trigger({ throughput: this.throughput });
   },

--- a/graylog2-web-interface/src/stores/metrics/GlobalThroughputStore.test.js
+++ b/graylog2-web-interface/src/stores/metrics/GlobalThroughputStore.test.js
@@ -1,0 +1,72 @@
+// @flow strict
+
+import GlobalThroughputStore from "./GlobalThroughputStore";
+
+const expectedThroughput = (input, output) => ({ throughput: { input, output, loading: false } });
+const nodeThroughput = (input, output) => ({
+  'org.graylog2.throughput.input.1-sec-rate': { metric: { value: input } },
+  'org.graylog2.throughput.output.1-sec-rate': { metric: { value: output } },
+});
+const metricsUpdate = (metrics) => ({ metrics });
+
+const onUpdate = (fn, done) => GlobalThroughputStore.listen((newThroughput) => {
+  fn(newThroughput);
+  done();
+});
+
+describe('GlobalThroughputStore', () => {
+  let unsub;
+
+  afterEach(() => {
+    if (unsub) { unsub(); }
+  });
+  it('should return zeroed response if response does not contain metrics', (done) => {
+    unsub = onUpdate((newThroughput) => {
+      expect(newThroughput).toEqual(expectedThroughput(0, 0));
+    }, done);
+
+    GlobalThroughputStore.updateMetrics(metricsUpdate({}));
+  });
+  it('should extract throughput from response', (done) => {
+    unsub = onUpdate((newThroughput) => {
+      expect(newThroughput).toEqual(expectedThroughput(42, 17));
+    }, done);
+
+    GlobalThroughputStore.updateMetrics(metricsUpdate({
+        node1: nodeThroughput(42, 17),
+    }));
+  });
+  it('should sum individual throughputs from response', (done) => {
+    unsub = onUpdate((newThroughput) => {
+      expect(newThroughput).toEqual(expectedThroughput(609, 5187));
+    }, done);
+
+    GlobalThroughputStore.updateMetrics(metricsUpdate({
+        node1: nodeThroughput(42, 17),
+        node2: nodeThroughput(549, 4980),
+        node3: nodeThroughput(18, 190),
+    }));
+  });
+  it('should reset values between sequential updates', (done) => {
+    unsub = onUpdate((newThroughput) => {
+      expect(newThroughput).toEqual(expectedThroughput(609, 5187));
+    }, () => {});
+
+    GlobalThroughputStore.updateMetrics(metricsUpdate({
+      node1: nodeThroughput(42, 17),
+      node2: nodeThroughput(549, 4980),
+      node3: nodeThroughput(18, 190),
+    }));
+    unsub();
+
+    unsub = onUpdate((newThroughput) => {
+      expect(newThroughput).toEqual(expectedThroughput(0, 0));
+    }, done);
+
+    GlobalThroughputStore.updateMetrics(metricsUpdate({
+      node1: nodeThroughput(0, 0),
+      node2: nodeThroughput(0, 0),
+      node3: nodeThroughput(0, 0),
+    }));
+  });
+});

--- a/graylog2-web-interface/src/stores/metrics/GlobalThroughputStore.test.js
+++ b/graylog2-web-interface/src/stores/metrics/GlobalThroughputStore.test.js
@@ -1,6 +1,5 @@
 // @flow strict
-
-import GlobalThroughputStore from "./GlobalThroughputStore";
+import GlobalThroughputStore from './GlobalThroughputStore';
 
 const expectedThroughput = (input, output) => ({ throughput: { input, output, loading: false } });
 const nodeThroughput = (input, output) => ({
@@ -33,7 +32,7 @@ describe('GlobalThroughputStore', () => {
     }, done);
 
     GlobalThroughputStore.updateMetrics(metricsUpdate({
-        node1: nodeThroughput(42, 17),
+      node1: nodeThroughput(42, 17),
     }));
   });
   it('should sum individual throughputs from response', (done) => {
@@ -42,9 +41,9 @@ describe('GlobalThroughputStore', () => {
     }, done);
 
     GlobalThroughputStore.updateMetrics(metricsUpdate({
-        node1: nodeThroughput(42, 17),
-        node2: nodeThroughput(549, 4980),
-        node3: nodeThroughput(18, 190),
+      node1: nodeThroughput(42, 17),
+      node2: nodeThroughput(549, 4980),
+      node3: nodeThroughput(18, 190),
     }));
   });
   it('should reset values between sequential updates', (done) => {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #8019 a refactoring went wrong introducing a bug that causes global throughputs to not be summed up, but use the throughput of the last node instead.
    
This change is fixing this by summing up individual node's throughputs again.
    
Fixes #8172.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.