### PR TITLE
Extract interface from `Indices` class, isolate ES-specific details.

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Module.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Module.java
@@ -1,5 +1,6 @@
 package org.graylog.storage.elasticsearch6;
 
+import org.graylog2.indexer.indices.IndicesAdapter;
 import org.graylog.events.search.MoreSearchAdapter;
 import org.graylog2.indexer.searches.SearchesAdapter;
 import org.graylog2.indexer.messages.MessagesAdapter;
@@ -8,6 +9,7 @@ import org.graylog2.plugin.PluginModule;
 public class Elasticsearch6Module extends PluginModule {
     @Override
     protected void configure() {
+        bind(IndicesAdapter.class).to(IndicesAdapterES6.class);
         bind(SearchesAdapter.class).to(SearchesAdapterES6.class);
         bind(MoreSearchAdapter.class).to(MoreSearchAdapterES6.class);
         bind(MessagesAdapter.class).to(MessagesAdapterES6.class);

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndexingHelper.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndexingHelper.java
@@ -1,0 +1,19 @@
+package org.graylog.storage.elasticsearch6;
+
+import io.searchbox.core.Index;
+import org.graylog2.indexer.IndexMapping;
+import org.graylog2.plugin.Message;
+
+import java.util.Map;
+
+public class IndexingHelper {
+    public Index prepareIndexRequest(String index, Map<String, Object> source, String id) {
+        source.remove(Message.FIELD_ID);
+
+        return new Index.Builder(source)
+                .index(index)
+                .type(IndexMapping.TYPE_MESSAGE)
+                .id(id)
+                .build();
+    }
+}

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
@@ -621,4 +621,22 @@ public class IndicesAdapterES6 implements IndicesAdapter {
     private JsonNode getClusterStateIndicesMetadata(JsonNode clusterStateJson) {
         return clusterStateJson.path("metadata").path("indices");
     }
+
+    @Override
+    public boolean isOpen(String index) {
+        return getIndexState(index).equals("open");
+    }
+
+    @Override
+    public boolean isClosed(String index) {
+        return getIndexState(index).equals("close");
+    }
+
+    private String getIndexState(String index) {
+        final State request = new State.Builder().indices(index).withMetadata().build();
+
+        final JestResult response = JestUtils.execute(jestClient, request, () -> "Failed to get index metadata");
+
+        return response.getJsonObject().path("metadata").path("indices").path(index).path("state").asText();
+    }
 }

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
@@ -1,0 +1,613 @@
+package org.graylog.storage.elasticsearch6;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.github.joschi.jadconfig.util.Duration;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterators;
+import com.google.common.primitives.Ints;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestResult;
+import io.searchbox.cluster.Health;
+import io.searchbox.cluster.State;
+import io.searchbox.core.Bulk;
+import io.searchbox.core.BulkResult;
+import io.searchbox.core.Cat;
+import io.searchbox.core.CatResult;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import io.searchbox.core.SearchScroll;
+import io.searchbox.core.search.aggregation.FilterAggregation;
+import io.searchbox.core.search.aggregation.MaxAggregation;
+import io.searchbox.core.search.aggregation.MinAggregation;
+import io.searchbox.core.search.aggregation.TermsAggregation;
+import io.searchbox.indices.CloseIndex;
+import io.searchbox.indices.CreateIndex;
+import io.searchbox.indices.DeleteIndex;
+import io.searchbox.indices.Flush;
+import io.searchbox.indices.ForceMerge;
+import io.searchbox.indices.OpenIndex;
+import io.searchbox.indices.Stats;
+import io.searchbox.indices.aliases.AddAliasMapping;
+import io.searchbox.indices.aliases.AliasMapping;
+import io.searchbox.indices.aliases.GetAliases;
+import io.searchbox.indices.aliases.ModifyAliases;
+import io.searchbox.indices.aliases.RemoveAliasMapping;
+import io.searchbox.indices.settings.GetSettings;
+import io.searchbox.indices.settings.UpdateSettings;
+import io.searchbox.indices.template.DeleteTemplate;
+import io.searchbox.indices.template.PutTemplate;
+import io.searchbox.params.Parameters;
+import io.searchbox.params.SearchType;
+import org.apache.http.client.config.RequestConfig;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.sort.FieldSortBuilder;
+import org.elasticsearch.search.sort.SortBuilders;
+import org.graylog2.indexer.ElasticsearchException;
+import org.graylog2.indexer.IndexMapping;
+import org.graylog2.indexer.IndexNotFoundException;
+import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog2.indexer.indices.IndexMoveResult;
+import org.graylog2.indexer.indices.IndexSettings;
+import org.graylog2.indexer.indices.Indices;
+import org.graylog2.indexer.indices.IndicesAdapter;
+import org.graylog2.indexer.indices.stats.IndexStatistics;
+import org.graylog2.indexer.messages.Messages;
+import org.graylog2.indexer.searches.IndexRangeStats;
+import org.graylog2.jackson.TypeReferences;
+import org.graylog2.plugin.Message;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import static java.util.stream.Collectors.toList;
+import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
+
+public class IndicesAdapterES6 implements IndicesAdapter {
+    private static final Logger LOG = LoggerFactory.getLogger(IndicesAdapterES6.class);
+    private final JestClient jestClient;
+    private ObjectMapper objectMapper;
+    private Messages messages;
+
+    @Inject
+    public IndicesAdapterES6(JestClient jestClient, ObjectMapper objectMapper, Messages messages) {
+        this.jestClient = jestClient;
+        this.objectMapper = objectMapper;
+        this.messages = messages;
+    }
+
+    @Override
+    public void move(String source, String target, Consumer<IndexMoveResult> resultCallback) {
+        // TODO: This method should use the Re-index API: https://www.elastic.co/guide/en/elasticsearch/reference/5.3/docs-reindex.html
+        final String query = SearchSourceBuilder.searchSource()
+                .query(QueryBuilders.matchAllQuery())
+                .size(350)
+                .sort(SortBuilders.fieldSort(FieldSortBuilder.DOC_FIELD_NAME))
+                .toString();
+
+        final Search request = new Search.Builder(query)
+                .setParameter(Parameters.SCROLL, "10s")
+                .addIndex(source)
+                .build();
+
+        final SearchResult searchResult = JestUtils.execute(jestClient, request, () -> "Couldn't process search query response");
+
+        final String scrollId = searchResult.getJsonObject().path("_scroll_id").asText(null);
+        if (scrollId == null) {
+            throw new ElasticsearchException("Couldn't find scroll ID in search query response");
+        }
+
+        while (true) {
+            final SearchScroll scrollRequest = new SearchScroll.Builder(scrollId, "1m").build();
+            final JestResult scrollResult = JestUtils.execute(jestClient, scrollRequest, () -> "Couldn't process result of scroll query");
+            final JsonNode scrollHits = scrollResult.getJsonObject().path("hits").path("hits");
+
+            // No more hits.
+            if (scrollHits.size() == 0) {
+                break;
+            }
+
+            final Bulk.Builder bulkRequestBuilder = new Bulk.Builder();
+            for (JsonNode jsonElement : scrollHits) {
+                final Map<String, Object> doc = Optional.ofNullable(jsonElement.path("_source"))
+                        .map(sourceJson -> objectMapper.<Map<String, Object>>convertValue(sourceJson, TypeReferences.MAP_STRING_OBJECT))
+                        .orElse(Collections.emptyMap());
+                final String id = (String) doc.remove("_id");
+
+                bulkRequestBuilder.addAction(messages.prepareIndexRequest(target, doc, id));
+            }
+
+            final BulkResult bulkResult = JestUtils.execute(jestClient, bulkRequestBuilder.build(), () -> "Couldn't bulk index messages into index " + target);
+
+            final boolean hasFailedItems = !bulkResult.getFailedItems().isEmpty();
+            final IndexMoveResult result = IndexMoveResult.create(bulkResult.getItems().size(), bulkResult.getJsonObject().path("took").asLong(), hasFailedItems);
+            resultCallback.accept(result);
+        }
+    }
+
+    @Override
+    public void delete(String indexName) {
+        JestUtils.execute(jestClient, new DeleteIndex.Builder(indexName).build(), () -> "Couldn't delete index " + indexName);
+    }
+
+    @Override
+    public Set<String> resolveAlias(String alias) {
+        // TODO: This is basically getting all indices and later we filter out the alias we want to check for.
+        //       This can be done in a more efficient way by either using the /_cat/aliases/<alias-name> API or
+        //       the regular /_alias/<alias-name> API.
+        final GetAliases request = new GetAliases.Builder().build();
+        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't collect indices for alias " + alias);
+
+        // The ES return value of this has an awkward format: The first key of the hash is the target index. Thanks.
+        final ImmutableSet.Builder<String> indicesBuilder = ImmutableSet.builder();
+        final Iterator<Map.Entry<String, JsonNode>> it = jestResult.getJsonObject().fields();
+        while (it.hasNext()) {
+            Map.Entry<String, JsonNode> entry = it.next();
+            final String indexName = entry.getKey();
+            Optional.of(entry.getValue())
+                    .map(json -> json.path("aliases"))
+                    .map(JsonNode::fields)
+                    .map(ImmutableList::copyOf)
+                    .filter(aliases -> !aliases.isEmpty())
+                    .filter(aliases -> aliases.stream().anyMatch(aliasEntry -> aliasEntry.getKey().equals(alias)))
+                    .ifPresent(x -> indicesBuilder.add(indexName));
+        }
+
+        return indicesBuilder.build();
+    }
+
+    @Override
+    public void create(String indexName, IndexSettings indexSettings, String templateName, Map<String, Object> template) {
+        final Map<String, Object> settings = new HashMap<>();
+        settings.put("number_of_shards", indexSettings.shards());
+        settings.put("number_of_replicas", indexSettings.replicas());
+
+        final CreateIndex request = new CreateIndex.Builder(indexName)
+                .settings(settings)
+                .build();
+
+        // Make sure our index template exists before creating an index!
+        ensureIndexTemplate(templateName, template);
+
+        final JestResult jestResult;
+        try {
+            jestResult = jestClient.execute(request);
+        } catch (IOException e) {
+            throw new ElasticsearchException("Couldn't create index " + indexName, e);
+        }
+
+        if (!jestResult.isSucceeded()){
+            throw new ElasticsearchException(jestResult.getErrorMessage());
+        }
+    }
+
+    @Override
+    public boolean ensureIndexTemplate(String templateName, Map<String, Object> template) {
+        final PutTemplate request = new PutTemplate.Builder(templateName, template).build();
+
+        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Unable to create index template " + templateName);
+        return jestResult.isSucceeded();
+    }
+
+    @Override
+    public Optional<DateTime> indexCreationDate(String index) {
+        final GetSettings request = new GetSettings.Builder()
+                .addIndex(index)
+                .ignoreUnavailable(true)
+                .build();
+        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't read settings of index " + index);
+
+        return Optional.of(jestResult.getJsonObject().path(index).path("settings").path("index").path("creation_date"))
+                .filter(JsonNode::isValueNode)
+                .map(JsonNode::asLong)
+                .map(creationDate -> new DateTime(creationDate, DateTimeZone.UTC));
+    }
+
+    @Override
+    public void openIndex(String index) {
+        JestUtils.execute(jestClient, new OpenIndex.Builder(index).build(), () -> "Couldn't open index " + index);
+    }
+
+    @Override
+    public void setReadOnly(String index) {
+        // https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-update-settings.html
+        final Map<String, Object> settings = ImmutableMap.of(
+                "index", ImmutableMap.of("blocks",
+                        ImmutableMap.of(
+                                "write", true, // Block writing.
+                                "read", false, // Allow reading.
+                                "metadata", false) // Allow getting metadata.
+                )
+        );
+
+        final UpdateSettings request = new UpdateSettings.Builder(settings).addIndex(index).build();
+        JestUtils.execute(jestClient, request, () -> "Couldn't set index " + index + " to read-only");
+    }
+
+    @Override
+    public void flush(String index) {
+        JestUtils.execute(jestClient, new Flush.Builder().addIndex(index).force().build(), () -> "Couldn't flush index " + index);
+    }
+
+    @Override
+    public String markIndexReopened(String index) {
+        final String aliasName = index + Indices.REOPENED_ALIAS_SUFFIX;
+        final ModifyAliases request = new ModifyAliases.Builder(new AddAliasMapping.Builder(index, aliasName).build()).build();
+
+        JestUtils.execute(jestClient, request, () -> "Couldn't create reopened alias for index " + index);
+
+        return aliasName;
+    }
+
+    @Override
+    public void removeAlias(String indexName, String alias) {
+        JestUtils.execute(jestClient,
+                new ModifyAliases.Builder(new RemoveAliasMapping.Builder(indexName, alias).build()).build(),
+                () -> "Couldn't remove reopened alias for index " + indexName + " before closing.");
+    }
+
+    @Override
+    public void removeAliases(Set<String> indices, String alias) {
+        final AliasMapping removeAliasMapping = new RemoveAliasMapping.Builder(ImmutableList.copyOf(indices), alias).build();
+        final ModifyAliases request = new ModifyAliases.Builder(removeAliasMapping).build();
+        JestUtils.execute(jestClient, request, () -> "Couldn't remove alias " + alias + " from indices " + indices);
+    }
+
+    @Override
+    public void optimizeIndex(String index, int maxNumSegments, Duration timeout) {
+        final RequestConfig requestConfig = RequestConfig.custom()
+                .setSocketTimeout(Ints.saturatedCast(timeout.toMilliseconds()))
+                .build();
+
+        final ForceMerge request = new ForceMerge.Builder()
+                .addIndex(index)
+                .maxNumSegments(maxNumSegments)
+                .flush(true)
+                .onlyExpungeDeletes(false)
+                .build();
+
+        JestUtils.execute(jestClient, requestConfig, request, () -> "Couldn't force merge index " + index);
+    }
+
+    @Override
+    public IndexRangeStats indexRangeStatsOfIndex(String index) {
+        final FilterAggregationBuilder builder = AggregationBuilders.filter("agg", QueryBuilders.existsQuery(Message.FIELD_TIMESTAMP))
+                .subAggregation(AggregationBuilders.min("ts_min").field(Message.FIELD_TIMESTAMP))
+                .subAggregation(AggregationBuilders.max("ts_max").field(Message.FIELD_TIMESTAMP))
+                .subAggregation(AggregationBuilders.terms("streams").size(Integer.MAX_VALUE).field(Message.FIELD_STREAMS));
+        final String query = searchSource()
+                .aggregation(builder)
+                .size(0)
+                .toString();
+
+        final Search request = new Search.Builder(query)
+                .addIndex(index)
+                .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
+                .ignoreUnavailable(true)
+                .build();
+
+        if (LOG.isDebugEnabled()) {
+            String data = "{}";
+            try {
+                data = request.getData(objectMapper.copy().enable(SerializationFeature.INDENT_OUTPUT));
+            } catch (IOException e) {
+                LOG.debug("Couldn't pretty print request payload", e);
+            }
+            LOG.debug("Index range query: _search/{}: {}", index, data);
+        }
+
+        final SearchResult result = JestUtils.execute(jestClient, request, () -> "Couldn't build index range of index " + index);
+
+        final FilterAggregation f = result.getAggregations().getFilterAggregation("agg");
+        if (f == null) {
+            throw new IndexNotFoundException("Couldn't build index range of index " + index + " because it doesn't exist.");
+        } else if (f.getCount() == 0L) {
+            LOG.debug("No documents with attribute \"timestamp\" found in index <{}>", index);
+            return IndexRangeStats.EMPTY;
+        }
+
+        final MinAggregation minAgg = f.getMinAggregation("ts_min");
+        final DateTime min = new DateTime(minAgg.getMin().longValue(), DateTimeZone.UTC);
+        final MaxAggregation maxAgg = f.getMaxAggregation("ts_max");
+        final DateTime max = new DateTime(maxAgg.getMax().longValue(), DateTimeZone.UTC);
+        // make sure we return an empty list, so we can differentiate between old indices that don't have this information
+        // and newer ones that simply have no streams.
+        final TermsAggregation streams = f.getTermsAggregation("streams");
+        final List<String> streamIds = streams.getBuckets().stream()
+                .map(TermsAggregation.Entry::getKeyAsString)
+                .collect(toList());
+
+
+        return IndexRangeStats.create(min, max, streamIds);
+    }
+
+    @Override
+    public Health.Status waitForRecovery(String index) {
+        return waitForStatus(index, Health.Status.YELLOW);
+    }
+
+    private Health.Status waitForStatus(String index, Health.Status clusterHealthStatus) {
+        final Health request = new Health.Builder()
+                .addIndex(index)
+                .waitForStatus(clusterHealthStatus)
+                .build();
+        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't read health status for index " + index);
+
+        final String status = jestResult.getJsonObject().path("status").asText();
+        return Health.Status.valueOf(status.toUpperCase(Locale.ENGLISH));
+    }
+
+    @Override
+    public void close(String indexName) {
+        JestUtils.execute(jestClient, new CloseIndex.Builder(indexName).build(), () -> "Couldn't close index " + indexName);
+    }
+
+    @Override
+    public long numberOfMessages(String indexName) {
+        return indexStats(indexName).path("primaries").path("docs").path("count").asLong();
+    }
+
+    private JsonNode indexStats(final String indexName) {
+        final Stats request = new Stats.Builder()
+                .addIndex(indexName)
+                .build();
+
+        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't check stats of index " + indexName);
+
+        return jestResult.getJsonObject().path("indices").path(indexName);
+    }
+
+    @Override
+    public boolean aliasExists(String alias) throws IOException {
+        final JestResult result = jestClient.execute(new GetSettings.Builder().addIndex(alias).build());
+        return result.isSucceeded() && !Iterators.contains(result.getJsonObject().fieldNames(), alias);
+    }
+
+    @Override
+    public Map<String, Set<String>> aliases(String indexPattern) {
+        // only request indices matching the name or pattern in `indexPattern` and only get the alias names for each index,
+        // not the settings or mappings
+        final GetAliases request = new GetAliases.Builder()
+                .addIndex(indexPattern)
+                // ES 6 changed the "expand_wildcards" default value for the /_alias API from "open" to "all".
+                // Since our code expects only open indices to be returned, we have to explicitly set the parameter now.
+                .setParameter("expand_wildcards", "open")
+                .build();
+
+        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't collect aliases for index pattern " + indexPattern);
+
+        final ImmutableMap.Builder<String, Set<String>> indexAliasesBuilder = ImmutableMap.builder();
+        final Iterator<Map.Entry<String, JsonNode>> it = jestResult.getJsonObject().fields();
+        while (it.hasNext()) {
+            final Map.Entry<String, JsonNode> entry = it.next();
+            final String indexName = entry.getKey();
+            final JsonNode aliasMetaData = entry.getValue().path("aliases");
+            if (aliasMetaData.isObject()) {
+                final ImmutableSet<String> aliasNames = ImmutableSet.copyOf(aliasMetaData.fieldNames());
+                indexAliasesBuilder.put(indexName, aliasNames);
+            }
+        }
+
+        return indexAliasesBuilder.build();
+    }
+
+    @Override
+    public boolean deleteIndexTemplate(String templateName) {
+        final JestResult result = JestUtils.execute(jestClient, new DeleteTemplate.Builder(templateName).build(), () -> "Unable to delete the Graylog index template " + templateName);
+        return result.isSucceeded();
+    }
+
+    @Override
+    public Map<String, Set<String>> fieldsInIndices(String[] writeIndexWildcards) {
+        final String indices = String.join(",", writeIndexWildcards);
+        final State request = new State.Builder()
+                .indices(indices)
+                .withMetadata()
+                .build();
+
+        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't read cluster state for indices " + indices);
+
+        final JsonNode indicesJson = getClusterStateIndicesMetadata(jestResult.getJsonObject());
+        final ImmutableMap.Builder<String, Set<String>> fields = ImmutableMap.builder();
+        final Iterator<Map.Entry<String, JsonNode>> it = indicesJson.fields();
+        while (it.hasNext()) {
+            final Map.Entry<String, JsonNode> entry = it.next();
+            final String indexName = entry.getKey();
+            final Set<String> fieldNames = ImmutableSet.copyOf(
+                    entry.getValue()
+                            .path("mappings")
+                            .path(IndexMapping.TYPE_MESSAGE)
+                            .path("properties").fieldNames()
+            );
+            if (!fieldNames.isEmpty()) {
+                fields.put(indexName, fieldNames);
+            }
+        }
+
+        return fields.build();
+    }
+
+    @Override
+    public Set<String> closedIndices(Collection<String> indices) {
+        final JsonNode catIndices = catIndices(indices, "index", "status");
+
+        final ImmutableSet.Builder<String> closedIndices = ImmutableSet.builder();
+        for (JsonNode jsonElement : catIndices) {
+            if (jsonElement.isObject()) {
+                final String index = jsonElement.path("index").asText(null);
+                final String status = jsonElement.path("status").asText(null);
+                if (index != null && "close".equals(status)) {
+                    closedIndices.add(index);
+                }
+            }
+        }
+
+        return closedIndices.build();
+    }
+
+    @Override
+    public Set<IndexStatistics> indicesStats(Collection<String> indices) {
+        final ImmutableSet.Builder<IndexStatistics> result = ImmutableSet.builder();
+
+        final JsonNode allWithShardLevel = getAllWithShardLevel(indices);
+        final Iterator<Map.Entry<String, JsonNode>> fields = allWithShardLevel.fields();
+        while (fields.hasNext()) {
+            final Map.Entry<String, JsonNode> entry = fields.next();
+            final String index = entry.getKey();
+            final JsonNode indexStats = entry.getValue();
+            if (indexStats.isObject()) {
+                result.add(buildIndexStatistics(index, indexStats));
+            }
+        }
+
+        return result.build();
+    }
+
+    @Override
+    public Optional<IndexStatistics> getIndexStats(String index) {
+        final JsonNode indexStats = indexStatsWithShardLevel(index);
+        return indexStats.isMissingNode() ? Optional.empty() : Optional.of(buildIndexStatistics(index, indexStats));
+    }
+
+    @Override
+    public JsonNode getIndexStats(final Collection<String> indices) {
+        final Stats request = new Stats.Builder()
+                .addIndex(indices)
+                .docs(true)
+                .store(true)
+                .build();
+
+        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't check stats of indices " + indices);
+
+        return jestResult.getJsonObject().path("indices");
+    }
+
+    @Override
+    public boolean exists(String indexName) throws IOException {
+        final JestResult result = jestClient.execute(new GetSettings.Builder().addIndex(indexName).build());
+        return result.isSucceeded() && Iterators.contains(result.getJsonObject().fieldNames(), indexName);
+    }
+
+    @Override
+    public Set<String> indices(String indexWildcard, List<String> status, String indexSetId) {
+        final Cat catRequest = new Cat.IndicesBuilder()
+                .addIndex(indexWildcard)
+                .setParameter("h", "index,status")
+                .build();
+
+        final CatResult result = JestUtils.execute(jestClient, catRequest,
+                () -> "Couldn't get index list for index set <" + indexSetId + ">");
+
+        return StreamSupport.stream(result.getJsonObject().path("result").spliterator(), false)
+                .filter(cat -> status.isEmpty() || status.contains(cat.path("status").asText()))
+                .map(cat -> cat.path("index").asText())
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Optional<Long> storeSizeInBytes(String index) {
+        final Stats request = new Stats.Builder()
+                .addIndex(index)
+                .store(true)
+                .build();
+
+        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't check store stats of index " + index);
+        final JsonNode sizeInBytes = jestResult.getJsonObject()
+                .path("indices")
+                .path(index)
+                .path("primaries")
+                .path("store")
+                .path("size_in_bytes");
+        return Optional.of(sizeInBytes).filter(JsonNode::isNumber).map(JsonNode::asLong);
+    }
+
+    @Override
+    public void cycleAlias(String aliasName, String targetIndex) {
+        final AddAliasMapping addAliasMapping = new AddAliasMapping.Builder(targetIndex, aliasName).build();
+        JestUtils.execute(jestClient, new ModifyAliases.Builder(addAliasMapping).build(), () -> "Couldn't point alias " + aliasName + " to index " + targetIndex);
+    }
+
+    @Override
+    public void cycleAlias(String aliasName, String targetIndex, String oldIndex) {
+        final AliasMapping addAliasMapping = new AddAliasMapping.Builder(targetIndex, aliasName).build();
+        final AliasMapping removeAliasMapping = new RemoveAliasMapping.Builder(oldIndex, aliasName).build();
+        final ModifyAliases request = new ModifyAliases.Builder(Arrays.asList(removeAliasMapping, addAliasMapping)).build();
+
+        JestUtils.execute(jestClient, request, () -> "Couldn't switch alias " + aliasName + " from index " + oldIndex + " to index " + targetIndex);
+    }
+
+    private JsonNode indexStatsWithShardLevel(final String indexName) {
+        final Stats request = new Stats.Builder()
+                .addIndex(indexName)
+                .setParameter("level", "shards")
+                .ignoreUnavailable(true)
+                .build();
+
+        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't check stats of index " + indexName);
+
+        return jestResult.getJsonObject().path("indices").path(indexName);
+    }
+
+    private JsonNode getAllWithShardLevel(final Collection<String> indices) {
+        final Stats request = new Stats.Builder()
+                .addIndex(indices)
+                .setParameter("level", "shards")
+                .build();
+        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't fetch index stats of indices " + indices);
+        final JsonNode responseJson = jestResult.getJsonObject();
+        final int failedShards = responseJson.path("_shards").path("failed").asInt();
+
+        if (failedShards > 0) {
+            throw new ElasticsearchException("Index stats response contains failed shards, response is incomplete");
+        }
+
+        return responseJson.path("indices");
+    }
+
+    private IndexStatistics buildIndexStatistics(String index, JsonNode indexStats) {
+        return IndexStatistics.create(index, indexStats);
+    }
+
+    /**
+     * Retrieve the response for the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html">cat indices</a> request from Elasticsearch.
+     *
+     * @param fields The fields to show, see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html">cat indices API</a>.
+     * @return A {@link JsonNode} with the result of the cat indices request.
+     */
+    private JsonNode catIndices(Collection<String> indices, String... fields) {
+        final String fieldNames = String.join(",", fields);
+        final Cat request = new Cat.IndicesBuilder()
+                .addIndex(indices)
+                .setParameter("h", fieldNames)
+                .build();
+        final CatResult response = JestUtils.execute(jestClient, request, () -> "Unable to read information for indices " + indices);
+        return response.getJsonObject().path("result");
+    }
+
+    private JsonNode getClusterStateIndicesMetadata(JsonNode clusterStateJson) {
+        return clusterStateJson.path("metadata").path("indices");
+    }
+}

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
@@ -235,7 +235,7 @@ public class IndicesAdapterES6 implements IndicesAdapter {
 
     @Override
     public void setReadOnly(String index) {
-        // https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-update-settings.html
+        // https://www.elastic.co/guide/en/elasticsearch/reference/6.8/indices-update-settings.html
         final Map<String, Object> settings = ImmutableMap.of(
                 "index", ImmutableMap.of("blocks",
                         ImmutableMap.of(
@@ -361,7 +361,7 @@ public class IndicesAdapterES6 implements IndicesAdapter {
         }
     }
 
-    private Health.Status waitForStatus(String index, Health.Status clusterHealthStatus) {
+    private Health.Status waitForStatus(String index, @SuppressWarnings("SameParameterValue") Health.Status clusterHealthStatus) {
         final Health request = new Health.Builder()
                 .addIndex(index)
                 .waitForStatus(clusterHealthStatus)

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
@@ -53,6 +53,7 @@ import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.indexer.IndexMapping;
 import org.graylog2.indexer.IndexNotFoundException;
 import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog2.indexer.indices.HealthStatus;
 import org.graylog2.indexer.indices.IndexMoveResult;
 import org.graylog2.indexer.indices.IndexSettings;
 import org.graylog2.indexer.indices.Indices;
@@ -345,8 +346,18 @@ public class IndicesAdapterES6 implements IndicesAdapter {
     }
 
     @Override
-    public Health.Status waitForRecovery(String index) {
-        return waitForStatus(index, Health.Status.YELLOW);
+    public HealthStatus waitForRecovery(String index) {
+        final Health.Status status = waitForStatus(index, Health.Status.YELLOW);
+        return mapHealthStatus(status);
+    }
+
+    private HealthStatus mapHealthStatus(Health.Status status) {
+        switch (status) {
+            case RED: return HealthStatus.Red;
+            case YELLOW: return HealthStatus.Yellow;
+            case GREEN: return HealthStatus.Green;
+            default: throw new IllegalStateException("Unexpected cluster status: " + status);
+        }
     }
 
     private Health.Status waitForStatus(String index, Health.Status clusterHealthStatus) {

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
@@ -59,7 +59,6 @@ import org.graylog2.indexer.indices.IndexSettings;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.indexer.indices.IndicesAdapter;
 import org.graylog2.indexer.indices.stats.IndexStatistics;
-import org.graylog2.indexer.messages.Messages;
 import org.graylog2.indexer.searches.IndexRangeStats;
 import org.graylog2.jackson.TypeReferences;
 import org.graylog2.plugin.Message;
@@ -90,14 +89,14 @@ import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
 public class IndicesAdapterES6 implements IndicesAdapter {
     private static final Logger LOG = LoggerFactory.getLogger(IndicesAdapterES6.class);
     private final JestClient jestClient;
-    private ObjectMapper objectMapper;
-    private Messages messages;
+    private final ObjectMapper objectMapper;
+    private final IndexingHelper indexingHelper;
 
     @Inject
-    public IndicesAdapterES6(JestClient jestClient, ObjectMapper objectMapper, Messages messages) {
+    public IndicesAdapterES6(JestClient jestClient, ObjectMapper objectMapper, IndexingHelper indexingHelper) {
         this.jestClient = jestClient;
         this.objectMapper = objectMapper;
-        this.messages = messages;
+        this.indexingHelper = indexingHelper;
     }
 
     @Override
@@ -138,7 +137,7 @@ public class IndicesAdapterES6 implements IndicesAdapter {
                         .orElse(Collections.emptyMap());
                 final String id = (String) doc.remove("_id");
 
-                bulkRequestBuilder.addAction(messages.prepareIndexRequest(target, doc, id));
+                bulkRequestBuilder.addAction(indexingHelper.prepareIndexRequest(target, doc, id));
             }
 
             final BulkResult bulkResult = JestUtils.execute(jestClient, bulkRequestBuilder.build(), () -> "Couldn't bulk index messages into index " + target);

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/IndexFieldTypePollerES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/IndexFieldTypePollerES6IT.java
@@ -3,15 +3,12 @@ package org.graylog.storage.elasticsearch6;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.graylog2.indexer.fieldtypes.IndexFieldTypePollerIT;
 import org.graylog2.indexer.indices.IndicesAdapter;
-import org.graylog2.indexer.messages.Messages;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
-
-import static org.mockito.Mockito.mock;
 
 public class IndexFieldTypePollerES6IT extends IndexFieldTypePollerIT {
     @Override
     protected IndicesAdapter createIndicesAdapter() {
         final ObjectMapper objectMapper = new ObjectMapperProvider().get();
-        return new IndicesAdapterES6(jestClient(), objectMapper, mock(Messages.class));
+        return new IndicesAdapterES6(jestClient(), objectMapper, new IndexingHelper());
     }
 }

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/IndexFieldTypePollerES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/IndexFieldTypePollerES6IT.java
@@ -1,0 +1,17 @@
+package org.graylog.storage.elasticsearch6;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.graylog2.indexer.fieldtypes.IndexFieldTypePollerIT;
+import org.graylog2.indexer.indices.IndicesAdapter;
+import org.graylog2.indexer.messages.Messages;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+
+import static org.mockito.Mockito.mock;
+
+public class IndexFieldTypePollerES6IT extends IndexFieldTypePollerIT {
+    @Override
+    protected IndicesAdapter createIndicesAdapter() {
+        final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+        return new IndicesAdapterES6(jestClient(), objectMapper, mock(Messages.class));
+    }
+}

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/IndicesES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/IndicesES6IT.java
@@ -2,16 +2,13 @@ package org.graylog.storage.elasticsearch6;
 
 import org.graylog2.indexer.indices.IndicesAdapter;
 import org.graylog2.indexer.indices.IndicesIT;
-import org.graylog2.indexer.messages.Messages;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
-
-import static org.mockito.Mockito.mock;
 
 public class IndicesES6IT extends IndicesIT {
     @Override
     protected IndicesAdapter indicesAdapter() {
         return new IndicesAdapterES6(jestClient(),
                 new ObjectMapperProvider().get(),
-                mock(Messages.class));
+                new IndexingHelper());
     }
 }

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/IndicesES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/IndicesES6IT.java
@@ -1,0 +1,17 @@
+package org.graylog.storage.elasticsearch6;
+
+import com.codahale.metrics.MetricRegistry;
+import org.graylog2.indexer.indices.IndicesAdapter;
+import org.graylog2.indexer.indices.IndicesIT;
+import org.graylog2.indexer.messages.Messages;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.graylog2.system.processing.InMemoryProcessingStatusRecorder;
+
+public class IndicesES6IT extends IndicesIT {
+    @Override
+    protected IndicesAdapter indicesAdapter() {
+        return new IndicesAdapterES6(jestClient(),
+                new ObjectMapperProvider().get(),
+                new Messages(new MetricRegistry(), jestClient(), new InMemoryProcessingStatusRecorder(), true));
+    }
+}

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/IndicesES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/IndicesES6IT.java
@@ -1,17 +1,17 @@
 package org.graylog.storage.elasticsearch6;
 
-import com.codahale.metrics.MetricRegistry;
 import org.graylog2.indexer.indices.IndicesAdapter;
 import org.graylog2.indexer.indices.IndicesIT;
 import org.graylog2.indexer.messages.Messages;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
-import org.graylog2.system.processing.InMemoryProcessingStatusRecorder;
+
+import static org.mockito.Mockito.mock;
 
 public class IndicesES6IT extends IndicesIT {
     @Override
     protected IndicesAdapter indicesAdapter() {
         return new IndicesAdapterES6(jestClient(),
                 new ObjectMapperProvider().get(),
-                new Messages(new MetricRegistry(), jestClient(), new InMemoryProcessingStatusRecorder(), true));
+                mock(Messages.class));
     }
 }

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/IndicesGetAllMessageFieldsES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/IndicesGetAllMessageFieldsES6IT.java
@@ -2,16 +2,13 @@ package org.graylog.storage.elasticsearch6;
 
 import org.graylog2.indexer.indices.IndicesAdapter;
 import org.graylog2.indexer.indices.IndicesGetAllMessageFieldsIT;
-import org.graylog2.indexer.messages.Messages;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
-
-import static org.mockito.Mockito.mock;
 
 public class IndicesGetAllMessageFieldsES6IT extends IndicesGetAllMessageFieldsIT {
     @Override
     protected IndicesAdapter indicesAdapter() {
         return new IndicesAdapterES6(jestClient(),
                 new ObjectMapperProvider().get(),
-                mock(Messages.class));
+                new IndexingHelper());
     }
 }

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/IndicesGetAllMessageFieldsES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/IndicesGetAllMessageFieldsES6IT.java
@@ -1,0 +1,17 @@
+package org.graylog.storage.elasticsearch6;
+
+import com.codahale.metrics.MetricRegistry;
+import org.graylog2.indexer.indices.IndicesAdapter;
+import org.graylog2.indexer.indices.IndicesGetAllMessageFieldsIT;
+import org.graylog2.indexer.messages.Messages;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.graylog2.system.processing.InMemoryProcessingStatusRecorder;
+
+public class IndicesGetAllMessageFieldsES6IT extends IndicesGetAllMessageFieldsIT {
+    @Override
+    protected IndicesAdapter indicesAdapter() {
+        return new IndicesAdapterES6(jestClient(),
+                new ObjectMapperProvider().get(),
+                new Messages(new MetricRegistry(), jestClient(), new InMemoryProcessingStatusRecorder(), true));
+    }
+}

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/IndicesGetAllMessageFieldsES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/IndicesGetAllMessageFieldsES6IT.java
@@ -1,17 +1,17 @@
 package org.graylog.storage.elasticsearch6;
 
-import com.codahale.metrics.MetricRegistry;
 import org.graylog2.indexer.indices.IndicesAdapter;
 import org.graylog2.indexer.indices.IndicesGetAllMessageFieldsIT;
 import org.graylog2.indexer.messages.Messages;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
-import org.graylog2.system.processing.InMemoryProcessingStatusRecorder;
+
+import static org.mockito.Mockito.mock;
 
 public class IndicesGetAllMessageFieldsES6IT extends IndicesGetAllMessageFieldsIT {
     @Override
     protected IndicesAdapter indicesAdapter() {
         return new IndicesAdapterES6(jestClient(),
                 new ObjectMapperProvider().get(),
-                new Messages(new MetricRegistry(), jestClient(), new InMemoryProcessingStatusRecorder(), true));
+                mock(Messages.class));
     }
 }

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/MessagesES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/MessagesES6IT.java
@@ -35,13 +35,6 @@ public class MessagesES6IT extends MessagesIT {
         return result.getCount();
     }
 
-    protected boolean indexMessage(String index, Map<String, Object> source, String id) {
-        final Index indexRequest = indexingHelper.prepareIndexRequest(index, source, id);
-        final DocumentResult indexResponse = JestUtils.execute(jestClient(), indexRequest, () -> "Unable to index message");
-
-        return indexResponse.isSucceeded();
-    }
-
     @Test
     public void getResultDoesNotContainJestMetadataFields() throws Exception {
         final String index = UUID.randomUUID().toString();
@@ -57,5 +50,12 @@ public class MessagesES6IT extends MessagesIT {
         assertThat(message).isNotNull();
         assertThat(message.hasField(JestResult.ES_METADATA_ID)).isFalse();
         assertThat(message.hasField(JestResult.ES_METADATA_VERSION)).isFalse();
+    }
+
+    protected boolean indexMessage(String index, Map<String, Object> source, @SuppressWarnings("SameParameterValue") String id) {
+        final Index indexRequest = indexingHelper.prepareIndexRequest(index, source, id);
+        final DocumentResult indexResponse = JestUtils.execute(jestClient(), indexRequest, () -> "Unable to index message");
+
+        return indexResponse.isSucceeded();
     }
 }

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/MessagesES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/MessagesES6IT.java
@@ -1,13 +1,23 @@
 package org.graylog.storage.elasticsearch6;
 
 import com.codahale.metrics.MetricRegistry;
+import io.searchbox.client.JestResult;
+import io.searchbox.core.Count;
+import io.searchbox.core.CountResult;
 import io.searchbox.core.DocumentResult;
 import io.searchbox.core.Index;
 import org.graylog2.indexer.cluster.jest.JestUtils;
 import org.graylog2.indexer.messages.MessagesAdapter;
 import org.graylog2.indexer.messages.MessagesIT;
+import org.graylog2.indexer.results.ResultMessage;
+import org.graylog2.plugin.Message;
+import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MessagesES6IT extends MessagesIT {
     private final IndexingHelper indexingHelper = new IndexingHelper();
@@ -18,10 +28,34 @@ public class MessagesES6IT extends MessagesIT {
     }
 
     @Override
+    protected Double messageCount(String indexName) {
+        final Count count = new Count.Builder().addIndex(indexName).build();
+
+        final CountResult result = JestUtils.execute(jestClient(), count, () -> "Unable to count documents");
+        return result.getCount();
+    }
+
     protected boolean indexMessage(String index, Map<String, Object> source, String id) {
-        final Index indexRequest = indexingHelper.prepareIndexRequest(index, source, "1");
+        final Index indexRequest = indexingHelper.prepareIndexRequest(index, source, id);
         final DocumentResult indexResponse = JestUtils.execute(jestClient(), indexRequest, () -> "Unable to index message");
 
         return indexResponse.isSucceeded();
+    }
+
+    @Test
+    public void getResultDoesNotContainJestMetadataFields() throws Exception {
+        final String index = UUID.randomUUID().toString();
+        final Map<String, Object> source = new HashMap<>();
+        source.put("message", "message");
+        source.put("source", "source");
+        source.put("timestamp", "2017-04-13 15:29:00.000");
+
+        assertThat(indexMessage(index, source, "1")).isTrue();
+
+        final ResultMessage resultMessage = messages.get("1", index);
+        final Message message = resultMessage.getMessage();
+        assertThat(message).isNotNull();
+        assertThat(message.hasField(JestResult.ES_METADATA_ID)).isFalse();
+        assertThat(message.hasField(JestResult.ES_METADATA_VERSION)).isFalse();
     }
 }

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/MessagesES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/MessagesES6IT.java
@@ -1,12 +1,27 @@
 package org.graylog.storage.elasticsearch6;
 
 import com.codahale.metrics.MetricRegistry;
+import io.searchbox.core.DocumentResult;
+import io.searchbox.core.Index;
+import org.graylog2.indexer.cluster.jest.JestUtils;
 import org.graylog2.indexer.messages.MessagesAdapter;
 import org.graylog2.indexer.messages.MessagesIT;
 
+import java.util.Map;
+
 public class MessagesES6IT extends MessagesIT {
+    private final IndexingHelper indexingHelper = new IndexingHelper();
+
     @Override
     protected MessagesAdapter createMessagesAdapter(MetricRegistry metricRegistry) {
         return new MessagesAdapterES6(jestClient(), true, metricRegistry);
+    }
+
+    @Override
+    protected boolean indexMessage(String index, Map<String, Object> source, String id) {
+        final Index indexRequest = indexingHelper.prepareIndexRequest(index, source, "1");
+        final DocumentResult indexResponse = JestUtils.execute(jestClient(), indexRequest, () -> "Unable to index message");
+
+        return indexResponse.isSucceeded();
     }
 }

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/MessagesES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/MessagesES6IT.java
@@ -52,7 +52,7 @@ public class MessagesES6IT extends MessagesIT {
         assertThat(message.hasField(JestResult.ES_METADATA_VERSION)).isFalse();
     }
 
-    protected boolean indexMessage(String index, Map<String, Object> source, @SuppressWarnings("SameParameterValue") String id) {
+    private boolean indexMessage(String index, Map<String, Object> source, @SuppressWarnings("SameParameterValue") String id) {
         final Index indexRequest = indexingHelper.prepareIndexRequest(index, source, id);
         final DocumentResult indexResponse = JestUtils.execute(jestClient(), indexRequest, () -> "Unable to index message");
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSet.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/MongoIndexSet.java
@@ -21,10 +21,10 @@ import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.inject.assistedinject.Assisted;
-import io.searchbox.cluster.Health;
 import org.graylog2.audit.AuditActor;
 import org.graylog2.audit.AuditEventSender;
 import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indices.HealthStatus;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.indexer.indices.TooManyAliasesException;
 import org.graylog2.indexer.indices.jobs.SetIndexReadOnlyAndCalculateRangeJob;
@@ -295,7 +295,7 @@ public class MongoIndexSet implements IndexSet {
         }
 
         LOG.info("Waiting for allocation of index <{}>.", newTarget);
-        Health.Status healthStatus = indices.waitForRecovery(newTarget);
+        HealthStatus healthStatus = indices.waitForRecovery(newTarget);
         LOG.debug("Health status of index <{}>: {}", newTarget, healthStatus);
 
         addDeflectorIndexRange(newTarget);

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/HealthStatus.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/HealthStatus.java
@@ -1,0 +1,7 @@
+package org.graylog2.indexer.indices;
+
+public enum HealthStatus {
+    Red,
+    Yellow,
+    Green
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/HealthStatus.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/HealthStatus.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.indexer.indices;
 
 public enum HealthStatus {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/IndexMoveResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/IndexMoveResult.java
@@ -16,20 +16,17 @@
  */
 package org.graylog2.indexer.indices;
 
-import org.graylog2.indexer.ElasticsearchException;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.google.auto.value.AutoValue;
 
-import java.util.Set;
+@AutoValue
+@JsonAutoDetect
+public abstract class IndexMoveResult {
+    public abstract int movedDocuments();
+    public abstract long tookMs();
+    public abstract boolean hasFailedItems();
 
-// TODO: This should actually be a `TooManyIndicesForAliasException`?
-public class TooManyAliasesException extends ElasticsearchException {
-    private final Set<String> indices;
-
-    public TooManyAliasesException(final Set<String> indices) {
-        super("More than one index in deflector alias: " + indices.toString());
-        this.indices = indices;
-    }
-
-    public Set<String> getIndices() {
-        return indices;
+    public static IndexMoveResult create(int movedDocuments, long tookMs, boolean hasFailedItems) {
+        return new AutoValue_IndexMoveResult(movedDocuments, tookMs, hasFailedItems);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/IndexSettings.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/IndexSettings.java
@@ -16,20 +16,16 @@
  */
 package org.graylog2.indexer.indices;
 
-import org.graylog2.indexer.ElasticsearchException;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.google.auto.value.AutoValue;
 
-import java.util.Set;
+@AutoValue
+@JsonAutoDetect
+public abstract class IndexSettings {
+    public abstract int shards();
+    public abstract int replicas();
 
-// TODO: This should actually be a `TooManyIndicesForAliasException`?
-public class TooManyAliasesException extends ElasticsearchException {
-    private final Set<String> indices;
-
-    public TooManyAliasesException(final Set<String> indices) {
-        super("More than one index in deflector alias: " + indices.toString());
-        this.indices = indices;
-    }
-
-    public Set<String> getIndices() {
-        return indices;
+    public static IndexSettings create(int shards, int replicas) {
+        return new AutoValue_IndexSettings(shards, replicas);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -17,12 +17,10 @@
 package org.graylog2.indexer.indices;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.joschi.jadconfig.util.Duration;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.eventbus.EventBus;
-import io.searchbox.cluster.Health;
 import org.graylog2.audit.AuditActor;
 import org.graylog2.audit.AuditEventSender;
 import org.graylog2.indexer.ElasticsearchException;
@@ -62,17 +60,18 @@ public class Indices {
     private static final Logger LOG = LoggerFactory.getLogger(Indices.class);
     public static final String REOPENED_ALIAS_SUFFIX = "_reopened";
 
-    private final ObjectMapper objectMapper;
     private final IndexMappingFactory indexMappingFactory;
     private final NodeId nodeId;
     private final AuditEventSender auditEventSender;
     private final EventBus eventBus;
-    private IndicesAdapter indicesAdapter;
+    private final IndicesAdapter indicesAdapter;
 
     @Inject
-    public Indices(ObjectMapper objectMapper, IndexMappingFactory indexMappingFactory,
-                   NodeId nodeId, AuditEventSender auditEventSender, EventBus eventBus, IndicesAdapter indicesAdapter) {
-        this.objectMapper = objectMapper;
+    public Indices(IndexMappingFactory indexMappingFactory,
+                   NodeId nodeId,
+                   AuditEventSender auditEventSender,
+                   EventBus eventBus,
+                   IndicesAdapter indicesAdapter) {
         this.indexMappingFactory = indexMappingFactory;
         this.nodeId = nodeId;
         this.auditEventSender = auditEventSender;
@@ -345,7 +344,7 @@ public class Indices {
         indicesAdapter.optimizeIndex(index, maxNumSegments, timeout);
     }
 
-    public Health.Status waitForRecovery(String index) {
+    public HealthStatus waitForRecovery(String index) {
         LOG.debug("Waiting until index health status of index {} is healthy", index);
         return indicesAdapter.waitForRecovery(index);
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -18,75 +18,26 @@ package org.graylog2.indexer.indices;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.github.joschi.jadconfig.util.Duration;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterators;
 import com.google.common.eventbus.EventBus;
-import com.google.common.primitives.Ints;
-import io.searchbox.client.JestClient;
-import io.searchbox.client.JestResult;
 import io.searchbox.cluster.Health;
-import io.searchbox.cluster.State;
-import io.searchbox.core.Bulk;
-import io.searchbox.core.BulkResult;
-import io.searchbox.core.Cat;
-import io.searchbox.core.CatResult;
-import io.searchbox.core.Search;
-import io.searchbox.core.SearchResult;
-import io.searchbox.core.SearchScroll;
-import io.searchbox.core.search.aggregation.FilterAggregation;
-import io.searchbox.core.search.aggregation.MaxAggregation;
-import io.searchbox.core.search.aggregation.MinAggregation;
-import io.searchbox.core.search.aggregation.TermsAggregation;
-import io.searchbox.indices.CloseIndex;
-import io.searchbox.indices.CreateIndex;
-import io.searchbox.indices.DeleteIndex;
-import io.searchbox.indices.Flush;
-import io.searchbox.indices.ForceMerge;
-import io.searchbox.indices.OpenIndex;
-import io.searchbox.indices.Stats;
-import io.searchbox.indices.aliases.AddAliasMapping;
-import io.searchbox.indices.aliases.AliasMapping;
-import io.searchbox.indices.aliases.GetAliases;
-import io.searchbox.indices.aliases.ModifyAliases;
-import io.searchbox.indices.aliases.RemoveAliasMapping;
-import io.searchbox.indices.settings.GetSettings;
-import io.searchbox.indices.settings.UpdateSettings;
-import io.searchbox.indices.template.DeleteTemplate;
-import io.searchbox.indices.template.PutTemplate;
-import io.searchbox.params.Parameters;
-import io.searchbox.params.SearchType;
-import org.apache.http.client.config.RequestConfig;
-import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.search.aggregations.AggregationBuilders;
-import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
-import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.elasticsearch.search.sort.FieldSortBuilder;
-import org.elasticsearch.search.sort.SortBuilders;
 import org.graylog2.audit.AuditActor;
 import org.graylog2.audit.AuditEventSender;
 import org.graylog2.indexer.ElasticsearchException;
-import org.graylog2.indexer.IndexMapping;
 import org.graylog2.indexer.IndexMappingFactory;
 import org.graylog2.indexer.IndexMappingTemplate;
 import org.graylog2.indexer.IndexNotFoundException;
 import org.graylog2.indexer.IndexSet;
-import org.graylog2.indexer.cluster.jest.JestUtils;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indices.events.IndicesClosedEvent;
 import org.graylog2.indexer.indices.events.IndicesDeletedEvent;
 import org.graylog2.indexer.indices.events.IndicesReopenedEvent;
 import org.graylog2.indexer.indices.stats.IndexStatistics;
-import org.graylog2.indexer.messages.Messages;
 import org.graylog2.indexer.searches.IndexRangeStats;
-import org.graylog2.jackson.TypeReferences;
-import org.graylog2.plugin.Message;
 import org.graylog2.plugin.system.NodeId;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,174 +48,72 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
-import static java.util.stream.Collectors.toList;
-import static org.elasticsearch.search.builder.SearchSourceBuilder.searchSource;
 import static org.graylog2.audit.AuditEventTypes.ES_INDEX_CREATE;
 
 @Singleton
 public class Indices {
     private static final Logger LOG = LoggerFactory.getLogger(Indices.class);
-    private static final String REOPENED_ALIAS_SUFFIX = "_reopened";
+    public static final String REOPENED_ALIAS_SUFFIX = "_reopened";
 
-    private final JestClient jestClient;
     private final ObjectMapper objectMapper;
     private final IndexMappingFactory indexMappingFactory;
-    private final Messages messages;
     private final NodeId nodeId;
     private final AuditEventSender auditEventSender;
     private final EventBus eventBus;
+    private IndicesAdapter indicesAdapter;
 
     @Inject
-    public Indices(JestClient jestClient, ObjectMapper objectMapper, IndexMappingFactory indexMappingFactory,
-                   Messages messages, NodeId nodeId, AuditEventSender auditEventSender,
-                   EventBus eventBus) {
-        this.jestClient = jestClient;
+    public Indices(ObjectMapper objectMapper, IndexMappingFactory indexMappingFactory,
+                   NodeId nodeId, AuditEventSender auditEventSender, EventBus eventBus, IndicesAdapter indicesAdapter) {
         this.objectMapper = objectMapper;
         this.indexMappingFactory = indexMappingFactory;
-        this.messages = messages;
         this.nodeId = nodeId;
         this.auditEventSender = auditEventSender;
         this.eventBus = eventBus;
+        this.indicesAdapter = indicesAdapter;
     }
 
     public void move(String source, String target) {
-        // TODO: This method should use the Re-index API: https://www.elastic.co/guide/en/elasticsearch/reference/5.3/docs-reindex.html
-        final String query = SearchSourceBuilder.searchSource()
-                .query(QueryBuilders.matchAllQuery())
-                .size(350)
-                .sort(SortBuilders.fieldSort(FieldSortBuilder.DOC_FIELD_NAME))
-                .toString();
-
-        final Search request = new Search.Builder(query)
-                .setParameter(Parameters.SCROLL, "10s")
-                .addIndex(source)
-                .build();
-
-        final SearchResult searchResult = JestUtils.execute(jestClient, request, () -> "Couldn't process search query response");
-
-        final String scrollId = searchResult.getJsonObject().path("_scroll_id").asText(null);
-        if (scrollId == null) {
-            throw new ElasticsearchException("Couldn't find scroll ID in search query response");
-        }
-
-        while (true) {
-            final SearchScroll scrollRequest = new SearchScroll.Builder(scrollId, "1m").build();
-            final JestResult scrollResult = JestUtils.execute(jestClient, scrollRequest, () -> "Couldn't process result of scroll query");
-            final JsonNode scrollHits = scrollResult.getJsonObject().path("hits").path("hits");
-
-            // No more hits.
-            if (scrollHits.size() == 0) {
-                break;
-            }
-
-            final Bulk.Builder bulkRequestBuilder = new Bulk.Builder();
-            for (JsonNode jsonElement : scrollHits) {
-                final Map<String, Object> doc = Optional.ofNullable(jsonElement.path("_source"))
-                        .map(sourceJson -> objectMapper.<Map<String, Object>>convertValue(sourceJson, TypeReferences.MAP_STRING_OBJECT))
-                        .orElse(Collections.emptyMap());
-                final String id = (String) doc.remove("_id");
-
-                bulkRequestBuilder.addAction(messages.prepareIndexRequest(target, doc, id));
-            }
-
-            final BulkResult bulkResult = JestUtils.execute(jestClient, bulkRequestBuilder.build(), () -> "Couldn't bulk index messages into index " + target);
-
-            final boolean hasFailedItems = !bulkResult.getFailedItems().isEmpty();
+        indicesAdapter.move(source, target, (result) -> {
             LOG.info("Moving index <{}> to <{}>: Bulk indexed {} messages, took {} ms, failures: {}",
                     source,
                     target,
-                    bulkResult.getItems().size(),
-                    bulkResult.getJsonObject().path("took").asLong(),
-                    hasFailedItems);
+                    result,
+                    result.tookMs(),
+                    result.hasFailedItems());
 
-            if (hasFailedItems) {
+            if (result.hasFailedItems()) {
                 throw new ElasticsearchException("Failed to move a message. Check your indexer log.");
             }
-        }
+        });
     }
 
     public void delete(String indexName) {
-        JestUtils.execute(jestClient, new DeleteIndex.Builder(indexName).build(), () -> "Couldn't delete index " + indexName);
+        indicesAdapter.delete(indexName);
         eventBus.post(IndicesDeletedEvent.create(indexName));
     }
 
     public void close(String indexName) {
         if (isReopened(indexName)) {
-            JestUtils.execute(jestClient,
-                new ModifyAliases.Builder(new RemoveAliasMapping.Builder(indexName, indexName + REOPENED_ALIAS_SUFFIX).build()).build(),
-                () -> "Couldn't remove reopened alias for index " + indexName + " before closing.");
+            indicesAdapter.removeAlias(indexName, indexName + REOPENED_ALIAS_SUFFIX);
         }
-        JestUtils.execute(jestClient, new CloseIndex.Builder(indexName).build(), () -> "Couldn't close index " + indexName);
+        indicesAdapter.close(indexName);
         eventBus.post(IndicesClosedEvent.create(indexName));
     }
 
     public long numberOfMessages(String indexName) throws IndexNotFoundException {
-        return indexStats(indexName).path("primaries").path("docs").path("count").asLong();
-    }
-
-    private JsonNode getAllWithShardLevel(final Collection<String> indices) {
-        final Stats request = new Stats.Builder()
-                .addIndex(indices)
-                .setParameter("level", "shards")
-                .build();
-        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't fetch index stats of indices " + indices);
-        final JsonNode responseJson = jestResult.getJsonObject();
-        final int failedShards = responseJson.path("_shards").path("failed").asInt();
-
-        if (failedShards > 0) {
-            throw new ElasticsearchException("Index stats response contains failed shards, response is incomplete");
-        }
-
-        return responseJson.path("indices");
+        return indicesAdapter.numberOfMessages(indexName);
     }
 
     public JsonNode getIndexStats(final IndexSet indexSet) {
-        return getIndexStats(Collections.singleton(indexSet.getIndexWildcard()));
-    }
-
-    private JsonNode getIndexStats(final Collection<String> indices) {
-        final Stats request = new Stats.Builder()
-                .addIndex(indices)
-                .docs(true)
-                .store(true)
-                .build();
-
-        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't check stats of indices " + indices);
-
-        return jestResult.getJsonObject().path("indices");
-    }
-
-    private JsonNode indexStats(final String indexName) {
-        final Stats request = new Stats.Builder()
-                .addIndex(indexName)
-                .build();
-
-        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't check stats of index " + indexName);
-
-        return jestResult.getJsonObject().path("indices").path(indexName);
-    }
-
-    private JsonNode indexStatsWithShardLevel(final String indexName) {
-        final Stats request = new Stats.Builder()
-                .addIndex(indexName)
-                .setParameter("level", "shards")
-                .ignoreUnavailable(true)
-                .build();
-
-        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't check stats of index " + indexName);
-
-        return jestResult.getJsonObject().path("indices").path(indexName);
+        return indicesAdapter.getIndexStats(Collections.singleton(indexSet.getIndexWildcard()));
     }
 
     /**
@@ -275,8 +124,7 @@ public class Indices {
      */
     public boolean exists(String indexName) {
         try {
-            final JestResult result = jestClient.execute(new GetSettings.Builder().addIndex(indexName).build());
-            return result.isSucceeded() && Iterators.contains(result.getJsonObject().fieldNames(), indexName);
+            return indicesAdapter.exists(indexName);
         } catch (IOException e) {
             throw new ElasticsearchException("Couldn't check existence of index " + indexName, e);
         }
@@ -290,8 +138,7 @@ public class Indices {
      */
     public boolean aliasExists(String alias) {
         try {
-            final JestResult result = jestClient.execute(new GetSettings.Builder().addIndex(alias).build());
-            return result.isSucceeded() && !Iterators.contains(result.getJsonObject().fieldNames(), alias);
+            return indicesAdapter.aliasExists(alias);
         } catch (IOException e) {
             throw new ElasticsearchException("Couldn't check existence of alias " + alias, e);
         }
@@ -302,55 +149,11 @@ public class Indices {
      */
     @NotNull
     public Map<String, Set<String>> getIndexNamesAndAliases(String indexPattern) {
-        // only request indices matching the name or pattern in `indexPattern` and only get the alias names for each index,
-        // not the settings or mappings
-        final GetAliases request = new GetAliases.Builder()
-                .addIndex(indexPattern)
-                // ES 6 changed the "expand_wildcards" default value for the /_alias API from "open" to "all".
-                // Since our code expects only open indices to be returned, we have to explicitly set the parameter now.
-                .setParameter("expand_wildcards", "open")
-                .build();
-
-        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't collect aliases for index pattern " + indexPattern);
-
-        final ImmutableMap.Builder<String, Set<String>> indexAliasesBuilder = ImmutableMap.builder();
-        final Iterator<Map.Entry<String, JsonNode>> it = jestResult.getJsonObject().fields();
-        while (it.hasNext()) {
-            final Map.Entry<String, JsonNode> entry = it.next();
-            final String indexName = entry.getKey();
-            final JsonNode aliasMetaData = entry.getValue().path("aliases");
-            if (aliasMetaData.isObject()) {
-                final ImmutableSet<String> aliasNames = ImmutableSet.copyOf(aliasMetaData.fieldNames());
-                indexAliasesBuilder.put(indexName, aliasNames);
-            }
-        }
-
-        return indexAliasesBuilder.build();
+        return indicesAdapter.aliases(indexPattern);
     }
 
     public Optional<String> aliasTarget(String alias) throws TooManyAliasesException {
-        // TODO: This is basically getting all indices and later we filter out the alias we want to check for.
-        //       This can be done in a more efficient way by either using the /_cat/aliases/<alias-name> API or
-        //       the regular /_alias/<alias-name> API.
-        final GetAliases request = new GetAliases.Builder().build();
-        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't collect indices for alias " + alias);
-
-        // The ES return value of this has an awkward format: The first key of the hash is the target index. Thanks.
-        final ImmutableSet.Builder<String> indicesBuilder = ImmutableSet.builder();
-        final Iterator<Map.Entry<String, JsonNode>> it = jestResult.getJsonObject().fields();
-        while (it.hasNext()) {
-            Map.Entry<String, JsonNode> entry = it.next();
-            final String indexName = entry.getKey();
-            Optional.of(entry.getValue())
-                    .map(json -> json.path("aliases"))
-                    .map(JsonNode::fields)
-                    .map(ImmutableList::copyOf)
-                    .filter(aliases -> !aliases.isEmpty())
-                    .filter(aliases -> aliases.stream().anyMatch(aliasEntry -> aliasEntry.getKey().equals(alias)))
-                    .ifPresent(x -> indicesBuilder.add(indexName));
-        }
-
-        final Set<String> indices = indicesBuilder.build();
+        final Set<String> indices = indicesAdapter.resolveAlias(alias);
         if (indices.size() > 1) {
             throw new TooManyAliasesException(indices);
         }
@@ -362,13 +165,12 @@ public class Indices {
         final IndexSetConfig indexSetConfig = indexSet.getConfig();
         final String templateName = indexSetConfig.indexTemplateName();
         final IndexMappingTemplate indexMapping = indexMappingFactory.createIndexMapping(indexSetConfig.indexTemplateType().orElse(IndexSetConfig.DEFAULT_INDEX_TEMPLATE_TYPE));
+
         final Map<String, Object> template = indexMapping.toTemplate(indexSetConfig, indexSet.getIndexWildcard(), -1);
 
-        final PutTemplate request = new PutTemplate.Builder(templateName, template).build();
+        final boolean result = indicesAdapter.ensureIndexTemplate(templateName, template);
 
-        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Unable to create index template " + templateName);
-
-        if (jestResult.isSucceeded()) {
+        if (result) {
             LOG.info("Successfully created index template {}", templateName);
         }
     }
@@ -382,78 +184,48 @@ public class Indices {
     public Map<String, Object> getIndexTemplate(IndexSet indexSet) {
         final String indexWildcard = indexSet.getIndexWildcard();
 
-        return indexMappingFactory.createIndexMapping(indexSet.getConfig().indexTemplateType().orElse(IndexSetConfig.DEFAULT_INDEX_TEMPLATE_TYPE)).toTemplate(indexSet.getConfig(), indexWildcard);
+        return indexMappingFactory.createIndexMapping(
+                indexSet.getConfig()
+                        .indexTemplateType()
+                        .orElse(IndexSetConfig.DEFAULT_INDEX_TEMPLATE_TYPE)
+        ).toTemplate(indexSet.getConfig(), indexWildcard);
     }
 
     public void deleteIndexTemplate(IndexSet indexSet) {
         final String templateName = indexSet.getConfig().indexTemplateName();
-        final JestResult result = JestUtils.execute(jestClient, new DeleteTemplate.Builder(templateName).build(), () -> "Unable to delete the Graylog index template " + templateName);
-        if (result.isSucceeded()) {
+
+        final boolean result = indicesAdapter.deleteIndexTemplate(templateName);
+        if (result) {
             LOG.info("Successfully deleted index template {}", templateName);
         }
     }
 
     public boolean create(String indexName, IndexSet indexSet) {
-        return create(indexName, indexSet, Collections.emptyMap());
-    }
+        final IndexSettings indexSettings = IndexSettings.create(
+                indexSet.getConfig().shards(),
+                indexSet.getConfig().replicas()
+        );
 
-    public boolean create(String indexName, IndexSet indexSet, Map<String, Object> customSettings) {
-        final Map<String, Object> settings = new HashMap<>();
-        settings.put("number_of_shards", indexSet.getConfig().shards());
-        settings.put("number_of_replicas", indexSet.getConfig().replicas());
-        settings.putAll(customSettings);
+        final IndexSetConfig indexSetConfig = indexSet.getConfig();
+        final String templateName = indexSetConfig.indexTemplateName();
+        final IndexMappingTemplate indexMapping = indexMappingFactory.createIndexMapping(indexSetConfig.indexTemplateType().orElse(IndexSetConfig.DEFAULT_INDEX_TEMPLATE_TYPE));
 
-        final CreateIndex request = new CreateIndex.Builder(indexName)
-                .settings(settings)
-                .build();
+        final Map<String, Object> template = indexMapping.toTemplate(indexSetConfig, indexSet.getIndexWildcard(), -1);
 
-        // Make sure our index template exists before creating an index!
-        ensureIndexTemplate(indexSet);
-
-        final JestResult jestResult;
         try {
-            jestResult = jestClient.execute(request);
-        } catch (IOException e) {
-            throw new ElasticsearchException("Couldn't create index " + indexName, e);
+            indicesAdapter.create(indexName, indexSettings, templateName, template);
+        } catch (Exception e) {
+            LOG.warn("Couldn't create index {}. Error: {}", indexName, e.getMessage());
+            auditEventSender.failure(AuditActor.system(nodeId), ES_INDEX_CREATE, ImmutableMap.of("indexName", indexName));
+            return false;
         }
 
-        final boolean succeeded = jestResult.isSucceeded();
-        if (succeeded) {
-            auditEventSender.success(AuditActor.system(nodeId), ES_INDEX_CREATE, ImmutableMap.of("indexName", indexName));
-        } else {
-            LOG.warn("Couldn't create index {}. Error: {}", indexName, jestResult.getErrorMessage());
-            auditEventSender.failure(AuditActor.system(nodeId), ES_INDEX_CREATE, ImmutableMap.of("indexName", indexName));
-        }
-        return succeeded;
+        auditEventSender.success(AuditActor.system(nodeId), ES_INDEX_CREATE, ImmutableMap.of("indexName", indexName));
+        return true;
     }
 
     public Map<String, Set<String>> getAllMessageFieldsForIndices(final String[] writeIndexWildcards) {
-        final String indices = String.join(",", writeIndexWildcards);
-        final State request = new State.Builder()
-                .indices(indices)
-                .withMetadata()
-                .build();
-
-        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't read cluster state for indices " + indices);
-
-        final JsonNode indicesJson = getClusterStateIndicesMetadata(jestResult.getJsonObject());
-        final ImmutableMap.Builder<String, Set<String>> fields = ImmutableMap.builder();
-        final Iterator<Map.Entry<String, JsonNode>> it = indicesJson.fields();
-        while (it.hasNext()) {
-            final Map.Entry<String, JsonNode> entry = it.next();
-            final String indexName = entry.getKey();
-            final Set<String> fieldNames = ImmutableSet.copyOf(
-                    entry.getValue()
-                            .path("mappings")
-                            .path(IndexMapping.TYPE_MESSAGE)
-                            .path("properties").fieldNames()
-            );
-            if (!fieldNames.isEmpty()) {
-                fields.put(indexName, fieldNames);
-            }
-        }
-
-        return fields.build();
+        return indicesAdapter.fieldsInIndices(writeIndexWildcards);
     }
 
     public Set<String> getAllMessageFields(final String[] writeIndexWildcards) {
@@ -466,22 +238,11 @@ public class Indices {
     }
 
     public void setReadOnly(String index) {
-        // https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-update-settings.html
-        final Map<String, Object> settings = ImmutableMap.of(
-                "index", ImmutableMap.of("blocks",
-                        ImmutableMap.of(
-                                "write", true, // Block writing.
-                                "read", false, // Allow reading.
-                                "metadata", false) // Allow getting metadata.
-                )
-        );
-
-        final UpdateSettings request = new UpdateSettings.Builder(settings).addIndex(index).build();
-        JestUtils.execute(jestClient, request, () -> "Couldn't set index " + index + " to read-only");
+        indicesAdapter.setReadOnly(index);
     }
 
     public void flush(String index) {
-        JestUtils.execute(jestClient, new Flush.Builder().addIndex(index).force().build(), () -> "Couldn't flush index " + index);
+        indicesAdapter.flush(index);
     }
 
     public void reopenIndex(String index) {
@@ -493,16 +254,11 @@ public class Indices {
     }
 
     public String markIndexReopened(String index) {
-        final String aliasName = index + REOPENED_ALIAS_SUFFIX;
-        final ModifyAliases request = new ModifyAliases.Builder(new AddAliasMapping.Builder(index, aliasName).build()).build();
-
-        JestUtils.execute(jestClient, request, () -> "Couldn't create reopened alias for index " + index);
-
-        return aliasName;
+        return indicesAdapter.markIndexReopened(index);
     }
 
     private void openIndex(String index) {
-        JestUtils.execute(jestClient, new OpenIndex.Builder(index).build(), () -> "Couldn't open index " + index);
+        indicesAdapter.openIndex(index);
         eventBus.post(IndicesReopenedEvent.create(index));
     }
 
@@ -517,20 +273,7 @@ public class Indices {
     }
 
     public Set<String> getClosedIndices(final Collection<String> indices) {
-        final JsonNode catIndices = catIndices(indices, "index", "status");
-
-        final ImmutableSet.Builder<String> closedIndices = ImmutableSet.builder();
-        for (JsonNode jsonElement : catIndices) {
-            if (jsonElement.isObject()) {
-                final String index = jsonElement.path("index").asText(null);
-                final String status = jsonElement.path("status").asText(null);
-                if (index != null && "close".equals(status)) {
-                    closedIndices.add(index);
-                }
-            }
-        }
-
-        return closedIndices.build();
+        return indicesAdapter.closedIndices(indices);
     }
 
     public Set<String> getClosedIndices(final IndexSet indexSet) {
@@ -547,43 +290,13 @@ public class Indices {
      * @return the set of indices in the given index set
      */
     public Set<String> getIndices(final IndexSet indexSet, final String... statusFilter) {
+        final String indexWildcard = indexSet.getIndexWildcard();
         final List<String> status = Arrays.asList(statusFilter);
-        final Cat catRequest = new Cat.IndicesBuilder()
-                .addIndex(indexSet.getIndexWildcard())
-                .setParameter("h", "index,status")
-                .build();
-
-        final CatResult result = JestUtils.execute(jestClient, catRequest,
-                () -> "Couldn't get index list for index set <" + indexSet.getConfig().id() + ">");
-
-        return StreamSupport.stream(result.getJsonObject().path("result").spliterator(), false)
-                .filter(cat -> status.isEmpty() || status.contains(cat.path("status").asText()))
-                .map(cat -> cat.path("index").asText())
-                .collect(Collectors.toSet());
+        return indicesAdapter.indices(indexWildcard, status, indexSet.getConfig().id());
     }
 
     public boolean isClosed(final String indexName) {
         return getClosedIndices(Collections.singleton(indexName)).contains(indexName);
-    }
-
-    /**
-     * Retrieve the response for the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html">cat indices</a> request from Elasticsearch.
-     *
-     * @param fields The fields to show, see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-indices.html">cat indices API</a>.
-     * @return A {@link JsonNode} with the result of the cat indices request.
-     */
-    private JsonNode catIndices(Collection<String> indices, String... fields) {
-        final String fieldNames = String.join(",", fields);
-        final Cat request = new Cat.IndicesBuilder()
-                .addIndex(indices)
-                .setParameter("h", fieldNames)
-                .build();
-        final CatResult response = JestUtils.execute(jestClient, request, () -> "Unable to read information for indices " + indices);
-        return response.getJsonObject().path("result");
-    }
-
-    private JsonNode getClusterStateIndicesMetadata(JsonNode clusterStateJson) {
-        return clusterStateJson.path("metadata").path("indices");
     }
 
     public Set<String> getReopenedIndices(final Collection<String> indices) {
@@ -597,8 +310,7 @@ public class Indices {
     }
 
     public Optional<IndexStatistics> getIndexStats(String index) {
-        final JsonNode indexStats = indexStatsWithShardLevel(index);
-        return indexStats.isMissingNode() ? Optional.empty() : Optional.of(buildIndexStatistics(index, indexStats));
+        return indicesAdapter.getIndexStats(index);
     }
 
     private IndexStatistics buildIndexStatistics(String index, JsonNode indexStats) {
@@ -606,19 +318,7 @@ public class Indices {
     }
 
     public Optional<Long> getStoreSizeInBytes(String index) {
-        final Stats request = new Stats.Builder()
-                .addIndex(index)
-                .store(true)
-                .build();
-
-        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't check store stats of index " + index);
-        final JsonNode sizeInBytes = jestResult.getJsonObject()
-                .path("indices")
-                .path(index)
-                .path("primaries")
-                .path("store")
-                .path("size_in_bytes");
-        return Optional.of(sizeInBytes).filter(JsonNode::isNumber).map(JsonNode::asLong);
+        return indicesAdapter.storeSizeInBytes(index);
     }
 
     public Set<IndexStatistics> getIndicesStats(final IndexSet indexSet) {
@@ -626,83 +326,32 @@ public class Indices {
     }
 
     public Set<IndexStatistics> getIndicesStats(final Collection<String> indices) {
-        final ImmutableSet.Builder<IndexStatistics> result = ImmutableSet.builder();
-
-        final JsonNode allWithShardLevel = getAllWithShardLevel(indices);
-        final Iterator<Map.Entry<String, JsonNode>> fields = allWithShardLevel.fields();
-        while (fields.hasNext()) {
-            final Map.Entry<String, JsonNode> entry = fields.next();
-            final String index = entry.getKey();
-            final JsonNode indexStats = entry.getValue();
-            if (indexStats.isObject()) {
-                result.add(buildIndexStatistics(index, indexStats));
-            }
-        }
-
-        return result.build();
+        return indicesAdapter.indicesStats(indices);
     }
 
     public void cycleAlias(String aliasName, String targetIndex) {
-        final AddAliasMapping addAliasMapping = new AddAliasMapping.Builder(targetIndex, aliasName).build();
-        JestUtils.execute(jestClient, new ModifyAliases.Builder(addAliasMapping).build(), () -> "Couldn't point alias " + aliasName + " to index " + targetIndex);
+        indicesAdapter.cycleAlias(aliasName, targetIndex);
     }
 
     public void cycleAlias(String aliasName, String targetIndex, String oldIndex) {
-        final AliasMapping addAliasMapping = new AddAliasMapping.Builder(targetIndex, aliasName).build();
-        final AliasMapping removeAliasMapping = new RemoveAliasMapping.Builder(oldIndex, aliasName).build();
-        final ModifyAliases request = new ModifyAliases.Builder(Arrays.asList(removeAliasMapping, addAliasMapping)).build();
-
-        JestUtils.execute(jestClient, request, () -> "Couldn't switch alias " + aliasName + " from index " + oldIndex + " to index " + targetIndex);
+        indicesAdapter.cycleAlias(aliasName, targetIndex, oldIndex);
     }
 
     public void removeAliases(String alias, Set<String> indices) {
-        final AliasMapping removeAliasMapping = new RemoveAliasMapping.Builder(ImmutableList.copyOf(indices), alias).build();
-        final ModifyAliases request = new ModifyAliases.Builder(removeAliasMapping).build();
-        JestUtils.execute(jestClient, request, () -> "Couldn't remove alias " + alias + " from indices " + indices);
+        indicesAdapter.removeAliases(indices, alias);
     }
 
     public void optimizeIndex(String index, int maxNumSegments, Duration timeout) {
-        final RequestConfig requestConfig = RequestConfig.custom()
-                .setSocketTimeout(Ints.saturatedCast(timeout.toMilliseconds()))
-                .build();
-
-        final ForceMerge request = new ForceMerge.Builder()
-                .addIndex(index)
-                .maxNumSegments(maxNumSegments)
-                .flush(true)
-                .onlyExpungeDeletes(false)
-                .build();
-
-        JestUtils.execute(jestClient, requestConfig, request, () -> "Couldn't force merge index " + index);
+        indicesAdapter.optimizeIndex(index, maxNumSegments, timeout);
     }
 
     public Health.Status waitForRecovery(String index) {
-        return waitForStatus(index, Health.Status.YELLOW);
-    }
-
-    private Health.Status waitForStatus(String index, Health.Status clusterHealthStatus) {
-        LOG.debug("Waiting until index health status of index {} is {}", index, clusterHealthStatus);
-        final Health request = new Health.Builder()
-                .addIndex(index)
-                .waitForStatus(clusterHealthStatus)
-                .build();
-        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't read health status for index " + index);
-
-        final String status = jestResult.getJsonObject().path("status").asText();
-        return Health.Status.valueOf(status.toUpperCase(Locale.ENGLISH));
+        LOG.debug("Waiting until index health status of index {} is healthy", index);
+        return indicesAdapter.waitForRecovery(index);
     }
 
     public Optional<DateTime> indexCreationDate(String index) {
-        final GetSettings request = new GetSettings.Builder()
-                .addIndex(index)
-                .ignoreUnavailable(true)
-                .build();
-        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't read settings of index " + index);
-
-        return Optional.of(jestResult.getJsonObject().path(index).path("settings").path("index").path("creation_date"))
-                .filter(JsonNode::isValueNode)
-                .map(JsonNode::asLong)
-                .map(creationDate -> new DateTime(creationDate, DateTimeZone.UTC));
+        return indicesAdapter.indexCreationDate(index);
     }
 
     /**
@@ -713,53 +362,6 @@ public class Indices {
      * @see org.elasticsearch.search.aggregations.metrics.stats.Stats
      */
     public IndexRangeStats indexRangeStatsOfIndex(String index) {
-        final FilterAggregationBuilder builder = AggregationBuilders.filter("agg", QueryBuilders.existsQuery(Message.FIELD_TIMESTAMP))
-                .subAggregation(AggregationBuilders.min("ts_min").field(Message.FIELD_TIMESTAMP))
-                .subAggregation(AggregationBuilders.max("ts_max").field(Message.FIELD_TIMESTAMP))
-                .subAggregation(AggregationBuilders.terms("streams").size(Integer.MAX_VALUE).field(Message.FIELD_STREAMS));
-        final String query = searchSource()
-                .aggregation(builder)
-                .size(0)
-                .toString();
-
-        final Search request = new Search.Builder(query)
-                .addIndex(index)
-                .setSearchType(SearchType.DFS_QUERY_THEN_FETCH)
-                .ignoreUnavailable(true)
-                .build();
-
-        if (LOG.isDebugEnabled()) {
-            String data = "{}";
-            try {
-                data = request.getData(objectMapper.copy().enable(SerializationFeature.INDENT_OUTPUT));
-            } catch (IOException e) {
-                LOG.debug("Couldn't pretty print request payload", e);
-            }
-            LOG.debug("Index range query: _search/{}: {}", index, data);
-        }
-
-        final SearchResult result = JestUtils.execute(jestClient, request, () -> "Couldn't build index range of index " + index);
-
-        final FilterAggregation f = result.getAggregations().getFilterAggregation("agg");
-        if (f == null) {
-            throw new IndexNotFoundException("Couldn't build index range of index " + index + " because it doesn't exist.");
-        } else if (f.getCount() == 0L) {
-            LOG.debug("No documents with attribute \"timestamp\" found in index <{}>", index);
-            return IndexRangeStats.EMPTY;
-        }
-
-        final MinAggregation minAgg = f.getMinAggregation("ts_min");
-        final DateTime min = new DateTime(minAgg.getMin().longValue(), DateTimeZone.UTC);
-        final MaxAggregation maxAgg = f.getMaxAggregation("ts_max");
-        final DateTime max = new DateTime(maxAgg.getMax().longValue(), DateTimeZone.UTC);
-        // make sure we return an empty list, so we can differentiate between old indices that don't have this information
-        // and newer ones that simply have no streams.
-        final TermsAggregation streams = f.getTermsAggregation("streams");
-        final List<String> streamIds = streams.getBuckets().stream()
-                .map(TermsAggregation.Entry::getKeyAsString)
-                .collect(toList());
-
-
-        return IndexRangeStats.create(min, max, streamIds);
+        return indicesAdapter.indexRangeStatsOfIndex(index);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/IndicesAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/IndicesAdapter.java
@@ -1,0 +1,94 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.indices;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.joschi.jadconfig.util.Duration;
+import io.searchbox.cluster.Health;
+import org.graylog2.indexer.indices.stats.IndexStatistics;
+import org.graylog2.indexer.searches.IndexRangeStats;
+import org.joda.time.DateTime;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+
+public interface IndicesAdapter {
+    void move(String source, String target, Consumer<IndexMoveResult> resultCallback);
+
+    void delete(String indexName);
+
+    Set<String> resolveAlias(String alias);
+
+    void create(String indexName, IndexSettings indexSettings, String templateName, Map<String, Object> template);
+
+    boolean ensureIndexTemplate(String templateName, Map<String, Object> template);
+
+    Optional<DateTime> indexCreationDate(String index);
+
+    void openIndex(String index);
+
+    void setReadOnly(String index);
+
+    void flush(String index);
+
+    String markIndexReopened(String index);
+
+    void removeAlias(String indexName, String alias);
+
+    void close(String indexName);
+
+    long numberOfMessages(String indexName);
+
+    boolean aliasExists(String alias) throws IOException;
+
+    Map<String, Set<String>> aliases(String indexPattern);
+
+    boolean deleteIndexTemplate(String templateName);
+
+    Map<String, Set<String>> fieldsInIndices(String[] writeIndexWildcards);
+
+    Set<String> closedIndices(Collection<String> indices);
+
+    Set<IndexStatistics> indicesStats(Collection<String> indices);
+
+    Optional<IndexStatistics> getIndexStats(String index);
+
+    JsonNode getIndexStats(Collection<String> index);
+
+    boolean exists(String indexName) throws IOException;
+
+    Set<String> indices(String indexWildcard, List<String> status, String id);
+
+    Optional<Long> storeSizeInBytes(String index);
+
+    void cycleAlias(String aliasName, String targetIndex);
+
+    void cycleAlias(String aliasName, String targetIndex, String oldIndex);
+
+    void removeAliases(Set<String> indices, String alias);
+
+    void optimizeIndex(String index, int maxNumSegments, Duration timeout);
+
+    IndexRangeStats indexRangeStatsOfIndex(String index);
+
+    Health.Status waitForRecovery(String index);
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/IndicesAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/IndicesAdapter.java
@@ -18,7 +18,6 @@ package org.graylog2.indexer.indices;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.joschi.jadconfig.util.Duration;
-import io.searchbox.cluster.Health;
 import org.graylog2.indexer.indices.stats.IndexStatistics;
 import org.graylog2.indexer.searches.IndexRangeStats;
 import org.joda.time.DateTime;
@@ -90,5 +89,5 @@ public interface IndicesAdapter {
 
     IndexRangeStats indexRangeStatsOfIndex(String index);
 
-    Health.Status waitForRecovery(String index);
+    HealthStatus waitForRecovery(String index);
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/IndicesAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/IndicesAdapter.java
@@ -90,4 +90,8 @@ public interface IndicesAdapter {
     IndexRangeStats indexRangeStatsOfIndex(String index);
 
     HealthStatus waitForRecovery(String index);
+
+    boolean isOpen(String index);
+
+    boolean isClosed(String index);
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -16,9 +16,7 @@
  */
 package org.graylog2.indexer.messages;
 
-import io.searchbox.core.Index;
 import org.graylog2.indexer.IndexFailure;
-import org.graylog2.indexer.IndexMapping;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.plugin.Message;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -130,16 +130,6 @@ public class Messages {
                 .collect(Collectors.toList());
     }
 
-    public Index prepareIndexRequest(String index, Map<String, Object> source, String id) {
-        source.remove(Message.FIELD_ID);
-
-        return new Index.Builder(source)
-                .index(index)
-                .type(IndexMapping.TYPE_MESSAGE)
-                .id(id)
-                .build();
-    }
-
     public LinkedBlockingQueue<List<IndexFailure>> getIndexFailureQueue() {
         return indexFailureQueue;
     }

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRotationThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRotationThread.java
@@ -16,12 +16,12 @@
  */
 package org.graylog2.periodical;
 
-import io.searchbox.cluster.Health;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.IndexSetRegistry;
 import org.graylog2.indexer.NoTargetIndexException;
 import org.graylog2.indexer.cluster.Cluster;
 import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indices.HealthStatus;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.indexer.indices.TooManyAliasesException;
 import org.graylog2.notifications.Notification;
@@ -160,7 +160,7 @@ public class IndexRotationThread extends Periodical {
                     LOG.warn(msg);
                     activityWriter.write(new Activity(msg, IndexRotationThread.class));
 
-                    if (Health.Status.RED == indices.waitForRecovery(shouldBeTarget)) {
+                    if (indices.waitForRecovery(shouldBeTarget) == HealthStatus.Red) {
                         LOG.error("New target index for deflector didn't get healthy within timeout. Skipping deflector update.");
                     } else {
                         indexSet.pointTo(shouldBeTarget, currentTarget);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/MongoIndexSetTest.java
@@ -18,9 +18,9 @@ package org.graylog2.indexer;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import io.searchbox.cluster.Health;
 import org.graylog2.audit.AuditEventSender;
 import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.indexer.indices.HealthStatus;
 import org.graylog2.indexer.indices.Indices;
 import org.graylog2.indexer.indices.jobs.SetIndexReadOnlyAndCalculateRangeJob;
 import org.graylog2.indexer.ranges.IndexRangeService;
@@ -261,7 +261,7 @@ public class MongoIndexSetTest {
 
         when(indices.getIndexNamesAndAliases(anyString())).thenReturn(indexNameAliases);
         when(indices.create(newIndexName, mongoIndexSet)).thenReturn(true);
-        when(indices.waitForRecovery(newIndexName)).thenReturn(Health.Status.GREEN);
+        when(indices.waitForRecovery(newIndexName)).thenReturn(HealthStatus.Green);
 
         final MongoIndexSet mongoIndexSet = new MongoIndexSet(config, indices, nodeId, indexRangeService, auditEventSender, systemJobManager, jobFactory, activityWriter);
         mongoIndexSet.cycle();
@@ -278,7 +278,7 @@ public class MongoIndexSetTest {
 
         when(indices.getIndexNamesAndAliases(anyString())).thenReturn(indexNameAliases);
         when(indices.create(newIndexName, mongoIndexSet)).thenReturn(true);
-        when(indices.waitForRecovery(newIndexName)).thenReturn(Health.Status.GREEN);
+        when(indices.waitForRecovery(newIndexName)).thenReturn(HealthStatus.Green);
 
         final SetIndexReadOnlyAndCalculateRangeJob rangeJob = mock(SetIndexReadOnlyAndCalculateRangeJob.class);
         when(jobFactory.create(oldIndexName)).thenReturn(rangeJob);
@@ -300,7 +300,7 @@ public class MongoIndexSetTest {
 
         when(indices.getIndexNamesAndAliases(anyString())).thenReturn(indexNameAliases);
         when(indices.create(newIndexName, mongoIndexSet)).thenReturn(true);
-        when(indices.waitForRecovery(newIndexName)).thenReturn(Health.Status.GREEN);
+        when(indices.waitForRecovery(newIndexName)).thenReturn(HealthStatus.Green);
 
         final MongoIndexSet mongoIndexSet = new MongoIndexSet(config, indices, nodeId, indexRangeService, auditEventSender, systemJobManager, jobFactory, activityWriter);
         mongoIndexSet.cycle();
@@ -315,7 +315,7 @@ public class MongoIndexSetTest {
 
         when(indices.getIndexNamesAndAliases(anyString())).thenReturn(indexNameAliases);
         when(indices.create(indexName, mongoIndexSet)).thenReturn(true);
-        when(indices.waitForRecovery(indexName)).thenReturn(Health.Status.GREEN);
+        when(indices.waitForRecovery(indexName)).thenReturn(HealthStatus.Green);
 
         final MongoIndexSet mongoIndexSet = new MongoIndexSet(config, indices, nodeId, indexRangeService, auditEventSender, systemJobManager, jobFactory, activityWriter);
         mongoIndexSet.cycle();

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
@@ -26,16 +26,13 @@ import org.graylog2.indexer.TestIndexSet;
 import org.graylog2.indexer.cluster.Node;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.indexer.indices.Indices;
-import org.graylog2.indexer.messages.Messages;
-import org.graylog2.indexer.messages.MessagesAdapter;
-import org.graylog2.indexer.messages.TrafficAccounting;
+import org.graylog2.indexer.indices.IndicesAdapter;
 import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategy;
 import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategyConfig;
 import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategyConfig;
 import org.graylog2.plugin.system.NodeId;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
-import org.graylog2.system.processing.ProcessingStatusRecorder;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -73,13 +70,13 @@ public class IndexFieldTypePollerIT extends ElasticsearchBaseTest {
 
     @Before
     public void setUp() throws Exception {
-        final Indices indices = new Indices(jestClient(),
+        final Indices indices = new Indices(
                 new ObjectMapperProvider().get(),
                 new IndexMappingFactory(new Node(jestClient())),
-                new Messages(mock(TrafficAccounting.class), mock(MessagesAdapter.class), mock(ProcessingStatusRecorder.class)),
                 mock(NodeId.class),
                 new NullAuditEventSender(),
-                new EventBus("index-field-type-poller-it"));
+                new EventBus("index-field-type-poller-it"),
+                mock(IndicesAdapter.class));
         poller = new IndexFieldTypePoller(jestClient(), indices, new MetricRegistry());
         indexSet = new TestIndexSet(indexSetConfig);
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
@@ -43,7 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 // JSON data in: src/test/resources/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.json
-public class IndexFieldTypePollerIT extends ElasticsearchBaseTest {
+public abstract class IndexFieldTypePollerIT extends ElasticsearchBaseTest {
     private static final String INDEX_NAME = "graylog_0";
 
     private IndexFieldTypePoller poller;
@@ -67,6 +67,8 @@ public class IndexFieldTypePollerIT extends ElasticsearchBaseTest {
             .build();
     private TestIndexSet indexSet;
 
+    protected abstract IndicesAdapter createIndicesAdapter();
+
     @Before
     public void setUp() throws Exception {
         final Indices indices = new Indices(
@@ -74,12 +76,12 @@ public class IndexFieldTypePollerIT extends ElasticsearchBaseTest {
                 mock(NodeId.class),
                 new NullAuditEventSender(),
                 new EventBus("index-field-type-poller-it"),
-                mock(IndicesAdapter.class)
+                createIndicesAdapter()
         );
         poller = new IndexFieldTypePoller(jestClient(), indices, new MetricRegistry());
         indexSet = new TestIndexSet(indexSetConfig);
 
-        importFixture("IndexFieldTypePollerIT.json");
+        importFixture("org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.json");
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
@@ -32,7 +32,6 @@ import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategyConfig
 import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategyConfig;
 import org.graylog2.plugin.system.NodeId;
-import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -71,12 +70,12 @@ public class IndexFieldTypePollerIT extends ElasticsearchBaseTest {
     @Before
     public void setUp() throws Exception {
         final Indices indices = new Indices(
-                new ObjectMapperProvider().get(),
                 new IndexMappingFactory(new Node(jestClient())),
                 mock(NodeId.class),
                 new NullAuditEventSender(),
                 new EventBus("index-field-type-poller-it"),
-                mock(IndicesAdapter.class));
+                mock(IndicesAdapter.class)
+        );
         poller = new IndexFieldTypePoller(jestClient(), indices, new MetricRegistry());
         indexSet = new TestIndexSet(indexSetConfig);
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerIT.java
@@ -71,11 +71,11 @@ public abstract class IndexFieldTypePollerIT extends ElasticsearchBaseTest {
 
     @Before
     public void setUp() throws Exception {
-        final Indices indices = new Indices(
+        @SuppressWarnings("UnstableApiUsage") final Indices indices = new Indices(
                 new IndexMappingFactory(new Node(jestClient())),
                 mock(NodeId.class),
                 new NullAuditEventSender(),
-                new EventBus("index-field-type-poller-it"),
+                mock(EventBus.class),
                 createIndicesAdapter()
         );
         poller = new IndexFieldTypePoller(jestClient(), indices, new MetricRegistry());

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesGetAllMessageFieldsIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesGetAllMessageFieldsIT.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.indexer.indices;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.eventbus.EventBus;
 import org.graylog.testing.elasticsearch.ElasticsearchBaseTest;
 import org.graylog.testing.elasticsearch.SkipDefaultIndexTemplate;
@@ -49,12 +48,12 @@ public abstract class IndicesGetAllMessageFieldsIT extends ElasticsearchBaseTest
         final Node node = new Node(jestClient());
         //noinspection UnstableApiUsage
         indices = new Indices(
-                new ObjectMapper(),
                 new IndexMappingFactory(node),
                 mock(NodeId.class),
                 new NullAuditEventSender(),
                 new EventBus(),
-                indicesAdapter());
+                indicesAdapter()
+        );
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesGetAllMessageFieldsIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesGetAllMessageFieldsIT.java
@@ -23,15 +23,10 @@ import org.graylog.testing.elasticsearch.SkipDefaultIndexTemplate;
 import org.graylog2.audit.NullAuditEventSender;
 import org.graylog2.indexer.IndexMappingFactory;
 import org.graylog2.indexer.cluster.Node;
-import org.graylog2.indexer.messages.Messages;
-import org.graylog2.indexer.messages.MessagesAdapter;
-import org.graylog2.indexer.messages.TrafficAccounting;
 import org.graylog2.plugin.system.NodeId;
-import org.graylog2.system.processing.ProcessingStatusRecorder;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
@@ -41,26 +36,25 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-public class IndicesGetAllMessageFieldsIT extends ElasticsearchBaseTest {
+public abstract class IndicesGetAllMessageFieldsIT extends ElasticsearchBaseTest {
     @Rule
     public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
-    @Mock
-    private MessagesAdapter messagesAdapter;
-
     private Indices indices;
+
+    protected abstract IndicesAdapter indicesAdapter();
 
     @Before
     public void setUp() throws Exception {
         final Node node = new Node(jestClient());
         //noinspection UnstableApiUsage
-        indices = new Indices(jestClient(),
+        indices = new Indices(
                 new ObjectMapper(),
                 new IndexMappingFactory(node),
-                new Messages(mock(TrafficAccounting.class), messagesAdapter, mock(ProcessingStatusRecorder.class)),
                 mock(NodeId.class),
                 new NullAuditEventSender(),
-                new EventBus());
+                new EventBus(),
+                indicesAdapter());
     }
 
     @Test
@@ -83,7 +77,7 @@ public class IndicesGetAllMessageFieldsIT extends ElasticsearchBaseTest {
     @Test
     @SkipDefaultIndexTemplate
     public void GetAllMessageFieldsForSingleIndexShouldReturnCompleteList() {
-        importFixture("IndicesGetAllMessageFieldsIT-MultipleIndices.json");
+        importFixture("org/graylog2/indexer/indices/IndicesGetAllMessageFieldsIT-MultipleIndices.json");
 
         final String[] indexNames = new String[]{"get_all_message_fields_0"};
         final Set<String> result = indices.getAllMessageFields(indexNames);
@@ -106,7 +100,7 @@ public class IndicesGetAllMessageFieldsIT extends ElasticsearchBaseTest {
     @Test
     @SkipDefaultIndexTemplate
     public void GetAllMessageFieldsForMultipleIndicesShouldReturnCompleteList() {
-        importFixture("IndicesGetAllMessageFieldsIT-MultipleIndices.json");
+        importFixture("org/graylog2/indexer/indices/IndicesGetAllMessageFieldsIT-MultipleIndices.json");
 
         final String[] indexNames = new String[]{"get_all_message_fields_0", "get_all_message_fields_1"};
         final Set<String> result = indices.getAllMessageFields(indexNames);
@@ -142,7 +136,7 @@ public class IndicesGetAllMessageFieldsIT extends ElasticsearchBaseTest {
     @Test
     @SkipDefaultIndexTemplate
     public void GetAllMessageFieldsForIndicesForSingleIndexShouldReturnCompleteList() {
-        importFixture("IndicesGetAllMessageFieldsIT-MultipleIndices.json");
+        importFixture("org/graylog2/indexer/indices/IndicesGetAllMessageFieldsIT-MultipleIndices.json");
 
         final String indexName = "get_all_message_fields_0";
         final String[] indexNames = new String[]{indexName};
@@ -177,7 +171,7 @@ public class IndicesGetAllMessageFieldsIT extends ElasticsearchBaseTest {
     @Test
     @SkipDefaultIndexTemplate
     public void GetAllMessageFieldsForIndicesForMultipleIndicesShouldReturnCompleteList() {
-        importFixture("IndicesGetAllMessageFieldsIT-MultipleIndices.json");
+        importFixture("org/graylog2/indexer/indices/IndicesGetAllMessageFieldsIT-MultipleIndices.json");
 
         final String[] indexNames = new String[]{"get_all_message_fields_0", "get_all_message_fields_1"};
         final Map<String, Set<String>> result = indices.getAllMessageFieldsForIndices(indexNames);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
@@ -102,12 +102,12 @@ public abstract class IndicesIT extends ElasticsearchBaseTest {
         final Node node = new Node(jestClient());
         indexMappingFactory = new IndexMappingFactory(node);
         indices = new Indices(
-                new ObjectMapperProvider().get(),
                 indexMappingFactory,
                 mock(NodeId.class),
                 new NullAuditEventSender(),
                 eventBus,
-                indicesAdapter());
+                indicesAdapter()
+        );
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
@@ -21,8 +21,6 @@ import com.google.common.collect.Maps;
 import io.searchbox.client.JestResult;
 import io.searchbox.core.Count;
 import io.searchbox.core.CountResult;
-import io.searchbox.core.DocumentResult;
-import io.searchbox.core.Index;
 import joptsimple.internal.Strings;
 import org.graylog.testing.elasticsearch.ElasticsearchBaseTest;
 import org.graylog2.indexer.IndexSet;
@@ -102,10 +100,8 @@ public abstract class MessagesIT extends ElasticsearchBaseTest {
         source.put("message", "message");
         source.put("source", "source");
         source.put("timestamp", "2017-04-13 15:29:00.000");
-        final Index indexRequest = messages.prepareIndexRequest(index, source, "1");
-        final DocumentResult indexResponse = jestClient().execute(indexRequest);
 
-        assertThat(indexResponse.isSucceeded()).isTrue();
+        assertThat(indexMessage(index, source, "1")).isTrue();
 
         final ResultMessage resultMessage = messages.get("1", index);
         final Message message = resultMessage.getMessage();
@@ -113,6 +109,8 @@ public abstract class MessagesIT extends ElasticsearchBaseTest {
         assertThat(message.hasField(JestResult.ES_METADATA_ID)).isFalse();
         assertThat(message.hasField(JestResult.ES_METADATA_VERSION)).isFalse();
     }
+
+    protected abstract boolean indexMessage(String index, Map<String, Object> source, String id);
 
     @Test
     public void testIfTooLargeBatchesGetSplitUp() throws Exception {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
@@ -18,15 +18,11 @@ package org.graylog2.indexer.messages;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Maps;
-import io.searchbox.client.JestResult;
-import io.searchbox.core.Count;
-import io.searchbox.core.CountResult;
 import joptsimple.internal.Strings;
 import org.graylog.testing.elasticsearch.ElasticsearchBaseTest;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.TestIndexSet;
 import org.graylog2.indexer.indexset.IndexSetConfig;
-import org.graylog2.indexer.results.ResultMessage;
 import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategy;
 import org.graylog2.indexer.retention.strategies.DeletionRetentionStrategyConfig;
 import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
@@ -42,10 +38,8 @@ import org.junit.Test;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -53,9 +47,7 @@ import static org.mockito.Mockito.mock;
 public abstract class MessagesIT extends ElasticsearchBaseTest {
     private static final String INDEX_NAME = "messages_it_deflector";
 
-    private Messages messages;
-
-    private Count count;
+    protected Messages messages;
 
     private static final IndexSetConfig indexSetConfig = IndexSetConfig.builder()
             .id("index-set-1")
@@ -83,7 +75,6 @@ public abstract class MessagesIT extends ElasticsearchBaseTest {
         client().deleteIndices(INDEX_NAME);
         client().createIndex(INDEX_NAME);
         client().waitForGreenStatus(INDEX_NAME);
-        count = new Count.Builder().addIndex(INDEX_NAME).build();
         final MetricRegistry metricRegistry = new MetricRegistry();
         messages = new Messages(mock(TrafficAccounting.class), createMessagesAdapter(metricRegistry), mock(ProcessingStatusRecorder.class));
     }
@@ -92,25 +83,6 @@ public abstract class MessagesIT extends ElasticsearchBaseTest {
     public void tearDown() {
         client().deleteIndices(INDEX_NAME);
     }
-
-    @Test
-    public void getResultDoesNotContainJestMetadataFields() throws Exception {
-        final String index = UUID.randomUUID().toString();
-        final Map<String, Object> source = new HashMap<>();
-        source.put("message", "message");
-        source.put("source", "source");
-        source.put("timestamp", "2017-04-13 15:29:00.000");
-
-        assertThat(indexMessage(index, source, "1")).isTrue();
-
-        final ResultMessage resultMessage = messages.get("1", index);
-        final Message message = resultMessage.getMessage();
-        assertThat(message).isNotNull();
-        assertThat(message.hasField(JestResult.ES_METADATA_ID)).isFalse();
-        assertThat(message.hasField(JestResult.ES_METADATA_VERSION)).isFalse();
-    }
-
-    protected abstract boolean indexMessage(String index, Map<String, Object> source, String id);
 
     @Test
     public void testIfTooLargeBatchesGetSplitUp() throws Exception {
@@ -125,9 +97,10 @@ public abstract class MessagesIT extends ElasticsearchBaseTest {
 
         Thread.sleep(2000); // wait for ES to finish indexing
 
-        final CountResult result = jestClient().execute(count);
-        assertThat(result.getCount()).isEqualTo(MESSAGECOUNT);
+        assertThat(messageCount(INDEX_NAME)).isEqualTo(MESSAGECOUNT);
     }
+
+    protected abstract Double messageCount(String indexName);
 
     @Test
     public void unevenTooLargeBatchesGetSplitUp() throws Exception {
@@ -140,9 +113,8 @@ public abstract class MessagesIT extends ElasticsearchBaseTest {
         assertThat(failedItems).isEmpty();
 
         Thread.sleep(2000); // wait for ES to finish indexing
-        final CountResult result = jestClient().execute(count);
 
-        assertThat(result.getCount()).isEqualTo(MESSAGECOUNT + LARGE_MESSAGECOUNT);
+        assertThat(messageCount(INDEX_NAME)).isEqualTo(MESSAGECOUNT + LARGE_MESSAGECOUNT);
     }
 
     private ArrayList<Map.Entry<IndexSet, Message>> createMessageBatch(int size, int count) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is extracting a `IndicesAdapter` interface from the `Indices` class, that allows us to separate the Elasticsearch-specific implementation details from the consumer of that interface. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.