### PR TITLE
Dynamically center search page loading indicator

### DIFF
--- a/graylog2-web-interface/src/components/common/LoadingIndicator.jsx
+++ b/graylog2-web-interface/src/components/common/LoadingIndicator.jsx
@@ -14,7 +14,7 @@ const StyledAlert = styled(Alert)`
   min-width: 200px;
   top: 60px;
   left: 50%;
-  margin-left: -100px; /* half of the element width */
+  transform: translateX(-50%);
   padding: 5px 20px;
   text-align: center;
   box-shadow: 0 2px 10px rgba(0,0,0,.2);


### PR DESCRIPTION
With https://github.com/Graylog2/graylog2-server/pull/8398 I defined a dynamic width for the loading indicator, but forgot to adjust the static positioning.

With this PR we center the loading indicator dynamically.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
