### PR TITLE
Wire Elasticsearch 6 storage module as plugin.

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/testing/fullbackend/BackendStartupIT.java
+++ b/full-backend-tests/src/test/java/org/graylog/testing/fullbackend/BackendStartupIT.java
@@ -65,7 +65,8 @@ class BackendStartupIT {
         assertThat(pluginNames).containsExactlyInAnyOrder(
                 "Threat Intelligence Plugin",
                 "Collector",
-                "AWS plugins");
+                "AWS plugins",
+                "Elasticsearch 6 Support");
     }
 
     @Test

--- a/graylog-storage-elasticsearch6/pom.xml
+++ b/graylog-storage-elasticsearch6/pom.xml
@@ -3,10 +3,10 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>org.graylog</groupId>
-        <artifactId>graylog-project-parent</artifactId>
+        <groupId>org.graylog.plugins</groupId>
+        <artifactId>graylog-plugin-parent</artifactId>
         <version>4.0.0-SNAPSHOT</version>
-        <relativePath>../graylog-project-parent</relativePath>
+        <relativePath>../graylog-plugin-parent</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
@@ -28,6 +28,12 @@
             <version>${project.parent.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value</artifactId>
+            <version>${auto-value.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Metadata.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Metadata.java
@@ -1,0 +1,51 @@
+package org.graylog.storage.elasticsearch6;
+
+import org.graylog2.plugin.PluginMetaData;
+import org.graylog2.plugin.ServerStatus;
+import org.graylog2.plugin.Version;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Set;
+
+public class Elasticsearch6Metadata implements PluginMetaData {
+    @Override
+    public String getUniqueId() {
+        return Elasticsearch6Plugin.class.getCanonicalName();
+    }
+
+    @Override
+    public String getName() {
+        return "Elasticsearch 6 Support";
+    }
+
+    @Override
+    public String getAuthor() {
+        return "Graylog, Inc.";
+    }
+
+    @Override
+    public URI getURL() {
+        return URI.create("https://www.graylog.org");
+    }
+
+    @Override
+    public Version getVersion() {
+        return Version.CURRENT_CLASSPATH;
+    }
+
+    @Override
+    public String getDescription() {
+        return "Support for Elasticsearch 6";
+    }
+
+    @Override
+    public Version getRequiredVersion() {
+        return Version.CURRENT_CLASSPATH;
+    }
+
+    @Override
+    public Set<ServerStatus.Capability> getRequiredCapabilities() {
+        return Collections.emptySet();
+    }
+}

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Module.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Module.java
@@ -1,0 +1,9 @@
+package org.graylog.storage.elasticsearch6;
+
+import org.graylog2.plugin.PluginModule;
+
+public class Elasticsearch6Module extends PluginModule {
+    @Override
+    protected void configure() {
+    }
+}

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Plugin.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Plugin.java
@@ -1,0 +1,20 @@
+package org.graylog.storage.elasticsearch6;
+
+import org.graylog2.plugin.Plugin;
+import org.graylog2.plugin.PluginMetaData;
+import org.graylog2.plugin.PluginModule;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class Elasticsearch6Plugin implements Plugin {
+    @Override
+    public PluginMetaData metadata() {
+        return new Elasticsearch6Metadata();
+    }
+
+    @Override
+    public Collection<PluginModule> modules() {
+        return Collections.singleton(new Elasticsearch6Module());
+    }
+}

--- a/graylog-storage-elasticsearch6/src/main/resources/META-INF/services/org.graylog2.plugin.Plugin
+++ b/graylog-storage-elasticsearch6/src/main/resources/META-INF/services/org.graylog2.plugin.Plugin
@@ -1,0 +1,1 @@
+org.graylog.storage.elasticsearch6.Elasticsearch6Plugin


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is adding the required boilerplate to load the Elasticsearch6
storage module as a plugin by reusing the existing plugin loading
mechanism. Therefore it exposes an implementation of the `Plugin`
interface, offering the metadata and the bindings module classes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.