### PR TITLE
Fixing `ViewActionsMenu` and `EntityListItem` prop type errors

### DIFF
--- a/graylog2-web-interface/src/components/common/EntityListItem.jsx
+++ b/graylog2-web-interface/src/components/common/EntityListItem.jsx
@@ -52,11 +52,12 @@ class EntityListItem extends React.Component {
      * Add any content that is related to the entity and needs more space to be displayed. This is mostly use
      * to show configuration options.
      */
-    contentRow: PropTypes.node.isRequired,
+    contentRow: PropTypes.node,
   };
 
   static defaultProps = {
     actions: undefined,
+    contentRow: undefined,
     createdFromContentPack: false,
     description: undefined,
     titleSuffix: undefined,
@@ -102,9 +103,11 @@ class EntityListItem extends React.Component {
           </Col>
         </Row>
 
-        <Row className="row-sm">
-          {contentRow}
-        </Row>
+        {contentRow && (
+          <Row className="row-sm">
+            {contentRow}
+          </Row>
+        )}
       </StyledListItem>
     );
   }

--- a/graylog2-web-interface/src/components/common/EntityListItem.jsx
+++ b/graylog2-web-interface/src/components/common/EntityListItem.jsx
@@ -36,59 +36,23 @@ const StyledListItem = styled.li(({ theme }) => `
  * Component that let you render an entity item using a similar look and feel as other entities in Graylog.
  * This component is meant to use alongside `EntityList`. Look there for an example of how to use this component.
  */
-class EntityListItem extends React.Component {
-  static propTypes = {
-    /** Entity's title. */
-    title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
-    /** Text to append to the title. Usually the type or a short description. */
-    titleSuffix: PropTypes.any,
-    /** Description of the element, which can accommodate more text than `titleSuffix`. */
-    description: PropTypes.any,
-    /** Action buttons or menus shown on the right side of the entity item container. */
-    actions: PropTypes.oneOfType([PropTypes.array, PropTypes.node]),
-    /** Flag that controls whether the content pack marker will be shown next to the description or not. */
-    createdFromContentPack: PropTypes.bool,
-    /**
-     * Add any content that is related to the entity and needs more space to be displayed. This is mostly use
-     * to show configuration options.
-     */
-    contentRow: PropTypes.node,
-  };
+const EntityListItem = ({ actions, contentRow, createdFromContentPack, description, title, titleSuffix }) => {
+  const wrappedTitleSuffix = titleSuffix ? <small>{titleSuffix}</small> : null;
+  const actionsContainer = (
+    <div className="item-actions text-right">
+      {actions}
+    </div>
+  );
 
-  static defaultProps = {
-    actions: undefined,
-    contentRow: undefined,
-    createdFromContentPack: false,
-    description: undefined,
-    titleSuffix: undefined,
-  };
-
-  render() {
-    const {
-      actions,
-      contentRow,
-      createdFromContentPack,
-      description,
-      title,
-      titleSuffix,
-    } = this.props;
-    const wrappedTitleSuffix = titleSuffix ? <small>{titleSuffix}</small> : null;
-
-    const actionsContainer = (
-      <div className="item-actions text-right">
-        {actions}
-      </div>
-    );
-
-    return (
-      <StyledListItem>
-        <Row className="row-sm">
-          <Col md={12}>
-            <div className="pull-right hidden-xs">
-              {actionsContainer}
-            </div>
-            <h2>{title} {wrappedTitleSuffix}</h2>
-            {(createdFromContentPack || description)
+  return (
+    <StyledListItem>
+      <Row className="row-sm">
+        <Col md={12}>
+          <div className="pull-right hidden-xs">
+            {actionsContainer}
+          </div>
+          <h2>{title} {wrappedTitleSuffix}</h2>
+          {(createdFromContentPack || description)
               && (
               <div className="item-description">
                 {createdFromContentPack
@@ -96,21 +60,47 @@ class EntityListItem extends React.Component {
                 <span>{description}</span>
               </div>
               )}
-          </Col>
+        </Col>
 
-          <Col sm={12} lgHidden mdHidden smHidden>
-            {actionsContainer}
-          </Col>
-        </Row>
+        <Col sm={12} lgHidden mdHidden smHidden>
+          {actionsContainer}
+        </Col>
+      </Row>
 
-        {contentRow && (
-          <Row className="row-sm">
-            {contentRow}
-          </Row>
-        )}
-      </StyledListItem>
-    );
-  }
-}
+      {contentRow && (
+      <Row className="row-sm">
+        {contentRow}
+      </Row>
+      )}
+    </StyledListItem>
+  );
+};
+
+
+EntityListItem.propTypes = {
+  /** Entity's title. */
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  /** Text to append to the title. Usually the type or a short description. */
+  titleSuffix: PropTypes.any,
+  /** Description of the element, which can accommodate more text than `titleSuffix`. */
+  description: PropTypes.any,
+  /** Action buttons or menus shown on the right side of the entity item container. */
+  actions: PropTypes.oneOfType([PropTypes.array, PropTypes.node]),
+  /** Flag that controls whether the content pack marker will be shown next to the description or not. */
+  createdFromContentPack: PropTypes.bool,
+  /**
+   * Add any content that is related to the entity and needs more space to be displayed. This is mostly use
+   * to show configuration options.
+   */
+  contentRow: PropTypes.node,
+};
+
+EntityListItem.defaultProps = {
+  actions: undefined,
+  contentRow: undefined,
+  createdFromContentPack: false,
+  description: undefined,
+  titleSuffix: undefined,
+};
 
 export default EntityListItem;

--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
@@ -106,7 +106,7 @@ ViewActionsMenu.propTypes = {
   metadata: PropTypes.shape({
     undeclared: ImmutablePropTypes.Set,
   }).isRequired,
-  view: PropTypes.instanceOf(View).isRequired,
+  view: PropTypes.object.isRequired,
   isNewView: PropTypes.bool.isRequired,
 };
 


### PR DESCRIPTION
This PR is fixing the prop type errors for the `EntityListItem` prop `contentRow`. It also avoids throwing a prop type error for the `ViewActionsMenu` `view` prop, by removing the `Proptypes.instanceOf` check.

Fixes: #7303

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
