### PR TITLE
Move widget to tab

### DIFF
--- a/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTab.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTab.jsx
@@ -1,0 +1,56 @@
+// @flow strict
+import React, { useState } from 'react';
+import { Map } from 'immutable';
+import { Button, ListGroup, ListGroupItem, Modal } from 'components/graylog';
+
+import View from 'views/logic/views/View';
+
+type Props = {
+  view: View,
+  widgetId: string,
+  onCancel: () => void,
+  onSubmit: (widgetId: string, selectedTab: ?string) => void,
+};
+
+type TabEntry = { id: string, name: string };
+
+const _tabList = (view: View): Array<TabEntry> => {
+  const queryIds = Object.keys(view.state.toObject());
+  return queryIds.map((queryId, index) => {
+    const tabTitle = view.state.get(queryId).titles.get('tab', Map({ title: `Page#${index + 1}` }));
+    return ({ id: queryId, name: tabTitle.get('title') });
+  });
+};
+
+const MoveWidgetToTab = ({ view, onCancel, onSubmit, widgetId }: Props) => {
+  const [selectedTab, setSelectedTab] = useState(null);
+  const list = _tabList(view);
+
+  const tabList = list.map(({ id, name }) => (
+    <ListGroupItem header={name}
+                   onClick={() => setSelectedTab(id)}
+                   active={id === selectedTab}
+                   key={id} />
+  ));
+  const renderResult = list && list.length > 0
+    ? <ListGroup>{tabList}</ListGroup>
+    : <span>No dashboards found</span>;
+
+  return (
+    <Modal show>
+      <Modal.Body>
+        {renderResult}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button bsStyle="primary"
+                disabled={selectedTab === null}
+                onClick={() => onSubmit(widgetId, selectedTab)}>
+          Select
+        </Button>
+        <Button onClick={onCancel}>Cancel</Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+export default MoveWidgetToTab;

--- a/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTab.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTab.jsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import { Map } from 'immutable';
 import { Button, ListGroup, ListGroupItem, Modal } from 'components/graylog';
+import Input from 'components/bootstrap/Input';
 
 import View from 'views/logic/views/View';
 
@@ -9,7 +10,7 @@ type Props = {
   view: View,
   widgetId: string,
   onCancel: () => void,
-  onSubmit: (widgetId: string, selectedTab: ?string) => void,
+  onSubmit: (widgetId: string, selectedTab: ?string, keepCopy: boolean) => void,
 };
 
 type TabEntry = { id: string, name: string };
@@ -24,6 +25,8 @@ const _tabList = (view: View): Array<TabEntry> => {
 
 const MoveWidgetToTab = ({ view, onCancel, onSubmit, widgetId }: Props) => {
   const [selectedTab, setSelectedTab] = useState(null);
+  const [keepCopy, setKeepCopy] = useState(false);
+
   const list = _tabList(view);
 
   const tabList = list.map(({ id, name }) => (
@@ -40,11 +43,18 @@ const MoveWidgetToTab = ({ view, onCancel, onSubmit, widgetId }: Props) => {
     <Modal show>
       <Modal.Body>
         {renderResult}
+        <Input type="checkbox"
+               id="keepCopy"
+               name="keepCopy"
+               label="Keep Copy on this Page"
+               onChange={(e) => setKeepCopy(e.target.checked)}
+               help="When 'Keep Copy on the Page' is enabled, the widget will be copied and not moved to another page"
+               checked={keepCopy} />
       </Modal.Body>
       <Modal.Footer>
         <Button bsStyle="primary"
                 disabled={selectedTab === null}
-                onClick={() => onSubmit(widgetId, selectedTab)}>
+                onClick={() => onSubmit(widgetId, selectedTab, keepCopy)}>
           Select
         </Button>
         <Button onClick={onCancel}>Cancel</Button>

--- a/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTabModal.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTabModal.jsx
@@ -4,6 +4,8 @@ import { Map } from 'immutable';
 import { ListGroup, ListGroupItem } from 'components/graylog';
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import Input from 'components/bootstrap/Input';
+import { useStore } from 'stores/connect';
+import { CurrentQueryStore } from 'views/stores/CurrentQueryStore';
 
 import View from 'views/logic/views/View';
 
@@ -27,8 +29,9 @@ const _tabList = (view: View): Array<TabEntry> => {
 const MoveWidgetToTabModal = ({ view, onCancel, onSubmit, widgetId }: Props) => {
   const [selectedTab, setSelectedTab] = useState(null);
   const [keepCopy, setKeepCopy] = useState(false);
+  const { id: activeQuery } = useStore(CurrentQueryStore);
 
-  const list = _tabList(view);
+  const list = _tabList(view).filter(({ id }) => id !== activeQuery);
 
   const tabList = list.map(({ id, name }) => (
     <ListGroupItem onClick={() => setSelectedTab(id)}

--- a/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTabModal.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTabModal.jsx
@@ -1,6 +1,5 @@
 // @flow strict
 import React, { useState } from 'react';
-import { Map } from 'immutable';
 import { ListGroup, ListGroupItem } from 'components/graylog';
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import Input from 'components/bootstrap/Input';

--- a/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTabModal.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTabModal.jsx
@@ -1,7 +1,8 @@
 // @flow strict
 import React, { useState } from 'react';
 import { Map } from 'immutable';
-import { Button, ListGroup, ListGroupItem, Modal } from 'components/graylog';
+import { ListGroup, ListGroupItem } from 'components/graylog';
+import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import Input from 'components/bootstrap/Input';
 
 import View from 'views/logic/views/View';
@@ -30,36 +31,30 @@ const MoveWidgetToTabModal = ({ view, onCancel, onSubmit, widgetId }: Props) => 
   const list = _tabList(view);
 
   const tabList = list.map(({ id, name }) => (
-    <ListGroupItem header={name}
-                   onClick={() => setSelectedTab(id)}
+    <ListGroupItem onClick={() => setSelectedTab(id)}
                    active={id === selectedTab}
-                   key={id} />
+                   key={id}>
+      {name}
+    </ListGroupItem>
   ));
   const renderResult = list && list.length > 0
     ? <ListGroup>{tabList}</ListGroup>
     : <span>No dashboards found</span>;
 
   return (
-    <Modal show>
-      <Modal.Body>
-        {renderResult}
-        <Input type="checkbox"
-               id="keepCopy"
-               name="keepCopy"
-               label="Keep Copy on this Page"
-               onChange={(e) => setKeepCopy(e.target.checked)}
-               help="When 'Keep Copy on the Page' is enabled, the widget will be copied and not moved to another page"
-               checked={keepCopy} />
-      </Modal.Body>
-      <Modal.Footer>
-        <Button bsStyle="primary"
-                disabled={selectedTab === null}
-                onClick={() => onSubmit(widgetId, selectedTab, keepCopy)}>
-          Select
-        </Button>
-        <Button onClick={onCancel}>Cancel</Button>
-      </Modal.Footer>
-    </Modal>
+    <BootstrapModalForm show
+                        onCancel={onCancel}
+                        onSubmitForm={() => onSubmit(widgetId, selectedTab, keepCopy)}
+                        title="Choose Target Page">
+      {renderResult}
+      <Input type="checkbox"
+             id="keepCopy"
+             name="keepCopy"
+             label="Keep Copy on this Page"
+             onChange={(e) => setKeepCopy(e.target.checked)}
+             help="When 'Keep Copy on the Page' is enabled, the widget will be copied and not moved to another page"
+             checked={keepCopy} />
+    </BootstrapModalForm>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTabModal.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTabModal.jsx
@@ -23,7 +23,7 @@ const _tabList = (view: View): Array<TabEntry> => {
   });
 };
 
-const MoveWidgetToTab = ({ view, onCancel, onSubmit, widgetId }: Props) => {
+const MoveWidgetToTabModal = ({ view, onCancel, onSubmit, widgetId }: Props) => {
   const [selectedTab, setSelectedTab] = useState(null);
   const [keepCopy, setKeepCopy] = useState(false);
 
@@ -63,4 +63,4 @@ const MoveWidgetToTab = ({ view, onCancel, onSubmit, widgetId }: Props) => {
   );
 };
 
-export default MoveWidgetToTab;
+export default MoveWidgetToTabModal;

--- a/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTabModal.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTabModal.jsx
@@ -48,6 +48,7 @@ const MoveWidgetToTabModal = ({ view, onCancel, onSubmit, widgetId }: Props) => 
   return (
     <BootstrapModalForm show
                         onCancel={onCancel}
+                        submitButtonDisabled={!selectedTab}
                         onSubmitForm={() => onSubmit(widgetId, selectedTab, keepCopy)}
                         title="Choose Target Page">
       {renderResult}

--- a/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTabModal.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTabModal.jsx
@@ -5,6 +5,7 @@ import { ListGroup, ListGroupItem } from 'components/graylog';
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import Input from 'components/bootstrap/Input';
 import { useStore } from 'stores/connect';
+import QueryTitle from 'views/logic/queries/QueryTitle';
 import { CurrentQueryStore } from 'views/stores/CurrentQueryStore';
 
 import View from 'views/logic/views/View';
@@ -20,9 +21,9 @@ type TabEntry = { id: string, name: string };
 
 const _tabList = (view: View): Array<TabEntry> => {
   const queryIds = Object.keys(view.state.toObject());
-  return queryIds.map((queryId, index) => {
-    const tabTitle = view.state.get(queryId).titles.get('tab', Map({ title: `Page#${index + 1}` }));
-    return ({ id: queryId, name: tabTitle.get('title') });
+  return queryIds.map((queryId) => {
+    const tabTitle = QueryTitle(view, queryId) || 'Unknown Page title';
+    return ({ id: queryId, name: tabTitle });
   });
 };
 

--- a/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTabModal.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTabModal.jsx
@@ -1,5 +1,5 @@
 // @flow strict
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { ListGroup, ListGroupItem } from 'components/graylog';
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import Input from 'components/bootstrap/Input';
@@ -31,6 +31,8 @@ const MoveWidgetToTabModal = ({ view, onCancel, onSubmit, widgetId }: Props) => 
   const [keepCopy, setKeepCopy] = useState(false);
   const { id: activeQuery } = useStore(CurrentQueryStore);
   const queryIds = useStore(QueryIdsStore);
+  const onKeepCopy = useCallback((e) => setKeepCopy(e.target.checked), [setKeepCopy]);
+  const submit = useCallback(() => onSubmit(widgetId, selectedTab, keepCopy), [widgetId, selectedTab, keepCopy]);
 
   const list = _tabList(view, queryIds.toArray()).filter(({ id }) => id !== activeQuery);
 
@@ -49,14 +51,14 @@ const MoveWidgetToTabModal = ({ view, onCancel, onSubmit, widgetId }: Props) => 
     <BootstrapModalForm show
                         onCancel={onCancel}
                         submitButtonDisabled={!selectedTab}
-                        onSubmitForm={() => onSubmit(widgetId, selectedTab, keepCopy)}
+                        onSubmitForm={submit}
                         title="Choose Target Page">
       {renderResult}
       <Input type="checkbox"
              id="keepCopy"
              name="keepCopy"
              label="Keep Copy on this Page"
-             onChange={(e) => setKeepCopy(e.target.checked)}
+             onChange={onKeepCopy}
              help="When 'Keep Copy on the Page' is enabled, the widget will be copied and not moved to another page"
              checked={keepCopy} />
     </BootstrapModalForm>

--- a/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTabModal.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MoveWidgetToTabModal.jsx
@@ -6,6 +6,7 @@ import Input from 'components/bootstrap/Input';
 import { useStore } from 'stores/connect';
 import QueryTitle from 'views/logic/queries/QueryTitle';
 import { CurrentQueryStore } from 'views/stores/CurrentQueryStore';
+import { QueryIdsStore } from 'views/stores/QueryIdsStore';
 
 import View from 'views/logic/views/View';
 
@@ -18,8 +19,7 @@ type Props = {
 
 type TabEntry = { id: string, name: string };
 
-const _tabList = (view: View): Array<TabEntry> => {
-  const queryIds = Object.keys(view.state.toObject());
+const _tabList = (view: View, queryIds): Array<TabEntry> => {
   return queryIds.map((queryId) => {
     const tabTitle = QueryTitle(view, queryId) || 'Unknown Page title';
     return ({ id: queryId, name: tabTitle });
@@ -30,8 +30,9 @@ const MoveWidgetToTabModal = ({ view, onCancel, onSubmit, widgetId }: Props) => 
   const [selectedTab, setSelectedTab] = useState(null);
   const [keepCopy, setKeepCopy] = useState(false);
   const { id: activeQuery } = useStore(CurrentQueryStore);
+  const queryIds = useStore(QueryIdsStore);
 
-  const list = _tabList(view).filter(({ id }) => id !== activeQuery);
+  const list = _tabList(view, queryIds.toArray()).filter(({ id }) => id !== activeQuery);
 
   const tabList = list.map(({ id, name }) => (
     <ListGroupItem onClick={() => setSelectedTab(id)}
@@ -42,7 +43,7 @@ const MoveWidgetToTabModal = ({ view, onCancel, onSubmit, widgetId }: Props) => 
   ));
   const renderResult = list && list.length > 0
     ? <ListGroup>{tabList}</ListGroup>
-    : <span>No dashboards found</span>;
+    : <span>No pages found</span>;
 
   return (
     <BootstrapModalForm show

--- a/graylog2-web-interface/src/views/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.jsx
@@ -189,7 +189,7 @@ class Widget extends React.Component<Props, State> {
     });
   };
 
-  _onMoveWidgetToTab = (widgetId, queryId) => {
+  _onMoveWidgetToTab = (widgetId, queryId, keepCopy) => {
     const { view } = this.props;
     const { view: activeView } = view;
 
@@ -197,7 +197,7 @@ class Widget extends React.Component<Props, State> {
       return;
     }
 
-    const newDashboard = MoveWidgetToTab(widgetId, queryId, activeView);
+    const newDashboard = MoveWidgetToTab(widgetId, queryId, activeView, keepCopy);
     if (newDashboard) {
       SearchActions.create(newDashboard.search).then((searchResponse) => {
         const updatedDashboard = newDashboard.toBuilder().search(searchResponse.search).build();
@@ -360,7 +360,7 @@ class Widget extends React.Component<Props, State> {
                         <MenuItem onSelect={this._onToggleCopyToDashboard}>Copy to Dashboard</MenuItem>
                       </IfSearch>
                       <IfDashboard>
-                      <MenuItem onSelect={this._onToggleMoveWidgetToTab}>Move to Tab</MenuItem>
+                      <MenuItem onSelect={this._onToggleMoveWidgetToTab}>Move to Page</MenuItem>
                     </IfDashboard>
                     <MenuItem divider />
                       <MenuItem onSelect={() => this._onDelete(widget)}>Delete</MenuItem>

--- a/graylog2-web-interface/src/views/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.jsx
@@ -13,7 +13,7 @@ import IfSearch from 'views/components/search/IfSearch';
 import { widgetDefinition } from 'views/logic/Widgets';
 import { WidgetActions } from 'views/stores/WidgetStore';
 import { TitlesActions, TitleTypes } from 'views/stores/TitlesStore';
-import { ViewStore } from 'views/stores/ViewStore';
+import { ViewActions, ViewStore } from 'views/stores/ViewStore';
 import type { ViewStoreState } from 'views/stores/ViewStore';
 import { RefreshActions } from 'views/stores/RefreshStore';
 import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
@@ -31,6 +31,7 @@ import type { TimeRange } from 'views/logic/queries/Query';
 import MessagesWidget from 'views/logic/widgets/MessagesWidget';
 import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
 import CSVExportModal from 'views/components/searchbar/csvexport/CSVExportModal';
+import MoveWidgetToTab from 'views/logic/views/MoveWidgetToTab';
 
 import WidgetFrame from './WidgetFrame';
 import WidgetHeader from './WidgetHeader';
@@ -47,6 +48,7 @@ import WidgetColorContext from './WidgetColorContext';
 import IfInteractive from '../dashboard/IfInteractive';
 import InteractiveContext from '../contexts/InteractiveContext';
 import CopyToDashboard from './CopyToDashboardForm';
+import MoveWidgetToTabForm from './MoveWidgetToTab';
 import WidgetErrorBoundary from './WidgetErrorBoundary';
 import IfDashboard from '../dashboard/IfDashboard';
 import ReplaySearchButton from './ReplaySearchButton';
@@ -82,6 +84,7 @@ type State = {
   oldWidget?: WidgetModel,
   showCopyToDashboard: boolean,
   showCsvExport: boolean,
+  showMoveWidgetToTab: boolean,
 };
 
 export type Result = {
@@ -149,6 +152,7 @@ class Widget extends React.Component<Props, State> {
       loading: false,
       showCopyToDashboard: false,
       showCsvExport: false,
+      showMoveWidgetToTab: false,
     };
     if (editing) {
       this.state = { ...this.state, oldWidget: props.widget };
@@ -174,6 +178,39 @@ class Widget extends React.Component<Props, State> {
     this.setState(({ showCopyToDashboard }) => ({ showCopyToDashboard: !showCopyToDashboard }));
   };
 
+  _onToggleMoveWidgetToTab = () => {
+    this.setState(({ showMoveWidgetToTab }) => ({ showMoveWidgetToTab: !showMoveWidgetToTab }));
+  };
+
+  _updateDashboardWithNewSearch = (dashboard: View, dashboardId: string) => ({ search: newSearch }) => {
+    const newDashboard = dashboard.toBuilder().search(newSearch).build();
+    ViewManagementActions.update(newDashboard).then(() => {
+      browserHistory.push(Routes.pluginRoute('DASHBOARDS_VIEWID')(dashboardId));
+    });
+  };
+
+  _onMoveWidgetToTab = (widgetId, queryId) => {
+    const { view } = this.props;
+    const { view: activeView } = view;
+
+    if (!queryId) {
+      return;
+    }
+
+    const newDashboard = MoveWidgetToTab(widgetId, queryId, activeView);
+    if (newDashboard) {
+      SearchActions.create(newDashboard.search).then((searchResponse) => {
+        const updatedDashboard = newDashboard.toBuilder().search(searchResponse.search).build();
+        ViewActions.update(updatedDashboard).then(() => {
+          this._onToggleMoveWidgetToTab();
+          ViewActions.selectQuery(queryId).then(() => {
+            SearchActions.executeWithCurrentState();
+          });
+        });
+      });
+    }
+  };
+
   _onCopyToDashboard = (widgetId: string, dashboardId: ?string): void => {
     const { view } = this.props;
     const { view: activeView } = view;
@@ -182,18 +219,11 @@ class Widget extends React.Component<Props, State> {
       return;
     }
 
-    const updateDashboardWithNewSearch = (dashboard: View) => ({ search: newSearch }) => {
-      const newDashboard = dashboard.toBuilder().search(newSearch).build();
-      ViewManagementActions.update(newDashboard).then(() => {
-        browserHistory.push(Routes.pluginRoute('DASHBOARDS_VIEWID')(dashboardId));
-      });
-    };
-
     const addWidgetToDashboard = (dashboard: View) => (searchJson) => {
       const search = Search.fromJSON(searchJson);
       const newDashboard = CopyWidgetToDashboard(widgetId, activeView, dashboard.toBuilder().search(search).build());
       if (newDashboard && newDashboard.search) {
-        SearchActions.create(newDashboard.search).then(updateDashboardWithNewSearch(newDashboard));
+        SearchActions.create(newDashboard.search).then(this._updateDashboardWithNewSearch(newDashboard, dashboardId));
       }
     };
 
@@ -273,7 +303,7 @@ class Widget extends React.Component<Props, State> {
   // TODO: Clean up different code paths for normal/edit modes
   render() {
     const { id, widget, fields, onSizeChange, title, position, onPositionsChange, view } = this.props;
-    const { editing, loading, showCopyToDashboard, showCsvExport } = this.state;
+    const { editing, loading, showCopyToDashboard, showCsvExport, showMoveWidgetToTab } = this.state;
     const { config, type } = widget;
     const visualization = this.visualize();
     if (editing) {
@@ -329,7 +359,10 @@ class Widget extends React.Component<Props, State> {
                       <IfSearch>
                         <MenuItem onSelect={this._onToggleCopyToDashboard}>Copy to Dashboard</MenuItem>
                       </IfSearch>
-                      <MenuItem divider />
+                      <IfDashboard>
+                      <MenuItem onSelect={this._onToggleMoveWidgetToTab}>Move to Tab</MenuItem>
+                    </IfDashboard>
+                    <MenuItem divider />
                       <MenuItem onSelect={() => this._onDelete(widget)}>Delete</MenuItem>
                     </WidgetActionDropdown>
                     {showCopyToDashboard && (
@@ -338,6 +371,12 @@ class Widget extends React.Component<Props, State> {
                                        onCancel={this._onToggleCopyToDashboard} />
                     )}
                     {showCsvExport && <CSVExportModal view={view.view} directExportWidgetId={widget.id} closeModal={this._onToggleCSVExport} />}
+                  {showMoveWidgetToTab && (
+                    <MoveWidgetToTabForm view={view.view}
+                                         widgetId={widget.id}
+                                         onCancel={this._onToggleMoveWidgetToTab}
+                                         onSubmit={this._onMoveWidgetToTab} />
+                  )}
                   </IfInteractive>
                 </WidgetActionsWBar>
               </WidgetHeader>

--- a/graylog2-web-interface/src/views/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.jsx
@@ -360,9 +360,9 @@ class Widget extends React.Component<Props, State> {
                         <MenuItem onSelect={this._onToggleCopyToDashboard}>Copy to Dashboard</MenuItem>
                       </IfSearch>
                       <IfDashboard>
-                      <MenuItem onSelect={this._onToggleMoveWidgetToTab}>Move to Page</MenuItem>
-                    </IfDashboard>
-                    <MenuItem divider />
+                        <MenuItem onSelect={this._onToggleMoveWidgetToTab}>Move to Page</MenuItem>
+                      </IfDashboard>
+                      <MenuItem divider />
                       <MenuItem onSelect={() => this._onDelete(widget)}>Delete</MenuItem>
                     </WidgetActionDropdown>
                     {showCopyToDashboard && (
@@ -371,12 +371,12 @@ class Widget extends React.Component<Props, State> {
                                        onCancel={this._onToggleCopyToDashboard} />
                     )}
                     {showCsvExport && <CSVExportModal view={view.view} directExportWidgetId={widget.id} closeModal={this._onToggleCSVExport} />}
-                  {showMoveWidgetToTab && (
-                    <MoveWidgetToTabModal view={view.view}
-                                          widgetId={widget.id}
-                                          onCancel={this._onToggleMoveWidgetToTab}
-                                          onSubmit={this._onMoveWidgetToTab} />
-                  )}
+                    {showMoveWidgetToTab && (
+                      <MoveWidgetToTabModal view={view.view}
+                                            widgetId={widget.id}
+                                            onCancel={this._onToggleMoveWidgetToTab}
+                                            onSubmit={this._onMoveWidgetToTab} />
+                    )}
                   </IfInteractive>
                 </WidgetActionsWBar>
               </WidgetHeader>

--- a/graylog2-web-interface/src/views/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.jsx
@@ -48,7 +48,7 @@ import WidgetColorContext from './WidgetColorContext';
 import IfInteractive from '../dashboard/IfInteractive';
 import InteractiveContext from '../contexts/InteractiveContext';
 import CopyToDashboard from './CopyToDashboardForm';
-import MoveWidgetToTabForm from './MoveWidgetToTab';
+import MoveWidgetToTabModal from './MoveWidgetToTabModal';
 import WidgetErrorBoundary from './WidgetErrorBoundary';
 import IfDashboard from '../dashboard/IfDashboard';
 import ReplaySearchButton from './ReplaySearchButton';
@@ -372,10 +372,10 @@ class Widget extends React.Component<Props, State> {
                     )}
                     {showCsvExport && <CSVExportModal view={view.view} directExportWidgetId={widget.id} closeModal={this._onToggleCSVExport} />}
                   {showMoveWidgetToTab && (
-                    <MoveWidgetToTabForm view={view.view}
-                                         widgetId={widget.id}
-                                         onCancel={this._onToggleMoveWidgetToTab}
-                                         onSubmit={this._onMoveWidgetToTab} />
+                    <MoveWidgetToTabModal view={view.view}
+                                          widgetId={widget.id}
+                                          onCancel={this._onToggleMoveWidgetToTab}
+                                          onSubmit={this._onMoveWidgetToTab} />
                   )}
                   </IfInteractive>
                 </WidgetActionsWBar>

--- a/graylog2-web-interface/src/views/logic/views/AddNewWidgetsToPositions.js
+++ b/graylog2-web-interface/src/views/logic/views/AddNewWidgetsToPositions.js
@@ -1,0 +1,22 @@
+// @flow strict
+import * as Immutable from 'immutable';
+
+import { widgetDefinition } from 'views/logic/Widgets';
+import WidgetPosition from 'views/logic/widgets/WidgetPosition';
+import Widget from '../widgets/Widget';
+
+export default (positionsMap: Immutable.Map<string, WidgetPosition>,
+  widgets: Array<Widget>,
+  overrideWidgetPositions: Immutable.Map<string, WidgetPosition> = Immutable.Map()): Immutable.Map<string, WidgetPosition> => {
+  const newWidgets = widgets.filter((widget) => !positionsMap.get(widget.id));
+
+  return newWidgets.reduce((nextPositionsMap, widget) => {
+    const widgetDef = widgetDefinition(widget.type);
+    const result = nextPositionsMap.reduce((newPosMap, position, id) => {
+      const pos = position.toBuilder().row(position.row + widgetDef.defaultHeight).build();
+      return newPosMap.set(id, pos);
+    }, Immutable.Map());
+    const position = overrideWidgetPositions.get(widget.id, new WidgetPosition(1, 1, widgetDef.defaultHeight, widgetDef.defaultWidth));
+    return result.set(widget.id, position.toBuilder().row(1).col(1).build());
+  }, positionsMap);
+};

--- a/graylog2-web-interface/src/views/logic/views/AddNewWidgetsToPositions.test.js
+++ b/graylog2-web-interface/src/views/logic/views/AddNewWidgetsToPositions.test.js
@@ -1,0 +1,37 @@
+// @flow strict
+import * as Immutable from 'immutable';
+
+import { PluginStore } from 'graylog-web-plugin/plugin';
+import Widget from 'views/logic/widgets/Widget';
+import WidgetPosition from 'views/logic/widgets/WidgetPosition';
+import AddNewWidgetsToPositions from './AddNewWidgetsToPositions';
+
+describe('AddNewWidgetsToPositions', () => {
+  PluginStore.exports = () => {
+    return [{ type: 'MESSAGES', defaultHeight: 5, defaultWidth: 6 }];
+  };
+  it('should add a new widget to the first row and column', () => {
+    const newMessageList = Widget.builder().id('foo-1').type('MESSAGES').build();
+    const widgets = [newMessageList];
+    const positions = Immutable.Map();
+    const newPositions = AddNewWidgetsToPositions(positions, widgets);
+
+    expect(newPositions).toMatchSnapshot();
+  });
+
+  it('should add a new widget to the first row and column to other widgets', () => {
+    const newMessageList = Widget.builder().id('foo-1').type('MESSAGES').build();
+    const oldMessageList = Widget.builder().id('foo').type('MESSAGES').build();
+    const oldWidgetPosition = WidgetPosition.builder()
+      .col(1)
+      .row(1)
+      .width(3)
+      .height(8)
+      .build();
+    const widgets = [newMessageList, oldMessageList];
+    const positions = Immutable.Map({ foo: oldWidgetPosition });
+    const newPositions = AddNewWidgetsToPositions(positions, widgets);
+
+    expect(newPositions).toMatchSnapshot();
+  });
+});

--- a/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.js
+++ b/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.js
@@ -3,25 +3,13 @@ import { List, Map } from 'immutable';
 
 import Widget from 'views/logic/widgets/Widget';
 import View from 'views/logic/views/View';
-import ViewState from 'views/logic/views/ViewState';
 import Query from 'views/logic/queries/Query';
 
+import FindWidgetAndQueryIdInView from './FindWidgetAndQueryIdInView';
 import UpdateSearchForWidgets from './UpdateSearchForWidgets';
 
 type QueryId = string;
 
-const _findWidgetAndQueryIdInView = (widgetId: string, view: View): ?[Widget, QueryId] => {
-  return view.state.reduce((foundWidget: ?[Widget, QueryId], state: ViewState, queryId: QueryId): ?[Widget, QueryId] => {
-    if (foundWidget) {
-      return foundWidget;
-    }
-    const widget = state.widgets.find((w) => w.id === widgetId);
-    if (widget) {
-      return [widget, queryId];
-    }
-    return undefined;
-  }, undefined);
-};
 
 const _addWidgetToDashboard = (widget: Widget, dashboard: View): View => {
   const dashboardQueryId = dashboard.state.keySeq().first();
@@ -40,7 +28,7 @@ const CopyWidgetToDashboard = (widgetId: string, search: View, dashboard: View):
   }
 
   const queryMap: Map<QueryId, Query> = Map(search.search.queries.map((q) => [q.id, q]));
-  const match: ?[Widget, QueryId] = _findWidgetAndQueryIdInView(widgetId, search);
+  const match: ?[Widget, QueryId] = FindWidgetAndQueryIdInView(widgetId, search);
 
   if (match) {
     const [widget, queryId] = match;

--- a/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.test.js
+++ b/graylog2-web-interface/src/views/logic/views/CopyWidgetToDashboard.test.js
@@ -8,6 +8,9 @@ import ValueParameter from '../parameters/ValueParameter';
 import Parameter from '../parameters/Parameter';
 
 jest.mock('uuid/v4', () => jest.fn(() => 'dead-beef'));
+jest.mock('bson-objectid', () => jest.fn(() => ({
+  toString: jest.fn(() => 'new-search-id'),
+})));
 
 jest.mock('../Widgets', () => ({
   widgetDefinition: () => ({ searchTypes: () => [{ type: 'pivot' }] }),

--- a/graylog2-web-interface/src/views/logic/views/FindWidgetAndQueryIdInView.js
+++ b/graylog2-web-interface/src/views/logic/views/FindWidgetAndQueryIdInView.js
@@ -1,11 +1,12 @@
 // @flow strict
+import type { QueryId } from 'views/logic/queries/Query';
+import type { WidgetId } from 'views/logic/views/types';
+
 import View from './View';
 import Widget from '../widgets/Widget';
 import ViewState from './ViewState';
 
-type QueryId = string;
-
-const FindWidgetAndQueryIdInView = (widgetId: string, view: View): ?[Widget, QueryId] => {
+const FindWidgetAndQueryIdInView = (widgetId: WidgetId, view: View): ?[Widget, QueryId] => {
   return view.state.reduce((foundWidget: ?[Widget, QueryId], state: ViewState, queryId: QueryId): ?[Widget, QueryId] => {
     if (foundWidget) {
       return foundWidget;

--- a/graylog2-web-interface/src/views/logic/views/FindWidgetAndQueryIdInView.js
+++ b/graylog2-web-interface/src/views/logic/views/FindWidgetAndQueryIdInView.js
@@ -1,0 +1,21 @@
+// @flow strict
+import View from './View';
+import Widget from '../widgets/Widget';
+import ViewState from './ViewState';
+
+type QueryId = string;
+
+const FindWidgetAndQueryIdInView = (widgetId: string, view: View): ?[Widget, QueryId] => {
+  return view.state.reduce((foundWidget: ?[Widget, QueryId], state: ViewState, queryId: QueryId): ?[Widget, QueryId] => {
+    if (foundWidget) {
+      return foundWidget;
+    }
+    const widget = state.widgets.find((w) => w.id === widgetId);
+    if (widget) {
+      return [widget, queryId];
+    }
+    return undefined;
+  }, undefined);
+};
+
+export default FindWidgetAndQueryIdInView;

--- a/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.Dashboard.fixture.json
+++ b/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.Dashboard.fixture.json
@@ -9,7 +9,11 @@
   "requires" : {},
   "state" : {
     "fa247d8f-7afa-45b7-b57e-3cdef4ee53be" : {
-      "titles" : {},
+      "titles" : {
+        "widget": {
+          "b34c3c6f-c49d-41d3-a65a-f746134f8f3e": "Widget Title"
+        }
+      },
       "widgets" : [
         {
           "id" : "b34c3c6f-c49d-41d3-a65a-f746134f8f3e",

--- a/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.Dashboard.fixture.json
+++ b/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.Dashboard.fixture.json
@@ -1,0 +1,67 @@
+{
+  "id" : "5ece5e1b74ff709b0b0dc69b",
+  "type" : "DASHBOARD",
+  "title" : "MoveWidgetToTab",
+  "summary" : "move widget to tab",
+  "description" : "move widget to tab",
+  "search_id" : "5ece5e0a74ff709b0b0dc69a",
+  "properties" : [],
+  "requires" : {},
+  "state" : {
+    "fa247d8f-7afa-45b7-b57e-3cdef4ee53be" : {
+      "titles" : {},
+      "widgets" : [
+        {
+          "id" : "b34c3c6f-c49d-41d3-a65a-f746134f8f3e",
+          "type" : "aggregation",
+          "timerange" : null,
+          "query" : null,
+          "streams" : [],
+          "config" : {
+            "row_pivots" : [],
+            "column_pivots" : [],
+            "series" : [
+              {
+                "config" : {
+                  "name" : "Message Count"
+                },
+                "function" : "count()"
+              }
+            ],
+            "sort" : [],
+            "visualization" : "numeric",
+            "rollup" : true,
+            "event_annotation" : false
+          }
+        }
+      ],
+      "widget_mapping" : {
+        "b34c3c6f-c49d-41d3-a65a-f746134f8f3e" : [
+          "ab258db5-d1f2-4d0c-8508-3b0e42a1b113"
+        ]
+      },
+      "positions" : {
+        "b34c3c6f-c49d-41d3-a65a-f746134f8f3e" : {
+          "col" : 1,
+          "row" : 1,
+          "height" : 4,
+          "width" : 4
+        }
+      },
+      "display_mode_settings" : {
+        "positions" : {}
+      }
+    },
+    "5faea09b-4187-4eda-9d59-7a86d4774c73" : {
+      "titles" : {},
+      "widgets" : [],
+      "widget_mapping" : {},
+      "positions" : {},
+      "display_mode_settings" : {
+        "positions" : {}
+      }
+    }
+  },
+  "owner" : "admin",
+  "created_at" : "2020-05-27T12:32:49.786Z"
+}

--- a/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.Search.fixture.json
+++ b/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.Search.fixture.json
@@ -1,0 +1,52 @@
+{
+  "id" : "5ece5e0a74ff709b0b0dc69a",
+  "queries" : [
+    {
+      "id" : "fa247d8f-7afa-45b7-b57e-3cdef4ee53be",
+      "timerange" : {
+        "type" : "relative",
+        "range" : 300
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : ""
+      },
+      "search_types" : [
+        {
+          "timerange" : null,
+          "query" : null,
+          "streams" : [],
+          "id" : "ab258db5-d1f2-4d0c-8508-3b0e42a1b113",
+          "name" : "chart",
+          "series" : [
+            {
+              "type" : "count",
+              "id" : "Message Count"
+            }
+          ],
+          "sort" : [],
+          "rollup" : true,
+          "type" : "pivot",
+          "row_groups" : [],
+          "column_groups" : []
+        }
+      ]
+    },
+    {
+      "id" : "5faea09b-4187-4eda-9d59-7a86d4774c73",
+      "timerange" : {
+        "type" : "relative",
+        "range" : 300
+      },
+      "query" : {
+        "type" : "elasticsearch",
+        "query_string" : ""
+      },
+      "search_types" : []
+    }
+  ],
+  "parameters" : [],
+  "requires" : {},
+  "owner" : "admin",
+  "created_at" : "2020-05-27T12:33:14.938Z"
+}

--- a/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.js
+++ b/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.js
@@ -1,0 +1,48 @@
+// @flow strict
+import View from './View';
+import FindWidgetAndQueryIdInView from './FindWidgetAndQueryIdInView';
+import Widget from '../widgets/Widget';
+import UpdateSearchForWidgets from './UpdateSearchForWidgets';
+
+type QueryId = string;
+
+const _removeWidgetFromTab = (widgetId: string, queryId: string, dashboard: View): View => {
+  const viewState = dashboard.state.get(queryId);
+  const widgetIndex = viewState.widgets.findIndex((widget) => widget.id === widgetId);
+  const widgetPosition = viewState.widgetPositions;
+  widgetPosition.delete(widgetId);
+  const newViewState = viewState.toBuilder()
+    .widgets(viewState.widgets.delete(widgetIndex))
+    .widgetPositions()
+    .build();
+  return dashboard.toBuilder()
+    .state(dashboard.state.set(queryId, newViewState))
+    .build();
+};
+
+const _addWidgetToTab = (widget: Widget, targetQueryId: QueryId, dashboard: View): View => {
+  const viewState = dashboard.state.get(targetQueryId);
+  const newViewState = viewState.toBuilder()
+    .widgets(viewState.widgets.push(widget))
+    .build();
+  return dashboard.toBuilder()
+    .state(dashboard.state.set(targetQueryId, newViewState))
+    .build();
+};
+
+const MoveWidgetToTab = (widgetId: string, targetQueryId: QueryId, dashboard: View, copy: boolean = false): ?View => {
+  if (dashboard.type !== View.Type.Dashboard) {
+    return undefined;
+  }
+
+  const match: ?[Widget, QueryId] = FindWidgetAndQueryIdInView(widgetId, dashboard);
+
+  if (match) {
+    const [widget, queryId] = match;
+    const tempDashboard = copy ? dashboard : _removeWidgetFromTab(widgetId, queryId, dashboard);
+    return UpdateSearchForWidgets(_addWidgetToTab(widget, targetQueryId, tempDashboard));
+  }
+  return undefined;
+};
+
+export default MoveWidgetToTab;

--- a/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.js
+++ b/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.js
@@ -1,5 +1,5 @@
 // @flow strict
-import * as Immutable from 'immutable';
+import uuid from 'uuid/v4';
 import View from './View';
 import FindWidgetAndQueryIdInView from './FindWidgetAndQueryIdInView';
 import Widget from '../widgets/Widget';
@@ -24,10 +24,11 @@ const _removeWidgetFromTab = (widgetId: string, queryId: string, dashboard: View
     .build();
 };
 
-const _addWidgetToTab = (widget: Widget, targetQueryId: QueryId, dashboard: View, searchTypeIds: Immutable.Set<string>): View => {
+const _addWidgetToTab = (widget: Widget, targetQueryId: QueryId, dashboard: View): View => {
   const viewState = dashboard.state.get(targetQueryId);
+  const newWidget = widget.toBuilder().id(uuid()).build();
   const newViewState = viewState.toBuilder()
-    .widgets(viewState.widgets.push(widget))
+    .widgets(viewState.widgets.push(newWidget))
     .build();
   return dashboard.toBuilder()
     .state(dashboard.state.set(targetQueryId, newViewState))
@@ -43,9 +44,8 @@ const MoveWidgetToTab = (widgetId: string, targetQueryId: QueryId, dashboard: Vi
 
   if (match) {
     const [widget, queryId] = match;
-    const searchTypes = dashboard.state.get(queryId).widgetMapping.get(widgetId);
     const tempDashboard = copy ? dashboard : _removeWidgetFromTab(widgetId, queryId, dashboard);
-    return UpdateSearchForWidgets(_addWidgetToTab(widget, targetQueryId, tempDashboard, searchTypes));
+    return UpdateSearchForWidgets(_addWidgetToTab(widget, targetQueryId, tempDashboard));
   }
   return undefined;
 };

--- a/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.js
+++ b/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.js
@@ -1,13 +1,14 @@
 // @flow strict
 import uuid from 'uuid/v4';
+import type { QueryId } from 'views/logic/queries/Query';
+import type { WidgetId } from 'views/logic/views/types';
 import View from './View';
 import FindWidgetAndQueryIdInView from './FindWidgetAndQueryIdInView';
 import Widget from '../widgets/Widget';
 import UpdateSearchForWidgets from './UpdateSearchForWidgets';
 
-type QueryId = string;
 
-const _removeWidgetFromTab = (widgetId: string, queryId: string, dashboard: View): View => {
+const _removeWidgetFromTab = (widgetId: WidgetId, queryId: QueryId, dashboard: View): View => {
   const viewState = dashboard.state.get(queryId);
   const widgetIndex = viewState.widgets.findIndex((widget) => widget.id === widgetId);
   const widgetPosition = viewState.widgetPositions;
@@ -35,7 +36,7 @@ const _addWidgetToTab = (widget: Widget, targetQueryId: QueryId, dashboard: View
     .build();
 };
 
-const MoveWidgetToTab = (widgetId: string, targetQueryId: QueryId, dashboard: View, copy: boolean = false): ?View => {
+const MoveWidgetToTab = (widgetId: WidgetId, targetQueryId: QueryId, dashboard: View, copy: boolean = false): ?View => {
   if (dashboard.type !== View.Type.Dashboard) {
     return undefined;
   }

--- a/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.js
+++ b/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.js
@@ -3,23 +3,35 @@ import * as Immutable from 'immutable';
 import uuid from 'uuid/v4';
 import type { QueryId } from 'views/logic/queries/Query';
 import type { WidgetId } from 'views/logic/views/types';
+import WidgetPosition from 'views/logic/widgets/WidgetPosition';
+import type { TitlesMap } from 'views/stores/TitleTypes';
 import View from './View';
 import FindWidgetAndQueryIdInView from './FindWidgetAndQueryIdInView';
 import Widget from '../widgets/Widget';
 import UpdateSearchForWidgets from './UpdateSearchForWidgets';
 import AddNewWidgetsToPositions from './AddNewWidgetsToPositions';
-import WidgetPosition from '../widgets/WidgetPosition';
+
+const _removeWidgetTitle = (titlesMap: TitlesMap, widgetId: WidgetId): TitlesMap => {
+  const widgetTitles = titlesMap.get('widget');
+  if (!widgetTitles) {
+    return titlesMap;
+  }
+  const newWidgetTitles = widgetTitles.remove(widgetId);
+  return titlesMap.set('widget', newWidgetTitles);
+};
 
 const _removeWidgetFromTab = (widgetId: WidgetId, queryId: QueryId, dashboard: View): View => {
   const viewState = dashboard.state.get(queryId);
   const widgetIndex = viewState.widgets.findIndex((widget) => widget.id === widgetId);
-  const { widgetPositions } = viewState;
+  const { widgetPositions, titles } = viewState;
+  const newTitles = _removeWidgetTitle(titles, widgetId);
   delete widgetPositions[widgetId];
   const { widgetMapping } = viewState;
   const newWidgetMapping = widgetMapping.remove(widgetId);
   const newViewState = viewState.toBuilder()
     .widgets(viewState.widgets.delete(widgetIndex))
     .widgetMapping(newWidgetMapping)
+    .titles(newTitles)
     .widgetPositions(widgetPositions)
     .build();
   return dashboard.toBuilder()
@@ -27,15 +39,26 @@ const _removeWidgetFromTab = (widgetId: WidgetId, queryId: QueryId, dashboard: V
     .build();
 };
 
-const _addWidgetToTab = (widget: Widget, targetQueryId: QueryId, dashboard: View, newWidgetPosition: WidgetPosition): View => {
+const _setWidgetTitle = (titlesMap: TitlesMap, widgetID: WidgetId, newTitle: ?string): TitlesMap => {
+  if (!newTitle) {
+    return titlesMap;
+  }
+  const widgetTitlesMap = titlesMap.get('widget', Immutable.Map());
+  const newWidgetTitleMap = widgetTitlesMap.set(widgetID, newTitle);
+  return titlesMap.set('widget', newWidgetTitleMap);
+};
+
+const _addWidgetToTab = (widget: Widget, targetQueryId: QueryId, dashboard: View, newWidgetPosition: WidgetPosition, widgetTitle: ?string): View => {
   const viewState = dashboard.state.get(targetQueryId);
   const newWidget = widget.toBuilder().id(uuid()).build();
   const newWidgets = viewState.widgets.push(newWidget);
   const overridePositions = Immutable.Map({ [newWidget.id]: newWidgetPosition });
   const { widgetPositions } = viewState;
   const newWidgetPositions = AddNewWidgetsToPositions(Immutable.Map(widgetPositions), newWidgets.toArray(), overridePositions);
+  const newTitleMap = _setWidgetTitle(viewState.titles, newWidget.id, widgetTitle);
   const newViewState = viewState.toBuilder()
     .widgets(newWidgets)
+    .titles(newTitleMap)
     .widgetPositions(newWidgetPositions)
     .build();
   return dashboard.toBuilder()
@@ -47,6 +70,10 @@ const _getWidgetPosition = (widgetId: WidgetId, queryId: QueryId, view: View): W
   return view.state.get(queryId).widgetPositions[widgetId];
 };
 
+const _getWidgetTitle = (widgetId: WidgetId, queryId: QueryId, view: View): ?string => {
+  return view.state.get(queryId).titles.get('widget').get(widgetId);
+};
+
 const MoveWidgetToTab = (widgetId: WidgetId, targetQueryId: QueryId, dashboard: View, copy: boolean = false): ?View => {
   if (dashboard.type !== View.Type.Dashboard) {
     throw new Error(`Unexpected type ${dashboard.type} expected ${View.Type.Dashboard}`);
@@ -56,12 +83,13 @@ const MoveWidgetToTab = (widgetId: WidgetId, targetQueryId: QueryId, dashboard: 
 
   if (match) {
     const [widget, queryId] = match;
+    const widgetTitle = _getWidgetTitle(widgetId, queryId, dashboard);
     const newWidgetPosition = _getWidgetPosition(widgetId, queryId, dashboard).toBuilder()
       .col(1)
       .row(1)
       .build();
     const tempDashboard = copy ? dashboard : _removeWidgetFromTab(widgetId, queryId, dashboard);
-    return UpdateSearchForWidgets(_addWidgetToTab(widget, targetQueryId, tempDashboard, newWidgetPosition));
+    return UpdateSearchForWidgets(_addWidgetToTab(widget, targetQueryId, tempDashboard, newWidgetPosition, widgetTitle));
   }
   return undefined;
 };

--- a/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.js
+++ b/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.js
@@ -54,8 +54,8 @@ const MoveWidgetToTab = (widgetId: WidgetId, targetQueryId: QueryId, dashboard: 
   if (match) {
     const [widget, queryId] = match;
     const newWidgetPosition = _getWidgetPosition(widgetId, queryId, dashboard).toBuilder()
-      .col(1)
-      .row(1)
+      .col(0)
+      .row(0)
       .build();
     const tempDashboard = copy ? dashboard : _removeWidgetFromTab(widgetId, queryId, dashboard);
     return UpdateSearchForWidgets(_addWidgetToTab(widget, targetQueryId, tempDashboard, newWidgetPosition));

--- a/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.js
+++ b/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.js
@@ -54,8 +54,8 @@ const MoveWidgetToTab = (widgetId: WidgetId, targetQueryId: QueryId, dashboard: 
   if (match) {
     const [widget, queryId] = match;
     const newWidgetPosition = _getWidgetPosition(widgetId, queryId, dashboard).toBuilder()
-      .col(0)
-      .row(0)
+      .col(1)
+      .row(1)
       .build();
     const tempDashboard = copy ? dashboard : _removeWidgetFromTab(widgetId, queryId, dashboard);
     return UpdateSearchForWidgets(_addWidgetToTab(widget, targetQueryId, tempDashboard, newWidgetPosition));

--- a/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.js
+++ b/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.js
@@ -11,14 +11,14 @@ import UpdateSearchForWidgets from './UpdateSearchForWidgets';
 const _removeWidgetFromTab = (widgetId: WidgetId, queryId: QueryId, dashboard: View): View => {
   const viewState = dashboard.state.get(queryId);
   const widgetIndex = viewState.widgets.findIndex((widget) => widget.id === widgetId);
-  const widgetPosition = viewState.widgetPositions;
-  delete widgetPosition[widgetId];
+  const { widgetPositions } = viewState;
+  delete widgetPositions[widgetId];
   const { widgetMapping } = viewState;
   const newWidgetMapping = widgetMapping.remove(widgetId);
   const newViewState = viewState.toBuilder()
     .widgets(viewState.widgets.delete(widgetIndex))
     .widgetMapping(newWidgetMapping)
-    .widgetPositions(widgetPosition)
+    .widgetPositions(widgetPositions)
     .build();
   return dashboard.toBuilder()
     .state(dashboard.state.set(queryId, newViewState))
@@ -38,7 +38,7 @@ const _addWidgetToTab = (widget: Widget, targetQueryId: QueryId, dashboard: View
 
 const MoveWidgetToTab = (widgetId: WidgetId, targetQueryId: QueryId, dashboard: View, copy: boolean = false): ?View => {
   if (dashboard.type !== View.Type.Dashboard) {
-    return undefined;
+    throw new Error(`Unexpected type ${dashboard.type} expected ${View.Type.Dashboard}`);
   }
 
   const match: ?[Widget, QueryId] = FindWidgetAndQueryIdInView(widgetId, dashboard);

--- a/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.test.js
+++ b/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.test.js
@@ -8,6 +8,9 @@ import View from './View';
 import Search from '../search/Search';
 
 jest.mock('uuid/v4', () => jest.fn(() => 'dead-beef'));
+jest.mock('bson-objectid', () => jest.fn(() => ({
+  toString: jest.fn(() => 'new-search-id'),
+})));
 
 jest.mock('../Widgets', () => ({
   widgetDefinition: () => ({ searchTypes: () => [{ type: 'pivot' }] }),

--- a/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.test.js
+++ b/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.test.js
@@ -1,0 +1,63 @@
+import { readFileSync } from 'fs';
+import { dirname } from 'path';
+
+import MoveWidgetToTab from './MoveWidgetToTab';
+import Parameter from '../parameters/Parameter';
+import ValueParameter from '../parameters/ValueParameter';
+import View from './View';
+import Search from '../search/Search';
+
+jest.mock('uuid/v4', () => jest.fn(() => 'dead-beef'));
+
+jest.mock('../Widgets', () => ({
+  widgetDefinition: () => ({ searchTypes: () => [{ type: 'pivot' }] }),
+}));
+
+jest.mock('../SearchType', () => jest.fn(() => ({
+  type: 'pivot',
+  handler: jest.fn(),
+  defaults: {},
+})));
+
+const cwd = dirname(__filename);
+const readFixture = (filename) => JSON.parse(readFileSync(`${cwd}/${filename}`).toString());
+
+describe('MoveWidgetToTab', () => {
+  beforeEach(() => {
+    Parameter.registerSubtype(ValueParameter.type, ValueParameter);
+  });
+
+  it('should move a Widget to a dashboard', () => {
+    const dashboardFixture = View.fromJSON(readFixture('./MoveWidgetToTab.Dashboard.fixture.json'));
+    const searchFixture = Search.fromJSON(readFixture('./MoveWidgetToTab.Search.fixture.json'));
+    const dashboaad = dashboardFixture.toBuilder()
+      .search(searchFixture)
+      .build();
+
+    const newDashboard = MoveWidgetToTab(
+      'b34c3c6f-c49d-41d3-a65a-f746134f8f3e',
+      '5faea09b-4187-4eda-9d59-7a86d4774c73',
+      dashboaad,
+      false,
+    );
+
+    expect(newDashboard).toMatchSnapshot();
+  });
+
+  it('should copy a Widget to a dashboard', () => {
+    const dashboardFixture = View.fromJSON(readFixture('./MoveWidgetToTab.Dashboard.fixture.json'));
+    const searchFixture = Search.fromJSON(readFixture('./MoveWidgetToTab.Search.fixture.json'));
+    const dashboaad = dashboardFixture.toBuilder()
+      .search(searchFixture)
+      .build();
+
+    const newDashboard = MoveWidgetToTab(
+      'b34c3c6f-c49d-41d3-a65a-f746134f8f3e',
+      '5faea09b-4187-4eda-9d59-7a86d4774c73',
+      dashboaad,
+      true,
+    );
+
+    expect(newDashboard).toMatchSnapshot();
+  });
+});

--- a/graylog2-web-interface/src/views/logic/views/UpdateSearchForWidgets.js
+++ b/graylog2-web-interface/src/views/logic/views/UpdateSearchForWidgets.js
@@ -10,7 +10,7 @@ const UpdateSearchForWidgets = (view: View): View => {
   const search = get(view, 'search');
   const newQueries = search.queries
     .map((q) => q.toBuilder().searchTypes(searchTypes.get(q.id, {}).searchTypes).build());
-  const newSearch = search.toBuilder().queries(newQueries).build();
+  const newSearch = search.toBuilder().newId().queries(newQueries).build();
   let newView = view.toBuilder().search(newSearch).build();
 
   searchTypes.map(({ widgetMapping }) => widgetMapping)

--- a/graylog2-web-interface/src/views/logic/views/UpdateSearchForWidgets.test.js
+++ b/graylog2-web-interface/src/views/logic/views/UpdateSearchForWidgets.test.js
@@ -11,6 +11,9 @@ import ValueParameter from '../parameters/ValueParameter';
 const cwd = dirname(__filename);
 const readFixture = (filename) => JSON.parse(readFileSync(`${cwd}/${filename}`).toString());
 
+jest.mock('bson-objectid', () => jest.fn(() => ({
+  toString: jest.fn(() => 'new-search-id'),
+})));
 jest.mock('uuid/v4', () => jest.fn(() => 'dead-beef'));
 
 jest.mock('../Widgets', () => ({

--- a/graylog2-web-interface/src/views/logic/views/__snapshots__/AddNewWidgetsToPositions.test.js.snap
+++ b/graylog2-web-interface/src/views/logic/views/__snapshots__/AddNewWidgetsToPositions.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AddNewWidgetsToPositions should add a new widget to the first row and column 1`] = `
+Immutable.Map {
+  "foo-1": Object {
+    "col": 1,
+    "height": 5,
+    "row": 1,
+    "width": 6,
+  },
+}
+`;
+
+exports[`AddNewWidgetsToPositions should add a new widget to the first row and column to other widgets 1`] = `
+Immutable.Map {
+  "foo": Object {
+    "col": 1,
+    "height": 8,
+    "row": 6,
+    "width": 3,
+  },
+  "foo-1": Object {
+    "col": 1,
+    "height": 5,
+    "row": 1,
+    "width": 6,
+  },
+}
+`;

--- a/graylog2-web-interface/src/views/logic/views/__snapshots__/CopyWidgetToDashboard.test.js.snap
+++ b/graylog2-web-interface/src/views/logic/views/__snapshots__/CopyWidgetToDashboard.test.js.snap
@@ -7,7 +7,7 @@ Object {
   "id": "5d03952f7aafdc6c1cdc014c",
   "owner": "admin",
   "properties": Immutable.List [],
-  "search_id": "5d9b51d6af140aba42e87469",
+  "search_id": "new-search-id",
   "state": Immutable.Map {
     "f0a1f93c-8400-40de-83ac-94149dbf447c": Object {
       "formatting": Object {

--- a/graylog2-web-interface/src/views/logic/views/__snapshots__/MoveWidgetToTab.test.js.snap
+++ b/graylog2-web-interface/src/views/logic/views/__snapshots__/MoveWidgetToTab.test.js.snap
@@ -1,0 +1,174 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MoveWidgetToTab should copy a Widget to a dashboard 1`] = `
+Object {
+  "created_at": "2020-05-27T12:32:49.786Z",
+  "description": "move widget to tab",
+  "id": "5ece5e1b74ff709b0b0dc69b",
+  "owner": "admin",
+  "properties": Immutable.List [],
+  "search_id": "5ece5e0a74ff709b0b0dc69a",
+  "state": Immutable.Map {
+    "fa247d8f-7afa-45b7-b57e-3cdef4ee53be": Object {
+      "formatting": Object {
+        "highlighting": Array [],
+      },
+      "positions": Immutable.Map {
+        "b34c3c6f-c49d-41d3-a65a-f746134f8f3e": Object {
+          "col": 1,
+          "height": 4,
+          "row": 1,
+          "width": 4,
+        },
+      },
+      "selected_fields": undefined,
+      "titles": Immutable.Map {},
+      "widget_mapping": Immutable.Map {
+        "b34c3c6f-c49d-41d3-a65a-f746134f8f3e": Immutable.Set [
+          "dead-beef",
+        ],
+      },
+      "widgets": Immutable.List [
+        Object {
+          "config": Object {
+            "column_pivots": Array [],
+            "event_annotation": false,
+            "rollup": true,
+            "row_pivots": Array [],
+            "series": Array [
+              Object {
+                "config": Object {
+                  "name": "Message Count",
+                },
+                "function": "count()",
+              },
+            ],
+            "sort": Array [],
+            "visualization": "numeric",
+          },
+          "filter": undefined,
+          "id": "b34c3c6f-c49d-41d3-a65a-f746134f8f3e",
+          "query": null,
+          "streams": Array [],
+          "timerange": null,
+          "type": "aggregation",
+        },
+      ],
+    },
+    "5faea09b-4187-4eda-9d59-7a86d4774c73": Object {
+      "formatting": Object {
+        "highlighting": Array [],
+      },
+      "positions": Immutable.Map {},
+      "selected_fields": undefined,
+      "titles": Immutable.Map {},
+      "widget_mapping": Immutable.Map {
+        "b34c3c6f-c49d-41d3-a65a-f746134f8f3e": Immutable.Set [
+          "dead-beef",
+        ],
+      },
+      "widgets": Immutable.List [
+        Object {
+          "config": Object {
+            "column_pivots": Array [],
+            "event_annotation": false,
+            "rollup": true,
+            "row_pivots": Array [],
+            "series": Array [
+              Object {
+                "config": Object {
+                  "name": "Message Count",
+                },
+                "function": "count()",
+              },
+            ],
+            "sort": Array [],
+            "visualization": "numeric",
+          },
+          "filter": undefined,
+          "id": "b34c3c6f-c49d-41d3-a65a-f746134f8f3e",
+          "query": null,
+          "streams": Array [],
+          "timerange": null,
+          "type": "aggregation",
+        },
+      ],
+    },
+  },
+  "summary": "move widget to tab",
+  "title": "MoveWidgetToTab",
+  "type": "DASHBOARD",
+}
+`;
+
+exports[`MoveWidgetToTab should move a Widget to a dashboard 1`] = `
+Object {
+  "created_at": "2020-05-27T12:32:49.786Z",
+  "description": "move widget to tab",
+  "id": "5ece5e1b74ff709b0b0dc69b",
+  "owner": "admin",
+  "properties": Immutable.List [],
+  "search_id": "5ece5e0a74ff709b0b0dc69a",
+  "state": Immutable.Map {
+    "fa247d8f-7afa-45b7-b57e-3cdef4ee53be": Object {
+      "formatting": Object {
+        "highlighting": Array [],
+      },
+      "positions": Immutable.Map {
+        "b34c3c6f-c49d-41d3-a65a-f746134f8f3e": Object {
+          "col": 1,
+          "height": 4,
+          "row": 1,
+          "width": 4,
+        },
+      },
+      "selected_fields": undefined,
+      "titles": Immutable.Map {},
+      "widget_mapping": Immutable.Map {},
+      "widgets": Immutable.List [],
+    },
+    "5faea09b-4187-4eda-9d59-7a86d4774c73": Object {
+      "formatting": Object {
+        "highlighting": Array [],
+      },
+      "positions": Immutable.Map {},
+      "selected_fields": undefined,
+      "titles": Immutable.Map {},
+      "widget_mapping": Immutable.Map {
+        "b34c3c6f-c49d-41d3-a65a-f746134f8f3e": Immutable.Set [
+          "dead-beef",
+        ],
+      },
+      "widgets": Immutable.List [
+        Object {
+          "config": Object {
+            "column_pivots": Array [],
+            "event_annotation": false,
+            "rollup": true,
+            "row_pivots": Array [],
+            "series": Array [
+              Object {
+                "config": Object {
+                  "name": "Message Count",
+                },
+                "function": "count()",
+              },
+            ],
+            "sort": Array [],
+            "visualization": "numeric",
+          },
+          "filter": undefined,
+          "id": "b34c3c6f-c49d-41d3-a65a-f746134f8f3e",
+          "query": null,
+          "streams": Array [],
+          "timerange": null,
+          "type": "aggregation",
+        },
+      ],
+    },
+  },
+  "summary": "move widget to tab",
+  "title": "MoveWidgetToTab",
+  "type": "DASHBOARD",
+}
+`;

--- a/graylog2-web-interface/src/views/logic/views/__snapshots__/MoveWidgetToTab.test.js.snap
+++ b/graylog2-web-interface/src/views/logic/views/__snapshots__/MoveWidgetToTab.test.js.snap
@@ -7,7 +7,7 @@ Object {
   "id": "5ece5e1b74ff709b0b0dc69b",
   "owner": "admin",
   "properties": Immutable.List [],
-  "search_id": "5ece5e0a74ff709b0b0dc69a",
+  "search_id": "new-search-id",
   "state": Immutable.Map {
     "fa247d8f-7afa-45b7-b57e-3cdef4ee53be": Object {
       "formatting": Object {
@@ -108,20 +108,13 @@ Object {
   "id": "5ece5e1b74ff709b0b0dc69b",
   "owner": "admin",
   "properties": Immutable.List [],
-  "search_id": "5ece5e0a74ff709b0b0dc69a",
+  "search_id": "new-search-id",
   "state": Immutable.Map {
     "fa247d8f-7afa-45b7-b57e-3cdef4ee53be": Object {
       "formatting": Object {
         "highlighting": Array [],
       },
-      "positions": Immutable.Map {
-        "b34c3c6f-c49d-41d3-a65a-f746134f8f3e": Object {
-          "col": 1,
-          "height": 4,
-          "row": 1,
-          "width": 4,
-        },
-      },
+      "positions": Immutable.Map {},
       "selected_fields": undefined,
       "titles": Immutable.Map {},
       "widget_mapping": Immutable.Map {},

--- a/graylog2-web-interface/src/views/logic/views/__snapshots__/MoveWidgetToTab.test.js.snap
+++ b/graylog2-web-interface/src/views/logic/views/__snapshots__/MoveWidgetToTab.test.js.snap
@@ -22,7 +22,11 @@ Object {
         },
       },
       "selected_fields": undefined,
-      "titles": Immutable.Map {},
+      "titles": Immutable.Map {
+        "widget": Immutable.Map {
+          "b34c3c6f-c49d-41d3-a65a-f746134f8f3e": "Widget Title",
+        },
+      },
       "widget_mapping": Immutable.Map {
         "b34c3c6f-c49d-41d3-a65a-f746134f8f3e": Immutable.Set [
           "dead-beef",
@@ -68,7 +72,11 @@ Object {
         },
       },
       "selected_fields": undefined,
-      "titles": Immutable.Map {},
+      "titles": Immutable.Map {
+        "widget": Immutable.Map {
+          "dead-beef": "Widget Title",
+        },
+      },
       "widget_mapping": Immutable.Map {
         "dead-beef": Immutable.Set [
           "dead-beef",
@@ -123,7 +131,9 @@ Object {
       },
       "positions": Immutable.Map {},
       "selected_fields": undefined,
-      "titles": Immutable.Map {},
+      "titles": Immutable.Map {
+        "widget": Immutable.Map {},
+      },
       "widget_mapping": Immutable.Map {},
       "widgets": Immutable.List [],
     },
@@ -140,7 +150,11 @@ Object {
         },
       },
       "selected_fields": undefined,
-      "titles": Immutable.Map {},
+      "titles": Immutable.Map {
+        "widget": Immutable.Map {
+          "dead-beef": "Widget Title",
+        },
+      },
       "widget_mapping": Immutable.Map {
         "dead-beef": Immutable.Set [
           "dead-beef",

--- a/graylog2-web-interface/src/views/logic/views/__snapshots__/MoveWidgetToTab.test.js.snap
+++ b/graylog2-web-interface/src/views/logic/views/__snapshots__/MoveWidgetToTab.test.js.snap
@@ -63,7 +63,7 @@ Object {
       "selected_fields": undefined,
       "titles": Immutable.Map {},
       "widget_mapping": Immutable.Map {
-        "b34c3c6f-c49d-41d3-a65a-f746134f8f3e": Immutable.Set [
+        "dead-beef": Immutable.Set [
           "dead-beef",
         ],
       },
@@ -86,7 +86,7 @@ Object {
             "visualization": "numeric",
           },
           "filter": undefined,
-          "id": "b34c3c6f-c49d-41d3-a65a-f746134f8f3e",
+          "id": "dead-beef",
           "query": null,
           "streams": Array [],
           "timerange": null,
@@ -128,7 +128,7 @@ Object {
       "selected_fields": undefined,
       "titles": Immutable.Map {},
       "widget_mapping": Immutable.Map {
-        "b34c3c6f-c49d-41d3-a65a-f746134f8f3e": Immutable.Set [
+        "dead-beef": Immutable.Set [
           "dead-beef",
         ],
       },
@@ -151,7 +151,7 @@ Object {
             "visualization": "numeric",
           },
           "filter": undefined,
-          "id": "b34c3c6f-c49d-41d3-a65a-f746134f8f3e",
+          "id": "dead-beef",
           "query": null,
           "streams": Array [],
           "timerange": null,

--- a/graylog2-web-interface/src/views/logic/views/__snapshots__/MoveWidgetToTab.test.js.snap
+++ b/graylog2-web-interface/src/views/logic/views/__snapshots__/MoveWidgetToTab.test.js.snap
@@ -59,7 +59,14 @@ Object {
       "formatting": Object {
         "highlighting": Array [],
       },
-      "positions": Immutable.Map {},
+      "positions": Immutable.Map {
+        "dead-beef": Object {
+          "col": 0,
+          "height": 4,
+          "row": 0,
+          "width": 4,
+        },
+      },
       "selected_fields": undefined,
       "titles": Immutable.Map {},
       "widget_mapping": Immutable.Map {
@@ -124,7 +131,14 @@ Object {
       "formatting": Object {
         "highlighting": Array [],
       },
-      "positions": Immutable.Map {},
+      "positions": Immutable.Map {
+        "dead-beef": Object {
+          "col": 0,
+          "height": 4,
+          "row": 0,
+          "width": 4,
+        },
+      },
       "selected_fields": undefined,
       "titles": Immutable.Map {},
       "widget_mapping": Immutable.Map {

--- a/graylog2-web-interface/src/views/logic/views/__snapshots__/MoveWidgetToTab.test.js.snap
+++ b/graylog2-web-interface/src/views/logic/views/__snapshots__/MoveWidgetToTab.test.js.snap
@@ -61,9 +61,9 @@ Object {
       },
       "positions": Immutable.Map {
         "dead-beef": Object {
-          "col": 0,
+          "col": 1,
           "height": 4,
-          "row": 0,
+          "row": 1,
           "width": 4,
         },
       },
@@ -133,9 +133,9 @@ Object {
       },
       "positions": Immutable.Map {
         "dead-beef": Object {
-          "col": 0,
+          "col": 1,
           "height": 4,
-          "row": 0,
+          "row": 1,
           "width": 4,
         },
       },

--- a/graylog2-web-interface/src/views/logic/views/__snapshots__/UpdateSearchForWidgets.test.js.snap
+++ b/graylog2-web-interface/src/views/logic/views/__snapshots__/UpdateSearchForWidgets.test.js.snap
@@ -7,7 +7,7 @@ Object {
   "id": "5d6d03909889ecf444527f98",
   "owner": "admin",
   "properties": Immutable.List [],
-  "search_id": "5d6ce7bd5d1eb45af534399e",
+  "search_id": "new-search-id",
   "state": Immutable.Map {
     "f678e6c5-43b1-4200-b5c3-d33eae164dea": Object {
       "formatting": Object {

--- a/graylog2-web-interface/src/views/logic/views/types.js
+++ b/graylog2-web-interface/src/views/logic/views/types.js
@@ -2,6 +2,6 @@
 import * as Immutable from 'immutable';
 
 type SearchTypeIds = Immutable.Set<string>;
-type WidgetId = string;
+export type WidgetId = string;
 
 export type WidgetMapping = Immutable.Map<WidgetId, SearchTypeIds>;

--- a/graylog2-web-interface/src/views/logic/views/types.js
+++ b/graylog2-web-interface/src/views/logic/views/types.js
@@ -1,4 +1,7 @@
 // @flow strict
 import * as Immutable from 'immutable';
 
-export type WidgetMapping = Immutable.Map<string, Immutable.Set<string>>;
+type SearchTypeIds = Immutable.Set<string>;
+type WidgetId = string;
+
+export type WidgetMapping = Immutable.Map<WidgetId, SearchTypeIds>;

--- a/graylog2-web-interface/src/views/stores/CurrentViewStateStore.js
+++ b/graylog2-web-interface/src/views/stores/CurrentViewStateStore.js
@@ -4,11 +4,10 @@ import * as Immutable from 'immutable';
 import { isEqual } from 'lodash';
 
 import type { RefluxActions } from 'stores/StoreTypes';
-import { widgetDefinition } from 'views/logic/Widgets';
-import WidgetPosition from 'views/logic/widgets/WidgetPosition';
 import FormattingSettings from 'views/logic/views/formatting/FormattingSettings';
 import Widget from 'views/logic/widgets/Widget';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
+import AddNewWidgetsToPositions from 'views/logic/views/AddNewWidgetsToPositions';
 
 import { ViewStore } from './ViewStore';
 import { ViewStatesActions, ViewStatesStore } from './ViewStatesStore';
@@ -86,18 +85,9 @@ export const CurrentViewStateStore = singletonStore(
 
     widgets(nextWidgets) {
       const positionsMap = Immutable.Map(this._activeState().widgetPositions);
-      const newWidgets = nextWidgets.filter((widget) => !positionsMap.get(widget.id));
       const nextWidgetIds = nextWidgets.map(({ id }) => id);
       const cleanedPositionsMap = positionsMap.filter((_, widgetId) => nextWidgetIds.includes(widgetId));
-
-      const newPositionMap = newWidgets.reduce((nextPositionsMap, widget) => {
-        const widgetDef = widgetDefinition(widget.type);
-        const result = nextPositionsMap.reduce((newPosMap, position, id) => {
-          const pos = position.toBuilder().row(position.row + widgetDef.defaultHeight).build();
-          return newPosMap.set(id, pos);
-        }, Immutable.Map());
-        return result.set(widget.id, new WidgetPosition(1, 1, widgetDef.defaultHeight, widgetDef.defaultWidth));
-      }, cleanedPositionsMap);
+      const newPositionMap = AddNewWidgetsToPositions(cleanedPositionsMap, nextWidgets);
 
       const newActiveState = this._activeState().toBuilder()
         .widgets(nextWidgets)


### PR DESCRIPTION
## Description
Add new menu item to widget menu: `Move to Page`. When clicking the user will see a modal
where he can select the target page. Optionally he can decide to keep a copy of the widget
on the current page. After selecting the target page he clicks on `Select`. The widget will
be moved to the new page and the active page will be set to the target query.

## Motivation and Context
A user was able to copy a widget from a search to the first page of a dashboard. But the widget
was stuck now there. There was no possibility to move the widget to a different page of the dashboard.

## How Has This Been Tested?
- Create a dashboard
- create a widget on the first page
- move the widget to a different page

Fixes #8152 

## Screenshots (if appropriate):
![Graylog (3)](https://user-images.githubusercontent.com/448763/83248262-1c053300-a1a5-11ea-9501-33b38caab88a.png)
![Graylog (2)](https://user-images.githubusercontent.com/448763/83248263-1c9dc980-a1a5-11ea-927a-61c1366e8291.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

