### PR TITLE
Don't reset grace period timer while in grace period (#8366)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationGracePeriodService.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationGracePeriodService.java
@@ -78,7 +78,10 @@ public class NotificationGracePeriodService {
         }
         final Optional<DateTime> lastEventTime = get(definition.id(), notificationId, event.toDto().key());
         final boolean isInGracePeriod = lastEventTime.map(dateTime -> dateTime.isAfter(event.getEventTimestamp().minus(gracePeriodMs))).orElse(false);
-        put(definition.id(), notificationId, event.toDto().key(), event.getEventTimestamp());
+        // Only update the timestamp if we are not within the grace period
+        if (!isInGracePeriod) {
+            put(definition.id(), notificationId, event.toDto().key(), event.getEventTimestamp());
+        }
         return isInGracePeriod;
     }
 

--- a/graylog2-server/src/test/java/org/graylog/events/processor/notification/NotificationGracePeriodServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/events/processor/notification/NotificationGracePeriodServiceTest.java
@@ -100,7 +100,7 @@ public class NotificationGracePeriodServiceTest {
 
         final Event event = new TestEvent(DateTime.now(UTC), "testkey");
         final Event event2 = new TestEvent(event.getEventTimestamp().plus(5L), "testkey");
-        final Event event3 = new TestEvent(event2.getEventTimestamp().plus(9L), "testkey");
+        final Event event3 = new TestEvent(event2.getEventTimestamp().plus(4L), "testkey");
 
         assertThat(notificationGracePeriodService.inGracePeriod(definition, "5678", event)).isFalse();
         assertThat(notificationGracePeriodService.inGracePeriod(definition, "5678", event2)).isTrue();
@@ -108,7 +108,7 @@ public class NotificationGracePeriodServiceTest {
     }
 
     @Test
-    public void insideThenOutsideGracePeriod() {
+    public void insideOutsideInsideGracePeriod() {
         final NotificationGracePeriodService notificationGracePeriodService = new NotificationGracePeriodService();
 
         when(settings.gracePeriodMs()).thenReturn(10L);
@@ -117,11 +117,13 @@ public class NotificationGracePeriodServiceTest {
 
         final Event event = new TestEvent(DateTime.now(UTC), "testkey");
         final Event event2 = new TestEvent(event.getEventTimestamp().plus(5L), "testkey");
-        final Event event3 = new TestEvent(event2.getEventTimestamp().plus(11L), "testkey");
+        final Event event3 = new TestEvent(event2.getEventTimestamp().plus(6L), "testkey");
+        final Event event4 = new TestEvent(event3.getEventTimestamp().plus(6L), "testkey");
 
         assertThat(notificationGracePeriodService.inGracePeriod(definition, "5678", event)).isFalse();
         assertThat(notificationGracePeriodService.inGracePeriod(definition, "5678", event2)).isTrue();
         assertThat(notificationGracePeriodService.inGracePeriod(definition, "5678", event3)).isFalse();
+        assertThat(notificationGracePeriodService.inGracePeriod(definition, "5678", event4)).isTrue();
     }
 
     @Test


### PR DESCRIPTION
If events continue to occur, while notifications are suppressed by an
active grace period, they will constantly reset the grace period timer
and will keep the grace period active.

Regression introduced with bugfix for #8065

Fixes #8365

(cherry picked from commit 026178950e3d9df49e2c9cb24afc9660bbbd62a5)
