### PR TITLE
Allow alert conditions with floating numbers

### DIFF
--- a/graylog2-web-interface/src/logic/alerts/AggregationExpressionValidation.js
+++ b/graylog2-web-interface/src/logic/alerts/AggregationExpressionValidation.js
@@ -16,7 +16,7 @@ const flattenValidationTree = (validationTree, errors = []) => {
 const validateExpressionTree = (expression, series, validationTree = {}) => {
   switch (expression.expr) {
     case 'number':
-      return (Number.isSafeInteger(expression.value) ? {} : { message: 'Threshold must be a valid number' });
+      return (Number.isNaN(expression.value) ? { message: 'Threshold must be a valid number' } : {});
     case 'number-ref':
       /* eslint-disable no-case-declarations */
       const error = { message: 'Function must be set' };

--- a/graylog2-web-interface/src/logic/alerts/AggregationExpressionValidation.js
+++ b/graylog2-web-interface/src/logic/alerts/AggregationExpressionValidation.js
@@ -16,7 +16,7 @@ const flattenValidationTree = (validationTree, errors = []) => {
 const validateExpressionTree = (expression, series, validationTree = {}) => {
   switch (expression.expr) {
     case 'number':
-      return (Number.isNaN(expression.value) ? { message: 'Threshold must be a valid number' } : {});
+      return (Number.isFinite(expression.value) ? {} : { message: 'Threshold must be a valid number' });
     case 'number-ref':
       /* eslint-disable no-case-declarations */
       const error = { message: 'Function must be set' };


### PR DESCRIPTION
This got changed with the introduction of multiple conditions in 3.2.
The backend treats every value as Double anyhow.
