### PR TITLE
Pass env var GRAYLOG_ELASTICSEARCH_VERSION to NodeInstance

### DIFF
--- a/full-backend-tests/src/test/java/org/graylog/storage/elasticsearch6/ElasticsearchInstanceES6Factory.java
+++ b/full-backend-tests/src/test/java/org/graylog/storage/elasticsearch6/ElasticsearchInstanceES6Factory.java
@@ -26,4 +26,9 @@ public class ElasticsearchInstanceES6Factory implements ElasticsearchInstanceFac
     public ElasticsearchInstance create(Network network) {
         return ElasticsearchInstanceES6.create(network);
     }
+
+    @Override
+    public String version() {
+        return "6";
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/ElasticsearchInstanceFactory.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/ElasticsearchInstanceFactory.java
@@ -21,4 +21,6 @@ import org.testcontainers.containers.Network;
 
 public interface ElasticsearchInstanceFactory {
     ElasticsearchInstance create(Network network);
+
+    String version();
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/completebackend/GraylogBackend.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/completebackend/GraylogBackend.java
@@ -61,7 +61,12 @@ public class GraylogBackend {
 
         MongoDBInstance mongoDB = MongoDBInstance.createStarted(network, MongoDBInstance.Lifecycle.CLASS);
 
-        NodeInstance node = NodeInstance.createStarted(network, MongoDBInstance.internalUri(), ElasticsearchInstance.internalUri(), extraPorts);
+        NodeInstance node = NodeInstance.createStarted(
+                network,
+                MongoDBInstance.internalUri(),
+                ElasticsearchInstance.internalUri(),
+                elasticsearchInstanceFactory.version(),
+                extraPorts);
 
         try {
             return new GraylogBackend(esFuture.get(), mongoDB, node);

--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerConfig.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerConfig.java
@@ -28,19 +28,21 @@ public class NodeContainerConfig {
 
     public final Network network;
     public final String mongoDbUri;
+    public final String elasticsearchVersion;
     public final String elasticsearchUri;
     public final int[] extraPorts;
     public final boolean enableDebugging;
     public final boolean skipPackaging;
 
-    public static NodeContainerConfig create(Network network, String mongoDbUri, String elasticsearchUri, int[] extraPorts) {
-        return new NodeContainerConfig(network, mongoDbUri, elasticsearchUri, extraPorts);
+    public static NodeContainerConfig create(Network network, String mongoDbUri, String elasticsearchUri, String elasticsearchVersion, int[] extraPorts) {
+        return new NodeContainerConfig(network, mongoDbUri, elasticsearchUri, elasticsearchVersion, extraPorts);
     }
 
-    public NodeContainerConfig(Network network, String mongoDbUri, String elasticsearchUri, int[] extraPorts) {
+    public NodeContainerConfig(Network network, String mongoDbUri, String elasticsearchUri, String elasticsearchVersion, int[] extraPorts) {
         this.network = network;
         this.mongoDbUri = mongoDbUri;
         this.elasticsearchUri = elasticsearchUri;
+        this.elasticsearchVersion = elasticsearchVersion;
         this.extraPorts = extraPorts == null ? new int[0] : extraPorts;
         this.enableDebugging = flagFromEnvVar("GRAYLOG_IT_DEBUG_SERVER");
         this.skipPackaging = flagFromEnvVar("GRAYLOG_IT_SKIP_PACKAGING");

--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerFactory.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeContainerFactory.java
@@ -82,6 +82,7 @@ public class NodeContainerFactory {
                 .withNetwork(config.network)
                 .withEnv("GRAYLOG_MONGODB_URI", config.mongoDbUri)
                 .withEnv("GRAYLOG_ELASTICSEARCH_HOSTS", config.elasticsearchUri)
+                .withEnv("GRAYLOG_ELASTICSEARCH_VERSION", config.elasticsearchVersion)
                 .withEnv("GRAYLOG_PASSWORD_SECRET", "M4lteserKreuzHerrStrack?")
                 .withEnv("GRAYLOG_NODE_ID_FILE", "data/config/node-id")
                 .withEnv("GRAYLOG_HTTP_BIND_ADDRESS", "0.0.0.0:" + API_PORT)

--- a/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/graylognode/NodeInstance.java
@@ -33,8 +33,8 @@ public class NodeInstance {
 
     private final GenericContainer<?> container;
 
-    public static NodeInstance createStarted(Network network, String mongoDbUri, String elasticsearchUri, int[] extraPorts) {
-        NodeContainerConfig config = NodeContainerConfig.create(network, mongoDbUri, elasticsearchUri, extraPorts);
+    public static NodeInstance createStarted(Network network, String mongoDbUri, String elasticsearchUri, String elasticsearchVersion, int[] extraPorts) {
+        NodeContainerConfig config = NodeContainerConfig.create(network, mongoDbUri, elasticsearchUri, elasticsearchVersion, extraPorts);
         GenericContainer<?> container = NodeContainerFactory.buildContainer(config);
         return new NodeInstance(container);
     }


### PR DESCRIPTION
The server will need a config setting to decide which Elasticsearch driver to bind.
This adds a `version` property to `ElasticsearchInstanceFactory`, the value of which is passed to server as an environment variable.

