### PR TITLE
Fix OperationSytemIcon icon props

### DIFF
--- a/graylog2-web-interface/src/components/sidecars/common/OperatingSystemIcon.jsx
+++ b/graylog2-web-interface/src/components/sidecars/common/OperatingSystemIcon.jsx
@@ -11,24 +11,24 @@ const SidecarIcon = styled(Icon)`
 
 const OperatingSystemIcon = ({ operatingSystem }) => {
   let iconName = 'question-circle';
-  let prefix = 'fas';
+  let iconType = 'solid';
 
   if (operatingSystem) {
     const os = operatingSystem.trim().toLowerCase();
     if (os.indexOf('darwin') !== -1 || os.indexOf('mac os') !== -1) {
       iconName = 'apple';
-      prefix = 'fab';
+      iconType = 'brand';
     } else if (os.indexOf('linux') !== -1) {
       iconName = 'linux';
-      prefix = 'fab';
+      iconType = 'brand';
     } else if (os.indexOf('win') !== -1) {
       iconName = 'windows';
-      prefix = 'fab';
+      iconType = 'brand';
     }
   }
 
   return (
-    <SidecarIcon name={{ prefix, iconName }} fixedWidth />
+    <SidecarIcon name={iconName} type={iconType} fixedWidth />
   );
 };
 


### PR DESCRIPTION
This PR is updating the `OperatingSystemIcon` icon props, which changed with https://github.com/Graylog2/graylog2-server/pull/8298

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
