### PR TITLE
Reset aggregation builder sort and sort direction select when related row pivot gets removed

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationbuilder/SortSelect.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/SortSelect.jsx
@@ -49,15 +49,12 @@ const SortSelect = ({ pivots, series, onChange, sort }: Props) => {
     const mappedValue = mapNewValue(fields, value);
     return onChange(mappedValue);
   };
-  const value = currentValue(sort, fields);
-  const key = `sort-${String(value)}`;
   return (
     <Select placeholder="None: click to add fields"
             onChange={_onChange}
             options={options}
             isClearable
-            key={key}
-            value={value} />
+            value={currentValue(sort, fields) ?? ''} />
   );
 };
 

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/SortSelect.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/SortSelect.jsx
@@ -54,7 +54,7 @@ const SortSelect = ({ pivots, series, onChange, sort }: Props) => {
             onChange={_onChange}
             options={options}
             isClearable
-            value={currentValue(sort, fields) ?? ''} />
+            value={currentValue(sort, fields) ?? null} />
   );
 };
 

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/SortSelect.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/SortSelect.jsx
@@ -49,12 +49,15 @@ const SortSelect = ({ pivots, series, onChange, sort }: Props) => {
     const mappedValue = mapNewValue(fields, value);
     return onChange(mappedValue);
   };
+  const value = currentValue(sort, fields);
+  const key = `sort-${String(value)}`;
   return (
     <Select placeholder="None: click to add fields"
             onChange={_onChange}
             options={options}
             isClearable
-            value={currentValue(sort, fields)} />
+            key={key}
+            value={value} />
   );
 };
 

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/SortSelect.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/SortSelect.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import * as Immutable from 'immutable';
 
 import Select from 'views/components/Select';
-
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
 import Series from 'views/logic/aggregationbuilder/Series';
 import { defaultCompare } from 'views/logic/DefaultCompare';

--- a/graylog2-web-interface/src/views/components/widgets/SortDirectionSelect.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/SortDirectionSelect.jsx
@@ -21,8 +21,7 @@ const SortDirectionSelect = ({ direction, disabled, onChange }: Props) => (
           ]}
           onChange={({ value }) => onChange(Direction.fromString(value))}
           placeholder={disabled ? 'No sorting selected' : 'Click to select direction'}
-          key={`sort-direction-${String(direction)}`}
-          value={direction && { label: direction, value: direction }} />
+          value={(direction && { label: direction, value: direction }) ?? null} />
 );
 
 SortDirectionSelect.propTypes = {

--- a/graylog2-web-interface/src/views/components/widgets/SortDirectionSelect.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/SortDirectionSelect.jsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 
 import Select from 'views/components/Select';
-
 import Direction from 'views/logic/aggregationbuilder/Direction';
 
 type Props = {
@@ -22,6 +21,7 @@ const SortDirectionSelect = ({ direction, disabled, onChange }: Props) => (
           ]}
           onChange={({ value }) => onChange(Direction.fromString(value))}
           placeholder={disabled ? 'No sorting selected' : 'Click to select direction'}
+          key={`sort-direction-${String(direction)}`}
           value={direction && { label: direction, value: direction }} />
 );
 


### PR DESCRIPTION
As described in #7198 the value of the sort and sort direction select in the aggregation builder persist when the related row pivot gets removed.

This PR is fixing the issue by defining an empty string for the select value, instead of undefined, when the provided value is empty.

Fixes #7198

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
