### PR TITLE
Add GRN support

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -89,6 +89,7 @@ import org.graylog2.users.RoleServiceImpl;
 import org.graylog2.users.StartPageCleanupListener;
 import org.graylog2.users.UserImpl;
 import org.graylog2.users.UserPermissionsCleanupListener;
+import org.graylog2.utilities.GRNRegistry;
 
 import javax.ws.rs.container.DynamicFeature;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -110,6 +111,7 @@ public class ServerBindings extends Graylog2Module {
         bindExceptionMappers();
         bindAdditionalJerseyComponents();
         bindEventBusListeners();
+        bindGRNRegistry();
         install(new AuthenticatingRealmModule(configuration));
         install(new AuthorizationOnlyRealmModule());
         bindSearchResponseDecorators();
@@ -215,5 +217,9 @@ public class ServerBindings extends Graylog2Module {
     private void bindSearchResponseDecorators() {
         // only triggering an initialize to make sure that the binding exists
         searchResponseDecoratorBinder();
+    }
+
+    private void bindGRNRegistry() {
+        bind(GRNRegistry.class).toInstance(GRNRegistry.createWithBuiltinTypes());
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/bindings/providers/ObjectMapperProvider.java
@@ -44,6 +44,10 @@ import org.graylog2.plugin.inject.JacksonSubTypes;
 import org.graylog2.shared.jackson.SizeSerializer;
 import org.graylog2.shared.plugins.GraylogClassLoader;
 import org.graylog2.shared.rest.RangeJsonSerializer;
+import org.graylog2.utilities.GRN;
+import org.graylog2.utilities.GRNDeserializer;
+import org.graylog2.utilities.GRNKeyDeserializer;
+import org.graylog2.utilities.GRNRegistry;
 import org.joda.time.Period;
 
 import javax.inject.Inject;
@@ -67,6 +71,7 @@ public class ObjectMapperProvider implements Provider<ObjectMapper> {
         final ObjectMapper mapper = new ObjectMapper();
         final TypeFactory typeFactory = mapper.getTypeFactory().withClassLoader(classLoader);
         final AutoValueSubtypeResolver subtypeResolver = new AutoValueSubtypeResolver();
+        final GRNRegistry grnRegistry = GRNRegistry.createWithBuiltinTypes();
 
         this.objectMapper = mapper
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
@@ -82,6 +87,7 @@ public class ObjectMapperProvider implements Provider<ObjectMapper> {
                 .registerModule(new MetricsModule(TimeUnit.SECONDS, TimeUnit.SECONDS, false))
                 .registerModule(new SimpleModule("Graylog")
                         .addKeyDeserializer(Period.class, new JodaTimePeriodKeyDeserializer())
+                        .addKeyDeserializer(GRN.class, new GRNKeyDeserializer(grnRegistry))
                         .addSerializer(new RangeJsonSerializer())
                         .addSerializer(new SizeSerializer())
                         .addSerializer(new ObjectIdSerializer())
@@ -91,6 +97,7 @@ public class ObjectMapperProvider implements Provider<ObjectMapper> {
                         .addDeserializer(Version.class, new VersionDeserializer())
                         .addDeserializer(Semver.class, new SemverDeserializer())
                         .addDeserializer(Requirement.class, new SemverRequirementDeserializer())
+                        .addDeserializer(GRN.class, new GRNDeserializer(grnRegistry))
                 );
 
         if (subtypes != null) {

--- a/graylog2-server/src/main/java/org/graylog2/utilities/GRN.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/GRN.java
@@ -16,8 +16,6 @@
  */
 package org.graylog2.utilities;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Splitter;
 
@@ -39,7 +37,6 @@ import java.util.StringJoiner;
  * </p>
  */
 @AutoValue
-@JsonSerialize(using = ToStringSerializer.class)
 public abstract class GRN {
     private static final Splitter SPLITTER = Splitter.on(":").trimResults();
 

--- a/graylog2-server/src/main/java/org/graylog2/utilities/GRN.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/GRN.java
@@ -1,10 +1,10 @@
 package org.graylog2.utilities;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Splitter;
+
 import java.util.List;
 import java.util.Locale;
 import java.util.StringJoiner;
@@ -24,7 +24,6 @@ import java.util.StringJoiner;
  */
 @AutoValue
 @JsonSerialize(using = ToStringSerializer.class)
-@JsonDeserialize(using = GRNDeserializer.class)
 public abstract class GRN {
     private static final Splitter SPLITTER = Splitter.on(":").trimResults();
 

--- a/graylog2-server/src/main/java/org/graylog2/utilities/GRN.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/GRN.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.utilities;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;

--- a/graylog2-server/src/main/java/org/graylog2/utilities/GRN.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/GRN.java
@@ -1,0 +1,123 @@
+package org.graylog2.utilities;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Splitter;
+import java.util.List;
+import java.util.Locale;
+import java.util.StringJoiner;
+
+/**
+ * This is a helper class for GRNs - Graylog Resource Names
+ * GRNs are like URNs that we use for internal purposes only
+ * <p>
+ * <pre>
+ * GRN format:
+ *   {@literal grn:<cluster>:<tenant>:<scope>:<type>:<entity>}
+ * Examples:
+ * grn::::stream:000000000001
+ * grn:local:0:internal:stream:000000000001
+ * </pre>
+ * </p>
+ */
+@AutoValue
+@JsonSerialize(using = ToStringSerializer.class)
+@JsonDeserialize(using = GRNDeserializer.class)
+public abstract class GRN {
+    private static final Splitter SPLITTER = Splitter.on(":").trimResults();
+
+    public abstract String cluster();
+
+    public abstract String tenant();
+
+    public abstract String scope();
+
+    public abstract String type();
+
+    public abstract String entity();
+
+    public abstract String permissionPrefix();
+
+    public boolean isPermissionApplicable(String permission) {
+        // ENTITY_OWN is applicable to any target
+        // TODO use constant from AdditionalRestPermissions
+        return permission.startsWith("entity:own") || permission.startsWith(permissionPrefix());
+    }
+
+    static GRN parse(String grn, GRNRegistry grnRegistry) {
+        final List<String> tokens = SPLITTER.splitToList(grn.toLowerCase(Locale.ENGLISH));
+
+        if (tokens.size() != 6) {
+            throw new IllegalArgumentException(String.format(Locale.US, "<%s> is not a valid GRN string", grn));
+        }
+        if (!tokens.get(0).equals("grn")) {
+            throw new IllegalArgumentException(String.format(Locale.US, "<%s> is not a grn scheme", tokens.get(0)));
+        }
+        final String type = tokens.get(4);
+        final Builder builder = grnRegistry.newGRNBuilder(type)
+                .cluster(tokens.get(1))
+                .tenant(tokens.get(2))
+                .scope(tokens.get(3))
+                .type(type)
+                .entity(tokens.get(5));
+
+        return builder.build();
+    }
+
+    public static Builder builder() {
+        return new AutoValue_GRN.Builder().cluster("").tenant("").scope("");
+    }
+
+    public abstract Builder toBuilder();
+
+    @Override
+    public String toString() {
+        final StringJoiner joiner = new StringJoiner(":");
+        joiner.add("grn")
+                .add(cluster())
+                .add(tenant())
+                .add(scope())
+                .add(type())
+                .add(entity());
+
+        return joiner.toString();
+    }
+
+    // We want to to ignore the permission prefix and auto-value doesn't offer a built-in way to ignore properties in equals()
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (o instanceof GRN) {
+            GRN that = (GRN) o;
+            return toString().equals(that.toString());
+        }
+        return false;
+    }
+
+    // We want to to ignore the permission prefix and auto-value doesn't offer a built-in way to ignore properties in hashCode()
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        public abstract Builder cluster(String cluster);
+
+        public abstract Builder tenant(String tenant);
+
+        public abstract Builder scope(String scope);
+
+        public abstract Builder type(String type);
+
+        public abstract Builder entity(String entity);
+
+        public abstract Builder permissionPrefix(String permissionPrefix);
+
+        public abstract GRN build();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/utilities/GRNDeserializer.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/GRNDeserializer.java
@@ -14,10 +14,9 @@ import java.io.IOException;
 public class GRNDeserializer extends StdDeserializer<GRN> {
     private final GRNRegistry grnRegistry;
 
-    public GRNDeserializer() {
+    public GRNDeserializer(GRNRegistry grnRegistry) {
         super(GRN.class);
-        // TODO set this up in the ObjectMapperProvider once we move this into server
-        grnRegistry = GRNRegistry.createWithBuiltinTypes();
+        this.grnRegistry = grnRegistry;
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/utilities/GRNDeserializer.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/GRNDeserializer.java
@@ -1,0 +1,28 @@
+
+package org.graylog2.utilities;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import java.io.IOException;
+
+/**
+ * Converts GRN strings format into a {@link GRN} object.
+ */
+public class GRNDeserializer extends StdDeserializer<GRN> {
+    private final GRNRegistry grnRegistry;
+
+    public GRNDeserializer() {
+        super(GRN.class);
+        // TODO set this up in the ObjectMapperProvider once we move this into server
+        grnRegistry = GRNRegistry.createWithBuiltinTypes();
+    }
+
+    @Override
+    public GRN deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        return grnRegistry.parse(p.getValueAsString());
+    }
+}
+

--- a/graylog2-server/src/main/java/org/graylog2/utilities/GRNDeserializer.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/GRNDeserializer.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 package org.graylog2.utilities;
 

--- a/graylog2-server/src/main/java/org/graylog2/utilities/GRNKeyDeserializer.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/GRNKeyDeserializer.java
@@ -10,10 +10,9 @@ import java.io.IOException;
 public class GRNKeyDeserializer extends KeyDeserializer {
     private final GRNRegistry grnRegistry;
 
-    public GRNKeyDeserializer() {
+    public GRNKeyDeserializer(GRNRegistry grnRegistry) {
         super();
-        // TODO set this up in the ObjectMapperProvider once we move this into server
-        grnRegistry = GRNRegistry.createWithBuiltinTypes();
+        this.grnRegistry = grnRegistry;
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/utilities/GRNKeyDeserializer.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/GRNKeyDeserializer.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 package org.graylog2.utilities;
 

--- a/graylog2-server/src/main/java/org/graylog2/utilities/GRNKeyDeserializer.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/GRNKeyDeserializer.java
@@ -1,0 +1,25 @@
+
+package org.graylog2.utilities;
+
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.KeyDeserializer;
+
+import java.io.IOException;
+
+// TODO Not sure why this is needed
+public class GRNKeyDeserializer extends KeyDeserializer {
+    private final GRNRegistry grnRegistry;
+
+    public GRNKeyDeserializer() {
+        super();
+        // TODO set this up in the ObjectMapperProvider once we move this into server
+        grnRegistry = GRNRegistry.createWithBuiltinTypes();
+    }
+
+    @Override
+    public Object deserializeKey(String key, DeserializationContext ctxt) throws IOException {
+        return grnRegistry.parse(key);
+    }
+
+}
+

--- a/graylog2-server/src/main/java/org/graylog2/utilities/GRNRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/GRNRegistry.java
@@ -17,6 +17,8 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 public class GRNRegistry {
     public static final String GLOBAL_USER_GRN = "grn::::builtin-team:everyone"; // TODO: Find a better name for the "everyone" grantee GRN type
 
+    // TODO This is essentially the same as org.graylog2.contentpacks.model.ModelTypes
+    // TODO find a way to unify these
     private static final ImmutableSet<GRNType> BUILTIN_TYPES = ImmutableSet.<GRNType>builder()
             .add(GRNType.create("collection", "collections:"))
             .add(GRNType.create("dashboard", "dashboards:"))

--- a/graylog2-server/src/main/java/org/graylog2/utilities/GRNRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/GRNRegistry.java
@@ -18,6 +18,7 @@ package org.graylog2.utilities;
 
 import com.google.common.collect.ImmutableSet;
 
+import javax.inject.Singleton;
 import java.util.Collection;
 import java.util.Locale;
 import java.util.Optional;
@@ -30,6 +31,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 /**
  * The global {@link GRN} registry.
  */
+@Singleton
 public class GRNRegistry {
     public static final String GLOBAL_USER_GRN = "grn::::builtin-team:everyone"; // TODO: Find a better name for the "everyone" grantee GRN type
 

--- a/graylog2-server/src/main/java/org/graylog2/utilities/GRNRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/GRNRegistry.java
@@ -1,0 +1,129 @@
+package org.graylog2.utilities;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+/**
+ * The global {@link GRN} registry.
+ */
+public class GRNRegistry {
+    public static final String GLOBAL_USER_GRN = "grn::::builtin-team:everyone"; // TODO: Find a better name for the "everyone" grantee GRN type
+
+    private static final ImmutableSet<GRNType> BUILTIN_TYPES = ImmutableSet.<GRNType>builder()
+            .add(GRNType.create("collection", "collections:"))
+            .add(GRNType.create("dashboard", "dashboards:"))
+            .add(GRNType.create("grant", "grants:"))
+            .add(GRNType.create("role", "roles:"))
+            .add(GRNType.create("stream", "streams:"))
+            .add(GRNType.create("user", "users:"))
+            .add(GRNType.create("team", "teams:"))
+            .add(GRNType.create("builtin-team", "XXX-NOT-A-REAL-TYPE-XXX:"))
+            .build();
+
+    private final ConcurrentMap<String, GRNType> REGISTRY = new ConcurrentHashMap<>();
+
+    // Don't allow direct instantiation
+    private GRNRegistry() {
+    }
+
+    /**
+     * Returns an empty registry.
+     *
+     * @return the registry
+     */
+    public static GRNRegistry createEmpty() {
+        return new GRNRegistry();
+    }
+
+    /**
+     * Returns a registry that has been initialized with the builtin Graylog GRN types.
+     *
+     * @return the registry
+     */
+    public static GRNRegistry createWithBuiltinTypes() {
+        return createWithTypes(BUILTIN_TYPES);
+    }
+
+    /**
+     * Returns a registry that has been initialized with the given GRN types.
+     *
+     * @param types the GRN types to initialize the registry with
+     * @return the registry
+     */
+    public static GRNRegistry createWithTypes(Collection<GRNType> types) {
+        final GRNRegistry grnRegistry = new GRNRegistry();
+
+        types.forEach(grnRegistry::registerType);
+
+        return grnRegistry;
+    }
+
+    /**
+     * Parses the given GRN string and returns a {@link GRN}.
+     *
+     * @param grnString the GRN string to parse
+     * @return the GRN
+     * @throws IllegalArgumentException when given GRN string is invalid
+     */
+    public GRN parse(String grnString) {
+        return GRN.parse(grnString, this);
+    }
+
+    /**
+     * Returns the {@link GRN} for the given type and entity.
+     *
+     * @param type   the GRN type string
+     * @param entity the entity string
+     * @return the GRN
+     * @throws IllegalArgumentException when given type doesn't exist or any arguments are null or empty
+     */
+    public GRN newGRN(String type, String entity) {
+        checkArgument(!isNullOrEmpty(type), "type cannot be null or empty");
+        checkArgument(!isNullOrEmpty(entity), "entity cannot be null or empty");
+
+        return newGRNBuilder(type).entity(entity).build();
+    }
+
+    /**
+     * Returns a new {@link GRN.Builder} for the given type string.
+     *
+     * @param type the GRN type string
+     * @return the GRN builder
+     * @throws IllegalArgumentException when given type doesn't exist
+     */
+    public GRN.Builder newGRNBuilder(String type) {
+        final GRNType grnType = Optional.ofNullable(REGISTRY.get(toKey(type)))
+                .orElseThrow(() -> new IllegalArgumentException("type <" + type + "> does not exist"));
+
+        return grnType.newGRNBuilder();
+    }
+
+    /**
+     * Registers the given GRN type.
+     *
+     * @param type the typt to register
+     * @throws IllegalStateException when given type is already registered
+     */
+    public void registerType(GRNType type) {
+        checkArgument(type != null, "type cannot be null");
+
+        if (REGISTRY.putIfAbsent(toKey(type.type()), type) != null) {
+            throw new IllegalStateException("Type <" + type.type() + "> already exists");
+        }
+    }
+
+    private String toKey(String type) {
+        checkArgument(type != null, "type cannot be null");
+        checkArgument(!type.trim().isEmpty(), "type name cannot be empty");
+
+        return type.trim().toLowerCase(Locale.US);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/utilities/GRNRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/GRNRegistry.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.utilities;
 
 import com.google.common.collect.ImmutableSet;

--- a/graylog2-server/src/main/java/org/graylog2/utilities/GRNType.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/GRNType.java
@@ -1,0 +1,28 @@
+package org.graylog2.utilities;
+
+import com.google.auto.value.AutoValue;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+@AutoValue
+public abstract class GRNType {
+    public abstract String type();
+
+    public abstract String permissionPrefix();
+
+    public GRN toGRN(String entity) {
+        return newGRNBuilder().entity(entity).build();
+    }
+
+    public GRN.Builder newGRNBuilder() {
+        return GRN.builder().type(type()).permissionPrefix(permissionPrefix());
+    }
+
+    public static GRNType create(String type, String permissionPrefix) {
+        checkArgument(!isNullOrEmpty(type), "type cannot be null or empty");
+        checkArgument(!isNullOrEmpty(permissionPrefix), "permissionPrefix cannot be null or empty");
+
+        return new AutoValue_GRNType(type, permissionPrefix);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/utilities/GRNType.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/GRNType.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.utilities;
 
 import com.google.auto.value.AutoValue;

--- a/graylog2-server/src/test/java/org/graylog2/utilities/GRNRegistryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/utilities/GRNRegistryTest.java
@@ -1,0 +1,72 @@
+package org.graylog2.utilities;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GRNRegistryTest {
+    private GRNRegistry registry;
+
+    @Nested
+    @DisplayName("with entries")
+    class WithBuiltins {
+        @BeforeEach
+        void setup() {
+            registry = GRNRegistry.createWithTypes(Collections.singleton(GRNType.create("test", "tests:")));
+        }
+
+        @Test
+        @DisplayName("parse with existing type")
+        void parseWithExistingType() {
+            assertThat(registry.parse("grn::::test:123")).satisfies(grn -> {
+                assertThat(grn.tenant()).isEmpty();
+                assertThat(grn.cluster()).isEmpty();
+                assertThat(grn.type()).isEqualTo("test");
+                assertThat(grn.entity()).isEqualTo("123");
+                assertThat(grn.permissionPrefix()).isEqualTo("tests:");
+            });
+        }
+
+        @Test
+        @DisplayName("parse with missing type should fail")
+        void parseWithMissingType() {
+            assertThatThrownBy(() -> registry.parse("grn::::__foo__:123"))
+                    .hasMessageContaining("__foo__")
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void newGRN() {
+            assertThat(registry.newGRN("test", "123").toString()).isEqualTo("grn::::test:123");
+        }
+    }
+
+    @Nested
+    @DisplayName("when empty")
+    class WhenEmpty {
+        @BeforeEach
+        void setup() {
+            registry = GRNRegistry.createEmpty();
+        }
+
+        @Test
+        @DisplayName("parse should fail")
+        void parse() {
+            assertThatThrownBy(() -> registry.parse("grn::::collection:123"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("newGRNBuilder should fail")
+        void newGRNBuilder() {
+            assertThatThrownBy(() -> registry.newGRNBuilder("collection"))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/utilities/GRNRegistryTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/utilities/GRNRegistryTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.utilities;
 
 import org.junit.jupiter.api.BeforeEach;

--- a/graylog2-server/src/test/java/org/graylog2/utilities/GRNTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/utilities/GRNTest.java
@@ -1,0 +1,51 @@
+package org.graylog2.utilities;
+
+import org.junit.Test;
+
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+
+public class GRNTest {
+
+    private static final GRNRegistry GRN_REGISTRY = GRNRegistry.createWithBuiltinTypes();
+
+    @Test
+    public void parse() {
+        final String testGRN = "grn::::stream:000000000000000001";
+        final GRN grn = GRN.parse(testGRN, GRN_REGISTRY);
+
+        assertEquals(grn.type(), "stream");
+        assertEquals(grn.entity(), "000000000000000001");
+
+        assertEquals(grn.toString(), testGRN);
+    }
+
+    @Test
+    public void parseNormalize() {
+        final String testGRN = "gRN::::stREAM:000000000000000001";
+        final GRN grn = GRN.parse(testGRN, GRN_REGISTRY);
+
+        assertEquals(grn.type(), "stream");
+        assertEquals(grn.entity(), "000000000000000001");
+
+        assertEquals(grn.toString(), testGRN.toLowerCase(Locale.ENGLISH));
+    }
+
+    @Test
+    public void builderWithEntitytTest() {
+        final GRN grn = GRN.builder().type("dashboard").entity("54e3deadbeefdeadbeef0000").permissionPrefix("dashboards:").build();
+
+        assertEquals(grn.toString(), "grn::::dashboard:54e3deadbeefdeadbeef0000");
+    }
+
+    @Test
+    public void compareGRNs() {
+        final String testGRN = "grn::::stream:000000000000000002";
+        final GRN grn1 = GRN.parse(testGRN, GRN_REGISTRY);
+        final GRN grn2 = GRN.builder().type("stream").entity("000000000000000002").permissionPrefix("streams:").build();
+
+        assertEquals(grn1, grn2);
+    }
+
+}

--- a/graylog2-server/src/test/java/org/graylog2/utilities/GRNTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/utilities/GRNTest.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.utilities;
 
 import org.junit.Test;


### PR DESCRIPTION
GRNs (Graylog Resource Names) are like URNs that we use for internal purposes only

GRN format:
  `grn:<cluster>:<tenant>:<scope>:<type>:<entity>`
Examples:
 `grn::::stream:000000000001`
 `grn:local:0:internal:stream:000000000001`

