### PR TITLE
Check only data nodes in Elasticsearch disk usage stats

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/Cluster.java
@@ -147,10 +147,10 @@ public class Cluster {
     }
 
     public Set<NodeDiskUsageStats> getDiskUsageStats() {
-        final JsonNode nodes = catNodes("name", "host", "ip", "diskUsed", "diskTotal","diskUsedPercent");
+        final JsonNode nodes = catNodes("name", "host", "ip", "nodeRole", "diskUsed", "diskTotal","diskUsedPercent");
         final ImmutableSet.Builder<NodeDiskUsageStats> setBuilder = ImmutableSet.builder();
         for (JsonNode jsonElement : nodes) {
-            if (jsonElement.isObject()) {
+            if (jsonElement.isObject() && jsonElement.path("nodeRole").asText().contains("d")) {
                 setBuilder.add(
                     NodeDiskUsageStats.create(
                         jsonElement.path("name").asText(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Just filtering the list of nodes by requesting de nodeRole attribute when querying Elasticsearch and filtering out all those nodes that are not data nodes (that don't include "d" in nodeRole response)

## Motivation and Context
Fixes #8239 

## How Has This Been Tested?
I tested it with an ES cluster with different types of nodes, some acting exclusively as masters for cluster coordination. After this fix, those nodes are no longer included in disk usage stats reporting

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

