### PR TITLE
Use an openjdk docker image with a fixed debian version

### DIFF
--- a/graylog2-server/src/test/resources/org/graylog/testing/graylognode/Dockerfile
+++ b/graylog2-server/src/test/resources/org/graylog/testing/graylognode/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-slim
+FROM openjdk:8-jre-slim-buster
 
 ARG GRAYLOG_VERSION
 ARG BUILD_DATE


### PR DESCRIPTION
Otherwise, the test build will fail on systems that still
have an older version of the openjdk image around.
(debian stretch in my case)

Our official docker image has been using buster since the 3.1
release.

For reference:
```
$ docker image ls |grep jdk
openjdk                                         8-jre-slim-buster   778bc46b8d12        4 weeks ago         184MB
openjdk                                         8-jre-slim          54567f06e0e8        17 months ago       204MB
```
