### PR TITLE
Merge Graylog Schema changes from 4.0 back to 3.3

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/schema/AlertFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/AlertFields.java
@@ -1,0 +1,29 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.schema;
+
+public class AlertFields {
+    public static final String ALERT_CATEGORY = "alert_category";
+    public static final String ALERT_DEFINITIONS_VERSION = "alert_definitions_version";
+    public static final String ALERT_INDICATOR = "alert_indicator";
+    public static final String ALERT_SIGNATURE = "alert_signature";
+    public static final String ALERT_SIGNATURE_ID = "alert_signature_id";
+
+    // Derived and Enriched Fields
+    public static final String ALERT_SEVERITY = "alert_severity";
+    public static final String ALERT_SEVERITY_LEVEL = "alert_severity_level";
+}

--- a/graylog2-server/src/main/java/org/graylog/schema/ApplicationFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/ApplicationFields.java
@@ -1,0 +1,23 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.schema;
+
+public class ApplicationFields {
+    public static final String APPLICATION_NAME = "application_name";
+    public static final String APPLICATION_SSO_SIGNONMODE = "application_sso_signonmode";
+    public static final String APPLICATION_SSO_TARGET_NAME = "application_sso_target_name";
+}

--- a/graylog2-server/src/main/java/org/graylog/schema/AssociatedFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/AssociatedFields.java
@@ -1,0 +1,28 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.schema;
+
+public class AssociatedFields {
+    public static final String ASSOCIATED_CATEGORY = "associated_category";
+    public static final String ASSOCIATED_HASH = "associated_hash";
+    public static final String ASSOCIATED_HOST = "associated_host";
+    public static final String ASSOCIATED_IP = "associated_ip";
+    public static final String ASSOCIATED_MAC = "associated_mac";
+    public static final String ASSOCIATED_USER_ID = "associated_user_id";
+    public static final String ASSOCIATED_USER_NAME = "associated_user_name";
+    public static final String ASSOCIATED_USER_REFERENCE = "associated_user_reference";
+}

--- a/graylog2-server/src/main/java/org/graylog/schema/AutonomousSystemFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/AutonomousSystemFields.java
@@ -1,0 +1,24 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.schema;
+
+public class AutonomousSystemFields {
+    public static final String AS_DOMAIN = "as_domain";
+    public static final String AS_ISP = "as_isp";
+    public static final String AS_NUMBER = "as_number";
+    public static final String AS_ORGANIZATION_NAME = "as_organization_name";
+}

--- a/graylog2-server/src/main/java/org/graylog/schema/DestinationFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/DestinationFields.java
@@ -1,0 +1,53 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.schema;
+
+public class DestinationFields {
+    private static final String DESTINATION_PREFIX = "destination_";
+
+    public static final String DESTINATION_APPLICATION_NAME = "destination_application_name";
+    public static final String DESTINATION_BYTES = "destination_bytes";
+    public static final String DESTINATION_HOSTNAME = "destination_hostname";
+    public static final String DESTINATION_IP = "destination_ip";
+    public static final String DESTINATION_NAT_IP = "destination_nat_ip";
+    public static final String DESTINATION_NAT_PORT = "destination_nat_port";
+    public static final String DESTINATION_PACKETS = "destination_packets";
+    public static final String DESTINATION_PORT = "destination_port";
+    public static final String DESTINATION_VSYS_UUID = "destination_vsys_uuid";
+    public static final String DESTINATION_ZONE = "destination_zone";
+
+    // Derived and Enriched Fields
+    public static final String DESTINATION_CATEGORY = "destination_category";
+    public static final String DESTINATION_LOCATION_NAME = "destination_location_name";
+    public static final String DESTINATION_MAC = "destination_mac";
+    public static final String DESTINATION_PRIORITY = "destination_priority";
+    public static final String DESTINATION_PRIORITY_LEVEL = "destination_priority_level";
+    public static final String DESTINATION_REFERENCE = "destination_reference";
+
+    // Autonomous System Fields
+    public static final String DESTINATION_AS_DOMAIN = DESTINATION_PREFIX + AutonomousSystemFields.AS_DOMAIN;
+    public static final String DESTINATION_AS_ISP = DESTINATION_PREFIX + AutonomousSystemFields.AS_ISP;
+    public static final String DESTINATION_AS_NUMBER = DESTINATION_PREFIX + AutonomousSystemFields.AS_NUMBER;
+    public static final String DESTINATION_AS_ORGANIZATION_NAME = DESTINATION_PREFIX + AutonomousSystemFields.AS_ORGANIZATION_NAME;
+
+    // Geo Fields
+    public static final String DESTINATION_GEO_CITY_NAME = DESTINATION_PREFIX + GeoFields.GEO_CITY_NAME;
+    public static final String DESTINATION_GEO_STATE_NAME = DESTINATION_PREFIX + GeoFields.GEO_STATE_NAME;
+    public static final String DESTINATION_GEO_ISO_CODE = DESTINATION_PREFIX + GeoFields.GEO_ISO_CODE;
+    public static final String DESTINATION_GEO_COUNTRY_NAME = DESTINATION_PREFIX + GeoFields.GEO_COUNTRY_NAME;
+    public static final String DESTINATION_GEO_COORDINATES = DESTINATION_PREFIX + GeoFields.GEO_COORDINATES;
+}

--- a/graylog2-server/src/main/java/org/graylog/schema/EmailFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/EmailFields.java
@@ -1,0 +1,22 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.schema;
+
+public class EmailFields {
+    public static final String EMAIL_MESSAGE_ID = "email_message_id";
+    public static final String EMAIL_SUBJECT = "email_subject";
+}

--- a/graylog2-server/src/main/java/org/graylog/schema/EventFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/EventFields.java
@@ -1,0 +1,45 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.schema;
+
+public class EventFields {
+    public static final String EVENT_CODE = "event_code";
+    public static final String EVENT_CREATED = "event_created";
+    public static final String EVENT_DURATION = "event_duration";
+    public static final String EVENT_ERROR_CODE = "event_error_code";
+    public static final String EVENT_ERROR_DESCRIPTION = "event_error_description";
+    public static final String EVENT_LOG_NAME = "event_log_name";
+    public static final String EVENT_OBSERVER = "event_observer";
+    public static final String EVENT_OBSERVER_HOSTNAME = "event_observer_hostname";
+    public static final String EVENT_OBSERVER_IP = "event_observer_ip";
+    public static final String EVENT_OBSERVER_UID = "event_observer_uid";
+    public static final String EVENT_RECEIVED_TIME = "event_received_time";
+    public static final String EVENT_REPEAT_COUNT = "event_repeat_count";
+    public static final String EVENT_REPORTER = "event_reporter";
+    public static final String EVENT_SOURCE = "event_source";
+    public static final String EVENT_SOURCE_API_VERSION = "event_source_api_version";
+    public static final String EVENT_SOURCE_PRODUCT = "event_source_product";
+    public static final String EVENT_START = "event_start";
+    public static final String EVENT_UID = "event_uid";
+
+    // Derived and Enriched Fields
+    public static final String EVENT_ACTION = "event_action";
+    public static final String EVENT_ACTION_TYPE = "event_action_type";
+    public static final String EVENT_OUTCOME = "event_outcome";
+    public static final String EVENT_SEVERITY = "event_severity";
+    public static final String EVENT_SEVERITY_LEVEL = "event_severity_level";
+}

--- a/graylog2-server/src/main/java/org/graylog/schema/FileFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/FileFields.java
@@ -1,0 +1,26 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.schema;
+
+public class FileFields {
+    public static final String FILE_COMPANY = "file_company";
+    public static final String FILE_COMPILE_TIME = "file_compile_time";
+    public static final String FILE_NAME = "file_name";
+    public static final String FILE_PATH = "file_path";
+    public static final String FILE_SIZE = "file_size";
+    public static final String FILE_TYPE = "file_type";
+}

--- a/graylog2-server/src/main/java/org/graylog/schema/GeoFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/GeoFields.java
@@ -1,0 +1,25 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.schema;
+
+public class GeoFields {
+    public static final String GEO_CITY_NAME = "geo_city_name";
+    public static final String GEO_STATE_NAME = "geo_state_name";
+    public static final String GEO_ISO_CODE = "geo_iso_code";
+    public static final String GEO_COUNTRY_NAME = "geo_country_name";
+    public static final String GEO_COORDINATES = "geo_coordinates";
+}

--- a/graylog2-server/src/main/java/org/graylog/schema/GraylogSchemaFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/GraylogSchemaFields.java
@@ -18,10 +18,10 @@ package org.graylog.schema;
 
 /**
  * Field names used in the standard Graylog Schema.
+ *
+ * @deprecated Please use the appropriate enums in this package rather than this collection of strings
  */
-
-
-
+@Deprecated
 public class GraylogSchemaFields {
 
     public static final String FIELD_USER_ID = "user_id";
@@ -50,20 +50,19 @@ public class GraylogSchemaFields {
     public static final String FIELD_EVENT_UID = "event_uid";
     public static final String FIELD_EVENT_SOURCE_PRODUCT = "event_source_product";
 
-    public static final String FIELD_APPLICATION_SSO_SIGNONMODE  = "application_sso_signonmode";
+    public static final String FIELD_APPLICATION_SSO_SIGNONMODE = "application_sso_signonmode";
     public static final String FIELD_APPLICATION_SSO_TARGET_NAME = "application_sso_target_name";
 
     public static final String FIELD_VENDOR_EVENT_ACTION = "vendor_event_action";
     public static final String FIELD_VENDOR_EVENT_DESCRIPTION = "vendor_event_description";
     public static final String FIELD_VENDOR_EVENT_SEVERITY = "vendor_event_severity";
-    public static final String FIELD_VENDOR_EVENT_OUTCOME  = "vendor_event_outcome";
+    public static final String FIELD_VENDOR_EVENT_OUTCOME = "vendor_event_outcome";
     public static final String FIELD_VENDOR_EVENT_OUTCOME_REASON = "vendor_event_outcome_reason";
     public static final String FIELD_VENDOR_SEVERITY_DESCRIPTION = "vendor_severity_description";
     public static final String FIELD_VENDOR_THREAT_SUSPECTED = "vendor_threat_suspected";
     public static final String FIELD_VENDOR_TRANSACTION_TYPE = "vendor_transaction_type";
-    public static final String FIELD_VENDOR_TRANSACTION_ID   = "vendor_transaction_id";
-    public static final String FIELD_VENDOR_USER_TYPE        = "vendor_user_type";
-
+    public static final String FIELD_VENDOR_TRANSACTION_ID = "vendor_transaction_id";
+    public static final String FIELD_VENDOR_USER_TYPE = "vendor_user_type";
 
 
 }

--- a/graylog2-server/src/main/java/org/graylog/schema/HostFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/HostFields.java
@@ -1,0 +1,51 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.schema;
+
+public class HostFields {
+    private static final String HOST_PREFIX = "host_";
+
+    public static final String HOST_HOSTNAME = "host_hostname";
+    public static final String HOST_ID = "host_id";
+    public static final String HOST_IP = "host_ip";
+    public static final String HOST_REFERENCE = "host_reference";
+    public static final String HOST_VIRTFW_HOSTNAME = "host_virtfw_hostname";
+    public static final String HOST_VIRTFW_ID = "host_virtfw_id";
+    public static final String HOST_VIRTFW_UID = "host_virtfw_uid";
+
+    // Derived and Enriched Fields
+    public static final String HOST_CATEGORY = "host_category";
+    public static final String HOST_LOCATION_NAME = "host_location_name";
+    public static final String HOST_MAC = "host_mac";
+    public static final String HOST_PRIORITY = "host_priority";
+    public static final String HOST_PRIORITY_LEVEL = "host_priority_level";
+    public static final String HOST_TYPE = "host_type";
+    public static final String HOST_TYPE_VERSION = "host_type_version";
+
+    // Autonomous System Fields
+    public static final String HOST_AS_DOMAIN = HOST_PREFIX + AutonomousSystemFields.AS_DOMAIN;
+    public static final String HOST_AS_ISP = HOST_PREFIX + AutonomousSystemFields.AS_ISP;
+    public static final String HOST_AS_NUMBER = HOST_PREFIX + AutonomousSystemFields.AS_NUMBER;
+    public static final String HOST_AS_ORGANIZATION_NAME = HOST_PREFIX + AutonomousSystemFields.AS_ORGANIZATION_NAME;
+
+    // Geo Fields
+    public static final String HOST_GEO_CITY_NAME = HOST_PREFIX + GeoFields.GEO_CITY_NAME;
+    public static final String HOST_GEO_STATE_NAME = HOST_PREFIX + GeoFields.GEO_STATE_NAME;
+    public static final String HOST_GEO_ISO_CODE = HOST_PREFIX + GeoFields.GEO_ISO_CODE;
+    public static final String HOST_GEO_COUNTRY_NAME = HOST_PREFIX + GeoFields.GEO_COUNTRY_NAME;
+    public static final String HOST_GEO_COORDINATES = HOST_PREFIX + GeoFields.GEO_COORDINATES;
+}

--- a/graylog2-server/src/main/java/org/graylog/schema/HttpFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/HttpFields.java
@@ -1,0 +1,45 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.schema;
+
+public class HttpFields {
+    public static final String HTTP_APPLICATION = "http_application";
+    public static final String HTTP_BYTES = "http_bytes";
+    public static final String HTTP_CONTENT_TYPE = "http_content_type";
+    public static final String HTTP_HEADERS = "http_headers";
+    public static final String HTTP_HOST = "http_host";
+    public static final String HTTP_METHOD = "http_method";
+    public static final String HTTP_REFERER = "http_referrer";
+    public static final String HTTP_REQUEST_BYTES = "http_request_bytes";
+    public static final String HTTP_REQUEST_METHOD = "http_request_method";
+    public static final String HTTP_RESPONSE = "http_response";
+    public static final String HTTP_RESPONSE_BYTES = "http_response_bytes";
+    public static final String HTTP_RESPONSE_CODE = "http_response_code";
+    public static final String HTTP_URL = "http_url";
+    public static final String HTTP_URL_CATEGORY = "http_url_category";
+    public static final String HTTP_USER_AGENT = "http_user_agent";
+    public static final String HTTP_USER_AGENT_NAME = "http_user_agent_name";
+    public static final String HTTP_USER_AGENT_OS = "http_user_agent_os";
+    public static final String HTTP_VERSION = "http_version";
+    public static final String HTTP_XFF = "http_version";
+
+    // Derived and Enriched Fields
+    public static final String HTTP_URL_ANALYZED = "http_url_analyzed";
+    public static final String HTTP_URL_LENGTH = "http_url_length";
+    public static final String HTTP_USER_AGENT_ANALYZED = "http_user_agent_analyzed";
+    public static final String HTTP_USER_AGENT_LENGTH = "http_user_agent_length";
+}

--- a/graylog2-server/src/main/java/org/graylog/schema/NetworkFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/NetworkFields.java
@@ -1,0 +1,38 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.schema;
+
+public class NetworkFields {
+    public static final String NETWORK_APPLICATION = "network_application";
+    public static final String NETWORK_BYTES = "network_bytes";
+    public static final String NETWORK_BYTES_RX = "network_bytes_rx";
+    public static final String NETWORK_BYTES_TX = "network_bytes_tx";
+    public static final String NETWORK_COMMUNITY_ID = "network_community_id";
+    public static final String NETWORK_DIRECTION = "network_direction";
+    public static final String NETWORK_FORWARDED_IP = "network_forwarded_ip";
+    public static final String NETWORK_IANA_NUMBER = "network_iana_number";
+    public static final String NETWORK_INNER = "network_inner";
+    public static final String NETWORK_INTERFACE_IN = "network_interface_in";
+    public static final String NETWORK_INTERFACE_OUT = "network_interface_out";
+    public static final String NETWORK_NAME = "network_name";
+    public static final String NETWORK_PACKETS = "network_packets";
+    public static final String NETWORK_PROTOCOL = "network_protocol";
+    public static final String NETWORK_TRANSPORT = "network_transport";
+    public static final String NETWORK_TUNNEL_DURATION = "network_tunnel_duration";
+    public static final String NETWORK_TUNNEL_TYPE = "network_tunnel_type";
+    public static final String NETWORK_TYPE = "network_type";
+}

--- a/graylog2-server/src/main/java/org/graylog/schema/ProcessFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/ProcessFields.java
@@ -1,0 +1,26 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.schema;
+
+public class ProcessFields {
+    public static final String PROCESS_COMMAND_LINE = "process_command_line";
+    public static final String PROCESS_ID = "process_id";
+    public static final String PROCESS_INTEGRITY_LEVEL = "process_integrity_level";
+    public static final String PROCESS_NAME = "process_name";
+    public static final String PROCESS_PATH = "process_path";
+    public static final String PROCESS_UID = "process_uid";
+}

--- a/graylog2-server/src/main/java/org/graylog/schema/ServiceFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/ServiceFields.java
@@ -1,0 +1,22 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.schema;
+
+public class ServiceFields {
+    public static final String SERVICE_NAME = "service_name";
+    public static final String SERVICE_VERSION = "service_version";
+}

--- a/graylog2-server/src/main/java/org/graylog/schema/SessionFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/SessionFields.java
@@ -1,0 +1,21 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.schema;
+
+public class SessionFields {
+    public static final String SESSION_ID = "session_id";
+}

--- a/graylog2-server/src/main/java/org/graylog/schema/SourceFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/SourceFields.java
@@ -1,0 +1,55 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.schema;
+
+public class SourceFields {
+    private static final String SOURCE_PREFIX = "source_";
+
+    public static final String SOURCE_BYTES = "source_bytes";
+    public static final String SOURCE_HOSTNAME = "source_hostname";
+    public static final String SOURCE_IP = "source_ip";
+    public static final String SOURCE_IPV6 = "source_ipv6";
+    public static final String SOURCE_NAT_IP = "source_nat_ip";
+    public static final String SOURCE_NAT_PORT = "source_nat_port";
+    public static final String SOURCE_PACKETS = "source_packets";
+    public static final String SOURCE_PORT = "source_port";
+    public static final String SOURCE_USER = "source_user";
+    public static final String SOURCE_USER_EMAIL = "source_user_email";
+    public static final String SOURCE_VSYS_UUID = "source_vsys_uuid";
+    public static final String SOURCE_ZONE = "source_zone";
+
+    // Derived and Enriched Fields
+    public static final String SOURCE_CATEGORY = "source_category";
+    public static final String SOURCE_LOCATION_NAME = "source_location_name";
+    public static final String SOURCE_MAC = "source_mac";
+    public static final String SOURCE_PRIORITY = "source_priority";
+    public static final String SOURCE_PRIORITY_LEVEL = "source_priority_level";
+    public static final String SOURCE_REFERENCE = "source_reference";
+
+    // Autonomous System Fields
+    public static final String SOURCE_AS_DOMAIN = SOURCE_PREFIX + AutonomousSystemFields.AS_DOMAIN;
+    public static final String SOURCE_AS_ISP = SOURCE_PREFIX + AutonomousSystemFields.AS_ISP;
+    public static final String SOURCE_AS_NUMBER = SOURCE_PREFIX + AutonomousSystemFields.AS_NUMBER;
+    public static final String SOURCE_AS_ORGANIZATION_NAME = SOURCE_PREFIX + AutonomousSystemFields.AS_ORGANIZATION_NAME;
+
+    // Geo Fields
+    public static final String SOURCE_GEO_CITY_NAME = SOURCE_PREFIX + GeoFields.GEO_CITY_NAME;
+    public static final String SOURCE_GEO_STATE_NAME = SOURCE_PREFIX + GeoFields.GEO_STATE_NAME;
+    public static final String SOURCE_GEO_ISO_CODE = SOURCE_PREFIX + GeoFields.GEO_ISO_CODE;
+    public static final String SOURCE_GEO_COUNTRY_NAME = SOURCE_PREFIX + GeoFields.GEO_COUNTRY_NAME;
+    public static final String SOURCE_GEO_COORDINATES = SOURCE_PREFIX + GeoFields.GEO_COORDINATES;
+}

--- a/graylog2-server/src/main/java/org/graylog/schema/ThreatFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/ThreatFields.java
@@ -1,0 +1,22 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.schema;
+
+public class ThreatFields {
+    public static final String THREAT_CATEGORY = "threat_category";
+    public static final String THREAT_DETECTED = "threat_detected";
+}

--- a/graylog2-server/src/main/java/org/graylog/schema/TraceFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/TraceFields.java
@@ -1,0 +1,21 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.schema;
+
+public class TraceFields {
+    public static final String TRACE_ID = "trace_id";
+}

--- a/graylog2-server/src/main/java/org/graylog/schema/UserFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/UserFields.java
@@ -1,0 +1,40 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.schema;
+
+public class UserFields {
+    public static final String USER_COMMAND = "user_command";
+    public static final String USER_COMMAND_PATH = "user_command_path";
+    public static final String USER_DOMAIN = "user_domain";
+    public static final String USER_EMAIL = "user_email";
+    public static final String USER_ID = "user_id";
+    public static final String USER_NAME = "user_name";
+
+    // Derived and Enriched Fields
+    public static final String USER_CATEGORY = "user_category";
+    public static final String USER_PRIORITY = "user_priority";
+    public static final String USER_PRIORITY_LEVEL = "user_priority_level";
+    public static final String USER_TYPE = "user_type";
+
+    // Target User Fields
+    private static final String TARGET_PREFIX = "target_";
+
+    public static final String TARGET_USER = "target_user";
+    public static final String TARGET_USER_EMAIL = TARGET_PREFIX + USER_EMAIL;
+    public static final String TARGET_USER_ID = TARGET_PREFIX + USER_ID;
+    public static final String TARGET_USER_NAME = TARGET_PREFIX + USER_NAME;
+}

--- a/graylog2-server/src/main/java/org/graylog/schema/VendorFields.java
+++ b/graylog2-server/src/main/java/org/graylog/schema/VendorFields.java
@@ -1,0 +1,36 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.schema;
+
+public class VendorFields {
+    public static final String VENDOR_ALERT_SEVERITY = "vendor_alert_severity";
+    public static final String VENDOR_EVENT_ACTION = "vendor_event_action";
+    public static final String VENDOR_EVENT_DESCRIPTION = "vendor_event_description";
+    public static final String VENDOR_EVENT_OUTCOME = "vendor_event_outcome";
+    public static final String VENDOR_EVENT_OUTCOME_REASON = "vendor_event_outcome_reason";
+    public static final String VENDOR_EVENT_SECURITY_LEVEL = "vendor_event_severity_level";
+    public static final String VENDOR_EVENT_SEVERITY = "vendor_event_severity";
+    public static final String VENDOR_PRIVATE_IP = "vendor_private_ip";
+    public static final String VENDOR_PRIVATE_IPV6 = "vendor_private_ipv6";
+    public static final String VENDOR_PUBLIC_IP = "vendor_public_ip";
+    public static final String VENDOR_PUBLIC_IPV6 = "vendor_public_ipv6";
+    public static final String VENDOR_SIGNIN_PROTOCOL = "vendor_signin_protocol";
+    public static final String VENDOR_THREAT_SUSPECTED = "vendor_threat_suspected";
+    public static final String VENDOR_TRANSACTION_ID = "vendor_transaction_id";
+    public static final String VENDOR_TRANSACTION_TYPE = "vendor_transaction_type";
+    public static final String VENDOR_USER_TYPE = "vendor_user_type";
+}


### PR DESCRIPTION
## Description
This change brings the Graylog Schema changes that were made on the 4.0 branch back to the 3.3 branch. These are needed for updates to the Palo Alto plugin.

## Motivation and Context
These schema updates are needed for an update to the Palo Alto plugin which will will be covered in a separate PR.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

