### PR TITLE
Update font awesome icon names regarding font awesome v5

### DIFF
--- a/graylog2-web-interface/package.json
+++ b/graylog2-web-interface/package.json
@@ -65,6 +65,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.28",
     "@fortawesome/free-brands-svg-icons": "^5.13.0",
+    "@fortawesome/free-regular-svg-icons": "^5.13.0",
     "@fortawesome/free-solid-svg-icons": "^5.13.0",
     "@fortawesome/react-fontawesome": "^0.1.9",
     "@openfonts/roboto-mono_latin": "^1.44.1",

--- a/graylog2-web-interface/src/components/common/Icon.jsx
+++ b/graylog2-web-interface/src/components/common/Icon.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { find, isString } from 'lodash';
+import { find } from 'lodash';
 
 import deprecationNotice from 'util/deprecationNotice';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -11,7 +11,9 @@ import compareIconNames from './icon-fallback';
 
 library.add(fas, faApple, faGithub, faGithubAlt, faLinux, faWindows);
 
-const cleanIconName = (icon) => {
+const removeFaPrefix = (name) => name.replace(/^fa-/, ''); // remove "fa-" prefix if it exists
+
+const updateLegacyName = (icon) => {
   const v4icon = find(compareIconNames, { v4: icon });
   const iconName = (v4icon && v4icon.v5) || icon;
 
@@ -19,7 +21,25 @@ const cleanIconName = (icon) => {
     deprecationNotice(`You have used a deprecated \`Icon\` name. \`${icon}\` should be \`${iconName}\``);
   }
 
-  return { prefix: 'fas', iconName };
+  return iconName;
+};
+
+const cleanIconName = (name, type) => {
+  const iconName = removeFaPrefix(name);
+  if (type !== 'brand') {
+    return updateLegacyName(iconName);
+  }
+  return iconName;
+};
+
+const getPrefixForType = (type) => {
+  switch (type) {
+    case 'brand':
+      return 'fab';
+    case 'solid':
+    default:
+      return 'fas';
+  }
 };
 
 /**
@@ -30,26 +50,23 @@ const cleanIconName = (icon) => {
  * Visit [React FontAwesome Features](https://github.com/FortAwesome/react-fontawesome#features) for more information.
  */
 
-const Icon = ({ name, ...props }) => {
-  let icon = name;
-  if (isString(name)) {
-    icon = cleanIconName(name.replace(/^fa-/, '')); // remove "fa-" prefix if it exists
-  }
-
+const Icon = ({ name, type, ...props }) => {
+  const iconName = cleanIconName(name, type);
+  const prefix = getPrefixForType(type);
   return (
-    <FontAwesomeIcon {...props} icon={icon} />
+    <FontAwesomeIcon {...props} icon={{ prefix, iconName }} />
   );
 };
 
 Icon.propTypes = {
   /** Name of Font Awesome 5 Icon without `fa-` prefix */
-  name: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.shape({
-      prefix: PropTypes.string,
-      iconName: PropTypes.string,
-    }),
-    PropTypes.arrayOf(PropTypes.string)]).isRequired,
+  name: PropTypes.string.isRequired,
+  /** Name of icon type, the brand type is needed for all brand icons */
+  type: PropTypes.oneOf(['brand', 'solid']),
+};
+
+Icon.defaultProps = {
+  type: 'solid',
 };
 
 export default Icon;

--- a/graylog2-web-interface/src/components/common/Icon.jsx
+++ b/graylog2-web-interface/src/components/common/Icon.jsx
@@ -6,10 +6,11 @@ import deprecationNotice from 'util/deprecationNotice';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { fas } from '@fortawesome/free-solid-svg-icons';
+import { far } from '@fortawesome/free-regular-svg-icons';
 import { faApple, faGithub, faGithubAlt, faLinux, faWindows } from '@fortawesome/free-brands-svg-icons';
 import compareIconNames from './icon-fallback';
 
-library.add(fas, faApple, faGithub, faGithubAlt, faLinux, faWindows);
+library.add(fas, far, faApple, faGithub, faGithubAlt, faLinux, faWindows);
 
 const removeFaPrefix = (name) => name.replace(/^fa-/, ''); // remove "fa-" prefix if it exists
 
@@ -36,6 +37,8 @@ const getPrefixForType = (type) => {
   switch (type) {
     case 'brand':
       return 'fab';
+    case 'regular':
+      return 'far';
     case 'solid':
     default:
       return 'fas';
@@ -61,8 +64,12 @@ const Icon = ({ name, type, ...props }) => {
 Icon.propTypes = {
   /** Name of Font Awesome 5 Icon without `fa-` prefix */
   name: PropTypes.string.isRequired,
-  /** Name of icon type, the brand type is needed for all brand icons */
-  type: PropTypes.oneOf(['brand', 'solid']),
+  /**
+   * Name of icon type, the brand type is needed for all brand icons.
+   * The type regular is needed to outlined icon.
+   * Not all icons can be outlined.
+   * */
+  type: PropTypes.oneOf(['brand', 'solid', 'regular']),
 };
 
 Icon.defaultProps = {

--- a/graylog2-web-interface/src/components/common/Icon.md
+++ b/graylog2-web-interface/src/components/common/Icon.md
@@ -9,7 +9,7 @@ Examples:
 <p><strong>Rotate:</strong> <Icon name="bars" rotate="90" /></p>
 
 <p>
-  <strong>Sizeable:</strong>
+  <strong>Sizeable:</strong>{' '}
   <Icon name="bolt" size="lg" />{' '}
   <Icon name="bolt" size="2x" />{' '}
   <Icon name="bolt" size="3x" />{' '}
@@ -18,8 +18,17 @@ Examples:
 </p>
 
 <p>
-  <strong>Flipped:</strong>
-  <Icon name="hand-paper" flip="horizontal" type="regular" />{' '}<Icon name="hand-paper" type="regular" />
+  <strong>Flipped:</strong>{' '}
+  <Icon name="hand-paper" flip="horizontal" />{' '}<Icon name="hand-paper" />
 </p>
 
+<p>
+  <strong>Outlined:</strong>{' '}
+  <Icon name="star" type="regular" />{' '}<Icon name="hand-paper" type="regular" />
+</p>
+
+<p>
+  <strong>Brand:</strong>{' '}
+  <Icon name="github" type="brand" />
+</p>
 ```

--- a/graylog2-web-interface/src/components/common/Icon.md
+++ b/graylog2-web-interface/src/components/common/Icon.md
@@ -19,7 +19,7 @@ Examples:
 
 <p>
   <strong>Flipped:</strong>
-  <Icon name="hand-paper" flip="horizontal" />{' '}<Icon name="hand-paper" />
+  <Icon name="hand-paper" flip="horizontal" type="regular" />{' '}<Icon name="hand-paper" type="regular" />
 </p>
 
 ```

--- a/graylog2-web-interface/src/components/common/Icon.md
+++ b/graylog2-web-interface/src/components/common/Icon.md
@@ -1,8 +1,8 @@
 Examples:
 ```js
-<p><strong>Default:</strong> <Icon name="pencil" /></p>
+<p><strong>Default:</strong> <Icon name="pencil-alt" /></p>
 
-<p><strong>Spinning:</strong> <Icon name="refresh" spin /></p>
+<p><strong>Spinning:</strong> <Icon name="sync" spin /></p>
 
 <p><strong>Pulsing:</strong> <Icon name="spinner" pulse /></p>
 
@@ -19,7 +19,7 @@ Examples:
 
 <p>
   <strong>Flipped:</strong>
-  <Icon name="hand-paper-o" flip="horizontal" />{' '}<Icon name="hand-paper-o" />
+  <Icon name="hand-paper" flip="horizontal" />{' '}<Icon name="hand-paper" />
 </p>
 
 ```

--- a/graylog2-web-interface/src/components/common/LinkToNode.jsx
+++ b/graylog2-web-interface/src/components/common/LinkToNode.jsx
@@ -37,7 +37,7 @@ const LinkToNode = createReactClass({
     const node = this.state.nodes[this.props.nodeId];
 
     if (node) {
-      const iconName = node.is_master ? 'star' : 'code-fork';
+      const iconName = node.is_master ? 'star' : 'code-branch';
       const iconClass = node.is_master ? 'master-node' : '';
       const iconTitle = node.is_master ? 'This is the master node in the cluster' : '';
       return (

--- a/graylog2-web-interface/src/components/common/Scratchpad.jsx
+++ b/graylog2-web-interface/src/components/common/Scratchpad.jsx
@@ -188,13 +188,13 @@ const Scratchpad = () => {
                   spellCheck={false} />
 
         <Footer>
-          <SavingMessage visible={recentlySaved}><Icon name="hdd-o" /> Saved!</SavingMessage>
+          <SavingMessage visible={recentlySaved}><Icon name="hdd" /> Saved!</SavingMessage>
           <SplitButton title={CopyWithIcon}
                        bsStyle="info"
                        data-clipboard-button
                        data-clipboard-target={`#${TEXTAREA_ID}`}
                        id="scratchpad-actions">
-            <MenuItem onClick={openConfirmClear}><Icon name="trash" /> Clear</MenuItem>
+            <MenuItem onClick={openConfirmClear}><Icon name="trash-alt" /> Clear</MenuItem>
           </SplitButton>
         </Footer>
 

--- a/graylog2-web-interface/src/components/common/Scratchpad.jsx
+++ b/graylog2-web-interface/src/components/common/Scratchpad.jsx
@@ -188,7 +188,7 @@ const Scratchpad = () => {
                   spellCheck={false} />
 
         <Footer>
-          <SavingMessage visible={recentlySaved}><Icon name="hdd" /> Saved!</SavingMessage>
+          <SavingMessage visible={recentlySaved}><Icon name="hdd" type="regular" /> Saved!</SavingMessage>
           <SplitButton title={CopyWithIcon}
                        bsStyle="info"
                        data-clipboard-button

--- a/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
+++ b/graylog2-web-interface/src/components/common/SourceCodeEditor.jsx
@@ -224,7 +224,7 @@ class SourceCodeEditor extends React.Component {
                                  disabled={this.isCopyDisabled()} />
                 <OverlayTrigger placement="top" trigger="click" overlay={overlay} rootClose>
                   <Button bsStyle="link" bsSize="sm" title="Paste (Ctrl+V / &#8984;V)" disabled={this.isPasteDisabled()}>
-                    <Icon name="paste" fixedWidth />
+                    <Icon name="clipboard" fixedWidth />
                   </Button>
                 </OverlayTrigger>
               </ButtonGroup>
@@ -241,7 +241,7 @@ class SourceCodeEditor extends React.Component {
                         onClick={this.handleRedo}
                         title="Redo (Ctrl+Shift+Z / &#8984;&#8679;Z)"
                         disabled={this.isRedoDisabled()}>
-                  <Icon name="repeat" fixedWidth />
+                  <Icon name="redo" fixedWidth />
                 </Button>
               </ButtonGroup>
             </ButtonToolbar>

--- a/graylog2-web-interface/src/components/common/__snapshots__/ExpandableList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/common/__snapshots__/ExpandableList.test.jsx.snap
@@ -168,6 +168,7 @@ exports[`<ExpandableList /> should render with a Item 1`] = `
                               <Icon
                                 className="fa-stack-1x"
                                 name="circle"
+                                type="solid"
                               >
                                 <FontAwesomeIcon
                                   className="fa-stack-1x"
@@ -186,6 +187,7 @@ exports[`<ExpandableList /> should render with a Item 1`] = `
                               <Icon
                                 className="fa-stack-1x"
                                 name="angle-up"
+                                type="solid"
                               >
                                 <FontAwesomeIcon
                                   className="fa-stack-1x"
@@ -495,6 +497,7 @@ exports[`<ExpandableList /> should render with a nested ExpandableList 1`] = `
                               <Icon
                                 className="fa-stack-1x"
                                 name="circle"
+                                type="solid"
                               >
                                 <FontAwesomeIcon
                                   className="fa-stack-1x"
@@ -513,6 +516,7 @@ exports[`<ExpandableList /> should render with a nested ExpandableList 1`] = `
                               <Icon
                                 className="fa-stack-1x"
                                 name="angle-down"
+                                type="solid"
                               >
                                 <FontAwesomeIcon
                                   className="fa-stack-1x"
@@ -811,6 +815,7 @@ exports[`<ExpandableList /> should render with a nested ExpandableList 1`] = `
                                                 <Icon
                                                   className="fa-stack-1x"
                                                   name="circle"
+                                                  type="solid"
                                                 >
                                                   <FontAwesomeIcon
                                                     className="fa-stack-1x"
@@ -829,6 +834,7 @@ exports[`<ExpandableList /> should render with a nested ExpandableList 1`] = `
                                                 <Icon
                                                   className="fa-stack-1x"
                                                   name="angle-up"
+                                                  type="solid"
                                                 >
                                                   <FontAwesomeIcon
                                                     className="fa-stack-1x"

--- a/graylog2-web-interface/src/components/common/__snapshots__/Wizard.test.jsx.snap
+++ b/graylog2-web-interface/src/components/common/__snapshots__/Wizard.test.jsx.snap
@@ -583,6 +583,7 @@ exports[`<Wizard /> should render in horizontal mode with 3 steps 1`] = `
                                 >
                                   <Icon
                                     name="caret-left"
+                                    type="solid"
                                   >
                                     <FontAwesomeIcon
                                       icon={
@@ -672,6 +673,7 @@ exports[`<Wizard /> should render in horizontal mode with 3 steps 1`] = `
                                 >
                                   <Icon
                                     name="caret-right"
+                                    type="solid"
                                   >
                                     <FontAwesomeIcon
                                       icon={
@@ -1443,6 +1445,7 @@ exports[`<Wizard /> should render in horizontal mode with 3 steps and children 1
                                 >
                                   <Icon
                                     name="caret-left"
+                                    type="solid"
                                   >
                                     <FontAwesomeIcon
                                       icon={
@@ -1532,6 +1535,7 @@ exports[`<Wizard /> should render in horizontal mode with 3 steps and children 1
                                 >
                                   <Icon
                                     name="caret-right"
+                                    type="solid"
                                   >
                                     <FontAwesomeIcon
                                       icon={

--- a/graylog2-web-interface/src/components/configurations/TimeRangeOptionsForm.jsx
+++ b/graylog2-web-interface/src/components/configurations/TimeRangeOptionsForm.jsx
@@ -98,7 +98,7 @@ class TimeRangeOptionsForm extends React.Component {
                        value={description}
                        onChange={this._onChange(idx, 'description')} />
                 <span className="input-group-addon">
-                  <Icon name="trash" style={{ cursor: 'pointer' }} onClick={this._onRemove(idx)} />
+                  <Icon name="trash-alt" style={{ cursor: 'pointer' }} onClick={this._onRemove(idx)} />
                 </span>
               </div>
             </Col>

--- a/graylog2-web-interface/src/components/configurations/__snapshots__/UrlWhiteListForm.test.jsx.snap
+++ b/graylog2-web-interface/src/components/configurations/__snapshots__/UrlWhiteListForm.test.jsx.snap
@@ -2134,6 +2134,7 @@ exports[`UrlWhitelistForm render the UrlWhitelistForm component should create ne
                                                     >
                                                       <Icon
                                                         name="caret-down"
+                                                        type="solid"
                                                       >
                                                         <FontAwesomeIcon
                                                           icon={
@@ -2235,6 +2236,7 @@ exports[`UrlWhitelistForm render the UrlWhitelistForm component should create ne
                         >
                           <Icon
                             name="trash-alt"
+                            type="solid"
                           >
                             <FontAwesomeIcon
                               icon={
@@ -4082,6 +4084,7 @@ exports[`UrlWhitelistForm render the UrlWhitelistForm component should create ne
                                                     >
                                                       <Icon
                                                         name="caret-down"
+                                                        type="solid"
                                                       >
                                                         <FontAwesomeIcon
                                                           icon={
@@ -4183,6 +4186,7 @@ exports[`UrlWhitelistForm render the UrlWhitelistForm component should create ne
                         >
                           <Icon
                             name="trash-alt"
+                            type="solid"
                           >
                             <FontAwesomeIcon
                               icon={
@@ -6030,6 +6034,7 @@ exports[`UrlWhitelistForm render the UrlWhitelistForm component should create ne
                                                     >
                                                       <Icon
                                                         name="caret-down"
+                                                        type="solid"
                                                       >
                                                         <FontAwesomeIcon
                                                           icon={
@@ -6131,6 +6136,7 @@ exports[`UrlWhitelistForm render the UrlWhitelistForm component should create ne
                         >
                           <Icon
                             name="trash-alt"
+                            type="solid"
                           >
                             <FontAwesomeIcon
                               icon={

--- a/graylog2-web-interface/src/components/content-packs/ContentPackDownloadControl.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackDownloadControl.jsx
@@ -61,7 +61,7 @@ class ContentPackDownloadControl extends React.Component {
           <p>{infoText}</p>
           <p>
             <a href={this._getDownloadUrl()} target="_blank" rel="noopener noreferrer">
-              <Icon name="cloud-download" />{' '}Download
+              <Icon name="cloud-download-alt" />{' '}Download
             </a>
           </p>
         </Modal.Body>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackConstraints.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackConstraints.test.jsx.snap
@@ -229,6 +229,7 @@ exports[`<ContentPackConstraints /> should render with created constraints 1`] =
                                       >
                                         <Icon
                                           name="times"
+                                          type="solid"
                                         >
                                           <FontAwesomeIcon
                                             icon={
@@ -354,6 +355,7 @@ exports[`<ContentPackConstraints /> should render with created constraints 1`] =
                                       >
                                         <Icon
                                           name="check"
+                                          type="solid"
                                         >
                                           <FontAwesomeIcon
                                             icon={
@@ -613,6 +615,7 @@ exports[`<ContentPackConstraints /> should render with new constraints with forc
                                       >
                                         <Icon
                                           name="check"
+                                          type="solid"
                                         >
                                           <FontAwesomeIcon
                                             icon={
@@ -738,6 +741,7 @@ exports[`<ContentPackConstraints /> should render with new constraints with forc
                                       >
                                         <Icon
                                           name="check"
+                                          type="solid"
                                         >
                                           <FontAwesomeIcon
                                             icon={
@@ -993,6 +997,7 @@ exports[`<ContentPackConstraints /> should render with new constraints without f
                                       >
                                         <Icon
                                           name="times"
+                                          type="solid"
                                         >
                                           <FontAwesomeIcon
                                             icon={
@@ -1114,6 +1119,7 @@ exports[`<ContentPackConstraints /> should render with new constraints without f
                                       >
                                         <Icon
                                           name="times"
+                                          type="solid"
                                         >
                                           <FontAwesomeIcon
                                             icon={

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
@@ -4597,6 +4597,7 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
                                                         <Icon
                                                           className="fa-stack-1x"
                                                           name="circle"
+                                                          type="solid"
                                                         >
                                                           <FontAwesomeIcon
                                                             className="fa-stack-1x"
@@ -4615,6 +4616,7 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
                                                         <Icon
                                                           className="fa-stack-1x"
                                                           name="angle-up"
+                                                          type="solid"
                                                         >
                                                           <FontAwesomeIcon
                                                             className="fa-stack-1x"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntitiesList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntitiesList.test.jsx.snap
@@ -824,6 +824,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
                             className="contentPackEntity"
                             name="archive"
                             title="Content Pack"
+                            type="solid"
                           >
                             <FontAwesomeIcon
                               className="contentPackEntity"
@@ -1292,6 +1293,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
                           <Icon
                             name="server"
                             title="Server"
+                            type="solid"
                           >
                             <FontAwesomeIcon
                               icon={

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameterList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameterList.test.jsx.snap
@@ -1248,6 +1248,7 @@ exports[`<ContentPackParameterList /> should render with parameters with readOnl
                                 >
                                   <Icon
                                     name="times"
+                                    type="solid"
                                   >
                                     <FontAwesomeIcon
                                       icon={
@@ -1941,6 +1942,7 @@ exports[`<ContentPackParameterList /> should render with parameters without read
                                 >
                                   <Icon
                                     name="times"
+                                    type="solid"
                                   >
                                     <FontAwesomeIcon
                                       icon={

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameters.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameters.test.jsx.snap
@@ -763,6 +763,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                                             >
                                               <Icon
                                                 name="times"
+                                                type="solid"
                                               >
                                                 <FontAwesomeIcon
                                                   icon={
@@ -1703,6 +1704,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                                         className="contentPackEntity"
                                         name="archive"
                                         title="Content Pack"
+                                        type="solid"
                                       >
                                         <FontAwesomeIcon
                                           className="contentPackEntity"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
@@ -2801,6 +2801,7 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
                     You can select between installed entities from the server (
                     <Icon
                       name="server"
+                      type="solid"
                     >
                       <FontAwesomeIcon
                         icon={
@@ -2819,6 +2820,7 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
                     <Icon
                       className="contentPackEntity"
                       name="archive"
+                      type="solid"
                     >
                       <FontAwesomeIcon
                         className="contentPackEntity"
@@ -3273,6 +3275,7 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
                                           <Icon
                                             className="fa-stack-1x"
                                             name="circle"
+                                            type="solid"
                                           >
                                             <FontAwesomeIcon
                                               className="fa-stack-1x"
@@ -3291,6 +3294,7 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
                                           <Icon
                                             className="fa-stack-1x"
                                             name="angle-up"
+                                            type="solid"
                                           >
                                             <FontAwesomeIcon
                                               className="fa-stack-1x"

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationsForm.jsx
@@ -80,7 +80,7 @@ class NotificationsForm extends React.Component {
         <Col md={6} lg={5}>
           <span className={styles.manageNotifications}>
             <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST} target="_blank">
-              <Button bsStyle="link" bsSize="small">Manage Notifications <Icon name="external-link" /></Button>
+              <Button bsStyle="link" bsSize="small">Manage Notifications <Icon name="external-link-alt" /></Button>
             </LinkContainer>
           </span>
           <h2 className={commonStyles.title}>Notifications <small>(optional)</small></h2>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/AggregationConditionsForm.jsx
@@ -87,7 +87,7 @@ class AggregationConditionsForm extends React.Component {
         <h3 className={commonStyles.title}>Create Events for Definition</h3>
         {validation.errors.conditions && (
           <StyledAlert bsStyle="danger">
-            <h4><Icon name="warning" />&nbsp;Errors found</h4>
+            <h4><Icon name="exclamation-triangle" />&nbsp;Errors found</h4>
             <p>{get(validation, 'errors.conditions[0]')}</p>
           </StyledAlert>
         )}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/__snapshots__/AggregationConditionExpression.test.jsx.snap
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/__snapshots__/AggregationConditionExpression.test.jsx.snap
@@ -1696,6 +1696,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                   >
                                                     <Icon
                                                       name="caret-down"
+                                                      type="solid"
                                                     >
                                                       <FontAwesomeIcon
                                                         icon={
@@ -3431,6 +3432,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                               >
                                                                 <Icon
                                                                   name="caret-down"
+                                                                  type="solid"
                                                                 >
                                                                   <FontAwesomeIcon
                                                                     icon={
@@ -5001,6 +5003,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                 >
                                                                   <Icon
                                                                     name="caret-down"
+                                                                    type="solid"
                                                                   >
                                                                     <FontAwesomeIcon
                                                                       icon={
@@ -6774,6 +6777,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                   >
                                                     <Icon
                                                       name="caret-down"
+                                                      type="solid"
                                                     >
                                                       <FontAwesomeIcon
                                                         icon={
@@ -7225,6 +7229,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                     <Icon
                                       fixedWidth={true}
                                       name="minus"
+                                      type="solid"
                                     >
                                       <FontAwesomeIcon
                                         fixedWidth={true}
@@ -7316,6 +7321,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                     <Icon
                                       fixedWidth={true}
                                       name="plus"
+                                      type="solid"
                                     >
                                       <FontAwesomeIcon
                                         fixedWidth={true}
@@ -8964,6 +8970,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                               >
                                                                 <Icon
                                                                   name="caret-down"
+                                                                  type="solid"
                                                                 >
                                                                   <FontAwesomeIcon
                                                                     icon={
@@ -10534,6 +10541,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                                 >
                                                                   <Icon
                                                                     name="caret-down"
+                                                                    type="solid"
                                                                   >
                                                                     <FontAwesomeIcon
                                                                       icon={
@@ -12267,6 +12275,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                                   >
                                                     <Icon
                                                       name="caret-down"
+                                                      type="solid"
                                                     >
                                                       <FontAwesomeIcon
                                                         icon={
@@ -12676,6 +12685,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                     <Icon
                                       fixedWidth={true}
                                       name="minus"
+                                      type="solid"
                                     >
                                       <FontAwesomeIcon
                                         fixedWidth={true}
@@ -12767,6 +12777,7 @@ exports[`AggregationConditionExpression rendering conditions should render a boo
                                     <Icon
                                       fixedWidth={true}
                                       name="plus"
+                                      type="solid"
                                     >
                                       <FontAwesomeIcon
                                         fixedWidth={true}
@@ -14576,6 +14587,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                   >
                                                     <Icon
                                                       name="caret-down"
+                                                      type="solid"
                                                     >
                                                       <FontAwesomeIcon
                                                         icon={
@@ -16323,6 +16335,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                               >
                                                                 <Icon
                                                                   name="caret-down"
+                                                                  type="solid"
                                                                 >
                                                                   <FontAwesomeIcon
                                                                     icon={
@@ -17893,6 +17906,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                 >
                                                                   <Icon
                                                                     name="caret-down"
+                                                                    type="solid"
                                                                   >
                                                                     <FontAwesomeIcon
                                                                       icon={
@@ -19666,6 +19680,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                   >
                                                     <Icon
                                                       name="caret-down"
+                                                      type="solid"
                                                     >
                                                       <FontAwesomeIcon
                                                         icon={
@@ -20117,6 +20132,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                     <Icon
                                       fixedWidth={true}
                                       name="minus"
+                                      type="solid"
                                     >
                                       <FontAwesomeIcon
                                         fixedWidth={true}
@@ -20208,6 +20224,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                     <Icon
                                       fixedWidth={true}
                                       name="plus"
+                                      type="solid"
                                     >
                                       <FontAwesomeIcon
                                         fixedWidth={true}
@@ -22043,6 +22060,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         >
                                                           <Icon
                                                             name="caret-down"
+                                                            type="solid"
                                                           >
                                                             <FontAwesomeIcon
                                                               icon={
@@ -23694,6 +23712,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                         >
                                                                           <Icon
                                                                             name="caret-down"
+                                                                            type="solid"
                                                                           >
                                                                             <FontAwesomeIcon
                                                                               icon={
@@ -25264,6 +25283,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                           >
                                                                             <Icon
                                                                               name="caret-down"
+                                                                              type="solid"
                                                                             >
                                                                               <FontAwesomeIcon
                                                                                 icon={
@@ -26997,6 +27017,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                             >
                                                               <Icon
                                                                 name="caret-down"
+                                                                type="solid"
                                                               >
                                                                 <FontAwesomeIcon
                                                                   icon={
@@ -27406,6 +27427,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                               <Icon
                                                 fixedWidth={true}
                                                 name="minus"
+                                                type="solid"
                                               >
                                                 <FontAwesomeIcon
                                                   fixedWidth={true}
@@ -27497,6 +27519,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                               <Icon
                                                 fixedWidth={true}
                                                 name="plus"
+                                                type="solid"
                                               >
                                                 <FontAwesomeIcon
                                                   fixedWidth={true}
@@ -29279,6 +29302,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                     >
                                                       <Icon
                                                         name="caret-down"
+                                                        type="solid"
                                                       >
                                                         <FontAwesomeIcon
                                                           icon={
@@ -30970,6 +30994,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                     >
                                                                       <Icon
                                                                         name="caret-down"
+                                                                        type="solid"
                                                                       >
                                                                         <FontAwesomeIcon
                                                                           icon={
@@ -32540,6 +32565,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                                       >
                                                                         <Icon
                                                                           name="caret-down"
+                                                                          type="solid"
                                                                         >
                                                                           <FontAwesomeIcon
                                                                             icon={
@@ -34313,6 +34339,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                                         >
                                                           <Icon
                                                             name="caret-down"
+                                                            type="solid"
                                                           >
                                                             <FontAwesomeIcon
                                                               icon={
@@ -34764,6 +34791,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                           <Icon
                                             fixedWidth={true}
                                             name="minus"
+                                            type="solid"
                                           >
                                             <FontAwesomeIcon
                                               fixedWidth={true}
@@ -34855,6 +34883,7 @@ exports[`AggregationConditionExpression rendering conditions should render a gro
                                           <Icon
                                             fixedWidth={true}
                                             name="plus"
+                                            type="solid"
                                           >
                                             <FontAwesomeIcon
                                               fixedWidth={true}
@@ -36643,6 +36672,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                   >
                                                     <Icon
                                                       name="caret-down"
+                                                      type="solid"
                                                     >
                                                       <FontAwesomeIcon
                                                         icon={
@@ -38221,6 +38251,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                           >
                                                             <Icon
                                                               name="caret-down"
+                                                              type="solid"
                                                             >
                                                               <FontAwesomeIcon
                                                                 icon={
@@ -39596,6 +39627,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                                             >
                                                               <Icon
                                                                 name="caret-down"
+                                                                type="solid"
                                                               >
                                                                 <FontAwesomeIcon
                                                                   icon={
@@ -41369,6 +41401,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                               >
                                                 <Icon
                                                   name="caret-down"
+                                                  type="solid"
                                                 >
                                                   <FontAwesomeIcon
                                                     icon={
@@ -41808,6 +41841,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                 <Icon
                                   fixedWidth={true}
                                   name="minus"
+                                  type="solid"
                                 >
                                   <FontAwesomeIcon
                                     fixedWidth={true}
@@ -41899,6 +41933,7 @@ exports[`AggregationConditionExpression rendering conditions should render empty
                                 <Icon
                                   fixedWidth={true}
                                   name="plus"
+                                  type="solid"
                                 >
                                   <FontAwesomeIcon
                                     fixedWidth={true}
@@ -43688,6 +43723,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                   >
                                                     <Icon
                                                       name="caret-down"
+                                                      type="solid"
                                                     >
                                                       <FontAwesomeIcon
                                                         icon={
@@ -45285,6 +45321,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                           >
                                                             <Icon
                                                               name="caret-down"
+                                                              type="solid"
                                                             >
                                                               <FontAwesomeIcon
                                                                 icon={
@@ -46855,6 +46892,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                                             >
                                                               <Icon
                                                                 name="caret-down"
+                                                                type="solid"
                                                               >
                                                                 <FontAwesomeIcon
                                                                   icon={
@@ -48663,6 +48701,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                               >
                                                 <Icon
                                                   name="caret-down"
+                                                  type="solid"
                                                 >
                                                   <FontAwesomeIcon
                                                     icon={
@@ -49114,6 +49153,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                 <Icon
                                   fixedWidth={true}
                                   name="minus"
+                                  type="solid"
                                 >
                                   <FontAwesomeIcon
                                     fixedWidth={true}
@@ -49205,6 +49245,7 @@ exports[`AggregationConditionExpression rendering conditions should render simpl
                                 <Icon
                                   fixedWidth={true}
                                   name="plus"
+                                  type="solid"
                                 >
                                   <FontAwesomeIcon
                                     fixedWidth={true}

--- a/graylog2-web-interface/src/components/events/events/EventsSearchBar.jsx
+++ b/graylog2-web-interface/src/components/events/events/EventsSearchBar.jsx
@@ -77,7 +77,7 @@ class EventsSearchBar extends React.Component {
                         topMargin={0}
                         useLoadingState>
               <Button onClick={this.handleSearchReload} disabled={isReloadingResults}>
-                <Icon name="refresh" spin={isReloadingResults} />
+                <Icon name="sync" spin={isReloadingResults} />
               </Button>
             </SearchForm>
           </div>

--- a/graylog2-web-interface/src/components/indexers/IndexerClusterHealthSummary.jsx
+++ b/graylog2-web-interface/src/components/indexers/IndexerClusterHealthSummary.jsx
@@ -39,7 +39,7 @@ class IndexerClusterHealthSummary extends React.Component {
   _iconNameForHealth = (health) => {
     switch (health.status) {
       case 'green': return 'check-circle';
-      case 'yellow': return 'warning';
+      case 'yellow': return 'exclamation-triangle';
       case 'red': return 'ambulance';
       default: return 'check-circle';
     }

--- a/graylog2-web-interface/src/components/loggers/NodeLoggers.jsx
+++ b/graylog2-web-interface/src/components/loggers/NodeLoggers.jsx
@@ -68,7 +68,7 @@ const NodeLoggers = createReactClass({
                         bsStyle="primary"
                         className="trigger-log-level-metrics"
                         onClick={() => this.setState({ showDetails: !this.state.showDetails })}>
-                  <Icon name="dashboard" />{' '}
+                  <Icon name="tachometer-alt" />{' '}
                   {this.state.showDetails ? 'Hide' : 'Show'} log level metrics
                 </Button>
               </div>

--- a/graylog2-web-interface/src/components/lookup-tables/ErrorPopover.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/ErrorPopover.jsx
@@ -28,7 +28,7 @@ class ErrorPopover extends React.Component {
     return (
       <OverlayTrigger trigger={['hover', 'focus']} placement={this.props.placement} overlay={overlay}>
         <span className={Styles.trigger}>
-          <Icon name="warning" className="text-danger" />
+          <Icon name="exclamation-triangle" className="text-danger" />
         </span>
       </OverlayTrigger>
     );

--- a/graylog2-web-interface/src/components/metrics/Metric.jsx
+++ b/graylog2-web-interface/src/components/metrics/Metric.jsx
@@ -22,10 +22,10 @@ const Metric = createReactClass({
   },
 
   iconMapping: {
-    timer: 'clock-o',
+    timer: 'clock',
     histogram: 'signal',
     meter: 'play-circle',
-    gauge: 'dashboard',
+    gauge: 'tachometer-alt',
     counter: 'circle',
     unknown: 'question-circle',
   },

--- a/graylog2-web-interface/src/components/navigation/UserMenu.jsx
+++ b/graylog2-web-interface/src/components/navigation/UserMenu.jsx
@@ -34,7 +34,7 @@ class UserMenu extends React.Component {
         <LinkContainer to={Routes.SYSTEM.AUTHENTICATION.USERS.edit(encodeURIComponent(loginName))}>
           <MenuItem>Edit profile</MenuItem>
         </LinkContainer>
-        <MenuItem onSelect={this.onLogoutClicked}><Icon name="sign-out" /> Log out</MenuItem>
+        <MenuItem onSelect={this.onLogoutClicked}><Icon name="sign-out-alt" /> Log out</MenuItem>
       </NavDropdown>
     );
   }

--- a/graylog2-web-interface/src/components/nodes/SystemOverviewDetails.jsx
+++ b/graylog2-web-interface/src/components/nodes/SystemOverviewDetails.jsx
@@ -53,7 +53,7 @@ class SystemOverviewDetails extends React.Component {
         <Col md={4}>
           <Alert bsStyle="info">
             <span className="pull-right"> <DocumentationLink page={DocsHelper.PAGES.LOAD_BALANCERS} text="What does this mean?" /></span>
-            <Icon name="exchange" />&nbsp;
+            <Icon name="exchange-alt" />&nbsp;
             Lifecycle state: <strong>{StringUtils.capitalizeFirstLetter(this.props.information.lifecycle)}</strong>
           </Alert>
         </Col>

--- a/graylog2-web-interface/src/components/pipelines/Stage.jsx
+++ b/graylog2-web-interface/src/components/pipelines/Stage.jsx
@@ -42,7 +42,7 @@ const Stage = createReactClass({
         id: `invalid-${ruleIdx}`,
         description: `Rule ${stage.rules[ruleIdx]} has been renamed or removed. This rule will be skipped.`,
       };
-      ruleTitle = <span><Icon name="warning" className="text-danger" /> {stage.rules[ruleIdx]}</span>;
+      ruleTitle = <span><Icon name="exclamation-triangle" className="text-danger" /> {stage.rules[ruleIdx]}</span>;
     } else {
       ruleTitle = (
         <Link to={Routes.SYSTEM.PIPELINES.RULE(rule.id)}>

--- a/graylog2-web-interface/src/components/search/MessageDetail.jsx
+++ b/graylog2-web-interface/src/components/search/MessageDetail.jsx
@@ -43,7 +43,7 @@ class MessageDetail extends React.Component {
       const nodeURL = Routes.node(nodeId);
       nodeInformation = (
         <a href={nodeURL}>
-          <Icon name="code-fork" />
+          <Icon name="code-branch" />
           &nbsp;
           <span style={{ wordBreak: 'break-word' }}>{node.short_node_id}</span>&nbsp;/&nbsp;
           <span style={{ wordBreak: 'break-word' }}>{node.hostname}</span>

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatus.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatus.jsx
@@ -75,7 +75,7 @@ const SidecarStatus = createReactClass({
         case SidecarStatusEnum.FAILING:
           statusMessage = status.message;
           statusClass = 'text-danger';
-          statusBadge = <Icon name="warning" fixedWidth />;
+          statusBadge = <Icon name="exclamation-triangle" fixedWidth />;
 
           if (status.verbose_message) {
             verboseButton = (

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatusFileList.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatusFileList.jsx
@@ -26,7 +26,7 @@ class SidecarStatusFileList extends React.Component {
     if (file.is_dir) {
       return (<span><Icon name="folder-open" />&nbsp;&nbsp;{file.path}</span>);
     }
-    return (<span><Icon name="file-o" />&nbsp;&nbsp;{file.path}</span>);
+    return (<span><Icon name="file" />&nbsp;&nbsp;{file.path}</span>);
   };
 
   _fileListFormatter = (file) => {

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatusFileList.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarStatusFileList.jsx
@@ -26,7 +26,7 @@ class SidecarStatusFileList extends React.Component {
     if (file.is_dir) {
       return (<span><Icon name="folder-open" />&nbsp;&nbsp;{file.path}</span>);
     }
-    return (<span><Icon name="file" />&nbsp;&nbsp;{file.path}</span>);
+    return (<span><Icon name="file" type="regular" />&nbsp;&nbsp;{file.path}</span>);
   };
 
   _fileListFormatter = (file) => {

--- a/graylog2-web-interface/src/components/streamrules/StreamRule.jsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRule.jsx
@@ -58,7 +58,7 @@ const StreamRule = ({ matchData, permissions, stream, streamRule, streamRuleType
         <Button bsStyle="link"
                 bsSize="xsmall"
                 onClick={_onDelete}>
-          <Icon name="trash-o" />
+          <Icon name="trash-alt" />
         </Button>
         <Button bsStyle="link"
                 bsSize="xsmall"

--- a/graylog2-web-interface/src/components/streamrules/StreamRule.jsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRule.jsx
@@ -58,7 +58,7 @@ const StreamRule = ({ matchData, permissions, stream, streamRule, streamRuleType
         <Button bsStyle="link"
                 bsSize="xsmall"
                 onClick={_onDelete}>
-          <Icon name="trash-alt" />
+          <Icon name="trash-alt" type="regular" />
         </Button>
         <Button bsStyle="link"
                 bsSize="xsmall"

--- a/graylog2-web-interface/src/components/streamrules/StreamRuleForm.jsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRuleForm.jsx
@@ -112,7 +112,7 @@ class StreamRuleForm extends React.Component {
               <br /><br />
               Regular expressions use Java syntax. <DocumentationLink page={DocsHelper.PAGES.STREAMS}
                                                                       title="More information"
-                                                                      text={<Icon name="lightbulb-o" />} />
+                                                                      text={<Icon name="lightbulb" />} />
             </Well>
           </Col>
         </div>

--- a/graylog2-web-interface/src/components/streamrules/StreamRuleForm.jsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRuleForm.jsx
@@ -112,7 +112,7 @@ class StreamRuleForm extends React.Component {
               <br /><br />
               Regular expressions use Java syntax. <DocumentationLink page={DocsHelper.PAGES.STREAMS}
                                                                       title="More information"
-                                                                      text={<Icon name="lightbulb" />} />
+                                                                      text={<Icon name="lightbulb" type="regular" />} />
             </Well>
           </Col>
         </div>

--- a/graylog2-web-interface/src/components/streamrules/StreamRuleForm.jsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRuleForm.jsx
@@ -104,7 +104,7 @@ class StreamRuleForm extends React.Component {
               The server will try to convert to strings or numbers based on the matcher type as well as it can.
 
               <br /><br />
-              <Icon name={{ prefix: 'fab', iconName: 'github' }} />
+              <Icon name="github" type="brand" />&nbsp;
               <a href={`https://github.com/Graylog2/graylog2-server/tree/${Version.getMajorAndMinorVersion()}/graylog2-server/src/main/java/org/graylog2/streams/matchers`}
                  target="_blank"
                  rel="noopener noreferrer"> Take a look at the matcher code on GitHub

--- a/graylog2-web-interface/src/components/streamrules/StreamRulesEditor.jsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRulesEditor.jsx
@@ -118,7 +118,7 @@ class StreamRulesEditor extends React.Component {
       }
       return (
         <>
-          <MatchIcon name="remove" /> This message would not be routed to this stream.
+          <MatchIcon name="times" /> This message would not be routed to this stream.
         </>
       );
     }

--- a/graylog2-web-interface/src/components/support/SmallSupportLink.jsx
+++ b/graylog2-web-interface/src/components/support/SmallSupportLink.jsx
@@ -20,7 +20,7 @@ class SmallSupportLink extends React.Component {
       <p className="description-tooltips">
         <IconStack className="fa-stack">
           <Icon name="circle" className="fa-stack-2x" />
-          <Icon name="lightbulb" className="fa-stack-1x" inverse />
+          <Icon name="lightbulb" className="fa-stack-1x" type="regular" inverse />
         </IconStack>
         <strong>
           {this.props.children}

--- a/graylog2-web-interface/src/components/support/SmallSupportLink.jsx
+++ b/graylog2-web-interface/src/components/support/SmallSupportLink.jsx
@@ -20,7 +20,7 @@ class SmallSupportLink extends React.Component {
       <p className="description-tooltips">
         <IconStack className="fa-stack">
           <Icon name="circle" className="fa-stack-2x" />
-          <Icon name="lightbulb-o" className="fa-stack-1x" inverse />
+          <Icon name="lightbulb" className="fa-stack-1x" inverse />
         </IconStack>
         <strong>
           {this.props.children}

--- a/graylog2-web-interface/src/components/support/SupportSources.jsx
+++ b/graylog2-web-interface/src/components/support/SupportSources.jsx
@@ -21,7 +21,7 @@ const SupportSources = () => (
 
     <SourcesList>
       <li>
-        <Icon name="group" />&nbsp;
+        <Icon name="users" />&nbsp;
         <a href="https://www.graylog.org/community-support/" target="_blank" rel="noopener noreferrer">Community support</a>
       </li>
       <li>

--- a/graylog2-web-interface/src/components/support/SupportSources.jsx
+++ b/graylog2-web-interface/src/components/support/SupportSources.jsx
@@ -25,7 +25,7 @@ const SupportSources = () => (
         <a href="https://www.graylog.org/community-support/" target="_blank" rel="noopener noreferrer">Community support</a>
       </li>
       <li>
-        <Icon name={{ prefix: 'fab', iconName: 'github-alt' }} />&nbsp;
+        <Icon name="github-alt" type="brand" />&nbsp;&nbsp;
         <a href="https://github.com/Graylog2/graylog2-server/issues" target="_blank" rel="noopener noreferrer">Issue tracker</a>
       </li>
       <li>

--- a/graylog2-web-interface/src/pages/LoadingPage.jsx
+++ b/graylog2-web-interface/src/pages/LoadingPage.jsx
@@ -10,7 +10,7 @@ const LoadingPage = ({ text }) => {
     <DocumentTitle title="Loading...">
       <AuthThemeStyles />
       <LoginBox>
-        <legend><Icon name="group" /> Welcome to Graylog</legend>
+        <legend><Icon name="users" /> Welcome to Graylog</legend>
         <p>
           <Spinner text={text} delay={0} />
         </p>

--- a/graylog2-web-interface/src/pages/LoginPage.jsx
+++ b/graylog2-web-interface/src/pages/LoginPage.jsx
@@ -67,7 +67,7 @@ const LoginPage = () => {
     <DocumentTitle title="Sign in">
       <AuthThemeStyles />
       <LoginBox>
-        <legend><Icon name="group" /> Welcome to Graylog</legend>
+        <legend><Icon name="users" /> Welcome to Graylog</legend>
         {formatLastError()}
         {renderLoginForm()}
       </LoginBox>

--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
@@ -68,7 +68,7 @@ const ViewActionsMenu = ({ view, isNewView, metadata, currentUser, router }) => 
         <MenuItem onSelect={() => setShareViewOpen(true)} disabled={isNewView || !allowedToEdit}>
           <Icon name="share-alt" /> Share
         </MenuItem>
-        <MenuItem onSelect={() => setCsvExportOpen(true)}><Icon name="cloud-download" /> Export to CSV</MenuItem>
+        <MenuItem onSelect={() => setCsvExportOpen(true)}><Icon name="cloud-download-alt" /> Export to CSV</MenuItem>
         {debugOverlay}
         <IfDashboard>
           <MenuItem divider />

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.jsx
@@ -122,7 +122,7 @@ const WidgetQueryControls = ({ availableStreams, config, globalOverride = {}, wi
                   <div className="pull-right search-help">
                     <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
                                        title="Search query syntax documentation"
-                                       text={<Icon name="lightbulb" />} />
+                                       text={<Icon name="lightbulb" type="regular" />} />
                   </div>
                   <SearchButton running={isSubmitting}
                                 disabled={isGloballyOverridden || isSubmitting || !isValid}

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.jsx
@@ -122,7 +122,7 @@ const WidgetQueryControls = ({ availableStreams, config, globalOverride = {}, wi
                   <div className="pull-right search-help">
                     <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
                                        title="Search query syntax documentation"
-                                       text={<Icon name="lightbulb-o" />} />
+                                       text={<Icon name="lightbulb" />} />
                   </div>
                   <SearchButton running={isSubmitting}
                                 disabled={isGloballyOverridden || isSubmitting || !isValid}

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/BarVisualizationConfiguration.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/BarVisualizationConfiguration.test.jsx.snap
@@ -22,6 +22,7 @@ exports[`BarVisualizationConfiguration should render with props 1`] = `
     >
       <Icon
         name="question-circle"
+        type="solid"
       >
         <FontAwesomeIcon
           icon={
@@ -1505,6 +1506,7 @@ exports[`BarVisualizationConfiguration should render without props 1`] = `
     >
       <Icon
         name="question-circle"
+        type="solid"
       >
         <FontAwesomeIcon
           icon={

--- a/graylog2-web-interface/src/views/components/messagelist/NodeName.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/NodeName.jsx
@@ -24,7 +24,7 @@ const NodeName = ({ nodeId, nodes }: Props) => {
     const nodeURL = Routes.node(nodeId);
     return (
       <a href={nodeURL}>
-        <Icon name="code-fork" />
+        <Icon name="code-branch" />
         &nbsp;
         <span style={{ wordBreak: 'break-word' }}>
           {node.short_node_id}

--- a/graylog2-web-interface/src/views/components/searchbar/__snapshots__/RefreshControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/__snapshots__/RefreshControls.test.jsx.snap
@@ -151,6 +151,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: fa
                           >
                             <Icon
                               name="play"
+                              type="solid"
                             >
                               <FontAwesomeIcon
                                 icon={
@@ -758,6 +759,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: fa
                           >
                             <Icon
                               name="play"
+                              type="solid"
                             >
                               <FontAwesomeIcon
                                 icon={
@@ -1365,6 +1367,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
                           >
                             <Icon
                               name="pause"
+                              type="solid"
                             >
                               <FontAwesomeIcon
                                 icon={
@@ -2029,6 +2032,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
                           >
                             <Icon
                               name="pause"
+                              type="solid"
                             >
                               <FontAwesomeIcon
                                 icon={
@@ -2693,6 +2697,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
                           >
                             <Icon
                               name="pause"
+                              type="solid"
                             >
                               <FontAwesomeIcon
                                 icon={
@@ -3357,6 +3362,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
                           >
                             <Icon
                               name="pause"
+                              type="solid"
                             >
                               <FontAwesomeIcon
                                 icon={
@@ -4021,6 +4027,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
                           >
                             <Icon
                               name="pause"
+                              type="solid"
                             >
                               <FontAwesomeIcon
                                 icon={
@@ -4685,6 +4692,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
                           >
                             <Icon
                               name="pause"
+                              type="solid"
                             >
                               <FontAwesomeIcon
                                 icon={
@@ -5349,6 +5357,7 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
                           >
                             <Icon
                               name="pause"
+                              type="solid"
                             >
                               <FontAwesomeIcon
                                 icon={

--- a/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/csvexport/CSVExportModal.jsx
@@ -112,7 +112,7 @@ const CSVExportModal = ({ closeModal, fields, view, directExportWidgetId, execut
         <Button type="button" onClick={_startDownload} disabled={!enableDownload} bsStyle="primary" data-testid="csv-download-button">
           {loading
             ? <Spinner text="Downloading..." delay={0} />
-            : <><Icon name="cloud-download" />&nbsp;Start Download</>}
+            : <><Icon name="cloud-download-alt" />&nbsp;Start Download</>}
         </Button>
       </Modal.Footer>
     </BootstrapModalWrapper>

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.jsx
@@ -226,7 +226,6 @@ class SavedSearchControls extends React.Component<Props, State> {
     );
 
     const loaded = (view && view.id);
-    const savedSearchStyle = loaded ? 'star' : 'star-o';
     let savedSearchColor: string = '';
     if (loaded) {
       savedSearchColor = dirty ? theme.colors.variant.warning : theme.colors.variant.info;
@@ -258,21 +257,21 @@ class SavedSearchControls extends React.Component<Props, State> {
             <ButtonGroup>
               <>
                 <Button title={title} ref={(elem) => { this.formTarget = elem; }} onClick={this.toggleFormModal}>
-                  <Icon style={{ color: savedSearchColor }} name={savedSearchStyle} /> Save
+                  <Icon style={{ color: savedSearchColor }} name="star" /> Save
                 </Button>
                 {savedSearchForm}
               </>
               <Button title="Load a previously saved search"
                       onClick={this.toggleListModal}>
-                <Icon name="folder-o" /> Load
+                <Icon name="folder" /> Load
               </Button>
               {savedSearchList}
               <DropdownButton title={<Icon name="ellipsis-h" />} id="search-actions-dropdown" pullRight noCaret>
                 <MenuItem onSelect={this.toggleMetadataEdit} disabled={!isAllowedToEdit}>
                   <Icon name="edit" /> Edit metadata
                 </MenuItem>
-                <MenuItem onSelect={this.loadAsDashboard}><Icon name="dashboard" /> Export to dashboard</MenuItem>
-                <MenuItem onSelect={this.toggleCSVExport}><Icon name="cloud-download" /> Export to CSV</MenuItem>
+                <MenuItem onSelect={this.loadAsDashboard}><Icon name="tachometer-alt" /> Export to dashboard</MenuItem>
+                <MenuItem onSelect={this.toggleCSVExport}><Icon name="cloud-download-alt" /> Export to CSV</MenuItem>
                 <MenuItem disabled={disableReset} onSelect={() => loadNewView()} data-testid="reset-search">
                   <Icon name="eraser" /> Reset search
                 </MenuItem>

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.jsx
@@ -257,13 +257,13 @@ class SavedSearchControls extends React.Component<Props, State> {
             <ButtonGroup>
               <>
                 <Button title={title} ref={(elem) => { this.formTarget = elem; }} onClick={this.toggleFormModal}>
-                  <Icon style={{ color: savedSearchColor }} name="star" /> Save
+                  <Icon style={{ color: savedSearchColor }} name="star" type={loaded ? 'solid' : 'regular'} /> Save
                 </Button>
                 {savedSearchForm}
               </>
               <Button title="Load a previously saved search"
                       onClick={this.toggleListModal}>
-                <Icon name="folder" /> Load
+                <Icon name="folder" type="regular" /> Load
               </Button>
               {savedSearchList}
               <DropdownButton title={<Icon name="ellipsis-h" />} id="search-actions-dropdown" pullRight noCaret>

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/__snapshots__/SavedSearchControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/__snapshots__/SavedSearchControls.test.jsx.snap
@@ -15,6 +15,7 @@ exports[`SavedSearchControls render the SavedSearchControls should render dirty 
         "color": "#ffd200",
       }
     }
+    type="solid"
   >
     <FontAwesomeIcon
       icon={
@@ -53,6 +54,7 @@ exports[`SavedSearchControls render the SavedSearchControls should render not di
         "color": "#0063be",
       }
     }
+    type="solid"
   >
     <FontAwesomeIcon
       icon={
@@ -85,18 +87,19 @@ exports[`SavedSearchControls render the SavedSearchControls should render not di
   type="button"
 >
   <Icon
-    name="star-o"
+    name="star"
     style={
       Object {
         "color": "",
       }
     }
+    type="regular"
   >
     <FontAwesomeIcon
       icon={
         Object {
           "iconName": "star",
-          "prefix": "fas",
+          "prefix": "far",
         }
       }
       style={

--- a/graylog2-web-interface/src/views/components/sidebar/FieldTypeIcon.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/FieldTypeIcon.jsx
@@ -18,9 +18,9 @@ const iconClass = (type) => {
     case 'int':
     case 'long':
     case 'short':
-      return 'line-chart';
+      return 'chart-line';
     case 'date':
-      return 'calendar';
+      return 'calendar-alt';
     default:
       return 'question-circle';
   }

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.jsx
@@ -80,7 +80,7 @@ const HighlightingRule = ({ rule }: Props) => {
         for <strong>{field}</strong> = <i>&quot;{value}&quot;</i>.
       </div>
       <DeleteIcon role="presentation" title="Remove this Highlighting Rule" onClick={(e) => onDelete(e, rule)}>
-        <Icon name="trash-o" />
+        <Icon name="trash-alt" />
       </DeleteIcon>
     </HighlightingRuleGrid>
   );

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRule.jsx
@@ -80,7 +80,7 @@ const HighlightingRule = ({ rule }: Props) => {
         for <strong>{field}</strong> = <i>&quot;{value}&quot;</i>.
       </div>
       <DeleteIcon role="presentation" title="Remove this Highlighting Rule" onClick={(e) => onDelete(e, rule)}>
-        <Icon name="trash-alt" />
+        <Icon name="trash-alt" type="regular" />
       </DeleteIcon>
     </HighlightingRuleGrid>
   );

--- a/graylog2-web-interface/src/views/components/widgets/EmptyResultWidget.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/EmptyResultWidget.jsx
@@ -19,7 +19,7 @@ const popover = (
         <a href="https://www.graylog.org/community-support/" target="_blank" rel="noopener noreferrer">Community support</a>
       </li>
       <li>
-        <Icon name={{ prefix: 'fab', iconName: 'github-alt' }} />&nbsp;
+        <Icon name="github-alt" type="brand" />&nbsp;
         <a href="https://github.com/Graylog2/graylog2-server/issues" target="_blank" rel="noopener noreferrer">Issue tracker</a>
       </li>
       <li>

--- a/graylog2-web-interface/src/views/components/widgets/EmptyResultWidget.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/EmptyResultWidget.jsx
@@ -15,7 +15,7 @@ const popover = (
 
     <ul>
       <li>
-        <Icon name="group" />&nbsp;
+        <Icon name="users" />&nbsp;
         <a href="https://www.graylog.org/community-support/" target="_blank" rel="noopener noreferrer">Community support</a>
       </li>
       <li>

--- a/graylog2-web-interface/src/views/components/widgets/FieldSortIcon.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/FieldSortIcon.jsx
@@ -54,14 +54,14 @@ const _isFieldSortActive = (config: MessagesWidgetConfig, fieldName: string) => 
 };
 
 const DirectionStrategyAsc: DirectionStrategy = {
-  icon: 'sort-amount-asc',
+  icon: 'sort-amount-down',
   tooltip: (fieldName: string) => _tooltip(fieldName, Direction.Descending),
   handleSortChange: (changeSort) => changeSort(Direction.Descending),
   sortActive: true,
 };
 
 const DirectionStrategyDesc: DirectionStrategy = {
-  icon: 'sort-amount-desc',
+  icon: 'sort-amount-up',
   tooltip: (fieldName: string) => _tooltip(fieldName, Direction.Ascending),
   handleSortChange: (changeSort) => changeSort(Direction.Ascending),
   sortActive: true,

--- a/graylog2-web-interface/src/views/components/widgets/LoadingWidget.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/LoadingWidget.jsx
@@ -5,7 +5,7 @@ import styles from './MessageWidgets.css';
 
 const LoadingWidget = () => (
   <div className={styles.spinnerContainer}>
-    <Icon data-testid="loading-widget" name="refresh" size="3x" className="spinner" />
+    <Icon data-testid="loading-widget" name="sync" size="3x" className="spinner" />
   </div>
 );
 

--- a/graylog2-web-interface/src/views/components/widgets/WidgetHorizontalStretch.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/WidgetHorizontalStretch.jsx
@@ -25,7 +25,7 @@ class WidgetHorizontalStretch extends React.Component {
     const { position } = this.props;
     const { width } = position;
     const stretched = width === Infinity;
-    const icon = stretched ? 'compress' : 'arrows-h';
+    const icon = stretched ? 'compress' : 'arrows-alt-h';
     const title = stretched ? 'Compress width' : 'Stretch width';
     return (
       <IconButton onClick={this._onClick} name={icon} title={title} />

--- a/graylog2-web-interface/yarn.lock
+++ b/graylog2-web-interface/yarn.lock
@@ -965,7 +965,6 @@
     core-js "^2.6.5"
     regenerator-runtime "^0.13.2"
 
-
 "@babel/preset-env@7.10.2", "@babel/preset-env@^7.8.4":
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.10.2.tgz#715930f2cf8573b0928005ee562bed52fb65fdfb"
@@ -1377,6 +1376,13 @@
   version "5.13.0"
   resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.13.0.tgz#e79de73ba6555055204828dca9c0691e7ce5242b"
   integrity sha512-/6xXiJFCMEQxqxXbL0FPJpwq5Cv6MRrjsbJEmH/t5vOvB4dILDpnY0f7zZSlA8+TG7jwlt12miF/yZpZkykucA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.28"
+
+"@fortawesome/free-regular-svg-icons@^5.13.0":
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.13.0.tgz#925a13d8bdda0678f71551828cac80ab47b8150c"
+  integrity sha512-70FAyiS5j+ANYD4dh9NGowTorNDnyvQHHpCM7FpnF7GxtDjBUCKdrFqCPzesEIpNDFNd+La3vex+jDk4nnUfpA==
   dependencies:
     "@fortawesome/fontawesome-common-types" "^0.2.28"
 
@@ -1982,6 +1988,11 @@
   dependencies:
     jest-diff "^25.1.0"
     pretty-format "^25.1.0"
+
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
 "@types/mime-types@^2.1.0":
   version "2.1.0"
@@ -2703,7 +2714,7 @@ array.prototype.find@^2.1.0:
     define-properties "^1.1.3"
     es-abstract "^1.17.4"
 
-array.prototype.flat@^1.2.1, array.prototype.flat@^1.2.3:
+array.prototype.flat@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz#0de82b426b0318dbfdb940089e38b043d37f6c7b"
   integrity sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==
@@ -5187,13 +5198,6 @@ dot-case@^3.0.3:
     no-case "^3.0.3"
     tslib "^1.10.0"
 
-dot-prop@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.2.0.tgz#c34ecc29556dc45f1f4c22697b6f4904e0cc4fcb"
-  integrity sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==
-  dependencies:
-    is-obj "^2.0.0"
-
 dotignore@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/dotignore/-/dotignore-0.1.2.tgz#f942f2200d28c3a76fbdd6f0ee9f3257c8a2e905"
@@ -5650,15 +5654,15 @@ eslint-config-airbnb@18.1.0:
     eslint-config-airbnb "18.1.0"
     eslint-import-resolver-webpack "0.12.1"
     eslint-plugin-flowtype "4.7.0"
-    eslint-plugin-import "2.20.2"
+    eslint-plugin-import "2.21.2"
     eslint-plugin-jsx-a11y "6.2.3"
     eslint-plugin-react "7.20.0"
     eslint-plugin-react-hooks "4.0.4"
 
-eslint-import-resolver-node@^0.3.2:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz#dbaa52b6b2816b50bc6711af75422de808e98404"
-  integrity sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==
+eslint-import-resolver-node@^0.3.3:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz#85ffa81942c25012d8231096ddf679c03042c717"
+  integrity sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==
   dependencies:
     debug "^2.6.9"
     resolve "^1.13.1"
@@ -5690,10 +5694,10 @@ eslint-loader@^3.0.3:
     object-hash "^2.0.1"
     schema-utils "^2.6.1"
 
-eslint-module-utils@^2.4.1:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.5.2.tgz#7878f7504824e1b857dd2505b59a8e5eda26a708"
-  integrity sha512-LGScZ/JSlqGKiT8OC+cYRxseMjyqt6QO54nl281CK93unD89ijSeRV6An8Ci/2nvWVKe8K/Tqdm75RQoIOCr+Q==
+eslint-module-utils@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz#579ebd094f56af7797d19c9866c9c9486629bfa6"
+  integrity sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==
   dependencies:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
@@ -5705,23 +5709,24 @@ eslint-plugin-flowtype@4.7.0:
   dependencies:
     lodash "^4.17.15"
 
-eslint-plugin-import@2.20.2:
-  version "2.20.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.20.2.tgz#91fc3807ce08be4837141272c8b99073906e588d"
-  integrity sha512-FObidqpXrR8OnCh4iNsxy+WACztJLXAHBO5hK79T1Hc77PgQZkyDGA5Ag9xAvRpglvLNxhH/zSmZ70/pZ31dHg==
+eslint-plugin-import@2.21.2:
+  version "2.21.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.21.2.tgz#8fef77475cc5510801bedc95f84b932f7f334a7c"
+  integrity sha512-FEmxeGI6yaz+SnEB6YgNHlQK1Bs2DKLM+YF+vuTk5H8J9CLbJLtlPvRFgZZ2+sXiKAlN5dpdlrWOjK8ZoZJpQA==
   dependencies:
-    array-includes "^3.0.3"
-    array.prototype.flat "^1.2.1"
+    array-includes "^3.1.1"
+    array.prototype.flat "^1.2.3"
     contains-path "^0.1.0"
     debug "^2.6.9"
     doctrine "1.5.0"
-    eslint-import-resolver-node "^0.3.2"
-    eslint-module-utils "^2.4.1"
+    eslint-import-resolver-node "^0.3.3"
+    eslint-module-utils "^2.6.0"
     has "^1.0.3"
     minimatch "^3.0.4"
-    object.values "^1.1.0"
+    object.values "^1.1.1"
     read-pkg-up "^2.0.0"
-    resolve "^1.12.0"
+    resolve "^1.17.0"
+    tsconfig-paths "^3.9.0"
 
 eslint-plugin-jsx-a11y@6.2.3:
   version "6.2.3"
@@ -7484,8 +7489,8 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   dependencies:
     "@babel/preset-env" "7.10.2"
     babel-eslint "9.0.0"
-    eslint-config-graylog "file:../../../../../../Library/Caches/Yarn/v6/npm-graylog-web-plugin-4.0.0-SNAPSHOT-ff9bc591-0037-4f92-a0d5-71bf40fddc8c-1591643295061/node_modules/eslint-config-graylog"
-    html-webpack-plugin "^3.2.0"
+    eslint-config-graylog "file:../../../../Library/Caches/Yarn/v6/npm-graylog-web-plugin-4.0.0-SNAPSHOT-0ea846fe-826b-4ffa-8762-d2d50b7c4d0f-1592481711868/node_modules/eslint-config-graylog"
+    html-webpack-plugin "^4.2.0"
     javascript-natural-sort "0.7.1"
     jquery "3.4.1"
     moment "2.26.0"
@@ -9286,13 +9291,6 @@ json3@^3.3.2:
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.3.tgz#7fc10e375fc5ae42c4705a5cc0aa6f62be305b81"
   integrity sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==
 
-json5@2.x, json5@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.1.tgz#81b6cb04e9ba496f1c7005d07b4368a2638f90b6"
-  integrity sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==
-  dependencies:
-    minimist "^1.2.0"
-
 json5@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
@@ -9602,7 +9600,7 @@ loader-utils@1.2.3:
     emojis-list "^2.0.0"
     json5 "^1.0.1"
 
-loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3:
+loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -9798,14 +9796,6 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
-
-loud-rejection@^1.0.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
-  integrity sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=
-  dependencies:
-    currently-unhandled "^0.4.1"
-    signal-exit "^3.0.0"
 
 lower-case@^2.0.1:
   version "2.0.1"
@@ -10923,7 +10913,7 @@ object.pick@^1.3.0:
   dependencies:
     isobject "^3.0.1"
 
-object.values@^1.1.0, object.values@^1.1.1:
+object.values@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.1.tgz#68a99ecde356b7e9295a3c5e0ce31dc8c953de5e"
   integrity sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==
@@ -13602,6 +13592,13 @@ resolve@^1.0.0, resolve@^1.1.5, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.
   dependencies:
     path-parse "^1.0.6"
 
+resolve@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
+  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
+  dependencies:
+    path-parse "^1.0.6"
+
 resolve@~1.14.2:
   version "1.14.2"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.14.2.tgz#dbf31d0fa98b1f29aa5169783b9c290cb865fea2"
@@ -15425,6 +15422,16 @@ ts-lib@^0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/ts-lib/-/ts-lib-0.0.5.tgz#7f319885478de67f575a3b890a3f30fc6159352a"
   integrity sha1-fzGYhUeN5n9XWjuJCj8w/GFZNSo=
+
+tsconfig-paths@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
+  integrity sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
 
 tslib@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
With https://github.com/Graylog2/graylog2-server/pull/7746 we've updated font awesome and implemented a fallback for old icon names. The fallback displays a deprecation warning in the console when using a deprecated name.

This PR updates the existing Icon names, based on https://github.com/Graylog2/graylog2-server/blob/master/graylog2-web-interface/src/components/common/icon-fallback.js

There are many linter warnings, which can't be fixed easily, due to the amount of changes files.

## Motivation and Context
Reducing the amount of warnings in the console.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
