### PR TITLE
Prevent single number widget flickering

### DIFF
--- a/graylog2-web-interface/src/views/components/visualizations/number/AutoFontSizer.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/AutoFontSizer.jsx
@@ -2,6 +2,14 @@
 import React, { type Element, type ElementRef, useEffect, useRef, useState } from 'react';
 import styled, { type StyledComponent } from 'styled-components';
 
+/**
+ * This component will update the font size based on the difference between the dimensions of the container and its child.
+ * The font size is being recalculated, until the mentioned difference is within the tolerance.
+ */
+
+const TOLERANCE = 0.05;
+const CHILD_SIZE_RATIO = 0.8; // Proportion of the child size in relation to the container
+
 const FontSize: StyledComponent<{ fontSize: number }, {}, HTMLDivElement> = styled.div`
   height: 100%;
   width: 100%;
@@ -16,25 +24,18 @@ type Props = {
 };
 
 const _multiplierForElement = (element, targetWidth, targetHeight) => {
-  const childSizeRatio = 0.8; // Propotion of the child size in relation to the container
   const contentWidth = element.offsetWidth;
   const contentHeight = element.offsetHeight;
 
-  const widthMultiplier = (targetWidth * childSizeRatio) / contentWidth;
-  const heightMultiplier = (targetHeight * childSizeRatio) / contentHeight;
+  const widthMultiplier = (targetWidth * CHILD_SIZE_RATIO) / contentWidth;
+  const heightMultiplier = (targetHeight * CHILD_SIZE_RATIO) / contentHeight;
+
   return Math.min(widthMultiplier, heightMultiplier);
 };
 
-const _updateFontSize = (setFontSize, currentSize, newSize) => {
-  if (currentSize !== newSize && newSize !== 0 && Number.isFinite(newSize)) {
-    setFontSize(newSize);
-  }
-};
+const isValidFontSize = (fontSize) => fontSize !== 0 && Number.isFinite(fontSize);
 
 const useAutoFontSize = (target, _container, height, width) => {
-  // This hook will update the font size based on the difference between the dimensions of the container and its child.
-  // The font size is being recalculated, until the mentioned difference is within the tolerance.
-  const tolerance = 0.05;
   const [fontSize, setFontSize] = useState(20);
 
   useEffect(() => {
@@ -47,12 +48,14 @@ const useAutoFontSize = (target, _container, height, width) => {
 
     const contentElement = containerChildren[0];
     const multiplier = _multiplierForElement(contentElement, width, height);
-    if (Math.abs(1 - multiplier) <= tolerance) {
+    if (Math.abs(1 - multiplier) <= TOLERANCE) {
       return;
     }
 
     const newFontSize = Math.floor(fontSize * multiplier);
-    _updateFontSize(setFontSize, fontSize, newFontSize);
+    if (newFontSize !== fontSize && isValidFontSize(newFontSize)) {
+      setFontSize(newFontSize);
+    }
   }, [target, _container, fontSize, height, width]);
 
   return fontSize;

--- a/graylog2-web-interface/src/views/components/visualizations/number/AutoFontSizer.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/AutoFontSizer.jsx
@@ -34,7 +34,7 @@ const _updateFontSize = (setFontSize, currentSize, newSize) => {
 const useAutoFontSize = (target, _container, height, width) => {
   // This hook will update the font size based on the difference between the dimensions of the container and its child.
   // The font size is being recalculated, until the mentioned difference is within the tolerance.
-  const tolerance = 0.01;
+  const tolerance = 0.05;
   const [fontSize, setFontSize] = useState(20);
 
   useEffect(() => {

--- a/graylog2-web-interface/src/views/components/visualizations/number/AutoFontSizer.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/AutoFontSizer.jsx
@@ -4,8 +4,8 @@ import styled, { type StyledComponent } from 'styled-components';
 
 /**
  * This component will calculate the largest possible font size for the provided child.
- * The calculation is based the difference between the dimensions of the container and its child.
- * The font size is being recalculated, until the mentioned difference is within the defined tolerance.
+ * The calculation is based on the ratio of the current dimensions of the child and the dimensions of its container.
+ * The font size is being multiplied by this ratio, unless it has a difference to 1 that is smaller than the defined tolerance.
  */
 
 const TOLERANCE = 0.05;

--- a/graylog2-web-interface/src/views/components/visualizations/number/AutoFontSizer.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/AutoFontSizer.jsx
@@ -3,8 +3,9 @@ import React, { type Element, type ElementRef, useEffect, useRef, useState } fro
 import styled, { type StyledComponent } from 'styled-components';
 
 /**
- * This component will update the font size based on the difference between the dimensions of the container and its child.
- * The font size is being recalculated, until the mentioned difference is within the tolerance.
+ * This component will calculate the largest possible font size for the provided child.
+ * The calculation is based the difference between the dimensions of the container and its child.
+ * The font size is being recalculated, until the mentioned difference is within the defined tolerance.
  */
 
 const TOLERANCE = 0.05;


### PR DESCRIPTION
**This PR needs a backport for 3.3.1 (or 3.3.2)**

As described in https://github.com/Graylog2/graylog2-server/issues/7563 the single number widget can flicker when the widget has a small height.

This happened because the font size always changed between `11px` and `10px`. in both cases the defined tolerance did not matched. This PR is fixing the issue by increasing the tolerance. It also refactors the `AutoFontSizer` code style.

The issue is currently not occurring on the master branch, because https://github.com/Graylog2/graylog2-server/pull/8064 changed the widget content height. You can reproduce the error, by checking out the commit `ed8998c3251` and following the steps in the mentioned issue.

Fixes https://github.com/Graylog2/graylog2-server/issues/7563

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

