### PR TITLE
Remove not needed tab index from `WidgetHorizontalStretch`

### DIFF
--- a/graylog2-web-interface/src/components/common/IconButton.jsx
+++ b/graylog2-web-interface/src/components/common/IconButton.jsx
@@ -31,6 +31,7 @@ const Wrapper: StyledComponent<{}, ThemeInterface, HTMLButtonElement> = styled.b
 
 
 type Props = {
+  focusable?: boolean,
   title: string,
   onClick?: () => void,
 };
@@ -41,8 +42,8 @@ const handleClick = (onClick) => {
   }
 };
 
-const IconButton = ({ title, onClick, ...rest }: Props) => (
-  <Wrapper title={title} onClick={() => handleClick(onClick)}>
+const IconButton = ({ title, onClick, focusable, ...rest }: Props) => (
+  <Wrapper tabIndex={focusable ? 0 : -1} title={title} onClick={() => handleClick(onClick)}>
     <Icon {...rest} />
   </Wrapper>
 );
@@ -53,6 +54,7 @@ IconButton.propTypes = {
 };
 
 IconButton.defaultProps = {
+  focusable: true,
   onClick: undefined,
   title: undefined,
 };

--- a/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/ReplaySearchButton.jsx
@@ -29,7 +29,7 @@ const ReplaySearchButton = () => {
   const searchLink = buildSearchLink(timerange, query.query_string, streams);
   return (
     <NeutralLink href={searchLink} target="_blank" rel="noopener noreferrer" title="Replay search">
-      <IconButton name="play" />
+      <IconButton name="play" focusable={false} />
     </NeutralLink>
   );
 };

--- a/graylog2-web-interface/src/views/components/widgets/WidgetHorizontalStretch.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetHorizontalStretch.jsx
@@ -28,7 +28,7 @@ class WidgetHorizontalStretch extends React.Component {
     const icon = stretched ? 'compress' : 'arrows-h';
     const title = stretched ? 'Compress width' : 'Stretch width';
     return (
-      <IconButton tabIndex={0} onClick={this._onClick} name={icon} title={title} />
+      <IconButton onClick={this._onClick} name={icon} title={title} />
     );
   }
 }

--- a/graylog2-web-interface/src/views/components/widgets/__snapshots__/Widget.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/widgets/__snapshots__/Widget.test.jsx.snap
@@ -19,6 +19,7 @@ exports[`<Widget /> should render with empty props 1`] = `
         >
           <button
             class="IconButton__Wrapper-sc-1q956yw-0 kZTuI"
+            tabindex="0"
             title="Stretch width"
           >
             <svg
@@ -34,6 +35,7 @@ exports[`<Widget /> should render with empty props 1`] = `
               <span>
                 <button
                   class="IconButton__Wrapper-sc-1q956yw-0 kZTuI"
+                  tabindex="0"
                   title="Open actions dropdown"
                 >
                   <svg


### PR DESCRIPTION
When using the tab navigation, the `WidgetHorizontalStretch` Icon captures the focus twice.
The first focus is on the `IconButton` the second focus is on the `Icon` itself due to the `tabIndex` prop. The same problem exists for the `ReplaySearchButton` because the `IconButton` is wrapped in a link.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
