### PR TITLE
Bump to 4.0.0-SNAPSHOT

### DIFF
--- a/full-backend-tests/pom.xml
+++ b/full-backend-tests/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.graylog</groupId>
         <artifactId>graylog-project-parent</artifactId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath>../graylog-project-parent</relativePath>
     </parent>
 
@@ -45,13 +45,13 @@
         <dependency>
             <groupId>org.graylog2</groupId>
             <artifactId>graylog2-server</artifactId>
-            <version>3.3.1-SNAPSHOT</version>
+            <version>4.0.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>org.graylog2</groupId>
             <artifactId>graylog2-server</artifactId>
-            <version>3.3.1-SNAPSHOT</version>
+            <version>4.0.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/graylog-plugin-archetype/pom.xml
+++ b/graylog-plugin-archetype/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.graylog</groupId>
         <artifactId>graylog-project-parent</artifactId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath>../graylog-project-parent</relativePath>
     </parent>
 

--- a/graylog-plugin-parent/graylog-plugin-web-parent/pom.xml
+++ b/graylog-plugin-parent/graylog-plugin-web-parent/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.graylog.plugins</groupId>
         <artifactId>graylog-plugin-parent</artifactId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>graylog-plugin-web-parent</artifactId>

--- a/graylog-plugin-parent/pom.xml
+++ b/graylog-plugin-parent/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.graylog</groupId>
         <artifactId>graylog-parent</artifactId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>org.graylog.plugins</groupId>

--- a/graylog-project-parent/pom.xml
+++ b/graylog-project-parent/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.graylog</groupId>
         <artifactId>graylog-parent</artifactId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>graylog-project-parent</artifactId>

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.graylog</groupId>
         <artifactId>graylog-project-parent</artifactId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath>../graylog-project-parent</relativePath>
     </parent>
 

--- a/graylog2-web-interface/manifests/package.json
+++ b/graylog2-web-interface/manifests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graylog-web-manifests",
-  "version": "3.3.1-SNAPSHOT",
+  "version": "4.0.0-SNAPSHOT",
   "description": "Manifests needed to reuse vendor & shared bundles in graylog web interface plugins",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graylog-web-interface",
-  "version": "3.3.1-SNAPSHOT",
+  "version": "4.0.0-SNAPSHOT",
   "description": "Graylog Web Interface",
   "author": "torch",
   "license": "GPL-3.0",

--- a/graylog2-web-interface/packages/graylog-web-plugin/package.json
+++ b/graylog2-web-interface/packages/graylog-web-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graylog-web-plugin",
-  "version": "3.3.1-SNAPSHOT",
+  "version": "4.0.0-SNAPSHOT",
   "description": "Helper code for streamlining Graylog web interface plugin development",
   "main": "index.js",
   "scripts": {

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.graylog</groupId>
         <artifactId>graylog-project-parent</artifactId>
-        <version>3.3.1-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
         <relativePath>../graylog-project-parent</relativePath>
     </parent>
 
@@ -45,13 +45,13 @@
         <dependency>
             <groupId>org.graylog2</groupId>
             <artifactId>graylog2-server</artifactId>
-            <version>3.3.1-SNAPSHOT</version>
+            <version>4.0.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>org.graylog2</groupId>
             <artifactId>graylog2-server</artifactId>
-            <version>3.3.1-SNAPSHOT</version>
+            <version>4.0.0-SNAPSHOT</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.graylog</groupId>
     <artifactId>graylog-parent</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Graylog Parent POM</name>


### PR DESCRIPTION
Bump the version in the `cloud-3.3` to 4.0.0-SNAPSHOT so that it can run with other plugins at the 4.0.0 version.