### PR TITLE
Display message table head in non interactive mode (Backport of #8385 for 3.3)

### DIFF
--- a/graylog2-web-interface/src/views/components/Field.jsx
+++ b/graylog2-web-interface/src/views/components/Field.jsx
@@ -30,7 +30,17 @@ const Field = ({ children, disabled = false, menuContainer, name, queryId, type 
           {name} = {type.type}
         </FieldActions>
       )
-      : <span>{children}</span>)}
+      : (
+        <span>
+          {name}
+          {children && (
+            <>
+              {' '}
+              {children}
+            </>
+          )}
+        </span>
+      ))}
   </InteractiveContext.Consumer>
 );
 

--- a/graylog2-web-interface/src/views/components/Field.test.jsx
+++ b/graylog2-web-interface/src/views/components/Field.test.jsx
@@ -8,38 +8,34 @@ import InteractiveContext from './contexts/InteractiveContext';
 
 describe('Field', () => {
   describe('handles value action menu depending on interactive context', () => {
-    const component = (interactive) => ({ children, ...props }) => (
+    const component = (interactive) => (props) => (
       <InteractiveContext.Provider value={interactive}>
-        <Field {...props}>
-          {children}
-        </Field>
+        <Field {...props} />
       </InteractiveContext.Provider>
     );
-    it('does not show value actions if interactive context is `false`', () => {
+    it('does not show value actions for field if interactive context is `false`', () => {
       const NoninteractiveComponent = component(false);
-      const wrapper = mount((
-        <NoninteractiveComponent name="foo"
+      const wrapper = mount(
+        <NoninteractiveComponent name="Field name"
                                  queryId="someQueryId"
                                  type={FieldType.Unknown}>
-          Foo
-        </NoninteractiveComponent>
-      ));
+          Field options like sorting
+        </NoninteractiveComponent>,
+      );
       const fieldActions = wrapper.find('FieldActions');
       expect(fieldActions).not.toExist();
-      expect(wrapper).toHaveText('Foo');
+      expect(wrapper).toHaveText('Field name Field options like sorting');
     });
-    it('shows value actions if interactive context is `true`', () => {
+    it('shows value actions for field if interactive context is `true`', () => {
       const InteractiveComponent = component(true);
-      const wrapper = mount((
-        <InteractiveComponent name="foo"
+      const wrapper = mount(
+        <InteractiveComponent name="Field name"
                               queryId="someQueryId"
-                              type={FieldType.Unknown}>
-          Foo
-        </InteractiveComponent>
-      ));
+                              type={FieldType.Unknown} />,
+      );
       const fieldActions = wrapper.find('FieldActions');
       expect(fieldActions).toExist();
-      expect(wrapper).toHaveText('Foo');
+      expect(wrapper).toHaveText('Field name');
     });
   });
 });

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
@@ -136,6 +136,7 @@ const TableHead: StyledComponent<{}, ThemeInterface, HTMLTableSectionElement> = 
   color: ${util.readableColor(theme.color.gray[90])};
 
   th {
+    min-width: 50px;
     border: 0;
     font-size: 11px;
     font-weight: normal;


### PR DESCRIPTION
_This is a backport of #8385 for 3.3_

The head of a message table is currently not being displayed in the non interactive mode (e.g. in the dashboard full screen view).
Displaying the table head is fixing layout problems similar to the problem described here: https://github.com/Graylog2/graylog2-server/pull/8334

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

