### PR TITLE
Unmount rendered components in `HTTPJSONPathAdapterFieldSet` test to fix test failure

### DIFF
--- a/graylog2-web-interface/src/components/lookup-tables/adapters/HTTPJSONPathAdapterFieldSet.test.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/HTTPJSONPathAdapterFieldSet.test.jsx
@@ -1,6 +1,6 @@
 // @flow strict
 import React from 'react';
-import { fireEvent, render } from 'wrappedTestingLibrary';
+import { fireEvent, render, cleanup } from 'wrappedTestingLibrary';
 import HTTPJSONPathAdapterFieldSet from './HTTPJSONPathAdapterFieldSet';
 
 describe('HTTPJSONPathAdapterFieldSet', () => {
@@ -11,6 +11,8 @@ describe('HTTPJSONPathAdapterFieldSet', () => {
     multi_value_jsonpath: 'bar.foo',
     user_agent: 'smith',
   };
+
+  afterEach(cleanup);
 
   it('should render the field set', () => {
     const { container } = render(


### PR DESCRIPTION
The `HTTPJSONPathAdapterFieldSet` test is currently sometimes failing on the master branch, with the warning `An update to URLWhiteListInput inside a test was not wrapped in act(...)`.

This problem can be fixed by unmounting the rendered components in the `HTTPJSONPathAdapterFieldSet` test.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
