### PR TITLE
Replacing usage of `ByteSizeValue` with own, stripped-down class.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/AbsoluteValueWatermarkSettings.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/AbsoluteValueWatermarkSettings.java
@@ -17,40 +17,39 @@
 package org.graylog2.indexer.cluster.health;
 
 import com.google.auto.value.AutoValue;
-import org.elasticsearch.common.unit.ByteSizeValue;
 import javax.annotation.Nullable;
 
 @AutoValue
-public abstract class AbsoluteValueWatermarkSettings implements WatermarkSettings<ByteSizeValue> {
+public abstract class AbsoluteValueWatermarkSettings implements WatermarkSettings<ByteSize> {
 
     public abstract SettingsType type();
 
-    public abstract ByteSizeValue low();
+    public abstract ByteSize low();
 
-    public abstract ByteSizeValue high();
+    public abstract ByteSize high();
 
     @Nullable
-    public abstract ByteSizeValue floodStage();
+    public abstract ByteSize floodStage();
 
     public static class Builder {
         private SettingsType type = SettingsType.ABSOLUTE;
-        private ByteSizeValue low;
-        private ByteSizeValue high;
-        private ByteSizeValue floodStage;
+        private ByteSize low;
+        private ByteSize high;
+        private ByteSize floodStage;
 
         public Builder(){}
 
-        public Builder low(ByteSizeValue low) {
+        public Builder low(ByteSize low) {
             this.low = low;
             return this;
         }
 
-        public Builder high(ByteSizeValue high) {
+        public Builder high(ByteSize high) {
             this.high = high;
             return this;
         }
 
-        public Builder floodStage(ByteSizeValue floodStage) {
+        public Builder floodStage(ByteSize floodStage) {
             this.floodStage = floodStage;
             return this;
         }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/ByteSize.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/ByteSize.java
@@ -1,0 +1,5 @@
+package org.graylog2.indexer.cluster.health;
+
+public interface ByteSize {
+    long getBytes();
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/ByteSize.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/ByteSize.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.indexer.cluster.health;
 
 public interface ByteSize {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/ClusterAllocationDiskSettingsFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/ClusterAllocationDiskSettingsFactory.java
@@ -16,8 +16,6 @@
  */
 package org.graylog2.indexer.cluster.health;
 
-import org.elasticsearch.common.unit.ByteSizeValue;
-
 import java.util.stream.Stream;
 
 public class ClusterAllocationDiskSettingsFactory {
@@ -34,10 +32,10 @@ public class ClusterAllocationDiskSettingsFactory {
         WatermarkSettings.SettingsType highType = getType(high);
         if (Stream.of(lowType, highType).allMatch(s -> s == WatermarkSettings.SettingsType.ABSOLUTE)) {
             AbsoluteValueWatermarkSettings.Builder builder = new AbsoluteValueWatermarkSettings.Builder()
-                .low(ByteSizeValue.parseBytesSizeValue(low, "lowWatermark"))
-                .high(ByteSizeValue.parseBytesSizeValue(high, "highWatermark"));
+                .low(SIUnitParser.parseBytesSizeValue(low))
+                .high(SIUnitParser.parseBytesSizeValue(high));
             if (!floodStage.isEmpty()) {
-                builder.floodStage(ByteSizeValue.parseBytesSizeValue(floodStage, "floodStageWatermark"));
+                builder.floodStage(SIUnitParser.parseBytesSizeValue(floodStage));
             }
             return builder.build();
         } else if (Stream.of(lowType, highType).allMatch(s -> s == WatermarkSettings.SettingsType.PERCENTAGE)) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/NodeDiskUsageStats.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/NodeDiskUsageStats.java
@@ -17,7 +17,6 @@
 package org.graylog2.indexer.cluster.health;
 
 import com.google.auto.value.AutoValue;
-import org.elasticsearch.common.unit.ByteSizeValue;
 
 import javax.annotation.Nullable;
 
@@ -32,18 +31,18 @@ public abstract class NodeDiskUsageStats {
     @Nullable
     public abstract String host();
 
-    public abstract ByteSizeValue diskTotal();
+    public abstract ByteSize diskTotal();
 
-    public abstract ByteSizeValue diskUsed();
+    public abstract ByteSize diskUsed();
 
-    public abstract ByteSizeValue diskAvailable();
+    public abstract ByteSize diskAvailable();
 
     public abstract Double diskUsedPercent();
 
     public static NodeDiskUsageStats create(String name, String ip, @Nullable String host, String diskUsedString, String diskTotalString, Double diskUsedPercent) {
-        ByteSizeValue diskTotal = ByteSizeValue.parseBytesSizeValue(diskTotalString, "diskTotal");
-        ByteSizeValue diskUsed = ByteSizeValue.parseBytesSizeValue(diskUsedString, "diskUsed");
-        ByteSizeValue diskAvailable = new ByteSizeValue(diskTotal.getBytes() - diskUsed.getBytes());
+        ByteSize diskTotal = SIUnitParser.parseBytesSizeValue(diskTotalString);
+        ByteSize diskUsed = SIUnitParser.parseBytesSizeValue(diskUsedString);
+        ByteSize diskAvailable = () -> diskTotal.getBytes() - diskUsed.getBytes();
         return new AutoValue_NodeDiskUsageStats(
                 name,
                 ip,

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/SIUnitParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/SIUnitParser.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.indexer.cluster.health;
 
 import java.util.Locale;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/SIUnitParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/cluster/health/SIUnitParser.java
@@ -1,0 +1,55 @@
+package org.graylog2.indexer.cluster.health;
+
+import java.util.Locale;
+
+public class SIUnitParser {
+    private static final long C0 = 1L;
+    private static final long C1 = C0 * 1024L;
+    private static final long C2 = C1 * 1024L;
+    private static final long C3 = C2 * 1024L;
+    private static final long C4 = C3 * 1024L;
+    private static final long C5 = C4 * 1024L;
+
+    private static Long toLong(String value) {
+        final String lowerSValue = value.toLowerCase(Locale.ROOT).trim();
+        if (lowerSValue.endsWith("k")) {
+            return (long) (Double.parseDouble(lowerSValue.substring(0, lowerSValue.length() - 1)) * C1);
+        } else if (lowerSValue.endsWith("kb")) {
+            return (long) (Double.parseDouble(lowerSValue.substring(0, lowerSValue.length() - 2)) * C1);
+        } else if (lowerSValue.endsWith("m")) {
+            return (long) (Double.parseDouble(lowerSValue.substring(0, lowerSValue.length() - 1)) * C2);
+        } else if (lowerSValue.endsWith("mb")) {
+            return (long) (Double.parseDouble(lowerSValue.substring(0, lowerSValue.length() - 2)) * C2);
+        } else if (lowerSValue.endsWith("g")) {
+            return (long) (Double.parseDouble(lowerSValue.substring(0, lowerSValue.length() - 1)) * C3);
+        } else if (lowerSValue.endsWith("gb")) {
+            return (long) (Double.parseDouble(lowerSValue.substring(0, lowerSValue.length() - 2)) * C3);
+        } else if (lowerSValue.endsWith("t")) {
+            return (long) (Double.parseDouble(lowerSValue.substring(0, lowerSValue.length() - 1)) * C4);
+        } else if (lowerSValue.endsWith("tb")) {
+            return (long) (Double.parseDouble(lowerSValue.substring(0, lowerSValue.length() - 2)) * C4);
+        } else if (lowerSValue.endsWith("p")) {
+            return (long) (Double.parseDouble(lowerSValue.substring(0, lowerSValue.length() - 1)) * C5);
+        } else if (lowerSValue.endsWith("pb")) {
+            return (long) (Double.parseDouble(lowerSValue.substring(0, lowerSValue.length() - 2)) * C5);
+        } else if (lowerSValue.endsWith("b")) {
+            return Long.parseLong(lowerSValue.substring(0, lowerSValue.length() - 1).trim());
+        } else if (lowerSValue.equals("-1")) {
+            // Allow this special value to be unit-less:
+            return -1L;
+        } else if (lowerSValue.equals("0")) {
+            // Allow this special value to be unit-less:
+            return 0L;
+        }
+
+        return null;
+    }
+
+    public static ByteSize parseBytesSizeValue(String value) {
+        final Long longValue = toLong(value);
+        if (longValue == null) {
+            return null;
+        }
+        return () -> longValue;
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/cluster/health/ClusterAllocationDiskSettingsFactoryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/cluster/health/ClusterAllocationDiskSettingsFactoryTest.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.indexer.cluster.health;
 
-import org.elasticsearch.common.unit.ByteSizeValue;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,11 +59,11 @@ public class ClusterAllocationDiskSettingsFactoryTest {
         AbsoluteValueWatermarkSettings settings = (AbsoluteValueWatermarkSettings) clusterAllocationDiskSettings.watermarkSettings();
 
         assertThat(settings.type()).isEqualTo(WatermarkSettings.SettingsType.ABSOLUTE);
-        assertThat(settings.low()).isInstanceOf(ByteSizeValue.class);
+        assertThat(settings.low()).isInstanceOf(ByteSize.class);
         assertThat(settings.low().getBytes()).isEqualTo(21474836480L);
-        assertThat(settings.high()).isInstanceOf(ByteSizeValue.class);
+        assertThat(settings.high()).isInstanceOf(ByteSize.class);
         assertThat(settings.high().getBytes()).isEqualTo(10737418240L);
-        assertThat(settings.floodStage()).isInstanceOf(ByteSizeValue.class);
+        assertThat(settings.floodStage()).isInstanceOf(ByteSize.class);
         assertThat(settings.floodStage().getBytes()).isEqualTo(5368709120L);
     }
 
@@ -79,9 +78,9 @@ public class ClusterAllocationDiskSettingsFactoryTest {
         AbsoluteValueWatermarkSettings settings = (AbsoluteValueWatermarkSettings) clusterAllocationDiskSettings.watermarkSettings();
 
         assertThat(settings.type()).isEqualTo(WatermarkSettings.SettingsType.ABSOLUTE);
-        assertThat(settings.low()).isInstanceOf(ByteSizeValue.class);
+        assertThat(settings.low()).isInstanceOf(ByteSize.class);
         assertThat(settings.low().getBytes()).isEqualTo(10737418240L);
-        assertThat(settings.high()).isInstanceOf(ByteSizeValue.class);
+        assertThat(settings.high()).isInstanceOf(ByteSize.class);
         assertThat(settings.high().getBytes()).isEqualTo(5368709120L);
         assertThat(settings.floodStage()).isNull();
     }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/cluster/health/SIUnitParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/cluster/health/SIUnitParserTest.java
@@ -1,0 +1,39 @@
+package org.graylog2.indexer.cluster.health;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SIUnitParserTest {
+    @DisplayName("Should parse SI Units properly and convert to bytes count")
+    @ParameterizedTest(name = "should parse {0} as {1} bytes")
+    @MethodSource("argumentsProvider")
+    void parsesStrings(String siUnitValue, Long expected) {
+        final ByteSize result = SIUnitParser.parseBytesSizeValue(siUnitValue);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getBytes()).isEqualTo(expected);
+    }
+
+    private static Stream<Arguments> argumentsProvider() {
+        return Stream.of(
+                Arguments.of("0", 0L),
+                Arguments.of("-1", -1L),
+                Arguments.of("0b", 0L),
+                Arguments.of("640b", 640L),
+                Arguments.of("640k", 655360L),
+                Arguments.of("640kb", 655360L),
+                Arguments.of("12m", 12582912L),
+                Arguments.of("2g", 2147483648L),
+                Arguments.of("2G", 2147483648L),
+                Arguments.of("2Gb", 2147483648L),
+                Arguments.of("24t", 26388279066624L),
+                Arguments.of("42p", 47287796087390208L)
+        );
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/cluster/health/SIUnitParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/cluster/health/SIUnitParserTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.indexer.cluster.health;
 
 import org.junit.jupiter.api.DisplayName;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/cluster/health/SIUnitParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/cluster/health/SIUnitParserTest.java
@@ -1,6 +1,7 @@
 package org.graylog2.indexer.cluster.health;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -10,6 +11,11 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class SIUnitParserTest {
+    @Test
+    void returnsNullForUnparseableValue() {
+        assertThat(SIUnitParser.parseBytesSizeValue("This is not a value")).isNull();
+    }
+
     @DisplayName("Should parse SI Units properly and convert to bytes count")
     @ParameterizedTest(name = "should parse {0} as {1} bytes")
     @MethodSource("argumentsProvider")

--- a/graylog2-server/src/test/java/org/graylog2/periodical/IndexerClusterCheckerThreadTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/periodical/IndexerClusterCheckerThreadTest.java
@@ -16,10 +16,14 @@
  */
 package org.graylog2.periodical;
 
-import org.elasticsearch.common.unit.ByteSizeUnit;
-import org.elasticsearch.common.unit.ByteSizeValue;
 import org.graylog2.indexer.cluster.Cluster;
-import org.graylog2.indexer.cluster.health.*;
+import org.graylog2.indexer.cluster.health.AbsoluteValueWatermarkSettings;
+import org.graylog2.indexer.cluster.health.ByteSize;
+import org.graylog2.indexer.cluster.health.ClusterAllocationDiskSettings;
+import org.graylog2.indexer.cluster.health.NodeDiskUsageStats;
+import org.graylog2.indexer.cluster.health.PercentageWatermarkSettings;
+import org.graylog2.indexer.cluster.health.SIUnitParser;
+import org.graylog2.indexer.cluster.health.WatermarkSettings;
 import org.graylog2.notifications.Notification;
 import org.graylog2.notifications.NotificationImpl;
 import org.graylog2.notifications.NotificationService;
@@ -171,9 +175,9 @@ public class IndexerClusterCheckerThreadTest {
         NodeDiskUsageStats nodeDiskUsageStats = mock(NodeDiskUsageStats.class);
 
         when(nodeDiskUsageStats.ip()).thenReturn("0.0.0.0");
-        when(nodeDiskUsageStats.diskTotal()).thenReturn(new ByteSizeValue(100L, ByteSizeUnit.GB));
-        when(nodeDiskUsageStats.diskUsed()).thenReturn(new ByteSizeValue(70L, ByteSizeUnit.GB));
-        when(nodeDiskUsageStats.diskAvailable()).thenReturn(new ByteSizeValue(30L, ByteSizeUnit.GB));
+        when(nodeDiskUsageStats.diskTotal()).thenReturn(SIUnitParser.parseBytesSizeValue("100GB"));
+        when(nodeDiskUsageStats.diskUsed()).thenReturn(SIUnitParser.parseBytesSizeValue("70GB"));
+        when(nodeDiskUsageStats.diskAvailable()).thenReturn(SIUnitParser.parseBytesSizeValue("30GB"));
         when(nodeDiskUsageStats.diskUsedPercent()).thenReturn(70D);
 
         nodesDiskUsageStats.add(nodeDiskUsageStats);
@@ -183,9 +187,9 @@ public class IndexerClusterCheckerThreadTest {
     private ClusterAllocationDiskSettings buildThresholdNotTriggeredClusterAllocationDiskSettings(WatermarkSettings.SettingsType type) {
         if (type == WatermarkSettings.SettingsType.ABSOLUTE) {
             AbsoluteValueWatermarkSettings absoluteValueWatermarkSettings = new AbsoluteValueWatermarkSettings.Builder()
-                    .low(new ByteSizeValue(15, ByteSizeUnit.GB))
-                    .high(new ByteSizeValue(10, ByteSizeUnit.GB))
-                    .floodStage(new ByteSizeValue(5, ByteSizeUnit.GB))
+                    .low(SIUnitParser.parseBytesSizeValue("15GB"))
+                    .high(SIUnitParser.parseBytesSizeValue("10GB"))
+                    .floodStage(SIUnitParser.parseBytesSizeValue("5GB"))
                     .build();
             return ClusterAllocationDiskSettings.create(true, absoluteValueWatermarkSettings);
         } else {
@@ -207,21 +211,21 @@ public class IndexerClusterCheckerThreadTest {
     }
 
     private ClusterAllocationDiskSettings buildThresholdTriggeredClusterAllocationDiskSettingsAbsolute(Notification.Type expectedNotificationType) {
-        ByteSizeValue low;
-        ByteSizeValue high;
-        ByteSizeValue floodStage;
+        ByteSize low;
+        ByteSize high;
+        ByteSize floodStage;
         if (expectedNotificationType == Notification.Type.ES_NODE_DISK_WATERMARK_LOW) {
-            low = new ByteSizeValue(35, ByteSizeUnit.GB);
-            high = new ByteSizeValue(10, ByteSizeUnit.GB);
-            floodStage = new ByteSizeValue(5, ByteSizeUnit.GB);
+            low = SIUnitParser.parseBytesSizeValue("35GB");
+            high = SIUnitParser.parseBytesSizeValue("10GB");
+            floodStage = SIUnitParser.parseBytesSizeValue("5GB");
         } else if (expectedNotificationType == Notification.Type.ES_NODE_DISK_WATERMARK_HIGH) {
-            low = new ByteSizeValue(45, ByteSizeUnit.GB);
-            high = new ByteSizeValue(35, ByteSizeUnit.GB);
-            floodStage = new ByteSizeValue(5, ByteSizeUnit.GB);
+            low = SIUnitParser.parseBytesSizeValue("45GB");
+            high = SIUnitParser.parseBytesSizeValue("35GB");
+            floodStage = SIUnitParser.parseBytesSizeValue("5GB");
         } else {
-            low = new ByteSizeValue(55, ByteSizeUnit.GB);
-            high = new ByteSizeValue(45, ByteSizeUnit.GB);
-            floodStage = new ByteSizeValue(35, ByteSizeUnit.GB);
+            low = SIUnitParser.parseBytesSizeValue("55GB");
+            high = SIUnitParser.parseBytesSizeValue("45GB");
+            floodStage = SIUnitParser.parseBytesSizeValue("35GB");
         }
         return ClusterAllocationDiskSettings.create(true, new AbsoluteValueWatermarkSettings.Builder()
                 .low(low)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In order to avoid dependencies to specific ES libraries in core, this PR
is replacing the usage of the `ByteSizeValue` class with an own
interface and a stripped down parser (`SIUnitParser`). The class itself
is used only to convert SI units from strings to longs (using the
`getBytes` method) and does not use/provide any ES-specific
functionality.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.