### PR TITLE
Retry messages if target index is read-only

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/IndexBlockRetryAttempt.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/IndexBlockRetryAttempt.java
@@ -1,0 +1,53 @@
+package org.graylog2.indexer.messages;
+
+import com.github.rholder.retry.Attempt;
+import org.apache.commons.lang.NotImplementedException;
+
+import java.util.concurrent.ExecutionException;
+
+/**
+ * This is only used for reuse of a wait strategy
+ */
+public class IndexBlockRetryAttempt implements Attempt<Void> {
+
+    private final long number;
+
+    public IndexBlockRetryAttempt(long number) {
+        this.number = number;
+    }
+
+    @Override
+    public long getAttemptNumber() {
+        return number;
+    }
+
+    @Override
+    public long getDelaySinceFirstAttempt() {
+        return 0;
+    }
+
+    @Override
+    public Void get() throws ExecutionException {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public boolean hasResult() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public boolean hasException() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public Void getResult() throws IllegalStateException {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public Throwable getExceptionCause() throws IllegalStateException {
+        throw new NotImplementedException();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/IndexBlockRetryAttempt.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/IndexBlockRetryAttempt.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.indexer.messages;
 
 import com.github.rholder.retry.Attempt;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -217,7 +217,7 @@ public class Messages {
 
             indexedSuccessfully += chunk.size();
 
-            Set<BulkResult.BulkResultItem> remainingFailures = retryIfIndexBlocksPresent(chunk, result.getFailedItems());
+            Set<BulkResult.BulkResultItem> remainingFailures = retryOnlyIndexBlockItemsForever(chunk, result.getFailedItems());
 
             failedItems.addAll(remainingFailures);
             if (isSystemTraffic) {
@@ -259,7 +259,7 @@ public class Messages {
         return runBulkRequest(bulk.build(), chunk.size());
     }
 
-    private Set<BulkResult.BulkResultItem> retryIfIndexBlocksPresent(List<Map.Entry<IndexSet, Message>> chunk, List<BulkResult.BulkResultItem> allFailedItems) {
+    private Set<BulkResult.BulkResultItem> retryOnlyIndexBlockItemsForever(List<Map.Entry<IndexSet, Message>> chunk, List<BulkResult.BulkResultItem> allFailedItems) {
         Set<BulkResult.BulkResultItem> indexBlocks = indexBlocksFrom(allFailedItems);
         final Set<BulkResult.BulkResultItem> otherFailures = new HashSet<>(Sets.difference(new HashSet<>(allFailedItems), indexBlocks));
         List<Map.Entry<IndexSet, Message>> blockedMessages = messagesForResultItems(chunk, indexBlocks);

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -269,7 +269,7 @@ public class Messages {
         long attempt = 1;
 
         while (!indexBlocks.isEmpty()) {
-            blockExecutionForAttempt(attempt++);
+            waitBeforeRetrying(attempt++);
 
             final BulkResult bulkResult = bulkIndexChunk(blockedMessages);
 
@@ -289,7 +289,7 @@ public class Messages {
         return otherFailures;
     }
 
-    private void blockExecutionForAttempt(long attempt) {
+    private void waitBeforeRetrying(long attempt) {
         try {
             final long sleepTime = exponentialWaitSeconds.computeSleepTime(new IndexBlockRetryAttempt(attempt));
             Thread.sleep(sleepTime);

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -246,7 +246,7 @@ public class Messages {
 
     private Set<BulkResult.BulkResultItem> retryOnlyIndexBlockItemsForever(List<Map.Entry<IndexSet, Message>> chunk, List<BulkResult.BulkResultItem> allFailedItems) {
         Set<BulkResult.BulkResultItem> indexBlocks = indexBlocksFrom(allFailedItems);
-        Set<BulkResult.BulkResultItem> otherFailures = Sets.difference(new HashSet<>(allFailedItems), indexBlocks);
+        Set<BulkResult.BulkResultItem> otherFailures = new HashSet<>(Sets.difference(new HashSet<>(allFailedItems), indexBlocks));
 
         List<Map.Entry<IndexSet, Message>> blockedMessages = messagesForResultItems(chunk, indexBlocks);
 
@@ -259,8 +259,13 @@ public class Messages {
 
             BulkResult bulkResult = bulkIndexChunk(blockedMessages);
 
-            indexBlocks = indexBlocksFrom(bulkResult.getFailedItems());
+            List<BulkResult.BulkResultItem> failedItems = bulkResult.getFailedItems();
+
+            indexBlocks = indexBlocksFrom(failedItems);
             blockedMessages = messagesForResultItems(blockedMessages, indexBlocks);
+
+            Set<BulkResult.BulkResultItem> newOtherFailures = Sets.difference(new HashSet<>(failedItems), indexBlocks);
+            otherFailures.addAll(newOtherFailures);
         }
 
         return otherFailures;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesRetryWaitTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesRetryWaitTest.java
@@ -1,0 +1,50 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.messages;
+
+import com.github.rholder.retry.WaitStrategy;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class MessagesRetryWaitTest {
+    @Test
+    void secondsBasedRetryWaitsForSecondsStartingWith1() {
+        WaitStrategy waitStrategy = Messages.exponentialWaitSeconds;
+        assertAll(
+                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(1))).isEqualTo(1000),
+                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(2))).isEqualTo(2000),
+                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(3))).isEqualTo(4000),
+                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(4))).isEqualTo(8000),
+                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(5))).isEqualTo(16000)
+        );
+    }
+
+    // This test was added to document how the retry strategy actually behaves since this is hard to deduct from the code
+    @Test
+    void millisecondsBasedRetryWaitsForMillisecondsStartingWith2() {
+        WaitStrategy waitStrategy = Messages.exponentialWaitMilliseconds;
+        assertAll(
+                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(1))).isEqualTo(2),
+                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(2))).isEqualTo(4),
+                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(3))).isEqualTo(8),
+                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(4))).isEqualTo(16),
+                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(5))).isEqualTo(32)
+        );
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MockedMessagesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MockedMessagesTest.java
@@ -24,7 +24,6 @@ import io.searchbox.core.BulkResult;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.plugin.Message;
 import org.graylog2.system.processing.InMemoryProcessingStatusRecorder;
-import org.jetbrains.annotations.NotNull;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Before;
@@ -201,7 +200,6 @@ public class MockedMessagesTest {
         assertThat(result).containsOnly("other-error-id");
     }
 
-    @NotNull
     private List<Map.Entry<IndexSet, Message>> messagesWithIds(String... ids) {
         return Arrays.stream(ids)
                 .map(this::messageWithId)
@@ -209,7 +207,6 @@ public class MockedMessagesTest {
                 .collect(Collectors.toList());
     }
 
-    @NotNull
     private Message messageWithId(String id) {
         final Message mockedMessage = mock(Message.class);
         when(mockedMessage.getId()).thenReturn(id);
@@ -217,7 +214,6 @@ public class MockedMessagesTest {
         return mockedMessage;
     }
 
-    @NotNull
     private List<Map.Entry<IndexSet, Message>> messageListWith(Message mockedMessage) {
         return ImmutableList.of(
                 new AbstractMap.SimpleEntry<>(mock(IndexSet.class), mockedMessage)


### PR DESCRIPTION
## Description
We are discarding messages, if an Elasticsearch index is blocked. This PR adds infinite retries for them. Indexing will practically be blocked until the the index block is resolved by an Elasticsearch administrator.

## Motivation and Context
Fixes #8211

## How Has This Been Tested?
- New unit tests
- Manual tests with local Elasticsearch in Docker

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

