### PR TITLE
Extract interface from `Cluster` class.

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/ClusterAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/ClusterAdapterES6.java
@@ -40,7 +40,7 @@ public class ClusterAdapterES6 implements ClusterAdapter {
 
     @Inject
     public ClusterAdapterES6(JestClient jestClient,
-                             @Named("elasticsearch_request_timeout") Duration requestTimeout) {
+                             @Named("elasticsearch_socket_timeout") Duration requestTimeout) {
         this.jestClient = jestClient;
         this.requestTimeout = requestTimeout;
     }

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/ClusterAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/ClusterAdapterES6.java
@@ -1,0 +1,231 @@
+package org.graylog.storage.elasticsearch6;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
+import com.github.joschi.jadconfig.util.Duration;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Ints;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestResult;
+import io.searchbox.cluster.Health;
+import io.searchbox.cluster.NodesInfo;
+import io.searchbox.core.Cat;
+import io.searchbox.core.CatResult;
+import org.graylog2.indexer.ElasticsearchException;
+import org.graylog2.indexer.cluster.ClusterAdapter;
+import org.graylog2.indexer.cluster.health.ClusterAllocationDiskSettings;
+import org.graylog2.indexer.cluster.health.ClusterAllocationDiskSettingsFactory;
+import org.graylog2.indexer.cluster.health.NodeDiskUsageStats;
+import org.graylog2.indexer.cluster.health.NodeFileDescriptorStats;
+import org.graylog2.indexer.cluster.jest.GetAllocationDiskSettings;
+import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog2.indexer.indices.HealthStatus;
+import org.graylog2.rest.models.system.indexer.responses.ClusterHealth;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+
+public class ClusterAdapterES6 implements ClusterAdapter {
+    private static final Logger LOG = LoggerFactory.getLogger(ClusterAdapterES6.class);
+    private final JestClient jestClient;
+    private final Duration requestTimeout;
+
+    @Inject
+    public ClusterAdapterES6(JestClient jestClient,
+                             @Named("elasticsearch_request_timeout") Duration requestTimeout) {
+        this.jestClient = jestClient;
+        this.requestTimeout = requestTimeout;
+    }
+
+    @Override
+    public Optional<HealthStatus> health(List<String> indices) {
+        final Optional<JsonNode> result = clusterHealth(indices);
+        return result.map(this::extractHealthStatus);
+    }
+
+    private HealthStatus extractHealthStatus(JsonNode node) {
+        final String statusString = node.path("status").asText().toLowerCase(Locale.ENGLISH);
+        switch (statusString) {
+            case "red": return HealthStatus.Red;
+            case "yellow": return HealthStatus.Yellow;
+            case "green": return HealthStatus.Green;
+            default: throw new IllegalStateException("Unable to parse health status (known: green/yellow/red): " + statusString);
+        }
+    }
+
+    @Override
+    public Optional<HealthStatus> deflectorHealth(List<String> indices) {
+        final Optional<JsonNode> result = clusterHealth(indices);
+        return result.map(this::extractHealthStatus);
+    }
+
+    @Override
+    public Set<NodeFileDescriptorStats> fileDescriptorStats() {
+        final JsonNode nodes = catNodes("name", "host", "ip", "fileDescriptorMax");
+        final ImmutableSet.Builder<NodeFileDescriptorStats> setBuilder = ImmutableSet.builder();
+        for (JsonNode jsonElement : nodes) {
+            if (jsonElement.isObject()) {
+                final String name = jsonElement.path("name").asText();
+                final String host = jsonElement.path("host").asText(null);
+                final String ip = jsonElement.path("ip").asText();
+                final JsonNode fileDescriptorMax = jsonElement.path("fileDescriptorMax");
+                final Long maxFileDescriptors = fileDescriptorMax.isLong() ? fileDescriptorMax.asLong() : null;
+                setBuilder.add(NodeFileDescriptorStats.create(name, ip, host, maxFileDescriptors));
+            }
+        }
+
+        return setBuilder.build();
+    }
+
+    @Override
+    public Set<NodeDiskUsageStats> diskUsageStats() {
+        final JsonNode nodes = catNodes("name", "host", "ip", "diskUsed", "diskTotal","diskUsedPercent");
+        final ImmutableSet.Builder<NodeDiskUsageStats> setBuilder = ImmutableSet.builder();
+        for (JsonNode jsonElement : nodes) {
+            if (jsonElement.isObject()) {
+                setBuilder.add(
+                        NodeDiskUsageStats.create(
+                                jsonElement.path("name").asText(),
+                                jsonElement.path("ip").asText(),
+                                jsonElement.path("host").asText(null),
+                                jsonElement.path("diskUsed").asText(),
+                                jsonElement.path("diskTotal").asText(),
+                                jsonElement.path("diskUsedPercent").asDouble(NodeDiskUsageStats.DEFAULT_DISK_USED_PERCENT)
+                        )
+                );
+            }
+        }
+        return setBuilder.build();
+    }
+
+    @Override
+    public ClusterAllocationDiskSettings clusterAllocationDiskSettings() {
+        final GetAllocationDiskSettings request = new GetAllocationDiskSettings.Builder().build();
+        final JestResult response = JestUtils.execute(jestClient, request, () -> "Unable to read Elasticsearch cluster settings");
+        final JsonNode json = response.getJsonObject();
+        final JsonNode floodStageSetting = findEffectiveSettingInSettingsGroups(json, "flood_stage", true);
+        return ClusterAllocationDiskSettingsFactory.create(
+                findEffectiveSettingInSettingsGroups(json, "threshold_enabled", false).asBoolean(),
+                findEffectiveSettingInSettingsGroups(json, "low", false).asText(),
+                findEffectiveSettingInSettingsGroups(json, "high", false).asText(),
+                floodStageSetting != null ? floodStageSetting.asText() : ""
+        );
+    }
+
+    @Override
+    public Optional<String> nodeIdToName(String nodeId) {
+        return Optional.ofNullable(getNodeInfo(nodeId).path("name").asText(null));
+    }
+
+    @Override
+    public Optional<String> nodeIdToHostName(String nodeId) {
+        return Optional.ofNullable(getNodeInfo(nodeId).path("host").asText(null));
+    }
+
+    @Override
+    public boolean isConnected() {
+        final Health request = new Health.Builder()
+                .local()
+                .timeout(Ints.saturatedCast(requestTimeout.toSeconds()))
+                .build();
+
+        try {
+            final JestResult result = JestUtils.execute(jestClient, request, () -> "Couldn't check connection status of Elasticsearch");
+            final int numberOfDataNodes = result.getJsonObject().path("number_of_data_nodes").asInt();
+            return numberOfDataNodes > 0;
+        } catch (ElasticsearchException e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.error(e.getMessage(), e);
+            }
+            return false;
+        }
+    }
+
+    @Override
+    public Optional<String> clusterName(List<String> indices) {
+        return clusterHealth(indices).map(health -> health.path("cluster_name").asText("<unknown>"));
+    }
+
+    @Override
+    public Optional<ClusterHealth> clusterHealthStats(List<String> indices) {
+        return clusterHealth(indices).map(health -> {
+            final ClusterHealth.ShardStatus shards = ClusterHealth.ShardStatus.create(
+                    health.path("active_shards").asInt(),
+                    health.path("initializing_shards").asInt(),
+                    health.path("relocating_shards").asInt(),
+                    health.path("unassigned_shards").asInt());
+
+            return ClusterHealth.create(health.path("status").asText().toLowerCase(Locale.ENGLISH), shards);
+        });
+    }
+
+    private JsonNode getNodeInfo(String nodeId) {
+        if (nodeId == null || nodeId.isEmpty()) {
+            return MissingNode.getInstance();
+        }
+
+        final NodesInfo request = new NodesInfo.Builder().addNode(nodeId).build();
+        final JestResult result = JestUtils.execute(jestClient, request, () -> "Couldn't read information of Elasticsearch node " + nodeId);
+        return result.getJsonObject().path("nodes").path(nodeId);
+    }
+
+    private JsonNode findEffectiveSettingInSettingsGroups(JsonNode jsonNode, String setting, boolean optional) {
+        List<String> settingsGroup = Arrays.asList("transient", "persistent", "defaults");
+        for(String group: settingsGroup) {
+            JsonNode foundGroup = jsonNode.findPath(group);
+            if (!(foundGroup instanceof MissingNode)) {
+                JsonNode foundSetting = foundGroup.findPath(setting);
+                if (!(foundSetting instanceof MissingNode)) {
+                    return foundSetting;
+                }
+            }
+        }
+        if (optional) {
+            return null;
+        }
+        throw new IllegalStateException(String.format(Locale.ENGLISH, "Could not find setting %s in Elasticsearch response", setting));
+    }
+
+    /**
+     * Retrieve the response for the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-nodes.html">cat nodes</a> request from Elasticsearch.
+     *
+     * @param fields The fields to show, see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-nodes.html">cat nodes API</a>.
+     * @return A {@link JsonNode} with the result of the cat nodes request.
+     */
+    private JsonNode catNodes(String... fields) {
+        final String fieldNames = String.join(",", fields);
+        final Cat request = new Cat.NodesBuilder()
+                .setParameter("h", fieldNames)
+                .setParameter("full_id", true)
+                .setParameter("format", "json")
+                .build();
+        final CatResult response = JestUtils.execute(jestClient, request, () -> "Unable to read Elasticsearch node information");
+        return response.getJsonObject().path("result");
+    }
+
+    private Optional<JsonNode> clusterHealth(Collection<? extends String> indices) {
+        final Health request = new Health.Builder()
+                .addIndex(indices)
+                .timeout(Ints.saturatedCast(requestTimeout.toSeconds()))
+                .build();
+        try {
+            final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't read cluster health for indices " + indices);
+            return Optional.of(jestResult.getJsonObject());
+        } catch(ElasticsearchException e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.error("{} ({})", e.getMessage(), Optional.ofNullable(e.getCause()).map(Throwable::getMessage).orElse("n/a"), e);
+            } else {
+                LOG.error("{} ({})", e.getMessage(), Optional.ofNullable(e.getCause()).map(Throwable::getMessage).orElse("n/a"));
+            }
+            return Optional.empty();
+        }
+    }
+}

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Module.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Module.java
@@ -1,17 +1,19 @@
 package org.graylog.storage.elasticsearch6;
 
-import org.graylog2.indexer.indices.IndicesAdapter;
+import org.graylog2.indexer.cluster.ClusterAdapter;
 import org.graylog.events.search.MoreSearchAdapter;
 import org.graylog2.indexer.searches.SearchesAdapter;
 import org.graylog2.indexer.messages.MessagesAdapter;
+import org.graylog2.indexer.indices.IndicesAdapter;
 import org.graylog2.plugin.PluginModule;
 
 public class Elasticsearch6Module extends PluginModule {
     @Override
     protected void configure() {
-        bind(IndicesAdapter.class).to(IndicesAdapterES6.class);
         bind(SearchesAdapter.class).to(SearchesAdapterES6.class);
         bind(MoreSearchAdapter.class).to(MoreSearchAdapterES6.class);
+        bind(IndicesAdapter.class).to(IndicesAdapterES6.class);
+        bind(ClusterAdapter.class).to(ClusterAdapterES6.class);
         bind(MessagesAdapter.class).to(MessagesAdapterES6.class);
     }
 }

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/ClusterES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/ClusterES6IT.java
@@ -1,0 +1,12 @@
+package org.graylog.storage.elasticsearch6;
+
+import com.github.joschi.jadconfig.util.Duration;
+import org.graylog2.indexer.cluster.ClusterAdapter;
+import org.graylog2.indexer.cluster.ClusterIT;
+
+public class ClusterES6IT extends ClusterIT {
+    @Override
+    protected ClusterAdapter clusterAdapter(Duration timeout) {
+        return new ClusterAdapterES6(jestClient(), timeout);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
@@ -16,25 +16,13 @@
  */
 package org.graylog2.indexer.cluster;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.MissingNode;
 import com.github.joschi.jadconfig.util.Duration;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.primitives.Ints;
-import io.searchbox.client.JestClient;
-import io.searchbox.client.JestResult;
-import io.searchbox.cluster.Health;
-import io.searchbox.cluster.NodesInfo;
-import io.searchbox.core.Cat;
-import io.searchbox.core.CatResult;
-import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.indexer.IndexSetRegistry;
-import org.graylog2.indexer.cluster.jest.GetAllocationDiskSettings;
-import org.graylog2.indexer.cluster.jest.JestUtils;
 import org.graylog2.indexer.cluster.health.ClusterAllocationDiskSettings;
-import org.graylog2.indexer.cluster.health.ClusterAllocationDiskSettingsFactory;
 import org.graylog2.indexer.cluster.health.NodeDiskUsageStats;
 import org.graylog2.indexer.cluster.health.NodeFileDescriptorStats;
+import org.graylog2.indexer.indices.HealthStatus;
+import org.graylog2.rest.models.system.indexer.responses.ClusterHealth;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,9 +30,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -57,38 +43,20 @@ import java.util.concurrent.TimeoutException;
 public class Cluster {
     private static final Logger LOG = LoggerFactory.getLogger(Cluster.class);
 
-    private final JestClient jestClient;
     private final IndexSetRegistry indexSetRegistry;
     private final ScheduledExecutorService scheduler;
     private final Duration requestTimeout;
+    private final ClusterAdapter clusterAdapter;
 
     @Inject
-    public Cluster(JestClient jestClient,
-                   IndexSetRegistry indexSetRegistry,
+    public Cluster(IndexSetRegistry indexSetRegistry,
                    @Named("daemonScheduler") ScheduledExecutorService scheduler,
-                   @Named("elasticsearch_socket_timeout") Duration requestTimeout) {
+                   @Named("elasticsearch_socket_timeout") Duration requestTimeout,
+                   ClusterAdapter clusterAdapter) {
         this.scheduler = scheduler;
-        this.jestClient = jestClient;
         this.indexSetRegistry = indexSetRegistry;
         this.requestTimeout = requestTimeout;
-    }
-
-    private Optional<JsonNode> clusterHealth(Collection<? extends String> indices) {
-        final Health request = new Health.Builder()
-                .addIndex(indices)
-                .timeout(Ints.saturatedCast(requestTimeout.toSeconds()))
-                .build();
-        try {
-            final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't read cluster health for indices " + indices);
-            return Optional.of(jestResult.getJsonObject());
-        } catch(ElasticsearchException e) {
-            if (LOG.isDebugEnabled()) {
-                LOG.error("{} ({})", e.getMessage(), Optional.ofNullable(e.getCause()).map(Throwable::getMessage).orElse("n/a"), e);
-            } else {
-                LOG.error("{} ({})", e.getMessage(), Optional.ofNullable(e.getCause()).map(Throwable::getMessage).orElse("n/a"));
-            }
-            return Optional.empty();
-        }
+        this.clusterAdapter = clusterAdapter;
     }
 
     /**
@@ -96,8 +64,12 @@ public class Cluster {
      *
      * @return the cluster health response
      */
-    public Optional<JsonNode> health() {
-        return clusterHealth(Arrays.asList(indexSetRegistry.getIndexWildcards()));
+    public Optional<HealthStatus> health() {
+        return clusterAdapter.health(allIndexWildcards());
+    }
+
+    private List<String> allIndexWildcards() {
+        return Arrays.asList(indexSetRegistry.getIndexWildcards());
     }
 
     /**
@@ -108,110 +80,28 @@ public class Cluster {
      *
      * @return the cluster health response
      */
-    public Optional<JsonNode> deflectorHealth() {
-        return clusterHealth(Arrays.asList(indexSetRegistry.getWriteIndexAliases()));
-    }
-
-    /**
-     * Retrieve the response for the <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-nodes.html">cat nodes</a> request from Elasticsearch.
-     *
-     * @param fields The fields to show, see <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/cat-nodes.html">cat nodes API</a>.
-     * @return A {@link JsonNode} with the result of the cat nodes request.
-     */
-    private JsonNode catNodes(String... fields) {
-        final String fieldNames = String.join(",", fields);
-        final Cat request = new Cat.NodesBuilder()
-                .setParameter("h", fieldNames)
-                .setParameter("full_id", true)
-                .setParameter("format", "json")
-                .build();
-        final CatResult response = JestUtils.execute(jestClient, request, () -> "Unable to read Elasticsearch node information");
-        return response.getJsonObject().path("result");
+    public Optional<HealthStatus> deflectorHealth() {
+        return clusterAdapter.deflectorHealth(Arrays.asList(indexSetRegistry.getWriteIndexAliases()));
     }
 
     public Set<NodeFileDescriptorStats> getFileDescriptorStats() {
-        final JsonNode nodes = catNodes("name", "host", "ip", "fileDescriptorMax");
-        final ImmutableSet.Builder<NodeFileDescriptorStats> setBuilder = ImmutableSet.builder();
-        for (JsonNode jsonElement : nodes) {
-            if (jsonElement.isObject()) {
-                final String name = jsonElement.path("name").asText();
-                final String host = jsonElement.path("host").asText(null);
-                final String ip = jsonElement.path("ip").asText();
-                final JsonNode fileDescriptorMax = jsonElement.path("fileDescriptorMax");
-                final Long maxFileDescriptors = fileDescriptorMax.isLong() ? fileDescriptorMax.asLong() : null;
-                setBuilder.add(NodeFileDescriptorStats.create(name, ip, host, maxFileDescriptors));
-            }
-        }
-
-        return setBuilder.build();
+        return clusterAdapter.fileDescriptorStats();
     }
 
     public Set<NodeDiskUsageStats> getDiskUsageStats() {
-        final JsonNode nodes = catNodes("name", "host", "ip", "nodeRole", "diskUsed", "diskTotal","diskUsedPercent");
-        final ImmutableSet.Builder<NodeDiskUsageStats> setBuilder = ImmutableSet.builder();
-        for (JsonNode jsonElement : nodes) {
-            if (jsonElement.isObject() && jsonElement.path("nodeRole").asText().contains("d")) {
-                setBuilder.add(
-                    NodeDiskUsageStats.create(
-                        jsonElement.path("name").asText(),
-                        jsonElement.path("ip").asText(),
-                        jsonElement.path("host").asText(null),
-                        jsonElement.path("diskUsed").asText(),
-                        jsonElement.path("diskTotal").asText(),
-                        jsonElement.path("diskUsedPercent").asDouble(NodeDiskUsageStats.DEFAULT_DISK_USED_PERCENT)
-                    )
-                );
-            }
-        }
-        return setBuilder.build();
+        return clusterAdapter.diskUsageStats();
     }
 
-    public ClusterAllocationDiskSettings getClusterAllocationDiskSettings() throws Exception {
-        final GetAllocationDiskSettings request = new GetAllocationDiskSettings.Builder().build();
-        final JestResult response = JestUtils.execute(jestClient, request, () -> "Unable to read Elasticsearch cluster settings");
-        final JsonNode json = response.getJsonObject();
-        final JsonNode floodStageSetting = findEffectiveSettingInSettingsGroups(json, "flood_stage", true);
-        return ClusterAllocationDiskSettingsFactory.create(
-                findEffectiveSettingInSettingsGroups(json, "threshold_enabled", false).asBoolean(),
-                findEffectiveSettingInSettingsGroups(json, "low", false).asText(),
-                findEffectiveSettingInSettingsGroups(json, "high", false).asText(),
-                floodStageSetting != null ? floodStageSetting.asText() : ""
-        );
-    }
-
-    private JsonNode findEffectiveSettingInSettingsGroups(JsonNode jsonNode, String setting, boolean optional) throws Exception{
-        List<String> settingsGroup = Arrays.asList("transient", "persistent", "defaults");
-        for(String group: settingsGroup) {
-            JsonNode foundGroup = jsonNode.findPath(group);
-            if (!(foundGroup instanceof MissingNode)) {
-                JsonNode foundSetting = foundGroup.findPath(setting);
-                if (!(foundSetting instanceof MissingNode)) {
-                    return foundSetting;
-                }
-            }
-        }
-        if (optional) {
-            return null;
-        }
-        throw new Exception(String.format(Locale.ENGLISH, "Could not find setting %s in Elasticsearch response", setting));
+    public ClusterAllocationDiskSettings getClusterAllocationDiskSettings() {
+        return clusterAdapter.clusterAllocationDiskSettings();
     }
 
     public Optional<String> nodeIdToName(String nodeId) {
-        return Optional.ofNullable(getNodeInfo(nodeId).path("name").asText(null));
+        return clusterAdapter.nodeIdToName(nodeId);
     }
 
     public Optional<String> nodeIdToHostName(String nodeId) {
-        return Optional.ofNullable(getNodeInfo(nodeId).path("host").asText(null));
-    }
-
-    private JsonNode getNodeInfo(String nodeId) {
-        if (nodeId == null || nodeId.isEmpty()) {
-            return MissingNode.getInstance();
-        }
-
-        final NodesInfo request = new NodesInfo.Builder().addNode(nodeId).build();
-        final JestResult result = JestUtils.execute(jestClient, request, () -> "Couldn't read information of Elasticsearch node " + nodeId);
-        return result.getJsonObject().path("nodes").path(nodeId);
+        return clusterAdapter.nodeIdToHostName(nodeId);
     }
 
     /**
@@ -220,21 +110,7 @@ public class Cluster {
      * @return {@code true} if the Elasticsearch client is up and the cluster contains data nodes, {@code false} otherwise
      */
     public boolean isConnected() {
-        final Health request = new Health.Builder()
-                .local()
-                .timeout(Ints.saturatedCast(requestTimeout.toSeconds()))
-                .build();
-
-        try {
-            final JestResult result = JestUtils.execute(jestClient, request, () -> "Couldn't check connection status of Elasticsearch");
-            final int numberOfDataNodes = result.getJsonObject().path("number_of_data_nodes").asInt();
-            return numberOfDataNodes > 0;
-        } catch (ElasticsearchException e) {
-            if (LOG.isDebugEnabled()) {
-                LOG.error(e.getMessage(), e);
-            }
-            return false;
-        }
+        return clusterAdapter.isConnected();
     }
 
     /**
@@ -245,7 +121,7 @@ public class Cluster {
      */
     public boolean isHealthy() {
         return health()
-                .map(health -> !"red".equals(health.path("status").asText()) && indexSetRegistry.isUp())
+                .map(health -> !health.equals(HealthStatus.Red) && indexSetRegistry.isUp())
                 .orElse(false);
     }
 
@@ -257,7 +133,7 @@ public class Cluster {
      */
     public boolean isDeflectorHealthy() {
         return deflectorHealth()
-                .map(health -> !"red".equals(health.path("status").asText()) && indexSetRegistry.isUp())
+                .map(health -> !health.equals(HealthStatus.Red) && indexSetRegistry.isUp())
                 .orElse(false);
     }
 
@@ -299,5 +175,13 @@ public class Cluster {
      */
     public void waitForConnectedAndDeflectorHealthy() throws InterruptedException, TimeoutException {
         waitForConnectedAndDeflectorHealthy(requestTimeout.getQuantity(), requestTimeout.getUnit());
+    }
+
+    public Optional<String> clusterName() {
+        return clusterAdapter.clusterName(allIndexWildcards());
+    }
+
+    public Optional<ClusterHealth> clusterHealthStats() {
+        return clusterAdapter.clusterHealthStats(allIndexWildcards());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/ClusterAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/ClusterAdapter.java
@@ -1,0 +1,49 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.cluster;
+
+import org.graylog2.indexer.cluster.health.ClusterAllocationDiskSettings;
+import org.graylog2.indexer.cluster.health.NodeDiskUsageStats;
+import org.graylog2.indexer.cluster.health.NodeFileDescriptorStats;
+import org.graylog2.indexer.indices.HealthStatus;
+import org.graylog2.rest.models.system.indexer.responses.ClusterHealth;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public interface ClusterAdapter {
+    Optional<HealthStatus> health(List<String> asList);
+
+    Optional<HealthStatus> deflectorHealth(List<String> indices);
+
+    Set<NodeFileDescriptorStats> fileDescriptorStats();
+
+    Set<NodeDiskUsageStats> diskUsageStats();
+
+    ClusterAllocationDiskSettings clusterAllocationDiskSettings();
+
+    Optional<String> nodeIdToName(String nodeId);
+
+    Optional<String> nodeIdToHostName(String nodeId);
+
+    boolean isConnected();
+
+    Optional<String> clusterName(List<String> indices);
+
+    Optional<ClusterHealth> clusterHealthStats(List<String> indices);
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/ClusterAllocationDiskSettingsFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/ClusterAllocationDiskSettingsFactory.java
@@ -22,14 +22,14 @@ import java.util.stream.Stream;
 
 public class ClusterAllocationDiskSettingsFactory {
 
-    public static ClusterAllocationDiskSettings create(boolean enabled, String low, String high, String floodStage) throws Exception {
+    public static ClusterAllocationDiskSettings create(boolean enabled, String low, String high, String floodStage) {
         if (!enabled) {
             return ClusterAllocationDiskSettings.create(enabled, null);
         }
         return ClusterAllocationDiskSettings.create(enabled, createWatermarkSettings(low, high, floodStage));
     }
 
-    private static WatermarkSettings<?> createWatermarkSettings(String low, String high, String floodStage) throws Exception {
+    private static WatermarkSettings<?> createWatermarkSettings(String low, String high, String floodStage) {
         WatermarkSettings.SettingsType lowType = getType(low);
         WatermarkSettings.SettingsType highType = getType(high);
         if (Stream.of(lowType, highType).allMatch(s -> s == WatermarkSettings.SettingsType.ABSOLUTE)) {
@@ -49,7 +49,7 @@ public class ClusterAllocationDiskSettingsFactory {
             }
             return builder.build();
         }
-        throw new Exception("Error creating ClusterAllocationDiskWatermarkSettings. This should never happen.");
+        throw new IllegalStateException("Error creating ClusterAllocationDiskWatermarkSettings. This should never happen.");
     }
 
     private static WatermarkSettings.SettingsType getType(String value) {

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerClusterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/indexer/IndexerClusterResource.java
@@ -17,7 +17,6 @@
 package org.graylog2.rest.resources.system.indexer;
 
 import com.codahale.metrics.annotation.Timed;
-import com.fasterxml.jackson.databind.JsonNode;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
@@ -34,7 +33,6 @@ import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import java.util.Locale;
 
 @RequiresAuthentication
 @Api(value = "Indexer/Cluster", description = "Indexer cluster information")
@@ -51,9 +49,8 @@ public class IndexerClusterResource extends RestResource {
     @ApiOperation(value = "Get the cluster name")
     @Produces(MediaType.APPLICATION_JSON)
     public ClusterName clusterName() {
-        final JsonNode health = cluster.health()
+        final String clusterName = cluster.clusterName()
                 .orElseThrow(() -> new InternalServerErrorException("Couldn't read Elasticsearch cluster health"));
-        final String clusterName = health.path("cluster_name").asText("<unknown>");
         return ClusterName.create(clusterName);
     }
 
@@ -64,14 +61,7 @@ public class IndexerClusterResource extends RestResource {
     @RequiresPermissions(RestPermissions.INDEXERCLUSTER_READ)
     @Produces(MediaType.APPLICATION_JSON)
     public ClusterHealth clusterHealth() {
-        final JsonNode health = cluster.health()
+        return cluster.clusterHealthStats()
                 .orElseThrow(() -> new InternalServerErrorException("Couldn't read Elasticsearch cluster health"));
-        final ClusterHealth.ShardStatus shards = ClusterHealth.ShardStatus.create(
-                health.path("active_shards").asInt(),
-                health.path("initializing_shards").asInt(),
-                health.path("relocating_shards").asInt(),
-                health.path("unassigned_shards").asInt());
-
-        return ClusterHealth.create(health.path("status").asText().toLowerCase(Locale.ENGLISH), shards);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/cluster/ClusterIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/cluster/ClusterIT.java
@@ -27,6 +27,7 @@ import org.graylog2.indexer.cluster.health.ClusterAllocationDiskSettings;
 import org.graylog2.indexer.cluster.health.NodeDiskUsageStats;
 import org.graylog2.indexer.cluster.health.NodeFileDescriptorStats;
 import org.graylog2.indexer.cluster.health.WatermarkSettings;
+import org.graylog2.indexer.indices.HealthStatus;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,7 +43,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-public class ClusterIT extends ElasticsearchBaseTest {
+public abstract class ClusterIT extends ElasticsearchBaseTest {
     private static final String INDEX_NAME = "cluster_it_" + System.nanoTime();
     private static final String ALIAS_NAME = "cluster_it_alias_" + System.nanoTime();
 
@@ -54,6 +55,8 @@ public class ClusterIT extends ElasticsearchBaseTest {
 
     private Cluster cluster;
 
+    protected abstract ClusterAdapter clusterAdapter(Duration timeout);
+
     @Before
     public void setUp() throws Exception {
         client().createIndex(INDEX_NAME, 1, 0);
@@ -63,7 +66,8 @@ public class ClusterIT extends ElasticsearchBaseTest {
         final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(
                 new ThreadFactoryBuilder().setNameFormat("cluster-it-%d").build()
         );
-        cluster = new Cluster(jestClient(), indexSetRegistry, scheduler, Duration.seconds(1L));
+        final Duration requestTimeout = Duration.seconds(1L);
+        cluster = new Cluster(indexSetRegistry, scheduler, requestTimeout, clusterAdapter(requestTimeout));
     }
 
     @Test
@@ -95,33 +99,33 @@ public class ClusterIT extends ElasticsearchBaseTest {
         final String index = client().createRandomIndex("cluster_it_");
         when(indexSetRegistry.getIndexWildcards()).thenReturn(new String[]{index});
 
-        final Optional<JsonNode> health = cluster.health();
+        final Optional<HealthStatus> health = cluster.health();
         assertThat(health)
                 .isPresent()
-                .hasValueSatisfying(json -> assertThat(json.path("status").asText()).isEqualTo("green"));
+                .hasValueSatisfying(status -> assertThat(status).isEqualTo(HealthStatus.Green));
 
     }
 
     @Test
     public void health_returns_empty_with_missing_index() {
         when(indexSetRegistry.getIndexWildcards()).thenReturn(new String[]{"does_not_exist"});
-        final Optional<JsonNode> health = cluster.health();
+        final Optional<HealthStatus> health = cluster.health();
         assertThat(health).isEmpty();
     }
 
     @Test
     public void deflectorHealth() {
         when(indexSetRegistry.getWriteIndexAliases()).thenReturn(new String[]{ALIAS_NAME});
-        final Optional<JsonNode> deflectorHealth = cluster.deflectorHealth();
+        final Optional<HealthStatus> deflectorHealth = cluster.deflectorHealth();
         assertThat(deflectorHealth)
                 .isPresent()
-                .hasValueSatisfying(json -> assertThat(json.path("status").asText()).isEqualTo("green"));
+                .hasValueSatisfying(status -> assertThat(status).isEqualTo(HealthStatus.Green));
     }
 
     @Test
     public void deflectorHealth_returns_empty_with_missing_index() {
         when(indexSetRegistry.getWriteIndexAliases()).thenReturn(new String[]{"does_not_exist"});
-        final Optional<JsonNode> deflectorHealth = cluster.deflectorHealth();
+        final Optional<HealthStatus> deflectorHealth = cluster.deflectorHealth();
         assertThat(deflectorHealth).isEmpty();
     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is extracting a `ClusterAdapter` interface from the `Cluster` class containing ES-specific implementation details and creates an implementation class (`ClusterAdapterES6`) containing the current code.
    
During the extraction most of the signatures were kept intact, besides those which use the ES `Health.Status` class. It was replaced with a very simple own `HealthStatus` enum which is mappable 1:1 with the current implementation of `Health.Status`. It might make sense to move away from colors to more precise identifiers (e.g. "Healthy", "Degraded", "Unhealthy"). Due to the change of the return type of those methods it was also required to change some of the logic in the consumers of these classes, but it was attempted to keep those to a minimum in favor of later refactorings.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.