### PR TITLE
Fix `ActionDropdown` toggle on child select, if child is wrapped in another element

### DIFF
--- a/graylog2-web-interface/src/views/components/common/ActionDropdown.test.tsx
+++ b/graylog2-web-interface/src/views/components/common/ActionDropdown.test.tsx
@@ -75,6 +75,27 @@ describe('ActionDropdown', () => {
     expect(wrapper).not.toContainMatchingElement('ul.dropdown-menu');
   });
 
+  it('closes menu when MenuItem with a parent element is clicked', () => {
+    const onSelect = jest.fn();
+    const wrapper = mount((
+      <ActionDropdown element={<div>Trigger!</div>}>
+        <div>
+          <MenuItem onSelect={onSelect}>Foo</MenuItem>
+        </div>
+      </ActionDropdown>
+    ));
+    const trigger = wrapper.find('ActionToggle');
+
+    trigger.simulate('click');
+
+    const menuItem = wrapper.find('a[children="Foo"]');
+
+    menuItem.simulate('click');
+
+    expect(onSelect).toHaveBeenCalled();
+    expect(wrapper).not.toContainMatchingElement('ul.dropdown-menu');
+  });
+
   it('stops click event when MenuItem is clicked', () => {
     const onClick = jest.fn();
     const onSelect = jest.fn();

--- a/graylog2-web-interface/src/views/components/common/ActionDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/common/ActionDropdown.tsx
@@ -121,7 +121,7 @@ class ActionDropdown extends React.Component<ActionDropdownProps, ActionDropdown
   };
 
   adjustChildOnSelectProp = (child: React.Element<*>, updateDepth: number) => {
-    if (child.props.onSelect) {
+    if (child.props?.onSelect) {
       return {
         onSelect: (eventKey: ?string, event: SyntheticInputEvent<HTMLButtonElement>) => {
           child.props.onSelect();
@@ -130,7 +130,7 @@ class ActionDropdown extends React.Component<ActionDropdownProps, ActionDropdown
       };
     }
 
-    if (child.props.children) {
+    if (child.props?.children) {
       return {
         children: this.adjustChildProps(child.props.children, updateDepth + 1),
       };

--- a/graylog2-web-interface/src/views/components/common/ActionDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/common/ActionDropdown.tsx
@@ -158,7 +158,7 @@ class ActionDropdown extends React.Component<ActionDropdownProps, ActionDropdown
   render() {
     const { children, container, element } = this.props;
     const { show } = this.state;
-    const mappedChildren = this.adjustChildProps(children, 1);
+    const mappedChildren = this.adjustChildProps(children, 0);
 
     return (
       <StopPropagation>

--- a/graylog2-web-interface/src/views/components/common/ActionDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/common/ActionDropdown.tsx
@@ -139,7 +139,7 @@ class ActionDropdown extends React.Component<ActionDropdownProps, ActionDropdown
     return {};
   };
 
-  closeOnChildrenSelect = (children: React.ReactElement | Array<React.ReactElement>, updateDepth: number) => {
+  closeOnChildrenSelect = (children: React.ReactNode, updateDepth: number) => {
     const maxChildDepth = 2;
 
     if (updateDepth > maxChildDepth) {
@@ -148,10 +148,10 @@ class ActionDropdown extends React.Component<ActionDropdownProps, ActionDropdown
 
     return React.Children.map(
       children,
-      (child: React.ReactElement) => child && React.cloneElement(child, {
+      (child: React.ReactElement) => (child?.props ? React.cloneElement(child, {
         ...child.props,
         ...this.closeOnChildSelect(child, updateDepth + 1),
-      }),
+      }) : child),
     );
   }
 

--- a/graylog2-web-interface/src/views/components/common/ActionDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/common/ActionDropdown.tsx
@@ -29,7 +29,7 @@ import StopPropagation from './StopPropagation';
  */
 
 type ActionToggleProps = {
-  children: React.ReactElement,
+  children: React.ReactElement | Array<React.ReactElement>,
   onClick: (event: SyntheticEvent) => void,
   // eslint-disable-next-line react/no-unused-prop-types
   bsRole?: string,
@@ -120,10 +120,10 @@ class ActionDropdown extends React.Component<ActionDropdownProps, ActionDropdown
     this.setState(({ show }) => ({ show: !show }));
   };
 
-  adjustChildOnSelectProp = (child: React.Element<*>, updateDepth: number) => {
+  closeOnChildSelect = (child: React.ReactElement, updateDepth: number) => {
     if (child.props?.onSelect) {
       return {
-        onSelect: (eventKey: ?string, event: SyntheticInputEvent<HTMLButtonElement>) => {
+        onSelect: (eventKey: string | null | undefined, event: SyntheticEvent<HTMLButtonElement>) => {
           child.props.onSelect();
           this._onToggle(event);
         },
@@ -132,14 +132,14 @@ class ActionDropdown extends React.Component<ActionDropdownProps, ActionDropdown
 
     if (child.props?.children) {
       return {
-        children: this.adjustChildProps(child.props.children, updateDepth + 1),
+        children: this.closeOnChildrenSelect(child.props.children, updateDepth + 1),
       };
     }
 
     return {};
   };
 
-  adjustChildProps = (children: React.Node, updateDepth: number) => {
+  closeOnChildrenSelect = (children: React.ReactElement | Array<React.ReactElement>, updateDepth: number) => {
     const maxChildDepth = 2;
 
     if (updateDepth > maxChildDepth) {
@@ -150,7 +150,7 @@ class ActionDropdown extends React.Component<ActionDropdownProps, ActionDropdown
       children,
       (child: React.ReactElement) => child && React.cloneElement(child, {
         ...child.props,
-        ...this.adjustChildOnSelectProp(child, updateDepth + 1),
+        ...this.closeOnChildSelect(child, updateDepth + 1),
       }),
     );
   }
@@ -158,7 +158,7 @@ class ActionDropdown extends React.Component<ActionDropdownProps, ActionDropdown
   render() {
     const { children, container, element } = this.props;
     const { show } = this.state;
-    const mappedChildren = this.adjustChildProps(children, 0);
+    const mappedChildren = this.closeOnChildrenSelect(children, 0);
 
     return (
       <StopPropagation>

--- a/graylog2-web-interface/src/views/components/common/ActionDropdown.tsx
+++ b/graylog2-web-interface/src/views/components/common/ActionDropdown.tsx
@@ -120,26 +120,26 @@ class ActionDropdown extends React.Component<ActionDropdownProps, ActionDropdown
     this.setState(({ show }) => ({ show: !show }));
   };
 
-  adjustOptionOnSelectProp = (option: React.Element<*>, updateDepth: number) => {
-    if (option.props.onSelect) {
+  adjustChildOnSelectProp = (child: React.Element<*>, updateDepth: number) => {
+    if (child.props.onSelect) {
       return {
         onSelect: (eventKey: ?string, event: SyntheticInputEvent<HTMLButtonElement>) => {
-          option.props.onSelect();
+          child.props.onSelect();
           this._onToggle(event);
         },
       };
     }
 
-    if (option.props.children) {
+    if (child.props.children) {
       return {
-        children: this.adjustOptionsProps(option.props.children, updateDepth + 1),
+        children: this.adjustChildProps(child.props.children, updateDepth + 1),
       };
     }
 
     return {};
   };
 
-  adjustOptionsProps = (children: React.Node, updateDepth: number) => {
+  adjustChildProps = (children: React.Node, updateDepth: number) => {
     const maxChildDepth = 2;
 
     if (updateDepth > maxChildDepth) {
@@ -150,7 +150,7 @@ class ActionDropdown extends React.Component<ActionDropdownProps, ActionDropdown
       children,
       (child: React.ReactElement) => child && React.cloneElement(child, {
         ...child.props,
-        ...this.adjustOptionOnSelectProp(child, updateDepth + 1),
+        ...this.adjustChildOnSelectProp(child, updateDepth + 1),
       }),
     );
   }
@@ -158,7 +158,7 @@ class ActionDropdown extends React.Component<ActionDropdownProps, ActionDropdown
   render() {
     const { children, container, element } = this.props;
     const { show } = this.state;
-    const mappedChildren = this.adjustOptionsProps(children, 1);
+    const mappedChildren = this.adjustChildProps(children, 1);
 
     return (
       <StopPropagation>


### PR DESCRIPTION
The `ActionDropdown` manipulates the `onSelect` prop of its children, to close the dropdown when `onSelect` is being executed. This is currently not working, when a child is wrapped in an element like `IfDashboard`.
With this PR we also apply this manipulation to the children of the `ActionDropdown` children, if the main child does not have an `onSelect` prop.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
