### PR TITLE
Update `/rebase` action.

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -3,10 +3,14 @@ name: Automatic Rebase
 jobs:
   rebase:
     name: Rebase
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Automatic Rebase
-      uses: Graylog2/rebase@1.2
+      uses: Graylog2/rebase@1.3.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -3,7 +3,7 @@ name: Automatic Rebase
 jobs:
   rebase:
     name: Rebase
-    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
+    if: github.event.issue.pull_request != '' && github.event.comment.body == '/rebase'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This change is doing the following:

  - updating the `/rebase` action to v1.3.1, to fix a couple of bugs (e.g. returning the error if the rebase failed)
  - adding an inline condition to skip the action if no `/rebase` was specified