### PR TITLE
Retry messages if target index is read-only

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/IndexBlockRetryAttempt.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/IndexBlockRetryAttempt.java
@@ -1,0 +1,69 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.messages;
+
+import com.github.rholder.retry.Attempt;
+import org.apache.commons.lang.NotImplementedException;
+
+import java.util.concurrent.ExecutionException;
+
+/**
+ * This is only used for reuse of a wait strategy
+ */
+public class IndexBlockRetryAttempt implements Attempt<Void> {
+
+    private final long number;
+
+    public IndexBlockRetryAttempt(long number) {
+        this.number = number;
+    }
+
+    @Override
+    public long getAttemptNumber() {
+        return number;
+    }
+
+    @Override
+    public long getDelaySinceFirstAttempt() {
+        return 0;
+    }
+
+    @Override
+    public Void get() throws ExecutionException {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public boolean hasResult() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public boolean hasException() {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public Void getResult() throws IllegalStateException {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public Throwable getExceptionCause() throws IllegalStateException {
+        throw new NotImplementedException();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -26,8 +26,11 @@ import com.github.rholder.retry.RetryListener;
 import com.github.rholder.retry.Retryer;
 import com.github.rholder.retry.RetryerBuilder;
 import com.github.rholder.retry.WaitStrategies;
+import com.github.rholder.retry.WaitStrategy;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
 import io.searchbox.core.Bulk;
@@ -56,6 +59,7 @@ import javax.inject.Singleton;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -71,10 +75,23 @@ import static com.codahale.metrics.MetricRegistry.name;
 @Singleton
 public class Messages {
     private static final Logger LOG = LoggerFactory.getLogger(Messages.class);
+
     private static final Duration MAX_WAIT_TIME = Duration.seconds(30L);
+
+    @VisibleForTesting
+    static final WaitStrategy exponentialWaitMilliseconds = WaitStrategies.exponentialWait(MAX_WAIT_TIME.getQuantity(), MAX_WAIT_TIME.getUnit());
+
+    // the wait strategy uses powers of 2 to compute wait times.
+    // see https://github.com/rholder/guava-retrying/blob/177b6c9b9f3e7957f404f0bdb8e23374cb1de43f/src/main/java/com/github/rholder/retry/WaitStrategies.java#L304
+    // using 500 leads to the expected exponential pattern of 1000, 2000, 4000, 8000, ...
+    private static final int retrySecondsMultiplier = 500;
+
+    @VisibleForTesting
+    static final WaitStrategy exponentialWaitSeconds = WaitStrategies.exponentialWait(retrySecondsMultiplier, MAX_WAIT_TIME.getQuantity(), MAX_WAIT_TIME.getUnit());
+
     private static final Retryer<BulkResult> BULK_REQUEST_RETRYER = RetryerBuilder.<BulkResult>newBuilder()
             .retryIfException(t -> t instanceof IOException)
-            .withWaitStrategy(WaitStrategies.exponentialWait(MAX_WAIT_TIME.getQuantity(), MAX_WAIT_TIME.getUnit()))
+            .withWaitStrategy(exponentialWaitMilliseconds)
             .withRetryListener(new RetryListener() {
                 @Override
                 public <V> void onRetry(Attempt<V> attempt) {
@@ -86,6 +103,9 @@ public class Messages {
                 }
             })
             .build();
+
+    static final String INDEX_BLOCK_ERROR = "cluster_block_exception";
+    static final String INDEX_BLOCK_REASON = "blocked by: [FORBIDDEN/12/index read-only / allow delete (api)];";
 
     private final Meter invalidTimestampMeter;
     private final JestClient client;
@@ -108,7 +128,7 @@ public class Messages {
         this.useExpectContinue = useExpectContinue;
 
         // TODO: Magic number
-        this.indexFailureQueue =  new LinkedBlockingQueue<>(1000);
+        this.indexFailureQueue = new LinkedBlockingQueue<>(1000);
     }
 
     public ResultMessage get(String messageId, String index) throws DocumentNotFoundException, IOException {
@@ -119,8 +139,7 @@ public class Messages {
             throw new DocumentNotFoundException(index, messageId);
         }
 
-        @SuppressWarnings("unchecked")
-        final Map<String, Object> message = (Map<String, Object>) result.getSourceAsObject(Map.class, false);
+        @SuppressWarnings("unchecked") final Map<String, Object> message = (Map<String, Object>) result.getSourceAsObject(Map.class, false);
 
         return ResultMessage.parseFromSource(result.getId(), result.getIndex(), message);
     }
@@ -129,10 +148,9 @@ public class Messages {
         final Analyze analyze = new Analyze.Builder().index(index).analyzer(analyzer).text(toAnalyze).build();
         final JestResult result = client.execute(analyze);
 
-        @SuppressWarnings("unchecked")
-        final List<Map<String, Object>> tokens = (List<Map<String, Object>>) result.getValue("tokens");
+        @SuppressWarnings("unchecked") final List<Map<String, Object>> tokens = (List<Map<String, Object>>) result.getValue("tokens");
         final List<String> terms = new ArrayList<>(tokens.size());
-        tokens.forEach(token -> terms.add((String)token.get("token")));
+        tokens.forEach(token -> terms.add((String) token.get("token")));
 
         return terms;
     }
@@ -151,7 +169,8 @@ public class Messages {
         List<BulkResult.BulkResultItem> failedItems = new ArrayList<>();
         for (;;) {
             try {
-                failedItems.addAll(bulkIndexChunked(messageList, isSystemTraffic, offset, chunkSize));
+                List<BulkResult.BulkResultItem> failures = bulkIndexChunked(messageList, isSystemTraffic, offset, chunkSize);
+                failedItems.addAll(failures);
                 break; // on success
             } catch (EntityTooLargeException e) {
                 LOG.warn("Bulk index failed with 'Request Entity Too Large' error. Retrying by splitting up batch size <{}>.", chunkSize);
@@ -167,7 +186,6 @@ public class Messages {
             }
         }
 
-
         if (!failedItems.isEmpty()) {
             final Set<String> failedIds = failedItems.stream().map(item -> item.id).collect(Collectors.toSet());
             recordTimestamp(messageList, failedIds);
@@ -182,25 +200,14 @@ public class Messages {
         chunkSize = Math.min(messageList.size(), chunkSize);
 
         final List<BulkResult.BulkResultItem> failedItems = new ArrayList<>();
-        final Iterable<List<Map.Entry<IndexSet, Message>>> partition = Iterables.partition(messageList.subList(offset, messageList.size()), chunkSize);
-        int partitionCount = 1;
+        final Iterable<List<Map.Entry<IndexSet, Message>>> chunks = Iterables.partition(messageList.subList(offset, messageList.size()), chunkSize);
+        int chunkCount = 1;
         int indexedSuccessfully = 0;
-        for (List<Map.Entry<IndexSet, Message>> subMessageList: partition) {
-            Bulk.Builder bulk = new Bulk.Builder();
+        for (List<Map.Entry<IndexSet, Message>> chunk : chunks) {
 
-            long messageSizes = 0;
-            for (Map.Entry<IndexSet, Message> entry : subMessageList) {
-                final Message message = entry.getValue();
-                messageSizes += message.getSize();
+            long messageSizes = chunk.stream().mapToLong(m -> m.getValue().getSize()).sum();
 
-                bulk.addAction(new Index.Builder(message.toElasticSearchObject(invalidTimestampMeter))
-                        .index(entry.getKey().getWriteIndexAlias())
-                        .type(IndexMapping.TYPE_MESSAGE)
-                        .id(message.getId())
-                        .build());
-            }
-
-            final BulkResult result = runBulkRequest(bulk.build(), subMessageList.size());
+            final BulkResult result = bulkIndexChunk(chunk);
 
             if (result.getResponseCode() == 413) {
                 throw new EntityTooLargeException(indexedSuccessfully, failedItems);
@@ -208,8 +215,11 @@ public class Messages {
 
             // TODO should we check result.isSucceeded()?
 
-            indexedSuccessfully += subMessageList.size();
-            failedItems.addAll(result.getFailedItems());
+            indexedSuccessfully += chunk.size();
+
+            Set<BulkResult.BulkResultItem> remainingFailures = retryOnlyIndexBlockItemsForever(chunk, result.getFailedItems());
+
+            failedItems.addAll(remainingFailures);
             if (isSystemTraffic) {
                 systemTrafficCounter.inc(messageSizes);
             } else {
@@ -218,19 +228,90 @@ public class Messages {
             if (LOG.isDebugEnabled()) {
                 String chunkInfo = "";
                 if (chunkSize != messageList.size()) {
-                    chunkInfo = String.format(Locale.ROOT, " (chunk %d/%d offset %d)", partitionCount,
-                            (int) Math.ceil((double)messageList.size() / chunkSize), offset);
+                    chunkInfo = String.format(Locale.ROOT, " (chunk %d/%d offset %d)", chunkCount,
+                            (int) Math.ceil((double) messageList.size() / chunkSize), offset);
                 }
                 LOG.debug("Index: Bulk indexed {} messages{}, failures: {}",
                         result.getItems().size(), chunkInfo, failedItems.size());
             }
-            if (!result.getFailedItems().isEmpty()) {
+            if (!remainingFailures.isEmpty()) {
                 LOG.error("Failed to index [{}] messages. Please check the index error log in your web interface for the reason. Error: {}",
-                        result.getFailedItems().size(), result.getErrorMessage());
+                        remainingFailures.size(), result.getErrorMessage());
             }
-            partitionCount++;
+            chunkCount++;
         }
         return failedItems;
+    }
+
+    private BulkResult bulkIndexChunk(List<Map.Entry<IndexSet, Message>> chunk) {
+        Bulk.Builder bulk = new Bulk.Builder();
+
+        for (Map.Entry<IndexSet, Message> entry : chunk) {
+            final Message message = entry.getValue();
+
+            bulk.addAction(new Index.Builder(message.toElasticSearchObject(invalidTimestampMeter))
+                    .index(entry.getKey().getWriteIndexAlias())
+                    .type(IndexMapping.TYPE_MESSAGE)
+                    .id(message.getId())
+                    .build());
+        }
+
+        return runBulkRequest(bulk.build(), chunk.size());
+    }
+
+    private Set<BulkResult.BulkResultItem> retryOnlyIndexBlockItemsForever(List<Map.Entry<IndexSet, Message>> chunk, List<BulkResult.BulkResultItem> allFailedItems) {
+        Set<BulkResult.BulkResultItem> indexBlocks = indexBlocksFrom(allFailedItems);
+        final Set<BulkResult.BulkResultItem> otherFailures = new HashSet<>(Sets.difference(new HashSet<>(allFailedItems), indexBlocks));
+        List<Map.Entry<IndexSet, Message>> blockedMessages = messagesForResultItems(chunk, indexBlocks);
+
+        if (!indexBlocks.isEmpty()) {
+            LOG.warn("Retrying {} messages, because their indices are blocked with status [read-only / allow delete]", indexBlocks.size());
+        }
+
+        long attempt = 1;
+
+        while (!indexBlocks.isEmpty()) {
+            waitBeforeRetrying(attempt++);
+
+            final BulkResult bulkResult = bulkIndexChunk(blockedMessages);
+
+            final List<BulkResult.BulkResultItem> failedItems = bulkResult.getFailedItems();
+
+            indexBlocks = indexBlocksFrom(failedItems);
+            blockedMessages = messagesForResultItems(blockedMessages, indexBlocks);
+
+            final Set<BulkResult.BulkResultItem> newOtherFailures = Sets.difference(new HashSet<>(failedItems), indexBlocks);
+            otherFailures.addAll(newOtherFailures);
+
+            if (indexBlocks.isEmpty()) {
+                LOG.info("Retries were successful after {} attempts. Ingestion will continue now.", attempt);
+            }
+        }
+
+        return otherFailures;
+    }
+
+    private void waitBeforeRetrying(long attempt) {
+        try {
+            final long sleepTime = exponentialWaitSeconds.computeSleepTime(new IndexBlockRetryAttempt(attempt));
+            Thread.sleep(sleepTime);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private List<Map.Entry<IndexSet, Message>> messagesForResultItems(List<Map.Entry<IndexSet, Message>> chunk, Set<BulkResult.BulkResultItem> indexBlocks) {
+        final Set<String> blockedMessageIds = indexBlocks.stream().map(item -> item.id).collect(Collectors.toSet());
+
+        return chunk.stream().filter(entry -> blockedMessageIds.contains(entry.getValue().getId())).collect(Collectors.toList());
+    }
+
+    private Set<BulkResult.BulkResultItem> indexBlocksFrom(List<BulkResult.BulkResultItem> allFailedItems) {
+        return allFailedItems.stream().filter(this::hasFailedDueToBlockedIndex).collect(Collectors.toSet());
+    }
+
+    private boolean hasFailedDueToBlockedIndex(BulkResult.BulkResultItem item) {
+        return item.errorType.equals(INDEX_BLOCK_ERROR) && item.errorReason.equals(INDEX_BLOCK_REASON);
     }
 
     private void recordTimestamp(List<Map.Entry<IndexSet, Message>> messageList, Set<String> failedIds) {
@@ -266,9 +347,9 @@ public class Messages {
 
     private List<String> propagateFailure(List<BulkResult.BulkResultItem> items, List<Map.Entry<IndexSet, Message>> messageList) {
         final Map<String, Message> messageMap = messageList.stream()
-            .map(Map.Entry::getValue)
-            .distinct()
-            .collect(Collectors.toMap(Message::getId, Function.identity()));
+                .map(Map.Entry::getValue)
+                .distinct()
+                .collect(Collectors.toMap(Message::getId, Function.identity()));
         final List<String> failedMessageIds = new ArrayList<>(items.size());
         final List<IndexFailure> indexFailures = new ArrayList<>(items.size());
         for (BulkResult.BulkResultItem item : items) {
@@ -317,7 +398,7 @@ public class Messages {
         private final int indexedSuccessfully;
         private final List<BulkResult.BulkResultItem> failedItems;
 
-        public EntityTooLargeException(int indexedSuccessfully, List<BulkResult.BulkResultItem> failedItems)  {
+        public EntityTooLargeException(int indexedSuccessfully, List<BulkResult.BulkResultItem> failedItems) {
             this.indexedSuccessfully = indexedSuccessfully;
             this.failedItems = failedItems;
         }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesRetryWaitTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesRetryWaitTest.java
@@ -1,0 +1,50 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.messages;
+
+import com.github.rholder.retry.WaitStrategy;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class MessagesRetryWaitTest {
+    @Test
+    void secondsBasedRetryWaitsForSecondsStartingWith1() {
+        WaitStrategy waitStrategy = Messages.exponentialWaitSeconds;
+        assertAll(
+                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(1))).isEqualTo(1000),
+                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(2))).isEqualTo(2000),
+                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(3))).isEqualTo(4000),
+                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(4))).isEqualTo(8000),
+                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(5))).isEqualTo(16000)
+        );
+    }
+
+    // This test was added to document how the retry strategy actually behaves since this is hard to deduct from the code
+    @Test
+    void millisecondsBasedRetryWaitsForMillisecondsStartingWith2() {
+        WaitStrategy waitStrategy = Messages.exponentialWaitMilliseconds;
+        assertAll(
+                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(1))).isEqualTo(2),
+                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(2))).isEqualTo(4),
+                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(3))).isEqualTo(8),
+                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(4))).isEqualTo(16),
+                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(5))).isEqualTo(32)
+        );
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesRetryWaitTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesRetryWaitTest.java
@@ -17,34 +17,29 @@
 package org.graylog2.indexer.messages;
 
 import com.github.rholder.retry.WaitStrategy;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class MessagesRetryWaitTest {
     @Test
-    void secondsBasedRetryWaitsForSecondsStartingWith1() {
+    public void secondsBasedRetryWaitsForSecondsStartingWith1() {
         WaitStrategy waitStrategy = Messages.exponentialWaitSeconds;
-        assertAll(
-                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(1))).isEqualTo(1000),
-                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(2))).isEqualTo(2000),
-                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(3))).isEqualTo(4000),
-                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(4))).isEqualTo(8000),
-                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(5))).isEqualTo(16000)
-        );
+        assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(1))).isEqualTo(1000);
+        assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(2))).isEqualTo(2000);
+        assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(3))).isEqualTo(4000);
+        assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(4))).isEqualTo(8000);
+        assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(5))).isEqualTo(16000);
     }
 
     // This test was added to document how the retry strategy actually behaves since this is hard to deduct from the code
     @Test
-    void millisecondsBasedRetryWaitsForMillisecondsStartingWith2() {
+    public void millisecondsBasedRetryWaitsForMillisecondsStartingWith2() {
         WaitStrategy waitStrategy = Messages.exponentialWaitMilliseconds;
-        assertAll(
-                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(1))).isEqualTo(2),
-                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(2))).isEqualTo(4),
-                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(3))).isEqualTo(8),
-                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(4))).isEqualTo(16),
-                () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(5))).isEqualTo(32)
-        );
+        assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(1))).isEqualTo(2);
+        assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(2))).isEqualTo(4);
+        assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(3))).isEqualTo(8);
+        assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(4))).isEqualTo(16);
+        assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(5))).isEqualTo(32);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MockedMessagesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MockedMessagesTest.java
@@ -35,11 +35,15 @@ import org.mockito.junit.MockitoRule;
 
 import java.io.IOException;
 import java.util.AbstractMap;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog2.indexer.messages.Messages.INDEX_BLOCK_ERROR;
+import static org.graylog2.indexer.messages.Messages.INDEX_BLOCK_REASON;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -50,7 +54,7 @@ import static org.mockito.Mockito.when;
 public class MockedMessagesTest {
     public static class MockedBulkResult extends BulkResult {
         MockedBulkResult() {
-            super((ObjectMapper)null);
+            super((ObjectMapper) null);
         }
 
         class MockedBulkResultItem extends BulkResult.BulkResultItem {
@@ -59,6 +63,7 @@ public class MockedMessagesTest {
             }
         }
 
+        @SuppressWarnings("SameParameterValue")
         MockedBulkResultItem createResultItem(String operation, String index, String type, String id, int status, String error, Integer version, String errorType, String errorReason) {
             return new MockedBulkResultItem(operation, index, type, id, status, error, version, errorType, errorReason);
         }
@@ -81,7 +86,7 @@ public class MockedMessagesTest {
         final List<String> result = messages.bulkIndex(Collections.emptyList());
 
         assertThat(result).isNotNull()
-            .isEmpty();
+                .isEmpty();
 
         verify(jestClient, never()).execute(any());
     }
@@ -93,53 +98,139 @@ public class MockedMessagesTest {
         when(jestResult.getFailedItems()).thenReturn(Collections.emptyList());
 
         when(jestClient.execute(any()))
-            .thenThrow(new IOException("Boom!"))
-            .thenReturn(jestResult);
+                .thenThrow(new IOException("Boom!"))
+                .thenReturn(jestResult);
 
-        final List<Map.Entry<IndexSet, Message>> messageList = ImmutableList.of(
-            new AbstractMap.SimpleEntry(mock(IndexSet.class), mock(Message.class))
-        );
+        final List<Map.Entry<IndexSet, Message>> messageList = messageListWith(mock(Message.class));
         final List<String> result = messages.bulkIndex(messageList);
 
         assertThat(result).isNotNull().isEmpty();
 
         verify(jestClient, times(2)).execute(any());
     }
+
     @Test
     public void bulkIndexingShouldNotRetryForIndexMappingErrors() throws Exception {
         final String messageId = "BOOMID";
 
         final BulkResult jestResult = mock(BulkResult.class);
         final BulkResult.BulkResultItem bulkResultItem = new MockedBulkResult().createResultItem(
-            "index",
-            "someindex",
-            "message",
-            messageId,
-            400,
-            "{\"type\":\"mapper_parsing_exception\",\"reason\":\"failed to parse [http_response_code]\",\"caused_by\":{\"type\":\"number_format_exception\",\"reason\":\"For input string: \\\"FOOBAR\\\"\"}}",
-            null,
-            "mapper_parsing_exception",
-            "failed to parse [http_response_code]"
+                "index",
+                "someindex",
+                "message",
+                messageId,
+                400,
+                "{\"type\":\"mapper_parsing_exception\",\"reason\":\"failed to parse [http_response_code]\",\"caused_by\":{\"type\":\"number_format_exception\",\"reason\":\"For input string: \\\"FOOBAR\\\"\"}}",
+                null,
+                "mapper_parsing_exception",
+                "failed to parse [http_response_code]"
         );
         when(jestResult.isSucceeded()).thenReturn(false);
         when(jestResult.getFailedItems()).thenReturn(ImmutableList.of(bulkResultItem));
 
         when(jestClient.execute(any()))
-            .thenReturn(jestResult)
-            .thenThrow(new IllegalStateException("JestResult#execute should not be called twice."));
+                .thenReturn(jestResult)
+                .thenThrow(new IllegalStateException("JestResult#execute should not be called twice."));
 
-        final Message mockedMessage = mock(Message.class);
-        when(mockedMessage.getId()).thenReturn(messageId);
-        when(mockedMessage.getTimestamp()).thenReturn(DateTime.now(DateTimeZone.UTC));
-
-        final List<Map.Entry<IndexSet, Message>> messageList = ImmutableList.of(
-            new AbstractMap.SimpleEntry(mock(IndexSet.class), mockedMessage)
-        );
+        final List<Map.Entry<IndexSet, Message>> messageList = messageListWith(messageWithId(messageId));
 
         final List<String> result = messages.bulkIndex(messageList);
 
         assertThat(result).hasSize(1);
 
         verify(jestClient, times(1)).execute(any());
+    }
+
+    @Test
+    public void bulkIndexingShouldRetryIfIndexBlocked() throws IOException {
+        final BulkResult errorResult = mock(BulkResult.class);
+        final BulkResult.BulkResultItem errorItem = errorResultItem("blocked-id", INDEX_BLOCK_ERROR, INDEX_BLOCK_REASON);
+        when(errorResult.isSucceeded()).thenReturn(false);
+        when(errorResult.getFailedItems()).thenReturn(ImmutableList.of(errorItem));
+
+        final BulkResult successResult = mock(BulkResult.class);
+
+        when(jestClient.execute(any()))
+                .thenReturn(errorResult)
+                .thenReturn(successResult);
+
+        final List<String> result = messages.bulkIndex(messagesWithIds("blocked-id"));
+
+        verify(jestClient, times(2)).execute(any());
+        assertThat(result).isNotNull().isEmpty();
+    }
+
+    @Test
+    public void indexBlockedRetriesShouldOnlyRetryIndexBlockedErrors() throws IOException {
+        final BulkResult errorResult = mock(BulkResult.class);
+        final BulkResult.BulkResultItem indexBlockedError = errorResultItem("blocked-id", INDEX_BLOCK_ERROR, INDEX_BLOCK_REASON);
+        final BulkResult.BulkResultItem otherError = errorResultItem("other-error-id", "something else", "something else");
+        when(errorResult.getFailedItems()).thenReturn(ImmutableList.of(indexBlockedError, otherError));
+
+        final BulkResult successResult = mock(BulkResult.class);
+
+        when(jestClient.execute(any()))
+                .thenReturn(errorResult)
+                .thenReturn(successResult);
+
+        final List<String> result = messages.bulkIndex(messagesWithIds("blocked-id", "other-error-id"));
+
+        verify(jestClient, times(2)).execute(any());
+        assertThat(result).containsOnly("other-error-id");
+    }
+
+    @Test
+    public void retriedIndexBlockErrorsThatFailWithDifferentErrorsAreTreatedAsPersistentFailures() throws IOException {
+        final BulkResult errorResult = mock(BulkResult.class);
+        final BulkResult.BulkResultItem indexBlockedError = errorResultItem("blocked-id", INDEX_BLOCK_ERROR, INDEX_BLOCK_REASON);
+        final BulkResult.BulkResultItem initialIndexBlockedError = errorResultItem("other-error-id", INDEX_BLOCK_ERROR, INDEX_BLOCK_REASON);
+        when(errorResult.getFailedItems()).thenReturn(ImmutableList.of(indexBlockedError, initialIndexBlockedError));
+
+        final BulkResult secondErrorResult = mock(BulkResult.class);
+        final BulkResult.BulkResultItem otherError = errorResultItem("other-error-id", "something else", "something else");
+        when(secondErrorResult.getFailedItems()).thenReturn(ImmutableList.of(otherError));
+
+        when(jestClient.execute(any()))
+                .thenReturn(errorResult)
+                .thenReturn(secondErrorResult);
+
+        final List<String> result = messages.bulkIndex(messagesWithIds("blocked-id", "other-error-id"));
+
+        verify(jestClient, times(2)).execute(any());
+        assertThat(result).containsOnly("other-error-id");
+    }
+
+    private List<Map.Entry<IndexSet, Message>> messagesWithIds(String... ids) {
+        return Arrays.stream(ids)
+                .map(this::messageWithId)
+                .map(m -> new AbstractMap.SimpleEntry<>(mock(IndexSet.class), m))
+                .collect(Collectors.toList());
+    }
+
+    private Message messageWithId(String id) {
+        final Message mockedMessage = mock(Message.class);
+        when(mockedMessage.getId()).thenReturn(id);
+        when(mockedMessage.getTimestamp()).thenReturn(DateTime.now(DateTimeZone.UTC));
+        return mockedMessage;
+    }
+
+    private List<Map.Entry<IndexSet, Message>> messageListWith(Message mockedMessage) {
+        return ImmutableList.of(
+                new AbstractMap.SimpleEntry<>(mock(IndexSet.class), mockedMessage)
+        );
+    }
+
+    private BulkResult.BulkResultItem errorResultItem(String messageId, String errorType, String errorReason) {
+        return new MockedBulkResult().createResultItem(
+                "index",
+                "someindex",
+                "message",
+                messageId,
+                400,
+                "{\"type\":\"" + errorType + "\",\"reason\":\"" + errorReason + "\"}}",
+                null,
+                errorType,
+                errorReason
+        );
     }
 }


### PR DESCRIPTION
* Retry messages if target index is read-only (#8245)

* Draft solution for retrying index failures due to flood stage reached (WIP)

- Added additional retry loop in `Messages`. While it's not ideal to complicate the indexing code further, this error case can't be included in the existing retry logic, because the we have to modify the next request to only include items that have failed due to this particular error
- Added a simple test to `MockedMessagesTest`

* Add test verifying that other errors occurring in same chunk as index block errors are not retried

* Treat retried index block errors that fail differently as persistent failures

* Reuse `com.github.rholder.retry.WaitStrategy` for index block retries

* add license headers

* Keep using milliseconds-based waiting for `BULK_REQUEST_RETRYER`

...but go with seconds-based for index block retries.

- extracted a seconds-based wait strategy to a field in Messages
- add explanatory comment for why a multiplier of 500 works, which is unintuitive
- added separate unit tests to document how the waiting strategies actually work

* Cleaned up code based on @dennisoelkers' feedback

- Mark variables as final where possible
- Rename method from `retryOnlyIndexBlockItemsForever` to `retryIfIndexBlocksPresent`
- Log warning, if index blocks present
- Log info after retries have been successful
- Removed `org.jetbrains.annotations.NotNull` annotation

* Renamed private method `blockExecutionForAttempt` to `waitBeforeRetrying`

* Renamed private method `retryIfIndexBlocksPresent` back to `retryOnlyIndexBlockItemsForever`.

It does indicate more clearly that only index blocks are retied here and that retries will go on "forever", if the blocks are not resolved.

(cherry picked from commit e7045448dccfede6f1d7710ab8d29093f1096efe)

* fix formatting glitch

(cherry picked from commit ed8a80ae118b63fb247ab4722c83457e5da06538)

* Fix unconditional warning

This was an oversight in pr #8245, which led to tons of misleading
warnings.

(cherry picked from commit 4295704d47a23195e45b257b359577ecda787f24)
(cherry picked from commit 76dddea85eaa6d441a63c75ba739449048a11aa1)