### PR TITLE
Write facility_num to facilitate direct translation of facility

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/inputs/codecs/SyslogCodec.java
+++ b/graylog2-server/src/main/java/org/graylog2/inputs/codecs/SyslogCodec.java
@@ -145,6 +145,7 @@ public class SyslogCodec extends AbstractCodec {
         final Message m = new Message(syslogMessage, parseHost(e, remoteAddress), parseDate(e, receivedTimestamp));
         m.addField("facility", Tools.syslogFacilityToReadable(e.getFacility()));
         m.addField("level", e.getLevel());
+        m.addField("facility_num", e.getFacility());
 
         // I can haz pattern matching?
         if (e instanceof CiscoSyslogServerEvent) {

--- a/graylog2-server/src/test/java/org/graylog2/inputs/codecs/SyslogCodecTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/inputs/codecs/SyslogCodecTest.java
@@ -89,6 +89,7 @@ public class SyslogCodecTest {
         assertEquals("1011", message.getField("eventID"));
         assertEquals("3", message.getField("iut"));
         assertEquals("evntslog", message.getField("application_name"));
+        assertEquals(20, message.getField("facility_num"));
     }
 
     @Test
@@ -107,6 +108,7 @@ public class SyslogCodecTest {
         assertEquals("user@example.com", message.getField("user"));
         assertEquals("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/7.1.2 Safari/537.85.11", message.getField("user-agent"));
         assertEquals("app", message.getField("application_name"));
+        assertEquals(23, message.getField("facility_num"));
     }
 
     @Test
@@ -128,6 +130,7 @@ public class SyslogCodecTest {
         assertEquals("user@example.com", message.getField("mdc@18060_user"));
         assertEquals("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_5) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/7.1.2 Safari/537.85.11", message.getField("mdc@18060_user-agent"));
         assertEquals("app", message.getField("application_name"));
+        assertEquals(23, message.getField("facility_num"));
     }
 
     @Test
@@ -140,6 +143,7 @@ public class SyslogCodecTest {
         assertEquals("s000000.example.com", message.getField("source"));
         assertEquals(0, message.getField("level"));
         assertEquals("local0", message.getField("facility"));
+        assertEquals(16, message.getField("facility_num"));
     }
 
     @Test
@@ -159,6 +163,7 @@ public class SyslogCodecTest {
         assertEquals("1011", message.getField("eventID"));
         assertEquals("3", message.getField("iut"));
         assertEquals("evntslog", message.getField("application_name"));
+        assertEquals(20, message.getField("facility_num"));
     }
 
     @Test
@@ -184,6 +189,7 @@ public class SyslogCodecTest {
         assertEquals("N/A", message.getField("roles"));
         assertEquals("reth6.0", message.getField("packet-incoming-interface"));
         assertEquals("No", message.getField("encrypted"));
+        assertEquals(1, message.getField("facility_num"));
     }
 
     @Test
@@ -197,6 +203,7 @@ public class SyslogCodecTest {
         assertEquals(5, message.getField("level"));
         assertEquals("syslogd", message.getField("facility"));
         assertNull(message.getField("full_message"));
+        assertEquals(5, message.getField("facility_num"));
     }
 
     @Test
@@ -212,6 +219,7 @@ public class SyslogCodecTest {
         assertEquals(5, message.getField("level"));
         assertEquals("syslogd", message.getField("facility"));
         assertEquals(UNSTRUCTURED, message.getField("full_message"));
+        assertEquals(5, message.getField("facility_num"));
     }
 
     @Test
@@ -334,6 +342,7 @@ public class SyslogCodecTest {
         assertEquals("hostname", message.getSource());
         assertEquals(6, message.getField("level"));
         assertEquals("kernel", message.getField("facility"));
+        assertEquals(0, message.getField("facility_num"));
     }
 
     @Test
@@ -349,6 +358,7 @@ public class SyslogCodecTest {
         assertEquals(6, message.getField("level"));
         assertEquals("kernel", message.getField("facility"));
         assertEquals("test", message.getField("application_name"));
+        assertEquals(0, message.getField("facility_num"));
     }
 
     @Test
@@ -424,6 +434,7 @@ public class SyslogCodecTest {
         assertThat(message.getField("facility")).isEqualTo("syslogd");
         assertThat(message.getField("logid")).isEqualTo("0000000013");
         assertThat(message.getField("app")).isEqualTo("SSL_TLSv1.2");
+        assertThat(message.getField("facility_num")).isEqualTo(5);
     }
 
     private RawMessage buildRawMessage(String message) {


### PR DESCRIPTION
## Description
Currently, when reading Syslog input, incoming messages with `AUTH` and `AUTHPRIV` facility saved as literal field `security/authorization`. This results in losing a distinction between `AUTH` and `AUTHPRIV` facilities. It is based on a straightforward interpretation of https://tools.ietf.org/html/rfc5424#section-6.2.1

`AUTHPRIV` however, could contain more sensitive information so might need to be treated differently in certain cases. 

## Motivation and Context
I am the author and maintainer of https://github.com/wizecore/graylog2-output-syslog
and this PR is an enhancement which corresponds to the following issue: https://github.com/wizecore/graylog2-output-syslog/issues/35

## How Has This Been Tested?
Minor change, tested by building graylog2 server JAR and running it with local distribution. As a result, the new field `facility_num` added to messages which were created by Syslog input.

## Screenshots (if appropriate):
Not applicable.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

