### PR TITLE
Allow alert conditions with floating numbers

### DIFF
--- a/graylog2-web-interface/src/logic/alerts/AggregationExpressionValidation.js
+++ b/graylog2-web-interface/src/logic/alerts/AggregationExpressionValidation.js
@@ -16,7 +16,7 @@ const flattenValidationTree = (validationTree, errors = []) => {
 const validateExpressionTree = (expression, series, validationTree = {}) => {
   switch (expression.expr) {
     case 'number':
-      return (Number.isSafeInteger(expression.value) ? {} : { message: 'Threshold must be a valid number' });
+      return (Number.isFinite(expression.value) ? {} : { message: 'Threshold must be a valid number' });
     case 'number-ref':
       /* eslint-disable no-case-declarations */
       const error = { message: 'Function must be set' };


### PR DESCRIPTION
* Allow alert conditions with floating numbers

This got changed with the introduction of multiple conditions in 3.2.
The backend treats every value as Double anyhow.

* Use isFinite instead

(cherry picked from commit 6ca165d587c6976a7b2661a38f0c204574b8f3f3)
(cherry picked from commit b25de895fb05dea6aa9eeaf709fde2db4bda7b1d)
