### PR TITLE
 Define bar width if bar chart contains only data for a single date

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/AggregationBuilder.jsx
@@ -6,7 +6,7 @@ import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationW
 import type { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
 import type { Events } from 'views/logic/searchtypes/events/EventHandler';
-import type { TimeRange } from 'views/logic/queries/Query';
+import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
 
 import EmptyAggregationContent from './EmptyAggregationContent';
 import FullSizeContainer from './FullSizeContainer';
@@ -18,7 +18,7 @@ type RowResult = {
   type: 'pivot',
   total: number,
   rows: Rows,
-  effective_timerange: TimeRange,
+  effective_timerange: AbsoluteTimeRange,
 };
 
 type EventResult = {
@@ -31,7 +31,7 @@ export type VisualizationComponentProps = {
   config: AggregationWidgetConfig,
   data: { [string]: Rows, events?: Events },
   editing?: boolean,
-  effectiveTimerange: TimeRange,
+  effectiveTimerange: AbsoluteTimeRange,
   fields: FieldTypeMappingsList,
   height: number,
   onChange: OnVisualizationConfigChange,

--- a/graylog2-web-interface/src/views/components/datatable/DataTable.test.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/DataTable.test.jsx
@@ -47,8 +47,9 @@ describe('DataTable', () => {
                data={{}}
                fields={Immutable.List([])}
                effectiveTimerange={{
-                 type: 'relative',
-                 range: 300,
+                 from: '2020-01-10T13:23:42.000Z',
+                 to: '2020-01-10T14:23:42.000Z',
+                 type: 'absolute',
                }}
                toggleEdit={() => {}}
                onChange={() => {}}

--- a/graylog2-web-interface/src/views/components/datatable/__snapshots__/DataTable.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/datatable/__snapshots__/DataTable.test.jsx.snap
@@ -67,8 +67,9 @@ exports[`DataTable renders column pivot header without offset when rollup is dis
   }
   effectiveTimerange={
     Object {
-      "range": 300,
-      "type": "relative",
+      "from": "2020-01-10T13:23:42.000Z",
+      "to": "2020-01-10T14:23:42.000Z",
+      "type": "absolute",
     }
   }
   fields={Immutable.List []}
@@ -143,8 +144,9 @@ exports[`DataTable renders column pivot header without offset when rollup is dis
     }
     effectiveTimerange={
       Object {
-        "range": 300,
-        "type": "relative",
+        "from": "2020-01-10T13:23:42.000Z",
+        "to": "2020-01-10T14:23:42.000Z",
+        "type": "absolute",
       }
     }
     fields={Immutable.List []}
@@ -1125,8 +1127,9 @@ exports[`DataTable should render with empty data 1`] = `
   data={Object {}}
   effectiveTimerange={
     Object {
-      "range": 300,
-      "type": "relative",
+      "from": "2020-01-10T13:23:42.000Z",
+      "to": "2020-01-10T14:23:42.000Z",
+      "type": "absolute",
     }
   }
   fields={Immutable.List []}
@@ -1157,8 +1160,9 @@ exports[`DataTable should render with empty data 1`] = `
     data={Object {}}
     effectiveTimerange={
       Object {
-        "range": 300,
-        "type": "relative",
+        "from": "2020-01-10T13:23:42.000Z",
+        "to": "2020-01-10T14:23:42.000Z",
+        "type": "absolute",
       }
     }
     fields={Immutable.List []}
@@ -1350,8 +1354,9 @@ exports[`DataTable should render with filled data with rollup 1`] = `
   }
   effectiveTimerange={
     Object {
-      "range": 300,
-      "type": "relative",
+      "from": "2020-01-10T13:23:42.000Z",
+      "to": "2020-01-10T14:23:42.000Z",
+      "type": "absolute",
     }
   }
   fields={Immutable.List []}
@@ -1435,8 +1440,9 @@ exports[`DataTable should render with filled data with rollup 1`] = `
     }
     effectiveTimerange={
       Object {
-        "range": 300,
-        "type": "relative",
+        "from": "2020-01-10T13:23:42.000Z",
+        "to": "2020-01-10T14:23:42.000Z",
+        "type": "absolute",
       }
     }
     fields={Immutable.List []}
@@ -2721,8 +2727,9 @@ exports[`DataTable should render with filled data without rollup 1`] = `
   }
   effectiveTimerange={
     Object {
-      "range": 300,
-      "type": "relative",
+      "from": "2020-01-10T13:23:42.000Z",
+      "to": "2020-01-10T14:23:42.000Z",
+      "type": "absolute",
     }
   }
   fields={Immutable.List []}
@@ -2806,8 +2813,9 @@ exports[`DataTable should render with filled data without rollup 1`] = `
     }
     effectiveTimerange={
       Object {
-        "range": 300,
-        "type": "relative",
+        "from": "2020-01-10T13:23:42.000Z",
+        "to": "2020-01-10T14:23:42.000Z",
+        "type": "absolute",
       }
     }
     fields={Immutable.List []}

--- a/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { AggregationType } from 'views/components/aggregationbuilder/AggregationBuilderPropTypes';
 import type { VisualizationComponent, VisualizationComponentProps } from 'views/components/aggregationbuilder/AggregationBuilder';
 import EventHandler from 'views/logic/searchtypes/events/EventHandler';
+import { DateType } from 'views/logic/aggregationbuilder/Pivot';
 import { makeVisualization } from 'views/components/aggregationbuilder/AggregationBuilder';
 
 import { chartData } from '../ChartData';
@@ -30,6 +31,25 @@ const getChartColor = (fullData, name) => {
 
 const setChartColor = (chart, colors) => ({ marker: { color: colors[chart.name] } });
 
+const defineSingleDateBarWidth = (chartDataResult, config, timerangeFrom, timerangeTo) => {
+  const barWidth = 0.03; // width in percentage, relative to chart width
+  const minXUnits = 30;
+  if (config.rowPivots.length !== 1 || config.rowPivots[0].type !== DateType) {
+    return chartDataResult;
+  }
+  return chartDataResult.map((data) => {
+    if (data?.x?.length === 1) {
+      const timerangeMS = new Date(timerangeTo) - new Date(timerangeFrom);
+      const widthXUnits = timerangeMS * barWidth;
+      return {
+        ...data,
+        width: [Math.max(minXUnits, widthXUnits)],
+      };
+    }
+    return data;
+  });
+};
+
 const BarVisualization: VisualizationComponent = makeVisualization(({ config, data, effectiveTimerange, height }: VisualizationComponentProps) => {
   const { visualizationConfig } = config;
   const layout = {};
@@ -53,7 +73,7 @@ const BarVisualization: VisualizationComponent = makeVisualization(({ config, da
 
   return (
     <XYPlot config={config}
-            chartData={chartDataResult}
+            chartData={defineSingleDateBarWidth(chartDataResult, config, effectiveTimerange.from, effectiveTimerange.to)}
             effectiveTimerange={effectiveTimerange}
             getChartColor={getChartColor}
             height={height}

--- a/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/bar/BarVisualization.jsx
@@ -31,7 +31,7 @@ const getChartColor = (fullData, name) => {
 
 const setChartColor = (chart, colors) => ({ marker: { color: colors[chart.name] } });
 
-const defineSingleDateBarWidth = (chartDataResult, config, timerangeFrom, timerangeTo) => {
+const defineSingleDateBarWidth = (chartDataResult, config, timeRangeFrom, timeRangeTo) => {
   const barWidth = 0.03; // width in percentage, relative to chart width
   const minXUnits = 30;
   if (config.rowPivots.length !== 1 || config.rowPivots[0].type !== DateType) {
@@ -39,8 +39,8 @@ const defineSingleDateBarWidth = (chartDataResult, config, timerangeFrom, timera
   }
   return chartDataResult.map((data) => {
     if (data?.x?.length === 1) {
-      const timerangeMS = new Date(timerangeTo) - new Date(timerangeFrom);
-      const widthXUnits = timerangeMS * barWidth;
+      const timeRangeMS = new Date(timeRangeTo) - new Date(timeRangeFrom);
+      const widthXUnits = timeRangeMS * barWidth;
       return {
         ...data,
         width: [Math.max(minXUnits, widthXUnits)],
@@ -73,7 +73,7 @@ const BarVisualization: VisualizationComponent = makeVisualization(({ config, da
 
   return (
     <XYPlot config={config}
-            chartData={defineSingleDateBarWidth(chartDataResult, config, effectiveTimerange.from, effectiveTimerange.to)}
+            chartData={defineSingleDateBarWidth(chartDataResult, config, effectiveTimerange?.from, effectiveTimerange?.to)}
             effectiveTimerange={effectiveTimerange}
             getChartColor={getChartColor}
             height={height}

--- a/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.test.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/number/NumberVisualization.test.jsx
@@ -55,8 +55,9 @@ describe('NumberVisualization', () => {
                          onChange={() => {}}
                          toggleEdit={() => {}}
                          effectiveTimerange={{
-                           type: 'relative',
-                           range: 300,
+                           from: '2020-01-10T13:23:42.000Z',
+                           to: '2020-01-10T14:23:42.000Z',
+                           type: 'absolute',
                          }}
                          config={AggregationWidgetConfig.builder().build()}
                          {...props} />

--- a/graylog2-web-interface/src/views/components/visualizations/number/__snapshots__/NumberVisualization.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/visualizations/number/__snapshots__/NumberVisualization.test.jsx.snap
@@ -42,8 +42,9 @@ exports[`NumberVisualization should render a number visualization 1`] = `
   }
   effectiveTimerange={
     Object {
-      "range": 300,
-      "type": "relative",
+      "from": "2020-01-10T13:23:42.000Z",
+      "to": "2020-01-10T14:23:42.000Z",
+      "type": "absolute",
     }
   }
   fields={

--- a/graylog2-web-interface/src/views/components/widgets/Widget.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.jsx
@@ -27,7 +27,7 @@ import Search from 'views/logic/search/Search';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
 import type { FieldTypeMappingsList } from 'views/stores/FieldTypesStore';
 import type { Rows } from 'views/logic/searchtypes/pivot/PivotHandler';
-import type { TimeRange } from 'views/logic/queries/Query';
+import type { AbsoluteTimeRange } from 'views/logic/queries/Query';
 import MessagesWidget from 'views/logic/widgets/MessagesWidget';
 import VisualizationConfig from 'views/logic/aggregationbuilder/visualizations/VisualizationConfig';
 import CSVExportModal from 'views/components/searchbar/csvexport/CSVExportModal';
@@ -90,7 +90,7 @@ type State = {
 export type Result = {
   total: number,
   rows: Rows,
-  effective_timerange: TimeRange,
+  effective_timerange: AbsoluteTimeRange,
 };
 
 export type OnVisualizationConfigChange = (VisualizationConfig) => void;

--- a/graylog2-web-interface/src/views/logic/aggregationbuilder/Pivot.js
+++ b/graylog2-web-interface/src/views/logic/aggregationbuilder/Pivot.js
@@ -2,6 +2,9 @@
 
 type ConfigType = { [string]: mixed };
 
+export const DateType = 'time';
+export const ValuesType = 'values';
+
 export type PivotJson = {
   field: string,
   type: string,


### PR DESCRIPTION
As described in #7167 a bar chart with a time range and only one search result, results in one very small bar. This PR is fixing the problem by defining a width for the bar. The width can't be defined in px, it has to be the unit of the x axis (in this case ms).

Fixes #7167

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)