### PR TITLE
Extract interface from `MoreSearch` class, isolate ES-specific details.

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Module.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Module.java
@@ -1,5 +1,6 @@
 package org.graylog.storage.elasticsearch6;
 
+import org.graylog.events.search.MoreSearchAdapter;
 import org.graylog2.indexer.searches.SearchesAdapter;
 import org.graylog2.plugin.PluginModule;
 
@@ -7,5 +8,6 @@ public class Elasticsearch6Module extends PluginModule {
     @Override
     protected void configure() {
         bind(SearchesAdapter.class).to(SearchesAdapterES6.class);
+        bind(MoreSearchAdapter.class).to(MoreSearchAdapterES6.class);
     }
 }

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/MoreSearchAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/MoreSearchAdapterES6.java
@@ -1,0 +1,177 @@
+package org.graylog.storage.elasticsearch6;
+
+import com.google.common.base.Stopwatch;
+import io.searchbox.core.Search;
+import io.searchbox.core.search.sort.Sort;
+import io.searchbox.params.Parameters;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.graylog.events.event.EventDto;
+import org.graylog.events.processor.EventProcessorException;
+import org.graylog.events.search.MoreSearch;
+import org.graylog.events.search.MoreSearchAdapter;
+import org.graylog2.Configuration;
+import org.graylog2.indexer.IndexHelper;
+import org.graylog2.indexer.IndexMapping;
+import org.graylog2.indexer.results.ResultMessage;
+import org.graylog2.indexer.results.ScrollResult;
+import org.graylog2.indexer.searches.Sorting;
+import org.graylog2.plugin.Message;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNull;
+import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
+import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
+
+public class MoreSearchAdapterES6 implements MoreSearchAdapter {
+    private static final Logger LOG = LoggerFactory.getLogger(MoreSearchAdapterES6.class);
+    private final Configuration configuration;
+    private final MultiSearch multiSearch;
+    private final Scroll scroll;
+
+    @Inject
+    public MoreSearchAdapterES6(Configuration configuration, MultiSearch multiSearch, Scroll scroll) {
+        this.configuration = configuration;
+        this.multiSearch = multiSearch;
+        this.scroll = scroll;
+    }
+
+    @Override
+    public MoreSearch.Result eventSearch(String queryString, TimeRange timerange, Set<String> affectedIndices, Sorting sorting, int page, int perPage, Set<String> eventStreams, String filterString, Set<String> forbiddenSourceStreams) {
+        final QueryBuilder query = (queryString.isEmpty() || queryString.equals("*")) ?
+                matchAllQuery() :
+                queryStringQuery(queryString).allowLeadingWildcard(configuration.isAllowLeadingWildcardSearches());
+
+        final BoolQueryBuilder filter = boolQuery()
+                .filter(query)
+                .filter(termsQuery(EventDto.FIELD_STREAMS, eventStreams))
+                .filter(requireNonNull(IndexHelper.getTimestampRangeFilter(timerange)));
+
+        if (!isNullOrEmpty(filterString)) {
+            filter.filter(queryStringQuery(filterString));
+        }
+
+        if (!forbiddenSourceStreams.isEmpty()) {
+            // If an event has any stream in "source_streams" that the calling search user is not allowed to access,
+            // the event must not be in the search result.
+            filter.filter(boolQuery().mustNot(termsQuery(EventDto.FIELD_SOURCE_STREAMS, forbiddenSourceStreams)));
+        }
+
+        final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
+                .query(filter)
+                .from((page - 1) * perPage)
+                .size(perPage)
+                .sort(sorting.getField(), sorting.asElastic());
+
+        final Search.Builder searchBuilder = new Search.Builder(searchSourceBuilder.toString())
+                .addType(IndexMapping.TYPE_MESSAGE)
+                .addIndex(affectedIndices.isEmpty() ? Collections.singleton("") : affectedIndices)
+                .allowNoIndices(false)
+                .ignoreUnavailable(false);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Query:\n{}", searchSourceBuilder.toString(new ToXContent.MapParams(Collections.singletonMap("pretty", "true"))));
+            LOG.debug("Execute search: {}", searchBuilder.build().toString());
+        }
+
+        final io.searchbox.core.SearchResult searchResult = multiSearch.wrap(searchBuilder.build(), () -> "Unable to perform search query");
+
+        @SuppressWarnings("unchecked") final List<ResultMessage> hits = searchResult.getHits(Map.class, false).stream()
+                .map(hit -> ResultMessage.parseFromSource(hit.id, hit.index, (Map<String, Object>) hit.source, hit.highlight))
+                .collect(Collectors.toList());
+
+        return MoreSearch.Result.builder()
+                .results(hits)
+                .resultsCount(searchResult.getTotal())
+                .duration(multiSearch.tookMsFromSearchResult(searchResult))
+                .usedIndexNames(affectedIndices)
+                .executedQuery(searchSourceBuilder.toString())
+                .build();
+    }
+
+    @Override
+    public void scrollEvents(String queryString, TimeRange timeRange, Set<String> affectedIndices, Set<String> streams, String scrollTime, int batchSize, ScrollEventsCallback resultCallback) throws EventProcessorException {
+        final QueryBuilder query = (queryString.trim().isEmpty() || queryString.trim().equals("*")) ?
+                matchAllQuery() :
+                queryStringQuery(queryString).allowLeadingWildcard(configuration.isAllowLeadingWildcardSearches());
+
+        final BoolQueryBuilder filter = boolQuery()
+                .filter(query)
+                .filter(requireNonNull(IndexHelper.getTimestampRangeFilter(timeRange)));
+
+        // Filtering with an empty streams list doesn't work and would return zero results
+        if (!streams.isEmpty()) {
+            filter.filter(termsQuery(Message.FIELD_STREAMS, streams));
+        }
+
+        final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
+                .query(filter)
+                .size(batchSize);
+
+        final Search.Builder searchBuilder = new Search.Builder(searchSourceBuilder.toString())
+                .addType(IndexMapping.TYPE_MESSAGE)
+                // Scroll requests contain the indices in the URL. If the list of indices is too long, the request can
+                // fail. There is no way of executing a scroll search without having the list of indices in the URL,
+                // as of this writing. (ES 6.8/7.1)
+                .addIndex(affectedIndices.isEmpty() ? Collections.singleton("") : affectedIndices)
+                // For correlation need the oldest messages to come in first
+                .addSort(new Sort("timestamp", Sort.Sorting.ASC))
+                .allowNoIndices(false)
+                .ignoreUnavailable(false)
+                .setParameter(Parameters.SCROLL, scrollTime);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Query:\n{}", searchSourceBuilder.toString(new ToXContent.MapParams(Collections.singletonMap("pretty", "true"))));
+            LOG.debug("Execute search: {}", searchBuilder.build().toString());
+        }
+
+        final ScrollResult scrollResult = scroll.scroll(searchBuilder.build(), () -> "Unable to scroll indices.", searchSourceBuilder.toString(), scrollTime, Collections.emptyList());
+        final AtomicBoolean continueScrolling = new AtomicBoolean(true);
+
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+        try {
+            ScrollResult.ScrollChunk scrollChunk = scrollResult.nextChunk();
+            while (continueScrolling.get() && scrollChunk != null) {
+                final List<ResultMessage> messages = scrollChunk.getMessages();
+
+                LOG.debug("Passing <{}> messages to callback", messages.size());
+                resultCallback.accept(Collections.unmodifiableList(messages), continueScrolling);
+
+                // Stop if the resultCallback told us to stop
+                if (!continueScrolling.get()) {
+                    break;
+                }
+
+                scrollChunk = scrollResult.nextChunk();
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } finally {
+            try {
+                // Tell Elasticsearch that we are done with the scroll so it can release resources as soon as possible
+                // instead of waiting for the scroll timeout to kick in.
+                scrollResult.cancel();
+            } catch (Exception ignored) {
+            }
+            LOG.debug("Scrolling done - took {} ms", stopwatch.stop().elapsed(TimeUnit.MILLISECONDS));
+        }
+    }
+}

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/MoreSearchAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/MoreSearchAdapterES6.java
@@ -48,7 +48,7 @@ public class MoreSearchAdapterES6 implements MoreSearchAdapter {
     private Boolean allowLeadingWildcard;
 
     @Inject
-    public MoreSearchAdapterES6(@Named("allow_leading_wildcard") Boolean allowLeadingWildcard, MultiSearch multiSearch, Scroll scroll) {
+    public MoreSearchAdapterES6(@Named("allow_leading_wildcard_searches") Boolean allowLeadingWildcard, MultiSearch multiSearch, Scroll scroll) {
         this.allowLeadingWildcard = allowLeadingWildcard;
         this.multiSearch = multiSearch;
         this.scroll = scroll;

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/MultiSearch.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/MultiSearch.java
@@ -1,0 +1,73 @@
+package org.graylog.storage.elasticsearch6;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestResult;
+import io.searchbox.core.MultiSearchResult;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.graylog2.indexer.ElasticsearchException;
+import org.graylog2.indexer.FieldTypeException;
+import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog2.indexer.searches.SearchFailure;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class MultiSearch {
+    private final JestClient jestClient;
+
+    @Inject
+    public MultiSearch(JestClient jestClient) {
+        this.jestClient = jestClient;
+    }
+
+    public SearchResult wrap(Search search, Supplier<String> errorMessage) {
+        final io.searchbox.core.MultiSearch multiSearch = new io.searchbox.core.MultiSearch.Builder(search).build();
+        final MultiSearchResult multiSearchResult = JestUtils.execute(jestClient, multiSearch, errorMessage);
+
+        final List<MultiSearchResult.MultiSearchResponse> responses = multiSearchResult.getResponses();
+        if (responses.size() != 1) {
+            throw new ElasticsearchException("Expected exactly 1 search result, but got " + responses.size());
+        }
+
+        final MultiSearchResult.MultiSearchResponse response = responses.get(0);
+        if (response.isError) {
+            throw JestUtils.specificException(errorMessage, response.error);
+        }
+
+        return checkForFailedShards(response.searchResult);
+    }
+
+    public long tookMsFromSearchResult(JestResult searchResult) {
+        final JsonNode tookMs = searchResult.getJsonObject().path("took");
+        if (tookMs.isNumber()) {
+            return tookMs.asLong();
+        } else {
+            throw new ElasticsearchException("Unexpected response structure: " + searchResult.getJsonString());
+        }
+    }
+
+    public <T extends JestResult> T checkForFailedShards(T result) throws FieldTypeException {
+        // unwrap shard failure due to non-numeric mapping. this happens when searching across index sets
+        // if at least one of the index sets comes back with a result, the overall result will have the aggregation
+        // but not considered failed entirely. however, if one shard has the error, we will refuse to respond
+        // otherwise we would be showing empty graphs for non-numeric fields.
+        final JsonNode shards = result.getJsonObject().path("_shards");
+        final double failedShards = shards.path("failed").asDouble();
+
+        if (failedShards > 0) {
+            final SearchFailure searchFailure = new SearchFailure(shards);
+            final List<String> nonNumericFieldErrors = searchFailure.getNonNumericFieldErrors();
+
+            if (!nonNumericFieldErrors.isEmpty()) {
+                throw new FieldTypeException("Unable to perform search query", nonNumericFieldErrors);
+            }
+
+            throw new ElasticsearchException("Unable to perform search query", searchFailure.getErrors());
+        }
+
+        return result;
+    }
+}

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/MultiSearch.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/MultiSearch.java
@@ -7,13 +7,14 @@ import io.searchbox.core.MultiSearchResult;
 import io.searchbox.core.Search;
 import io.searchbox.core.SearchResult;
 import org.graylog2.indexer.ElasticsearchException;
-import org.graylog2.indexer.FieldTypeException;
 import org.graylog2.indexer.cluster.jest.JestUtils;
-import org.graylog2.indexer.searches.SearchFailure;
 
 import javax.inject.Inject;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
+
+import static org.graylog2.indexer.cluster.jest.JestUtils.checkForFailedShards;
 
 public class MultiSearch {
     private final JestClient jestClient;
@@ -37,7 +38,9 @@ public class MultiSearch {
             throw JestUtils.specificException(errorMessage, response.error);
         }
 
-        return checkForFailedShards(response.searchResult);
+        final Optional<ElasticsearchException> elasticsearchException = checkForFailedShards(response.searchResult);
+        elasticsearchException.ifPresent(e -> { throw e; });
+        return response.searchResult;
     }
 
     public long tookMsFromSearchResult(JestResult searchResult) {
@@ -47,27 +50,5 @@ public class MultiSearch {
         } else {
             throw new ElasticsearchException("Unexpected response structure: " + searchResult.getJsonString());
         }
-    }
-
-    public <T extends JestResult> T checkForFailedShards(T result) throws FieldTypeException {
-        // unwrap shard failure due to non-numeric mapping. this happens when searching across index sets
-        // if at least one of the index sets comes back with a result, the overall result will have the aggregation
-        // but not considered failed entirely. however, if one shard has the error, we will refuse to respond
-        // otherwise we would be showing empty graphs for non-numeric fields.
-        final JsonNode shards = result.getJsonObject().path("_shards");
-        final double failedShards = shards.path("failed").asDouble();
-
-        if (failedShards > 0) {
-            final SearchFailure searchFailure = new SearchFailure(shards);
-            final List<String> nonNumericFieldErrors = searchFailure.getNonNumericFieldErrors();
-
-            if (!nonNumericFieldErrors.isEmpty()) {
-                throw new FieldTypeException("Unable to perform search query", nonNumericFieldErrors);
-            }
-
-            throw new ElasticsearchException("Unable to perform search query", searchFailure.getErrors());
-        }
-
-        return result;
     }
 }

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Scroll.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Scroll.java
@@ -1,0 +1,27 @@
+package org.graylog.storage.elasticsearch6;
+
+import io.searchbox.client.JestClient;
+import io.searchbox.core.Search;
+import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog2.indexer.results.ScrollResult;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class Scroll {
+    private final ScrollResult.Factory scrollResultFactory;
+    private final JestClient jestClient;
+
+    @Inject
+    public Scroll(ScrollResult.Factory scrollResultFactory, JestClient jestClient) {
+        this.scrollResultFactory = scrollResultFactory;
+        this.jestClient = jestClient;
+    }
+
+    public ScrollResult scroll(Search search, Supplier<String> errorMessage,  String query, String scrollTime, List<String> fields) {
+        final io.searchbox.core.SearchResult result = JestUtils.execute(jestClient, search, errorMessage);
+
+        return scrollResultFactory.create(result, query, scrollTime, fields);
+    }
+}

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Scroll.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Scroll.java
@@ -2,11 +2,13 @@ package org.graylog.storage.elasticsearch6;
 
 import io.searchbox.client.JestClient;
 import io.searchbox.core.Search;
+import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.indexer.cluster.jest.JestUtils;
 import org.graylog2.indexer.results.ScrollResult;
 
 import javax.inject.Inject;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 public class Scroll {
@@ -21,7 +23,8 @@ public class Scroll {
 
     public ScrollResult scroll(Search search, Supplier<String> errorMessage,  String query, String scrollTime, List<String> fields) {
         final io.searchbox.core.SearchResult result = JestUtils.execute(jestClient, search, errorMessage);
-
+        final Optional<ElasticsearchException> elasticsearchException = JestUtils.checkForFailedShards(result);
+        elasticsearchException.ifPresent(e -> { throw e; });
         return scrollResultFactory.create(result, query, scrollTime, fields);
     }
 }

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/SearchesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/SearchesAdapterES6.java
@@ -1,15 +1,25 @@
 package org.graylog.storage.elasticsearch6;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
 import io.searchbox.core.MultiSearch;
 import io.searchbox.core.MultiSearchResult;
 import io.searchbox.core.Search;
-import io.searchbox.core.search.aggregation.*;
+import io.searchbox.core.search.aggregation.CardinalityAggregation;
+import io.searchbox.core.search.aggregation.DateHistogramAggregation;
+import io.searchbox.core.search.aggregation.ExtendedStatsAggregation;
+import io.searchbox.core.search.aggregation.FilterAggregation;
+import io.searchbox.core.search.aggregation.HistogramAggregation;
+import io.searchbox.core.search.aggregation.MissingAggregation;
+import io.searchbox.core.search.aggregation.TermsAggregation;
+import io.searchbox.core.search.aggregation.ValueCountAggregation;
+import io.searchbox.core.search.sort.Sort;
 import io.searchbox.params.Parameters;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -23,6 +33,9 @@ import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInter
 import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder;
+import org.graylog.events.event.EventDto;
+import org.graylog.events.processor.EventProcessorException;
+import org.graylog.events.search.MoreSearch;
 import org.graylog2.Configuration;
 import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.indexer.FieldTypeException;
@@ -30,25 +43,49 @@ import org.graylog2.indexer.IndexHelper;
 import org.graylog2.indexer.IndexMapping;
 import org.graylog2.indexer.cluster.jest.JestUtils;
 import org.graylog2.indexer.ranges.IndexRange;
-import org.graylog2.indexer.results.*;
-import org.graylog2.indexer.searches.*;
+import org.graylog2.indexer.results.CountResult;
+import org.graylog2.indexer.results.DateHistogramResult;
+import org.graylog2.indexer.results.FieldHistogramResult;
+import org.graylog2.indexer.results.FieldStatsResult;
+import org.graylog2.indexer.results.HistogramResult;
+import org.graylog2.indexer.results.ResultMessage;
+import org.graylog2.indexer.results.ScrollResult;
+import org.graylog2.indexer.results.SearchResult;
+import org.graylog2.indexer.results.TermsHistogramResult;
+import org.graylog2.indexer.results.TermsResult;
+import org.graylog2.indexer.results.TermsStatsResult;
+import org.graylog2.indexer.searches.SearchFailure;
+import org.graylog2.indexer.searches.Searches;
+import org.graylog2.indexer.searches.SearchesAdapter;
+import org.graylog2.indexer.searches.SearchesConfig;
+import org.graylog2.indexer.searches.Sorting;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNull;
+import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
 
 public class SearchesAdapterES6 implements SearchesAdapter {
+    private static final Logger LOG = LoggerFactory.getLogger(SearchesAdapterES6.class);
     public static final String AGG_CARDINALITY = "gl2_field_cardinality";
     public static final String AGG_HISTOGRAM = "gl2_histogram";
     public static final String AGG_EXTENDED_STATS = "gl2_extended_stats";
@@ -391,6 +428,129 @@ public class SearchesAdapterES6 implements SearchesAdapter {
                 searchSourceBuilder.toString(),
                 interval,
                 tookMsFromSearchResult(searchResult));
+    }
+
+    @Override
+    public MoreSearch.Result eventSearch(String queryString, TimeRange timerange, Set<String> affectedIndices, Sorting sorting, int page, int perPage, Set<String> eventStreams, String filterString, Set<String> forbiddenSourceStreams) {
+        final QueryBuilder query = (queryString.isEmpty() || queryString.equals("*")) ?
+                matchAllQuery() :
+                queryStringQuery(queryString).allowLeadingWildcard(configuration.isAllowLeadingWildcardSearches());
+
+        final BoolQueryBuilder filter = boolQuery()
+                .filter(query)
+                .filter(termsQuery(EventDto.FIELD_STREAMS, eventStreams))
+                .filter(requireNonNull(IndexHelper.getTimestampRangeFilter(timerange)));
+
+        if (!isNullOrEmpty(filterString)) {
+            filter.filter(queryStringQuery(filterString));
+        }
+
+        if (!forbiddenSourceStreams.isEmpty()) {
+            // If an event has any stream in "source_streams" that the calling search user is not allowed to access,
+            // the event must not be in the search result.
+            filter.filter(boolQuery().mustNot(termsQuery(EventDto.FIELD_SOURCE_STREAMS, forbiddenSourceStreams)));
+        }
+
+        final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
+                .query(filter)
+                .from((page - 1) * perPage)
+                .size(perPage)
+                .sort(sorting.getField(), sorting.asElastic());
+
+        final Search.Builder searchBuilder = new Search.Builder(searchSourceBuilder.toString())
+                .addType(IndexMapping.TYPE_MESSAGE)
+                .addIndex(affectedIndices.isEmpty() ? Collections.singleton("") : affectedIndices)
+                .allowNoIndices(false)
+                .ignoreUnavailable(false);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Query:\n{}", searchSourceBuilder.toString(new ToXContent.MapParams(Collections.singletonMap("pretty", "true"))));
+            LOG.debug("Execute search: {}", searchBuilder.build().toString());
+        }
+
+        final io.searchbox.core.SearchResult searchResult = wrapInMultiSearch(searchBuilder.build(), () -> "Unable to perform search query");
+
+        @SuppressWarnings("unchecked") final List<ResultMessage> hits = searchResult.getHits(Map.class, false).stream()
+                .map(hit -> ResultMessage.parseFromSource(hit.id, hit.index, (Map<String, Object>) hit.source, hit.highlight))
+                .collect(Collectors.toList());
+
+        return MoreSearch.Result.builder()
+                .results(hits)
+                .resultsCount(searchResult.getTotal())
+                .duration(tookMsFromSearchResult(searchResult))
+                .usedIndexNames(affectedIndices)
+                .executedQuery(searchSourceBuilder.toString())
+                .build();
+    }
+
+    @Override
+    public void scrollEvents(String queryString, TimeRange timeRange, Set<String> affectedIndices, Set<String> streams, String scrollTime, int batchSize, ScrollEventsCallback resultCallback) throws EventProcessorException {
+        final QueryBuilder query = (queryString.trim().isEmpty() || queryString.trim().equals("*")) ?
+                matchAllQuery() :
+                queryStringQuery(queryString).allowLeadingWildcard(configuration.isAllowLeadingWildcardSearches());
+
+        final BoolQueryBuilder filter = boolQuery()
+                .filter(query)
+                .filter(requireNonNull(IndexHelper.getTimestampRangeFilter(timeRange)));
+
+        // Filtering with an empty streams list doesn't work and would return zero results
+        if (!streams.isEmpty()) {
+            filter.filter(termsQuery(Message.FIELD_STREAMS, streams));
+        }
+
+        final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
+                .query(filter)
+                .size(batchSize);
+
+        final Search.Builder searchBuilder = new Search.Builder(searchSourceBuilder.toString())
+                .addType(IndexMapping.TYPE_MESSAGE)
+                // Scroll requests contain the indices in the URL. If the list of indices is too long, the request can
+                // fail. There is no way of executing a scroll search without having the list of indices in the URL,
+                // as of this writing. (ES 6.8/7.1)
+                .addIndex(affectedIndices.isEmpty() ? Collections.singleton("") : affectedIndices)
+                // For correlation need the oldest messages to come in first
+                .addSort(new Sort("timestamp", Sort.Sorting.ASC))
+                .allowNoIndices(false)
+                .ignoreUnavailable(false)
+                .setParameter(Parameters.SCROLL, scrollTime);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Query:\n{}", searchSourceBuilder.toString(new ToXContent.MapParams(Collections.singletonMap("pretty", "true"))));
+            LOG.debug("Execute search: {}", searchBuilder.build().toString());
+        }
+
+        final io.searchbox.core.SearchResult result = JestUtils.execute(jestClient, searchBuilder.build(), () -> "Unable to scroll indices.");
+
+        final ScrollResult scrollResult = scrollResultFactory.create(result, searchSourceBuilder.toString(), scrollTime, Collections.emptyList());
+        final AtomicBoolean continueScrolling = new AtomicBoolean(true);
+
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+        try {
+            ScrollResult.ScrollChunk scrollChunk = scrollResult.nextChunk();
+            while (continueScrolling.get() && scrollChunk != null) {
+                final List<ResultMessage> messages = scrollChunk.getMessages();
+
+                LOG.debug("Passing <{}> messages to callback", messages.size());
+                resultCallback.accept(Collections.unmodifiableList(messages), continueScrolling);
+
+                // Stop if the resultCallback told us to stop
+                if (!continueScrolling.get()) {
+                    break;
+                }
+
+                scrollChunk = scrollResult.nextChunk();
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } finally {
+            try {
+                // Tell Elasticsearch that we are done with the scroll so it can release resources as soon as possible
+                // instead of waiting for the scroll timeout to kick in.
+                scrollResult.cancel();
+            } catch (Exception ignored) {
+            }
+            LOG.debug("Scrolling done - took {} ms", stopwatch.stop().elapsed(TimeUnit.MILLISECONDS));
+        }
     }
 
     private QueryBuilder standardAggregationFilters(TimeRange range, String filter) {

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/SearchesES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/SearchesES6IT.java
@@ -29,7 +29,7 @@ public class SearchesES6IT extends SearchesIT {
                 streamService,
                 indices,
                 indexSetRegistry,
-                new SearchesAdapterES6(jestClient(), new Configuration(), scrollResultFactory)
+                new SearchesAdapterES6(new Configuration(), new MultiSearch(jestClient()), new Scroll(scrollResultFactory, jestClient()))
         );
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
@@ -17,24 +17,9 @@
 package org.graylog.events.search;
 
 import com.codahale.metrics.MetricRegistry;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableSet;
-import io.searchbox.client.JestClient;
-import io.searchbox.client.JestResult;
-import io.searchbox.core.MultiSearch;
-import io.searchbox.core.MultiSearchResult;
-import io.searchbox.core.Search;
-import io.searchbox.core.SearchResult;
-import io.searchbox.core.search.sort.Sort;
-import io.searchbox.params.Parameters;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.graylog.events.event.EventDto;
 import org.graylog.events.processor.EventProcessorException;
 import org.graylog.plugins.views.search.Parameter;
 import org.graylog.plugins.views.search.Query;
@@ -44,24 +29,15 @@ import org.graylog.plugins.views.search.elasticsearch.ElasticsearchQueryString;
 import org.graylog.plugins.views.search.elasticsearch.IndexRangeContainsOneOfStreams;
 import org.graylog.plugins.views.search.errors.EmptyParameterError;
 import org.graylog.plugins.views.search.errors.SearchException;
-import org.graylog2.Configuration;
 import org.graylog2.database.NotFoundException;
-import org.graylog2.indexer.ElasticsearchException;
-import org.graylog2.indexer.FieldTypeException;
-import org.graylog2.indexer.IndexHelper;
-import org.graylog2.indexer.IndexMapping;
 import org.graylog2.indexer.IndexSetRegistry;
-import org.graylog2.indexer.cluster.jest.JestUtils;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.indexer.ranges.IndexRange;
 import org.graylog2.indexer.ranges.IndexRangeService;
 import org.graylog2.indexer.results.ResultMessage;
-import org.graylog2.indexer.results.ScrollResult;
-import org.graylog2.indexer.searches.SearchFailure;
 import org.graylog2.indexer.searches.Searches;
 import org.graylog2.indexer.searches.SearchesAdapter;
 import org.graylog2.indexer.searches.Sorting;
-import org.graylog2.plugin.Message;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 import org.graylog2.plugin.streams.Stream;
 import org.graylog2.streams.StreamService;
@@ -69,27 +45,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Strings.isNullOrEmpty;
-import static java.util.Objects.requireNonNull;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
-import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
-import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
-import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
 
 /**
  * This class contains search helper for the events system.
@@ -99,10 +63,8 @@ public class MoreSearch extends Searches {
 
     private final StreamService streamService;
     private final IndexRangeService indexRangeService;
-    private final ScrollResult.Factory scrollResultFactory;
-    private final JestClient jestClient;
-    private final boolean allowLeadingWildcardSearches;
     private final ESQueryDecorators esQueryDecorators;
+    private final SearchesAdapter searchesAdapter;
 
     @Inject
     public MoreSearch(StreamService streamService,
@@ -110,18 +72,13 @@ public class MoreSearch extends Searches {
                       IndexRangeService indexRangeService,
                       IndexSetRegistry indexSetRegistry,
                       MetricRegistry metricRegistry,
-                      ScrollResult.Factory scrollResultFactory,
-                      JestClient jestClient,
-                      Configuration configuration,
                       ESQueryDecorators esQueryDecorators,
                       SearchesAdapter searchesAdapter) {
         super(indexRangeService, metricRegistry, streamService, indices, indexSetRegistry, searchesAdapter);
         this.streamService = streamService;
         this.indexRangeService = indexRangeService;
-        this.scrollResultFactory = scrollResultFactory;
-        this.jestClient = jestClient;
-        this.allowLeadingWildcardSearches = configuration.isAllowLeadingWildcardSearches();
         this.esQueryDecorators = esQueryDecorators;
+        this.searchesAdapter = searchesAdapter;
     }
 
     /**
@@ -145,103 +102,7 @@ public class MoreSearch extends Searches {
         final String queryString = parameters.query().trim();
         final Set<String> affectedIndices = getAffectedIndices(eventStreams, parameters.timerange());
 
-        final QueryBuilder query = (queryString.isEmpty() || queryString.equals("*")) ?
-                matchAllQuery() :
-                queryStringQuery(queryString).allowLeadingWildcard(allowLeadingWildcardSearches);
-
-        final BoolQueryBuilder filter = boolQuery()
-                .filter(query)
-                .filter(termsQuery(EventDto.FIELD_STREAMS, eventStreams))
-                .filter(requireNonNull(IndexHelper.getTimestampRangeFilter(parameters.timerange())));
-
-        if (!isNullOrEmpty(filterString)) {
-            filter.filter(queryStringQuery(filterString));
-        }
-
-        if (!forbiddenSourceStreams.isEmpty()) {
-            // If an event has any stream in "source_streams" that the calling search user is not allowed to access,
-            // the event must not be in the search result.
-            filter.filter(boolQuery().mustNot(termsQuery(EventDto.FIELD_SOURCE_STREAMS, forbiddenSourceStreams)));
-        }
-
-        final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
-                .query(filter)
-                .from((parameters.page() - 1) * parameters.perPage())
-                .size(parameters.perPage())
-                .sort(sorting.getField(), sorting.asElastic());
-
-        final Search.Builder searchBuilder = new Search.Builder(searchSourceBuilder.toString())
-                .addType(IndexMapping.TYPE_MESSAGE)
-                .addIndex(affectedIndices.isEmpty() ? Collections.singleton("") : affectedIndices)
-                .allowNoIndices(false)
-                .ignoreUnavailable(false);
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Query:\n{}", searchSourceBuilder.toString(new ToXContent.MapParams(Collections.singletonMap("pretty", "true"))));
-            LOG.debug("Execute search: {}", searchBuilder.build().toString());
-        }
-
-        final SearchResult searchResult = wrapInMultiSearch(searchBuilder.build(), () -> "Unable to perform search query");
-
-        @SuppressWarnings("unchecked") final List<ResultMessage> hits = searchResult.getHits(Map.class, false).stream()
-                .map(hit -> ResultMessage.parseFromSource(hit.id, hit.index, (Map<String, Object>) hit.source, hit.highlight))
-                .collect(Collectors.toList());
-
-        return Result.builder()
-                .results(hits)
-                .resultsCount(searchResult.getTotal())
-                .duration(tookMsFromSearchResult(searchResult))
-                .usedIndexNames(affectedIndices)
-                .executedQuery(searchSourceBuilder.toString())
-                .build();
-    }
-
-    protected long tookMsFromSearchResult(JestResult searchResult) {
-        final JsonNode tookMs = searchResult.getJsonObject().path("took");
-        if (tookMs.isNumber()) {
-            return tookMs.asLong();
-        } else {
-            throw new ElasticsearchException("Unexpected response structure: " + searchResult.getJsonString());
-        }
-    }
-
-    private <T extends JestResult> T checkForFailedShards(T result) throws FieldTypeException {
-        // unwrap shard failure due to non-numeric mapping. this happens when searching across index sets
-        // if at least one of the index sets comes back with a result, the overall result will have the aggregation
-        // but not considered failed entirely. however, if one shard has the error, we will refuse to respond
-        // otherwise we would be showing empty graphs for non-numeric fields.
-        final JsonNode shards = result.getJsonObject().path("_shards");
-        final double failedShards = shards.path("failed").asDouble();
-
-        if (failedShards > 0) {
-            final SearchFailure searchFailure = new SearchFailure(shards);
-            final List<String> nonNumericFieldErrors = searchFailure.getNonNumericFieldErrors();
-
-            if (!nonNumericFieldErrors.isEmpty()) {
-                throw new FieldTypeException("Unable to perform search query", nonNumericFieldErrors);
-            }
-
-            throw new ElasticsearchException("Unable to perform search query", searchFailure.getErrors());
-        }
-
-        return result;
-    }
-
-    protected io.searchbox.core.SearchResult wrapInMultiSearch(Search search, Supplier<String> errorMessage) {
-        final MultiSearch multiSearch = new MultiSearch.Builder(search).build();
-        final MultiSearchResult multiSearchResult = JestUtils.execute(jestClient, multiSearch, errorMessage);
-
-        final List<MultiSearchResult.MultiSearchResponse> responses = multiSearchResult.getResponses();
-        if (responses.size() != 1) {
-            throw new ElasticsearchException("Expected exactly 1 search result, but got " + responses.size());
-        }
-
-        final MultiSearchResult.MultiSearchResponse response = responses.get(0);
-        if (response.isError) {
-            throw JestUtils.specificException(errorMessage, response.error);
-        }
-
-        return checkForFailedShards(response.searchResult);
+        return searchesAdapter.eventSearch(queryString, parameters.timerange(), affectedIndices, sorting, parameters.page(), parameters.perPage(), eventStreams, filterString, forbiddenSourceStreams);
     }
 
     private Set<String> getAffectedIndices(Set<String> streamIds, TimeRange timeRange) {
@@ -294,72 +155,7 @@ public class MoreSearch extends Searches {
             throw e;
         }
 
-        final QueryBuilder query = (queryString.trim().isEmpty() || queryString.trim().equals("*")) ?
-                matchAllQuery() :
-                queryStringQuery(queryString).allowLeadingWildcard(allowLeadingWildcardSearches);
-
-        final BoolQueryBuilder filter = boolQuery()
-                .filter(query)
-                .filter(requireNonNull(IndexHelper.getTimestampRangeFilter(timeRange)));
-
-        // Filtering with an empty streams list doesn't work and would return zero results
-        if (!streams.isEmpty()) {
-            filter.filter(termsQuery(Message.FIELD_STREAMS, streams));
-        }
-
-        final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder()
-                .query(filter)
-                .size(batchSize);
-
-        final Search.Builder searchBuilder = new Search.Builder(searchSourceBuilder.toString())
-                .addType(IndexMapping.TYPE_MESSAGE)
-                // Scroll requests contain the indices in the URL. If the list of indices is too long, the request can
-                // fail. There is no way of executing a scroll search without having the list of indices in the URL,
-                // as of this writing. (ES 6.8/7.1)
-                .addIndex(affectedIndices.isEmpty() ? Collections.singleton("") : affectedIndices)
-                // For correlation need the oldest messages to come in first
-                .addSort(new Sort("timestamp", Sort.Sorting.ASC))
-                .allowNoIndices(false)
-                .ignoreUnavailable(false)
-                .setParameter(Parameters.SCROLL, scrollTime);
-
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Query:\n{}", searchSourceBuilder.toString(new ToXContent.MapParams(Collections.singletonMap("pretty", "true"))));
-            LOG.debug("Execute search: {}", searchBuilder.build().toString());
-        }
-
-        final SearchResult result = JestUtils.execute(jestClient, searchBuilder.build(), () -> "Unable to scroll indices.");
-
-        final ScrollResult scrollResult = scrollResultFactory.create(result, searchSourceBuilder.toString(), scrollTime, Collections.emptyList());
-        final AtomicBoolean continueScrolling = new AtomicBoolean(true);
-
-        final Stopwatch stopwatch = Stopwatch.createStarted();
-        try {
-            ScrollResult.ScrollChunk scrollChunk = scrollResult.nextChunk();
-            while (continueScrolling.get() && scrollChunk != null) {
-                final List<ResultMessage> messages = scrollChunk.getMessages();
-
-                LOG.debug("Passing <{}> messages to callback", messages.size());
-                resultCallback.call(Collections.unmodifiableList(messages), continueScrolling);
-
-                // Stop if the resultCallback told us to stop
-                if (!continueScrolling.get()) {
-                    break;
-                }
-
-                scrollChunk = scrollResult.nextChunk();
-            }
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        } finally {
-            try {
-                // Tell Elasticsearch that we are done with the scroll so it can release resources as soon as possible
-                // instead of waiting for the scroll timeout to kick in.
-                scrollResult.cancel();
-            } catch (Exception ignored) {
-            }
-            LOG.debug("Scrolling done - took {} ms", stopwatch.stop().elapsed(TimeUnit.MILLISECONDS));
-        }
+        searchesAdapter.scrollEvents(queryString, timeRange, affectedIndices, streams, scrollTime, batchSize, resultCallback::call);searchesAdapter.scrollEvents(queryString, timeRange, affectedIndices, streams, scrollTime, batchSize, resultCallback::call);
     }
 
     public Set<Stream> loadStreams(Set<String> streamIds) {

--- a/graylog2-server/src/main/java/org/graylog/events/search/MoreSearchAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/MoreSearchAdapter.java
@@ -1,0 +1,19 @@
+package org.graylog.events.search;
+
+import org.graylog.events.processor.EventProcessorException;
+import org.graylog2.indexer.results.ResultMessage;
+import org.graylog2.indexer.searches.Sorting;
+import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public interface MoreSearchAdapter {
+    MoreSearch.Result eventSearch(String queryString, TimeRange timerange, Set<String> affectedIndices, Sorting sorting, int page, int perPage, Set<String> eventStreams, String filterString, Set<String> forbiddenSourceStreams);
+
+    interface ScrollEventsCallback {
+        void accept(List<ResultMessage> results, AtomicBoolean requestContinue) throws EventProcessorException;
+    }
+    void scrollEvents(String queryString, TimeRange timeRange, Set<String> affectedIndices, Set<String> streams, String scrollTime, int batchSize, ScrollEventsCallback resultCallback) throws EventProcessorException;
+}

--- a/graylog2-server/src/main/java/org/graylog/events/search/MoreSearchAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/MoreSearchAdapter.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.events.search;
 
 import org.graylog.events.processor.EventProcessorException;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesAdapter.java
@@ -16,13 +16,10 @@
  */
 package org.graylog2.indexer.searches;
 
-import org.graylog.events.processor.EventProcessorException;
-import org.graylog.events.search.MoreSearch;
 import org.graylog2.indexer.ranges.IndexRange;
 import org.graylog2.indexer.results.CountResult;
 import org.graylog2.indexer.results.FieldStatsResult;
 import org.graylog2.indexer.results.HistogramResult;
-import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.indexer.results.ScrollResult;
 import org.graylog2.indexer.results.SearchResult;
 import org.graylog2.indexer.results.TermsHistogramResult;
@@ -32,7 +29,6 @@ import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 public interface SearchesAdapter {
     CountResult count(Set<String> affectedIndices, String query, TimeRange range, String filter);
@@ -52,11 +48,4 @@ public interface SearchesAdapter {
     HistogramResult histogram(String query, String filter, TimeRange range, Set<String> affectedIndices, Searches.DateHistogramInterval interval);
 
     HistogramResult fieldHistogram(String query, String filter, TimeRange range, Set<String> affectedIndices, String field, Searches.DateHistogramInterval interval, boolean includeStats, boolean includeCardinality);
-
-    MoreSearch.Result eventSearch(String queryString, TimeRange timerange, Set<String> affectedIndices, Sorting sorting, int page, int perPage, Set<String> eventStreams, String filterString, Set<String> forbiddenSourceStreams);
-
-    interface ScrollEventsCallback {
-        void accept(List<ResultMessage> results, AtomicBoolean requestContinue) throws EventProcessorException;
-    }
-    void scrollEvents(String queryString, TimeRange timeRange, Set<String> affectedIndices, Set<String> streams, String scrollTime, int batchSize, ScrollEventsCallback resultCallback) throws EventProcessorException;
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/SearchesAdapter.java
@@ -16,12 +16,23 @@
  */
 package org.graylog2.indexer.searches;
 
+import org.graylog.events.processor.EventProcessorException;
+import org.graylog.events.search.MoreSearch;
 import org.graylog2.indexer.ranges.IndexRange;
-import org.graylog2.indexer.results.*;
+import org.graylog2.indexer.results.CountResult;
+import org.graylog2.indexer.results.FieldStatsResult;
+import org.graylog2.indexer.results.HistogramResult;
+import org.graylog2.indexer.results.ResultMessage;
+import org.graylog2.indexer.results.ScrollResult;
+import org.graylog2.indexer.results.SearchResult;
+import org.graylog2.indexer.results.TermsHistogramResult;
+import org.graylog2.indexer.results.TermsResult;
+import org.graylog2.indexer.results.TermsStatsResult;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public interface SearchesAdapter {
     CountResult count(Set<String> affectedIndices, String query, TimeRange range, String filter);
@@ -41,4 +52,11 @@ public interface SearchesAdapter {
     HistogramResult histogram(String query, String filter, TimeRange range, Set<String> affectedIndices, Searches.DateHistogramInterval interval);
 
     HistogramResult fieldHistogram(String query, String filter, TimeRange range, Set<String> affectedIndices, String field, Searches.DateHistogramInterval interval, boolean includeStats, boolean includeCardinality);
+
+    MoreSearch.Result eventSearch(String queryString, TimeRange timerange, Set<String> affectedIndices, Sorting sorting, int page, int perPage, Set<String> eventStreams, String filterString, Set<String> forbiddenSourceStreams);
+
+    interface ScrollEventsCallback {
+        void accept(List<ResultMessage> results, AtomicBoolean requestContinue) throws EventProcessorException;
+    }
+    void scrollEvents(String queryString, TimeRange timeRange, Set<String> affectedIndices, Set<String> streams, String scrollTime, int batchSize, ScrollEventsCallback resultCallback) throws EventProcessorException;
 }


### PR DESCRIPTION
## Description
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is extracting a `MoreSearchAdapter` interface from the `MoreSearch` class, that allows us to separate the Elasticsearch-specific implementation details from the consumer of that interface. 

Before this change, the `MoreSearch` class was inheriting from the `Searches` class. This relationship was removed, to decouple those classes. The only relevant reuse was the `checkForFailedShards` method, which is now replaced with a reuse of `JestUtils.checkForFailedShards`.

Refs #8155, #8156.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.