### PR TITLE
Backport: Add support for more verbose authentication failure

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/providers/DefaultSecurityManagerProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/providers/DefaultSecurityManagerProvider.java
@@ -34,6 +34,7 @@ import org.graylog2.security.MongoDbSessionDAO;
 import org.graylog2.security.OrderedAuthenticatingRealms;
 import org.graylog2.security.realm.MongoDbAuthorizationRealm;
 import org.graylog2.security.realm.RootAccountRealm;
+import org.graylog2.shared.security.ThrowingFirstSuccessfulStrategy;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -58,7 +59,7 @@ public class DefaultSecurityManagerProvider implements Provider<DefaultSecurityM
         sm = new DefaultSecurityManager(orderedAuthenticatingRealms);
         final Authenticator authenticator = sm.getAuthenticator();
         if (authenticator instanceof ModularRealmAuthenticator) {
-            FirstSuccessfulStrategy strategy = new FirstSuccessfulStrategy();
+            FirstSuccessfulStrategy strategy = new ThrowingFirstSuccessfulStrategy();
             strategy.setStopAfterFirstSuccess(true);
             ((ModularRealmAuthenticator) authenticator).setAuthenticationStrategy(strategy);
         }

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/AuthenticationServiceUnavailableException.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/AuthenticationServiceUnavailableException.java
@@ -1,0 +1,40 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.security;
+
+import org.apache.shiro.authc.AuthenticationException;
+
+/**
+ * Thrown when authentication fails due to an external service being unavailable.
+ */
+public class AuthenticationServiceUnavailableException extends AuthenticationException {
+    public AuthenticationServiceUnavailableException() {
+        super();
+    }
+
+    public AuthenticationServiceUnavailableException(String message) {
+        super(message);
+    }
+
+    public AuthenticationServiceUnavailableException(Throwable cause) {
+        super(cause);
+    }
+
+    public AuthenticationServiceUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/ThrowingFirstSuccessfulStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/ThrowingFirstSuccessfulStrategy.java
@@ -1,0 +1,68 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.security;
+
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.pam.FirstSuccessfulStrategy;
+import org.apache.shiro.realm.Realm;
+
+/**
+ * An authentication strategy pretty much the same as the {@link FirstSuccessfulStrategy} with the difference that it
+ * will memoize a {@link AuthenticationServiceUnavailableException} thrown by any attempt. It will rethrow this
+ * exception on the final {@link #afterAllAttempts(AuthenticationToken, AuthenticationInfo)} call, if none of the
+ * attempts were successful.
+ * <p>
+ * This way we can retain the fact that authentication probably failed due to a service being unavailable and not
+ * because the user's credentials were wrong.
+ */
+public class ThrowingFirstSuccessfulStrategy extends FirstSuccessfulStrategy {
+
+    private AuthenticationServiceUnavailableException unavailableException;
+
+    /**
+     * If the attempt failed due to an {@link AuthenticationServiceUnavailableException}, memoize that exception. Will
+     * overwrite any previously memoized exception.
+     */
+    @Override
+    public AuthenticationInfo afterAttempt(Realm realm, AuthenticationToken token, AuthenticationInfo singleRealmInfo,
+            AuthenticationInfo aggregateInfo, Throwable t) throws AuthenticationException {
+        if (t instanceof AuthenticationServiceUnavailableException) {
+            unavailableException = (AuthenticationServiceUnavailableException) t;
+        }
+        return super.afterAttempt(realm, token, singleRealmInfo, aggregateInfo, t);
+    }
+
+    /**
+     * If none of the attempts was successful and at least one of the attempts was throwing a
+     * {@link AuthenticationServiceUnavailableException}, we'll re-throw this exception here.
+     * @throws AuthenticationServiceUnavailableException if none of the attempts was successful and at least one of
+     * them was throwing an exception of this type.
+     */
+    @Override
+    public AuthenticationInfo afterAllAttempts(AuthenticationToken token,
+            AuthenticationInfo aggregate) throws AuthenticationServiceUnavailableException {
+
+        final AuthenticationInfo authenticationInfo = super.afterAllAttempts(token, aggregate);
+
+        if (authenticationInfo == null && unavailableException != null) {
+            throw unavailableException;
+        }
+        return authenticationInfo;
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/shared/security/SessionCreatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/security/SessionCreatorTest.java
@@ -16,8 +16,16 @@
  */
 package org.graylog2.shared.security;
 
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.pam.FirstSuccessfulStrategy;
+import org.apache.shiro.authc.pam.ModularRealmAuthenticator;
 import org.apache.shiro.mgt.DefaultSecurityManager;
+import org.apache.shiro.realm.Realm;
 import org.apache.shiro.realm.SimpleAccountRealm;
 import org.apache.shiro.session.Session;
 import org.apache.shiro.session.mgt.DefaultSessionManager;
@@ -28,6 +36,7 @@ import org.graylog2.audit.AuditActor;
 import org.graylog2.audit.AuditEventSender;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.users.UserService;
+import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,11 +44,24 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.anyMap;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class SessionCreatorTest {
     private static final long SESSION_TIMEOUT = Long.MAX_VALUE;
@@ -65,7 +87,12 @@ public class SessionCreatorTest {
 
         SimpleAccountRealm realm = new SimpleAccountRealm();
         realm.addAccount(validToken.getUsername(), String.valueOf(validToken.getPassword()));
+
+        // Set up a security manager like in DefaultSecurityManagerProvider
         securityManager = new DefaultSecurityManager(realm);
+        FirstSuccessfulStrategy strategy = new ThrowingFirstSuccessfulStrategy();
+        strategy.setStopAfterFirstSuccess(true);
+        ((ModularRealmAuthenticator) securityManager.getAuthenticator()).setAuthenticationStrategy(strategy);
         SecurityUtils.setSecurityManager(securityManager);
     }
 
@@ -136,9 +163,53 @@ public class SessionCreatorTest {
         assertTrue(SecurityUtils.getSubject().isAuthenticated());
     }
 
+    @Test
+    public void throwingRealmDoesNotInhibitAuthentication() {
+        setUpUserMock();
+
+        assertFalse(SecurityUtils.getSubject().isAuthenticated());
+
+        // Put a throwing realm in the first position. Authentication should still be successful, because the second
+        // realm will find an account for the user
+        final List<Realm> realms = new ArrayList<>(securityManager.getRealms());
+        realms.add(0, throwingRealm());
+        securityManager.setRealms(realms);
+
+        assertThat(sessionCreator.create(null, "host", validToken)).isPresent();
+        assertThat(SecurityUtils.getSubject().isAuthenticated()).isTrue();
+        verify(auditEventSender).success(eq(AuditActor.user("username")), anyString(), anyMap());
+    }
+
+    @Test
+    public void serviceUnavailable() {
+        setUpUserMock();
+
+        assertFalse(SecurityUtils.getSubject().isAuthenticated());
+
+        // First realm will throw, second realm will be unable to authenticate because user has no account
+        securityManager.setRealms(ImmutableList.of(throwingRealm(), new SimpleAccountRealm()));
+
+        assertThatThrownBy(() -> sessionCreator.create(null, "host", validToken)).isInstanceOf(
+                AuthenticationServiceUnavailableException.class);
+        assertThat(SecurityUtils.getSubject().isAuthenticated()).isFalse();
+        verify(auditEventSender).failure(eq(AuditActor.user("username")), anyString(),
+                argThat(map -> StringUtils.containsIgnoreCase((String) map.get("message"), "unavailable")));
+    }
+
     private void setUpUserMock() {
         User user = mock(User.class);
         when(user.getSessionTimeoutMs()).thenReturn(SESSION_TIMEOUT);
         when(userService.load("username")).thenReturn(user);
+    }
+
+    @NotNull
+    private SimpleAccountRealm throwingRealm() {
+        return new SimpleAccountRealm() {
+            @Override
+            protected AuthenticationInfo doGetAuthenticationInfo(
+                    AuthenticationToken token) throws AuthenticationException {
+                throw new AuthenticationServiceUnavailableException("not available");
+            }
+        };
     }
 }


### PR DESCRIPTION
Backport PR #8136 to `cloud-3.3`, so that plugins that depend on it will work.

Please merge https://github.com/Graylog2/graylog-project-internal/pull/28 before merging this PR.