### PR TITLE
Post event when dashboard is deleted.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
@@ -30,7 +30,9 @@ import org.graylog.plugins.views.search.views.sharing.IsViewSharedForUser;
 import org.graylog.plugins.views.search.views.sharing.ViewSharing;
 import org.graylog.plugins.views.search.views.sharing.ViewSharingService;
 import org.graylog2.audit.jersey.AuditEvent;
+import org.graylog2.dashboards.events.DashboardDeletedEvent;
 import org.graylog2.database.PaginatedList;
+import org.graylog2.events.ClusterEventBus;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.plugin.rest.PluginRestResource;
@@ -82,14 +84,17 @@ public class ViewsResource extends RestResource implements PluginRestResource {
     private final SearchQueryParser searchQueryParser;
     private final ViewSharingService viewSharingService;
     private final IsViewSharedForUser isViewSharedForUser;
+    private final ClusterEventBus clusterEventBus;
 
     @Inject
     public ViewsResource(ViewService dbService,
                          ViewSharingService viewSharingService,
-                         IsViewSharedForUser isViewSharedForUser) {
+                         IsViewSharedForUser isViewSharedForUser,
+                         ClusterEventBus clusterEventBus) {
         this.dbService = dbService;
         this.viewSharingService = viewSharingService;
         this.isViewSharedForUser = isViewSharedForUser;
+        this.clusterEventBus = clusterEventBus;
         this.searchQueryParser = new SearchQueryParser(ViewDTO.FIELD_TITLE, SEARCH_FIELD_MAPPING);
     }
 
@@ -202,7 +207,15 @@ public class ViewsResource extends RestResource implements PluginRestResource {
         final ViewDTO dto = loadView(id);
         dbService.delete(id);
         removeUserPermissions(dto);
+        triggerDeletedEvent(dto);
         return dto;
+    }
+
+    private void triggerDeletedEvent(ViewDTO dto) {
+        if (dto != null && dto.type() != null && dto.type().equals(ViewDTO.Type.DASHBOARD)) {
+            final DashboardDeletedEvent dashboardDeletedEvent = DashboardDeletedEvent.create(dto.id());
+            clusterEventBus.post(dashboardDeletedEvent);
+        }
     }
 
     private ViewDTO loadView(String id) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
@@ -214,6 +214,7 @@ public class ViewsResource extends RestResource implements PluginRestResource {
     private void triggerDeletedEvent(ViewDTO dto) {
         if (dto != null && dto.type() != null && dto.type().equals(ViewDTO.Type.DASHBOARD)) {
             final DashboardDeletedEvent dashboardDeletedEvent = DashboardDeletedEvent.create(dto.id());
+            //noinspection UnstableApiUsage
             clusterEventBus.post(dashboardDeletedEvent);
         }
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Since the replacement of dashboards with view-based ones, we are not
posting an event when a dashboard is deleted anymore. This is important
e.g. for housekeeping of a user's start page.

This change is now adding back posting events whenever a dashboard is
deleted.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.