### PR TITLE
Unify visualization prop types

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilderPropTypes.js
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilderPropTypes.js
@@ -21,3 +21,4 @@ export const VisualizationType = PropTypes.string;
 export const VisualizationConfigType = CustomPropTypes.instanceOf(VisualizationConfig);
 
 export const AggregationType = CustomPropTypes.instanceOf(AggregationWidgetConfig);
+export const AggregationData = PropTypes.objectOf(PropTypes.arrayOf(PropTypes.object));

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilderPropTypes.js
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilderPropTypes.js
@@ -21,4 +21,4 @@ export const VisualizationType = PropTypes.string;
 export const VisualizationConfigType = CustomPropTypes.instanceOf(VisualizationConfig);
 
 export const AggregationType = CustomPropTypes.instanceOf(AggregationWidgetConfig);
-export const AggregationData = PropTypes.objectOf(PropTypes.arrayOf(PropTypes.object));
+export const AggregationResult = PropTypes.objectOf(PropTypes.arrayOf(PropTypes.object));

--- a/graylog2-web-interface/src/views/components/visualizations/ChartData.js
+++ b/graylog2-web-interface/src/views/components/visualizations/ChartData.js
@@ -15,6 +15,7 @@ export type ChartDefinition = {
 
 export type ChartData = [any, Array<Key>, Array<any>, Array<Array<any>>];
 export type ExtractedSeries = Array<ChartData>;
+export type ValuesBySeries = { [string]: Array<number>};
 
 export type KeyJoiner = (Array<any>) => string;
 
@@ -28,7 +29,7 @@ export const flattenLeafs = (leafs: Array<Leaf>, matcher: Value => boolean = ({ 
   return flatten(leafs.map((l) => l.values.filter((value) => matcher(value)).map((v) => [l.key, v])));
 };
 
-export const formatSeries = ({ valuesBySeries = {}, xLabels = [] }: {valuesBySeries: Object, xLabels: Array<any>}): ExtractedSeries => {
+export const formatSeries = ({ valuesBySeries = {}, xLabels = [] }: {valuesBySeries: ValuesBySeries, xLabels: Array<any>}): ExtractedSeries => {
   return Object.keys(valuesBySeries).map((value) => [
     value,
     xLabels,
@@ -91,7 +92,7 @@ export const chartData = (
   data: Rows,
   chartType: string,
   generator: Generator = _defaultChartGenerator,
-  customSeriesFormatter?: ({valuesBySeries: Object, xLabels: Array<any>}) => ExtractedSeries = formatSeries,
+  customSeriesFormatter?: ({valuesBySeries: ValuesBySeries, xLabels: Array<any>}) => ExtractedSeries = formatSeries,
   leafValueMatcher?: Value => boolean,
 ): Array<ChartDefinition> => {
   const { rowPivots, columnPivots, series } = config;

--- a/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import EventHandler from 'views/logic/searchtypes/events/EventHandler';
 import toPlotly from 'views/logic/aggregationbuilder/visualizations/Interpolation';
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
-import { AggregationType, AggregationData } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
+import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import AreaVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig';
 import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
 import type { ChartDefinition } from '../ChartData';
@@ -57,7 +57,7 @@ const AreaVisualization: VisualizationComponent = makeVisualization(({ config, d
 
 AreaVisualization.propTypes = {
   config: AggregationType.isRequired,
-  data: AggregationData.isRequired,
+  data: AggregationResult.isRequired,
   height: PropTypes.number,
 };
 

--- a/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/area/AreaVisualization.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import EventHandler from 'views/logic/searchtypes/events/EventHandler';
 import toPlotly from 'views/logic/aggregationbuilder/visualizations/Interpolation';
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
-import { AggregationType } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
+import { AggregationType, AggregationData } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import AreaVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/AreaVisualizationConfig';
 import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
 import type { ChartDefinition } from '../ChartData';
@@ -57,7 +57,7 @@ const AreaVisualization: VisualizationComponent = makeVisualization(({ config, d
 
 AreaVisualization.propTypes = {
   config: AggregationType.isRequired,
-  data: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
+  data: AggregationData.isRequired,
   height: PropTypes.number,
 };
 

--- a/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.jsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 
-import { AggregationType, AggregationData } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
+import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import EventHandler from 'views/logic/searchtypes/events/EventHandler';
 import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
@@ -64,7 +64,7 @@ const BarVisualization: VisualizationComponent = makeVisualization(({ config, da
 
 BarVisualization.propTypes = {
   config: AggregationType.isRequired,
-  data: AggregationData.isRequired,
+  data: AggregationResult.isRequired,
   height: PropTypes.number,
 };
 

--- a/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.jsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 
-import { AggregationType } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
+import { AggregationType, AggregationData } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import EventHandler from 'views/logic/searchtypes/events/EventHandler';
 import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
@@ -64,7 +64,7 @@ const BarVisualization: VisualizationComponent = makeVisualization(({ config, da
 
 BarVisualization.propTypes = {
   config: AggregationType.isRequired,
-  data: PropTypes.object.isRequired,
+  data: AggregationData.isRequired,
   height: PropTypes.number,
 };
 

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.jsx
@@ -8,7 +8,7 @@ import { makeVisualization } from 'views/components/aggregationbuilder/Aggregati
 import type { ChartDefinition, ExtractedSeries } from '../ChartData';
 
 import GenericPlot from '../GenericPlot';
-import { chartData } from '../ChartData';
+import { chartData, type ValuesBySeries } from '../ChartData';
 
 const BG_COLOR = '#440154';
 
@@ -77,7 +77,7 @@ const _transposeMatrix = (z: Array<Array<any>> = []) => {
   return z[0].map((_, c) => { return z.map((r) => { return r[c]; }); });
 };
 
-const _formatSeries = ({ valuesBySeries, xLabels }: {valuesBySeries: Object, xLabels: Array<any>}): ExtractedSeries => {
+const _formatSeries = ({ valuesBySeries, xLabels }: {valuesBySeries: ValuesBySeries, xLabels: Array<any>}): ExtractedSeries => {
   // When using the hovertemplate, we need to provie a value for empty z values.
   // Otherwise plotly would throw errors when hovering over a field.
   // We need to transpose the z matrix, because we are changing the x and y label in the generator function

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.jsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { values, merge, fill, find, isEmpty, get } from 'lodash';
 
-import { AggregationType, AggregationData } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
+import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
 import type { ChartDefinition, ExtractedSeries } from '../ChartData';
@@ -129,7 +129,7 @@ const HeatmapVisualization: VisualizationComponent = makeVisualization(({ config
 
 HeatmapVisualization.propTypes = {
   config: AggregationType.isRequired,
-  data: AggregationData.isRequired,
+  data: AggregationResult.isRequired,
 };
 
 export default HeatmapVisualization;

--- a/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/heatmap/HeatmapVisualization.jsx
@@ -1,10 +1,8 @@
 // @flow strict
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { values, merge, fill, find, isEmpty, get } from 'lodash';
 
-
-import { AggregationType } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
+import { AggregationType, AggregationData } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
 import type { ChartDefinition, ExtractedSeries } from '../ChartData';
@@ -131,7 +129,7 @@ const HeatmapVisualization: VisualizationComponent = makeVisualization(({ config
 
 HeatmapVisualization.propTypes = {
   config: AggregationType.isRequired,
-  data: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
+  data: AggregationData.isRequired,
 };
 
 export default HeatmapVisualization;

--- a/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.jsx
@@ -2,7 +2,7 @@
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 
-import { AggregationType } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
+import { AggregationType, AggregationData } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import LineVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/LineVisualizationConfig';
 import toPlotly from 'views/logic/aggregationbuilder/visualizations/Interpolation';
@@ -25,7 +25,7 @@ const getChartColor = (fullData, name) => {
 const setChartColor = (chart, colors) => ({ line: { color: colors[chart.name] } });
 
 const LineVisualization: VisualizationComponent = makeVisualization(({ config, data, effectiveTimerange, height }: VisualizationComponentProps) => {
-// $FlowFixMe: We need to assume it is a LineVisualizationConfig instance
+  // $FlowFixMe: We need to assume it is a LineVisualizationConfig instance
   const visualizationConfig: LineVisualizationConfig = config.visualizationConfig || LineVisualizationConfig.empty();
   const { interpolation = 'linear' } = visualizationConfig;
   const chartGenerator = useCallback((type, name, labels, values): ChartDefinition => ({
@@ -57,7 +57,7 @@ const LineVisualization: VisualizationComponent = makeVisualization(({ config, d
 
 LineVisualization.propTypes = {
   config: AggregationType.isRequired,
-  data: PropTypes.arrayOf(PropTypes.object).isRequired,
+  data: AggregationData.isRequired,
   height: PropTypes.number,
 };
 

--- a/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/line/LineVisualization.jsx
@@ -2,7 +2,7 @@
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 
-import { AggregationType, AggregationData } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
+import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import LineVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/LineVisualizationConfig';
 import toPlotly from 'views/logic/aggregationbuilder/visualizations/Interpolation';
@@ -57,7 +57,7 @@ const LineVisualization: VisualizationComponent = makeVisualization(({ config, d
 
 LineVisualization.propTypes = {
   config: AggregationType.isRequired,
-  data: AggregationData.isRequired,
+  data: AggregationResult.isRequired,
   height: PropTypes.number,
 };
 

--- a/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.jsx
@@ -1,7 +1,7 @@
 // @flow strict
 import * as React from 'react';
 
-import { AggregationType, AggregationData } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
+import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type {
   VisualizationComponent,
   VisualizationComponentProps,
@@ -68,7 +68,7 @@ const PieVisualization: VisualizationComponent = makeVisualization(({ config, da
 
 PieVisualization.propTypes = {
   config: AggregationType.isRequired,
-  data: AggregationData.isRequired,
+  data: AggregationResult.isRequired,
 };
 
 export default PieVisualization;

--- a/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/pie/PieVisualization.jsx
@@ -1,8 +1,7 @@
 // @flow strict
 import * as React from 'react';
-import PropTypes from 'prop-types';
 
-import { AggregationType } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
+import { AggregationType, AggregationData } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type {
   VisualizationComponent,
   VisualizationComponentProps,
@@ -69,7 +68,7 @@ const PieVisualization: VisualizationComponent = makeVisualization(({ config, da
 
 PieVisualization.propTypes = {
   config: AggregationType.isRequired,
-  data: PropTypes.arrayOf(PropTypes.object).isRequired,
+  data: AggregationData.isRequired,
 };
 
 export default PieVisualization;

--- a/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 
 import EventHandler from 'views/logic/searchtypes/events/EventHandler';
-import { AggregationType } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
+import { AggregationType, AggregationData } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
 
@@ -31,7 +31,7 @@ const ScatterVisualization: VisualizationComponent = makeVisualization(({ config
 
 ScatterVisualization.propTypes = {
   config: AggregationType.isRequired,
-  data: PropTypes.arrayOf(PropTypes.object).isRequired,
+  data: AggregationData.isRequired,
   height: PropTypes.number,
 };
 

--- a/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/scatter/ScatterVisualization.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 
 import EventHandler from 'views/logic/searchtypes/events/EventHandler';
-import { AggregationType, AggregationData } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
+import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
 
@@ -31,7 +31,7 @@ const ScatterVisualization: VisualizationComponent = makeVisualization(({ config
 
 ScatterVisualization.propTypes = {
   config: AggregationType.isRequired,
-  data: AggregationData.isRequired,
+  data: AggregationResult.isRequired,
   height: PropTypes.number,
 };
 

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/WorldMapVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/WorldMapVisualization.jsx
@@ -3,7 +3,7 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { flow, fromPairs, get, zip, isEmpty } from 'lodash';
 
-import { AggregationType, AggregationData } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
+import { AggregationType, AggregationResult } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import WorldMapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/WorldMapVisualizationConfig';
 import Viewport from 'views/logic/aggregationbuilder/visualizations/Viewport';
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
@@ -82,7 +82,7 @@ const WorldMapVisualization: VisualizationComponent = makeVisualization(({ confi
 
 WorldMapVisualization.propTypes = {
   config: AggregationType.isRequired,
-  data: AggregationData.isRequired,
+  data: AggregationResult.isRequired,
   onChange: PropTypes.func.isRequired,
   width: PropTypes.number.isRequired,
 };

--- a/graylog2-web-interface/src/views/components/visualizations/worldmap/WorldMapVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/worldmap/WorldMapVisualization.jsx
@@ -3,7 +3,7 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { flow, fromPairs, get, zip, isEmpty } from 'lodash';
 
-import { AggregationType } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
+import { AggregationType, AggregationData } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import WorldMapVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/WorldMapVisualizationConfig';
 import Viewport from 'views/logic/aggregationbuilder/visualizations/Viewport';
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
@@ -82,7 +82,7 @@ const WorldMapVisualization: VisualizationComponent = makeVisualization(({ confi
 
 WorldMapVisualization.propTypes = {
   config: AggregationType.isRequired,
-  data: PropTypes.any.isRequired,
+  data: AggregationData.isRequired,
   onChange: PropTypes.func.isRequired,
   width: PropTypes.number.isRequired,
 };


### PR DESCRIPTION
This PR unifies the prop type definitions for all visualizations by creating a custom `AggregationResult` prop type for the `data` attribute.

## Motivation and Context
Removing all prop type errors for visualization components.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
