### PR TITLE
Create separate context for highlighting rules (Backport of #8276 for 3.3)

### DIFF
--- a/graylog2-web-interface/src/views/components/contexts/HighlightingRulesContext.jsx
+++ b/graylog2-web-interface/src/views/components/contexts/HighlightingRulesContext.jsx
@@ -1,0 +1,8 @@
+// @flow strict
+import * as React from 'react';
+import { singleton } from 'views/logic/singleton';
+import HighlightingRule from 'views/logic/views/formatting/highlighting/HighlightingRule';
+
+const HighlightingRules = React.createContext<?Array<HighlightingRule>>();
+
+export default singleton('contexts.HighlightingRules', () => HighlightingRules);

--- a/graylog2-web-interface/src/views/components/contexts/HighlightingRulesProvider.jsx
+++ b/graylog2-web-interface/src/views/components/contexts/HighlightingRulesProvider.jsx
@@ -1,0 +1,24 @@
+// @flow strict
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+import { useStore } from 'stores/connect';
+import { HighlightingRulesStore } from 'views/stores/HighlightingRulesStore';
+import HighlightingRulesContext from './HighlightingRulesContext';
+
+const HighlightingRulesProvider = ({ children }: { children: React.Node }) => {
+  const highlightingRules = useStore(HighlightingRulesStore);
+  return highlightingRules
+    ? (
+      <HighlightingRulesContext.Provider value={highlightingRules}>
+        {children}
+      </HighlightingRulesContext.Provider>
+    )
+    : children;
+};
+
+HighlightingRulesProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default HighlightingRulesProvider;

--- a/graylog2-web-interface/src/views/components/contexts/HighlightingRulesProvider.test.jsx
+++ b/graylog2-web-interface/src/views/components/contexts/HighlightingRulesProvider.test.jsx
@@ -1,0 +1,52 @@
+// @flow strict
+import * as React from 'react';
+import { cleanup, render } from 'wrappedTestingLibrary';
+
+import asMock from 'helpers/mocking/AsMock';
+import HighlightingRule from 'views/logic/views/formatting/highlighting/HighlightingRule';
+import { HighlightingRulesStore } from 'views/stores/HighlightingRulesStore';
+import HighlightingRulesContext from './HighlightingRulesContext';
+import HighlightingRulesProvider from './HighlightingRulesProvider';
+
+jest.mock('views/stores/HighlightingRulesStore', () => ({
+  HighlightingRulesStore: {
+    listen: jest.fn(),
+    getInitialState: jest.fn(() => {}),
+  },
+}));
+
+describe('HighlightingRulesProvider', () => {
+  afterEach(cleanup);
+
+  const renderSUT = () => {
+    const consume = jest.fn();
+    render(
+      <HighlightingRulesProvider>
+        <HighlightingRulesContext.Consumer>
+          {consume}
+        </HighlightingRulesContext.Consumer>
+      </HighlightingRulesProvider>,
+    );
+    return consume;
+  };
+
+  it('provides no data when highlighting rules store is empty', () => {
+    const consume = renderSUT();
+
+    expect(consume).toHaveBeenCalledWith(undefined);
+  });
+
+
+  it('provides highlighting rules', () => {
+    const rule = HighlightingRule.builder()
+      .field('field-name')
+      .value(String(42))
+      .color('#bc98fd')
+      .build();
+    asMock(HighlightingRulesStore.getInitialState).mockReturnValue([rule]);
+
+    const consume = renderSUT();
+
+    expect(consume).toHaveBeenCalledWith([rule]);
+  });
+});

--- a/graylog2-web-interface/src/views/components/datatable/__snapshots__/DataTable.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/datatable/__snapshots__/DataTable.test.jsx.snap
@@ -685,19 +685,51 @@ exports[`DataTable renders column pivot header without offset when rollup is dis
                                     }
                                   }
                                 >
-                                  <ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules
+                                  <CustomHighlighting
                                     field="count()"
                                     value={239}
                                   >
-                                    <CustomHighlighting
+                                    <Value
                                       field="count()"
-                                      highlightingRules={Object {}}
+                                      queryId="deadbeef-23"
+                                      render={[Function]}
+                                      type={
+                                        FieldType {
+                                          "value": Immutable.Map {
+                                            "type": "long",
+                                            "properties": Immutable.Set [
+                                              "numeric",
+                                              "enumerable",
+                                            ],
+                                            "indexNames": Immutable.Set [],
+                                          },
+                                        }
+                                      }
                                       value={239}
                                     >
-                                      <Value
+                                      <ValueActions
+                                        element={
+                                          <TypeSpecificValue
+                                            field="count()"
+                                            render={[Function]}
+                                            type={
+                                              FieldType {
+                                                "value": Immutable.Map {
+                                                  "type": "long",
+                                                  "properties": Immutable.Set [
+                                                    "numeric",
+                                                    "enumerable",
+                                                  ],
+                                                  "indexNames": Immutable.Set [],
+                                                },
+                                              }
+                                            }
+                                            value={239}
+                                          />
+                                        }
                                         field="count()"
+                                        menuContainer={<body />}
                                         queryId="deadbeef-23"
-                                        render={[Function]}
                                         type={
                                           FieldType {
                                             "value": Immutable.Map {
@@ -712,8 +744,12 @@ exports[`DataTable renders column pivot header without offset when rollup is dis
                                         }
                                         value={239}
                                       >
-                                        <ValueActions
-                                          element={
+                                        <OverlayDropdown
+                                          menuContainer={<body />}
+                                          onToggle={[Function]}
+                                          placement="right"
+                                          show={false}
+                                          toggle={
                                             <TypeSpecificValue
                                               field="count()"
                                               render={[Function]}
@@ -732,56 +768,31 @@ exports[`DataTable renders column pivot header without offset when rollup is dis
                                               value={239}
                                             />
                                           }
-                                          field="count()"
-                                          menuContainer={<body />}
-                                          queryId="deadbeef-23"
-                                          type={
-                                            FieldType {
-                                              "value": Immutable.Map {
-                                                "type": "long",
-                                                "properties": Immutable.Set [
-                                                  "numeric",
-                                                  "enumerable",
-                                                ],
-                                                "indexNames": Immutable.Set [],
-                                              },
-                                            }
-                                          }
-                                          value={239}
                                         >
-                                          <OverlayDropdown
-                                            menuContainer={<body />}
-                                            onToggle={[Function]}
-                                            placement="right"
-                                            show={false}
-                                            toggle={
-                                              <TypeSpecificValue
-                                                field="count()"
-                                                render={[Function]}
-                                                type={
-                                                  FieldType {
-                                                    "value": Immutable.Map {
-                                                      "type": "long",
-                                                      "properties": Immutable.Set [
-                                                        "numeric",
-                                                        "enumerable",
-                                                      ],
-                                                      "indexNames": Immutable.Set [],
-                                                    },
-                                                  }
-                                                }
-                                                value={239}
-                                              />
-                                            }
+                                          <span
+                                            className="dropdowntoggle"
+                                            onClick={[Function]}
+                                            role="presentation"
                                           >
-                                            <span
-                                              className="dropdowntoggle"
-                                              onClick={[Function]}
-                                              role="presentation"
+                                            <TypeSpecificValue
+                                              field="count()"
+                                              render={[Function]}
+                                              type={
+                                                FieldType {
+                                                  "value": Immutable.Map {
+                                                    "type": "long",
+                                                    "properties": Immutable.Set [
+                                                      "numeric",
+                                                      "enumerable",
+                                                    ],
+                                                    "indexNames": Immutable.Set [],
+                                                  },
+                                                }
+                                              }
+                                              value={239}
                                             >
-                                              <TypeSpecificValue
+                                              <Component
                                                 field="count()"
-                                                render={[Function]}
                                                 type={
                                                   FieldType {
                                                     "value": Immutable.Map {
@@ -794,9 +805,9 @@ exports[`DataTable renders column pivot header without offset when rollup is dis
                                                     },
                                                   }
                                                 }
-                                                value={239}
+                                                value="239"
                                               >
-                                                <Component
+                                                <DecoratedValue
                                                   field="count()"
                                                   type={
                                                     FieldType {
@@ -812,7 +823,7 @@ exports[`DataTable renders column pivot header without offset when rollup is dis
                                                   }
                                                   value="239"
                                                 >
-                                                  <DecoratedValue
+                                                  <Component
                                                     field="count()"
                                                     type={
                                                       FieldType {
@@ -828,7 +839,7 @@ exports[`DataTable renders column pivot header without offset when rollup is dis
                                                     }
                                                     value="239"
                                                   >
-                                                    <Component
+                                                    <Highlight
                                                       field="count()"
                                                       type={
                                                         FieldType {
@@ -844,44 +855,27 @@ exports[`DataTable renders column pivot header without offset when rollup is dis
                                                       }
                                                       value="239"
                                                     >
-                                                      <Highlight
+                                                      <PossiblyHighlight
+                                                        color="#ffec3d"
                                                         field="count()"
-                                                        type={
-                                                          FieldType {
-                                                            "value": Immutable.Map {
-                                                              "type": "long",
-                                                              "properties": Immutable.Set [
-                                                                "numeric",
-                                                                "enumerable",
-                                                              ],
-                                                              "indexNames": Immutable.Set [],
-                                                            },
-                                                          }
-                                                        }
+                                                        highlightRanges={Object {}}
                                                         value="239"
                                                       >
-                                                        <PossiblyHighlight
-                                                          color="#ffec3d"
-                                                          field="count()"
-                                                          highlightRanges={Object {}}
-                                                          value="239"
-                                                        >
-                                                          239
-                                                        </PossiblyHighlight>
-                                                      </Highlight>
-                                                    </Component>
-                                                  </DecoratedValue>
-                                                </Component>
-                                              </TypeSpecificValue>
-                                              <span
-                                                className="caret"
-                                              />
-                                            </span>
-                                          </OverlayDropdown>
-                                        </ValueActions>
-                                      </Value>
-                                    </CustomHighlighting>
-                                  </ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules>
+                                                        239
+                                                      </PossiblyHighlight>
+                                                    </Highlight>
+                                                  </Component>
+                                                </DecoratedValue>
+                                              </Component>
+                                            </TypeSpecificValue>
+                                            <span
+                                              className="caret"
+                                            />
+                                          </span>
+                                        </OverlayDropdown>
+                                      </ValueActions>
+                                    </Value>
+                                  </CustomHighlighting>
                                 </Provider>
                               </td>
                               <td
@@ -898,19 +892,51 @@ exports[`DataTable renders column pivot header without offset when rollup is dis
                                     }
                                   }
                                 >
-                                  <ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules
+                                  <CustomHighlighting
                                     field="count()"
                                     value={226}
                                   >
-                                    <CustomHighlighting
+                                    <Value
                                       field="count()"
-                                      highlightingRules={Object {}}
+                                      queryId="deadbeef-23"
+                                      render={[Function]}
+                                      type={
+                                        FieldType {
+                                          "value": Immutable.Map {
+                                            "type": "long",
+                                            "properties": Immutable.Set [
+                                              "numeric",
+                                              "enumerable",
+                                            ],
+                                            "indexNames": Immutable.Set [],
+                                          },
+                                        }
+                                      }
                                       value={226}
                                     >
-                                      <Value
+                                      <ValueActions
+                                        element={
+                                          <TypeSpecificValue
+                                            field="count()"
+                                            render={[Function]}
+                                            type={
+                                              FieldType {
+                                                "value": Immutable.Map {
+                                                  "type": "long",
+                                                  "properties": Immutable.Set [
+                                                    "numeric",
+                                                    "enumerable",
+                                                  ],
+                                                  "indexNames": Immutable.Set [],
+                                                },
+                                              }
+                                            }
+                                            value={226}
+                                          />
+                                        }
                                         field="count()"
+                                        menuContainer={<body />}
                                         queryId="deadbeef-23"
-                                        render={[Function]}
                                         type={
                                           FieldType {
                                             "value": Immutable.Map {
@@ -925,8 +951,12 @@ exports[`DataTable renders column pivot header without offset when rollup is dis
                                         }
                                         value={226}
                                       >
-                                        <ValueActions
-                                          element={
+                                        <OverlayDropdown
+                                          menuContainer={<body />}
+                                          onToggle={[Function]}
+                                          placement="right"
+                                          show={false}
+                                          toggle={
                                             <TypeSpecificValue
                                               field="count()"
                                               render={[Function]}
@@ -945,56 +975,31 @@ exports[`DataTable renders column pivot header without offset when rollup is dis
                                               value={226}
                                             />
                                           }
-                                          field="count()"
-                                          menuContainer={<body />}
-                                          queryId="deadbeef-23"
-                                          type={
-                                            FieldType {
-                                              "value": Immutable.Map {
-                                                "type": "long",
-                                                "properties": Immutable.Set [
-                                                  "numeric",
-                                                  "enumerable",
-                                                ],
-                                                "indexNames": Immutable.Set [],
-                                              },
-                                            }
-                                          }
-                                          value={226}
                                         >
-                                          <OverlayDropdown
-                                            menuContainer={<body />}
-                                            onToggle={[Function]}
-                                            placement="right"
-                                            show={false}
-                                            toggle={
-                                              <TypeSpecificValue
-                                                field="count()"
-                                                render={[Function]}
-                                                type={
-                                                  FieldType {
-                                                    "value": Immutable.Map {
-                                                      "type": "long",
-                                                      "properties": Immutable.Set [
-                                                        "numeric",
-                                                        "enumerable",
-                                                      ],
-                                                      "indexNames": Immutable.Set [],
-                                                    },
-                                                  }
-                                                }
-                                                value={226}
-                                              />
-                                            }
+                                          <span
+                                            className="dropdowntoggle"
+                                            onClick={[Function]}
+                                            role="presentation"
                                           >
-                                            <span
-                                              className="dropdowntoggle"
-                                              onClick={[Function]}
-                                              role="presentation"
+                                            <TypeSpecificValue
+                                              field="count()"
+                                              render={[Function]}
+                                              type={
+                                                FieldType {
+                                                  "value": Immutable.Map {
+                                                    "type": "long",
+                                                    "properties": Immutable.Set [
+                                                      "numeric",
+                                                      "enumerable",
+                                                    ],
+                                                    "indexNames": Immutable.Set [],
+                                                  },
+                                                }
+                                              }
+                                              value={226}
                                             >
-                                              <TypeSpecificValue
+                                              <Component
                                                 field="count()"
-                                                render={[Function]}
                                                 type={
                                                   FieldType {
                                                     "value": Immutable.Map {
@@ -1007,9 +1012,9 @@ exports[`DataTable renders column pivot header without offset when rollup is dis
                                                     },
                                                   }
                                                 }
-                                                value={226}
+                                                value="226"
                                               >
-                                                <Component
+                                                <DecoratedValue
                                                   field="count()"
                                                   type={
                                                     FieldType {
@@ -1025,7 +1030,7 @@ exports[`DataTable renders column pivot header without offset when rollup is dis
                                                   }
                                                   value="226"
                                                 >
-                                                  <DecoratedValue
+                                                  <Component
                                                     field="count()"
                                                     type={
                                                       FieldType {
@@ -1041,7 +1046,7 @@ exports[`DataTable renders column pivot header without offset when rollup is dis
                                                     }
                                                     value="226"
                                                   >
-                                                    <Component
+                                                    <Highlight
                                                       field="count()"
                                                       type={
                                                         FieldType {
@@ -1057,44 +1062,27 @@ exports[`DataTable renders column pivot header without offset when rollup is dis
                                                       }
                                                       value="226"
                                                     >
-                                                      <Highlight
+                                                      <PossiblyHighlight
+                                                        color="#ffec3d"
                                                         field="count()"
-                                                        type={
-                                                          FieldType {
-                                                            "value": Immutable.Map {
-                                                              "type": "long",
-                                                              "properties": Immutable.Set [
-                                                                "numeric",
-                                                                "enumerable",
-                                                              ],
-                                                              "indexNames": Immutable.Set [],
-                                                            },
-                                                          }
-                                                        }
+                                                        highlightRanges={Object {}}
                                                         value="226"
                                                       >
-                                                        <PossiblyHighlight
-                                                          color="#ffec3d"
-                                                          field="count()"
-                                                          highlightRanges={Object {}}
-                                                          value="226"
-                                                        >
-                                                          226
-                                                        </PossiblyHighlight>
-                                                      </Highlight>
-                                                    </Component>
-                                                  </DecoratedValue>
-                                                </Component>
-                                              </TypeSpecificValue>
-                                              <span
-                                                className="caret"
-                                              />
-                                            </span>
-                                          </OverlayDropdown>
-                                        </ValueActions>
-                                      </Value>
-                                    </CustomHighlighting>
-                                  </ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules>
+                                                        226
+                                                      </PossiblyHighlight>
+                                                    </Highlight>
+                                                  </Component>
+                                                </DecoratedValue>
+                                              </Component>
+                                            </TypeSpecificValue>
+                                            <span
+                                              className="caret"
+                                            />
+                                          </span>
+                                        </OverlayDropdown>
+                                      </ValueActions>
+                                    </Value>
+                                  </CustomHighlighting>
                                 </Provider>
                               </td>
                             </tr>
@@ -2057,19 +2045,45 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                                     }
                                   }
                                 >
-                                  <ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules
+                                  <CustomHighlighting
                                     field="timestamp"
                                     value="2018-10-04T09:43:50.000Z"
                                   >
-                                    <CustomHighlighting
+                                    <Value
                                       field="timestamp"
-                                      highlightingRules={Object {}}
+                                      queryId="deadbeef-23"
+                                      render={[Function]}
+                                      type={
+                                        FieldType {
+                                          "value": Immutable.Map {
+                                            "type": "unknown",
+                                            "properties": Immutable.Set [],
+                                            "indexNames": Immutable.Set [],
+                                          },
+                                        }
+                                      }
                                       value="2018-10-04T09:43:50.000Z"
                                     >
-                                      <Value
+                                      <ValueActions
+                                        element={
+                                          <TypeSpecificValue
+                                            field="timestamp"
+                                            render={[Function]}
+                                            type={
+                                              FieldType {
+                                                "value": Immutable.Map {
+                                                  "type": "unknown",
+                                                  "properties": Immutable.Set [],
+                                                  "indexNames": Immutable.Set [],
+                                                },
+                                              }
+                                            }
+                                            value="2018-10-04T09:43:50.000Z"
+                                          />
+                                        }
                                         field="timestamp"
+                                        menuContainer={<body />}
                                         queryId="deadbeef-23"
-                                        render={[Function]}
                                         type={
                                           FieldType {
                                             "value": Immutable.Map {
@@ -2081,8 +2095,12 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                                         }
                                         value="2018-10-04T09:43:50.000Z"
                                       >
-                                        <ValueActions
-                                          element={
+                                        <OverlayDropdown
+                                          menuContainer={<body />}
+                                          onToggle={[Function]}
+                                          placement="right"
+                                          show={false}
+                                          toggle={
                                             <TypeSpecificValue
                                               field="timestamp"
                                               render={[Function]}
@@ -2098,50 +2116,28 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                                               value="2018-10-04T09:43:50.000Z"
                                             />
                                           }
-                                          field="timestamp"
-                                          menuContainer={<body />}
-                                          queryId="deadbeef-23"
-                                          type={
-                                            FieldType {
-                                              "value": Immutable.Map {
-                                                "type": "unknown",
-                                                "properties": Immutable.Set [],
-                                                "indexNames": Immutable.Set [],
-                                              },
-                                            }
-                                          }
-                                          value="2018-10-04T09:43:50.000Z"
                                         >
-                                          <OverlayDropdown
-                                            menuContainer={<body />}
-                                            onToggle={[Function]}
-                                            placement="right"
-                                            show={false}
-                                            toggle={
-                                              <TypeSpecificValue
-                                                field="timestamp"
-                                                render={[Function]}
-                                                type={
-                                                  FieldType {
-                                                    "value": Immutable.Map {
-                                                      "type": "unknown",
-                                                      "properties": Immutable.Set [],
-                                                      "indexNames": Immutable.Set [],
-                                                    },
-                                                  }
-                                                }
-                                                value="2018-10-04T09:43:50.000Z"
-                                              />
-                                            }
+                                          <span
+                                            className="dropdowntoggle"
+                                            onClick={[Function]}
+                                            role="presentation"
                                           >
-                                            <span
-                                              className="dropdowntoggle"
-                                              onClick={[Function]}
-                                              role="presentation"
+                                            <TypeSpecificValue
+                                              field="timestamp"
+                                              render={[Function]}
+                                              type={
+                                                FieldType {
+                                                  "value": Immutable.Map {
+                                                    "type": "unknown",
+                                                    "properties": Immutable.Set [],
+                                                    "indexNames": Immutable.Set [],
+                                                  },
+                                                }
+                                              }
+                                              value="2018-10-04T09:43:50.000Z"
                                             >
-                                              <TypeSpecificValue
+                                              <Component
                                                 field="timestamp"
-                                                render={[Function]}
                                                 type={
                                                   FieldType {
                                                     "value": Immutable.Map {
@@ -2153,7 +2149,7 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                                                 }
                                                 value="2018-10-04T09:43:50.000Z"
                                               >
-                                                <Component
+                                                <DecoratedValue
                                                   field="timestamp"
                                                   type={
                                                     FieldType {
@@ -2166,7 +2162,7 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                                                   }
                                                   value="2018-10-04T09:43:50.000Z"
                                                 >
-                                                  <DecoratedValue
+                                                  <Component
                                                     field="timestamp"
                                                     type={
                                                       FieldType {
@@ -2179,7 +2175,7 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                                                     }
                                                     value="2018-10-04T09:43:50.000Z"
                                                   >
-                                                    <Component
+                                                    <Highlight
                                                       field="timestamp"
                                                       type={
                                                         FieldType {
@@ -2192,41 +2188,27 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                                                       }
                                                       value="2018-10-04T09:43:50.000Z"
                                                     >
-                                                      <Highlight
+                                                      <PossiblyHighlight
+                                                        color="#ffec3d"
                                                         field="timestamp"
-                                                        type={
-                                                          FieldType {
-                                                            "value": Immutable.Map {
-                                                              "type": "unknown",
-                                                              "properties": Immutable.Set [],
-                                                              "indexNames": Immutable.Set [],
-                                                            },
-                                                          }
-                                                        }
+                                                        highlightRanges={Object {}}
                                                         value="2018-10-04T09:43:50.000Z"
                                                       >
-                                                        <PossiblyHighlight
-                                                          color="#ffec3d"
-                                                          field="timestamp"
-                                                          highlightRanges={Object {}}
-                                                          value="2018-10-04T09:43:50.000Z"
-                                                        >
-                                                          2018-10-04T09:43:50.000Z
-                                                        </PossiblyHighlight>
-                                                      </Highlight>
-                                                    </Component>
-                                                  </DecoratedValue>
-                                                </Component>
-                                              </TypeSpecificValue>
-                                              <span
-                                                className="caret"
-                                              />
-                                            </span>
-                                          </OverlayDropdown>
-                                        </ValueActions>
-                                      </Value>
-                                    </CustomHighlighting>
-                                  </ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules>
+                                                        2018-10-04T09:43:50.000Z
+                                                      </PossiblyHighlight>
+                                                    </Highlight>
+                                                  </Component>
+                                                </DecoratedValue>
+                                              </Component>
+                                            </TypeSpecificValue>
+                                            <span
+                                              className="caret"
+                                            />
+                                          </span>
+                                        </OverlayDropdown>
+                                      </ValueActions>
+                                    </Value>
+                                  </CustomHighlighting>
                                 </Provider>
                               </td>
                               <td
@@ -2243,19 +2225,51 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                                     }
                                   }
                                 >
-                                  <ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules
+                                  <CustomHighlighting
                                     field="count()"
                                     value={408}
                                   >
-                                    <CustomHighlighting
+                                    <Value
                                       field="count()"
-                                      highlightingRules={Object {}}
+                                      queryId="deadbeef-23"
+                                      render={[Function]}
+                                      type={
+                                        FieldType {
+                                          "value": Immutable.Map {
+                                            "type": "long",
+                                            "properties": Immutable.Set [
+                                              "numeric",
+                                              "enumerable",
+                                            ],
+                                            "indexNames": Immutable.Set [],
+                                          },
+                                        }
+                                      }
                                       value={408}
                                     >
-                                      <Value
+                                      <ValueActions
+                                        element={
+                                          <TypeSpecificValue
+                                            field="count()"
+                                            render={[Function]}
+                                            type={
+                                              FieldType {
+                                                "value": Immutable.Map {
+                                                  "type": "long",
+                                                  "properties": Immutable.Set [
+                                                    "numeric",
+                                                    "enumerable",
+                                                  ],
+                                                  "indexNames": Immutable.Set [],
+                                                },
+                                              }
+                                            }
+                                            value={408}
+                                          />
+                                        }
                                         field="count()"
+                                        menuContainer={<body />}
                                         queryId="deadbeef-23"
-                                        render={[Function]}
                                         type={
                                           FieldType {
                                             "value": Immutable.Map {
@@ -2270,8 +2284,12 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                                         }
                                         value={408}
                                       >
-                                        <ValueActions
-                                          element={
+                                        <OverlayDropdown
+                                          menuContainer={<body />}
+                                          onToggle={[Function]}
+                                          placement="right"
+                                          show={false}
+                                          toggle={
                                             <TypeSpecificValue
                                               field="count()"
                                               render={[Function]}
@@ -2290,56 +2308,31 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                                               value={408}
                                             />
                                           }
-                                          field="count()"
-                                          menuContainer={<body />}
-                                          queryId="deadbeef-23"
-                                          type={
-                                            FieldType {
-                                              "value": Immutable.Map {
-                                                "type": "long",
-                                                "properties": Immutable.Set [
-                                                  "numeric",
-                                                  "enumerable",
-                                                ],
-                                                "indexNames": Immutable.Set [],
-                                              },
-                                            }
-                                          }
-                                          value={408}
                                         >
-                                          <OverlayDropdown
-                                            menuContainer={<body />}
-                                            onToggle={[Function]}
-                                            placement="right"
-                                            show={false}
-                                            toggle={
-                                              <TypeSpecificValue
-                                                field="count()"
-                                                render={[Function]}
-                                                type={
-                                                  FieldType {
-                                                    "value": Immutable.Map {
-                                                      "type": "long",
-                                                      "properties": Immutable.Set [
-                                                        "numeric",
-                                                        "enumerable",
-                                                      ],
-                                                      "indexNames": Immutable.Set [],
-                                                    },
-                                                  }
-                                                }
-                                                value={408}
-                                              />
-                                            }
+                                          <span
+                                            className="dropdowntoggle"
+                                            onClick={[Function]}
+                                            role="presentation"
                                           >
-                                            <span
-                                              className="dropdowntoggle"
-                                              onClick={[Function]}
-                                              role="presentation"
+                                            <TypeSpecificValue
+                                              field="count()"
+                                              render={[Function]}
+                                              type={
+                                                FieldType {
+                                                  "value": Immutable.Map {
+                                                    "type": "long",
+                                                    "properties": Immutable.Set [
+                                                      "numeric",
+                                                      "enumerable",
+                                                    ],
+                                                    "indexNames": Immutable.Set [],
+                                                  },
+                                                }
+                                              }
+                                              value={408}
                                             >
-                                              <TypeSpecificValue
+                                              <Component
                                                 field="count()"
-                                                render={[Function]}
                                                 type={
                                                   FieldType {
                                                     "value": Immutable.Map {
@@ -2352,9 +2345,9 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                                                     },
                                                   }
                                                 }
-                                                value={408}
+                                                value="408"
                                               >
-                                                <Component
+                                                <DecoratedValue
                                                   field="count()"
                                                   type={
                                                     FieldType {
@@ -2370,7 +2363,7 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                                                   }
                                                   value="408"
                                                 >
-                                                  <DecoratedValue
+                                                  <Component
                                                     field="count()"
                                                     type={
                                                       FieldType {
@@ -2386,7 +2379,7 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                                                     }
                                                     value="408"
                                                   >
-                                                    <Component
+                                                    <Highlight
                                                       field="count()"
                                                       type={
                                                         FieldType {
@@ -2402,44 +2395,27 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                                                       }
                                                       value="408"
                                                     >
-                                                      <Highlight
+                                                      <PossiblyHighlight
+                                                        color="#ffec3d"
                                                         field="count()"
-                                                        type={
-                                                          FieldType {
-                                                            "value": Immutable.Map {
-                                                              "type": "long",
-                                                              "properties": Immutable.Set [
-                                                                "numeric",
-                                                                "enumerable",
-                                                              ],
-                                                              "indexNames": Immutable.Set [],
-                                                            },
-                                                          }
-                                                        }
+                                                        highlightRanges={Object {}}
                                                         value="408"
                                                       >
-                                                        <PossiblyHighlight
-                                                          color="#ffec3d"
-                                                          field="count()"
-                                                          highlightRanges={Object {}}
-                                                          value="408"
-                                                        >
-                                                          408
-                                                        </PossiblyHighlight>
-                                                      </Highlight>
-                                                    </Component>
-                                                  </DecoratedValue>
-                                                </Component>
-                                              </TypeSpecificValue>
-                                              <span
-                                                className="caret"
-                                              />
-                                            </span>
-                                          </OverlayDropdown>
-                                        </ValueActions>
-                                      </Value>
-                                    </CustomHighlighting>
-                                  </ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules>
+                                                        408
+                                                      </PossiblyHighlight>
+                                                    </Highlight>
+                                                  </Component>
+                                                </DecoratedValue>
+                                              </Component>
+                                            </TypeSpecificValue>
+                                            <span
+                                              className="caret"
+                                            />
+                                          </span>
+                                        </OverlayDropdown>
+                                      </ValueActions>
+                                    </Value>
+                                  </CustomHighlighting>
                                 </Provider>
                               </td>
                               <td
@@ -2459,19 +2435,51 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                                     }
                                   }
                                 >
-                                  <ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules
+                                  <CustomHighlighting
                                     field="count()"
                                     value={408}
                                   >
-                                    <CustomHighlighting
+                                    <Value
                                       field="count()"
-                                      highlightingRules={Object {}}
+                                      queryId="deadbeef-23"
+                                      render={[Function]}
+                                      type={
+                                        FieldType {
+                                          "value": Immutable.Map {
+                                            "type": "long",
+                                            "properties": Immutable.Set [
+                                              "numeric",
+                                              "enumerable",
+                                            ],
+                                            "indexNames": Immutable.Set [],
+                                          },
+                                        }
+                                      }
                                       value={408}
                                     >
-                                      <Value
+                                      <ValueActions
+                                        element={
+                                          <TypeSpecificValue
+                                            field="count()"
+                                            render={[Function]}
+                                            type={
+                                              FieldType {
+                                                "value": Immutable.Map {
+                                                  "type": "long",
+                                                  "properties": Immutable.Set [
+                                                    "numeric",
+                                                    "enumerable",
+                                                  ],
+                                                  "indexNames": Immutable.Set [],
+                                                },
+                                              }
+                                            }
+                                            value={408}
+                                          />
+                                        }
                                         field="count()"
+                                        menuContainer={<body />}
                                         queryId="deadbeef-23"
-                                        render={[Function]}
                                         type={
                                           FieldType {
                                             "value": Immutable.Map {
@@ -2486,8 +2494,12 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                                         }
                                         value={408}
                                       >
-                                        <ValueActions
-                                          element={
+                                        <OverlayDropdown
+                                          menuContainer={<body />}
+                                          onToggle={[Function]}
+                                          placement="right"
+                                          show={false}
+                                          toggle={
                                             <TypeSpecificValue
                                               field="count()"
                                               render={[Function]}
@@ -2506,56 +2518,31 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                                               value={408}
                                             />
                                           }
-                                          field="count()"
-                                          menuContainer={<body />}
-                                          queryId="deadbeef-23"
-                                          type={
-                                            FieldType {
-                                              "value": Immutable.Map {
-                                                "type": "long",
-                                                "properties": Immutable.Set [
-                                                  "numeric",
-                                                  "enumerable",
-                                                ],
-                                                "indexNames": Immutable.Set [],
-                                              },
-                                            }
-                                          }
-                                          value={408}
                                         >
-                                          <OverlayDropdown
-                                            menuContainer={<body />}
-                                            onToggle={[Function]}
-                                            placement="right"
-                                            show={false}
-                                            toggle={
-                                              <TypeSpecificValue
-                                                field="count()"
-                                                render={[Function]}
-                                                type={
-                                                  FieldType {
-                                                    "value": Immutable.Map {
-                                                      "type": "long",
-                                                      "properties": Immutable.Set [
-                                                        "numeric",
-                                                        "enumerable",
-                                                      ],
-                                                      "indexNames": Immutable.Set [],
-                                                    },
-                                                  }
-                                                }
-                                                value={408}
-                                              />
-                                            }
+                                          <span
+                                            className="dropdowntoggle"
+                                            onClick={[Function]}
+                                            role="presentation"
                                           >
-                                            <span
-                                              className="dropdowntoggle"
-                                              onClick={[Function]}
-                                              role="presentation"
+                                            <TypeSpecificValue
+                                              field="count()"
+                                              render={[Function]}
+                                              type={
+                                                FieldType {
+                                                  "value": Immutable.Map {
+                                                    "type": "long",
+                                                    "properties": Immutable.Set [
+                                                      "numeric",
+                                                      "enumerable",
+                                                    ],
+                                                    "indexNames": Immutable.Set [],
+                                                  },
+                                                }
+                                              }
+                                              value={408}
                                             >
-                                              <TypeSpecificValue
+                                              <Component
                                                 field="count()"
-                                                render={[Function]}
                                                 type={
                                                   FieldType {
                                                     "value": Immutable.Map {
@@ -2568,9 +2555,9 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                                                     },
                                                   }
                                                 }
-                                                value={408}
+                                                value="408"
                                               >
-                                                <Component
+                                                <DecoratedValue
                                                   field="count()"
                                                   type={
                                                     FieldType {
@@ -2586,7 +2573,7 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                                                   }
                                                   value="408"
                                                 >
-                                                  <DecoratedValue
+                                                  <Component
                                                     field="count()"
                                                     type={
                                                       FieldType {
@@ -2602,7 +2589,7 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                                                     }
                                                     value="408"
                                                   >
-                                                    <Component
+                                                    <Highlight
                                                       field="count()"
                                                       type={
                                                         FieldType {
@@ -2618,44 +2605,27 @@ exports[`DataTable should render with filled data with rollup 1`] = `
                                                       }
                                                       value="408"
                                                     >
-                                                      <Highlight
+                                                      <PossiblyHighlight
+                                                        color="#ffec3d"
                                                         field="count()"
-                                                        type={
-                                                          FieldType {
-                                                            "value": Immutable.Map {
-                                                              "type": "long",
-                                                              "properties": Immutable.Set [
-                                                                "numeric",
-                                                                "enumerable",
-                                                              ],
-                                                              "indexNames": Immutable.Set [],
-                                                            },
-                                                          }
-                                                        }
+                                                        highlightRanges={Object {}}
                                                         value="408"
                                                       >
-                                                        <PossiblyHighlight
-                                                          color="#ffec3d"
-                                                          field="count()"
-                                                          highlightRanges={Object {}}
-                                                          value="408"
-                                                        >
-                                                          408
-                                                        </PossiblyHighlight>
-                                                      </Highlight>
-                                                    </Component>
-                                                  </DecoratedValue>
-                                                </Component>
-                                              </TypeSpecificValue>
-                                              <span
-                                                className="caret"
-                                              />
-                                            </span>
-                                          </OverlayDropdown>
-                                        </ValueActions>
-                                      </Value>
-                                    </CustomHighlighting>
-                                  </ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules>
+                                                        408
+                                                      </PossiblyHighlight>
+                                                    </Highlight>
+                                                  </Component>
+                                                </DecoratedValue>
+                                              </Component>
+                                            </TypeSpecificValue>
+                                            <span
+                                              className="caret"
+                                            />
+                                          </span>
+                                        </OverlayDropdown>
+                                      </ValueActions>
+                                    </Value>
+                                  </CustomHighlighting>
                                 </Provider>
                               </td>
                             </tr>
@@ -3333,19 +3303,45 @@ exports[`DataTable should render with filled data without rollup 1`] = `
                                     }
                                   }
                                 >
-                                  <ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules
+                                  <CustomHighlighting
                                     field="timestamp"
                                     value="2018-10-04T09:43:50.000Z"
                                   >
-                                    <CustomHighlighting
+                                    <Value
                                       field="timestamp"
-                                      highlightingRules={Object {}}
+                                      queryId="deadbeef-23"
+                                      render={[Function]}
+                                      type={
+                                        FieldType {
+                                          "value": Immutable.Map {
+                                            "type": "unknown",
+                                            "properties": Immutable.Set [],
+                                            "indexNames": Immutable.Set [],
+                                          },
+                                        }
+                                      }
                                       value="2018-10-04T09:43:50.000Z"
                                     >
-                                      <Value
+                                      <ValueActions
+                                        element={
+                                          <TypeSpecificValue
+                                            field="timestamp"
+                                            render={[Function]}
+                                            type={
+                                              FieldType {
+                                                "value": Immutable.Map {
+                                                  "type": "unknown",
+                                                  "properties": Immutable.Set [],
+                                                  "indexNames": Immutable.Set [],
+                                                },
+                                              }
+                                            }
+                                            value="2018-10-04T09:43:50.000Z"
+                                          />
+                                        }
                                         field="timestamp"
+                                        menuContainer={<body />}
                                         queryId="deadbeef-23"
-                                        render={[Function]}
                                         type={
                                           FieldType {
                                             "value": Immutable.Map {
@@ -3357,8 +3353,12 @@ exports[`DataTable should render with filled data without rollup 1`] = `
                                         }
                                         value="2018-10-04T09:43:50.000Z"
                                       >
-                                        <ValueActions
-                                          element={
+                                        <OverlayDropdown
+                                          menuContainer={<body />}
+                                          onToggle={[Function]}
+                                          placement="right"
+                                          show={false}
+                                          toggle={
                                             <TypeSpecificValue
                                               field="timestamp"
                                               render={[Function]}
@@ -3374,50 +3374,28 @@ exports[`DataTable should render with filled data without rollup 1`] = `
                                               value="2018-10-04T09:43:50.000Z"
                                             />
                                           }
-                                          field="timestamp"
-                                          menuContainer={<body />}
-                                          queryId="deadbeef-23"
-                                          type={
-                                            FieldType {
-                                              "value": Immutable.Map {
-                                                "type": "unknown",
-                                                "properties": Immutable.Set [],
-                                                "indexNames": Immutable.Set [],
-                                              },
-                                            }
-                                          }
-                                          value="2018-10-04T09:43:50.000Z"
                                         >
-                                          <OverlayDropdown
-                                            menuContainer={<body />}
-                                            onToggle={[Function]}
-                                            placement="right"
-                                            show={false}
-                                            toggle={
-                                              <TypeSpecificValue
-                                                field="timestamp"
-                                                render={[Function]}
-                                                type={
-                                                  FieldType {
-                                                    "value": Immutable.Map {
-                                                      "type": "unknown",
-                                                      "properties": Immutable.Set [],
-                                                      "indexNames": Immutable.Set [],
-                                                    },
-                                                  }
-                                                }
-                                                value="2018-10-04T09:43:50.000Z"
-                                              />
-                                            }
+                                          <span
+                                            className="dropdowntoggle"
+                                            onClick={[Function]}
+                                            role="presentation"
                                           >
-                                            <span
-                                              className="dropdowntoggle"
-                                              onClick={[Function]}
-                                              role="presentation"
+                                            <TypeSpecificValue
+                                              field="timestamp"
+                                              render={[Function]}
+                                              type={
+                                                FieldType {
+                                                  "value": Immutable.Map {
+                                                    "type": "unknown",
+                                                    "properties": Immutable.Set [],
+                                                    "indexNames": Immutable.Set [],
+                                                  },
+                                                }
+                                              }
+                                              value="2018-10-04T09:43:50.000Z"
                                             >
-                                              <TypeSpecificValue
+                                              <Component
                                                 field="timestamp"
-                                                render={[Function]}
                                                 type={
                                                   FieldType {
                                                     "value": Immutable.Map {
@@ -3429,7 +3407,7 @@ exports[`DataTable should render with filled data without rollup 1`] = `
                                                 }
                                                 value="2018-10-04T09:43:50.000Z"
                                               >
-                                                <Component
+                                                <DecoratedValue
                                                   field="timestamp"
                                                   type={
                                                     FieldType {
@@ -3442,7 +3420,7 @@ exports[`DataTable should render with filled data without rollup 1`] = `
                                                   }
                                                   value="2018-10-04T09:43:50.000Z"
                                                 >
-                                                  <DecoratedValue
+                                                  <Component
                                                     field="timestamp"
                                                     type={
                                                       FieldType {
@@ -3455,7 +3433,7 @@ exports[`DataTable should render with filled data without rollup 1`] = `
                                                     }
                                                     value="2018-10-04T09:43:50.000Z"
                                                   >
-                                                    <Component
+                                                    <Highlight
                                                       field="timestamp"
                                                       type={
                                                         FieldType {
@@ -3468,41 +3446,27 @@ exports[`DataTable should render with filled data without rollup 1`] = `
                                                       }
                                                       value="2018-10-04T09:43:50.000Z"
                                                     >
-                                                      <Highlight
+                                                      <PossiblyHighlight
+                                                        color="#ffec3d"
                                                         field="timestamp"
-                                                        type={
-                                                          FieldType {
-                                                            "value": Immutable.Map {
-                                                              "type": "unknown",
-                                                              "properties": Immutable.Set [],
-                                                              "indexNames": Immutable.Set [],
-                                                            },
-                                                          }
-                                                        }
+                                                        highlightRanges={Object {}}
                                                         value="2018-10-04T09:43:50.000Z"
                                                       >
-                                                        <PossiblyHighlight
-                                                          color="#ffec3d"
-                                                          field="timestamp"
-                                                          highlightRanges={Object {}}
-                                                          value="2018-10-04T09:43:50.000Z"
-                                                        >
-                                                          2018-10-04T09:43:50.000Z
-                                                        </PossiblyHighlight>
-                                                      </Highlight>
-                                                    </Component>
-                                                  </DecoratedValue>
-                                                </Component>
-                                              </TypeSpecificValue>
-                                              <span
-                                                className="caret"
-                                              />
-                                            </span>
-                                          </OverlayDropdown>
-                                        </ValueActions>
-                                      </Value>
-                                    </CustomHighlighting>
-                                  </ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules>
+                                                        2018-10-04T09:43:50.000Z
+                                                      </PossiblyHighlight>
+                                                    </Highlight>
+                                                  </Component>
+                                                </DecoratedValue>
+                                              </Component>
+                                            </TypeSpecificValue>
+                                            <span
+                                              className="caret"
+                                            />
+                                          </span>
+                                        </OverlayDropdown>
+                                      </ValueActions>
+                                    </Value>
+                                  </CustomHighlighting>
                                 </Provider>
                               </td>
                               <td
@@ -3522,19 +3486,51 @@ exports[`DataTable should render with filled data without rollup 1`] = `
                                     }
                                   }
                                 >
-                                  <ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules
+                                  <CustomHighlighting
                                     field="count()"
                                     value={408}
                                   >
-                                    <CustomHighlighting
+                                    <Value
                                       field="count()"
-                                      highlightingRules={Object {}}
+                                      queryId="deadbeef-23"
+                                      render={[Function]}
+                                      type={
+                                        FieldType {
+                                          "value": Immutable.Map {
+                                            "type": "long",
+                                            "properties": Immutable.Set [
+                                              "numeric",
+                                              "enumerable",
+                                            ],
+                                            "indexNames": Immutable.Set [],
+                                          },
+                                        }
+                                      }
                                       value={408}
                                     >
-                                      <Value
+                                      <ValueActions
+                                        element={
+                                          <TypeSpecificValue
+                                            field="count()"
+                                            render={[Function]}
+                                            type={
+                                              FieldType {
+                                                "value": Immutable.Map {
+                                                  "type": "long",
+                                                  "properties": Immutable.Set [
+                                                    "numeric",
+                                                    "enumerable",
+                                                  ],
+                                                  "indexNames": Immutable.Set [],
+                                                },
+                                              }
+                                            }
+                                            value={408}
+                                          />
+                                        }
                                         field="count()"
+                                        menuContainer={<body />}
                                         queryId="deadbeef-23"
-                                        render={[Function]}
                                         type={
                                           FieldType {
                                             "value": Immutable.Map {
@@ -3549,8 +3545,12 @@ exports[`DataTable should render with filled data without rollup 1`] = `
                                         }
                                         value={408}
                                       >
-                                        <ValueActions
-                                          element={
+                                        <OverlayDropdown
+                                          menuContainer={<body />}
+                                          onToggle={[Function]}
+                                          placement="right"
+                                          show={false}
+                                          toggle={
                                             <TypeSpecificValue
                                               field="count()"
                                               render={[Function]}
@@ -3569,56 +3569,31 @@ exports[`DataTable should render with filled data without rollup 1`] = `
                                               value={408}
                                             />
                                           }
-                                          field="count()"
-                                          menuContainer={<body />}
-                                          queryId="deadbeef-23"
-                                          type={
-                                            FieldType {
-                                              "value": Immutable.Map {
-                                                "type": "long",
-                                                "properties": Immutable.Set [
-                                                  "numeric",
-                                                  "enumerable",
-                                                ],
-                                                "indexNames": Immutable.Set [],
-                                              },
-                                            }
-                                          }
-                                          value={408}
                                         >
-                                          <OverlayDropdown
-                                            menuContainer={<body />}
-                                            onToggle={[Function]}
-                                            placement="right"
-                                            show={false}
-                                            toggle={
-                                              <TypeSpecificValue
-                                                field="count()"
-                                                render={[Function]}
-                                                type={
-                                                  FieldType {
-                                                    "value": Immutable.Map {
-                                                      "type": "long",
-                                                      "properties": Immutable.Set [
-                                                        "numeric",
-                                                        "enumerable",
-                                                      ],
-                                                      "indexNames": Immutable.Set [],
-                                                    },
-                                                  }
-                                                }
-                                                value={408}
-                                              />
-                                            }
+                                          <span
+                                            className="dropdowntoggle"
+                                            onClick={[Function]}
+                                            role="presentation"
                                           >
-                                            <span
-                                              className="dropdowntoggle"
-                                              onClick={[Function]}
-                                              role="presentation"
+                                            <TypeSpecificValue
+                                              field="count()"
+                                              render={[Function]}
+                                              type={
+                                                FieldType {
+                                                  "value": Immutable.Map {
+                                                    "type": "long",
+                                                    "properties": Immutable.Set [
+                                                      "numeric",
+                                                      "enumerable",
+                                                    ],
+                                                    "indexNames": Immutable.Set [],
+                                                  },
+                                                }
+                                              }
+                                              value={408}
                                             >
-                                              <TypeSpecificValue
+                                              <Component
                                                 field="count()"
-                                                render={[Function]}
                                                 type={
                                                   FieldType {
                                                     "value": Immutable.Map {
@@ -3631,9 +3606,9 @@ exports[`DataTable should render with filled data without rollup 1`] = `
                                                     },
                                                   }
                                                 }
-                                                value={408}
+                                                value="408"
                                               >
-                                                <Component
+                                                <DecoratedValue
                                                   field="count()"
                                                   type={
                                                     FieldType {
@@ -3649,7 +3624,7 @@ exports[`DataTable should render with filled data without rollup 1`] = `
                                                   }
                                                   value="408"
                                                 >
-                                                  <DecoratedValue
+                                                  <Component
                                                     field="count()"
                                                     type={
                                                       FieldType {
@@ -3665,7 +3640,7 @@ exports[`DataTable should render with filled data without rollup 1`] = `
                                                     }
                                                     value="408"
                                                   >
-                                                    <Component
+                                                    <Highlight
                                                       field="count()"
                                                       type={
                                                         FieldType {
@@ -3681,44 +3656,27 @@ exports[`DataTable should render with filled data without rollup 1`] = `
                                                       }
                                                       value="408"
                                                     >
-                                                      <Highlight
+                                                      <PossiblyHighlight
+                                                        color="#ffec3d"
                                                         field="count()"
-                                                        type={
-                                                          FieldType {
-                                                            "value": Immutable.Map {
-                                                              "type": "long",
-                                                              "properties": Immutable.Set [
-                                                                "numeric",
-                                                                "enumerable",
-                                                              ],
-                                                              "indexNames": Immutable.Set [],
-                                                            },
-                                                          }
-                                                        }
+                                                        highlightRanges={Object {}}
                                                         value="408"
                                                       >
-                                                        <PossiblyHighlight
-                                                          color="#ffec3d"
-                                                          field="count()"
-                                                          highlightRanges={Object {}}
-                                                          value="408"
-                                                        >
-                                                          408
-                                                        </PossiblyHighlight>
-                                                      </Highlight>
-                                                    </Component>
-                                                  </DecoratedValue>
-                                                </Component>
-                                              </TypeSpecificValue>
-                                              <span
-                                                className="caret"
-                                              />
-                                            </span>
-                                          </OverlayDropdown>
-                                        </ValueActions>
-                                      </Value>
-                                    </CustomHighlighting>
-                                  </ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules>
+                                                        408
+                                                      </PossiblyHighlight>
+                                                    </Highlight>
+                                                  </Component>
+                                                </DecoratedValue>
+                                              </Component>
+                                            </TypeSpecificValue>
+                                            <span
+                                              className="caret"
+                                            />
+                                          </span>
+                                        </OverlayDropdown>
+                                      </ValueActions>
+                                    </Value>
+                                  </CustomHighlighting>
                                 </Provider>
                               </td>
                             </tr>

--- a/graylog2-web-interface/src/views/components/datatable/__snapshots__/DataTableEntry.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/datatable/__snapshots__/DataTableEntry.test.jsx.snap
@@ -102,19 +102,45 @@ exports[`DataTableEntry does not fail without types 1`] = `
               }
             }
           >
-            <ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules
+            <CustomHighlighting
               field="nf_dst_address"
               value="192.168.1.24"
             >
-              <CustomHighlighting
+              <Value
                 field="nf_dst_address"
-                highlightingRules={Object {}}
+                queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
+                render={[Function]}
+                type={
+                  FieldType {
+                    "value": Immutable.Map {
+                      "type": "unknown",
+                      "properties": Immutable.Set [],
+                      "indexNames": Immutable.Set [],
+                    },
+                  }
+                }
                 value="192.168.1.24"
               >
-                <Value
+                <ValueActions
+                  element={
+                    <TypeSpecificValue
+                      field="nf_dst_address"
+                      render={[Function]}
+                      type={
+                        FieldType {
+                          "value": Immutable.Map {
+                            "type": "unknown",
+                            "properties": Immutable.Set [],
+                            "indexNames": Immutable.Set [],
+                          },
+                        }
+                      }
+                      value="192.168.1.24"
+                    />
+                  }
                   field="nf_dst_address"
+                  menuContainer={<body />}
                   queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
-                  render={[Function]}
                   type={
                     FieldType {
                       "value": Immutable.Map {
@@ -126,8 +152,12 @@ exports[`DataTableEntry does not fail without types 1`] = `
                   }
                   value="192.168.1.24"
                 >
-                  <ValueActions
-                    element={
+                  <OverlayDropdown
+                    menuContainer={<body />}
+                    onToggle={[Function]}
+                    placement="right"
+                    show={false}
+                    toggle={
                       <TypeSpecificValue
                         field="nf_dst_address"
                         render={[Function]}
@@ -143,50 +173,28 @@ exports[`DataTableEntry does not fail without types 1`] = `
                         value="192.168.1.24"
                       />
                     }
-                    field="nf_dst_address"
-                    menuContainer={<body />}
-                    queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
-                    type={
-                      FieldType {
-                        "value": Immutable.Map {
-                          "type": "unknown",
-                          "properties": Immutable.Set [],
-                          "indexNames": Immutable.Set [],
-                        },
-                      }
-                    }
-                    value="192.168.1.24"
                   >
-                    <OverlayDropdown
-                      menuContainer={<body />}
-                      onToggle={[Function]}
-                      placement="right"
-                      show={false}
-                      toggle={
-                        <TypeSpecificValue
-                          field="nf_dst_address"
-                          render={[Function]}
-                          type={
-                            FieldType {
-                              "value": Immutable.Map {
-                                "type": "unknown",
-                                "properties": Immutable.Set [],
-                                "indexNames": Immutable.Set [],
-                              },
-                            }
-                          }
-                          value="192.168.1.24"
-                        />
-                      }
+                    <span
+                      className="dropdowntoggle"
+                      onClick={[Function]}
+                      role="presentation"
                     >
-                      <span
-                        className="dropdowntoggle"
-                        onClick={[Function]}
-                        role="presentation"
+                      <TypeSpecificValue
+                        field="nf_dst_address"
+                        render={[Function]}
+                        type={
+                          FieldType {
+                            "value": Immutable.Map {
+                              "type": "unknown",
+                              "properties": Immutable.Set [],
+                              "indexNames": Immutable.Set [],
+                            },
+                          }
+                        }
+                        value="192.168.1.24"
                       >
-                        <TypeSpecificValue
+                        <Component
                           field="nf_dst_address"
-                          render={[Function]}
                           type={
                             FieldType {
                               "value": Immutable.Map {
@@ -198,7 +206,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                           }
                           value="192.168.1.24"
                         >
-                          <Component
+                          <DecoratedValue
                             field="nf_dst_address"
                             type={
                               FieldType {
@@ -211,7 +219,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                             }
                             value="192.168.1.24"
                           >
-                            <DecoratedValue
+                            <Component
                               field="nf_dst_address"
                               type={
                                 FieldType {
@@ -224,7 +232,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                               }
                               value="192.168.1.24"
                             >
-                              <Component
+                              <Highlight
                                 field="nf_dst_address"
                                 type={
                                   FieldType {
@@ -237,41 +245,27 @@ exports[`DataTableEntry does not fail without types 1`] = `
                                 }
                                 value="192.168.1.24"
                               >
-                                <Highlight
+                                <PossiblyHighlight
+                                  color="#ffec3d"
                                   field="nf_dst_address"
-                                  type={
-                                    FieldType {
-                                      "value": Immutable.Map {
-                                        "type": "unknown",
-                                        "properties": Immutable.Set [],
-                                        "indexNames": Immutable.Set [],
-                                      },
-                                    }
-                                  }
+                                  highlightRanges={Object {}}
                                   value="192.168.1.24"
                                 >
-                                  <PossiblyHighlight
-                                    color="#ffec3d"
-                                    field="nf_dst_address"
-                                    highlightRanges={Object {}}
-                                    value="192.168.1.24"
-                                  >
-                                    192.168.1.24
-                                  </PossiblyHighlight>
-                                </Highlight>
-                              </Component>
-                            </DecoratedValue>
-                          </Component>
-                        </TypeSpecificValue>
-                        <span
-                          className="caret"
-                        />
-                      </span>
-                    </OverlayDropdown>
-                  </ValueActions>
-                </Value>
-              </CustomHighlighting>
-            </ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules>
+                                  192.168.1.24
+                                </PossiblyHighlight>
+                              </Highlight>
+                            </Component>
+                          </DecoratedValue>
+                        </Component>
+                      </TypeSpecificValue>
+                      <span
+                        className="caret"
+                      />
+                    </span>
+                  </OverlayDropdown>
+                </ValueActions>
+              </Value>
+            </CustomHighlighting>
           </Provider>
         </td>
         <td
@@ -288,19 +282,51 @@ exports[`DataTableEntry does not fail without types 1`] = `
               }
             }
           >
-            <ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules
+            <CustomHighlighting
               field="count()"
               value={84}
             >
-              <CustomHighlighting
+              <Value
                 field="count()"
-                highlightingRules={Object {}}
+                queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
+                render={[Function]}
+                type={
+                  FieldType {
+                    "value": Immutable.Map {
+                      "type": "long",
+                      "properties": Immutable.Set [
+                        "numeric",
+                        "enumerable",
+                      ],
+                      "indexNames": Immutable.Set [],
+                    },
+                  }
+                }
                 value={84}
               >
-                <Value
+                <ValueActions
+                  element={
+                    <TypeSpecificValue
+                      field="count()"
+                      render={[Function]}
+                      type={
+                        FieldType {
+                          "value": Immutable.Map {
+                            "type": "long",
+                            "properties": Immutable.Set [
+                              "numeric",
+                              "enumerable",
+                            ],
+                            "indexNames": Immutable.Set [],
+                          },
+                        }
+                      }
+                      value={84}
+                    />
+                  }
                   field="count()"
+                  menuContainer={<body />}
                   queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
-                  render={[Function]}
                   type={
                     FieldType {
                       "value": Immutable.Map {
@@ -315,8 +341,12 @@ exports[`DataTableEntry does not fail without types 1`] = `
                   }
                   value={84}
                 >
-                  <ValueActions
-                    element={
+                  <OverlayDropdown
+                    menuContainer={<body />}
+                    onToggle={[Function]}
+                    placement="right"
+                    show={false}
+                    toggle={
                       <TypeSpecificValue
                         field="count()"
                         render={[Function]}
@@ -335,56 +365,31 @@ exports[`DataTableEntry does not fail without types 1`] = `
                         value={84}
                       />
                     }
-                    field="count()"
-                    menuContainer={<body />}
-                    queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
-                    type={
-                      FieldType {
-                        "value": Immutable.Map {
-                          "type": "long",
-                          "properties": Immutable.Set [
-                            "numeric",
-                            "enumerable",
-                          ],
-                          "indexNames": Immutable.Set [],
-                        },
-                      }
-                    }
-                    value={84}
                   >
-                    <OverlayDropdown
-                      menuContainer={<body />}
-                      onToggle={[Function]}
-                      placement="right"
-                      show={false}
-                      toggle={
-                        <TypeSpecificValue
-                          field="count()"
-                          render={[Function]}
-                          type={
-                            FieldType {
-                              "value": Immutable.Map {
-                                "type": "long",
-                                "properties": Immutable.Set [
-                                  "numeric",
-                                  "enumerable",
-                                ],
-                                "indexNames": Immutable.Set [],
-                              },
-                            }
-                          }
-                          value={84}
-                        />
-                      }
+                    <span
+                      className="dropdowntoggle"
+                      onClick={[Function]}
+                      role="presentation"
                     >
-                      <span
-                        className="dropdowntoggle"
-                        onClick={[Function]}
-                        role="presentation"
+                      <TypeSpecificValue
+                        field="count()"
+                        render={[Function]}
+                        type={
+                          FieldType {
+                            "value": Immutable.Map {
+                              "type": "long",
+                              "properties": Immutable.Set [
+                                "numeric",
+                                "enumerable",
+                              ],
+                              "indexNames": Immutable.Set [],
+                            },
+                          }
+                        }
+                        value={84}
                       >
-                        <TypeSpecificValue
+                        <Component
                           field="count()"
-                          render={[Function]}
                           type={
                             FieldType {
                               "value": Immutable.Map {
@@ -397,9 +402,9 @@ exports[`DataTableEntry does not fail without types 1`] = `
                               },
                             }
                           }
-                          value={84}
+                          value="84"
                         >
-                          <Component
+                          <DecoratedValue
                             field="count()"
                             type={
                               FieldType {
@@ -415,7 +420,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                             }
                             value="84"
                           >
-                            <DecoratedValue
+                            <Component
                               field="count()"
                               type={
                                 FieldType {
@@ -431,7 +436,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                               }
                               value="84"
                             >
-                              <Component
+                              <Highlight
                                 field="count()"
                                 type={
                                   FieldType {
@@ -447,44 +452,27 @@ exports[`DataTableEntry does not fail without types 1`] = `
                                 }
                                 value="84"
                               >
-                                <Highlight
+                                <PossiblyHighlight
+                                  color="#ffec3d"
                                   field="count()"
-                                  type={
-                                    FieldType {
-                                      "value": Immutable.Map {
-                                        "type": "long",
-                                        "properties": Immutable.Set [
-                                          "numeric",
-                                          "enumerable",
-                                        ],
-                                        "indexNames": Immutable.Set [],
-                                      },
-                                    }
-                                  }
+                                  highlightRanges={Object {}}
                                   value="84"
                                 >
-                                  <PossiblyHighlight
-                                    color="#ffec3d"
-                                    field="count()"
-                                    highlightRanges={Object {}}
-                                    value="84"
-                                  >
-                                    84
-                                  </PossiblyHighlight>
-                                </Highlight>
-                              </Component>
-                            </DecoratedValue>
-                          </Component>
-                        </TypeSpecificValue>
-                        <span
-                          className="caret"
-                        />
-                      </span>
-                    </OverlayDropdown>
-                  </ValueActions>
-                </Value>
-              </CustomHighlighting>
-            </ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules>
+                                  84
+                                </PossiblyHighlight>
+                              </Highlight>
+                            </Component>
+                          </DecoratedValue>
+                        </Component>
+                      </TypeSpecificValue>
+                      <span
+                        className="caret"
+                      />
+                    </span>
+                  </OverlayDropdown>
+                </ValueActions>
+              </Value>
+            </CustomHighlighting>
           </Provider>
         </td>
         <td
@@ -504,19 +492,45 @@ exports[`DataTableEntry does not fail without types 1`] = `
               }
             }
           >
-            <ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules
+            <CustomHighlighting
               field="max(timestamp)"
               value={1554106041841}
             >
-              <CustomHighlighting
+              <Value
                 field="max(timestamp)"
-                highlightingRules={Object {}}
+                queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
+                render={[Function]}
+                type={
+                  FieldType {
+                    "value": Immutable.Map {
+                      "type": "unknown",
+                      "properties": Immutable.Set [],
+                      "indexNames": Immutable.Set [],
+                    },
+                  }
+                }
                 value={1554106041841}
               >
-                <Value
+                <ValueActions
+                  element={
+                    <TypeSpecificValue
+                      field="max(timestamp)"
+                      render={[Function]}
+                      type={
+                        FieldType {
+                          "value": Immutable.Map {
+                            "type": "unknown",
+                            "properties": Immutable.Set [],
+                            "indexNames": Immutable.Set [],
+                          },
+                        }
+                      }
+                      value={1554106041841}
+                    />
+                  }
                   field="max(timestamp)"
+                  menuContainer={<body />}
                   queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
-                  render={[Function]}
                   type={
                     FieldType {
                       "value": Immutable.Map {
@@ -528,8 +542,12 @@ exports[`DataTableEntry does not fail without types 1`] = `
                   }
                   value={1554106041841}
                 >
-                  <ValueActions
-                    element={
+                  <OverlayDropdown
+                    menuContainer={<body />}
+                    onToggle={[Function]}
+                    placement="right"
+                    show={false}
+                    toggle={
                       <TypeSpecificValue
                         field="max(timestamp)"
                         render={[Function]}
@@ -545,50 +563,28 @@ exports[`DataTableEntry does not fail without types 1`] = `
                         value={1554106041841}
                       />
                     }
-                    field="max(timestamp)"
-                    menuContainer={<body />}
-                    queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
-                    type={
-                      FieldType {
-                        "value": Immutable.Map {
-                          "type": "unknown",
-                          "properties": Immutable.Set [],
-                          "indexNames": Immutable.Set [],
-                        },
-                      }
-                    }
-                    value={1554106041841}
                   >
-                    <OverlayDropdown
-                      menuContainer={<body />}
-                      onToggle={[Function]}
-                      placement="right"
-                      show={false}
-                      toggle={
-                        <TypeSpecificValue
-                          field="max(timestamp)"
-                          render={[Function]}
-                          type={
-                            FieldType {
-                              "value": Immutable.Map {
-                                "type": "unknown",
-                                "properties": Immutable.Set [],
-                                "indexNames": Immutable.Set [],
-                              },
-                            }
-                          }
-                          value={1554106041841}
-                        />
-                      }
+                    <span
+                      className="dropdowntoggle"
+                      onClick={[Function]}
+                      role="presentation"
                     >
-                      <span
-                        className="dropdowntoggle"
-                        onClick={[Function]}
-                        role="presentation"
+                      <TypeSpecificValue
+                        field="max(timestamp)"
+                        render={[Function]}
+                        type={
+                          FieldType {
+                            "value": Immutable.Map {
+                              "type": "unknown",
+                              "properties": Immutable.Set [],
+                              "indexNames": Immutable.Set [],
+                            },
+                          }
+                        }
+                        value={1554106041841}
                       >
-                        <TypeSpecificValue
+                        <Component
                           field="max(timestamp)"
-                          render={[Function]}
                           type={
                             FieldType {
                               "value": Immutable.Map {
@@ -598,9 +594,9 @@ exports[`DataTableEntry does not fail without types 1`] = `
                               },
                             }
                           }
-                          value={1554106041841}
+                          value="1554106041841"
                         >
-                          <Component
+                          <DecoratedValue
                             field="max(timestamp)"
                             type={
                               FieldType {
@@ -613,7 +609,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                             }
                             value="1554106041841"
                           >
-                            <DecoratedValue
+                            <Component
                               field="max(timestamp)"
                               type={
                                 FieldType {
@@ -626,7 +622,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                               }
                               value="1554106041841"
                             >
-                              <Component
+                              <Highlight
                                 field="max(timestamp)"
                                 type={
                                   FieldType {
@@ -639,41 +635,27 @@ exports[`DataTableEntry does not fail without types 1`] = `
                                 }
                                 value="1554106041841"
                               >
-                                <Highlight
+                                <PossiblyHighlight
+                                  color="#ffec3d"
                                   field="max(timestamp)"
-                                  type={
-                                    FieldType {
-                                      "value": Immutable.Map {
-                                        "type": "unknown",
-                                        "properties": Immutable.Set [],
-                                        "indexNames": Immutable.Set [],
-                                      },
-                                    }
-                                  }
+                                  highlightRanges={Object {}}
                                   value="1554106041841"
                                 >
-                                  <PossiblyHighlight
-                                    color="#ffec3d"
-                                    field="max(timestamp)"
-                                    highlightRanges={Object {}}
-                                    value="1554106041841"
-                                  >
-                                    1554106041841
-                                  </PossiblyHighlight>
-                                </Highlight>
-                              </Component>
-                            </DecoratedValue>
-                          </Component>
-                        </TypeSpecificValue>
-                        <span
-                          className="caret"
-                        />
-                      </span>
-                    </OverlayDropdown>
-                  </ValueActions>
-                </Value>
-              </CustomHighlighting>
-            </ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules>
+                                  1554106041841
+                                </PossiblyHighlight>
+                              </Highlight>
+                            </Component>
+                          </DecoratedValue>
+                        </Component>
+                      </TypeSpecificValue>
+                      <span
+                        className="caret"
+                      />
+                    </span>
+                  </OverlayDropdown>
+                </ValueActions>
+              </Value>
+            </CustomHighlighting>
           </Provider>
         </td>
         <td
@@ -693,19 +675,51 @@ exports[`DataTableEntry does not fail without types 1`] = `
               }
             }
           >
-            <ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules
+            <CustomHighlighting
               field="card(timestamp)"
               value={20}
             >
-              <CustomHighlighting
+              <Value
                 field="card(timestamp)"
-                highlightingRules={Object {}}
+                queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
+                render={[Function]}
+                type={
+                  FieldType {
+                    "value": Immutable.Map {
+                      "type": "long",
+                      "properties": Immutable.Set [
+                        "numeric",
+                        "enumerable",
+                      ],
+                      "indexNames": Immutable.Set [],
+                    },
+                  }
+                }
                 value={20}
               >
-                <Value
+                <ValueActions
+                  element={
+                    <TypeSpecificValue
+                      field="card(timestamp)"
+                      render={[Function]}
+                      type={
+                        FieldType {
+                          "value": Immutable.Map {
+                            "type": "long",
+                            "properties": Immutable.Set [
+                              "numeric",
+                              "enumerable",
+                            ],
+                            "indexNames": Immutable.Set [],
+                          },
+                        }
+                      }
+                      value={20}
+                    />
+                  }
                   field="card(timestamp)"
+                  menuContainer={<body />}
                   queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
-                  render={[Function]}
                   type={
                     FieldType {
                       "value": Immutable.Map {
@@ -720,8 +734,12 @@ exports[`DataTableEntry does not fail without types 1`] = `
                   }
                   value={20}
                 >
-                  <ValueActions
-                    element={
+                  <OverlayDropdown
+                    menuContainer={<body />}
+                    onToggle={[Function]}
+                    placement="right"
+                    show={false}
+                    toggle={
                       <TypeSpecificValue
                         field="card(timestamp)"
                         render={[Function]}
@@ -740,56 +758,31 @@ exports[`DataTableEntry does not fail without types 1`] = `
                         value={20}
                       />
                     }
-                    field="card(timestamp)"
-                    menuContainer={<body />}
-                    queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
-                    type={
-                      FieldType {
-                        "value": Immutable.Map {
-                          "type": "long",
-                          "properties": Immutable.Set [
-                            "numeric",
-                            "enumerable",
-                          ],
-                          "indexNames": Immutable.Set [],
-                        },
-                      }
-                    }
-                    value={20}
                   >
-                    <OverlayDropdown
-                      menuContainer={<body />}
-                      onToggle={[Function]}
-                      placement="right"
-                      show={false}
-                      toggle={
-                        <TypeSpecificValue
-                          field="card(timestamp)"
-                          render={[Function]}
-                          type={
-                            FieldType {
-                              "value": Immutable.Map {
-                                "type": "long",
-                                "properties": Immutable.Set [
-                                  "numeric",
-                                  "enumerable",
-                                ],
-                                "indexNames": Immutable.Set [],
-                              },
-                            }
-                          }
-                          value={20}
-                        />
-                      }
+                    <span
+                      className="dropdowntoggle"
+                      onClick={[Function]}
+                      role="presentation"
                     >
-                      <span
-                        className="dropdowntoggle"
-                        onClick={[Function]}
-                        role="presentation"
+                      <TypeSpecificValue
+                        field="card(timestamp)"
+                        render={[Function]}
+                        type={
+                          FieldType {
+                            "value": Immutable.Map {
+                              "type": "long",
+                              "properties": Immutable.Set [
+                                "numeric",
+                                "enumerable",
+                              ],
+                              "indexNames": Immutable.Set [],
+                            },
+                          }
+                        }
+                        value={20}
                       >
-                        <TypeSpecificValue
+                        <Component
                           field="card(timestamp)"
-                          render={[Function]}
                           type={
                             FieldType {
                               "value": Immutable.Map {
@@ -802,9 +795,9 @@ exports[`DataTableEntry does not fail without types 1`] = `
                               },
                             }
                           }
-                          value={20}
+                          value="20"
                         >
-                          <Component
+                          <DecoratedValue
                             field="card(timestamp)"
                             type={
                               FieldType {
@@ -820,7 +813,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                             }
                             value="20"
                           >
-                            <DecoratedValue
+                            <Component
                               field="card(timestamp)"
                               type={
                                 FieldType {
@@ -836,7 +829,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                               }
                               value="20"
                             >
-                              <Component
+                              <Highlight
                                 field="card(timestamp)"
                                 type={
                                   FieldType {
@@ -852,44 +845,27 @@ exports[`DataTableEntry does not fail without types 1`] = `
                                 }
                                 value="20"
                               >
-                                <Highlight
+                                <PossiblyHighlight
+                                  color="#ffec3d"
                                   field="card(timestamp)"
-                                  type={
-                                    FieldType {
-                                      "value": Immutable.Map {
-                                        "type": "long",
-                                        "properties": Immutable.Set [
-                                          "numeric",
-                                          "enumerable",
-                                        ],
-                                        "indexNames": Immutable.Set [],
-                                      },
-                                    }
-                                  }
+                                  highlightRanges={Object {}}
                                   value="20"
                                 >
-                                  <PossiblyHighlight
-                                    color="#ffec3d"
-                                    field="card(timestamp)"
-                                    highlightRanges={Object {}}
-                                    value="20"
-                                  >
-                                    20
-                                  </PossiblyHighlight>
-                                </Highlight>
-                              </Component>
-                            </DecoratedValue>
-                          </Component>
-                        </TypeSpecificValue>
-                        <span
-                          className="caret"
-                        />
-                      </span>
-                    </OverlayDropdown>
-                  </ValueActions>
-                </Value>
-              </CustomHighlighting>
-            </ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules>
+                                  20
+                                </PossiblyHighlight>
+                              </Highlight>
+                            </Component>
+                          </DecoratedValue>
+                        </Component>
+                      </TypeSpecificValue>
+                      <span
+                        className="caret"
+                      />
+                    </span>
+                  </OverlayDropdown>
+                </ValueActions>
+              </Value>
+            </CustomHighlighting>
           </Provider>
         </td>
         <td
@@ -909,19 +885,51 @@ exports[`DataTableEntry does not fail without types 1`] = `
               }
             }
           >
-            <ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules
+            <CustomHighlighting
               field="count()"
               value={20}
             >
-              <CustomHighlighting
+              <Value
                 field="count()"
-                highlightingRules={Object {}}
+                queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
+                render={[Function]}
+                type={
+                  FieldType {
+                    "value": Immutable.Map {
+                      "type": "long",
+                      "properties": Immutable.Set [
+                        "numeric",
+                        "enumerable",
+                      ],
+                      "indexNames": Immutable.Set [],
+                    },
+                  }
+                }
                 value={20}
               >
-                <Value
+                <ValueActions
+                  element={
+                    <TypeSpecificValue
+                      field="count()"
+                      render={[Function]}
+                      type={
+                        FieldType {
+                          "value": Immutable.Map {
+                            "type": "long",
+                            "properties": Immutable.Set [
+                              "numeric",
+                              "enumerable",
+                            ],
+                            "indexNames": Immutable.Set [],
+                          },
+                        }
+                      }
+                      value={20}
+                    />
+                  }
                   field="count()"
+                  menuContainer={<body />}
                   queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
-                  render={[Function]}
                   type={
                     FieldType {
                       "value": Immutable.Map {
@@ -936,8 +944,12 @@ exports[`DataTableEntry does not fail without types 1`] = `
                   }
                   value={20}
                 >
-                  <ValueActions
-                    element={
+                  <OverlayDropdown
+                    menuContainer={<body />}
+                    onToggle={[Function]}
+                    placement="right"
+                    show={false}
+                    toggle={
                       <TypeSpecificValue
                         field="count()"
                         render={[Function]}
@@ -956,56 +968,31 @@ exports[`DataTableEntry does not fail without types 1`] = `
                         value={20}
                       />
                     }
-                    field="count()"
-                    menuContainer={<body />}
-                    queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
-                    type={
-                      FieldType {
-                        "value": Immutable.Map {
-                          "type": "long",
-                          "properties": Immutable.Set [
-                            "numeric",
-                            "enumerable",
-                          ],
-                          "indexNames": Immutable.Set [],
-                        },
-                      }
-                    }
-                    value={20}
                   >
-                    <OverlayDropdown
-                      menuContainer={<body />}
-                      onToggle={[Function]}
-                      placement="right"
-                      show={false}
-                      toggle={
-                        <TypeSpecificValue
-                          field="count()"
-                          render={[Function]}
-                          type={
-                            FieldType {
-                              "value": Immutable.Map {
-                                "type": "long",
-                                "properties": Immutable.Set [
-                                  "numeric",
-                                  "enumerable",
-                                ],
-                                "indexNames": Immutable.Set [],
-                              },
-                            }
-                          }
-                          value={20}
-                        />
-                      }
+                    <span
+                      className="dropdowntoggle"
+                      onClick={[Function]}
+                      role="presentation"
                     >
-                      <span
-                        className="dropdowntoggle"
-                        onClick={[Function]}
-                        role="presentation"
+                      <TypeSpecificValue
+                        field="count()"
+                        render={[Function]}
+                        type={
+                          FieldType {
+                            "value": Immutable.Map {
+                              "type": "long",
+                              "properties": Immutable.Set [
+                                "numeric",
+                                "enumerable",
+                              ],
+                              "indexNames": Immutable.Set [],
+                            },
+                          }
+                        }
+                        value={20}
                       >
-                        <TypeSpecificValue
+                        <Component
                           field="count()"
-                          render={[Function]}
                           type={
                             FieldType {
                               "value": Immutable.Map {
@@ -1018,9 +1005,9 @@ exports[`DataTableEntry does not fail without types 1`] = `
                               },
                             }
                           }
-                          value={20}
+                          value="20"
                         >
-                          <Component
+                          <DecoratedValue
                             field="count()"
                             type={
                               FieldType {
@@ -1036,7 +1023,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                             }
                             value="20"
                           >
-                            <DecoratedValue
+                            <Component
                               field="count()"
                               type={
                                 FieldType {
@@ -1052,7 +1039,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                               }
                               value="20"
                             >
-                              <Component
+                              <Highlight
                                 field="count()"
                                 type={
                                   FieldType {
@@ -1068,44 +1055,27 @@ exports[`DataTableEntry does not fail without types 1`] = `
                                 }
                                 value="20"
                               >
-                                <Highlight
+                                <PossiblyHighlight
+                                  color="#ffec3d"
                                   field="count()"
-                                  type={
-                                    FieldType {
-                                      "value": Immutable.Map {
-                                        "type": "long",
-                                        "properties": Immutable.Set [
-                                          "numeric",
-                                          "enumerable",
-                                        ],
-                                        "indexNames": Immutable.Set [],
-                                      },
-                                    }
-                                  }
+                                  highlightRanges={Object {}}
                                   value="20"
                                 >
-                                  <PossiblyHighlight
-                                    color="#ffec3d"
-                                    field="count()"
-                                    highlightRanges={Object {}}
-                                    value="20"
-                                  >
-                                    20
-                                  </PossiblyHighlight>
-                                </Highlight>
-                              </Component>
-                            </DecoratedValue>
-                          </Component>
-                        </TypeSpecificValue>
-                        <span
-                          className="caret"
-                        />
-                      </span>
-                    </OverlayDropdown>
-                  </ValueActions>
-                </Value>
-              </CustomHighlighting>
-            </ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules>
+                                  20
+                                </PossiblyHighlight>
+                              </Highlight>
+                            </Component>
+                          </DecoratedValue>
+                        </Component>
+                      </TypeSpecificValue>
+                      <span
+                        className="caret"
+                      />
+                    </span>
+                  </OverlayDropdown>
+                </ValueActions>
+              </Value>
+            </CustomHighlighting>
           </Provider>
         </td>
         <td
@@ -1128,19 +1098,45 @@ exports[`DataTableEntry does not fail without types 1`] = `
               }
             }
           >
-            <ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules
+            <CustomHighlighting
               field="max(timestamp)"
               value={1554106041841}
             >
-              <CustomHighlighting
+              <Value
                 field="max(timestamp)"
-                highlightingRules={Object {}}
+                queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
+                render={[Function]}
+                type={
+                  FieldType {
+                    "value": Immutable.Map {
+                      "type": "unknown",
+                      "properties": Immutable.Set [],
+                      "indexNames": Immutable.Set [],
+                    },
+                  }
+                }
                 value={1554106041841}
               >
-                <Value
+                <ValueActions
+                  element={
+                    <TypeSpecificValue
+                      field="max(timestamp)"
+                      render={[Function]}
+                      type={
+                        FieldType {
+                          "value": Immutable.Map {
+                            "type": "unknown",
+                            "properties": Immutable.Set [],
+                            "indexNames": Immutable.Set [],
+                          },
+                        }
+                      }
+                      value={1554106041841}
+                    />
+                  }
                   field="max(timestamp)"
+                  menuContainer={<body />}
                   queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
-                  render={[Function]}
                   type={
                     FieldType {
                       "value": Immutable.Map {
@@ -1152,8 +1148,12 @@ exports[`DataTableEntry does not fail without types 1`] = `
                   }
                   value={1554106041841}
                 >
-                  <ValueActions
-                    element={
+                  <OverlayDropdown
+                    menuContainer={<body />}
+                    onToggle={[Function]}
+                    placement="right"
+                    show={false}
+                    toggle={
                       <TypeSpecificValue
                         field="max(timestamp)"
                         render={[Function]}
@@ -1169,50 +1169,28 @@ exports[`DataTableEntry does not fail without types 1`] = `
                         value={1554106041841}
                       />
                     }
-                    field="max(timestamp)"
-                    menuContainer={<body />}
-                    queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
-                    type={
-                      FieldType {
-                        "value": Immutable.Map {
-                          "type": "unknown",
-                          "properties": Immutable.Set [],
-                          "indexNames": Immutable.Set [],
-                        },
-                      }
-                    }
-                    value={1554106041841}
                   >
-                    <OverlayDropdown
-                      menuContainer={<body />}
-                      onToggle={[Function]}
-                      placement="right"
-                      show={false}
-                      toggle={
-                        <TypeSpecificValue
-                          field="max(timestamp)"
-                          render={[Function]}
-                          type={
-                            FieldType {
-                              "value": Immutable.Map {
-                                "type": "unknown",
-                                "properties": Immutable.Set [],
-                                "indexNames": Immutable.Set [],
-                              },
-                            }
-                          }
-                          value={1554106041841}
-                        />
-                      }
+                    <span
+                      className="dropdowntoggle"
+                      onClick={[Function]}
+                      role="presentation"
                     >
-                      <span
-                        className="dropdowntoggle"
-                        onClick={[Function]}
-                        role="presentation"
+                      <TypeSpecificValue
+                        field="max(timestamp)"
+                        render={[Function]}
+                        type={
+                          FieldType {
+                            "value": Immutable.Map {
+                              "type": "unknown",
+                              "properties": Immutable.Set [],
+                              "indexNames": Immutable.Set [],
+                            },
+                          }
+                        }
+                        value={1554106041841}
                       >
-                        <TypeSpecificValue
+                        <Component
                           field="max(timestamp)"
-                          render={[Function]}
                           type={
                             FieldType {
                               "value": Immutable.Map {
@@ -1222,9 +1200,9 @@ exports[`DataTableEntry does not fail without types 1`] = `
                               },
                             }
                           }
-                          value={1554106041841}
+                          value="1554106041841"
                         >
-                          <Component
+                          <DecoratedValue
                             field="max(timestamp)"
                             type={
                               FieldType {
@@ -1237,7 +1215,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                             }
                             value="1554106041841"
                           >
-                            <DecoratedValue
+                            <Component
                               field="max(timestamp)"
                               type={
                                 FieldType {
@@ -1250,7 +1228,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                               }
                               value="1554106041841"
                             >
-                              <Component
+                              <Highlight
                                 field="max(timestamp)"
                                 type={
                                   FieldType {
@@ -1263,41 +1241,27 @@ exports[`DataTableEntry does not fail without types 1`] = `
                                 }
                                 value="1554106041841"
                               >
-                                <Highlight
+                                <PossiblyHighlight
+                                  color="#ffec3d"
                                   field="max(timestamp)"
-                                  type={
-                                    FieldType {
-                                      "value": Immutable.Map {
-                                        "type": "unknown",
-                                        "properties": Immutable.Set [],
-                                        "indexNames": Immutable.Set [],
-                                      },
-                                    }
-                                  }
+                                  highlightRanges={Object {}}
                                   value="1554106041841"
                                 >
-                                  <PossiblyHighlight
-                                    color="#ffec3d"
-                                    field="max(timestamp)"
-                                    highlightRanges={Object {}}
-                                    value="1554106041841"
-                                  >
-                                    1554106041841
-                                  </PossiblyHighlight>
-                                </Highlight>
-                              </Component>
-                            </DecoratedValue>
-                          </Component>
-                        </TypeSpecificValue>
-                        <span
-                          className="caret"
-                        />
-                      </span>
-                    </OverlayDropdown>
-                  </ValueActions>
-                </Value>
-              </CustomHighlighting>
-            </ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules>
+                                  1554106041841
+                                </PossiblyHighlight>
+                              </Highlight>
+                            </Component>
+                          </DecoratedValue>
+                        </Component>
+                      </TypeSpecificValue>
+                      <span
+                        className="caret"
+                      />
+                    </span>
+                  </OverlayDropdown>
+                </ValueActions>
+              </Value>
+            </CustomHighlighting>
           </Provider>
         </td>
         <td
@@ -1320,19 +1284,51 @@ exports[`DataTableEntry does not fail without types 1`] = `
               }
             }
           >
-            <ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules
+            <CustomHighlighting
               field="card(timestamp)"
               value={14}
             >
-              <CustomHighlighting
+              <Value
                 field="card(timestamp)"
-                highlightingRules={Object {}}
+                queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
+                render={[Function]}
+                type={
+                  FieldType {
+                    "value": Immutable.Map {
+                      "type": "long",
+                      "properties": Immutable.Set [
+                        "numeric",
+                        "enumerable",
+                      ],
+                      "indexNames": Immutable.Set [],
+                    },
+                  }
+                }
                 value={14}
               >
-                <Value
+                <ValueActions
+                  element={
+                    <TypeSpecificValue
+                      field="card(timestamp)"
+                      render={[Function]}
+                      type={
+                        FieldType {
+                          "value": Immutable.Map {
+                            "type": "long",
+                            "properties": Immutable.Set [
+                              "numeric",
+                              "enumerable",
+                            ],
+                            "indexNames": Immutable.Set [],
+                          },
+                        }
+                      }
+                      value={14}
+                    />
+                  }
                   field="card(timestamp)"
+                  menuContainer={<body />}
                   queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
-                  render={[Function]}
                   type={
                     FieldType {
                       "value": Immutable.Map {
@@ -1347,8 +1343,12 @@ exports[`DataTableEntry does not fail without types 1`] = `
                   }
                   value={14}
                 >
-                  <ValueActions
-                    element={
+                  <OverlayDropdown
+                    menuContainer={<body />}
+                    onToggle={[Function]}
+                    placement="right"
+                    show={false}
+                    toggle={
                       <TypeSpecificValue
                         field="card(timestamp)"
                         render={[Function]}
@@ -1367,56 +1367,31 @@ exports[`DataTableEntry does not fail without types 1`] = `
                         value={14}
                       />
                     }
-                    field="card(timestamp)"
-                    menuContainer={<body />}
-                    queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
-                    type={
-                      FieldType {
-                        "value": Immutable.Map {
-                          "type": "long",
-                          "properties": Immutable.Set [
-                            "numeric",
-                            "enumerable",
-                          ],
-                          "indexNames": Immutable.Set [],
-                        },
-                      }
-                    }
-                    value={14}
                   >
-                    <OverlayDropdown
-                      menuContainer={<body />}
-                      onToggle={[Function]}
-                      placement="right"
-                      show={false}
-                      toggle={
-                        <TypeSpecificValue
-                          field="card(timestamp)"
-                          render={[Function]}
-                          type={
-                            FieldType {
-                              "value": Immutable.Map {
-                                "type": "long",
-                                "properties": Immutable.Set [
-                                  "numeric",
-                                  "enumerable",
-                                ],
-                                "indexNames": Immutable.Set [],
-                              },
-                            }
-                          }
-                          value={14}
-                        />
-                      }
+                    <span
+                      className="dropdowntoggle"
+                      onClick={[Function]}
+                      role="presentation"
                     >
-                      <span
-                        className="dropdowntoggle"
-                        onClick={[Function]}
-                        role="presentation"
+                      <TypeSpecificValue
+                        field="card(timestamp)"
+                        render={[Function]}
+                        type={
+                          FieldType {
+                            "value": Immutable.Map {
+                              "type": "long",
+                              "properties": Immutable.Set [
+                                "numeric",
+                                "enumerable",
+                              ],
+                              "indexNames": Immutable.Set [],
+                            },
+                          }
+                        }
+                        value={14}
                       >
-                        <TypeSpecificValue
+                        <Component
                           field="card(timestamp)"
-                          render={[Function]}
                           type={
                             FieldType {
                               "value": Immutable.Map {
@@ -1429,9 +1404,9 @@ exports[`DataTableEntry does not fail without types 1`] = `
                               },
                             }
                           }
-                          value={14}
+                          value="14"
                         >
-                          <Component
+                          <DecoratedValue
                             field="card(timestamp)"
                             type={
                               FieldType {
@@ -1447,7 +1422,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                             }
                             value="14"
                           >
-                            <DecoratedValue
+                            <Component
                               field="card(timestamp)"
                               type={
                                 FieldType {
@@ -1463,7 +1438,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                               }
                               value="14"
                             >
-                              <Component
+                              <Highlight
                                 field="card(timestamp)"
                                 type={
                                   FieldType {
@@ -1479,44 +1454,27 @@ exports[`DataTableEntry does not fail without types 1`] = `
                                 }
                                 value="14"
                               >
-                                <Highlight
+                                <PossiblyHighlight
+                                  color="#ffec3d"
                                   field="card(timestamp)"
-                                  type={
-                                    FieldType {
-                                      "value": Immutable.Map {
-                                        "type": "long",
-                                        "properties": Immutable.Set [
-                                          "numeric",
-                                          "enumerable",
-                                        ],
-                                        "indexNames": Immutable.Set [],
-                                      },
-                                    }
-                                  }
+                                  highlightRanges={Object {}}
                                   value="14"
                                 >
-                                  <PossiblyHighlight
-                                    color="#ffec3d"
-                                    field="card(timestamp)"
-                                    highlightRanges={Object {}}
-                                    value="14"
-                                  >
-                                    14
-                                  </PossiblyHighlight>
-                                </Highlight>
-                              </Component>
-                            </DecoratedValue>
-                          </Component>
-                        </TypeSpecificValue>
-                        <span
-                          className="caret"
-                        />
-                      </span>
-                    </OverlayDropdown>
-                  </ValueActions>
-                </Value>
-              </CustomHighlighting>
-            </ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules>
+                                  14
+                                </PossiblyHighlight>
+                              </Highlight>
+                            </Component>
+                          </DecoratedValue>
+                        </Component>
+                      </TypeSpecificValue>
+                      <span
+                        className="caret"
+                      />
+                    </span>
+                  </OverlayDropdown>
+                </ValueActions>
+              </Value>
+            </CustomHighlighting>
           </Provider>
         </td>
         <td
@@ -1536,19 +1494,51 @@ exports[`DataTableEntry does not fail without types 1`] = `
               }
             }
           >
-            <ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules
+            <CustomHighlighting
               field="count()"
               value={64}
             >
-              <CustomHighlighting
+              <Value
                 field="count()"
-                highlightingRules={Object {}}
+                queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
+                render={[Function]}
+                type={
+                  FieldType {
+                    "value": Immutable.Map {
+                      "type": "long",
+                      "properties": Immutable.Set [
+                        "numeric",
+                        "enumerable",
+                      ],
+                      "indexNames": Immutable.Set [],
+                    },
+                  }
+                }
                 value={64}
               >
-                <Value
+                <ValueActions
+                  element={
+                    <TypeSpecificValue
+                      field="count()"
+                      render={[Function]}
+                      type={
+                        FieldType {
+                          "value": Immutable.Map {
+                            "type": "long",
+                            "properties": Immutable.Set [
+                              "numeric",
+                              "enumerable",
+                            ],
+                            "indexNames": Immutable.Set [],
+                          },
+                        }
+                      }
+                      value={64}
+                    />
+                  }
                   field="count()"
+                  menuContainer={<body />}
                   queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
-                  render={[Function]}
                   type={
                     FieldType {
                       "value": Immutable.Map {
@@ -1563,8 +1553,12 @@ exports[`DataTableEntry does not fail without types 1`] = `
                   }
                   value={64}
                 >
-                  <ValueActions
-                    element={
+                  <OverlayDropdown
+                    menuContainer={<body />}
+                    onToggle={[Function]}
+                    placement="right"
+                    show={false}
+                    toggle={
                       <TypeSpecificValue
                         field="count()"
                         render={[Function]}
@@ -1583,56 +1577,31 @@ exports[`DataTableEntry does not fail without types 1`] = `
                         value={64}
                       />
                     }
-                    field="count()"
-                    menuContainer={<body />}
-                    queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
-                    type={
-                      FieldType {
-                        "value": Immutable.Map {
-                          "type": "long",
-                          "properties": Immutable.Set [
-                            "numeric",
-                            "enumerable",
-                          ],
-                          "indexNames": Immutable.Set [],
-                        },
-                      }
-                    }
-                    value={64}
                   >
-                    <OverlayDropdown
-                      menuContainer={<body />}
-                      onToggle={[Function]}
-                      placement="right"
-                      show={false}
-                      toggle={
-                        <TypeSpecificValue
-                          field="count()"
-                          render={[Function]}
-                          type={
-                            FieldType {
-                              "value": Immutable.Map {
-                                "type": "long",
-                                "properties": Immutable.Set [
-                                  "numeric",
-                                  "enumerable",
-                                ],
-                                "indexNames": Immutable.Set [],
-                              },
-                            }
-                          }
-                          value={64}
-                        />
-                      }
+                    <span
+                      className="dropdowntoggle"
+                      onClick={[Function]}
+                      role="presentation"
                     >
-                      <span
-                        className="dropdowntoggle"
-                        onClick={[Function]}
-                        role="presentation"
+                      <TypeSpecificValue
+                        field="count()"
+                        render={[Function]}
+                        type={
+                          FieldType {
+                            "value": Immutable.Map {
+                              "type": "long",
+                              "properties": Immutable.Set [
+                                "numeric",
+                                "enumerable",
+                              ],
+                              "indexNames": Immutable.Set [],
+                            },
+                          }
+                        }
+                        value={64}
                       >
-                        <TypeSpecificValue
+                        <Component
                           field="count()"
-                          render={[Function]}
                           type={
                             FieldType {
                               "value": Immutable.Map {
@@ -1645,9 +1614,9 @@ exports[`DataTableEntry does not fail without types 1`] = `
                               },
                             }
                           }
-                          value={64}
+                          value="64"
                         >
-                          <Component
+                          <DecoratedValue
                             field="count()"
                             type={
                               FieldType {
@@ -1663,7 +1632,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                             }
                             value="64"
                           >
-                            <DecoratedValue
+                            <Component
                               field="count()"
                               type={
                                 FieldType {
@@ -1679,7 +1648,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                               }
                               value="64"
                             >
-                              <Component
+                              <Highlight
                                 field="count()"
                                 type={
                                   FieldType {
@@ -1695,44 +1664,27 @@ exports[`DataTableEntry does not fail without types 1`] = `
                                 }
                                 value="64"
                               >
-                                <Highlight
+                                <PossiblyHighlight
+                                  color="#ffec3d"
                                   field="count()"
-                                  type={
-                                    FieldType {
-                                      "value": Immutable.Map {
-                                        "type": "long",
-                                        "properties": Immutable.Set [
-                                          "numeric",
-                                          "enumerable",
-                                        ],
-                                        "indexNames": Immutable.Set [],
-                                      },
-                                    }
-                                  }
+                                  highlightRanges={Object {}}
                                   value="64"
                                 >
-                                  <PossiblyHighlight
-                                    color="#ffec3d"
-                                    field="count()"
-                                    highlightRanges={Object {}}
-                                    value="64"
-                                  >
-                                    64
-                                  </PossiblyHighlight>
-                                </Highlight>
-                              </Component>
-                            </DecoratedValue>
-                          </Component>
-                        </TypeSpecificValue>
-                        <span
-                          className="caret"
-                        />
-                      </span>
-                    </OverlayDropdown>
-                  </ValueActions>
-                </Value>
-              </CustomHighlighting>
-            </ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules>
+                                  64
+                                </PossiblyHighlight>
+                              </Highlight>
+                            </Component>
+                          </DecoratedValue>
+                        </Component>
+                      </TypeSpecificValue>
+                      <span
+                        className="caret"
+                      />
+                    </span>
+                  </OverlayDropdown>
+                </ValueActions>
+              </Value>
+            </CustomHighlighting>
           </Provider>
         </td>
         <td
@@ -1755,19 +1707,45 @@ exports[`DataTableEntry does not fail without types 1`] = `
               }
             }
           >
-            <ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules
+            <CustomHighlighting
               field="max(timestamp)"
               value={1554106041841}
             >
-              <CustomHighlighting
+              <Value
                 field="max(timestamp)"
-                highlightingRules={Object {}}
+                queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
+                render={[Function]}
+                type={
+                  FieldType {
+                    "value": Immutable.Map {
+                      "type": "unknown",
+                      "properties": Immutable.Set [],
+                      "indexNames": Immutable.Set [],
+                    },
+                  }
+                }
                 value={1554106041841}
               >
-                <Value
+                <ValueActions
+                  element={
+                    <TypeSpecificValue
+                      field="max(timestamp)"
+                      render={[Function]}
+                      type={
+                        FieldType {
+                          "value": Immutable.Map {
+                            "type": "unknown",
+                            "properties": Immutable.Set [],
+                            "indexNames": Immutable.Set [],
+                          },
+                        }
+                      }
+                      value={1554106041841}
+                    />
+                  }
                   field="max(timestamp)"
+                  menuContainer={<body />}
                   queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
-                  render={[Function]}
                   type={
                     FieldType {
                       "value": Immutable.Map {
@@ -1779,8 +1757,12 @@ exports[`DataTableEntry does not fail without types 1`] = `
                   }
                   value={1554106041841}
                 >
-                  <ValueActions
-                    element={
+                  <OverlayDropdown
+                    menuContainer={<body />}
+                    onToggle={[Function]}
+                    placement="right"
+                    show={false}
+                    toggle={
                       <TypeSpecificValue
                         field="max(timestamp)"
                         render={[Function]}
@@ -1796,50 +1778,28 @@ exports[`DataTableEntry does not fail without types 1`] = `
                         value={1554106041841}
                       />
                     }
-                    field="max(timestamp)"
-                    menuContainer={<body />}
-                    queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
-                    type={
-                      FieldType {
-                        "value": Immutable.Map {
-                          "type": "unknown",
-                          "properties": Immutable.Set [],
-                          "indexNames": Immutable.Set [],
-                        },
-                      }
-                    }
-                    value={1554106041841}
                   >
-                    <OverlayDropdown
-                      menuContainer={<body />}
-                      onToggle={[Function]}
-                      placement="right"
-                      show={false}
-                      toggle={
-                        <TypeSpecificValue
-                          field="max(timestamp)"
-                          render={[Function]}
-                          type={
-                            FieldType {
-                              "value": Immutable.Map {
-                                "type": "unknown",
-                                "properties": Immutable.Set [],
-                                "indexNames": Immutable.Set [],
-                              },
-                            }
-                          }
-                          value={1554106041841}
-                        />
-                      }
+                    <span
+                      className="dropdowntoggle"
+                      onClick={[Function]}
+                      role="presentation"
                     >
-                      <span
-                        className="dropdowntoggle"
-                        onClick={[Function]}
-                        role="presentation"
+                      <TypeSpecificValue
+                        field="max(timestamp)"
+                        render={[Function]}
+                        type={
+                          FieldType {
+                            "value": Immutable.Map {
+                              "type": "unknown",
+                              "properties": Immutable.Set [],
+                              "indexNames": Immutable.Set [],
+                            },
+                          }
+                        }
+                        value={1554106041841}
                       >
-                        <TypeSpecificValue
+                        <Component
                           field="max(timestamp)"
-                          render={[Function]}
                           type={
                             FieldType {
                               "value": Immutable.Map {
@@ -1849,9 +1809,9 @@ exports[`DataTableEntry does not fail without types 1`] = `
                               },
                             }
                           }
-                          value={1554106041841}
+                          value="1554106041841"
                         >
-                          <Component
+                          <DecoratedValue
                             field="max(timestamp)"
                             type={
                               FieldType {
@@ -1864,7 +1824,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                             }
                             value="1554106041841"
                           >
-                            <DecoratedValue
+                            <Component
                               field="max(timestamp)"
                               type={
                                 FieldType {
@@ -1877,7 +1837,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                               }
                               value="1554106041841"
                             >
-                              <Component
+                              <Highlight
                                 field="max(timestamp)"
                                 type={
                                   FieldType {
@@ -1890,41 +1850,27 @@ exports[`DataTableEntry does not fail without types 1`] = `
                                 }
                                 value="1554106041841"
                               >
-                                <Highlight
+                                <PossiblyHighlight
+                                  color="#ffec3d"
                                   field="max(timestamp)"
-                                  type={
-                                    FieldType {
-                                      "value": Immutable.Map {
-                                        "type": "unknown",
-                                        "properties": Immutable.Set [],
-                                        "indexNames": Immutable.Set [],
-                                      },
-                                    }
-                                  }
+                                  highlightRanges={Object {}}
                                   value="1554106041841"
                                 >
-                                  <PossiblyHighlight
-                                    color="#ffec3d"
-                                    field="max(timestamp)"
-                                    highlightRanges={Object {}}
-                                    value="1554106041841"
-                                  >
-                                    1554106041841
-                                  </PossiblyHighlight>
-                                </Highlight>
-                              </Component>
-                            </DecoratedValue>
-                          </Component>
-                        </TypeSpecificValue>
-                        <span
-                          className="caret"
-                        />
-                      </span>
-                    </OverlayDropdown>
-                  </ValueActions>
-                </Value>
-              </CustomHighlighting>
-            </ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules>
+                                  1554106041841
+                                </PossiblyHighlight>
+                              </Highlight>
+                            </Component>
+                          </DecoratedValue>
+                        </Component>
+                      </TypeSpecificValue>
+                      <span
+                        className="caret"
+                      />
+                    </span>
+                  </OverlayDropdown>
+                </ValueActions>
+              </Value>
+            </CustomHighlighting>
           </Provider>
         </td>
         <td
@@ -1947,19 +1893,51 @@ exports[`DataTableEntry does not fail without types 1`] = `
               }
             }
           >
-            <ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules
+            <CustomHighlighting
               field="card(timestamp)"
               value={16}
             >
-              <CustomHighlighting
+              <Value
                 field="card(timestamp)"
-                highlightingRules={Object {}}
+                queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
+                render={[Function]}
+                type={
+                  FieldType {
+                    "value": Immutable.Map {
+                      "type": "long",
+                      "properties": Immutable.Set [
+                        "numeric",
+                        "enumerable",
+                      ],
+                      "indexNames": Immutable.Set [],
+                    },
+                  }
+                }
                 value={16}
               >
-                <Value
+                <ValueActions
+                  element={
+                    <TypeSpecificValue
+                      field="card(timestamp)"
+                      render={[Function]}
+                      type={
+                        FieldType {
+                          "value": Immutable.Map {
+                            "type": "long",
+                            "properties": Immutable.Set [
+                              "numeric",
+                              "enumerable",
+                            ],
+                            "indexNames": Immutable.Set [],
+                          },
+                        }
+                      }
+                      value={16}
+                    />
+                  }
                   field="card(timestamp)"
+                  menuContainer={<body />}
                   queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
-                  render={[Function]}
                   type={
                     FieldType {
                       "value": Immutable.Map {
@@ -1974,8 +1952,12 @@ exports[`DataTableEntry does not fail without types 1`] = `
                   }
                   value={16}
                 >
-                  <ValueActions
-                    element={
+                  <OverlayDropdown
+                    menuContainer={<body />}
+                    onToggle={[Function]}
+                    placement="right"
+                    show={false}
+                    toggle={
                       <TypeSpecificValue
                         field="card(timestamp)"
                         render={[Function]}
@@ -1994,56 +1976,31 @@ exports[`DataTableEntry does not fail without types 1`] = `
                         value={16}
                       />
                     }
-                    field="card(timestamp)"
-                    menuContainer={<body />}
-                    queryId="6ca0ea05-6fc1-4f46-9b22-20a5baab7b0d"
-                    type={
-                      FieldType {
-                        "value": Immutable.Map {
-                          "type": "long",
-                          "properties": Immutable.Set [
-                            "numeric",
-                            "enumerable",
-                          ],
-                          "indexNames": Immutable.Set [],
-                        },
-                      }
-                    }
-                    value={16}
                   >
-                    <OverlayDropdown
-                      menuContainer={<body />}
-                      onToggle={[Function]}
-                      placement="right"
-                      show={false}
-                      toggle={
-                        <TypeSpecificValue
-                          field="card(timestamp)"
-                          render={[Function]}
-                          type={
-                            FieldType {
-                              "value": Immutable.Map {
-                                "type": "long",
-                                "properties": Immutable.Set [
-                                  "numeric",
-                                  "enumerable",
-                                ],
-                                "indexNames": Immutable.Set [],
-                              },
-                            }
-                          }
-                          value={16}
-                        />
-                      }
+                    <span
+                      className="dropdowntoggle"
+                      onClick={[Function]}
+                      role="presentation"
                     >
-                      <span
-                        className="dropdowntoggle"
-                        onClick={[Function]}
-                        role="presentation"
+                      <TypeSpecificValue
+                        field="card(timestamp)"
+                        render={[Function]}
+                        type={
+                          FieldType {
+                            "value": Immutable.Map {
+                              "type": "long",
+                              "properties": Immutable.Set [
+                                "numeric",
+                                "enumerable",
+                              ],
+                              "indexNames": Immutable.Set [],
+                            },
+                          }
+                        }
+                        value={16}
                       >
-                        <TypeSpecificValue
+                        <Component
                           field="card(timestamp)"
-                          render={[Function]}
                           type={
                             FieldType {
                               "value": Immutable.Map {
@@ -2056,9 +2013,9 @@ exports[`DataTableEntry does not fail without types 1`] = `
                               },
                             }
                           }
-                          value={16}
+                          value="16"
                         >
-                          <Component
+                          <DecoratedValue
                             field="card(timestamp)"
                             type={
                               FieldType {
@@ -2074,7 +2031,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                             }
                             value="16"
                           >
-                            <DecoratedValue
+                            <Component
                               field="card(timestamp)"
                               type={
                                 FieldType {
@@ -2090,7 +2047,7 @@ exports[`DataTableEntry does not fail without types 1`] = `
                               }
                               value="16"
                             >
-                              <Component
+                              <Highlight
                                 field="card(timestamp)"
                                 type={
                                   FieldType {
@@ -2106,44 +2063,27 @@ exports[`DataTableEntry does not fail without types 1`] = `
                                 }
                                 value="16"
                               >
-                                <Highlight
+                                <PossiblyHighlight
+                                  color="#ffec3d"
                                   field="card(timestamp)"
-                                  type={
-                                    FieldType {
-                                      "value": Immutable.Map {
-                                        "type": "long",
-                                        "properties": Immutable.Set [
-                                          "numeric",
-                                          "enumerable",
-                                        ],
-                                        "indexNames": Immutable.Set [],
-                                      },
-                                    }
-                                  }
+                                  highlightRanges={Object {}}
                                   value="16"
                                 >
-                                  <PossiblyHighlight
-                                    color="#ffec3d"
-                                    field="card(timestamp)"
-                                    highlightRanges={Object {}}
-                                    value="16"
-                                  >
-                                    16
-                                  </PossiblyHighlight>
-                                </Highlight>
-                              </Component>
-                            </DecoratedValue>
-                          </Component>
-                        </TypeSpecificValue>
-                        <span
-                          className="caret"
-                        />
-                      </span>
-                    </OverlayDropdown>
-                  </ValueActions>
-                </Value>
-              </CustomHighlighting>
-            </ConnectStoresWrapper[CustomHighlighting] stores=highlightingRules>
+                                  16
+                                </PossiblyHighlight>
+                              </Highlight>
+                            </Component>
+                          </DecoratedValue>
+                        </Component>
+                      </TypeSpecificValue>
+                      <span
+                        className="caret"
+                      />
+                    </span>
+                  </OverlayDropdown>
+                </ValueActions>
+              </Value>
+            </CustomHighlighting>
           </Provider>
         </td>
       </tr>

--- a/graylog2-web-interface/src/views/components/messagelist/CustomHighlighting.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/CustomHighlighting.jsx
@@ -1,12 +1,10 @@
 // @flow strict
 import * as React from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
 
-import connect from 'stores/connect';
-
-import { HighlightingRulesStore } from 'views/stores/HighlightingRulesStore';
 import DecoratorContext from 'views/components/messagelist/decoration/DecoratorContext';
-import HighlightingRule from 'views/logic/views/formatting/highlighting/HighlightingRule';
+import HighlightingRulesContext from 'views/components/contexts/HighlightingRulesContext';
 
 import PossiblyHighlight from './PossiblyHighlight';
 import Highlight from './Highlight';
@@ -14,13 +12,15 @@ import Highlight from './Highlight';
 type Props = {
   children: ?React.Node,
   field: string,
-  highlightingRules: { [string]: Array<HighlightingRule> },
   value?: any,
 };
 
-const CustomHighlighting = ({ children, field: fieldName, value: fieldValue, highlightingRules }: Props) => {
+const CustomHighlighting = ({ children, field: fieldName, value: fieldValue }: Props) => {
   const decorators = [];
-  const rules = highlightingRules[fieldName] || [];
+  const highlightingRules = useContext(HighlightingRulesContext) ?? [];
+
+  const highlightingRulesMap = highlightingRules.reduce((prev, cur) => ({ ...prev, [cur.field]: prev[cur.field] ? [...prev[cur.field], cur] : [cur] }), {});
+  const rules = highlightingRulesMap[fieldName] || [];
   rules.forEach((rule) => {
     const ranges = [];
     if (String(fieldValue) === String(rule.value)) {
@@ -60,12 +60,4 @@ CustomHighlighting.defaultProps = {
   value: undefined,
 };
 
-export default connect(CustomHighlighting,
-  {
-    highlightingRules: HighlightingRulesStore,
-  },
-  ({ highlightingRules }) => {
-    const highlightingRulesMap = highlightingRules
-      .reduce((prev, cur) => ({ ...prev, [cur.field]: prev[cur.field] ? [...prev[cur.field], cur] : [cur] }), {});
-    return { highlightingRules: highlightingRulesMap };
-  });
+export default CustomHighlighting;

--- a/graylog2-web-interface/src/views/components/messagelist/CustomHighlighting.test.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/CustomHighlighting.test.jsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { mount } from 'wrappedEnzyme';
 
+import HighlightingRulesContext from 'views/components/contexts/HighlightingRulesContext';
 import DecoratorContext from 'views/components/messagelist/decoration/DecoratorContext';
 import HighlightingRule from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import FieldType from 'views/logic/fieldtypes/FieldType';
@@ -17,29 +18,36 @@ const renderDecorators = (decorators, field, value) => decorators.map((Decorator
 describe('CustomHighlighting', () => {
   const field = 'foo';
   const value = 42;
+  const SimpleCustomHighlighting = () => (
+    <CustomHighlighting field={field} value={value}>
+      <DecoratorContext.Consumer>
+        {(decorators) => renderDecorators(decorators, field, value)}
+      </DecoratorContext.Consumer>
+    </CustomHighlighting>
+  );
+
+  const CustomHighlightingWithContext = ({ highlightingRules }: {highlightingRules: Array<HighlightingRule>}) => (
+    <HighlightingRulesContext.Provider value={highlightingRules}>
+      <SimpleCustomHighlighting />
+    </HighlightingRulesContext.Provider>
+  );
+
+  it('renders value when HighlightingRulesContext is not provided', () => {
+    const wrapper = mount(<SimpleCustomHighlighting />);
+    expect(wrapper.find('PossiblyHighlight')).toMatchSnapshot();
+  });
   it('renders value as is when no rules exist', () => {
-    const wrapper = mount((
-      <CustomHighlighting field={field} value={value} highlightingRules={{}}>
-        <DecoratorContext.Consumer>
-          {(decorators) => renderDecorators(decorators, field, value)}
-        </DecoratorContext.Consumer>
-      </CustomHighlighting>
-    ));
+    const wrapper = mount(<CustomHighlightingWithContext highlightingRules={[]} />);
     expect(wrapper.find('PossiblyHighlight')).toMatchSnapshot();
   });
   it('renders value as is when no rule for this field exists', () => {
     const rule = HighlightingRule.builder()
-      .field(field)
+      .field('bar')
       .value(String(value))
       .color('#bc98fd')
       .build();
-    const wrapper = mount((
-      <CustomHighlighting field={field} value={value} highlightingRules={{ bar: [rule] }}>
-        <DecoratorContext.Consumer>
-          {(decorators) => renderDecorators(decorators, field, value)}
-        </DecoratorContext.Consumer>
-      </CustomHighlighting>
-    ));
+    const wrapper = mount(<CustomHighlightingWithContext highlightingRules={[rule]} />);
+
     expect(wrapper.find('PossiblyHighlight')).toMatchSnapshot();
   });
   it('renders highlighted value if rule for value exists', () => {
@@ -48,13 +56,7 @@ describe('CustomHighlighting', () => {
       .value(String(value))
       .color('#bc98fd')
       .build();
-    const wrapper = mount((
-      <CustomHighlighting field={field} value={value} highlightingRules={{ [field]: [rule] }}>
-        <DecoratorContext.Consumer>
-          {(decorators) => renderDecorators(decorators, field, value)}
-        </DecoratorContext.Consumer>
-      </CustomHighlighting>
-    ));
+    const wrapper = mount(<CustomHighlightingWithContext highlightingRules={[rule]} />);
     expect(wrapper.find('PossiblyHighlight')).toMatchSnapshot();
   });
   it('does not render highlight if rule value only matches substring', () => {
@@ -63,13 +65,7 @@ describe('CustomHighlighting', () => {
       .value('2')
       .color('#bc98fd')
       .build();
-    const wrapper = mount((
-      <CustomHighlighting field={field} value={value} highlightingRules={{ [field]: [rule] }}>
-        <DecoratorContext.Consumer>
-          {(decorators) => renderDecorators(decorators, field, value)}
-        </DecoratorContext.Consumer>
-      </CustomHighlighting>
-    ));
+    const wrapper = mount(<CustomHighlightingWithContext highlightingRules={[rule]} />);
     expect(wrapper.find('PossiblyHighlight')).toMatchSnapshot();
   });
   it('does not render highlight if rule value does not match', () => {
@@ -78,13 +74,7 @@ describe('CustomHighlighting', () => {
       .value('23')
       .color('#bc98fd')
       .build();
-    const wrapper = mount((
-      <CustomHighlighting field={field} value={value} highlightingRules={{ [field]: [rule] }}>
-        <DecoratorContext.Consumer>
-          {(decorators) => renderDecorators(decorators, field, value)}
-        </DecoratorContext.Consumer>
-      </CustomHighlighting>
-    ));
+    const wrapper = mount(<CustomHighlightingWithContext highlightingRules={[rule]} />);
     expect(wrapper.find('PossiblyHighlight')).toMatchSnapshot();
   });
 });

--- a/graylog2-web-interface/src/views/components/messagelist/__snapshots__/CustomHighlighting.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/messagelist/__snapshots__/CustomHighlighting.test.jsx.snap
@@ -72,3 +72,14 @@ exports[`CustomHighlighting renders value as is when no rules exist 1`] = `
   42
 </PossiblyHighlight>
 `;
+
+exports[`CustomHighlighting renders value when HighlightingRulesContext is not provided 1`] = `
+<PossiblyHighlight
+  color="#ffec3d"
+  field="foo"
+  highlightRanges={Object {}}
+  value={42}
+>
+  42
+</PossiblyHighlight>
+`;

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRules.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRules.jsx
@@ -1,13 +1,10 @@
 // @flow strict
 import * as React from 'react';
-import PropTypes from 'prop-types';
+import { useContext } from 'react';
 import styled from 'styled-components';
 
-import connect from 'stores/connect';
-
 import { DEFAULT_HIGHLIGHT_COLOR } from 'views/Constants';
-import { HighlightingRulesStore } from 'views/stores/HighlightingRulesStore';
-import Rule from 'views/logic/views/formatting/highlighting/HighlightingRule';
+import HighlightingRulesContext from 'views/components/contexts/HighlightingRulesContext';
 
 import HighlightingRule, { HighlightingRuleGrid } from './HighlightingRule';
 import ColorPreview from './ColorPreview';
@@ -16,11 +13,8 @@ const Headline = styled.h4`
   margin-bottom: 10px;
 `;
 
-type Props = {
-  rules: Array<Rule>,
-};
-
-const HighlightingRules = ({ rules = [] }: Props) => {
+const HighlightingRules = () => {
+  const rules = useContext(HighlightingRulesContext) ?? [];
   return (
     <>
       <Headline>Highlighting</Headline>
@@ -34,12 +28,4 @@ const HighlightingRules = ({ rules = [] }: Props) => {
   );
 };
 
-HighlightingRules.propTypes = {
-  rules: PropTypes.arrayOf(PropTypes.instanceOf(Rule)),
-};
-
-HighlightingRules.defaultProps = {
-  rules: [],
-};
-
-export default connect(HighlightingRules, { rules: HighlightingRulesStore });
+export default HighlightingRules;

--- a/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRules.test.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/highlighting/HighlightingRules.test.jsx
@@ -2,14 +2,23 @@
 import * as React from 'react';
 import { mount } from 'wrappedEnzyme';
 
+import HighlightingRuleContext from 'views/components/contexts/HighlightingRulesContext';
 import HighlightingRule from 'views/logic/views/formatting/highlighting/HighlightingRule';
 import HighlightingRules from './HighlightingRules';
 
 jest.mock('stores/connect', () => (x) => x);
 
 describe('HighlightingRules', () => {
-  it('includes search term legend even if rules are empty', () => {
+  it('renders search term legend even when HighlightingRulesContext is not provided', () => {
     const wrapper = mount(<HighlightingRules />);
+    expect(wrapper.text()).toMatch(/Search terms/);
+  });
+  it('renders search term legend even when rules are empty', () => {
+    const wrapper = mount(
+      <HighlightingRuleContext.Provider value={[]}>
+        <HighlightingRules />
+      </HighlightingRuleContext.Provider>,
+    );
     expect(wrapper.text()).toMatch(/Search terms/);
   });
   it('renders element for each HighlightingRule', () => {
@@ -17,7 +26,11 @@ describe('HighlightingRules', () => {
       HighlightingRule.create('foo', 'bar', undefined, '#f4f141'),
       HighlightingRule.create('response_time', '250', undefined, '#f44242'),
     ];
-    const wrapper = mount(<HighlightingRules rules={rules} />);
+    const wrapper = mount(
+      <HighlightingRuleContext.Provider value={rules}>
+        <HighlightingRules />
+      </HighlightingRuleContext.Provider>,
+    );
     expect(wrapper.text()).toMatch(/for foo = "bar"/);
     expect(wrapper.text()).toMatch(/for response_time = "250"/);
   });

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -40,6 +40,7 @@ import IfSearch from 'views/components/search/IfSearch';
 import { AdditionalContext } from 'views/logic/ActionContext';
 import IfInteractive from 'views/components/dashboard/IfInteractive';
 import InteractiveContext from 'views/components/contexts/InteractiveContext';
+import HighlightingRulesProvider from 'views/components/contexts/HighlightingRulesProvider';
 import bindSearchParamsFromQuery from 'views/hooks/BindSearchParamsFromQuery';
 import { useSyncWithQueryParameters } from 'views/hooks/SyncWithQueryParameters';
 
@@ -160,34 +161,36 @@ const ExtendedSearchPage = ({ route, location = { query: {} }, router, searchRef
       <InteractiveContext.Consumer>
         {(interactive) => (
           <ViewAdditionalContextProvider>
-            <GridContainer id="main-row" interactive={interactive}>
-              <IfInteractive>
-                <ConnectedSideBar>
-                  <ConnectedFieldList />
-                </ConnectedSideBar>
-              </IfInteractive>
-              <SearchArea>
+            <HighlightingRulesProvider>
+              <GridContainer id="main-row" interactive={interactive}>
                 <IfInteractive>
-                  <HeaderElements />
-                  <IfDashboard>
-                    <DashboardSearchBarWithStatus onExecute={refreshIfNotUndeclared} />
-                  </IfDashboard>
-                  <IfSearch>
-                    <SearchBarWithStatus onExecute={refreshIfNotUndeclared} />
-                  </IfSearch>
-
-                  <QueryBarElements />
-
-                  <IfDashboard>
-                    <QueryBar />
-                  </IfDashboard>
+                  <ConnectedSideBar>
+                    <ConnectedFieldList />
+                  </ConnectedSideBar>
                 </IfInteractive>
-                <HighlightMessageInQuery query={location.query}>
-                  <SearchResult />
-                </HighlightMessageInQuery>
-                <Footer />
-              </SearchArea>
-            </GridContainer>
+                <SearchArea>
+                  <IfInteractive>
+                    <HeaderElements />
+                    <IfDashboard>
+                      <DashboardSearchBarWithStatus onExecute={refreshIfNotUndeclared} />
+                    </IfDashboard>
+                    <IfSearch>
+                      <SearchBarWithStatus onExecute={refreshIfNotUndeclared} />
+                    </IfSearch>
+
+                    <QueryBarElements />
+
+                    <IfDashboard>
+                      <QueryBar />
+                    </IfDashboard>
+                  </IfInteractive>
+                  <HighlightMessageInQuery query={location.query}>
+                    <SearchResult />
+                  </HighlightMessageInQuery>
+                  <Footer />
+                </SearchArea>
+              </GridContainer>
+            </HighlightingRulesProvider>
           </ViewAdditionalContextProvider>
         )}
       </InteractiveContext.Consumer>


### PR DESCRIPTION
**This is a backport of #8276 for 3.3**

This PR creates a context for the highlighting rules. Its value is being provided by the `HighlightingRulesProvider` which connects to the `HighlightingRulesStore`.

The `HighlightingRulesProvider` is being used in the `ExtendedSearchPage`, this way we don't need to connect the `HighlightingRulesStore` in `CustomHighlighting` and `HighlightingRules`.

## Motivation an Context
We should reduce the times we call `connect` -> `render` and `connect` -> `shouldComponentUpdate`. Currently `render` is being called over 1000 times and `shouldComponentUpdate` over 600 times on the default search page.

Just removing `connect` from `UserTimezoneTimestamp` (https://github.com/Graylog2/graylog2-server/pull/7836) and `CustomHighlighting` reduces the calls of `connect` -> `render` to ~50 and `connect` -> `shouldComponentUpdate` to ~ 20 times.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

