### PR TITLE
Fix adding a new header to Http Json Path Data Adapter (Backport of #8188 for 3.3.1)

### DIFF
--- a/graylog2-web-interface/src/components/common/KeyValueTable.jsx
+++ b/graylog2-web-interface/src/components/common/KeyValueTable.jsx
@@ -130,6 +130,7 @@ class KeyValueTable extends React.Component {
           <Input type="text"
                  name="newKey"
                  id="newKey"
+                 data-testid="newKey"
                  bsSize="small"
                  placeholder={this.props.headers[0]}
                  value={this.state.newKey}
@@ -139,6 +140,7 @@ class KeyValueTable extends React.Component {
           <Input type="text"
                  name="newValue"
                  id="newValue"
+                 data-testid="newValue"
                  bsSize="small"
                  placeholder={this.props.headers[1]}
                  value={this.state.newValue}

--- a/graylog2-web-interface/src/components/common/URLWhiteListInput.jsx
+++ b/graylog2-web-interface/src/components/common/URLWhiteListInput.jsx
@@ -82,6 +82,7 @@ const URLWhiteListInput = ({ label, onChange, validationMessage, validationState
 
   const addButton = isWhitelistError() && !isWhitelisted ? <URLWhiteListFormModal newUrlEntry={suggestedUrl} onUpdate={onUpdate} urlType={urlType} /> : '';
   const helpMessage = <>{validationState === null ? ownValidationMessage : validationMessage} {addButton}</>;
+  const bsStyle = currentValidationState === '' ? null : currentValidationState;
   return (
     <Input type="text"
            id="url"
@@ -92,7 +93,7 @@ const URLWhiteListInput = ({ label, onChange, validationMessage, validationState
            required
            onChange={onChange}
            help={helpMessage}
-           bsStyle={currentValidationState}
+           bsStyle={bsStyle}
            value={url}
            labelClassName={labelClassName}
            wrapperClassName={wrapperClassName} />

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/HTTPJSONPathAdapterFieldSet.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/HTTPJSONPathAdapterFieldSet.jsx
@@ -1,3 +1,4 @@
+// @flow strict
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Input } from 'components/bootstrap';
@@ -5,23 +6,38 @@ import { URLWhiteListInput, KeyValueTable } from 'components/common';
 
 import ObjectUtils from 'util/ObjectUtils';
 
-class HTTPJSONPathAdapterFieldSet extends React.Component {
+type Headers = {[string]: string };
+
+type Config = {
+  headers: Headers,
+  url: string,
+  single_value_jsonpath: string,
+  multi_value_jsonpath: string,
+  user_agent: string,
+};
+
+type Props = {
+  config: Config,
+  updateConfig: (Config) => void,
+  handleFormEvent: (Event) => void,
+  validationState: (string) => void,
+  validationMessage: (string, string) => void,
+};
+
+class HTTPJSONPathAdapterFieldSet extends React.Component<Props> {
   static propTypes = {
     config: PropTypes.object.isRequired,
-    // eslint-disable-next-line react/no-unused-prop-types
     updateConfig: PropTypes.func.isRequired,
     handleFormEvent: PropTypes.func.isRequired,
     validationState: PropTypes.func.isRequired,
     validationMessage: PropTypes.func.isRequired,
   };
 
-  state = {};
-
-  onHTTPHeaderUpdate = (headers) => {
+  onHTTPHeaderUpdate = (headers: Headers) => {
     const { config, updateConfig } = this.props;
     const configChange = ObjectUtils.clone(config);
     configChange.headers = headers;
-    updateConfig(config);
+    updateConfig(configChange);
   };
 
   render() {

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/HTTPJSONPathAdapterFieldSet.test.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/HTTPJSONPathAdapterFieldSet.test.jsx
@@ -1,0 +1,59 @@
+// @flow strict
+import React from 'react';
+import { fireEvent, render } from 'wrappedTestingLibrary';
+import HTTPJSONPathAdapterFieldSet from './HTTPJSONPathAdapterFieldSet';
+
+describe('HTTPJSONPathAdapterFieldSet', () => {
+  const config = {
+    url: 'https://example.org/test',
+    headers: { test: 'headers' },
+    single_value_jsonpath: 'foo.bar',
+    multi_value_jsonpath: 'bar.foo',
+    user_agent: 'smith',
+  };
+
+  it('should render the field set', () => {
+    const { container } = render(
+      <HTTPJSONPathAdapterFieldSet config={config}
+                                   updateConfig={() => {
+                                   }}
+                                   handleFormEvent={() => {
+                                   }}
+                                   validationState={() => {
+                                   }}
+                                   validationMessage={() => {
+                                   }} />,
+    );
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should add a header', () => {
+    const updateConfig = jest.fn();
+    const { getByTestId, getByText } = render(
+      <HTTPJSONPathAdapterFieldSet config={config}
+                                   updateConfig={updateConfig}
+                                   handleFormEvent={() => {
+                                   }}
+                                   validationState={() => {
+                                   }}
+                                   validationMessage={() => {
+                                   }} />,
+    );
+    const newKeyInput = getByTestId('newKey');
+    const newValueInput = getByTestId('newValue');
+    const addBtn = getByText('Add');
+
+    fireEvent.change(newKeyInput, { target: { value: 'new Key' } });
+    fireEvent.change(newValueInput, { target: { value: 'new Value' } });
+    fireEvent.click(addBtn);
+
+    const newConfig = {
+      ...config,
+      headers: {
+        ...config.headers,
+        'new Key': 'new Value',
+      },
+    };
+    expect(updateConfig).toBeCalledWith(newConfig);
+  });
+});

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/__snapshots__/HTTPJSONPathAdapterFieldSet.test.jsx.snap
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/__snapshots__/HTTPJSONPathAdapterFieldSet.test.jsx.snap
@@ -1,0 +1,232 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HTTPJSONPathAdapterFieldSet should render the field set 1`] = `
+<div>
+  <fieldset>
+    <div
+      class="FormGroup__StyledFormGroup-sc-1wv4cm9-0 ekazNr form-group"
+    >
+      <label
+        class="ControlLabel-sc-1edmum5-0 hCskeX col-sm-3 control-label"
+        for="url"
+      >
+        Lookup URL
+      </label>
+      <div
+        class="col-sm-9"
+      >
+        <input
+          class="FormControl-sc-1amoaox-0 fdBWEX form-control"
+          id="url"
+          label="Lookup URL"
+          name="url"
+          placeholder=""
+          required=""
+          type="text"
+          value="https://example.org/test"
+        />
+        <span
+          class="HelpBlock-i8is92-0 kxWRDS help-block"
+        >
+          
+           
+          
+        </span>
+      </div>
+    </div>
+    <div
+      class="FormGroup__StyledFormGroup-sc-1wv4cm9-0 ekazNr form-group"
+    >
+      <label
+        class="ControlLabel-sc-1edmum5-0 hCskeX col-sm-3 control-label"
+        for="single_value_jsonpath"
+      >
+        Single value JSONPath
+      </label>
+      <div
+        class="col-sm-9"
+      >
+        <input
+          class="FormControl-sc-1amoaox-0 fdBWEX form-control"
+          id="single_value_jsonpath"
+          label="Single value JSONPath"
+          name="single_value_jsonpath"
+          placeholder=""
+          required=""
+          type="text"
+          value="foo.bar"
+        />
+        
+      </div>
+    </div>
+    <div
+      class="FormGroup__StyledFormGroup-sc-1wv4cm9-0 ekazNr form-group"
+    >
+      <label
+        class="ControlLabel-sc-1edmum5-0 hCskeX col-sm-3 control-label"
+        for="multi_value_jsonpath"
+      >
+        Multi value JSONPath
+      </label>
+      <div
+        class="col-sm-9"
+      >
+        <input
+          class="FormControl-sc-1amoaox-0 fdBWEX form-control"
+          id="multi_value_jsonpath"
+          label="Multi value JSONPath"
+          name="multi_value_jsonpath"
+          placeholder=""
+          type="text"
+          value="bar.foo"
+        />
+        
+      </div>
+    </div>
+    <div
+      class="FormGroup__StyledFormGroup-sc-1wv4cm9-0 ekazNr form-group"
+    >
+      <label
+        class="ControlLabel-sc-1edmum5-0 hCskeX col-sm-3 control-label"
+        for="user_agent"
+      >
+        HTTP User-Agent
+      </label>
+      <div
+        class="col-sm-9"
+      >
+        <input
+          class="FormControl-sc-1amoaox-0 fdBWEX form-control"
+          id="user_agent"
+          label="HTTP User-Agent"
+          name="user_agent"
+          placeholder=""
+          required=""
+          type="text"
+          value="smith"
+        />
+        <span
+          class="HelpBlock-i8is92-0 kxWRDS help-block"
+        >
+          The User-Agent header to use for the HTTP request.
+        </span>
+      </div>
+    </div>
+    <div
+      class="FormGroup__StyledFormGroup-sc-1wv4cm9-0 ekazNr form-group"
+    >
+      <label
+        class="ControlLabel-sc-1edmum5-0 hCskeX col-sm-3 control-label"
+        for="http_headers"
+      >
+        HTTP Headers
+      </label>
+      <div
+        class="col-sm-9"
+      >
+        <div
+          class="key-value-table-component"
+        >
+          <div
+            class="table-responsive "
+          >
+            <table
+              class="table table-striped "
+            >
+              <thead>
+                <tr>
+                  <th>
+                    Name
+                  </th>
+                  <th>
+                    Value
+                  </th>
+                  <th
+                    style="width: 75px;"
+                  >
+                    Actions
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    test
+                  </td>
+                  <td>
+                    headers
+                  </td>
+                  <td>
+                    <button
+                      class="Button__StyledButton-c9cbmb-0 jVYrA btn btn-xs btn-danger"
+                      type="button"
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <div
+                      class="FormGroup__StyledFormGroup-sc-1wv4cm9-0 ekazNr form-group"
+                    >
+                      
+                      <span>
+                        <input
+                          class="FormControl-sc-1amoaox-0 fdBWEX form-control input-sm"
+                          data-testid="newKey"
+                          id="newKey"
+                          label=""
+                          name="newKey"
+                          placeholder="Name"
+                          type="text"
+                          value=""
+                        />
+                        
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <div
+                      class="FormGroup__StyledFormGroup-sc-1wv4cm9-0 ekazNr form-group"
+                    >
+                      
+                      <span>
+                        <input
+                          class="FormControl-sc-1amoaox-0 fdBWEX form-control input-sm"
+                          data-testid="newValue"
+                          id="newValue"
+                          label=""
+                          name="newValue"
+                          placeholder="Value"
+                          type="text"
+                          value=""
+                        />
+                        
+                      </span>
+                    </div>
+                  </td>
+                  <td>
+                    <button
+                      class="Button__StyledButton-c9cbmb-0 jVYrA btn btn-sm btn-success"
+                      disabled=""
+                      type="button"
+                    >
+                      Add
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <span
+          class="HelpBlock-i8is92-0 kxWRDS help-block"
+        >
+          The custom HTTP headers to use for the HTTP request. Multiple values must be comma-separated.
+        </span>
+      </div>
+    </div>
+  </fieldset>
+</div>
+`;


### PR DESCRIPTION
**Backport of https://github.com/Graylog2/graylog2-server/pull/8188 for 3.3.1**

## Motivation
Prior to this change, when the user add a new header,
the newly resulting config would be ignored and instead
the old config was passed to the updateConfig function.

## Description
This change will use the update config with the new headers.

Also:
  - Add test to verify the fix applies
  - Fix warning in URLWhiteListInput: Without the fix
    the test would throw an warning which would prevent
    to pass the test.
  - Add testid to KeyValueTable to make it possible to
    add new rows in a test.

## How Has This Been Tested?
- Add a new header to a HttpJsonPathDataAdapter

Fixes #8186 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

