### PR TITLE
Replace direct imports of react-select select with custom select

### DIFF
--- a/graylog2-web-interface/src/views/components/Select.jsx
+++ b/graylog2-web-interface/src/views/components/Select.jsx
@@ -67,6 +67,7 @@ const option = (base) => ({
 const valueContainer = (base) => ({
   ...base,
   minWidth: '6.5vw',
+  minHeight: '30px',
 });
 
 type Props = {

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/NumberVisualizationConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/NumberVisualizationConfiguration.jsx
@@ -1,9 +1,9 @@
 // @flow strict
 import React, { useCallback } from 'react';
-import Select from 'react-select';
 import { capitalize } from 'lodash';
 
 import { Input } from 'components/bootstrap';
+import Select from 'views/components/Select';
 import NumberVisualizationConfig from 'views/logic/aggregationbuilder/visualizations/NumberVisualizationConfig';
 import HoverForHelp from './HoverForHelp';
 

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/SortSelect.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/SortSelect.jsx
@@ -1,8 +1,9 @@
 // @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import Select from 'react-select';
 import * as Immutable from 'immutable';
+
+import Select from 'views/components/Select';
 
 import Pivot from 'views/logic/aggregationbuilder/Pivot';
 import Series from 'views/logic/aggregationbuilder/Series';

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/BarVisualizationConfiguration.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/BarVisualizationConfiguration.test.jsx.snap
@@ -648,7 +648,7 @@ exports[`BarVisualizationConfiguration should render with props 1`] = `
                   }
                 >
                   <div
-                    className="css-5b48ez"
+                    className="css-1sqh0jz"
                   >
                     <SingleValue
                       clearValue={[Function]}
@@ -2131,7 +2131,7 @@ exports[`BarVisualizationConfiguration should render without props 1`] = `
                   }
                 >
                   <div
-                    className="css-5b48ez"
+                    className="css-1sqh0jz"
                   >
                     <SingleValue
                       clearValue={[Function]}

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/SeriesSelect.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/SeriesSelect.test.jsx.snap
@@ -455,7 +455,7 @@ exports[`SeriesSelect renders with minimal props 1`] = `
                   }
                 >
                   <div
-                    className="css-5b48ez"
+                    className="css-1sqh0jz"
                   >
                     <Placeholder
                       clearValue={[Function]}

--- a/graylog2-web-interface/src/views/components/widgets/SortDirectionSelect.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/SortDirectionSelect.jsx
@@ -1,7 +1,8 @@
 // @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import Select from 'react-select';
+
+import Select from 'views/components/Select';
 
 import Direction from 'views/logic/aggregationbuilder/Direction';
 
@@ -11,12 +12,7 @@ type Props = {
   onChange: (Direction) => any,
 };
 
-const valueContainer = (base) => ({
-  ...base,
-  minHeight: '35px',
-});
-
-const SortDirectionSelect = ({ direction, disabled, onChange }: Props): Select => (
+const SortDirectionSelect = ({ direction, disabled, onChange }: Props) => (
   <Select isDisabled={disabled}
           isClearable={false}
           isSearchable={false}
@@ -26,7 +22,6 @@ const SortDirectionSelect = ({ direction, disabled, onChange }: Props): Select =
           ]}
           onChange={({ value }) => onChange(Direction.fromString(value))}
           placeholder={disabled ? 'No sorting selected' : 'Click to select direction'}
-          styles={{ valueContainer }}
           value={direction && { label: direction, value: direction }} />
 );
 


### PR DESCRIPTION
We have or own `Select` component for the search, which has e.g. its own styling. There were still a few cases, where we use the `Select` component from `react-select`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)