### PR TITLE
Updating word usage for node's Primary and Secondary

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/ClusterAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/ClusterAdapterES6.java
@@ -230,9 +230,9 @@ public class ClusterAdapterES6 implements ClusterAdapter {
 
         final NodesStats nodesStats = NodesStats.create(
                 countStats.path("total").asInt(-1),
-                countStats.path("parent_only").asInt(-1),
+                countStats.path("primary_only").asInt(-1),
                 countStats.path("data_only").asInt(-1),
-                countStats.path("parent_data").asInt(-1),
+                countStats.path("primary_data").asInt(-1),
                 countStats.path("client").asInt(-1)
         );
 

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/ClusterAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/ClusterAdapterES6.java
@@ -230,9 +230,9 @@ public class ClusterAdapterES6 implements ClusterAdapter {
 
         final NodesStats nodesStats = NodesStats.create(
                 countStats.path("total").asInt(-1),
-                countStats.path("master_only").asInt(-1),
+                countStats.path("parent_only").asInt(-1),
                 countStats.path("data_only").asInt(-1),
-                countStats.path("master_data").asInt(-1),
+                countStats.path("parent_data").asInt(-1),
                 countStats.path("client").asInt(-1)
         );
 

--- a/graylog2-server/src/main/java/org/graylog/events/periodicals/EventNotificationStatusCleanUp.java
+++ b/graylog2-server/src/main/java/org/graylog/events/periodicals/EventNotificationStatusCleanUp.java
@@ -54,7 +54,7 @@ public class EventNotificationStatusCleanUp extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog/events/periodicals/EventNotificationStatusCleanUp.java
+++ b/graylog2-server/src/main/java/org/graylog/events/periodicals/EventNotificationStatusCleanUp.java
@@ -54,7 +54,7 @@ public class EventNotificationStatusCleanUp extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsFrameDecoder.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsFrameDecoder.java
@@ -43,7 +43,7 @@ import java.util.zip.InflaterInputStream;
 /**
  * FrameDecoder for the Beats/Lumberjack protocol.
  *
- * @see <a href="https://github.com/logstash-plugins/logstash-input-beats/blob/parent/PROTOCOL.md">Lumberjack protocol</a>
+ * @see <a href="https://github.com/logstash-plugins/logstash-input-beats/blob/master/PROTOCOL.md">Lumberjack protocol</a>
  */
 public class BeatsFrameDecoder extends ReplayingDecoder<BeatsFrameDecoder.DecodingState> {
     private static final Logger LOG = LoggerFactory.getLogger(BeatsFrameDecoder.class);

--- a/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsFrameDecoder.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/beats/BeatsFrameDecoder.java
@@ -43,7 +43,7 @@ import java.util.zip.InflaterInputStream;
 /**
  * FrameDecoder for the Beats/Lumberjack protocol.
  *
- * @see <a href="https://github.com/logstash-plugins/logstash-input-beats/blob/master/PROTOCOL.md">Lumberjack protocol</a>
+ * @see <a href="https://github.com/logstash-plugins/logstash-input-beats/blob/parent/PROTOCOL.md">Lumberjack protocol</a>
  */
 public class BeatsFrameDecoder extends ReplayingDecoder<BeatsFrameDecoder.DecodingState> {
     private static final Logger LOG = LoggerFactory.getLogger(BeatsFrameDecoder.class);

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/periodical/LegacyDefaultStreamMigration.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/periodical/LegacyDefaultStreamMigration.java
@@ -52,7 +52,7 @@ public class LegacyDefaultStreamMigration extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/periodical/LegacyDefaultStreamMigration.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/pipelineprocessor/periodical/LegacyDefaultStreamMigration.java
@@ -52,7 +52,7 @@ public class LegacyDefaultStreamMigration extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/periodical/PurgeExpiredConfigurationUploads.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/periodical/PurgeExpiredConfigurationUploads.java
@@ -45,7 +45,7 @@ public class PurgeExpiredConfigurationUploads extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/periodical/PurgeExpiredConfigurationUploads.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/periodical/PurgeExpiredConfigurationUploads.java
@@ -45,7 +45,7 @@ public class PurgeExpiredConfigurationUploads extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/periodical/PurgeExpiredSidecarsThread.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/periodical/PurgeExpiredSidecarsThread.java
@@ -50,7 +50,7 @@ public class PurgeExpiredSidecarsThread extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/sidecar/periodical/PurgeExpiredSidecarsThread.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/sidecar/periodical/PurgeExpiredSidecarsThread.java
@@ -50,7 +50,7 @@ public class PurgeExpiredSidecarsThread extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/SearchesCleanUpJob.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/SearchesCleanUpJob.java
@@ -56,7 +56,7 @@ public class SearchesCleanUpJob extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/SearchesCleanUpJob.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/db/SearchesCleanUpJob.java
@@ -56,7 +56,7 @@ public class SearchesCleanUpJob extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog/scheduler/DefaultJobSchedulerConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/DefaultJobSchedulerConfig.java
@@ -42,7 +42,7 @@ public class DefaultJobSchedulerConfig implements JobSchedulerConfig {
     @Override
     public boolean canStart() {
         try {
-            return nodeService.byNodeId(nodeId).isParent();
+            return nodeService.byNodeId(nodeId).isPrimary();
         } catch (NodeNotFoundException e) {
             LOG.error("Couldn't find current node <{}> in the database", nodeId.toString(), e);
             return false;

--- a/graylog2-server/src/main/java/org/graylog/scheduler/DefaultJobSchedulerConfig.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/DefaultJobSchedulerConfig.java
@@ -42,7 +42,7 @@ public class DefaultJobSchedulerConfig implements JobSchedulerConfig {
     @Override
     public boolean canStart() {
         try {
-            return nodeService.byNodeId(nodeId).isMaster();
+            return nodeService.byNodeId(nodeId).isParent();
         } catch (NodeNotFoundException e) {
             LOG.error("Couldn't find current node <{}> in the database", nodeId.toString(), e);
             return false;

--- a/graylog2-server/src/main/java/org/graylog/scheduler/periodicals/ScheduleTriggerCleanUp.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/periodicals/ScheduleTriggerCleanUp.java
@@ -48,7 +48,7 @@ public class ScheduleTriggerCleanUp extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog/scheduler/periodicals/ScheduleTriggerCleanUp.java
+++ b/graylog2-server/src/main/java/org/graylog/scheduler/periodicals/ScheduleTriggerCleanUp.java
@@ -48,7 +48,7 @@ public class ScheduleTriggerCleanUp extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -45,8 +45,8 @@ import java.util.Set;
  */
 @SuppressWarnings("FieldMayBeFinal")
 public class Configuration extends BaseConfiguration {
-    @Parameter(value = "is_parent", required = true)
-    private boolean isParent = true;
+    @Parameter(value = "is_primary", required = true)
+    private boolean isPrimary = true;
 
     @Parameter(value = "password_secret", required = true, validator = StringNotBlankValidator.class)
     private String passwordSecret;
@@ -112,8 +112,8 @@ public class Configuration extends BaseConfiguration {
     @Parameter(value = "output_fault_penalty_seconds", validator = PositiveLongValidator.class)
     private long outputFaultPenaltySeconds = 30;
 
-    @Parameter(value = "stale_parent_timeout", validator = PositiveIntegerValidator.class)
-    private int staleParentTimeout = 2000;
+    @Parameter(value = "stale_primary_timeout", validator = PositiveIntegerValidator.class)
+    private int stalePrimaryTimeout = 2000;
 
     @Parameter(value = "ldap_connection_timeout", validator = PositiveIntegerValidator.class)
     private int ldapConnectionTimeout = 2000;
@@ -164,12 +164,12 @@ public class Configuration extends BaseConfiguration {
     private Set<String> enabledTlsProtocols = ImmutableSet.of("TLSv1.2", "TLSv1.3");
 
 
-    public boolean isParent() {
-        return isParent;
+    public boolean isPrimary() {
+        return isPrimary;
     }
 
-    public void setIsParent(boolean is) {
-        isParent = is;
+    public void setIsPrimary(boolean is) {
+        isPrimary = is;
     }
 
     public String getPasswordSecret() {
@@ -253,8 +253,8 @@ public class Configuration extends BaseConfiguration {
         return outputFaultPenaltySeconds;
     }
 
-    public int getstaleParentTimeout() {
-        return staleParentTimeout;
+    public int getstalePrimaryTimeout() {
+        return stalePrimaryTimeout;
     }
 
     public int getLdapConnectionTimeout() {
@@ -357,18 +357,18 @@ public class Configuration extends BaseConfiguration {
             final StringBuilder b = new StringBuilder();
 
             if (!file.exists()) {
-                final File parent = file.getParentFile();
-                if (!parent.isDirectory()) {
-                    throw new ValidationException("Parent path " + parent + " for Node ID file at " + path + " is not a directory");
+                final File primary = file.getPrimaryFile();
+                if (!primary.isDirectory()) {
+                    throw new ValidationException("Primary path " + primary + " for Node ID file at " + path + " is not a directory");
                 } else {
-                    if (!parent.canRead()) {
-                        throw new ValidationException("Parent directory " + parent + " for Node ID file at " + path + " is not readable");
+                    if (!primary.canRead()) {
+                        throw new ValidationException("Primary directory " + primary + " for Node ID file at " + path + " is not readable");
                     }
-                    if (!parent.canWrite()) {
-                        throw new ValidationException("Parent directory " + parent + " for Node ID file at " + path + " is not writable");
+                    if (!primary.canWrite()) {
+                        throw new ValidationException("Primary directory " + primary + " for Node ID file at " + path + " is not writable");
                     }
 
-                    // parent directory exists and is readable and writable
+                    // primary directory exists and is readable and writable
                     return;
                 }
             }

--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -45,8 +45,8 @@ import java.util.Set;
  */
 @SuppressWarnings("FieldMayBeFinal")
 public class Configuration extends BaseConfiguration {
-    @Parameter(value = "is_master", required = true)
-    private boolean isMaster = true;
+    @Parameter(value = "is_parent", required = true)
+    private boolean isParent = true;
 
     @Parameter(value = "password_secret", required = true, validator = StringNotBlankValidator.class)
     private String passwordSecret;
@@ -112,8 +112,8 @@ public class Configuration extends BaseConfiguration {
     @Parameter(value = "output_fault_penalty_seconds", validator = PositiveLongValidator.class)
     private long outputFaultPenaltySeconds = 30;
 
-    @Parameter(value = "stale_master_timeout", validator = PositiveIntegerValidator.class)
-    private int staleMasterTimeout = 2000;
+    @Parameter(value = "stale_parent_timeout", validator = PositiveIntegerValidator.class)
+    private int staleParentTimeout = 2000;
 
     @Parameter(value = "ldap_connection_timeout", validator = PositiveIntegerValidator.class)
     private int ldapConnectionTimeout = 2000;
@@ -164,12 +164,12 @@ public class Configuration extends BaseConfiguration {
     private Set<String> enabledTlsProtocols = ImmutableSet.of("TLSv1.2", "TLSv1.3");
 
 
-    public boolean isMaster() {
-        return isMaster;
+    public boolean isParent() {
+        return isParent;
     }
 
-    public void setIsMaster(boolean is) {
-        isMaster = is;
+    public void setIsParent(boolean is) {
+        isParent = is;
     }
 
     public String getPasswordSecret() {
@@ -253,8 +253,8 @@ public class Configuration extends BaseConfiguration {
         return outputFaultPenaltySeconds;
     }
 
-    public int getStaleMasterTimeout() {
-        return staleMasterTimeout;
+    public int getstaleParentTimeout() {
+        return staleParentTimeout;
     }
 
     public int getLdapConnectionTimeout() {

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -72,7 +72,7 @@ import org.graylog2.shared.journal.JournalReaderModule;
 import org.graylog2.shared.journal.KafkaJournalModule;
 import org.graylog2.shared.journal.NoopJournalModule;
 import org.graylog2.shared.metrics.jersey2.MetricsDynamicBinding;
-import org.graylog2.shared.security.RestrictToParentFeature;
+import org.graylog2.shared.security.RestrictToPrimaryFeature;
 import org.graylog2.shared.system.activities.ActivityWriter;
 import org.graylog2.streams.DefaultStreamChangeHandler;
 import org.graylog2.streams.StreamRouter;
@@ -187,7 +187,7 @@ public class ServerBindings extends Graylog2Module {
     private void bindDynamicFeatures() {
         final Multibinder<Class<? extends DynamicFeature>> dynamicFeatures = jerseyDynamicFeatureBinder();
         dynamicFeatures.addBinding().toInstance(MetricsDynamicBinding.class);
-        dynamicFeatures.addBinding().toInstance(RestrictToParentFeature.class);
+        dynamicFeatures.addBinding().toInstance(RestrictToPrimaryFeature.class);
     }
 
     private void bindExceptionMappers() {

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -72,7 +72,7 @@ import org.graylog2.shared.journal.JournalReaderModule;
 import org.graylog2.shared.journal.KafkaJournalModule;
 import org.graylog2.shared.journal.NoopJournalModule;
 import org.graylog2.shared.metrics.jersey2.MetricsDynamicBinding;
-import org.graylog2.shared.security.RestrictToMasterFeature;
+import org.graylog2.shared.security.RestrictToParentFeature;
 import org.graylog2.shared.system.activities.ActivityWriter;
 import org.graylog2.streams.DefaultStreamChangeHandler;
 import org.graylog2.streams.StreamRouter;
@@ -187,7 +187,7 @@ public class ServerBindings extends Graylog2Module {
     private void bindDynamicFeatures() {
         final Multibinder<Class<? extends DynamicFeature>> dynamicFeatures = jerseyDynamicFeatureBinder();
         dynamicFeatures.addBinding().toInstance(MetricsDynamicBinding.class);
-        dynamicFeatures.addBinding().toInstance(RestrictToMasterFeature.class);
+        dynamicFeatures.addBinding().toInstance(RestrictToParentFeature.class);
     }
 
     private void bindExceptionMappers() {

--- a/graylog2-server/src/main/java/org/graylog2/cluster/Node.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/Node.java
@@ -26,7 +26,7 @@ public interface Node extends Persisted {
 
     String getNodeId();
 
-    boolean isParent();
+    boolean isPrimary();
 
     String getTransportAddress();
 

--- a/graylog2-server/src/main/java/org/graylog2/cluster/Node.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/Node.java
@@ -26,7 +26,7 @@ public interface Node extends Persisted {
 
     String getNodeId();
 
-    boolean isMaster();
+    boolean isParent();
 
     String getTransportAddress();
 

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeImpl.java
@@ -46,9 +46,9 @@ public class NodeImpl extends PersistedImpl implements Node {
     }
 
     @Override
-    @JsonProperty("is_master")
-    public boolean isMaster() {
-        return (Boolean) fields.get("is_master");
+    @JsonProperty("is_parent")
+    public boolean isParent() {
+        return (Boolean) fields.get("is_parent");
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeImpl.java
@@ -46,9 +46,9 @@ public class NodeImpl extends PersistedImpl implements Node {
     }
 
     @Override
-    @JsonProperty("is_parent")
-    public boolean isParent() {
-        return (Boolean) fields.get("is_parent");
+    @JsonProperty("is_primary")
+    public boolean isPrimary() {
+        return (Boolean) fields.get("is_primary");
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeService.java
@@ -23,7 +23,7 @@ import java.net.URI;
 import java.util.Map;
 
 public interface NodeService extends PersistedService {
-    String registerServer(String nodeId, boolean isMaster, URI httpPublishUri, String hostname);
+    String registerServer(String nodeId, boolean isParent, URI httpPublishUri, String hostname);
 
     Node byNodeId(String nodeId) throws NodeNotFoundException;
 
@@ -35,11 +35,11 @@ public interface NodeService extends PersistedService {
 
     void dropOutdated();
 
-    void markAsAlive(Node node, boolean isMaster, String restTransportAddress);
+    void markAsAlive(Node node, boolean isParent, String restTransportAddress);
 
-    void markAsAlive(Node node, boolean isMaster, URI restTransportAddress);
+    void markAsAlive(Node node, boolean isParent, URI restTransportAddress);
 
-    boolean isOnlyMaster(NodeId nodeIde);
+    boolean isOnlyParent(NodeId nodeIde);
 
-    boolean isAnyMasterPresent();
+    boolean isAnyParentPresent();
 }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeService.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeService.java
@@ -23,7 +23,7 @@ import java.net.URI;
 import java.util.Map;
 
 public interface NodeService extends PersistedService {
-    String registerServer(String nodeId, boolean isParent, URI httpPublishUri, String hostname);
+    String registerServer(String nodeId, boolean isPrimary, URI httpPublishUri, String hostname);
 
     Node byNodeId(String nodeId) throws NodeNotFoundException;
 
@@ -35,11 +35,11 @@ public interface NodeService extends PersistedService {
 
     void dropOutdated();
 
-    void markAsAlive(Node node, boolean isParent, String restTransportAddress);
+    void markAsAlive(Node node, boolean isPrimary, String restTransportAddress);
 
-    void markAsAlive(Node node, boolean isParent, URI restTransportAddress);
+    void markAsAlive(Node node, boolean isPrimary, URI restTransportAddress);
 
-    boolean isOnlyParent(NodeId nodeIde);
+    boolean isOnlyPrimary(NodeId nodeIde);
 
-    boolean isAnyParentPresent();
+    boolean isAnyPrimaryPresent();
 }

--- a/graylog2-server/src/main/java/org/graylog2/cluster/NodeServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/cluster/NodeServiceImpl.java
@@ -38,16 +38,16 @@ public class NodeServiceImpl extends PersistedServiceImpl implements NodeService
     @Inject
     public NodeServiceImpl(final MongoConnection mongoConnection, final Configuration configuration) {
         super(mongoConnection);
-        this.pingTimeout = TimeUnit.MILLISECONDS.toSeconds(configuration.getStaleMasterTimeout());
+        this.pingTimeout = TimeUnit.MILLISECONDS.toSeconds(configuration.getstaleParentTimeout());
     }
 
     @Override
-    public String registerServer(String nodeId, boolean isMaster, URI httpPublishUri, String hostname) {
+    public String registerServer(String nodeId, boolean isParent, URI httpPublishUri, String hostname) {
         Map<String, Object> fields = Maps.newHashMap();
         fields.put("last_seen", Tools.getUTCTimestamp());
         fields.put("node_id", nodeId);
         fields.put("type", Node.Type.SERVER.toString());
-        fields.put("is_master", isMaster);
+        fields.put("is_parent", isParent);
         fields.put("transport_address", httpPublishUri.toString());
         fields.put("hostname", hostname);
 
@@ -123,13 +123,13 @@ public class NodeServiceImpl extends PersistedServiceImpl implements NodeService
     /**
      * Mark this node as alive and probably update some settings that may have changed since last server boot.
      *
-     * @param isMaster
+     * @param isParent
      * @param restTransportAddress
      */
     @Override
-    public void markAsAlive(Node node, boolean isMaster, String restTransportAddress) {
+    public void markAsAlive(Node node, boolean isParent, String restTransportAddress) {
         node.getFields().put("last_seen", Tools.getUTCTimestamp());
-        node.getFields().put("is_master", isMaster);
+        node.getFields().put("is_parent", isParent);
         node.getFields().put("transport_address", restTransportAddress);
         try {
             save(node);
@@ -139,27 +139,27 @@ public class NodeServiceImpl extends PersistedServiceImpl implements NodeService
     }
 
     @Override
-    public void markAsAlive(Node node, boolean isMaster, URI restTransportAddress) {
-        markAsAlive(node, isMaster, restTransportAddress.toString());
+    public void markAsAlive(Node node, boolean isParent, URI restTransportAddress) {
+        markAsAlive(node, isParent, restTransportAddress.toString());
     }
 
     @Override
-    public boolean isOnlyMaster(NodeId nodeId) {
+    public boolean isOnlyParent(NodeId nodeId) {
         BasicDBObject query = new BasicDBObject();
         query.put("type", Node.Type.SERVER.toString());
         query.put("last_seen", new BasicDBObject("$gte", Tools.getUTCTimestamp() - pingTimeout));
         query.put("node_id", new BasicDBObject("$ne", nodeId.toString()));
-        query.put("is_master", true);
+        query.put("is_parent", true);
 
         return query(NodeImpl.class, query).size() == 0;
     }
 
     @Override
-    public boolean isAnyMasterPresent() {
+    public boolean isAnyParentPresent() {
         BasicDBObject query = new BasicDBObject();
         query.put("type", Node.Type.SERVER.toString());
         query.put("last_seen", new BasicDBObject("$gte", Tools.getUTCTimestamp() - pingTimeout));
-        query.put("is_master", true);
+        query.put("is_parent", true);
 
         return query(NodeImpl.class, query).size() > 0;
     }

--- a/graylog2-server/src/main/java/org/graylog2/commands/journal/AbstractJournalCommand.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/journal/AbstractJournalCommand.java
@@ -59,7 +59,7 @@ public abstract class AbstractJournalCommand extends CmdLineTool {
 
     @Override
     protected Set<ServerStatus.Capability> capabilities() {
-        return configuration.isParent() ? Collections.singleton(ServerStatus.Capability.PARENT) : Collections.emptySet();
+        return configuration.isPrimary() ? Collections.singleton(ServerStatus.Capability.PRIMARY) : Collections.emptySet();
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/commands/journal/AbstractJournalCommand.java
+++ b/graylog2-server/src/main/java/org/graylog2/commands/journal/AbstractJournalCommand.java
@@ -59,7 +59,7 @@ public abstract class AbstractJournalCommand extends CmdLineTool {
 
     @Override
     protected Set<ServerStatus.Capability> capabilities() {
-        return configuration.isMaster() ? Collections.singleton(ServerStatus.Capability.MASTER) : Collections.emptySet();
+        return configuration.isParent() ? Collections.singleton(ServerStatus.Capability.PARENT) : Collections.emptySet();
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ExposedConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ExposedConfiguration.java
@@ -82,8 +82,8 @@ public abstract class ExposedConfiguration {
     @JsonProperty("output_module_timeout")
     public abstract long outputModuleTimeout();
 
-    @JsonProperty("stale_parent_timeout")
-    public abstract int staleParentTimeout();
+    @JsonProperty("stale_primary_timeout")
+    public abstract int stalePrimaryTimeout();
 
     @JsonProperty("gc_warning_threshold")
     public abstract String gcWarningThreshold();
@@ -106,7 +106,7 @@ public abstract class ExposedConfiguration {
                 configuration.getStreamProcessingTimeout(),
                 configuration.getStreamProcessingMaxFaults(),
                 configuration.getOutputModuleTimeout(),
-                configuration.getstaleParentTimeout(),
+                configuration.getstalePrimaryTimeout(),
                 configuration.getGcWarningThreshold().toString());
     }
 
@@ -128,7 +128,7 @@ public abstract class ExposedConfiguration {
             @JsonProperty("stream_processing_timeout") long streamProcessingTimeout,
             @JsonProperty("stream_processing_max_faults") int streamProcessingMaxFaults,
             @JsonProperty("output_module_timeout") long outputModuleTimeout,
-            @JsonProperty("stale_parent_timeout") int staleParentTimeout,
+            @JsonProperty("stale_primary_timeout") int stalePrimaryTimeout,
             @JsonProperty("gc_warning_threshold") String gcWarningThreshold) {
         return new AutoValue_ExposedConfiguration(
                 inputBufferProcessors,
@@ -147,7 +147,7 @@ public abstract class ExposedConfiguration {
                 streamProcessingTimeout,
                 streamProcessingMaxFaults,
                 outputModuleTimeout,
-                staleParentTimeout,
+                stalePrimaryTimeout,
                 gcWarningThreshold);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ExposedConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ExposedConfiguration.java
@@ -82,8 +82,8 @@ public abstract class ExposedConfiguration {
     @JsonProperty("output_module_timeout")
     public abstract long outputModuleTimeout();
 
-    @JsonProperty("stale_master_timeout")
-    public abstract int staleMasterTimeout();
+    @JsonProperty("stale_parent_timeout")
+    public abstract int staleParentTimeout();
 
     @JsonProperty("gc_warning_threshold")
     public abstract String gcWarningThreshold();
@@ -106,7 +106,7 @@ public abstract class ExposedConfiguration {
                 configuration.getStreamProcessingTimeout(),
                 configuration.getStreamProcessingMaxFaults(),
                 configuration.getOutputModuleTimeout(),
-                configuration.getStaleMasterTimeout(),
+                configuration.getstaleParentTimeout(),
                 configuration.getGcWarningThreshold().toString());
     }
 
@@ -128,7 +128,7 @@ public abstract class ExposedConfiguration {
             @JsonProperty("stream_processing_timeout") long streamProcessingTimeout,
             @JsonProperty("stream_processing_max_faults") int streamProcessingMaxFaults,
             @JsonProperty("output_module_timeout") long outputModuleTimeout,
-            @JsonProperty("stale_master_timeout") int staleMasterTimeout,
+            @JsonProperty("stale_parent_timeout") int staleParentTimeout,
             @JsonProperty("gc_warning_threshold") String gcWarningThreshold) {
         return new AutoValue_ExposedConfiguration(
                 inputBufferProcessors,
@@ -147,7 +147,7 @@ public abstract class ExposedConfiguration {
                 streamProcessingTimeout,
                 streamProcessingMaxFaults,
                 outputModuleTimeout,
-                staleMasterTimeout,
+                staleParentTimeout,
                 gcWarningThreshold);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventCleanupPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventCleanupPeriodical.java
@@ -68,7 +68,7 @@ public class ClusterEventCleanupPeriodical extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventCleanupPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventCleanupPeriodical.java
@@ -68,7 +68,7 @@ public class ClusterEventCleanupPeriodical extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
@@ -110,7 +110,7 @@ public class ClusterEventPeriodical extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return false;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/events/ClusterEventPeriodical.java
@@ -110,7 +110,7 @@ public class ClusterEventPeriodical extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return false;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodical.java
@@ -239,8 +239,8 @@ public class IndexFieldTypePollerPeriodical extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
-        // Only needs to run on the parent node because results are stored in the database
+    public boolean primaryOnly() {
+        // Only needs to run on the primary node because results are stored in the database
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodical.java
@@ -239,8 +239,8 @@ public class IndexFieldTypePollerPeriodical extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
-        // Only needs to run on the master node because results are stored in the database
+    public boolean parentOnly() {
+        // Only needs to run on the parent node because results are stored in the database
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
@@ -45,8 +45,8 @@ public interface Notification extends Persisted {
 
     enum Type {
         DEFLECTOR_EXISTS_AS_INDEX,
-        MULTI_PARENT,
-        NO_PARENT,
+        MULTI_PRIMARY,
+        NO_PRIMARY,
         ES_OPEN_FILES,
         ES_CLUSTER_RED,
         ES_UNAVAILABLE,

--- a/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
@@ -45,8 +45,8 @@ public interface Notification extends Persisted {
 
     enum Type {
         DEFLECTOR_EXISTS_AS_INDEX,
-        MULTI_MASTER,
-        NO_MASTER,
+        MULTI_PARENT,
+        NO_PARENT,
         ES_OPEN_FILES,
         ES_CLUSTER_RED,
         ES_UNAVAILABLE,

--- a/graylog2-server/src/main/java/org/graylog2/periodical/AlertScannerThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/AlertScannerThread.java
@@ -85,7 +85,7 @@ public class AlertScannerThread extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/AlertScannerThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/AlertScannerThread.java
@@ -85,7 +85,7 @@ public class AlertScannerThread extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/BatchedElasticSearchOutputFlushThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/BatchedElasticSearchOutputFlushThread.java
@@ -48,7 +48,7 @@ public class BatchedElasticSearchOutputFlushThread extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return false;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/BatchedElasticSearchOutputFlushThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/BatchedElasticSearchOutputFlushThread.java
@@ -48,7 +48,7 @@ public class BatchedElasticSearchOutputFlushThread extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return false;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ClusterHealthCheckThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ClusterHealthCheckThread.java
@@ -90,7 +90,7 @@ public class ClusterHealthCheckThread extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ClusterHealthCheckThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ClusterHealthCheckThread.java
@@ -90,7 +90,7 @@ public class ClusterHealthCheckThread extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ClusterIdGeneratorPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ClusterIdGeneratorPeriodical.java
@@ -46,7 +46,7 @@ public class ClusterIdGeneratorPeriodical extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ClusterIdGeneratorPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ClusterIdGeneratorPeriodical.java
@@ -46,7 +46,7 @@ public class ClusterIdGeneratorPeriodical extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ConfigurationManagementPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ConfigurationManagementPeriodical.java
@@ -58,7 +58,7 @@ public class ConfigurationManagementPeriodical extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ConfigurationManagementPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ConfigurationManagementPeriodical.java
@@ -58,7 +58,7 @@ public class ConfigurationManagementPeriodical extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ContentPackLoaderPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ContentPackLoaderPeriodical.java
@@ -82,7 +82,7 @@ public class ContentPackLoaderPeriodical extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ContentPackLoaderPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ContentPackLoaderPeriodical.java
@@ -82,7 +82,7 @@ public class ContentPackLoaderPeriodical extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/GarbageCollectionWarningThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/GarbageCollectionWarningThread.java
@@ -78,7 +78,7 @@ public class GarbageCollectionWarningThread extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return false;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/GarbageCollectionWarningThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/GarbageCollectionWarningThread.java
@@ -78,7 +78,7 @@ public class GarbageCollectionWarningThread extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return false;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexFailuresPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexFailuresPeriodical.java
@@ -86,7 +86,7 @@ public class IndexFailuresPeriodical extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return false;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexFailuresPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexFailuresPeriodical.java
@@ -86,7 +86,7 @@ public class IndexFailuresPeriodical extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return false;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesCleanupPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesCleanupPeriodical.java
@@ -99,7 +99,7 @@ public class IndexRangesCleanupPeriodical extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesCleanupPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesCleanupPeriodical.java
@@ -99,7 +99,7 @@ public class IndexRangesCleanupPeriodical extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesMigrationPeriodical.java
@@ -144,7 +144,7 @@ public class IndexRangesMigrationPeriodical extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRangesMigrationPeriodical.java
@@ -144,7 +144,7 @@ public class IndexRangesMigrationPeriodical extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRetentionThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRetentionThread.java
@@ -112,7 +112,7 @@ public class IndexRetentionThread extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRetentionThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRetentionThread.java
@@ -112,7 +112,7 @@ public class IndexRetentionThread extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRotationThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRotationThread.java
@@ -184,7 +184,7 @@ public class IndexRotationThread extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexRotationThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexRotationThread.java
@@ -184,7 +184,7 @@ public class IndexRotationThread extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexerClusterCheckerThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexerClusterCheckerThread.java
@@ -206,7 +206,7 @@ public class IndexerClusterCheckerThread extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/IndexerClusterCheckerThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/IndexerClusterCheckerThread.java
@@ -206,7 +206,7 @@ public class IndexerClusterCheckerThread extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/LdapGroupMappingMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/LdapGroupMappingMigration.java
@@ -79,7 +79,7 @@ public class LdapGroupMappingMigration extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/LdapGroupMappingMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/LdapGroupMappingMigration.java
@@ -79,7 +79,7 @@ public class LdapGroupMappingMigration extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/NodePingThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/NodePingThread.java
@@ -57,14 +57,14 @@ public class NodePingThread extends Periodical {
 
     @Override
     public void doRun() {
-        final boolean isParent = serverStatus.hasCapability(ServerStatus.Capability.PARENT);
+        final boolean isPrimary = serverStatus.hasCapability(ServerStatus.Capability.PRIMARY);
         try {
             Node node = nodeService.byNodeId(serverStatus.getNodeId());
-            nodeService.markAsAlive(node, isParent, httpConfiguration.getHttpPublishUri().resolve(HttpConfiguration.PATH_API));
+            nodeService.markAsAlive(node, isPrimary, httpConfiguration.getHttpPublishUri().resolve(HttpConfiguration.PATH_API));
         } catch (NodeNotFoundException e) {
             LOG.warn("Did not find meta info of this node. Re-registering.");
             nodeService.registerServer(serverStatus.getNodeId().toString(),
-                    isParent,
+                    isPrimary,
                     httpConfiguration.getHttpPublishUri().resolve(HttpConfiguration.PATH_API),
                     Tools.getLocalCanonicalHostname());
         }
@@ -72,20 +72,20 @@ public class NodePingThread extends Periodical {
             // Remove old nodes that are no longer running. (Just some housekeeping)
             nodeService.dropOutdated();
 
-            // Check that we still have a parent node in the cluster, if not, warn the user.
-            if (nodeService.isAnyParentPresent()) {
+            // Check that we still have a primary node in the cluster, if not, warn the user.
+            if (nodeService.isAnyPrimaryPresent()) {
                 Notification notification = notificationService.build()
-                        .addType(Notification.Type.NO_PARENT);
+                        .addType(Notification.Type.NO_PRIMARY);
                 boolean removedNotification = notificationService.fixed(notification);
                 if (removedNotification) {
                     activityWriter.write(
-                        new Activity("Notification condition [" + NotificationImpl.Type.NO_PARENT + "] " +
+                        new Activity("Notification condition [" + NotificationImpl.Type.NO_PRIMARY + "] " +
                                              "has been fixed.", NodePingThread.class));
                 }
             } else {
                 Notification notification = notificationService.buildNow()
                         .addNode(serverStatus.getNodeId().toString())
-                        .addType(Notification.Type.NO_PARENT)
+                        .addType(Notification.Type.NO_PRIMARY)
                         .addSeverity(Notification.Severity.URGENT);
                 notificationService.publishIfFirst(notification);
             }
@@ -111,7 +111,7 @@ public class NodePingThread extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return false;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ThrottleStateUpdaterThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ThrottleStateUpdaterThread.java
@@ -160,7 +160,7 @@ public class ThrottleStateUpdaterThread extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return false;
     }
 
@@ -231,7 +231,7 @@ public class ThrottleStateUpdaterThread extends Periodical {
 
         // the journal needs this to provide information to rest clients
         journal.setThrottleState(throttleState);
-        
+
         // publish to interested parties
         eventBus.post(throttleState);
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ThrottleStateUpdaterThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ThrottleStateUpdaterThread.java
@@ -160,7 +160,7 @@ public class ThrottleStateUpdaterThread extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return false;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ThroughputCalculator.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ThroughputCalculator.java
@@ -70,7 +70,7 @@ public class ThroughputCalculator extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return false;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ThroughputCalculator.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ThroughputCalculator.java
@@ -70,7 +70,7 @@ public class ThroughputCalculator extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return false;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/TrafficCounterCalculator.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/TrafficCounterCalculator.java
@@ -99,7 +99,7 @@ public class TrafficCounterCalculator extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return false;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/TrafficCounterCalculator.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/TrafficCounterCalculator.java
@@ -99,7 +99,7 @@ public class TrafficCounterCalculator extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return false;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/UserPermissionMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/UserPermissionMigrationPeriodical.java
@@ -137,7 +137,7 @@ public class UserPermissionMigrationPeriodical extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/UserPermissionMigrationPeriodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/UserPermissionMigrationPeriodical.java
@@ -137,7 +137,7 @@ public class UserPermissionMigrationPeriodical extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/VersionCheckThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/VersionCheckThread.java
@@ -152,7 +152,7 @@ public class VersionCheckThread extends Periodical {
     }
 
     @Override
-    public boolean parentOnly() {
+    public boolean primaryOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/periodical/VersionCheckThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/VersionCheckThread.java
@@ -152,7 +152,7 @@ public class VersionCheckThread extends Periodical {
     }
 
     @Override
-    public boolean masterOnly() {
+    public boolean parentOnly() {
         return true;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/ServerStatus.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/ServerStatus.java
@@ -49,7 +49,7 @@ public class ServerStatus {
 
     public enum Capability {
         SERVER,
-        MASTER,
+        PARENT,
         LOCALMODE
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/ServerStatus.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/ServerStatus.java
@@ -49,7 +49,7 @@ public class ServerStatus {
 
     public enum Capability {
         SERVER,
-        PARENT,
+        PRIMARY,
         LOCALMODE
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/periodical/Periodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/periodical/Periodical.java
@@ -37,11 +37,11 @@ public abstract class Periodical implements Runnable {
     public abstract boolean stopOnGracefulShutdown();
 
     /**
-     * Only start this thread on parent nodes?
+     * Only start this thread on primary nodes?
      *
      * @return
      */
-    public abstract boolean parentOnly();
+    public abstract boolean primaryOnly();
 
     /**
      * Start on this node? Useful to decide if to start the periodical based on local configuration.

--- a/graylog2-server/src/main/java/org/graylog2/plugin/periodical/Periodical.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/periodical/Periodical.java
@@ -37,11 +37,11 @@ public abstract class Periodical implements Runnable {
     public abstract boolean stopOnGracefulShutdown();
 
     /**
-     * Only start this thread on master nodes?
+     * Only start this thread on parent nodes?
      *
      * @return
      */
-    public abstract boolean masterOnly();
+    public abstract boolean parentOnly();
 
     /**
      * Start on this node? Useful to decide if to start the periodical based on local configuration.

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/cluster/responses/NodeSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/cluster/responses/NodeSummary.java
@@ -32,8 +32,8 @@ public abstract class NodeSummary {
     public abstract String nodeId();
     @JsonProperty
     public abstract String type();
-    @JsonProperty("is_master")
-    public abstract boolean isMaster();
+    @JsonProperty("is_parent")
+    public abstract boolean isParent();
     @JsonProperty
     public abstract String transportAddress();
     @JsonProperty
@@ -47,11 +47,11 @@ public abstract class NodeSummary {
     public static NodeSummary create(@JsonProperty("cluster_id") String clusterId,
                                      @JsonProperty("node_id") String nodeId,
                                      @JsonProperty("type") String type,
-                                     @JsonProperty("is_master") boolean isMaster,
+                                     @JsonProperty("is_parent") boolean isParent,
                                      @JsonProperty("transport_address") String transportAddress,
                                      @JsonProperty("last_seen") String lastSeen,
                                      @JsonProperty("short_node_id") String shortNodeId,
                                      @JsonProperty("hostname") String hostname) {
-        return new AutoValue_NodeSummary(clusterId, nodeId, type, isMaster, transportAddress, lastSeen, shortNodeId, hostname);
+        return new AutoValue_NodeSummary(clusterId, nodeId, type, isParent, transportAddress, lastSeen, shortNodeId, hostname);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/models/system/cluster/responses/NodeSummary.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/models/system/cluster/responses/NodeSummary.java
@@ -32,8 +32,8 @@ public abstract class NodeSummary {
     public abstract String nodeId();
     @JsonProperty
     public abstract String type();
-    @JsonProperty("is_parent")
-    public abstract boolean isParent();
+    @JsonProperty("is_primary")
+    public abstract boolean isPrimary();
     @JsonProperty
     public abstract String transportAddress();
     @JsonProperty
@@ -47,11 +47,11 @@ public abstract class NodeSummary {
     public static NodeSummary create(@JsonProperty("cluster_id") String clusterId,
                                      @JsonProperty("node_id") String nodeId,
                                      @JsonProperty("type") String type,
-                                     @JsonProperty("is_parent") boolean isParent,
+                                     @JsonProperty("is_primary") boolean isPrimary,
                                      @JsonProperty("transport_address") String transportAddress,
                                      @JsonProperty("last_seen") String lastSeen,
                                      @JsonProperty("short_node_id") String shortNodeId,
                                      @JsonProperty("hostname") String hostname) {
-        return new AutoValue_NodeSummary(clusterId, nodeId, type, isParent, transportAddress, lastSeen, shortNodeId, hostname);
+        return new AutoValue_NodeSummary(clusterId, nodeId, type, isPrimary, transportAddress, lastSeen, shortNodeId, hostname);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterDeflectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterDeflectorResource.java
@@ -59,7 +59,7 @@ public class ClusterDeflectorResource extends ProxiedResource {
 
     @POST
     @Timed
-    @ApiOperation(value = "Finds parent node and triggers deflector cycle")
+    @ApiOperation(value = "Finds primary node and triggers deflector cycle")
     @Path("/cycle")
     @NoAuditEvent("this is a proxy resource, the event will be triggered on the individual nodes")
     public void cycle() throws IOException {
@@ -68,7 +68,7 @@ public class ClusterDeflectorResource extends ProxiedResource {
 
     @POST
     @Timed
-    @ApiOperation(value = "Finds parent node and triggers deflector cycle")
+    @ApiOperation(value = "Finds primary node and triggers deflector cycle")
     @Path("/{indexSetId}/cycle")
     @NoAuditEvent("this is a proxy resource, the event will be triggered on the individual nodes")
     public void cycle(@ApiParam(name = "indexSetId") @PathParam("indexSetId") String indexSetId) throws IOException {
@@ -76,18 +76,18 @@ public class ClusterDeflectorResource extends ProxiedResource {
     }
 
     private RemoteDeflectorResource getDeflectorResource() {
-        final Node parent = findParentNode();
+        final Node primary = findPrimaryNode();
         final Function<String, Optional<RemoteDeflectorResource>> remoteInterfaceProvider = createRemoteInterfaceProvider(RemoteDeflectorResource.class);
-        final Optional<RemoteDeflectorResource> deflectorResource = remoteInterfaceProvider.apply(parent.getNodeId());
+        final Optional<RemoteDeflectorResource> deflectorResource = remoteInterfaceProvider.apply(primary.getNodeId());
 
         return deflectorResource
                 .orElseThrow(() -> new InternalServerErrorException("Unable to get remote deflector resource."));
     }
 
-    private Node findParentNode() {
+    private Node findPrimaryNode() {
         return nodeService.allActive().values().stream()
-                .filter(Node::isParent)
+                .filter(Node::isPrimary)
                 .findFirst()
-                .orElseThrow(() -> new ServiceUnavailableException("No parent present."));
+                .orElseThrow(() -> new ServiceUnavailableException("No primary present."));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterDeflectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterDeflectorResource.java
@@ -59,7 +59,7 @@ public class ClusterDeflectorResource extends ProxiedResource {
 
     @POST
     @Timed
-    @ApiOperation(value = "Finds master node and triggers deflector cycle")
+    @ApiOperation(value = "Finds parent node and triggers deflector cycle")
     @Path("/cycle")
     @NoAuditEvent("this is a proxy resource, the event will be triggered on the individual nodes")
     public void cycle() throws IOException {
@@ -68,7 +68,7 @@ public class ClusterDeflectorResource extends ProxiedResource {
 
     @POST
     @Timed
-    @ApiOperation(value = "Finds master node and triggers deflector cycle")
+    @ApiOperation(value = "Finds parent node and triggers deflector cycle")
     @Path("/{indexSetId}/cycle")
     @NoAuditEvent("this is a proxy resource, the event will be triggered on the individual nodes")
     public void cycle(@ApiParam(name = "indexSetId") @PathParam("indexSetId") String indexSetId) throws IOException {
@@ -76,18 +76,18 @@ public class ClusterDeflectorResource extends ProxiedResource {
     }
 
     private RemoteDeflectorResource getDeflectorResource() {
-        final Node master = findMasterNode();
+        final Node parent = findParentNode();
         final Function<String, Optional<RemoteDeflectorResource>> remoteInterfaceProvider = createRemoteInterfaceProvider(RemoteDeflectorResource.class);
-        final Optional<RemoteDeflectorResource> deflectorResource = remoteInterfaceProvider.apply(master.getNodeId());
+        final Optional<RemoteDeflectorResource> deflectorResource = remoteInterfaceProvider.apply(parent.getNodeId());
 
         return deflectorResource
                 .orElseThrow(() -> new InternalServerErrorException("Unable to get remote deflector resource."));
     }
 
-    private Node findMasterNode() {
+    private Node findParentNode() {
         return nodeService.allActive().values().stream()
-                .filter(Node::isMaster)
+                .filter(Node::isParent)
                 .findFirst()
-                .orElseThrow(() -> new ServiceUnavailableException("No master present."));
+                .orElseThrow(() -> new ServiceUnavailableException("No parent present."));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterResource.java
@@ -107,7 +107,7 @@ public class ClusterResource extends RestResource {
                 clusterId.clusterId(),
                 node.getNodeId(),
                 node.getType().toString().toLowerCase(Locale.ENGLISH),
-                node.isMaster(),
+                node.isParent(),
                 node.getTransportAddress(),
                 Tools.getISO8601String(node.getLastSeen()),
                 node.getShortNodeId(),

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ClusterResource.java
@@ -107,7 +107,7 @@ public class ClusterResource extends RestResource {
                 clusterId.clusterId(),
                 node.getNodeId(),
                 node.getType().toString().toLowerCase(Locale.ENGLISH),
-                node.isParent(),
+                node.isPrimary(),
                 node.getTransportAddress(),
                 Tools.getISO8601String(node.getLastSeen()),
                 node.getShortNodeId(),

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/DeflectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/DeflectorResource.java
@@ -30,7 +30,7 @@ import org.graylog2.indexer.indices.TooManyAliasesException;
 import org.graylog2.rest.models.system.deflector.responses.DeflectorSummary;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
-import org.graylog2.shared.security.RestrictToMaster;
+import org.graylog2.shared.security.RestrictToParent;
 import org.graylog2.shared.system.activities.Activity;
 import org.graylog2.shared.system.activities.ActivityWriter;
 import org.slf4j.Logger;
@@ -90,7 +90,7 @@ public class DeflectorResource extends RestResource {
     @ApiOperation(value = "Cycle deflector to new/next index")
     @RequiresPermissions(RestPermissions.DEFLECTOR_CYCLE)
     @Path("/cycle")
-    @RestrictToMaster
+    @RestrictToParent
     @AuditEvent(type = AuditEventTypes.ES_WRITE_INDEX_UPDATE_JOB_START)
     @Deprecated
     public void deprecatedCycle() {
@@ -110,7 +110,7 @@ public class DeflectorResource extends RestResource {
     @ApiOperation(value = "Cycle deflector to new/next index in index set")
     @RequiresPermissions(RestPermissions.DEFLECTOR_CYCLE)
     @Path("/{indexSetId}/cycle")
-    @RestrictToMaster
+    @RestrictToParent
     @AuditEvent(type = AuditEventTypes.ES_WRITE_INDEX_UPDATE_JOB_START)
     public void cycle(@ApiParam(name = "indexSetId") @PathParam("indexSetId") String indexSetId) {
         final IndexSet indexSet = getIndexSet(indexSetRegistry, indexSetId);

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/DeflectorResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/DeflectorResource.java
@@ -30,7 +30,7 @@ import org.graylog2.indexer.indices.TooManyAliasesException;
 import org.graylog2.rest.models.system.deflector.responses.DeflectorSummary;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
-import org.graylog2.shared.security.RestrictToParent;
+import org.graylog2.shared.security.RestrictToPrimary;
 import org.graylog2.shared.system.activities.Activity;
 import org.graylog2.shared.system.activities.ActivityWriter;
 import org.slf4j.Logger;
@@ -90,7 +90,7 @@ public class DeflectorResource extends RestResource {
     @ApiOperation(value = "Cycle deflector to new/next index")
     @RequiresPermissions(RestPermissions.DEFLECTOR_CYCLE)
     @Path("/cycle")
-    @RestrictToParent
+    @RestrictToPrimary
     @AuditEvent(type = AuditEventTypes.ES_WRITE_INDEX_UPDATE_JOB_START)
     @Deprecated
     public void deprecatedCycle() {
@@ -110,7 +110,7 @@ public class DeflectorResource extends RestResource {
     @ApiOperation(value = "Cycle deflector to new/next index in index set")
     @RequiresPermissions(RestPermissions.DEFLECTOR_CYCLE)
     @Path("/{indexSetId}/cycle")
-    @RestrictToParent
+    @RestrictToPrimary
     @AuditEvent(type = AuditEventTypes.ES_WRITE_INDEX_UPDATE_JOB_START)
     public void cycle(@ApiParam(name = "indexSetId") @PathParam("indexSetId") String indexSetId) {
         final IndexSet indexSet = getIndexSet(indexSetRegistry, indexSetId);

--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/PeriodicalsService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/PeriodicalsService.java
@@ -56,8 +56,8 @@ public class PeriodicalsService extends AbstractIdleService {
             try {
                 periodical.initialize();
 
-                if (periodical.masterOnly() && !serverStatus.hasCapability(ServerStatus.Capability.MASTER)) {
-                    LOG.info("Not starting [{}] periodical. Only started on Graylog master nodes.", periodical.getClass().getCanonicalName());
+                if (periodical.parentOnly() && !serverStatus.hasCapability(ServerStatus.Capability.PARENT)) {
+                    LOG.info("Not starting [{}] periodical. Only started on Graylog parent nodes.", periodical.getClass().getCanonicalName());
                     continue;
                 }
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/initializers/PeriodicalsService.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/initializers/PeriodicalsService.java
@@ -56,8 +56,8 @@ public class PeriodicalsService extends AbstractIdleService {
             try {
                 periodical.initialize();
 
-                if (periodical.parentOnly() && !serverStatus.hasCapability(ServerStatus.Capability.PARENT)) {
-                    LOG.info("Not starting [{}] periodical. Only started on Graylog parent nodes.", periodical.getClass().getCanonicalName());
+                if (periodical.primaryOnly() && !serverStatus.hasCapability(ServerStatus.Capability.PRIMARY)) {
+                    LOG.info("Not starting [{}] periodical. Only started on Graylog primary nodes.", periodical.getClass().getCanonicalName());
                     continue;
                 }
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/ProxiedResource.java
@@ -120,35 +120,35 @@ public abstract class ProxiedResource extends RestResource {
     }
 
     /**
-     * Execute the given remote interface function on the master node.
+     * Execute the given remote interface function on the parent node.
      * <p>
-     * This is used to forward an API request to the master node. It is useful in situations where an API call can
-     * only be executed on the master node.
+     * This is used to forward an API request to the parent node. It is useful in situations where an API call can
+     * only be executed on the parent node.
      * <p>
-     * The returned {@link MasterResponse} object is constructed from the remote response's status code and body.
+     * The returned {@link ParentResponse} object is constructed from the remote response's status code and body.
      */
-    protected <RemoteInterfaceType, RemoteCallResponseType> MasterResponse<RemoteCallResponseType> requestOnMaster(
+    protected <RemoteInterfaceType, RemoteCallResponseType> ParentResponse<RemoteCallResponseType> requestOnParent(
             Function<RemoteInterfaceType, Call<RemoteCallResponseType>> remoteInterfaceFunction,
             Function<String, Optional<RemoteInterfaceType>> remoteInterfaceProvider
     ) throws IOException {
-        final Node masterNode = nodeService.allActive().values().stream()
-                .filter(Node::isMaster)
+        final Node parentNode = nodeService.allActive().values().stream()
+                .filter(Node::isParent)
                 .findFirst()
-                .orElseThrow(() -> new IllegalStateException("No active master node found"));
+                .orElseThrow(() -> new IllegalStateException("No active parent node found"));
 
-        final RemoteInterfaceType remoteInterfaceType = remoteInterfaceProvider.apply(masterNode.getNodeId())
-                .orElseThrow(() -> new IllegalStateException("Master node " + masterNode.getNodeId() + " not found"));
+        final RemoteInterfaceType remoteInterfaceType = remoteInterfaceProvider.apply(parentNode.getNodeId())
+                .orElseThrow(() -> new IllegalStateException("Parent node " + parentNode.getNodeId() + " not found"));
 
         final Call<RemoteCallResponseType> call = remoteInterfaceFunction.apply(remoteInterfaceType);
         final Response<RemoteCallResponseType> response = call.execute();
 
         final byte[] errorBody = response.errorBody() == null ? null : response.errorBody().bytes();
 
-        return MasterResponse.create(response.isSuccessful(), response.code(), response.body(), errorBody);
+        return ParentResponse.create(response.isSuccessful(), response.code(), response.body(), errorBody);
     }
 
     @AutoValue
-    protected static abstract class MasterResponse<ResponseType> {
+    protected static abstract class ParentResponse<ResponseType> {
         /**
          * Indicates whether the request has been successful or not.
          * @return {@code true} for a successful request, {@code false} otherwise
@@ -187,11 +187,11 @@ public abstract class ProxiedResource extends RestResource {
             return entity().isPresent() ? entity().get() : error().orElse(null);
         }
 
-        public static <ResponseType> MasterResponse<ResponseType> create(boolean isSuccess,
+        public static <ResponseType> ParentResponse<ResponseType> create(boolean isSuccess,
                                                                          int code,
                                                                          @Nullable ResponseType entity,
                                                                          @Nullable byte[] error) {
-            return new AutoValue_ProxiedResource_MasterResponse<>(isSuccess, code, Optional.ofNullable(entity), Optional.ofNullable(error));
+            return new AutoValue_ProxiedResource_ParentResponse<>(isSuccess, code, Optional.ofNullable(entity), Optional.ofNullable(error));
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestrictToMaster.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestrictToMaster.java
@@ -23,5 +23,5 @@ import java.lang.annotation.Target;
 
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface RestrictToParent {
+public @interface RestrictToPrimary {
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestrictToMaster.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestrictToMaster.java
@@ -23,5 +23,5 @@ import java.lang.annotation.Target;
 
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
-public @interface RestrictToMaster {
+public @interface RestrictToParent {
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestrictToMasterFeature.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestrictToMasterFeature.java
@@ -24,14 +24,14 @@ import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.FeatureContext;
 import java.lang.reflect.Method;
 
-public class RestrictToMasterFeature implements DynamicFeature {
+public class RestrictToParentFeature implements DynamicFeature {
     private final ServerStatus serverStatus;
-    private final RestrictToMasterFilter restrictToMasterFilter;
+    private final RestrictToParentFilter restrictToParentFilter;
 
     @Inject
-    public RestrictToMasterFeature(ServerStatus serverStatus) {
+    public RestrictToParentFeature(ServerStatus serverStatus) {
         this.serverStatus = serverStatus;
-        this.restrictToMasterFilter = new RestrictToMasterFilter();
+        this.restrictToParentFilter = new RestrictToParentFilter();
     }
 
     @Override
@@ -39,11 +39,11 @@ public class RestrictToMasterFeature implements DynamicFeature {
         final Class<?> resourceClass = resourceInfo.getResourceClass();
         final Method resourceMethod = resourceInfo.getResourceMethod();
 
-        if (serverStatus.hasCapability(ServerStatus.Capability.MASTER))
+        if (serverStatus.hasCapability(ServerStatus.Capability.PARENT))
             return;
 
-        if (resourceMethod.isAnnotationPresent(RestrictToMaster.class) || resourceClass.isAnnotationPresent(RestrictToMaster.class)) {
-            context.register(restrictToMasterFilter);
+        if (resourceMethod.isAnnotationPresent(RestrictToParent.class) || resourceClass.isAnnotationPresent(RestrictToParent.class)) {
+            context.register(restrictToParentFilter);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestrictToMasterFeature.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestrictToMasterFeature.java
@@ -24,14 +24,14 @@ import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.FeatureContext;
 import java.lang.reflect.Method;
 
-public class RestrictToParentFeature implements DynamicFeature {
+public class RestrictToPrimaryFeature implements DynamicFeature {
     private final ServerStatus serverStatus;
-    private final RestrictToParentFilter restrictToParentFilter;
+    private final RestrictToPrimaryFilter restrictToPrimaryFilter;
 
     @Inject
-    public RestrictToParentFeature(ServerStatus serverStatus) {
+    public RestrictToPrimaryFeature(ServerStatus serverStatus) {
         this.serverStatus = serverStatus;
-        this.restrictToParentFilter = new RestrictToParentFilter();
+        this.restrictToPrimaryFilter = new RestrictToPrimaryFilter();
     }
 
     @Override
@@ -39,11 +39,11 @@ public class RestrictToParentFeature implements DynamicFeature {
         final Class<?> resourceClass = resourceInfo.getResourceClass();
         final Method resourceMethod = resourceInfo.getResourceMethod();
 
-        if (serverStatus.hasCapability(ServerStatus.Capability.PARENT))
+        if (serverStatus.hasCapability(ServerStatus.Capability.PRIMARY))
             return;
 
-        if (resourceMethod.isAnnotationPresent(RestrictToParent.class) || resourceClass.isAnnotationPresent(RestrictToParent.class)) {
-            context.register(restrictToParentFilter);
+        if (resourceMethod.isAnnotationPresent(RestrictToPrimary.class) || resourceClass.isAnnotationPresent(RestrictToPrimary.class)) {
+            context.register(restrictToPrimaryFilter);
         }
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestrictToMasterFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestrictToMasterFilter.java
@@ -27,12 +27,12 @@ import javax.ws.rs.container.ContainerRequestFilter;
 import java.io.IOException;
 
 @Priority(Priorities.AUTHORIZATION)
-public class RestrictToParentFilter implements ContainerRequestFilter {
-    private static final Logger LOG = LoggerFactory.getLogger(RestrictToParentFilter.class);
+public class RestrictToPrimaryFilter implements ContainerRequestFilter {
+    private static final Logger LOG = LoggerFactory.getLogger(RestrictToPrimaryFilter.class);
 
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
-        LOG.warn("Rejected request to <{}> which is only allowed against parent nodes.", requestContext.getUriInfo().getPath());
-        throw new ForbiddenException("Request is only allowed against parent nodes.");
+        LOG.warn("Rejected request to <{}> which is only allowed against primary nodes.", requestContext.getUriInfo().getPath());
+        throw new ForbiddenException("Request is only allowed against primary nodes.");
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestrictToMasterFilter.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestrictToMasterFilter.java
@@ -27,12 +27,12 @@ import javax.ws.rs.container.ContainerRequestFilter;
 import java.io.IOException;
 
 @Priority(Priorities.AUTHORIZATION)
-public class RestrictToMasterFilter implements ContainerRequestFilter {
-    private static final Logger LOG = LoggerFactory.getLogger(RestrictToMasterFilter.class);
+public class RestrictToParentFilter implements ContainerRequestFilter {
+    private static final Logger LOG = LoggerFactory.getLogger(RestrictToParentFilter.class);
 
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
-        LOG.warn("Rejected request to <{}> which is only allowed against master nodes.", requestContext.getUriInfo().getPath());
-        throw new ForbiddenException("Request is only allowed against master nodes.");
+        LOG.warn("Rejected request to <{}> which is only allowed against parent nodes.", requestContext.getUriInfo().getPath());
+        throw new ForbiddenException("Request is only allowed against parent nodes.");
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/system/stats/elasticsearch/NodesStats.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/elasticsearch/NodesStats.java
@@ -29,22 +29,22 @@ public abstract class NodesStats {
     public abstract int total();
 
     @JsonProperty
-    public abstract int parentOnly();
+    public abstract int primaryOnly();
 
     @JsonProperty
     public abstract int dataOnly();
 
     @JsonProperty
-    public abstract int parentData();
+    public abstract int primaryData();
 
     @JsonProperty
     public abstract int client();
 
     public static NodesStats create(int total,
-                                   int parentOnly,
+                                   int primaryOnly,
                                    int dataOnly,
-                                   int parentData,
+                                   int primaryData,
                                    int client) {
-        return new AutoValue_NodesStats(total, parentOnly, dataOnly, parentData, client);
+        return new AutoValue_NodesStats(total, primaryOnly, dataOnly, primaryData, client);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/system/stats/elasticsearch/NodesStats.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/elasticsearch/NodesStats.java
@@ -29,22 +29,22 @@ public abstract class NodesStats {
     public abstract int total();
 
     @JsonProperty
-    public abstract int masterOnly();
+    public abstract int parentOnly();
 
     @JsonProperty
     public abstract int dataOnly();
 
     @JsonProperty
-    public abstract int masterData();
+    public abstract int parentData();
 
     @JsonProperty
     public abstract int client();
 
     public static NodesStats create(int total,
-                                   int masterOnly,
+                                   int parentOnly,
                                    int dataOnly,
-                                   int masterData,
+                                   int parentData,
                                    int client) {
-        return new AutoValue_NodesStats(total, masterOnly, dataOnly, masterData, client);
+        return new AutoValue_NodesStats(total, parentOnly, dataOnly, parentData, client);
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/cluster/NodeServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/NodeServiceImplTest.java
@@ -73,7 +73,7 @@ public class NodeServiceImplTest {
         assertThat(node).isNotNull();
         assertThat(node.getHostname()).isEqualTo(LOCAL_CANONICAL_HOSTNAME);
         assertThat(node.getTransportAddress()).isEqualTo(TRANSPORT_URI.toString());
-        assertThat(node.isParent()).isTrue();
+        assertThat(node.isPrimary()).isTrue();
     }
 
     @Test
@@ -99,6 +99,6 @@ public class NodeServiceImplTest {
         assertThat(node2).isNotNull();
         assertThat(node2.getHostname()).isEqualTo(LOCAL_CANONICAL_HOSTNAME);
         assertThat(node2.getTransportAddress()).isEqualTo(TRANSPORT_URI.toString());
-        assertThat(node2.isParent()).isTrue();
+        assertThat(node2.isPrimary()).isTrue();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/cluster/NodeServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/cluster/NodeServiceImplTest.java
@@ -73,7 +73,7 @@ public class NodeServiceImplTest {
         assertThat(node).isNotNull();
         assertThat(node.getHostname()).isEqualTo(LOCAL_CANONICAL_HOSTNAME);
         assertThat(node.getTransportAddress()).isEqualTo(TRANSPORT_URI.toString());
-        assertThat(node.isMaster()).isTrue();
+        assertThat(node.isParent()).isTrue();
     }
 
     @Test
@@ -99,6 +99,6 @@ public class NodeServiceImplTest {
         assertThat(node2).isNotNull();
         assertThat(node2.getHostname()).isEqualTo(LOCAL_CANONICAL_HOSTNAME);
         assertThat(node2.getTransportAddress()).isEqualTo(TRANSPORT_URI.toString());
-        assertThat(node2.isMaster()).isTrue();
+        assertThat(node2.isParent()).isTrue();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/configuration/ExposedConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/ExposedConfigurationTest.java
@@ -51,7 +51,7 @@ public class ExposedConfigurationTest {
         assertThat(c.streamProcessingTimeout()).isEqualTo(configuration.getStreamProcessingTimeout());
         assertThat(c.streamProcessingMaxFaults()).isEqualTo(configuration.getStreamProcessingMaxFaults());
         assertThat(c.outputModuleTimeout()).isEqualTo(configuration.getOutputModuleTimeout());
-        assertThat(c.staleParentTimeout()).isEqualTo(configuration.getstaleParentTimeout());
+        assertThat(c.stalePrimaryTimeout()).isEqualTo(configuration.getstalePrimaryTimeout());
         assertThat(c.gcWarningThreshold()).isEqualTo(configuration.getGcWarningThreshold().toString());
     }
 
@@ -77,7 +77,7 @@ public class ExposedConfigurationTest {
         assertThat((int) JsonPath.read(json, "$.stream_processing_timeout")).isEqualTo((int) c.streamProcessingTimeout());
         assertThat((int) JsonPath.read(json, "$.stream_processing_max_faults")).isEqualTo(c.streamProcessingMaxFaults());
         assertThat((int) JsonPath.read(json, "$.output_module_timeout")).isEqualTo((int) c.outputModuleTimeout());
-        assertThat((int) JsonPath.read(json, "$.stale_parent_timeout")).isEqualTo(c.staleParentTimeout());
+        assertThat((int) JsonPath.read(json, "$.stale_primary_timeout")).isEqualTo(c.stalePrimaryTimeout());
         assertThat((String) JsonPath.read(json, "$.gc_warning_threshold")).isEqualTo(c.gcWarningThreshold());
     }
 
@@ -100,7 +100,7 @@ public class ExposedConfigurationTest {
                 "  \"stream_processing_timeout\": 2000," +
                 "  \"stream_processing_max_faults\": 3," +
                 "  \"output_module_timeout\": 10000," +
-                "  \"stale_parent_timeout\": 2000," +
+                "  \"stale_primary_timeout\": 2000," +
                 "  \"gc_warning_threshold\": \"1 second\"" +
                 "}";
 
@@ -122,7 +122,7 @@ public class ExposedConfigurationTest {
         assertThat((int) c.streamProcessingTimeout()).isEqualTo(JsonPath.read(json, "$.stream_processing_timeout"));
         assertThat(c.streamProcessingMaxFaults()).isEqualTo(JsonPath.read(json, "$.stream_processing_max_faults"));
         assertThat((int) c.outputModuleTimeout()).isEqualTo(JsonPath.read(json, "$.output_module_timeout"));
-        assertThat(c.staleParentTimeout()).isEqualTo(JsonPath.read(json, "$.stale_parent_timeout"));
+        assertThat(c.stalePrimaryTimeout()).isEqualTo(JsonPath.read(json, "$.stale_primary_timeout"));
         assertThat(c.gcWarningThreshold()).isEqualTo(JsonPath.read(json, "$.gc_warning_threshold"));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/configuration/ExposedConfigurationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/configuration/ExposedConfigurationTest.java
@@ -51,7 +51,7 @@ public class ExposedConfigurationTest {
         assertThat(c.streamProcessingTimeout()).isEqualTo(configuration.getStreamProcessingTimeout());
         assertThat(c.streamProcessingMaxFaults()).isEqualTo(configuration.getStreamProcessingMaxFaults());
         assertThat(c.outputModuleTimeout()).isEqualTo(configuration.getOutputModuleTimeout());
-        assertThat(c.staleMasterTimeout()).isEqualTo(configuration.getStaleMasterTimeout());
+        assertThat(c.staleParentTimeout()).isEqualTo(configuration.getstaleParentTimeout());
         assertThat(c.gcWarningThreshold()).isEqualTo(configuration.getGcWarningThreshold().toString());
     }
 
@@ -77,7 +77,7 @@ public class ExposedConfigurationTest {
         assertThat((int) JsonPath.read(json, "$.stream_processing_timeout")).isEqualTo((int) c.streamProcessingTimeout());
         assertThat((int) JsonPath.read(json, "$.stream_processing_max_faults")).isEqualTo(c.streamProcessingMaxFaults());
         assertThat((int) JsonPath.read(json, "$.output_module_timeout")).isEqualTo((int) c.outputModuleTimeout());
-        assertThat((int) JsonPath.read(json, "$.stale_master_timeout")).isEqualTo(c.staleMasterTimeout());
+        assertThat((int) JsonPath.read(json, "$.stale_parent_timeout")).isEqualTo(c.staleParentTimeout());
         assertThat((String) JsonPath.read(json, "$.gc_warning_threshold")).isEqualTo(c.gcWarningThreshold());
     }
 
@@ -100,7 +100,7 @@ public class ExposedConfigurationTest {
                 "  \"stream_processing_timeout\": 2000," +
                 "  \"stream_processing_max_faults\": 3," +
                 "  \"output_module_timeout\": 10000," +
-                "  \"stale_master_timeout\": 2000," +
+                "  \"stale_parent_timeout\": 2000," +
                 "  \"gc_warning_threshold\": \"1 second\"" +
                 "}";
 
@@ -122,7 +122,7 @@ public class ExposedConfigurationTest {
         assertThat((int) c.streamProcessingTimeout()).isEqualTo(JsonPath.read(json, "$.stream_processing_timeout"));
         assertThat(c.streamProcessingMaxFaults()).isEqualTo(JsonPath.read(json, "$.stream_processing_max_faults"));
         assertThat((int) c.outputModuleTimeout()).isEqualTo(JsonPath.read(json, "$.output_module_timeout"));
-        assertThat(c.staleMasterTimeout()).isEqualTo(JsonPath.read(json, "$.stale_master_timeout"));
+        assertThat(c.staleParentTimeout()).isEqualTo(JsonPath.read(json, "$.stale_parent_timeout"));
         assertThat(c.gcWarningThreshold()).isEqualTo(JsonPath.read(json, "$.gc_warning_threshold"));
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/constraints/PluginVersionConstraintCheckerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/constraints/PluginVersionConstraintCheckerTest.java
@@ -102,7 +102,7 @@ public class PluginVersionConstraintCheckerTest {
 
         @Override
         public Set<ServerStatus.Capability> getRequiredCapabilities() {
-            return Collections.singleton(ServerStatus.Capability.MASTER);
+            return Collections.singleton(ServerStatus.Capability.PARENT);
         }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/contentpacks/constraints/PluginVersionConstraintCheckerTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/contentpacks/constraints/PluginVersionConstraintCheckerTest.java
@@ -102,7 +102,7 @@ public class PluginVersionConstraintCheckerTest {
 
         @Override
         public Set<ServerStatus.Capability> getRequiredCapabilities() {
-            return Collections.singleton(ServerStatus.Capability.PARENT);
+            return Collections.singleton(ServerStatus.Capability.PRIMARY);
         }
     }
 }

--- a/graylog2-server/src/test/java/org/graylog2/grok/MongoDbGrokPatternServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/grok/MongoDbGrokPatternServiceTest.java
@@ -142,7 +142,7 @@ public class MongoDbGrokPatternServiceTest {
         patternSet.add(GrokPattern.create("POSTFIX_DNSBLOG", "%{POSTFIX_DNSBLOG_LISTING}|%{POSTFIX_WARNING}"));
         patternSet.add(GrokPattern.create("POSTFIX_PICKUP", "%{POSTFIX_KEYVALUE}"));
         patternSet.add(GrokPattern.create("POSTFIX_LMTP", "%{POSTFIX_SMTP}"));
-        patternSet.add(GrokPattern.create("POSTFIX_PARENT", "%{POSTFIX_PARENT_START}|%{POSTFIX_PARENT_EXIT}|%{POSTFIX_WARNING}"));
+        patternSet.add(GrokPattern.create("POSTFIX_PRIMARY", "%{POSTFIX_PRIMARY_START}|%{POSTFIX_PRIMARY_EXIT}|%{POSTFIX_WARNING}"));
         patternSet.add(GrokPattern.create("POSTFIX_TLSPROXY", "%{POSTFIX_TLSPROXY_CONN}|%{POSTFIX_WARNING}"));
         patternSet.add(GrokPattern.create("POSTFIX_SENDMAIL", "%{POSTFIX_WARNING}"));
         patternSet.add(GrokPattern.create("POSTFIX_BOUNCE", "%{POSTFIX_BOUNCE_NOTIFICATION}"));
@@ -166,8 +166,8 @@ public class MongoDbGrokPatternServiceTest {
         patternSet.add(GrokPattern.create("POSTFIX_SMTP_RELAYERR", "%{POSTFIX_QUEUEID:postfix_queueid}: host %{POSTFIX_RELAY_INFO} said: %{GREEDYDATA:postfix_smtp_response} \\(in reply to %{POSTFIX_SMTP_STAGE:postfix_smtp_stage} command\\)"));
         patternSet.add(GrokPattern.create("POSTFIX_STATUS_CODE_ENHANCED", "\\d\\.\\d\\.\\d"));
         patternSet.add(GrokPattern.create("POSTFIX_SMTP_TIMEOUT", "%{POSTFIX_QUEUEID:postfix_queueid}: conversation with %{POSTFIX_RELAY_INFO} timed out( while %{POSTFIX_LOSTCONN_REASONS:postfix_smtp_lostconn_reason})?"));
-        patternSet.add(GrokPattern.create("POSTFIX_PARENT_EXIT", "terminating on signal %{INT:postfix_termination_signal}"));
-        patternSet.add(GrokPattern.create("POSTFIX_PARENT_START", "(daemon started|reload) -- version %{DATA:postfix_version}, configuration %{PATH:postfix_config_path}"));
+        patternSet.add(GrokPattern.create("POSTFIX_PRIMARY_EXIT", "terminating on signal %{INT:postfix_termination_signal}"));
+        patternSet.add(GrokPattern.create("POSTFIX_PRIMARY_START", "(daemon started|reload) -- version %{DATA:postfix_version}, configuration %{PATH:postfix_config_path}"));
         patternSet.add(GrokPattern.create("POSTFIX_SCACHE_LOOKUPS", "statistics: (address|domain) lookup hits=%{INT:postfix_scache_hits} miss=%{INT:postfix_scache_miss} success=%{INT:postfix_scache_success}%"));
         patternSet.add(GrokPattern.create("POSTFIX_BOUNCE_NOTIFICATION", "%{POSTFIX_QUEUEID:postfix_queueid}: sender (non-delivery|delivery status|delay) notification: %{POSTFIX_QUEUEID:postfix_bounce_queueid}"));
         patternSet.add(GrokPattern.create("POSTFIX_SCACHE_TIMESTAMP", "statistics: start interval %{SYSLOGTIMESTAMP:postfix_scache_timestamp}"));

--- a/graylog2-server/src/test/java/org/graylog2/grok/MongoDbGrokPatternServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/grok/MongoDbGrokPatternServiceTest.java
@@ -142,7 +142,7 @@ public class MongoDbGrokPatternServiceTest {
         patternSet.add(GrokPattern.create("POSTFIX_DNSBLOG", "%{POSTFIX_DNSBLOG_LISTING}|%{POSTFIX_WARNING}"));
         patternSet.add(GrokPattern.create("POSTFIX_PICKUP", "%{POSTFIX_KEYVALUE}"));
         patternSet.add(GrokPattern.create("POSTFIX_LMTP", "%{POSTFIX_SMTP}"));
-        patternSet.add(GrokPattern.create("POSTFIX_MASTER", "%{POSTFIX_MASTER_START}|%{POSTFIX_MASTER_EXIT}|%{POSTFIX_WARNING}"));
+        patternSet.add(GrokPattern.create("POSTFIX_PARENT", "%{POSTFIX_PARENT_START}|%{POSTFIX_PARENT_EXIT}|%{POSTFIX_WARNING}"));
         patternSet.add(GrokPattern.create("POSTFIX_TLSPROXY", "%{POSTFIX_TLSPROXY_CONN}|%{POSTFIX_WARNING}"));
         patternSet.add(GrokPattern.create("POSTFIX_SENDMAIL", "%{POSTFIX_WARNING}"));
         patternSet.add(GrokPattern.create("POSTFIX_BOUNCE", "%{POSTFIX_BOUNCE_NOTIFICATION}"));
@@ -166,8 +166,8 @@ public class MongoDbGrokPatternServiceTest {
         patternSet.add(GrokPattern.create("POSTFIX_SMTP_RELAYERR", "%{POSTFIX_QUEUEID:postfix_queueid}: host %{POSTFIX_RELAY_INFO} said: %{GREEDYDATA:postfix_smtp_response} \\(in reply to %{POSTFIX_SMTP_STAGE:postfix_smtp_stage} command\\)"));
         patternSet.add(GrokPattern.create("POSTFIX_STATUS_CODE_ENHANCED", "\\d\\.\\d\\.\\d"));
         patternSet.add(GrokPattern.create("POSTFIX_SMTP_TIMEOUT", "%{POSTFIX_QUEUEID:postfix_queueid}: conversation with %{POSTFIX_RELAY_INFO} timed out( while %{POSTFIX_LOSTCONN_REASONS:postfix_smtp_lostconn_reason})?"));
-        patternSet.add(GrokPattern.create("POSTFIX_MASTER_EXIT", "terminating on signal %{INT:postfix_termination_signal}"));
-        patternSet.add(GrokPattern.create("POSTFIX_MASTER_START", "(daemon started|reload) -- version %{DATA:postfix_version}, configuration %{PATH:postfix_config_path}"));
+        patternSet.add(GrokPattern.create("POSTFIX_PARENT_EXIT", "terminating on signal %{INT:postfix_termination_signal}"));
+        patternSet.add(GrokPattern.create("POSTFIX_PARENT_START", "(daemon started|reload) -- version %{DATA:postfix_version}, configuration %{PATH:postfix_config_path}"));
         patternSet.add(GrokPattern.create("POSTFIX_SCACHE_LOOKUPS", "statistics: (address|domain) lookup hits=%{INT:postfix_scache_hits} miss=%{INT:postfix_scache_miss} success=%{INT:postfix_scache_success}%"));
         patternSet.add(GrokPattern.create("POSTFIX_BOUNCE_NOTIFICATION", "%{POSTFIX_QUEUEID:postfix_queueid}: sender (non-delivery|delivery status|delay) notification: %{POSTFIX_QUEUEID:postfix_bounce_queueid}"));
         patternSet.add(GrokPattern.create("POSTFIX_SCACHE_TIMESTAMP", "statistics: start interval %{SYSLOGTIMESTAMP:postfix_scache_timestamp}"));

--- a/graylog2-server/src/test/java/org/graylog2/periodical/ConfigurationManagementPeriodicalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/periodical/ConfigurationManagementPeriodicalTest.java
@@ -86,8 +86,8 @@ public class ConfigurationManagementPeriodicalTest {
     }
 
     @Test
-    public void masterOnly() throws Exception {
-        assertThat(periodical.masterOnly()).isTrue();
+    public void parentOnly() throws Exception {
+        assertThat(periodical.parentOnly()).isTrue();
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/periodical/ConfigurationManagementPeriodicalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/periodical/ConfigurationManagementPeriodicalTest.java
@@ -86,8 +86,8 @@ public class ConfigurationManagementPeriodicalTest {
     }
 
     @Test
-    public void parentOnly() throws Exception {
-        assertThat(periodical.parentOnly()).isTrue();
+    public void primaryOnly() throws Exception {
+        assertThat(periodical.primaryOnly()).isTrue();
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/periodical/PeriodicalsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/periodical/PeriodicalsTest.java
@@ -206,7 +206,7 @@ public class PeriodicalsTest {
             }
 
             @Override
-            public boolean parentOnly() {
+            public boolean primaryOnly() {
                 return false;
             }
 

--- a/graylog2-server/src/test/java/org/graylog2/periodical/PeriodicalsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/periodical/PeriodicalsTest.java
@@ -206,7 +206,7 @@ public class PeriodicalsTest {
             }
 
             @Override
-            public boolean masterOnly() {
+            public boolean parentOnly() {
                 return false;
             }
 

--- a/graylog2-server/src/test/java/org/graylog2/plugin/ServerStatusTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/ServerStatusTest.java
@@ -64,7 +64,7 @@ public class ServerStatusTest {
 
         when(config.getNodeIdFile()).thenReturn(tempFile.getPath());
 
-        status = new ServerStatus(config, Collections.singleton(ServerStatus.Capability.MASTER), eventBus, NullAuditEventSender::new);
+        status = new ServerStatus(config, Collections.singleton(ServerStatus.Capability.PARENT), eventBus, NullAuditEventSender::new);
     }
 
     @Test
@@ -172,13 +172,13 @@ public class ServerStatusTest {
     @Test
     public void testAddCapability() throws Exception {
         assertEquals(status, status.addCapability(ServerStatus.Capability.SERVER));
-        assertTrue(status.hasCapabilities(ServerStatus.Capability.MASTER, ServerStatus.Capability.SERVER));
+        assertTrue(status.hasCapabilities(ServerStatus.Capability.PARENT, ServerStatus.Capability.SERVER));
     }
 
     @Test
     public void testAddCapabilities() throws Exception {
         assertEquals(status, status.addCapabilities(ServerStatus.Capability.LOCALMODE));
-        assertTrue(status.hasCapabilities(ServerStatus.Capability.MASTER, ServerStatus.Capability.LOCALMODE));
+        assertTrue(status.hasCapabilities(ServerStatus.Capability.PARENT, ServerStatus.Capability.LOCALMODE));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/plugin/ServerStatusTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/plugin/ServerStatusTest.java
@@ -64,7 +64,7 @@ public class ServerStatusTest {
 
         when(config.getNodeIdFile()).thenReturn(tempFile.getPath());
 
-        status = new ServerStatus(config, Collections.singleton(ServerStatus.Capability.PARENT), eventBus, NullAuditEventSender::new);
+        status = new ServerStatus(config, Collections.singleton(ServerStatus.Capability.PRIMARY), eventBus, NullAuditEventSender::new);
     }
 
     @Test
@@ -172,13 +172,13 @@ public class ServerStatusTest {
     @Test
     public void testAddCapability() throws Exception {
         assertEquals(status, status.addCapability(ServerStatus.Capability.SERVER));
-        assertTrue(status.hasCapabilities(ServerStatus.Capability.PARENT, ServerStatus.Capability.SERVER));
+        assertTrue(status.hasCapabilities(ServerStatus.Capability.PRIMARY, ServerStatus.Capability.SERVER));
     }
 
     @Test
     public void testAddCapabilities() throws Exception {
         assertEquals(status, status.addCapabilities(ServerStatus.Capability.LOCALMODE));
-        assertTrue(status.hasCapabilities(ServerStatus.Capability.PARENT, ServerStatus.Capability.LOCALMODE));
+        assertTrue(status.hasCapabilities(ServerStatus.Capability.PRIMARY, ServerStatus.Capability.LOCALMODE));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/shared/journal/KafkaJournalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/journal/KafkaJournalTest.java
@@ -94,7 +94,7 @@ public class KafkaJournalTest {
                 return nodeId.getAbsolutePath();
             }
         };
-        serverStatus = new ServerStatus(configuration, EnumSet.of(ServerStatus.Capability.MASTER), new EventBus("KafkaJournalTest"), NullAuditEventSender::new);
+        serverStatus = new ServerStatus(configuration, EnumSet.of(ServerStatus.Capability.PARENT), new EventBus("KafkaJournalTest"), NullAuditEventSender::new);
     }
 
     @After

--- a/graylog2-server/src/test/java/org/graylog2/shared/journal/KafkaJournalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/journal/KafkaJournalTest.java
@@ -94,7 +94,7 @@ public class KafkaJournalTest {
                 return nodeId.getAbsolutePath();
             }
         };
-        serverStatus = new ServerStatus(configuration, EnumSet.of(ServerStatus.Capability.PARENT), new EventBus("KafkaJournalTest"), NullAuditEventSender::new);
+        serverStatus = new ServerStatus(configuration, EnumSet.of(ServerStatus.Capability.PRIMARY), new EventBus("KafkaJournalTest"), NullAuditEventSender::new);
     }
 
     @After

--- a/graylog2-server/src/test/java/org/graylog2/shared/rest/resources/ProxiedResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/rest/resources/ProxiedResourceTest.java
@@ -16,7 +16,7 @@
  */
 package org.graylog2.shared.rest.resources;
 
-import org.graylog2.shared.rest.resources.ProxiedResource.MasterResponse;
+import org.graylog2.shared.rest.resources.ProxiedResource.ParentResponse;
 import org.junit.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -25,8 +25,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProxiedResourceTest {
     @Test
-    public void masterResponse() {
-        final MasterResponse<String> response1 = MasterResponse.create(true, 200, "hello world", null);
+    public void parentResponse() {
+        final ParentResponse<String> response1 = ParentResponse.create(true, 200, "hello world", null);
 
         assertThat(response1.isSuccess()).isTrue();
         assertThat(response1.code()).isEqualTo(200);
@@ -34,7 +34,7 @@ public class ProxiedResourceTest {
         assertThat(response1.error()).isNotPresent();
         assertThat(response1.body()).isEqualTo("hello world");
 
-        final MasterResponse<String> response2 = MasterResponse.create(false, 400, null, "error".getBytes(UTF_8));
+        final ParentResponse<String> response2 = ParentResponse.create(false, 400, null, "error".getBytes(UTF_8));
 
         assertThat(response2.isSuccess()).isFalse();
         assertThat(response2.code()).isEqualTo(400);

--- a/graylog2-server/src/test/java/org/graylog2/shared/rest/resources/ProxiedResourceTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/rest/resources/ProxiedResourceTest.java
@@ -16,7 +16,7 @@
  */
 package org.graylog2.shared.rest.resources;
 
-import org.graylog2.shared.rest.resources.ProxiedResource.ParentResponse;
+import org.graylog2.shared.rest.resources.ProxiedResource.PrimaryResponse;
 import org.junit.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -25,8 +25,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProxiedResourceTest {
     @Test
-    public void parentResponse() {
-        final ParentResponse<String> response1 = ParentResponse.create(true, 200, "hello world", null);
+    public void primaryResponse() {
+        final PrimaryResponse<String> response1 = PrimaryResponse.create(true, 200, "hello world", null);
 
         assertThat(response1.isSuccess()).isTrue();
         assertThat(response1.code()).isEqualTo(200);
@@ -34,7 +34,7 @@ public class ProxiedResourceTest {
         assertThat(response1.error()).isNotPresent();
         assertThat(response1.body()).isEqualTo("hello world");
 
-        final ParentResponse<String> response2 = ParentResponse.create(false, 400, null, "error".getBytes(UTF_8));
+        final PrimaryResponse<String> response2 = PrimaryResponse.create(false, 400, null, "error".getBytes(UTF_8));
 
         assertThat(response2.isSuccess()).isFalse();
         assertThat(response2.code()).isEqualTo(400);

--- a/graylog2-server/src/test/resources/org/graylog2/bindings/providers/elasticsearch.yml
+++ b/graylog2-server/src/test/resources/org/graylog2/bindings/providers/elasticsearch.yml
@@ -4,6 +4,6 @@ discovery.zen.ping.multicast.enabled: false
 discovery.zen.ping.unicast.hosts: 127.0.0.1,123.3.3.3
 http.enabled: true
 node.data: true
-node.parent: true
+node.primary: true
 node.name: filenode
 transport.tcp.port: 1111

--- a/graylog2-server/src/test/resources/org/graylog2/bindings/providers/elasticsearch.yml
+++ b/graylog2-server/src/test/resources/org/graylog2/bindings/providers/elasticsearch.yml
@@ -4,6 +4,6 @@ discovery.zen.ping.multicast.enabled: false
 discovery.zen.ping.unicast.hosts: 127.0.0.1,123.3.3.3
 http.enabled: true
 node.data: true
-node.master: true
+node.parent: true
 node.name: filenode
 transport.tcp.port: 1111

--- a/graylog2-server/src/test/resources/org/graylog2/cluster/NodeServiceImplTest-one-node.json
+++ b/graylog2-server/src/test/resources/org/graylog2/cluster/NodeServiceImplTest-one-node.json
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "_id" : { "$oid": "569e0f60c83026b93fb2ecb6"},
-      "is_parent" : true,
+      "is_primary" : true,
       "last_seen" : 1453209426,
       "transport_address" : "http://10.0.0.1:12900",
       "type" : "SERVER",

--- a/graylog2-server/src/test/resources/org/graylog2/cluster/NodeServiceImplTest-one-node.json
+++ b/graylog2-server/src/test/resources/org/graylog2/cluster/NodeServiceImplTest-one-node.json
@@ -2,7 +2,7 @@
   "nodes": [
     {
       "_id" : { "$oid": "569e0f60c83026b93fb2ecb6"},
-      "is_master" : true,
+      "is_parent" : true,
       "last_seen" : 1453209426,
       "transport_address" : "http://10.0.0.1:12900",
       "type" : "SERVER",

--- a/graylog2-web-interface/src/components/common/LinkToNode.jsx
+++ b/graylog2-web-interface/src/components/common/LinkToNode.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { Link } from 'react-router';
@@ -14,7 +15,7 @@ const NodesStore = StoreProvider.getStore('Nodes');
 
 /**
  * Component that creates a link to a Graylog node. The information in the link includes:
- *  - Marker indicating whether the Graylog node is master or not
+ *  - Marker indicating whether the Graylog node is parent or not
  *  - Short Graylog node ID
  *  - Graylog node hostname
  *
@@ -38,8 +39,8 @@ const LinkToNode = createReactClass({
 
     if (node) {
       const iconName = node.is_parent ? 'star' : 'code-fork';
-      const iconClass = node.is_parent ? 'master-node' : '';
-      const iconTitle = node.is_parent ? 'This is the master node in the cluster' : '';
+      const iconClass = node.is_parent ? 'parent-node' : '';
+      const iconTitle = node.is_parent ? 'This is the parent node in the cluster' : '';
       return (
         <Link to={Routes.SYSTEM.NODES.SHOW(this.props.nodeId)}>
           <Icon name={iconName} className={iconClass} title={iconTitle} />

--- a/graylog2-web-interface/src/components/common/LinkToNode.jsx
+++ b/graylog2-web-interface/src/components/common/LinkToNode.jsx
@@ -37,9 +37,9 @@ const LinkToNode = createReactClass({
     const node = this.state.nodes[this.props.nodeId];
 
     if (node) {
-      const iconName = node.is_master ? 'star' : 'code-fork';
-      const iconClass = node.is_master ? 'master-node' : '';
-      const iconTitle = node.is_master ? 'This is the master node in the cluster' : '';
+      const iconName = node.is_parent ? 'star' : 'code-fork';
+      const iconClass = node.is_parent ? 'master-node' : '';
+      const iconTitle = node.is_parent ? 'This is the master node in the cluster' : '';
       return (
         <Link to={Routes.SYSTEM.NODES.SHOW(this.props.nodeId)}>
           <Icon name={iconName} className={iconClass} title={iconTitle} />

--- a/graylog2-web-interface/src/components/common/LinkToNode.jsx
+++ b/graylog2-web-interface/src/components/common/LinkToNode.jsx
@@ -15,7 +15,7 @@ const NodesStore = StoreProvider.getStore('Nodes');
 
 /**
  * Component that creates a link to a Graylog node. The information in the link includes:
- *  - Marker indicating whether the Graylog node is parent or not
+ *  - Marker indicating whether the Graylog node is primary or not
  *  - Short Graylog node ID
  *  - Graylog node hostname
  *
@@ -38,9 +38,9 @@ const LinkToNode = createReactClass({
     const node = this.state.nodes[this.props.nodeId];
 
     if (node) {
-      const iconName = node.is_parent ? 'star' : 'code-fork';
-      const iconClass = node.is_parent ? 'parent-node' : '';
-      const iconTitle = node.is_parent ? 'This is the parent node in the cluster' : '';
+      const iconName = node.is_primary ? 'star' : 'code-fork';
+      const iconClass = node.is_primary ? 'primary-node' : '';
+      const iconTitle = node.is_primary ? 'This is the primary node in the cluster' : '';
       return (
         <Link to={Routes.SYSTEM.NODES.SHOW(this.props.nodeId)}>
           <Icon name={iconName} className={iconClass} title={iconTitle} />

--- a/graylog2-web-interface/src/components/gettingstarted/GettingStarted.jsx
+++ b/graylog2-web-interface/src/components/gettingstarted/GettingStarted.jsx
@@ -32,8 +32,8 @@ class GettingStarted extends React.Component {
 
   static propTypes = {
     clusterId: PropTypes.string.isRequired,
-    masterOs: PropTypes.string.isRequired,
-    masterVersion: PropTypes.string.isRequired,
+    parentOs: PropTypes.string.isRequired,
+    parentVersion: PropTypes.string.isRequired,
     gettingStartedUrl: PropTypes.string.isRequired,
     noDismissButton: PropTypes.bool,
     onDismiss: PropTypes.func,
@@ -96,7 +96,7 @@ class GettingStarted extends React.Component {
   };
 
   render() {
-    const { noDismissButton, clusterId, masterOs, masterVersion, gettingStartedUrl } = this.props;
+    const { noDismissButton, clusterId, parentOs, parentVersion, gettingStartedUrl } = this.props;
     const { showStaticContent, guideLoaded, guideUrl } = this.state;
 
     let dismissButton = null;
@@ -125,8 +125,8 @@ class GettingStarted extends React.Component {
     } else {
       const query = Qs.stringify({
         c: clusterId,
-        o: masterOs,
-        v: masterVersion,
+        o: parentOs,
+        v: parentVersion,
         m: noDismissButton,
       });
 

--- a/graylog2-web-interface/src/components/gettingstarted/GettingStarted.jsx
+++ b/graylog2-web-interface/src/components/gettingstarted/GettingStarted.jsx
@@ -32,8 +32,8 @@ class GettingStarted extends React.Component {
 
   static propTypes = {
     clusterId: PropTypes.string.isRequired,
-    parentOs: PropTypes.string.isRequired,
-    parentVersion: PropTypes.string.isRequired,
+    primaryOs: PropTypes.string.isRequired,
+    primaryVersion: PropTypes.string.isRequired,
     gettingStartedUrl: PropTypes.string.isRequired,
     noDismissButton: PropTypes.bool,
     onDismiss: PropTypes.func,
@@ -96,7 +96,7 @@ class GettingStarted extends React.Component {
   };
 
   render() {
-    const { noDismissButton, clusterId, parentOs, parentVersion, gettingStartedUrl } = this.props;
+    const { noDismissButton, clusterId, primaryOs, primaryVersion, gettingStartedUrl } = this.props;
     const { showStaticContent, guideLoaded, guideUrl } = this.state;
 
     let dismissButton = null;
@@ -125,8 +125,8 @@ class GettingStarted extends React.Component {
     } else {
       const query = Qs.stringify({
         c: clusterId,
-        o: parentOs,
-        v: parentVersion,
+        o: primaryOs,
+        v: primaryVersion,
         m: noDismissButton,
       });
 

--- a/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
+++ b/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
@@ -157,7 +157,7 @@ class NotificationsFactory {
             <span>
               There were multiple Graylog server instances configured as master in your Graylog cluster. The cluster handles
               this automatically by launching new nodes as slaves if there already is a master but you should still fix this.
-              Check the graylog.conf of every node and make sure that only one instance has is_master set to true. Close this
+              Check the graylog.conf of every node and make sure that only one instance has is_parent set to true. Close this
               notification if you think you resolved the problem. It will pop back up if you start a second master node again.
             </span>
           ),
@@ -179,7 +179,7 @@ class NotificationsFactory {
           description: (
             <span>
               Certain operations of Graylog server require the presence of a master node, but no such master was started.
-              Please ensure that one of your Graylog server nodes contains the setting <code>is_master = true</code> in its
+              Please ensure that one of your Graylog server nodes contains the setting <code>is_parent = true</code> in its
               configuration and that it is running. Until this is resolved index cycling will not be able to run, which
               means that the index retention mechanism is also not running, leading to increased index sizes. Certain
               maintenance functions as well as a variety of web interface pages (e.g. Dashboards) are unavailable.

--- a/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
+++ b/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
@@ -150,15 +150,15 @@ class NotificationsFactory {
             </span>
           ),
         };
-      case 'multi_parent':
+      case 'multi_primary':
         return {
-          title: 'Multiple Graylog server parents in the cluster',
+          title: 'Multiple Graylog server primarys in the cluster',
           description: (
             <span>
-              There were multiple Graylog server instances configured as parent in your Graylog cluster. The cluster handles
-              this automatically by launching new nodes as children if there already is a parent but you should still fix this.
-              Check the graylog.conf of every node and make sure that only one instance has is_parent set to true. Close this
-              notification if you think you resolved the problem. It will pop back up if you start a second parent node again.
+              There were multiple Graylog server instances configured as primary in your Graylog cluster. The cluster handles
+              this automatically by launching new nodes as children if there already is a primary but you should still fix this.
+              Check the graylog.conf of every node and make sure that only one instance has is_primary set to true. Close this
+              notification if you think you resolved the problem. It will pop back up if you start a second primary node again.
             </span>
           ),
         };
@@ -173,13 +173,13 @@ class NotificationsFactory {
             </span>
           ),
         };
-      case 'no_parent':
+      case 'no_primary':
         return {
-          title: 'There was no parent Graylog server node detected in the cluster.',
+          title: 'There was no primary Graylog server node detected in the cluster.',
           description: (
             <span>
-              Certain operations of Graylog server require the presence of a parent node, but no such parent was started.
-              Please ensure that one of your Graylog server nodes contains the setting <code>is_parent = true</code> in its
+              Certain operations of Graylog server require the presence of a primary node, but no such primary was started.
+              Please ensure that one of your Graylog server nodes contains the setting <code>is_primary = true</code> in its
               configuration and that it is running. Until this is resolved index cycling will not be able to run, which
               means that the index retention mechanism is also not running, leading to increased index sizes. Certain
               maintenance functions as well as a variety of web interface pages (e.g. Dashboards) are unavailable.

--- a/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
+++ b/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
@@ -156,7 +156,7 @@ class NotificationsFactory {
           description: (
             <span>
               There were multiple Graylog server instances configured as parent in your Graylog cluster. The cluster handles
-              this automatically by launching new nodes as slaves if there already is a parent but you should still fix this.
+              this automatically by launching new nodes as children if there already is a parent but you should still fix this.
               Check the graylog.conf of every node and make sure that only one instance has is_parent set to true. Close this
               notification if you think you resolved the problem. It will pop back up if you start a second parent node again.
             </span>

--- a/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
+++ b/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
@@ -150,15 +150,15 @@ class NotificationsFactory {
             </span>
           ),
         };
-      case 'multi_master':
+      case 'multi_parent':
         return {
-          title: 'Multiple Graylog server masters in the cluster',
+          title: 'Multiple Graylog server parents in the cluster',
           description: (
             <span>
-              There were multiple Graylog server instances configured as master in your Graylog cluster. The cluster handles
-              this automatically by launching new nodes as slaves if there already is a master but you should still fix this.
+              There were multiple Graylog server instances configured as parent in your Graylog cluster. The cluster handles
+              this automatically by launching new nodes as slaves if there already is a parent but you should still fix this.
               Check the graylog.conf of every node and make sure that only one instance has is_parent set to true. Close this
-              notification if you think you resolved the problem. It will pop back up if you start a second master node again.
+              notification if you think you resolved the problem. It will pop back up if you start a second parent node again.
             </span>
           ),
         };
@@ -173,12 +173,12 @@ class NotificationsFactory {
             </span>
           ),
         };
-      case 'no_master':
+      case 'no_parent':
         return {
-          title: 'There was no master Graylog server node detected in the cluster.',
+          title: 'There was no parent Graylog server node detected in the cluster.',
           description: (
             <span>
-              Certain operations of Graylog server require the presence of a master node, but no such master was started.
+              Certain operations of Graylog server require the presence of a parent node, but no such parent was started.
               Please ensure that one of your Graylog server nodes contains the setting <code>is_parent = true</code> in its
               configuration and that it is running. Until this is resolved index cycling will not be able to run, which
               means that the index retention mechanism is also not running, leading to increased index sizes. Certain

--- a/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
+++ b/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
@@ -156,7 +156,7 @@ class NotificationsFactory {
           description: (
             <span>
               There were multiple Graylog server instances configured as primary in your Graylog cluster. The cluster handles
-              this automatically by launching new nodes as children if there already is a primary but you should still fix this.
+              this automatically by launching new nodes as secondary if there already is a primary but you should still fix this.
               Check the graylog.conf of every node and make sure that only one instance has is_primary set to true. Close this
               notification if you think you resolved the problem. It will pop back up if you start a second primary node again.
             </span>

--- a/graylog2-web-interface/src/pages/ExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/ExtractorsPage.jsx
@@ -44,7 +44,7 @@ const ExtractorsPage = createReactClass({
 
   onNodesChange(nodes) {
     const { params } = this.props;
-    const newNode = params.nodeId ? nodes.nodes[params.nodeId] : Object.values(nodes.nodes).filter((node) => node.is_parent);
+    const newNode = params.nodeId ? nodes.nodes[params.nodeId] : Object.values(nodes.nodes).filter((node) => node.is_primary);
 
     const { node } = this.state;
     if (!node || node.node_id !== newNode.node_id) {

--- a/graylog2-web-interface/src/pages/ExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/ExtractorsPage.jsx
@@ -44,7 +44,7 @@ const ExtractorsPage = createReactClass({
 
   onNodesChange(nodes) {
     const { params } = this.props;
-    const newNode = params.nodeId ? nodes.nodes[params.nodeId] : Object.values(nodes.nodes).filter((node) => node.is_master);
+    const newNode = params.nodeId ? nodes.nodes[params.nodeId] : Object.values(nodes.nodes).filter((node) => node.is_parent);
 
     const { node } = this.state;
     if (!node || node.node_id !== newNode.node_id) {

--- a/graylog2-web-interface/src/pages/GettingStartedPage.jsx
+++ b/graylog2-web-interface/src/pages/GettingStartedPage.jsx
@@ -40,8 +40,8 @@ const GettingStartedPage = createReactClass({
       <DocumentTitle title="Getting started">
         <div>
           <GettingStarted clusterId={this.state.system.cluster_id}
-                          masterOs={this.state.system.operating_system}
-                          masterVersion={this.state.system.version}
+                          parentOs={this.state.system.operating_system}
+                          parentVersion={this.state.system.version}
                           gettingStartedUrl={GETTING_STARTED_URL}
                           noDismissButton={Boolean(this.props.location.query.menu)}
                           onDismiss={this._onDismiss} />

--- a/graylog2-web-interface/src/pages/GettingStartedPage.jsx
+++ b/graylog2-web-interface/src/pages/GettingStartedPage.jsx
@@ -40,8 +40,8 @@ const GettingStartedPage = createReactClass({
       <DocumentTitle title="Getting started">
         <div>
           <GettingStarted clusterId={this.state.system.cluster_id}
-                          parentOs={this.state.system.operating_system}
-                          parentVersion={this.state.system.version}
+                          primaryOs={this.state.system.operating_system}
+                          primaryVersion={this.state.system.version}
                           gettingStartedUrl={GETTING_STARTED_URL}
                           noDismissButton={Boolean(this.props.location.query.menu)}
                           onDismiss={this._onDismiss} />

--- a/graylog2-web-interface/src/pages/ShowMetricsPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowMetricsPage.jsx
@@ -34,11 +34,11 @@ const ShowMetricsPage = createReactClass({
     }
 
     let { nodeId } = this.props.params;
-    // "parent" node ID is a placeholder for parent node, get first parent node ID
-    if (nodeId === 'parent') {
+    // "primary" node ID is a placeholder for primary node, get first primary node ID
+    if (nodeId === 'primary') {
       const nodeIDs = Object.keys(this.state.nodes);
-      const parentNodes = nodeIDs.filter((nodeID) => this.state.nodes[nodeID].is_parent);
-      nodeId = parentNodes[0] || nodeIDs[0];
+      const primaryNodes = nodeIDs.filter((nodeID) => this.state.nodes[nodeID].is_primary);
+      nodeId = primaryNodes[0] || nodeIDs[0];
     }
 
     const node = this.state.nodes[nodeId];

--- a/graylog2-web-interface/src/pages/ShowMetricsPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowMetricsPage.jsx
@@ -37,7 +37,7 @@ const ShowMetricsPage = createReactClass({
     // "master" node ID is a placeholder for master node, get first master node ID
     if (nodeId === 'master') {
       const nodeIDs = Object.keys(this.state.nodes);
-      const masterNodes = nodeIDs.filter((nodeID) => this.state.nodes[nodeID].is_master);
+      const masterNodes = nodeIDs.filter((nodeID) => this.state.nodes[nodeID].is_parent);
       nodeId = masterNodes[0] || nodeIDs[0];
     }
 

--- a/graylog2-web-interface/src/pages/ShowMetricsPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowMetricsPage.jsx
@@ -34,11 +34,11 @@ const ShowMetricsPage = createReactClass({
     }
 
     let { nodeId } = this.props.params;
-    // "master" node ID is a placeholder for master node, get first master node ID
-    if (nodeId === 'master') {
+    // "parent" node ID is a placeholder for parent node, get first parent node ID
+    if (nodeId === 'parent') {
       const nodeIDs = Object.keys(this.state.nodes);
-      const masterNodes = nodeIDs.filter((nodeID) => this.state.nodes[nodeID].is_parent);
-      nodeId = masterNodes[0] || nodeIDs[0];
+      const parentNodes = nodeIDs.filter((nodeID) => this.state.nodes[nodeID].is_parent);
+      nodeId = parentNodes[0] || nodeIDs[0];
     }
 
     const node = this.state.nodes[nodeId];

--- a/graylog2-web-interface/src/pages/ShowNodePage.jsx
+++ b/graylog2-web-interface/src/pages/ShowNodePage.jsx
@@ -85,7 +85,7 @@ const ShowNodePage = createReactClass({
               This page shows details of a Graylog server node that is active and reachable in your cluster.
             </span>
             <span>
-              {node.is_parent ? <span>This is the parent node.</span> : <span>This is <em>not</em> the parent node.</span>}
+              {node.is_primary ? <span>This is the primary node.</span> : <span>This is <em>not</em> the primary node.</span>}
             </span>
             <span><NodeMaintenanceDropdown node={node} /></span>
           </PageHeader>

--- a/graylog2-web-interface/src/pages/ShowNodePage.jsx
+++ b/graylog2-web-interface/src/pages/ShowNodePage.jsx
@@ -85,7 +85,7 @@ const ShowNodePage = createReactClass({
               This page shows details of a Graylog server node that is active and reachable in your cluster.
             </span>
             <span>
-              {node.is_parent ? <span>This is the master node.</span> : <span>This is <em>not</em> the master node.</span>}
+              {node.is_parent ? <span>This is the parent node.</span> : <span>This is <em>not</em> the parent node.</span>}
             </span>
             <span><NodeMaintenanceDropdown node={node} /></span>
           </PageHeader>

--- a/graylog2-web-interface/src/pages/ShowNodePage.jsx
+++ b/graylog2-web-interface/src/pages/ShowNodePage.jsx
@@ -85,7 +85,7 @@ const ShowNodePage = createReactClass({
               This page shows details of a Graylog server node that is active and reachable in your cluster.
             </span>
             <span>
-              {node.is_master ? <span>This is the master node.</span> : <span>This is <em>not</em> the master node.</span>}
+              {node.is_parent ? <span>This is the master node.</span> : <span>This is <em>not</em> the master node.</span>}
             </span>
             <span><NodeMaintenanceDropdown node={node} /></span>
           </PageHeader>

--- a/graylog2-web-interface/src/stores/nodes/NodesStore.js
+++ b/graylog2-web-interface/src/stores/nodes/NodesStore.js
@@ -12,7 +12,7 @@ const { SessionStore } = CombinedProvider.get('Session');
 type NodeInfo = {
   cluster_id: string,
   hostname: string,
-  is_parent: boolean,
+  is_primary: boolean,
   last_seen: string,
   node_id: string,
   short_node_id: string,

--- a/graylog2-web-interface/src/stores/nodes/NodesStore.js
+++ b/graylog2-web-interface/src/stores/nodes/NodesStore.js
@@ -12,7 +12,7 @@ const { SessionStore } = CombinedProvider.get('Session');
 type NodeInfo = {
   cluster_id: string,
   hostname: string,
-  is_master: boolean,
+  is_parent: boolean,
   last_seen: string,
   node_id: string,
   short_node_id: string,

--- a/graylog2-web-interface/src/theme/GlobalThemeStyles.jsx
+++ b/graylog2-web-interface/src/theme/GlobalThemeStyles.jsx
@@ -171,7 +171,7 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
     margin-bottom: 0;
   }
 
-  .parent-node {
+  .primary-node {
     color: ${theme.colors.variant.dark.warning};
   }
 

--- a/graylog2-web-interface/src/theme/GlobalThemeStyles.jsx
+++ b/graylog2-web-interface/src/theme/GlobalThemeStyles.jsx
@@ -171,7 +171,7 @@ const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
     margin-bottom: 0;
   }
 
-  .master-node {
+  .parent-node {
     color: ${theme.colors.variant.dark.warning};
   }
 

--- a/graylog2-web-interface/travis/server.conf
+++ b/graylog2-web-interface/travis/server.conf
@@ -1,4 +1,4 @@
-is_parent = true
+is_primary = true
 node_id_file = graylog2-server-node-id
 password_secret = IHRzmjWfc0mh7D1Pepv7Od6NRL7jqNb0k9g8fvjwyX4Vq1KIHvQSFOHLf4BO1k3hdKdFWmceKwy46BGqIk2NurWAUYSedspb
 root_username = admin

--- a/graylog2-web-interface/travis/server.conf
+++ b/graylog2-web-interface/travis/server.conf
@@ -1,4 +1,4 @@
-is_master = true
+is_parent = true
 node_id_file = graylog2-server-node-id
 password_secret = IHRzmjWfc0mh7D1Pepv7Od6NRL7jqNb0k9g8fvjwyX4Vq1KIHvQSFOHLf4BO1k3hdKdFWmceKwy46BGqIk2NurWAUYSedspb
 root_username = admin

--- a/misc/elasticsearch.yml
+++ b/misc/elasticsearch.yml
@@ -4,8 +4,8 @@ cluster.name: graylog
 # you could also leave this out, but makes it easier to identify the Graylog embedded Elasticsearch node
 node.name: "graylog-server"
 
-# we don't want the graylog2 client to store any data, or be master node
-node.master: false
+# we don't want the graylog2 client to store any data, or be parent node
+node.parent: false
 node.data: false
 
 # you might need to bind to a certain IP address, do that here
@@ -24,13 +24,13 @@ http.enabled: false
 ################################## Discovery ##################################
 
 # Discovery infrastructure ensures nodes can be found within a cluster
-# and master node is elected. Multicast discovery is the default.
+# and parent node is elected. Multicast discovery is the default.
 
-# Set to ensure a node sees N other master eligible nodes to be considered
+# Set to ensure a node sees N other parent eligible nodes to be considered
 # operational within the cluster. Set this option to a higher value (2-4)
 # for large clusters (>3 nodes):
 #
-# discovery.zen.minimum_master_nodes: 1
+# discovery.zen.minimum_parent_nodes: 1
 
 # Set the time to wait for ping responses from other nodes when discovering.
 # Set this option to a higher value on a slow or congested network
@@ -49,8 +49,8 @@ http.enabled: false
 #
 # discovery.zen.ping.multicast.enabled: false
 #
-# 2. Configure an initial list of master nodes in the cluster
-#    to perform discovery when new nodes (master or data) are started:
+# 2. Configure an initial list of parent nodes in the cluster
+#    to perform discovery when new nodes (parent or data) are started:
 #
 # discovery.zen.ping.unicast.hosts: ["host1", "host2:port", "host3[portX-portY]"]
 

--- a/misc/elasticsearch.yml
+++ b/misc/elasticsearch.yml
@@ -4,8 +4,8 @@ cluster.name: graylog
 # you could also leave this out, but makes it easier to identify the Graylog embedded Elasticsearch node
 node.name: "graylog-server"
 
-# we don't want the graylog2 client to store any data, or be parent node
-node.parent: false
+# we don't want the graylog2 client to store any data, or be primary node
+node.primary: false
 node.data: false
 
 # you might need to bind to a certain IP address, do that here
@@ -24,13 +24,13 @@ http.enabled: false
 ################################## Discovery ##################################
 
 # Discovery infrastructure ensures nodes can be found within a cluster
-# and parent node is elected. Multicast discovery is the default.
+# and primary node is elected. Multicast discovery is the default.
 
-# Set to ensure a node sees N other parent eligible nodes to be considered
+# Set to ensure a node sees N other primary eligible nodes to be considered
 # operational within the cluster. Set this option to a higher value (2-4)
 # for large clusters (>3 nodes):
 #
-# discovery.zen.minimum_parent_nodes: 1
+# discovery.zen.minimum_primary_nodes: 1
 
 # Set the time to wait for ping responses from other nodes when discovering.
 # Set this option to a higher value on a slow or congested network
@@ -49,8 +49,8 @@ http.enabled: false
 #
 # discovery.zen.ping.multicast.enabled: false
 #
-# 2. Configure an initial list of parent nodes in the cluster
-#    to perform discovery when new nodes (parent or data) are started:
+# 2. Configure an initial list of primary nodes in the cluster
+#    to perform discovery when new nodes (primary or data) are started:
 #
 # discovery.zen.ping.unicast.hosts: ["host1", "host2:port", "host3[portX-portY]"]
 

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -6,7 +6,7 @@
 # Characters that cannot be directly represented in this encoding can be written using Unicode escapes
 # as defined in https://docs.oracle.com/javase/specs/jls/se8/html/jls-3.html#jls-3.3, using the \u prefix.
 # For example, \u002c.
-# 
+#
 # * Entries are generally expected to be a single line of the form, one of the following:
 #
 # propertyName=propertyValue
@@ -14,7 +14,7 @@
 #
 # * White space that appears between the property name and property value is ignored,
 #   so the following are equivalent:
-# 
+#
 # name=Stephen
 # name = Stephen
 #
@@ -34,17 +34,17 @@
 #         Los Angeles
 #
 #   This is equivalent to targetCities=Detroit,Chicago,Los Angeles (white space at the beginning of lines is ignored).
-# 
+#
 # * The characters newline, carriage return, and tab can be inserted with characters \n, \r, and \t, respectively.
-# 
+#
 # * The backslash character must be escaped as a double backslash. For example:
-# 
+#
 # path=c:\\docs\\doc1
 #
 
 # If you are running more than one instances of Graylog server you have to select one of these
 # instances as master. The master will perform some periodical tasks that non-masters won't perform.
-is_master = true
+is_parent = true
 
 # The auto-generated node ID will be stored in this file and read after restarts. It is a good idea
 # to use an absolute file path here if you are starting Graylog server from init scripts or similar.

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -43,7 +43,7 @@
 #
 
 # If you are running more than one instances of Graylog server you have to select one of these
-# instances as master. The master will perform some periodical tasks that non-masters won't perform.
+# instances as parent. The parent will perform some periodical tasks that non-parents won't perform.
 is_parent = true
 
 # The auto-generated node ID will be stored in this file and read after restarts. It is a good idea
@@ -520,8 +520,8 @@ lb_recognition_period_seconds = 3
 # Time in milliseconds to wait for all message outputs to finish writing a single message.
 #output_module_timeout = 10000
 
-# Time in milliseconds after which a detected stale master node is being rechecked on startup.
-#stale_master_timeout = 2000
+# Time in milliseconds after which a detected stale parent node is being rechecked on startup.
+#stale_parent_timeout = 2000
 
 # Time in milliseconds which Graylog is waiting for all threads to stop on shutdown.
 #shutdown_timeout = 30000

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -43,8 +43,8 @@
 #
 
 # If you are running more than one instances of Graylog server you have to select one of these
-# instances as parent. The parent will perform some periodical tasks that non-parents won't perform.
-is_parent = true
+# instances as primary. The primary will perform some periodical tasks that non-primarys won't perform.
+is_primary = true
 
 # The auto-generated node ID will be stored in this file and read after restarts. It is a good idea
 # to use an absolute file path here if you are starting Graylog server from init scripts or similar.
@@ -520,8 +520,8 @@ lb_recognition_period_seconds = 3
 # Time in milliseconds to wait for all message outputs to finish writing a single message.
 #output_module_timeout = 10000
 
-# Time in milliseconds after which a detected stale parent node is being rechecked on startup.
-#stale_parent_timeout = 2000
+# Time in milliseconds after which a detected stale primary node is being rechecked on startup.
+#stale_primary_timeout = 2000
 
 # Time in milliseconds which Graylog is waiting for all threads to stop on shutdown.
 #shutdown_timeout = 30000


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
# HELP ME PLS!

Need some Java dev help on making sure we patch up `isMaster`, `isStaleMaster`, etc.
The existing server configs with `is_master` should continue to work, but output a deprecation notice. 

Also, need help verifying that no third-party tools (such as elastic search) were broken in this process

---

## Description
<!--- Describe your changes in detail -->
Updating node type references to Parent and Children

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Words Matter. Removing archaic references for less offensive ones.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

