### PR TITLE
Clear exception in auth strategy before all attempts

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/security/ThrowingFirstSuccessfulStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/ThrowingFirstSuccessfulStrategy.java
@@ -22,6 +22,8 @@ import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.authc.pam.FirstSuccessfulStrategy;
 import org.apache.shiro.realm.Realm;
 
+import java.util.Collection;
+
 /**
  * An authentication strategy pretty much the same as the {@link FirstSuccessfulStrategy} with the difference that it
  * will memoize a {@link AuthenticationServiceUnavailableException} thrown by any attempt. It will rethrow this
@@ -34,6 +36,17 @@ import org.apache.shiro.realm.Realm;
 public class ThrowingFirstSuccessfulStrategy extends FirstSuccessfulStrategy {
 
     private AuthenticationServiceUnavailableException unavailableException;
+
+    /**
+     * Clear a possible {@link AuthenticationServiceUnavailableException} because this strategy will be re-used for
+     * multiple authentication processes.
+     */
+    @Override
+    public AuthenticationInfo beforeAllAttempts(Collection<? extends Realm> realms,
+            AuthenticationToken token) throws AuthenticationException {
+        unavailableException = null;
+        return super.beforeAllAttempts(realms, token);
+    }
 
     /**
      * If the attempt failed due to an {@link AuthenticationServiceUnavailableException}, memoize that exception. Will


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `ThrowingFirstSuccessfulStrategy` now clears any exception before processing a new authentication request.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When the `ThrowingFirstSuccessfulStrategy` encountered an exception, it wouldn't clear it on subsequent authentication requests. Therefore, if authentication was unsuccessful, it would not return the normal `null` value but rather re-throw the exception from the previous attempt. I came across this bug while looking at https://github.com/Graylog2/graylog2-server/pull/8192.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with the setup described [here](https://github.com/Graylog2/graylog2-server/pull/8192#pullrequestreview-419835681): 
1. Perform a auth request with a wrong password. You'll get an error about wrong credentials.
2. Take down the LDAP server. Perform the same request as in **1.)**. You'll get an error indicating that the service is not available.
3. Take the LDAP server online again. Perform the same request as before. You'll get the same error as in **2.)** before the fix (which is wrong), but the same error as in **1.)** after the fix (which is correct).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

