### PR TITLE
Mark legacy aggregation API as deprecated.

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -4,6 +4,25 @@ Upgrading to Graylog 3.3.x
 
 .. _upgrade-from-32-to-33:
 
+Deprecating legacy Aggregation API endpoints
+============================================
+
+This release is marking several endpoints of the legacy (pre 3.2) aggregation API as being deprecated. They will be removed in 4.0. These include:
+
+- `/search/universal/(absolute|relative|keyword)/`
+    - `terms-histogram`
+    - `histogram`
+    - `fieldhistogram`
+    - `stats`
+    - `termsstats`
+    - `terms`
+- `/sources`
+
+These endpoints are not being used by the frontend anymore. In general, we try to replace very specific endpoints with more general, flexible ones.
+Deprecating and removing these endpoints frees development time for new things, which would otherwise need to be invested in maintaining legacy code.
+All of the functionality offered by these endpoints can be implemented by the `Views` API in a better way, please consult your local Swagger instance for details.
+
+
 API Access Token Encryption
 ===========================
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -293,6 +293,7 @@ public class Searches {
         return new SearchResult(hits, searchResult.getTotal(), indexRanges, config.query(), requestBuilder.toString(), tookMsFromSearchResult(searchResult));
     }
 
+    @Deprecated
     public AbstractAggregationBuilder createTermsBuilder(String field, List<String> stackedFields, int size, Terms.Order termsOrder) {
         if (stackedFields.isEmpty()) {
             // Wrap terms aggregation in a no-op filter to make sure the result structure is correct when not having
@@ -333,6 +334,7 @@ public class Searches {
                         .order(termsOrder));
     }
 
+    @Deprecated
     public TermsResult terms(String field, List<String> stackedFields, int size, String query, String filter, TimeRange range, Sorting.Direction sorting) {
         final Terms.Order termsOrder = sorting == Sorting.Direction.DESC ? Terms.Order.count(false) : Terms.Order.count(true);
 
@@ -370,18 +372,22 @@ public class Searches {
         );
     }
 
+    @Deprecated
     public TermsResult terms(String field, int size, String query, String filter, TimeRange range, Sorting.Direction sorting) {
         return terms(field, Collections.emptyList(), size, query, filter, range, sorting);
     }
 
+    @Deprecated
     public TermsResult terms(String field, int size, String query, String filter, TimeRange range) {
         return terms(field, size, query, filter, range, Sorting.Direction.DESC);
     }
 
+    @Deprecated
     public TermsResult terms(String field, int size, String query, TimeRange range) {
         return terms(field, size, query, null, range, Sorting.Direction.DESC);
     }
 
+    @Deprecated
     public TermsHistogramResult termsHistogram(String field,
                                                List<String> stackedFields,
                                                int size,
@@ -427,6 +433,7 @@ public class Searches {
                 ImmutableList.<String>builder().add(field).addAll(stackedFields).build());
     }
 
+    @Deprecated
     public TermsStatsResult termsStats(String keyField, String valueField, TermsStatsOrder order, int size, String query, String filter, TimeRange range) {
         if (size == 0) {
             size = 50;
@@ -515,6 +522,7 @@ public class Searches {
         );
     }
 
+    @Deprecated
     public TermsStatsResult termsStats(String keyField, String valueField, TermsStatsOrder order, int size, String query, TimeRange range) {
         return termsStats(keyField, valueField, order, size, query, null, range);
     }
@@ -596,10 +604,12 @@ public class Searches {
             .collect(Collectors.toSet());
     }
 
+    @Deprecated
     public HistogramResult histogram(String query, DateHistogramInterval interval, TimeRange range) {
         return histogram(query, interval, null, range);
     }
 
+    @Deprecated
     public HistogramResult histogram(String query, DateHistogramInterval interval, String filter, TimeRange range) {
         final DateHistogramAggregationBuilder histogramBuilder = AggregationBuilders.dateHistogram(AGG_HISTOGRAM)
                 .field(Message.FIELD_TIMESTAMP)
@@ -633,6 +643,7 @@ public class Searches {
         );
     }
 
+    @Deprecated
     public HistogramResult fieldHistogram(String query,
                                           String field,
                                           DateHistogramInterval interval,
@@ -642,6 +653,7 @@ public class Searches {
         return fieldHistogram(query, field, interval, filter, range, true, includeCardinality);
     }
 
+    @Deprecated
     public HistogramResult fieldHistogram(String query,
                                           String field,
                                           DateHistogramInterval interval,

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/AbsoluteSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/AbsoluteSearchResource.java
@@ -181,6 +181,7 @@ public class AbsoluteSearchResource extends SearchResource {
             .build();
     }
 
+    @Deprecated
     @GET
     @Path("/terms")
     @Timed
@@ -209,6 +210,7 @@ public class AbsoluteSearchResource extends SearchResource {
         return buildTermsResult(searches.terms(field, stackedFields, size, query, filter, buildAbsoluteTimeRange(from, to), sortOrder.getDirection()));
     }
 
+    @Deprecated
     @GET
     @Path("/terms-histogram")
     @Timed
@@ -241,6 +243,7 @@ public class AbsoluteSearchResource extends SearchResource {
         return buildTermsHistogramResult(searches.termsHistogram(field, stackedFields, size, query, filter, timeRange, SearchUtils.buildInterval(interval, timeRange), sortOrder.getDirection()));
     }
 
+    @Deprecated
     @GET
     @Path("/termsstats")
     @Timed
@@ -277,6 +280,7 @@ public class AbsoluteSearchResource extends SearchResource {
                 ));
     }
 
+    @Deprecated
     @GET
     @Path("/stats")
     @Timed
@@ -303,6 +307,7 @@ public class AbsoluteSearchResource extends SearchResource {
         return buildFieldStatsResult(fieldStats(field, query, filter, buildAbsoluteTimeRange(from, to)));
     }
 
+    @Deprecated
     @GET
     @Path("/histogram")
     @Timed
@@ -337,6 +342,7 @@ public class AbsoluteSearchResource extends SearchResource {
         );
     }
 
+    @Deprecated
     @GET
     @Path("/fieldhistogram")
     @Timed

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/KeywordSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/KeywordSearchResource.java
@@ -172,6 +172,7 @@ public class KeywordSearchResource extends SearchResource {
             .build();
     }
 
+    @Deprecated
     @GET
     @Path("/histogram")
     @Timed
@@ -204,6 +205,7 @@ public class KeywordSearchResource extends SearchResource {
         );
     }
 
+    @Deprecated
     @GET
     @Path("/terms")
     @Timed
@@ -230,6 +232,7 @@ public class KeywordSearchResource extends SearchResource {
         return buildTermsResult(searches.terms(field, stackedFields, size, query, filter, buildKeywordTimeRange(keyword), sortOrder.getDirection()));
     }
 
+    @Deprecated
     @GET
     @Path("/terms-histogram")
     @Timed
@@ -261,6 +264,7 @@ public class KeywordSearchResource extends SearchResource {
         return buildTermsHistogramResult(searches.termsHistogram(field, stackedFields, size, query, filter, timeRange, SearchUtils.buildInterval(interval, timeRange), sortOrder.getDirection()));
     }
 
+    @Deprecated
     @GET
     @Path("/termsstats")
     @Timed
@@ -289,6 +293,7 @@ public class KeywordSearchResource extends SearchResource {
         );
     }
 
+    @Deprecated
     @GET
     @Path("/stats")
     @Timed
@@ -313,6 +318,7 @@ public class KeywordSearchResource extends SearchResource {
         return buildFieldStatsResult(fieldStats(field, query, filter, buildKeywordTimeRange(keyword)));
     }
 
+    @Deprecated
     @GET
     @Path("/fieldhistogram")
     @Timed

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
@@ -177,6 +177,7 @@ public class RelativeSearchResource extends SearchResource {
             .build();
     }
 
+    @Deprecated
     @GET
     @Path("/terms")
     @Timed
@@ -203,6 +204,7 @@ public class RelativeSearchResource extends SearchResource {
         return buildTermsResult(searches.terms(field, stackedFields, size, query, filter, buildRelativeTimeRange(range), sortOrder.getDirection()));
     }
 
+    @Deprecated
     @GET
     @Path("/terms-histogram")
     @Timed
@@ -234,6 +236,7 @@ public class RelativeSearchResource extends SearchResource {
         return buildTermsHistogramResult(searches.termsHistogram(field, stackedFields, size, query, filter, timeRange, SearchUtils.buildInterval(interval, timeRange), sortOrder.getDirection()));
     }
 
+    @Deprecated
     @GET
     @Path("/termsstats")
     @Timed
@@ -262,6 +265,7 @@ public class RelativeSearchResource extends SearchResource {
         );
     }
 
+    @Deprecated
     @GET
     @Path("/stats")
     @Timed
@@ -286,6 +290,7 @@ public class RelativeSearchResource extends SearchResource {
         return buildFieldStatsResult(fieldStats(field, query, filter, buildRelativeTimeRange(range)));
     }
 
+    @Deprecated
     @GET
     @Path("/histogram")
     @Timed
@@ -318,6 +323,7 @@ public class RelativeSearchResource extends SearchResource {
         );
     }
 
+    @Deprecated
     @GET
     @Path("/fieldhistogram")
     @Timed

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/sources/SourcesResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/sources/SourcesResource.java
@@ -50,6 +50,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+@Deprecated
 @RequiresAuthentication
 @RequiresPermissions(RestPermissions.SOURCES_READ)
 @Api(value = "Sources", description = "Listing message sources (e.g. hosts sending logs)")
@@ -67,6 +68,7 @@ public class SourcesResource extends RestResource {
         this.searches = searches;
     }
 
+    @Deprecated
     @GET
     @Timed
     @ApiOperation(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In `3.2.0`, the Views API was introduced, offering extensive aggregation
capabilities. Since then, the previous aggregation API was not used by
the frontend anymore.

To free up time spent on maintaining another legacy API, those endpoints
are marked as deprecated and are removed in `4.0`, offering Graylog core
developers the chance to invest time on other parts of the product.

The deprecated endpoints include:

- `/search/universal/(absolute|relative|keyword)/`
    - `terms-histogram`
    - `histogram`
    - `fieldhistogram`
    - `stats`
    - `termsstats`
    - `terms`
- `/sources`

As well as the following methods from the `Searches` class:

- `fieldHistogram`
- `histogram`
- `terms`
- `termsHistogram`
- `termsStats`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.