### PR TITLE
Add min width for data table columns

### DIFF
--- a/graylog2-web-interface/src/views/components/datatable/MessagesTable.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/MessagesTable.jsx
@@ -18,7 +18,6 @@ const StyledTable = styled(Table)(({ theme }) => `
   border-collapse: collapse;
   padding-left: 13px;
   width: 100%;
-  word-break: break-all;
 
   thead > tr {
     color: ${theme.colors.global.textAlt};

--- a/graylog2-web-interface/src/views/components/datatable/MessagesTable.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/MessagesTable.jsx
@@ -18,6 +18,7 @@ const StyledTable = styled(Table)(({ theme }) => `
   border-collapse: collapse;
   padding-left: 13px;
   width: 100%;
+  word-break: break-all;
 
   thead > tr {
     color: ${theme.colors.global.textAlt};
@@ -57,6 +58,7 @@ const StyledTable = styled(Table)(({ theme }) => `
     cursor: pointer;
 
     td {
+      min-width: 50px;
       padding-top: 10px;
     }
   }

--- a/graylog2-web-interface/src/views/components/datatable/__snapshots__/DataTable.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/datatable/__snapshots__/DataTable.test.jsx.snap
@@ -201,7 +201,7 @@ exports[`DataTable renders column pivot header without offset when rollup is dis
                         "componentStyle": ComponentStyle {
                           "componentId": "MessagesTable__StyledTable-ptthov-1",
                           "isStatic": false,
-                          "lastClassName": "UpBLn",
+                          "lastClassName": "eoafYX",
                           "rules": Array [
                             [Function],
                             [Function],
@@ -224,14 +224,14 @@ exports[`DataTable renders column pivot header without offset when rollup is dis
                     <Table
                       bordered={false}
                       bsClass="table"
-                      className="Table-ztr4bi-0 MessagesTable__StyledTable-ptthov-1 UpBLn"
+                      className="Table-ztr4bi-0 MessagesTable__StyledTable-ptthov-1 eoafYX"
                       condensed={true}
                       hover={false}
                       responsive={false}
                       striped={false}
                     >
                       <table
-                        className="Table-ztr4bi-0 MessagesTable__StyledTable-ptthov-1 UpBLn table table-condensed"
+                        className="Table-ztr4bi-0 MessagesTable__StyledTable-ptthov-1 eoafYX table table-condensed"
                       >
                         <thead>
                           <Headers
@@ -1215,7 +1215,7 @@ exports[`DataTable should render with empty data 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "MessagesTable__StyledTable-ptthov-1",
                           "isStatic": false,
-                          "lastClassName": "UpBLn",
+                          "lastClassName": "eoafYX",
                           "rules": Array [
                             [Function],
                             [Function],
@@ -1238,14 +1238,14 @@ exports[`DataTable should render with empty data 1`] = `
                     <Table
                       bordered={false}
                       bsClass="table"
-                      className="Table-ztr4bi-0 MessagesTable__StyledTable-ptthov-1 UpBLn"
+                      className="Table-ztr4bi-0 MessagesTable__StyledTable-ptthov-1 eoafYX"
                       condensed={true}
                       hover={false}
                       responsive={false}
                       striped={false}
                     >
                       <table
-                        className="Table-ztr4bi-0 MessagesTable__StyledTable-ptthov-1 UpBLn table table-condensed"
+                        className="Table-ztr4bi-0 MessagesTable__StyledTable-ptthov-1 eoafYX table table-condensed"
                       >
                         <thead>
                           <Headers
@@ -1493,7 +1493,7 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "MessagesTable__StyledTable-ptthov-1",
                           "isStatic": false,
-                          "lastClassName": "UpBLn",
+                          "lastClassName": "eoafYX",
                           "rules": Array [
                             [Function],
                             [Function],
@@ -1516,14 +1516,14 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                     <Table
                       bordered={false}
                       bsClass="table"
-                      className="Table-ztr4bi-0 MessagesTable__StyledTable-ptthov-1 UpBLn"
+                      className="Table-ztr4bi-0 MessagesTable__StyledTable-ptthov-1 eoafYX"
                       condensed={true}
                       hover={false}
                       responsive={false}
                       striped={false}
                     >
                       <table
-                        className="Table-ztr4bi-0 MessagesTable__StyledTable-ptthov-1 UpBLn table table-condensed"
+                        className="Table-ztr4bi-0 MessagesTable__StyledTable-ptthov-1 eoafYX table table-condensed"
                       >
                         <thead>
                           <Headers
@@ -2864,7 +2864,7 @@ exports[`DataTable should render with filled data without rollup 1`] = `
                         "componentStyle": ComponentStyle {
                           "componentId": "MessagesTable__StyledTable-ptthov-1",
                           "isStatic": false,
-                          "lastClassName": "UpBLn",
+                          "lastClassName": "eoafYX",
                           "rules": Array [
                             [Function],
                             [Function],
@@ -2887,14 +2887,14 @@ exports[`DataTable should render with filled data without rollup 1`] = `
                     <Table
                       bordered={false}
                       bsClass="table"
-                      className="Table-ztr4bi-0 MessagesTable__StyledTable-ptthov-1 UpBLn"
+                      className="Table-ztr4bi-0 MessagesTable__StyledTable-ptthov-1 eoafYX"
                       condensed={true}
                       hover={false}
                       responsive={false}
                       striped={false}
                     >
                       <table
-                        className="Table-ztr4bi-0 MessagesTable__StyledTable-ptthov-1 UpBLn table table-condensed"
+                        className="Table-ztr4bi-0 MessagesTable__StyledTable-ptthov-1 eoafYX table table-condensed"
                       >
                         <thead>
                           <Headers


### PR DESCRIPTION
It is currently possible, that the content of a data table is not being displayed in a readable format. This is also a problem, when generating a report:
![image](https://user-images.githubusercontent.com/46300478/84491228-8093b800-aca4-11ea-864a-a0ddcc15de54.png)

One solution I thought about is using `word-break: normal;` instead of  `word-break: break-all;`
![image](https://user-images.githubusercontent.com/46300478/84491549-0283e100-aca5-11ea-91b4-b19776263d32.png)

But this can be a problem when the table contains a value like a very long id.
I also thought about increasing the table width (in the context of reports) but this does not solve the problem, the second column just gets larger.

For now I've just defined a `min-width` for the table columns to slightly increase the readability.

![image](https://user-images.githubusercontent.com/46300478/84496143-b9378f80-acac-11ea-879e-0ec26bcb9562.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
