### PR TITLE
feat: split multiple gelf messages on new line

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/inputs/codecs/GelfCodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/codecs/GelfCodecTest.java
@@ -33,6 +33,8 @@ import org.mockito.junit.MockitoRule;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.time.DateTimeException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -95,6 +97,33 @@ public class GelfCodecTest {
         assertThat(message).isNotNull();
         assertThat(message.getField("version")).isEqualTo("3.11");
         assertThat(message.getField("source")).isEqualTo("example.org");
+    }
+    @Test
+    public void decodeMessages() throws Exception {
+        final String json = "{"
+                + "\"version\": \"1.1\","
+                + "\"host\": \"example.org\","
+                + "\"short_message\": \"A short message that helps you identify what is going on\","
+                + "\"_version\": \"5.11\""
+                + "}"
+                + "\n"
+                + "{"
+                + "\"version\": \"1.1\","
+                + "\"host\": \"example.org\","
+                + "\"short_message\": \"A short message that helps you identify what is going on\","
+                + "\"_version\": \"3.11\","
+                + "\"foo\": \"bar\""
+                + "}";
+
+        final RawMessage rawMessage = new RawMessage(json.getBytes(StandardCharsets.UTF_8));
+        final ArrayList<Message> messages = (ArrayList<Message>) codec.decodeMessages(rawMessage);
+
+        assertThat(messages).isNotNull();
+        assertThat(messages).size().isEqualTo(2);
+        assertThat(messages.get(0).getField("version")).isEqualTo("5.11");
+        assertThat(messages.get(0).getField("source")).isEqualTo("example.org");
+        assertThat(messages.get(1).getField("version")).isEqualTo("3.11");
+        assertThat(messages.get(1).getField("foo")).isEqualTo("bar");
     }
 
     @Test


### PR DESCRIPTION
## Description
See https://github.com/Graylog2/graylog2-server/pull/5924
<!--- Describe your changes in detail -->

## Motivation and Context
Being able to transmit multiple messages over http gelf input (with them being split by the newline). 
In this way it should be possible to connect a lot of different log emitters (i.e. fluentd) without major issues. 

## How Has This Been Tested?
Running it in a patched version, so far no issues has arised. 
The most notable behaviour is that now GelfMessage returns an arraylist of messages.
Tests are running fine. 

This should not affect preexisting customers since as far as I know gelf message (even if coming from udp/tcp) doesn't contain any newline in it. If thats not the case, potentially we could add a checkbox in input type configuration I suppose (not sure how the config part works in Graylog inputs).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

