### PR TITLE
Moving creation of `FieldStatsResult` to storage module.

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/SearchesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/SearchesAdapterES6.java
@@ -1,5 +1,6 @@
 package org.graylog.storage.elasticsearch6;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.searchbox.core.Search;
 import io.searchbox.core.search.aggregation.CardinalityAggregation;
 import io.searchbox.core.search.aggregation.ExtendedStatsAggregation;
@@ -186,7 +187,8 @@ public class SearchesAdapterES6 implements SearchesAdapter {
         );
     }
 
-    private FieldStatsResult createFieldStatsResult(ValueCountAggregation valueCountAggregation,
+    @VisibleForTesting
+    FieldStatsResult createFieldStatsResult(ValueCountAggregation valueCountAggregation,
                                                     ExtendedStatsAggregation extendedStatsAggregation,
                                                     CardinalityAggregation cardinalityAggregation,
                                                     List<ResultMessage> hits,

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/SearchesAdapterES6Test.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/SearchesAdapterES6Test.java
@@ -1,23 +1,10 @@
-/**
- * This file is part of Graylog.
- *
- * Graylog is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * Graylog is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
- */
-package org.graylog2.indexer.results;
+package org.graylog.storage.elasticsearch6;
 
 import io.searchbox.core.search.aggregation.ExtendedStatsAggregation;
-import org.junit.Test;
+import org.graylog2.Configuration;
+import org.graylog2.indexer.results.FieldStatsResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 
@@ -25,7 +12,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class FieldStatsResultTest {
+class SearchesAdapterES6Test {
+    private SearchesAdapterES6 searchesAdapter;
+
+    @BeforeEach
+    void setUp() {
+        this.searchesAdapter = new SearchesAdapterES6(mock(Configuration.class), mock(MultiSearch.class), mock(Scroll.class), new SortOrderMapper());
+    }
+
     @Test
     public void worksForNullFieldsInAggregationResults() throws Exception {
         final ExtendedStatsAggregation extendedStatsAggregation = mock(ExtendedStatsAggregation.class);
@@ -39,7 +33,7 @@ public class FieldStatsResultTest {
         when(extendedStatsAggregation.getVariance()).thenReturn(null);
         when(extendedStatsAggregation.getStdDeviation()).thenReturn(null);
 
-        final FieldStatsResult result = new FieldStatsResult(null,
+        final FieldStatsResult result = searchesAdapter.createFieldStatsResult(null,
                 extendedStatsAggregation,
                 null,
                 Collections.emptyList(),

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/SearchesAdapterES6Test.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/SearchesAdapterES6Test.java
@@ -42,15 +42,15 @@ class SearchesAdapterES6Test {
                 0);
 
         assertThat(result).isNotNull();
-        assertThat(result.getSum()).isEqualTo(Double.NaN);
-        assertThat(result.getSumOfSquares()).isEqualTo(Double.NaN);
-        assertThat(result.getMean()).isEqualTo(Double.NaN);
-        assertThat(result.getMin()).isEqualTo(Double.NaN);
-        assertThat(result.getMax()).isEqualTo(Double.NaN);
-        assertThat(result.getVariance()).isEqualTo(Double.NaN);
-        assertThat(result.getStdDeviation()).isEqualTo(Double.NaN);
+        assertThat(result.sum()).isEqualTo(Double.NaN);
+        assertThat(result.sumOfSquares()).isEqualTo(Double.NaN);
+        assertThat(result.mean()).isEqualTo(Double.NaN);
+        assertThat(result.min()).isEqualTo(Double.NaN);
+        assertThat(result.max()).isEqualTo(Double.NaN);
+        assertThat(result.variance()).isEqualTo(Double.NaN);
+        assertThat(result.stdDeviation()).isEqualTo(Double.NaN);
 
-        assertThat(result.getCount()).isEqualTo(Long.MIN_VALUE);
-        assertThat(result.getCardinality()).isEqualTo(Long.MIN_VALUE);
+        assertThat(result.count()).isEqualTo(Long.MIN_VALUE);
+        assertThat(result.cardinality()).isEqualTo(Long.MIN_VALUE);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
+++ b/graylog2-server/src/main/java/org/graylog2/alerts/types/FieldValueAlertCondition.java
@@ -177,7 +177,7 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
             final FieldStatsResult fieldStatsResult = searches.fieldStats(field, "*", filter,
                 RelativeRange.create(time * 60), false, true, false);
 
-            if (fieldStatsResult.getCount() == 0) {
+            if (fieldStatsResult.count() == 0) {
                 LOG.debug("Alert check <{}> did not match any messages. Returning not triggered.", type);
                 return new NegativeCheckResult();
             }
@@ -185,19 +185,19 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
             final double result;
             switch (type) {
                 case MEAN:
-                    result = fieldStatsResult.getMean();
+                    result = fieldStatsResult.mean();
                     break;
                 case MIN:
-                    result = fieldStatsResult.getMin();
+                    result = fieldStatsResult.min();
                     break;
                 case MAX:
-                    result = fieldStatsResult.getMax();
+                    result = fieldStatsResult.max();
                     break;
                 case SUM:
-                    result = fieldStatsResult.getSum();
+                    result = fieldStatsResult.sum();
                     break;
                 case STDDEV:
-                    result = fieldStatsResult.getStdDeviation();
+                    result = fieldStatsResult.stdDeviation();
                     break;
                 default:
                     LOG.error("No such field value check type: [{}]. Returning not triggered.", type);
@@ -232,7 +232,7 @@ public class FieldValueAlertCondition extends AbstractAlertCondition {
 
                 final List<MessageSummary> summaries;
                 if (getBacklog() > 0) {
-                    final List<ResultMessage> searchResult = fieldStatsResult.getSearchHits();
+                    final List<ResultMessage> searchResult = fieldStatsResult.searchHits();
                     summaries = Lists.newArrayListWithCapacity(searchResult.size());
                     for (ResultMessage resultMessage : searchResult) {
                         final Message msg = resultMessage.getMessage();

--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldStatsResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldStatsResult.java
@@ -19,7 +19,7 @@ package org.graylog2.indexer.results;
 import java.util.Collections;
 import java.util.List;
 
-public class FieldStatsResult extends IndexQueryResult {
+public class FieldStatsResult {
     private final List<ResultMessage> searchHits;
 
     private final long count;
@@ -31,6 +31,9 @@ public class FieldStatsResult extends IndexQueryResult {
     private final double variance;
     private final double stdDeviation;
     private final long cardinality;
+    private final String originalQuery;
+    private final long tookMs;
+    private final String builtQuery;
 
     public static FieldStatsResult create(long count,
                                           double sum,
@@ -50,7 +53,9 @@ public class FieldStatsResult extends IndexQueryResult {
     }
 
     public FieldStatsResult(String originalQuery, String builtQuery, long tookMs, List<ResultMessage> searchHits, long count, double sum, double sumOfSquares, double mean, double min, double max, double variance, double stdDeviation, long cardinality) {
-        super(originalQuery, builtQuery, tookMs);
+        this.originalQuery = originalQuery;
+        this.builtQuery = builtQuery;
+        this.tookMs = tookMs;
         this.searchHits = searchHits;
         this.count = count;
         this.sum = sum;
@@ -106,5 +111,17 @@ public class FieldStatsResult extends IndexQueryResult {
 
     public List<ResultMessage> getSearchHits() {
         return searchHits;
+    }
+
+    public String getOriginalQuery() {
+        return originalQuery;
+    }
+
+    public String getBuiltQuery() {
+        return builtQuery;
+    }
+
+    public long tookMs() {
+        return tookMs;
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldStatsResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldStatsResult.java
@@ -24,6 +24,34 @@ import java.util.List;
 
 @AutoValue
 public abstract class FieldStatsResult {
+    public abstract long count();
+
+    public abstract double sum();
+
+    public abstract double sumOfSquares();
+
+    public abstract double mean();
+
+    public abstract double min();
+
+    public abstract double max();
+
+    public abstract double variance();
+
+    public abstract double stdDeviation();
+
+    public abstract long cardinality();
+
+    public abstract List<ResultMessage> searchHits();
+
+    @Nullable
+    public abstract String originalQuery();
+
+    @Nullable
+    public abstract String builtQuery();
+
+    public abstract long tookMs();
+
     public static FieldStatsResult create(long count,
                                           double sum,
                                           double sumOfSquares,
@@ -45,32 +73,4 @@ public abstract class FieldStatsResult {
         return create(Long.MIN_VALUE, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
                 Long.MIN_VALUE, Collections.emptyList(), query, builtQuery, 0);
     }
-
-    public abstract long getCount();
-
-    public abstract double getSum();
-
-    public abstract double getSumOfSquares();
-
-    public abstract double getMean();
-
-    public abstract double getMin();
-
-    public abstract double getMax();
-
-    public abstract double getVariance();
-
-    public abstract double getStdDeviation();
-
-    public abstract long getCardinality();
-
-    public abstract List<ResultMessage> getSearchHits();
-
-    @Nullable
-    public abstract String getOriginalQuery();
-
-    @Nullable
-    public abstract String getBuiltQuery();
-
-    public abstract long getTookMs();
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldStatsResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldStatsResult.java
@@ -16,25 +16,14 @@
  */
 package org.graylog2.indexer.results;
 
+import com.google.auto.value.AutoValue;
+
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 
-public class FieldStatsResult {
-    private final List<ResultMessage> searchHits;
-
-    private final long count;
-    private final double sum;
-    private final double sumOfSquares;
-    private final double mean;
-    private final double min;
-    private final double max;
-    private final double variance;
-    private final double stdDeviation;
-    private final long cardinality;
-    private final String originalQuery;
-    private final long tookMs;
-    private final String builtQuery;
-
+@AutoValue
+public abstract class FieldStatsResult {
     public static FieldStatsResult create(long count,
                                           double sum,
                                           double sumOfSquares,
@@ -48,24 +37,8 @@ public class FieldStatsResult {
                                           String originalQuery,
                                           String builtQuery,
                                           long tookMs) {
-        return new FieldStatsResult(originalQuery, builtQuery, tookMs, hits, count, sum, sumOfSquares, mean, min, max,
-                variance, stdDeviation, cardinality);
-    }
-
-    public FieldStatsResult(String originalQuery, String builtQuery, long tookMs, List<ResultMessage> searchHits, long count, double sum, double sumOfSquares, double mean, double min, double max, double variance, double stdDeviation, long cardinality) {
-        this.originalQuery = originalQuery;
-        this.builtQuery = builtQuery;
-        this.tookMs = tookMs;
-        this.searchHits = searchHits;
-        this.count = count;
-        this.sum = sum;
-        this.sumOfSquares = sumOfSquares;
-        this.mean = mean;
-        this.min = min;
-        this.max = max;
-        this.variance = variance;
-        this.stdDeviation = stdDeviation;
-        this.cardinality = cardinality;
+        return new AutoValue_FieldStatsResult(count, sum, sumOfSquares, mean, min, max, variance, stdDeviation, cardinality,
+                hits, originalQuery, builtQuery, tookMs);
     }
 
     public static FieldStatsResult empty(String query, String bytesReference) {
@@ -73,55 +46,31 @@ public class FieldStatsResult {
                 Long.MIN_VALUE, Collections.emptyList(), query, bytesReference, 0);
     }
 
-    public long getCount() {
-        return count;
-    }
+    public abstract long getCount();
 
-    public double getSum() {
-        return sum;
-    }
+    public abstract double getSum();
 
-    public double getSumOfSquares() {
-        return sumOfSquares;
-    }
+    public abstract double getSumOfSquares();
 
-    public double getMean() {
-        return mean;
-    }
+    public abstract double getMean();
 
-    public double getMin() {
-        return min;
-    }
+    public abstract double getMin();
 
-    public double getMax() {
-        return max;
-    }
+    public abstract double getMax();
 
-    public double getVariance() {
-        return variance;
-    }
+    public abstract double getVariance();
 
-    public double getStdDeviation() {
-        return stdDeviation;
-    }
+    public abstract double getStdDeviation();
 
-    public long getCardinality() {
-        return cardinality;
-    }
+    public abstract long getCardinality();
 
-    public List<ResultMessage> getSearchHits() {
-        return searchHits;
-    }
+    public abstract List<ResultMessage> getSearchHits();
 
-    public String getOriginalQuery() {
-        return originalQuery;
-    }
+    @Nullable
+    public abstract String getOriginalQuery();
 
-    public String getBuiltQuery() {
-        return builtQuery;
-    }
+    @Nullable
+    public abstract String getBuiltQuery();
 
-    public long tookMs() {
-        return tookMs;
-    }
+    public abstract long getTookMs();
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldStatsResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/results/FieldStatsResult.java
@@ -41,9 +41,9 @@ public abstract class FieldStatsResult {
                 hits, originalQuery, builtQuery, tookMs);
     }
 
-    public static FieldStatsResult empty(String query, String bytesReference) {
+    public static FieldStatsResult empty(String query, String builtQuery) {
         return create(Long.MIN_VALUE, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN,
-                Long.MIN_VALUE, Collections.emptyList(), query, bytesReference, 0);
+                Long.MIN_VALUE, Collections.emptyList(), query, builtQuery, 0);
     }
 
     public abstract long getCount();

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -164,7 +164,7 @@ public class Searches {
 
         final FieldStatsResult result = searchesAdapter.fieldStats(query, filter, range, indices, field, includeCardinality, includeStats, includeCount);
 
-        recordEsMetrics(result.tookMs(), range);
+        recordEsMetrics(result.getTookMs(), range);
         return result;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -159,7 +159,7 @@ public class Searches {
 
         final FieldStatsResult result = searchesAdapter.fieldStats(query, filter, range, indices, field, includeCardinality, includeStats, includeCount);
 
-        recordEsMetrics(result.getTookMs(), range);
+        recordEsMetrics(result.tookMs(), range);
         return result;
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -145,12 +145,7 @@ public class Searches {
     }
 
     public FieldStatsResult fieldStats(String field, String query, TimeRange range) {
-        return fieldStats(field, query, null, range);
-    }
-
-    public FieldStatsResult fieldStats(String field, String query, String filter, TimeRange range) {
-        // by default include the cardinality aggregation, as well.
-        return fieldStats(field, query, filter, range, true, true, true);
+        return fieldStats(field, query, null, range, true, true, true);
     }
 
     public FieldStatsResult fieldStats(String field,

--- a/graylog2-server/src/test/java/org/graylog2/alerts/types/FieldValueAlertConditionTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alerts/types/FieldValueAlertConditionTest.java
@@ -161,23 +161,23 @@ public class FieldValueAlertConditionTest extends AlertConditionTest {
         final Double value = (Double) retValue;
         final FieldStatsResult fieldStatsResult = mock(FieldStatsResult.class);
 
-        when(fieldStatsResult.getCount()).thenReturn(1L);
+        when(fieldStatsResult.count()).thenReturn(1L);
 
         switch (type) {
             case MIN:
-                when(fieldStatsResult.getMin()).thenReturn(value);
+                when(fieldStatsResult.min()).thenReturn(value);
                 break;
             case MAX:
-                when(fieldStatsResult.getMax()).thenReturn(value);
+                when(fieldStatsResult.max()).thenReturn(value);
                 break;
             case MEAN:
-                when(fieldStatsResult.getMean()).thenReturn(value);
+                when(fieldStatsResult.mean()).thenReturn(value);
                 break;
             case STDDEV:
-                when(fieldStatsResult.getStdDeviation()).thenReturn(value);
+                when(fieldStatsResult.stdDeviation()).thenReturn(value);
                 break;
             case SUM:
-                when(fieldStatsResult.getSum()).thenReturn(value);
+                when(fieldStatsResult.sum()).thenReturn(value);
                 break;
         }
         return fieldStatsResult;

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesIT.java
@@ -241,15 +241,15 @@ public abstract class SearchesIT extends ElasticsearchBaseTest {
                 new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC),
                 new DateTime(2015, 1, 2, 0, 0, DateTimeZone.UTC)));
 
-        assertThat(result.getSearchHits()).hasSize(10);
-        assertThat(result.getCount()).isEqualTo(8);
-        assertThat(result.getMin()).isEqualTo(1.0);
-        assertThat(result.getMax()).isEqualTo(4.0);
-        assertThat(result.getMean()).isEqualTo(2.375);
-        assertThat(result.getSum()).isEqualTo(19.0);
-        assertThat(result.getSumOfSquares()).isEqualTo(53.0);
-        assertThat(result.getVariance()).isEqualTo(0.984375);
-        assertThat(result.getStdDeviation()).isEqualTo(0.9921567416492215);
+        assertThat(result.searchHits()).hasSize(10);
+        assertThat(result.count()).isEqualTo(8);
+        assertThat(result.min()).isEqualTo(1.0);
+        assertThat(result.max()).isEqualTo(4.0);
+        assertThat(result.mean()).isEqualTo(2.375);
+        assertThat(result.sum()).isEqualTo(19.0);
+        assertThat(result.sumOfSquares()).isEqualTo(53.0);
+        assertThat(result.variance()).isEqualTo(0.984375);
+        assertThat(result.stdDeviation()).isEqualTo(0.9921567416492215);
     }
 
     @Test
@@ -445,9 +445,9 @@ public abstract class SearchesIT extends ElasticsearchBaseTest {
         final FieldStatsResult fieldStatsResult = searches.fieldStats("n", "_id:1", range);
 
         assertThat(fieldStatsResult).isNotNull();
-        assertThat(fieldStatsResult.getSearchHits()).isNotNull();
-        assertThat(fieldStatsResult.getSearchHits()).hasSize(1);
-        final ResultMessage resultMessage = fieldStatsResult.getSearchHits().get(0);
+        assertThat(fieldStatsResult.searchHits()).isNotNull();
+        assertThat(fieldStatsResult.searchHits()).hasSize(1);
+        final ResultMessage resultMessage = fieldStatsResult.searchHits().get(0);
         assertThat(resultMessage.getMessage().getFields()).doesNotContainKeys("es_metadata_id", "es_metadata_version");
     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In order to prevent the `FieldStatsResult` value class from knowing
about the ES result details, its instantiation details are moved to the
storage module.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.