### PR TITLE
Bind IndexToolsAdapter to ES6 implementation

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Module.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Module.java
@@ -1,6 +1,7 @@
 package org.graylog.storage.elasticsearch6;
 
 import org.graylog.events.indices.EventIndexerAdapter;
+import org.graylog2.indexer.IndexToolsAdapter;
 import org.graylog2.indexer.cluster.ClusterAdapter;
 import org.graylog2.indexer.cluster.NodeAdapter;
 import org.graylog2.indexer.fieldtypes.IndexFieldTypePollerAdapter;
@@ -21,5 +22,6 @@ public class Elasticsearch6Module extends PluginModule {
         bind(NodeAdapter.class).to(NodeAdapterES6.class);
         bind(EventIndexerAdapter.class).to(EventIndexerAdapterES6.class);
         bind(IndexFieldTypePollerAdapter.class).to(IndexFieldTypePollerAdapterES6.class);
+        bind(IndexToolsAdapter.class).to(IndexToolsAdapterES6.class);
     }
 }


### PR DESCRIPTION
bind new IndexToolsAdapter to the ES6 implementation, fails at runtime otherwise due to missing binding

