### PR TITLE
Moving Jest infrastructure classes to storage module.

### DIFF
--- a/distribution/src/main/assembly/graylog.xml
+++ b/distribution/src/main/assembly/graylog.xml
@@ -58,7 +58,7 @@
             <outputDirectory>.</outputDirectory>
         </file>
         <file>
-            <source>${project.basedir}/../graylog-storage-elasticsearch6/target/graylog-storage-elasticsearch6-${project.version}-with-dependencies.jar</source>
+            <source>${project.basedir}/../graylog-storage-elasticsearch6/target/graylog-storage-elasticsearch6-${project.version}.jar</source>
             <outputDirectory>plugin/</outputDirectory>
         </file>
     </files>

--- a/distribution/src/main/assembly/graylog.xml
+++ b/distribution/src/main/assembly/graylog.xml
@@ -58,7 +58,7 @@
             <outputDirectory>.</outputDirectory>
         </file>
         <file>
-            <source>${project.basedir}/../graylog-storage-elasticsearch6/target/graylog-storage-elasticsearch6-${project.version}.jar</source>
+            <source>${project.basedir}/../graylog-storage-elasticsearch6/target/graylog-storage-elasticsearch6-${project.version}-with-dependencies.jar</source>
             <outputDirectory>plugin/</outputDirectory>
         </file>
     </files>

--- a/full-backend-tests/pom.xml
+++ b/full-backend-tests/pom.xml
@@ -47,13 +47,18 @@
             <artifactId>graylog2-server</artifactId>
             <version>${project.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.graylog2</groupId>
             <artifactId>graylog2-server</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.graylog</groupId>
+            <artifactId>graylog-storage-elasticsearch6</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.graylog</groupId>
@@ -150,6 +155,18 @@
             <artifactId>elasticsearch</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Transitive dependencies of graylog-storage-elasticsearch6 -->
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <version>${elasticsearch.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.graylog.jest</groupId>
+            <artifactId>jest</artifactId>
+            <version>${jest.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -174,7 +191,6 @@
                     </execution>
                 </executions>
             </plugin>
-
         </plugins>
     </build>
 </project>

--- a/graylog-storage-elasticsearch6/assembly.xml
+++ b/graylog-storage-elasticsearch6/assembly.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+    <id>with-dependencies</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <unpack>true</unpack>
+            <scope>runtime</scope>
+            <useProjectArtifact>true</useProjectArtifact>
+            <includes>
+                <include>org.graylog:graylog-storage-elasticsearch6</include>
+                <include>org.elasticsearch:elasticsearch</include>
+                <include>org.graylog.jest:jest</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/graylog-storage-elasticsearch6/assembly.xml
+++ b/graylog-storage-elasticsearch6/assembly.xml
@@ -13,10 +13,14 @@
             <unpack>true</unpack>
             <scope>runtime</scope>
             <useProjectArtifact>true</useProjectArtifact>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
             <includes>
                 <include>org.graylog:graylog-storage-elasticsearch6</include>
                 <include>org.elasticsearch:elasticsearch</include>
                 <include>org.graylog.jest:jest</include>
+                <include>org.graylog.jest:jest-common</include>
+                <include>org.apache.lucene:lucene-core</include>
+                <include>org.apache.httpcomponents:*</include>
             </includes>
         </dependencySet>
     </dependencySets>

--- a/graylog-storage-elasticsearch6/pom.xml
+++ b/graylog-storage-elasticsearch6/pom.xml
@@ -33,6 +33,17 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+            <version>${elasticsearch.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.graylog.jest</groupId>
+            <artifactId>jest</artifactId>
+            <version>${jest.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.graylog2</groupId>
             <artifactId>graylog2-server</artifactId>
             <version>${project.parent.version}</version>

--- a/graylog-storage-elasticsearch6/pom.xml
+++ b/graylog-storage-elasticsearch6/pom.xml
@@ -123,6 +123,23 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptors>assembly.xml</descriptors>
+                    <appendAssemblyId>true</appendAssemblyId>
+                    <finalName>graylog-storage-elasticsearch6-${project.version}</finalName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/graylog-storage-elasticsearch6/pom.xml
+++ b/graylog-storage-elasticsearch6/pom.xml
@@ -128,8 +128,6 @@
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <descriptors>assembly.xml</descriptors>
-                    <appendAssemblyId>true</appendAssemblyId>
-                    <finalName>graylog-storage-elasticsearch6-${project.version}</finalName>
                 </configuration>
                 <executions>
                     <execution>

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/ClusterAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/ClusterAdapterES6.java
@@ -24,7 +24,7 @@ import org.graylog2.indexer.cluster.health.ClusterAllocationDiskSettingsFactory;
 import org.graylog2.indexer.cluster.health.NodeDiskUsageStats;
 import org.graylog2.indexer.cluster.health.NodeFileDescriptorStats;
 import org.graylog.storage.elasticsearch6.cluster.GetAllocationDiskSettings;
-import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog.storage.elasticsearch6.jest.JestUtils;
 import org.graylog2.indexer.indices.HealthStatus;
 import org.graylog2.rest.models.system.indexer.responses.ClusterHealth;
 import org.graylog2.system.stats.elasticsearch.ClusterStats;

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/CountsAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/CountsAdapterES6.java
@@ -6,7 +6,7 @@ import io.searchbox.core.MultiSearchResult;
 import io.searchbox.core.Search;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog.storage.elasticsearch6.jest.JestUtils;
 import org.graylog2.indexer.counts.CountsAdapter;
 
 import javax.inject.Inject;

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Module.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Module.java
@@ -5,7 +5,7 @@ import io.searchbox.client.JestClient;
 import org.graylog.events.indices.EventIndexerAdapter;
 import org.graylog.events.search.MoreSearchAdapter;
 import org.graylog.storage.elasticsearch6.migrations.V20170607164210_MigrateReopenedIndicesToAliasesClusterStateES6;
-import org.graylog2.bindings.providers.JestClientProvider;
+import org.graylog.storage.elasticsearch6.jest.JestClientProvider;
 import org.graylog2.indexer.IndexToolsAdapter;
 import org.graylog2.indexer.cluster.ClusterAdapter;
 import org.graylog2.indexer.cluster.NodeAdapter;

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Module.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Module.java
@@ -1,9 +1,11 @@
 package org.graylog.storage.elasticsearch6;
 
 import com.google.inject.assistedinject.FactoryModuleBuilder;
+import io.searchbox.client.JestClient;
 import org.graylog.events.indices.EventIndexerAdapter;
 import org.graylog.events.search.MoreSearchAdapter;
 import org.graylog.storage.elasticsearch6.migrations.V20170607164210_MigrateReopenedIndicesToAliasesClusterStateES6;
+import org.graylog2.bindings.providers.JestClientProvider;
 import org.graylog2.indexer.IndexToolsAdapter;
 import org.graylog2.indexer.cluster.ClusterAdapter;
 import org.graylog2.indexer.cluster.NodeAdapter;
@@ -31,5 +33,7 @@ public class Elasticsearch6Module extends PluginModule {
         bind(V20170607164210_MigrateReopenedIndicesToAliases.ClusterState.class).to(V20170607164210_MigrateReopenedIndicesToAliasesClusterStateES6.class);
 
         install(new FactoryModuleBuilder().build(ScrollResultES6.Factory.class));
+
+        bind(JestClient.class).toProvider(JestClientProvider.class).asEagerSingleton();
     }
 }

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndexFieldTypePollerAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndexFieldTypePollerAdapterES6.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
 import io.searchbox.indices.mapping.GetMapping;
-import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog.storage.elasticsearch6.jest.JestUtils;
 import org.graylog2.indexer.fieldtypes.FieldTypeDTO;
 import org.graylog2.indexer.fieldtypes.IndexFieldTypePollerAdapter;
 import org.graylog2.shared.utilities.ExceptionUtils;

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndexToolsAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndexToolsAdapterES6.java
@@ -19,7 +19,7 @@ import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuil
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.graylog2.indexer.IndexMapping;
 import org.graylog2.indexer.IndexToolsAdapter;
-import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog.storage.elasticsearch6.jest.JestUtils;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.streams.Stream;
 import org.joda.time.DateTime;

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/IndicesAdapterES6.java
@@ -53,7 +53,7 @@ import org.elasticsearch.search.sort.SortBuilders;
 import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.indexer.IndexMapping;
 import org.graylog2.indexer.IndexNotFoundException;
-import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog.storage.elasticsearch6.jest.JestUtils;
 import org.graylog2.indexer.indices.HealthStatus;
 import org.graylog2.indexer.indices.IndexMoveResult;
 import org.graylog2.indexer.indices.IndexSettings;

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/MessagesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/MessagesAdapterES6.java
@@ -27,7 +27,7 @@ import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.indexer.IndexFailure;
 import org.graylog2.indexer.IndexFailureImpl;
 import org.graylog2.indexer.IndexMapping;
-import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog.storage.elasticsearch6.jest.JestUtils;
 import org.graylog2.indexer.messages.DocumentNotFoundException;
 import org.graylog2.indexer.messages.IndexBlockRetryAttempt;
 import org.graylog2.indexer.messages.IndexingRequest;

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/MultiSearch.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/MultiSearch.java
@@ -7,14 +7,14 @@ import io.searchbox.core.MultiSearchResult;
 import io.searchbox.core.Search;
 import io.searchbox.core.SearchResult;
 import org.graylog2.indexer.ElasticsearchException;
-import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog.storage.elasticsearch6.jest.JestUtils;
 
 import javax.inject.Inject;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import static org.graylog2.indexer.cluster.jest.JestUtils.checkForFailedShards;
+import static org.graylog.storage.elasticsearch6.jest.JestUtils.checkForFailedShards;
 
 public class MultiSearch {
     private final JestClient jestClient;

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/NodeAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/NodeAdapterES6.java
@@ -4,7 +4,7 @@ import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
 import io.searchbox.core.Ping;
 import org.graylog2.indexer.cluster.NodeAdapter;
-import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog.storage.elasticsearch6.jest.JestUtils;
 
 import javax.inject.Inject;
 import java.util.Optional;

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Scroll.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Scroll.java
@@ -3,7 +3,7 @@ package org.graylog.storage.elasticsearch6;
 import io.searchbox.client.JestClient;
 import io.searchbox.core.Search;
 import org.graylog2.indexer.ElasticsearchException;
-import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog.storage.elasticsearch6.jest.JestUtils;
 import org.graylog2.indexer.results.ScrollResult;
 
 import javax.inject.Inject;

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/GraylogJestRetryHandler.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/GraylogJestRetryHandler.java
@@ -14,19 +14,20 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.indexer.cluster.jest;
+package org.graylog.storage.elasticsearch6.jest;
 
 import com.google.common.base.Preconditions;
 import io.searchbox.client.JestRetryHandler;
-import java.net.SocketException;
-import java.net.UnknownHostException;
-import java.util.Arrays;
-import java.util.Collection;
-import javax.net.ssl.SSLException;
 import org.apache.http.ConnectionClosedException;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLException;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Collection;
 
 public class GraylogJestRetryHandler implements JestRetryHandler<HttpUriRequest> {
     private static final Logger log = LoggerFactory.getLogger(GraylogJestRetryHandler.class);

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/JestClientProvider.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/JestClientProvider.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.bindings.providers;
+package org.graylog.storage.elasticsearch6.jest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.joschi.jadconfig.util.Duration;

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/JestClientProvider.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/JestClientProvider.java
@@ -29,7 +29,6 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.graylog2.indexer.cluster.jest.GraylogJestRetryHandler;
 import org.graylog2.indexer.cluster.jest.RequestResponseLogger;
 
 import javax.annotation.Nullable;

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/JestUtils.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/JestUtils.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.indexer.cluster.jest;
+package org.graylog.storage.elasticsearch6.jest;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.searchbox.action.Action;

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/migrations/V20170607164210_MigrateReopenedIndicesToAliasesClusterStateES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/migrations/V20170607164210_MigrateReopenedIndicesToAliasesClusterStateES6.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
 import io.searchbox.cluster.State;
-import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog.storage.elasticsearch6.jest.JestUtils;
 import org.graylog2.migrations.V20170607164210_MigrateReopenedIndicesToAliases;
 
 import javax.inject.Inject;

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackend.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/ElasticsearchBackend.java
@@ -52,7 +52,7 @@ import org.graylog.plugins.views.search.filter.StreamFilter;
 import org.graylog2.indexer.ElasticsearchException;
 import org.graylog.storage.elasticsearch6.TimeRangeQueryFactory;
 import org.graylog2.indexer.IndexMapping;
-import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog.storage.elasticsearch6.jest.JestUtils;
 import org.graylog2.plugin.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,7 +73,7 @@ import java.util.stream.StreamSupport;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.graylog2.indexer.cluster.jest.JestUtils.checkForFailedShards;
+import static org.graylog.storage.elasticsearch6.jest.JestUtils.checkForFailedShards;
 
 public class ElasticsearchBackend implements QueryBackend<ESGeneratedQueryContext> {
     private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchBackend.class);

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/export/JestWrapper.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/views/export/JestWrapper.java
@@ -21,13 +21,13 @@ import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
 import org.graylog.plugins.views.search.export.ExportException;
 import org.graylog2.indexer.ElasticsearchException;
-import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog.storage.elasticsearch6.jest.JestUtils;
 
 import javax.inject.Inject;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import static org.graylog2.indexer.cluster.jest.JestUtils.checkForFailedShards;
+import static org.graylog.storage.elasticsearch6.jest.JestUtils.checkForFailedShards;
 
 public class JestWrapper {
     private final JestClient jestClient;

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/ClusterES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/ClusterES6IT.java
@@ -8,7 +8,7 @@ import org.graylog.storage.elasticsearch6.testing.ElasticsearchInstanceES6;
 import org.graylog.testing.elasticsearch.ElasticsearchInstance;
 import org.graylog2.indexer.cluster.ClusterAdapter;
 import org.graylog2.indexer.cluster.ClusterIT;
-import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog.storage.elasticsearch6.jest.JestUtils;
 import org.junit.Rule;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/MessagesES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/MessagesES6IT.java
@@ -8,7 +8,7 @@ import io.searchbox.core.DocumentResult;
 import io.searchbox.core.Index;
 import org.graylog.storage.elasticsearch6.testing.ElasticsearchInstanceES6;
 import org.graylog.testing.elasticsearch.ElasticsearchInstance;
-import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog.storage.elasticsearch6.jest.JestUtils;
 import org.graylog2.indexer.messages.MessagesAdapter;
 import org.graylog2.indexer.messages.MessagesIT;
 import org.graylog2.indexer.results.ResultMessage;

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/ScrollResultES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/ScrollResultES6IT.java
@@ -25,7 +25,7 @@ import org.graylog.storage.elasticsearch6.testing.ElasticsearchInstanceES6;
 import org.graylog.testing.elasticsearch.ElasticsearchBaseTest;
 import org.graylog.testing.elasticsearch.ElasticsearchInstance;
 import org.graylog2.indexer.IndexMapping;
-import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog.storage.elasticsearch6.jest.JestUtils;
 import org.graylog2.indexer.results.ScrollResult;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.Rule;

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/jest/JestClientProviderTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/jest/JestClientProviderTest.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.bindings.providers;
+package org.graylog.storage.elasticsearch6.jest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.joschi.jadconfig.util.Duration;

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/jest/JestUtilsTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/jest/JestUtilsTest.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.indexer.cluster.jest;
+package org.graylog.storage.elasticsearch6.jest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ClientES6.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ClientES6.java
@@ -40,7 +40,7 @@ import io.searchbox.indices.template.GetTemplate;
 import io.searchbox.indices.template.PutTemplate;
 import org.graylog.testing.elasticsearch.BulkIndexRequest;
 import org.graylog.testing.elasticsearch.Client;
-import org.graylog2.indexer.cluster.jest.JestUtils;
+import org.graylog.storage.elasticsearch6.jest.JestUtils;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ElasticsearchInstanceES6.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ElasticsearchInstanceES6.java
@@ -8,7 +8,7 @@ import org.graylog.testing.PropertyLoader;
 import org.graylog.testing.elasticsearch.Client;
 import org.graylog.testing.elasticsearch.ElasticsearchInstance;
 import org.graylog.testing.elasticsearch.FixtureImporter;
-import org.graylog2.bindings.providers.JestClientProvider;
+import org.graylog.storage.elasticsearch6.jest.JestClientProvider;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -302,16 +302,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.elasticsearch</groupId>
-            <artifactId>elasticsearch</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.graylog.jest</groupId>
-            <artifactId>jest</artifactId>
-        </dependency>
-
-
-        <dependency>
             <groupId>com.lmax</groupId>
             <artifactId>disruptor</artifactId>
         </dependency>

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ElasticsearchModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ElasticsearchModule.java
@@ -17,14 +17,11 @@
 package org.graylog2.bindings;
 
 import com.google.inject.AbstractModule;
-import io.searchbox.client.JestClient;
-import org.graylog2.bindings.providers.JestClientProvider;
 import org.graylog2.indexer.IndexMappingFactory;
 
 public class ElasticsearchModule extends AbstractModule {
     @Override
     protected void configure() {
-        bind(JestClient.class).toProvider(JestClientProvider.class).asEagerSingleton();
         bind(IndexMappingFactory.class).asEagerSingleton();
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is moving over the remaining classes required to instantiate and wire a Jest client to the storage module. It also moves over maven dependencies for Elasticsearch and Jest. Version properties are still kept in the parent pom, those can be moved over later.

Requires #8361 to be merged before.

Fixes #8155.
Fixes #8156.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.