### PR TITLE
Support Forwarder wizard

### DIFF
--- a/graylog2-web-interface/flow-typed/npm/react-router_vx.x.x.js
+++ b/graylog2-web-interface/flow-typed/npm/react-router_vx.x.x.js
@@ -18,4 +18,12 @@ declare module 'react-router' {
   declare export class browserHistory {
     static push: ({pathname: string, state: {}}) => void,
   }
+  declare export class Link extends React$Component<Props> {
+    to: (string | { [key: string]: any } | () => {}),
+    activeStyle?: any,
+    activeClassName?: string,
+    onlyActiveOnIndex: boolean,
+    onClick?: () => void,
+    target?: string,
+  }
 }

--- a/graylog2-web-interface/src/stores/inputs/InputTypesStore.js
+++ b/graylog2-web-interface/src/stores/inputs/InputTypesStore.js
@@ -1,11 +1,42 @@
+// @flow strict
 import Reflux from 'reflux';
 
-import URLUtils from 'util/URLUtils';
+import { qualifyUrl } from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 import UserNotification from 'util/UserNotification';
 import ActionsProvider from 'injection/ActionsProvider';
 
 const InputTypesActions = ActionsProvider.getActions('InputTypes');
+
+export type InputTypes = {
+  [type: string]: string,
+};
+
+export type ConfigurationField = {
+  field_type: 'boolean' | 'text' | 'dropdown' | 'list' | 'number',
+  name: string,
+  human_name: string,
+  description: string,
+  default_value: any,
+  is_optional: boolean,
+  attributes: Array<string>,
+  additional_info: any,
+  position: number,
+};
+
+export type InputDescription = {
+  type: string,
+  name: string,
+  is_exclusive: boolean,
+  requested_configuration: {
+    [key: string]: ConfigurationField,
+  },
+  link_to_docs: string,
+};
+
+export type InputDescriptions = {
+  [type: string]: InputDescription,
+};
 
 const InputTypesStore = Reflux.createStore({
   listenables: [InputTypesActions],
@@ -17,19 +48,19 @@ const InputTypesStore = Reflux.createStore({
     this.list();
   },
 
-  getInitialState() {
+  getInitialState(): { inputTypes: InputTypes, inputDescriptions: InputDescriptions } {
     return { inputTypes: this.inputTypes, inputDescriptions: this.inputDescriptions };
   },
 
   list() {
-    const promiseTypes = fetch('GET', URLUtils.qualifyUrl(this.sourceUrl));
-    const promiseDescriptions = fetch('GET', URLUtils.qualifyUrl(`${this.sourceUrl}/all`));
+    const promiseTypes = fetch('GET', qualifyUrl(this.sourceUrl));
+    const promiseDescriptions = fetch('GET', qualifyUrl(`${this.sourceUrl}/all`));
     const promise = Promise.all([promiseTypes, promiseDescriptions]);
     promise
       .then(
-        (responses) => {
-          this.inputTypes = responses[0].types;
-          this.inputDescriptions = responses[1];
+        ([typesResponse: { types: InputTypes }, descriptionsResponse: InputDescriptions]) => {
+          this.inputTypes = typesResponse.types;
+          this.inputDescriptions = descriptionsResponse;
           this.trigger(this.getInitialState());
         },
         (error) => {
@@ -41,8 +72,8 @@ const InputTypesStore = Reflux.createStore({
     InputTypesActions.list.promise(promise);
   },
 
-  get(inputTypeId) {
-    const promise = fetch('GET', URLUtils.qualifyUrl(`${this.sourceUrl}/${inputTypeId}`));
+  get(inputTypeId: string) {
+    const promise = fetch('GET', qualifyUrl(`${this.sourceUrl}/${inputTypeId}`));
 
     promise
       .catch((error) => {

--- a/graylog2-web-interface/src/util/DocsHelper.js
+++ b/graylog2-web-interface/src/util/DocsHelper.js
@@ -17,6 +17,7 @@ class DocsHelper {
     INDEXER_FAILURES: 'indexer_failures.html',
     INDEX_MODEL: 'configuration/index_model.html',
     LOAD_BALANCERS: 'configuration/load_balancers.html',
+    LOOKUPTABLES: 'lookuptables.html',
     PAGE_FLEXIBLE_DATE_CONVERTER: 'extractors.html#the-flexible-date-converter',
     PAGE_STANDARD_DATE_CONVERTER: 'extractors.html#the-standard-date-converter',
     PIPELINE_FUNCTIONS: 'pipelines/functions.html',


### PR DESCRIPTION
This PR adds some changes to support current work on Forwarder UI:
- Add Flow definition of react-router's Link
- Add `InputTypes` and `InputDescriptions` Flow types
- Add URL to lookup tables in `DocumentationHelper`