### PR TITLE
Display error message for search bar time range inputs

### DIFF
--- a/graylog2-web-interface/src/components/graylog/Tooltip.jsx
+++ b/graylog2-web-interface/src/components/graylog/Tooltip.jsx
@@ -6,7 +6,9 @@ import styled, { css } from 'styled-components';
 
 import GraylogThemeProvider from 'theme/GraylogThemeProvider';
 
-const StyledTooltip = styled(BootstrapTooltip)(({ theme }) => css`
+const StyledTooltip = styled(BootstrapTooltip)(({ theme, allowLineBreaks }) => css`
+  white-space: ${allowLineBreaks ? 'normal' : 'nowrap'};
+
   &.top .tooltip-arrow {
     bottom: 0;
   }
@@ -46,7 +48,7 @@ const StyledTooltip = styled(BootstrapTooltip)(({ theme }) => css`
   }
 `);
 
-const Tooltip = ({ children, className, id, placement, positionTop, positionLeft, arrowOffsetTop, arrowOffsetLeft }) => {
+const Tooltip = ({ children, className, id, placement, positionTop, positionLeft, arrowOffsetTop, arrowOffsetLeft, allowLineBreaks }) => {
   return (
     <GraylogThemeProvider>
       <StyledTooltip className={className}
@@ -54,6 +56,7 @@ const Tooltip = ({ children, className, id, placement, positionTop, positionLeft
                      placement={placement}
                      positionTop={positionTop}
                      positionLeft={positionLeft}
+                     allowLineBreaks={allowLineBreaks}
                      arrowOffsetTop={arrowOffsetTop}
                      arrowOffsetLeft={arrowOffsetLeft}>
         {children}
@@ -94,6 +97,10 @@ Tooltip.propTypes = {
    * The "left" position value for the Tooltip arrow.
    */
   arrowOffsetLeft: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * Control if the tooltip text can have line breaks.
+   */
+  allowLineBreaks: PropTypes.bool,
 };
 
 Tooltip.defaultProps = {
@@ -103,6 +110,7 @@ Tooltip.defaultProps = {
   positionLeft: undefined,
   arrowOffsetTop: undefined,
   arrowOffsetLeft: undefined,
+  allowLineBreaks: true,
 };
 
 /** @component */

--- a/graylog2-web-interface/src/components/graylog/Tooltip.jsx
+++ b/graylog2-web-interface/src/components/graylog/Tooltip.jsx
@@ -6,9 +6,7 @@ import styled, { css } from 'styled-components';
 
 import GraylogThemeProvider from 'theme/GraylogThemeProvider';
 
-const StyledTooltip = styled(BootstrapTooltip)(({ theme, allowLineBreaks }) => css`
-  white-space: ${allowLineBreaks ? 'normal' : 'nowrap'};
-
+const StyledTooltip = styled(BootstrapTooltip)(({ theme }) => css`
   &.top .tooltip-arrow {
     bottom: 0;
   }
@@ -48,7 +46,7 @@ const StyledTooltip = styled(BootstrapTooltip)(({ theme, allowLineBreaks }) => c
   }
 `);
 
-const Tooltip = ({ children, className, id, placement, positionTop, positionLeft, arrowOffsetTop, arrowOffsetLeft, allowLineBreaks }) => {
+const Tooltip = ({ children, className, id, placement, positionTop, positionLeft, arrowOffsetTop, arrowOffsetLeft }) => {
   return (
     <GraylogThemeProvider>
       <StyledTooltip className={className}
@@ -56,7 +54,6 @@ const Tooltip = ({ children, className, id, placement, positionTop, positionLeft
                      placement={placement}
                      positionTop={positionTop}
                      positionLeft={positionLeft}
-                     allowLineBreaks={allowLineBreaks}
                      arrowOffsetTop={arrowOffsetTop}
                      arrowOffsetLeft={arrowOffsetLeft}>
         {children}
@@ -97,10 +94,6 @@ Tooltip.propTypes = {
    * The "left" position value for the Tooltip arrow.
    */
   arrowOffsetLeft: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  /**
-   * Control if the tooltip text can have line breaks.
-   */
-  allowLineBreaks: PropTypes.bool,
 };
 
 Tooltip.defaultProps = {
@@ -110,7 +103,6 @@ Tooltip.defaultProps = {
   positionLeft: undefined,
   arrowOffsetTop: undefined,
   arrowOffsetLeft: undefined,
-  allowLineBreaks: true,
 };
 
 /** @component */

--- a/graylog2-web-interface/src/views/components/searchbar/AbsoluteTimeRangeSelector.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/AbsoluteTimeRangeSelector.jsx
@@ -38,7 +38,7 @@ const _isValidDateString = (dateString: string) => {
 
   return DateTime.isValidDateString(dateString)
     ? undefined
-    : `Format must be: ${DateTime.Formats.TIMESTAMP}`;
+    : 'Format must be: YYYY-MM-DD [HH:mm:ss[.SSS]]';
 };
 
 const AbsoluteTimeRangeSelector = ({ disabled }: Props) => {

--- a/graylog2-web-interface/src/views/components/searchbar/AbsoluteTimeRangeSelector.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/AbsoluteTimeRangeSelector.jsx
@@ -38,7 +38,7 @@ const _isValidDateString = (dateString: string) => {
 
   return DateTime.isValidDateString(dateString)
     ? undefined
-    : `Format must be: ${DateTime.Formats.DATETIME}`;
+    : `Format must be: ${DateTime.Formats.TIMESTAMP}`;
 };
 
 const AbsoluteTimeRangeSelector = ({ disabled }: Props) => {

--- a/graylog2-web-interface/src/views/components/searchbar/AbsoluteTimeRangeSelector.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/AbsoluteTimeRangeSelector.jsx
@@ -38,7 +38,7 @@ const _isValidDateString = (dateString: string) => {
 
   return DateTime.isValidDateString(dateString)
     ? undefined
-    : `Invalid date: ${dateString}`;
+    : `Format must be: ${DateTime.Formats.DATETIME}`;
 };
 
 const AbsoluteTimeRangeSelector = ({ disabled }: Props) => {

--- a/graylog2-web-interface/src/views/components/searchbar/AbsoluteTimeRangeSelector.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/AbsoluteTimeRangeSelector.test.jsx
@@ -44,6 +44,7 @@ describe('AbsoluteTimeRangeSelector', () => {
 
     await wait(() => expect(getValidationStateOfInput(fromDate)).toEqual('error'));
   });
+
   it('does not try to parse an empty date in to field', async () => {
     const { getByDisplayValue } = renderWithForm((
       <AbsoluteTimeRangeSelector />
@@ -53,5 +54,29 @@ describe('AbsoluteTimeRangeSelector', () => {
     await changeInput(toDate, '');
 
     await wait(() => expect(getValidationStateOfInput(toDate)).toEqual('error'));
+  });
+
+  it('shows error message for from date if parsing fails after changing input', async () => {
+    const { getByDisplayValue, queryByText } = renderWithForm((
+      <AbsoluteTimeRangeSelector />
+    ));
+
+    const fromDate = getByDisplayValue('2020-01-16 10:04:30.329');
+
+    await changeInput(fromDate, 'invalid');
+
+    await wait(() => expect(queryByText('Format must be: YYYY-MM-DD HH:mm:ss.SSS')).not.toBeNull());
+  });
+
+  it('shows error message for to date if parsing fails after changing input', async () => {
+    const { getByDisplayValue, queryByText } = renderWithForm((
+      <AbsoluteTimeRangeSelector />
+    ));
+
+    const fromDate = getByDisplayValue('2020-01-16 12:04:30.329');
+
+    await changeInput(fromDate, 'invalid');
+
+    await wait(() => expect(queryByText('Format must be: YYYY-MM-DD HH:mm:ss.SSS')).not.toBeNull());
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/AbsoluteTimeRangeSelector.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/AbsoluteTimeRangeSelector.test.jsx
@@ -17,6 +17,7 @@ const renderWithForm = (element) => render((
 
 const _findValidationState = (container) => {
   const formGroup = container?.matches('.form-group') ? container : container?.querySelector('.form-group');
+
   return formGroup && formGroup.className.includes('has-error')
     ? 'error'
     : null;
@@ -28,6 +29,7 @@ const getValidationStateOfInput = (input) => _findValidationState(_findFormGroup
 
 const changeInput = async (input, value) => {
   const { name } = asElement(input, HTMLInputElement);
+
   await act(async () => { fireEvent.change(input, { target: { value, name } }); });
 };
 
@@ -65,7 +67,7 @@ describe('AbsoluteTimeRangeSelector', () => {
 
     await changeInput(fromDate, 'invalid');
 
-    await wait(() => expect(queryByText('Format must be: YYYY-MM-DD HH:mm:ss.SSS')).not.toBeNull());
+    await wait(() => expect(queryByText('Format must be: YYYY-MM-DD [HH:mm:ss[.SSS]]')).not.toBeNull());
   });
 
   it('shows error message for to date if parsing fails after changing input', async () => {
@@ -77,6 +79,6 @@ describe('AbsoluteTimeRangeSelector', () => {
 
     await changeInput(fromDate, 'invalid');
 
-    await wait(() => expect(queryByText('Format must be: YYYY-MM-DD HH:mm:ss.SSS')).not.toBeNull());
+    await wait(() => expect(queryByText('Format must be: YYYY-MM-DD [HH:mm:ss[.SSS]]')).not.toBeNull());
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/DateInputWithPicker.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/DateInputWithPicker.jsx
@@ -43,6 +43,7 @@ const DateInputWithPicker = ({ disabled = false, error, value, onBlur = () => {}
         <Input type="text"
                id={`date-input-${name}`}
                name={name}
+               autoComplete="off"
                disabled={disabled}
                className="absolute"
                value={value}

--- a/graylog2-web-interface/src/views/components/searchbar/DateInputWithPicker.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/DateInputWithPicker.jsx
@@ -4,7 +4,7 @@ import { useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 import { DatePicker, Icon } from 'components/common';
-import { Button } from 'components/graylog';
+import { Button, Tooltip } from 'components/graylog';
 import Input from 'components/bootstrap/Input';
 import DateTime from 'logic/datetimes/DateTime';
 
@@ -29,28 +29,35 @@ const DateInputWithPicker = ({ disabled = false, error, value, onBlur = () => {}
   const onDatePicked = useCallback((date) => _onChange(_onDateSelected(date).toString(DateTime.Formats.TIMESTAMP)), [_onChange]);
   const onSetTimeToNow = useCallback(() => _onChange(_setDateTimeToNow().toString(DateTime.Formats.TIMESTAMP)), [_onChange]);
   return (
-    <DatePicker id={`date-input-datepicker-${name}`}
-                disabled={disabled}
-                title={title}
-                date={value}
-                onChange={onDatePicked}>
-      <Input type="text"
-             id={`date-input-${name}`}
-             name={name}
-             disabled={disabled}
-             className="absolute"
-             value={value}
-             onBlur={onBlur}
-             onChange={onChange}
-             placeholder={DateTime.Formats.DATETIME}
-             buttonAfter={(
-               <Button disabled={disabled} onClick={onSetTimeToNow} title="Insert current date">
-                 <Icon name="magic" />
-               </Button>
+    <div>
+      {error && (
+        <Tooltip placement="top" className="in" id="tooltip-top" positionTop="-30px">
+          {error}
+        </Tooltip>
+      )}
+      <DatePicker id={`date-input-datepicker-${name}`}
+                  disabled={disabled}
+                  title={title}
+                  date={value}
+                  onChange={onDatePicked}>
+        <Input type="text"
+               id={`date-input-${name}`}
+               name={name}
+               disabled={disabled}
+               className="absolute"
+               value={value}
+               onBlur={onBlur}
+               onChange={onChange}
+               placeholder={DateTime.Formats.DATETIME}
+               buttonAfter={(
+                 <Button disabled={disabled} onClick={onSetTimeToNow} title="Insert current date">
+                   <Icon name="magic" />
+                 </Button>
              )}
-             bsStyle={error ? 'error' : null}
-             required />
-    </DatePicker>
+               bsStyle={error ? 'error' : null}
+               required />
+      </DatePicker>
+    </div>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/searchbar/DateInputWithPicker.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/DateInputWithPicker.jsx
@@ -12,6 +12,7 @@ const _setDateTimeToNow = () => new DateTime();
 
 const _onDateSelected = (date) => {
   const midnightDate = date.setHours(0);
+
   return DateTime.ignoreTZ(midnightDate);
 };
 
@@ -28,6 +29,7 @@ const DateInputWithPicker = ({ disabled = false, error, value, onBlur = () => {}
   const _onChange = useCallback((newValue) => onChange({ target: { name, value: newValue } }), [onChange]);
   const onDatePicked = useCallback((date) => _onChange(_onDateSelected(date).toString(DateTime.Formats.TIMESTAMP)), [_onChange]);
   const onSetTimeToNow = useCallback(() => _onChange(_setDateTimeToNow().toString(DateTime.Formats.TIMESTAMP)), [_onChange]);
+
   return (
     <div>
       {error && (

--- a/graylog2-web-interface/src/views/components/searchbar/KeywordTimeRangeSelector.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/KeywordTimeRangeSelector.jsx
@@ -7,8 +7,9 @@ import styled, { type StyledComponent } from 'styled-components';
 import { trim } from 'lodash';
 import { connect, Field, useFormikContext } from 'formik';
 
-import { Alert, Col, FormControl, FormGroup, InputGroup, Row } from 'components/graylog';
+import { Alert, Col, FormControl, FormGroup, InputGroup, Row, Tooltip } from 'components/graylog';
 import DateTime from 'logic/datetimes/DateTime';
+
 import StoreProvider from 'injection/StoreProvider';
 import type { ThemeInterface } from 'theme';
 
@@ -99,6 +100,11 @@ const KeywordTimeRangeSelector = ({ disabled }: Props) => {
                        style={{ marginRight: 5, width: '100%', marginBottom: 0 }}
                        validationState={error ? 'error' : null}>
               <InputGroup>
+                {error && (
+                  <Tooltip placement="top" className="in" id="tooltip-top" positionTop="-30px" allowLineBreaks={false}>
+                    {error}
+                  </Tooltip>
+                )}
                 <KeywordInput type="text"
                               className="input-sm"
                               name={name}

--- a/graylog2-web-interface/src/views/components/searchbar/KeywordTimeRangeSelector.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/KeywordTimeRangeSelector.jsx
@@ -29,6 +29,10 @@ const KeywordInput: StyledComponent<{}, ThemeInterface, *> = styled(FormControl)
   font-size: ${theme.fonts.size.large};
 `);
 
+const StyledTooltip = styled(Tooltip)`
+  white-space: nowrap;
+`;
+
 const _parseKeywordPreview = (data) => {
   const from = DateTime.fromUTCDateTime(data.from).toString();
   const to = DateTime.fromUTCDateTime(data.to).toString();
@@ -101,9 +105,9 @@ const KeywordTimeRangeSelector = ({ disabled }: Props) => {
                        validationState={error ? 'error' : null}>
               <InputGroup>
                 {error && (
-                  <Tooltip placement="top" className="in" id="tooltip-top" positionTop="-30px" allowLineBreaks={false}>
+                  <StyledTooltip placement="top" className="in" id="tooltip-top" positionTop="-30px">
                     {error}
-                  </Tooltip>
+                  </StyledTooltip>
                 )}
                 <KeywordInput type="text"
                               className="input-sm"

--- a/graylog2-web-interface/src/views/components/searchbar/KeywordTimeRangeSelector.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/KeywordTimeRangeSelector.jsx
@@ -9,7 +9,6 @@ import { connect, Field, useFormikContext } from 'formik';
 
 import { Alert, Col, FormControl, FormGroup, InputGroup, Row, Tooltip } from 'components/graylog';
 import DateTime from 'logic/datetimes/DateTime';
-
 import StoreProvider from 'injection/StoreProvider';
 import type { ThemeInterface } from 'theme';
 

--- a/graylog2-web-interface/src/views/components/searchbar/KeywordTimeRangeSelector.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/KeywordTimeRangeSelector.test.jsx
@@ -140,4 +140,15 @@ describe('KeywordTimeRangeSelector', () => {
 
     expect(queryByText('Preview:')).toBeNull();
   });
+
+  it('shows error message if parsing fails after changing input', async () => {
+    const { getByDisplayValue, queryByText } = await asyncRender(<KeywordTimeRangeSelector value="last week" />);
+
+    asMock(ToolsStore.testNaturalDate).mockImplementation(() => Promise.reject());
+    const input = getByDisplayValue('last week');
+
+    await changeInput(input, 'invalid');
+
+    expect(queryByText('Unable to parse keyword.')).not.toBeNull();
+  });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/KeywordTimeRangeSelector.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/KeywordTimeRangeSelector.test.jsx
@@ -35,6 +35,7 @@ describe('KeywordTimeRangeSelector', () => {
 
   const findValidationState = (container) => {
     const formGroup = container.querySelector('.form-group');
+
     return formGroup && formGroup.className.includes('has-error')
       ? 'error'
       : null;
@@ -42,20 +43,25 @@ describe('KeywordTimeRangeSelector', () => {
 
   const changeInput = async (input, value) => act(async () => {
     const { name } = asElement(input, HTMLInputElement);
+
     fireEvent.change(input, { target: { value, name } });
   });
 
   const asyncRender = async (element) => {
     let wrapper;
+
     await act(async () => { wrapper = render(element); });
+
     if (!wrapper) {
       throw new Error('Render returned `null`.');
     }
+
     return wrapper;
   };
 
   it('renders value passed to it', async () => {
     const { getByDisplayValue } = await asyncRender(<KeywordTimeRangeSelector value="Last hour" />);
+
     expect(getByDisplayValue('Last hour')).not.toBeNull();
   });
 

--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.jsx
@@ -5,8 +5,8 @@ import { useCallback } from 'react';
 import { Form, Formik } from 'formik';
 import { isFunction } from 'lodash';
 import type { FormikProps } from 'formik/@flow-typed';
-import DateTime from 'logic/datetimes/DateTime';
 
+import DateTime from 'logic/datetimes/DateTime';
 import type { TimeRange } from 'views/logic/queries/Query';
 import { onInitializingTimerange, onSubmittingTimerange } from 'views/components/TimerangeForForm';
 

--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.jsx
@@ -5,6 +5,7 @@ import { useCallback } from 'react';
 import { Form, Formik } from 'formik';
 import { isFunction } from 'lodash';
 import type { FormikProps } from 'formik/@flow-typed';
+import DateTime from 'logic/datetimes/DateTime';
 
 import type { TimeRange } from 'views/logic/queries/Query';
 import { onInitializingTimerange, onSubmittingTimerange } from 'views/components/TimerangeForForm';
@@ -19,6 +20,16 @@ type Props = {
   initialValues: Values,
   onSubmit: (Values) => void | Promise<any>,
   children: ((props: FormikProps<Values>) => React$Node) | React$Node,
+};
+
+const validate = (values) => {
+  const errors = {};
+  if (values.timerange.type === 'absolute' && DateTime.isValidDateString(values.timerange.from) && values.timerange.from > values.timerange.to) {
+    errors.timerange = {
+      from: 'Start date must be before end date',
+    };
+  }
+  return errors;
 };
 
 const SearchBarForm = ({ initialValues, onSubmit, children }: Props) => {
@@ -39,7 +50,8 @@ const SearchBarForm = ({ initialValues, onSubmit, children }: Props) => {
   return (
     <Formik initialValues={_initialValues}
             enableReinitialize
-            onSubmit={_onSubmit}>
+            onSubmit={_onSubmit}
+            validate={validate}>
       {(...args) => (
         <Form>
           {isFunction(children) ? children(...args) : children}

--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.jsx
@@ -24,17 +24,20 @@ type Props = {
 
 const validate = (values) => {
   const errors = {};
+
   if (values.timerange.type === 'absolute' && DateTime.isValidDateString(values.timerange.from) && values.timerange.from > values.timerange.to) {
     errors.timerange = {
       from: 'Start date must be before end date',
     };
   }
+
   return errors;
 };
 
 const SearchBarForm = ({ initialValues, onSubmit, children }: Props) => {
   const _onSubmit = useCallback(({ timerange, streams, queryString }) => {
     const newTimerange = onSubmittingTimerange(timerange);
+
     return onSubmit({
       timerange: newTimerange,
       streams,
@@ -47,6 +50,7 @@ const SearchBarForm = ({ initialValues, onSubmit, children }: Props) => {
     streams,
     timerange: onInitializingTimerange(timerange),
   };
+
   return (
     <Formik initialValues={_initialValues}
             enableReinitialize

--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.test.jsx
@@ -14,7 +14,7 @@ const changeInput = async (input, value) => {
 describe('SearchBarForm', () => {
   afterEach(cleanup);
 
-  describe('with AbsoulteTimeRangeSelector', () => {
+  describe('with AbsoluteTimeRangeSelector', () => {
     it('validates if timerange "from" date is after "to" date', async () => {
       const initialValues = {
         timerange: { type: 'absolute', from: '2020-01-16 10:04:30.329', to: '2020-01-17 10:04:30.329' },

--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.test.jsx
@@ -1,0 +1,35 @@
+// @flow strict
+import * as React from 'react';
+import { asElement, cleanup, fireEvent, render, wait } from 'wrappedTestingLibrary';
+import { act } from 'react-dom/test-utils';
+
+import SearchBarForm from './SearchBarForm';
+import AbsoluteTimeRangeSelector from './AbsoluteTimeRangeSelector';
+
+const changeInput = async (input, value) => {
+  const { name } = asElement(input, HTMLInputElement);
+  await act(async () => { fireEvent.change(input, { target: { value, name } }); });
+};
+
+describe('SearchBarForm', () => {
+  afterEach(cleanup);
+
+  it('validates if timerange "from" date is after "to" date', async () => {
+    const initialValues = {
+      timerange: { type: 'absolute', from: '2020-01-16 10:04:30.329', to: '2020-01-17 10:04:30.329' },
+      queryString: '*',
+      streams: [],
+    };
+    const { getByDisplayValue, queryByText } = render(
+      <SearchBarForm onSubmit={() => {}}
+                     initialValues={initialValues}>
+        <AbsoluteTimeRangeSelector />
+      </SearchBarForm>,
+    );
+    const fromDate = getByDisplayValue('2020-01-16 10:04:30.329');
+
+    await changeInput(fromDate, '2020-01-18 10:04:30.329');
+
+    await wait(() => expect(queryByText('Start date must be before end date')).not.toBeNull());
+  });
+});

--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.test.jsx
@@ -14,22 +14,24 @@ const changeInput = async (input, value) => {
 describe('SearchBarForm', () => {
   afterEach(cleanup);
 
-  it('validates if timerange "from" date is after "to" date', async () => {
-    const initialValues = {
-      timerange: { type: 'absolute', from: '2020-01-16 10:04:30.329', to: '2020-01-17 10:04:30.329' },
-      queryString: '*',
-      streams: [],
-    };
-    const { getByDisplayValue, queryByText } = render(
-      <SearchBarForm onSubmit={() => {}}
-                     initialValues={initialValues}>
-        <AbsoluteTimeRangeSelector />
-      </SearchBarForm>,
-    );
-    const fromDate = getByDisplayValue('2020-01-16 10:04:30.329');
+  describe('with AbsoulteTimeRangeSelector', () => {
+    it('validates if timerange "from" date is after "to" date', async () => {
+      const initialValues = {
+        timerange: { type: 'absolute', from: '2020-01-16 10:04:30.329', to: '2020-01-17 10:04:30.329' },
+        queryString: '*',
+        streams: [],
+      };
+      const { getByDisplayValue, queryByText } = render(
+        <SearchBarForm onSubmit={() => {}}
+                       initialValues={initialValues}>
+          <AbsoluteTimeRangeSelector />
+        </SearchBarForm>,
+      );
+      const fromDate = getByDisplayValue('2020-01-16 10:04:30.329');
 
-    await changeInput(fromDate, '2020-01-18 10:04:30.329');
+      await changeInput(fromDate, '2020-01-18 10:04:30.329');
 
-    await wait(() => expect(queryByText('Start date must be before end date')).not.toBeNull());
+      await wait(() => expect(queryByText('Start date must be before end date')).not.toBeNull());
+    });
   });
 });

--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.test.jsx
@@ -8,6 +8,7 @@ import AbsoluteTimeRangeSelector from './AbsoluteTimeRangeSelector';
 
 const changeInput = async (input, value) => {
   const { name } = asElement(input, HTMLInputElement);
+
   await act(async () => { fireEvent.change(input, { target: { value, name } }); });
 };
 


### PR DESCRIPTION
With this PR we are displaying an error message when the validation of a time range input in the search bar fails. The error message is being displayed as a tooltip above the input.

It also adds a validation for the absolute time range selector, to throw an error if the date "from" is after the date "to".

Fixes #7191

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

