### PR TITLE
Extract jestclient dependency from migration

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Module.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Module.java
@@ -1,14 +1,16 @@
 package org.graylog.storage.elasticsearch6;
 
 import org.graylog.events.indices.EventIndexerAdapter;
+import org.graylog.events.search.MoreSearchAdapter;
+import org.graylog.storage.elasticsearch6.migrations.V20170607164210_MigrateReopenedIndicesToAliasesClusterStateES6;
 import org.graylog2.indexer.IndexToolsAdapter;
 import org.graylog2.indexer.cluster.ClusterAdapter;
 import org.graylog2.indexer.cluster.NodeAdapter;
 import org.graylog2.indexer.fieldtypes.IndexFieldTypePollerAdapter;
 import org.graylog2.indexer.indices.IndicesAdapter;
-import org.graylog.events.search.MoreSearchAdapter;
-import org.graylog2.indexer.searches.SearchesAdapter;
 import org.graylog2.indexer.messages.MessagesAdapter;
+import org.graylog2.indexer.searches.SearchesAdapter;
+import org.graylog2.migrations.V20170607164210_MigrateReopenedIndicesToAliases;
 import org.graylog2.plugin.PluginModule;
 
 public class Elasticsearch6Module extends PluginModule {
@@ -23,5 +25,6 @@ public class Elasticsearch6Module extends PluginModule {
         bind(EventIndexerAdapter.class).to(EventIndexerAdapterES6.class);
         bind(IndexFieldTypePollerAdapter.class).to(IndexFieldTypePollerAdapterES6.class);
         bind(IndexToolsAdapter.class).to(IndexToolsAdapterES6.class);
+        bind(V20170607164210_MigrateReopenedIndicesToAliases.ClusterState.class).to(V20170607164210_MigrateReopenedIndicesToAliasesClusterStateES6.class);
     }
 }

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/migrations/V20170607164210_MigrateReopenedIndicesToAliasesClusterStateES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/migrations/V20170607164210_MigrateReopenedIndicesToAliasesClusterStateES6.java
@@ -1,0 +1,31 @@
+package org.graylog.storage.elasticsearch6.migrations;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestResult;
+import io.searchbox.cluster.State;
+import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog2.migrations.V20170607164210_MigrateReopenedIndicesToAliases;
+
+import javax.inject.Inject;
+import java.util.Collection;
+
+public class V20170607164210_MigrateReopenedIndicesToAliasesClusterStateES6 implements V20170607164210_MigrateReopenedIndicesToAliases.ClusterState {
+    private final JestClient jestClient;
+
+    @Inject
+    public V20170607164210_MigrateReopenedIndicesToAliasesClusterStateES6(JestClient jestClient) {
+        this.jestClient = jestClient;
+    }
+
+    @Override
+    public JsonNode getForIndices(Collection<String> indices) {
+        final String indexList = String.join(",", indices);
+
+        final State request = new State.Builder().withMetadata().indices(indexList).build();
+
+        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't read cluster state for reopened indices " + indices);
+
+        return jestResult.getJsonObject();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20170607164210_MigrateReopenedIndicesToAliases.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20170607164210_MigrateReopenedIndicesToAliases.java
@@ -19,14 +19,10 @@ package org.graylog2.migrations;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.zafarkhaja.semver.Version;
 import com.google.common.collect.ImmutableSet;
-import io.searchbox.client.JestClient;
-import io.searchbox.client.JestResult;
-import io.searchbox.cluster.State;
 import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.MongoIndexSet;
 import org.graylog2.indexer.cluster.Node;
-import org.graylog2.indexer.cluster.jest.JestUtils;
 import org.graylog2.indexer.indexset.IndexSetService;
 import org.graylog2.indexer.indices.Indices;
 import org.slf4j.Logger;
@@ -49,19 +45,23 @@ public class V20170607164210_MigrateReopenedIndicesToAliases extends Migration {
     private final IndexSetService indexSetService;
     private final MongoIndexSet.Factory mongoIndexSetFactory;
     private final Indices indices;
-    private final JestClient jestClient;
+    private final ClusterState clusterState;
+
+    public interface ClusterState {
+        JsonNode getForIndices(Collection<String> indices);
+    }
 
     @Inject
     public V20170607164210_MigrateReopenedIndicesToAliases(Node node,
                                                            IndexSetService indexSetService,
                                                            MongoIndexSet.Factory mongoIndexSetFactory,
                                                            Indices indices,
-                                                           JestClient jestClient) {
+                                                           ClusterState clusterState) {
         this.node = node;
         this.indexSetService = indexSetService;
         this.mongoIndexSetFactory = mongoIndexSetFactory;
         this.indices = indices;
-        this.jestClient = jestClient;
+        this.clusterState = clusterState;
     }
 
     @Override
@@ -82,11 +82,9 @@ public class V20170607164210_MigrateReopenedIndicesToAliases extends Migration {
 
     private Set<String> getReopenedIndices(final Collection<String> indices) {
         final Version elasticsearchVersion = node.getVersion().orElseThrow(() -> new ElasticsearchException("Unable to retrieve Elasticsearch version."));
-        final String indexList = String.join(",", indices);
-        final State request = new State.Builder().withMetadata().indices(indexList).build();
 
-        final JestResult jestResult = JestUtils.execute(jestClient, request, () -> "Couldn't read cluster state for reopened indices " + indices);
-        final JsonNode clusterStateJson = jestResult.getJsonObject();
+        final JsonNode clusterStateJson = clusterState.getForIndices(indices);
+
         final JsonNode indicesJson = clusterStateJson.path("metadata").path("indices");
 
         final ImmutableSet.Builder<String> reopenedIndices = ImmutableSet.builder();

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20170607164210_MigrateReopenedIndicesToAliases.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20170607164210_MigrateReopenedIndicesToAliases.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableSet;
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
 import io.searchbox.cluster.State;
-import javax.annotation.Nonnull;
 import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.MongoIndexSet;
@@ -33,7 +32,7 @@ import org.graylog2.indexer.indices.Indices;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import java.time.ZonedDateTime;
 import java.util.Collection;
@@ -46,7 +45,7 @@ public class V20170607164210_MigrateReopenedIndicesToAliases extends Migration {
     private static final Logger LOG = LoggerFactory.getLogger(V20170607164210_MigrateReopenedIndicesToAliases.class);
     private static final String REOPENED_INDEX_SETTING = "graylog2_reopened";
 
-    private Node node;
+    private final Node node;
     private final IndexSetService indexSetService;
     private final MongoIndexSet.Factory mongoIndexSetFactory;
     private final Indices indices;
@@ -74,10 +73,10 @@ public class V20170607164210_MigrateReopenedIndicesToAliases extends Migration {
     @Override
     public void upgrade() {
         this.indexSetService.findAll()
-            .stream()
-            .map(mongoIndexSetFactory::create)
-            .flatMap(indexSet -> getReopenedIndices(indexSet).stream())
-            .map(indexName -> { LOG.debug("Marking index {} to be reopened using alias.", indexName); return indexName; })
+                .stream()
+                .map(mongoIndexSetFactory::create)
+                .flatMap(indexSet -> getReopenedIndices(indexSet).stream())
+                .peek(indexName -> LOG.debug("Marking index {} to be reopened using alias.", indexName))
             .forEach(indices::markIndexReopened);
     }
 


### PR DESCRIPTION
## Description
This PR extracts the dependency on `JestClient` from a migration class (`V20170607164210_MigrateReopenedIndicesToAliases`)

## Motivation and Context
We want to remove all Elasticsearch dependencies from the server core. At the same time we ant to touch old migrations as little as possible, especially if they have no automatic test coverage like this one.
We there fore decided to only extract the technical dependency on `JestClient` by defining a custom interface only for this migration. The logical dependency on the JSON format of the client's response can remain in the migration class, because that should never have to change.

## How Has This Been Tested?
Started server locally and debugged into the code to verify that it runs.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


