### PR TITLE
Implement `MessagesAdapter` for ES7.

### DIFF
--- a/graylog-storage-elasticsearch6/pom.xml
+++ b/graylog-storage-elasticsearch6/pom.xml
@@ -55,6 +55,26 @@
             <artifactId>log4j-core</artifactId>
             <version>${log4j.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.graylog2</groupId>

--- a/graylog-storage-elasticsearch6/pom.xml
+++ b/graylog-storage-elasticsearch6/pom.xml
@@ -17,7 +17,7 @@
     <description>Graylog Storage Module for Elasticsearch 6</description>
 
     <properties>
-        <it.es.version>5.6.12</it.es.version>
+        <it.es.version>6.8.0</it.es.version>
         <elasticsearch.version>5.6.12</elasticsearch.version>
         <jest.version>2.4.15+jackson</jest.version>
     </properties>

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/MessagesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/MessagesAdapterES6.java
@@ -192,9 +192,8 @@ public class MessagesAdapterES6 implements MessagesAdapter {
     private List<IndexFailure> bulkIndexChunked(ChunkedBulkIndexer.Chunk command) throws ChunkedBulkIndexer.EntityTooLargeException {
         final List<IndexingRequest> messageList = command.requests;
         final int offset = command.offset;
-        int chunkSize = command.size;
 
-        chunkSize = Math.min(messageList.size(), chunkSize);
+        int chunkSize = Math.min(messageList.size(), command.size);
 
         final List<BulkResult.BulkResultItem> failedItems = new ArrayList<>();
         final Iterable<List<IndexingRequest>> chunks = Iterables.partition(messageList.subList(offset, messageList.size()), chunkSize);

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/MessagesAdapterES6Test.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/MessagesAdapterES6Test.java
@@ -7,6 +7,7 @@ import io.searchbox.client.JestClient;
 import io.searchbox.core.BulkResult;
 import org.graylog2.indexer.IndexFailure;
 import org.graylog2.indexer.IndexSet;
+import org.graylog2.indexer.messages.ChunkedBulkIndexer;
 import org.graylog2.indexer.messages.IndexingRequest;
 import org.graylog2.plugin.Message;
 import org.joda.time.DateTime;
@@ -38,7 +39,7 @@ class MessagesAdapterES6Test {
     void setUp() {
         this.jestClient = mock(JestClient.class);
         final MetricRegistry metricRegistry = mock(MetricRegistry.class);
-        this.messagesAdapter = new MessagesAdapterES6(jestClient, true, metricRegistry);
+        this.messagesAdapter = new MessagesAdapterES6(jestClient, true, metricRegistry, new ChunkedBulkIndexer());
     }
 
     public static class MockedBulkResult extends BulkResult {

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/MessagesES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/MessagesES6IT.java
@@ -65,7 +65,8 @@ public class MessagesES6IT extends MessagesIT {
         assertThat(message.hasField(JestResult.ES_METADATA_VERSION)).isFalse();
     }
 
-    private boolean indexMessage(String index, Map<String, Object> source, @SuppressWarnings("SameParameterValue") String id) {
+    @Override
+    protected boolean indexMessage(String index, Map<String, Object> source, @SuppressWarnings("SameParameterValue") String id) {
         final Index indexRequest = indexingHelper.prepareIndexRequest(index, source, id);
         final DocumentResult indexResponse = JestUtils.execute(jestClient(elasticsearch), indexRequest, () -> "Unable to index message");
 

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/MessagesES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/MessagesES6IT.java
@@ -9,6 +9,7 @@ import io.searchbox.core.Index;
 import org.graylog.storage.elasticsearch6.testing.ElasticsearchInstanceES6;
 import org.graylog.testing.elasticsearch.ElasticsearchInstance;
 import org.graylog.storage.elasticsearch6.jest.JestUtils;
+import org.graylog2.indexer.messages.ChunkedBulkIndexer;
 import org.graylog2.indexer.messages.MessagesAdapter;
 import org.graylog2.indexer.messages.MessagesIT;
 import org.graylog2.indexer.results.ResultMessage;
@@ -36,7 +37,7 @@ public class MessagesES6IT extends MessagesIT {
 
     @Override
     protected MessagesAdapter createMessagesAdapter(MetricRegistry metricRegistry) {
-        return new MessagesAdapterES6(jestClient(elasticsearch), true, metricRegistry);
+        return new MessagesAdapterES6(jestClient(elasticsearch), true, metricRegistry, new ChunkedBulkIndexer());
     }
 
     @Override

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/MessagesES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/MessagesES6IT.java
@@ -40,11 +40,11 @@ public class MessagesES6IT extends MessagesIT {
     }
 
     @Override
-    protected Double messageCount(String indexName) {
+    protected long messageCount(String indexName) {
         final Count count = new Count.Builder().addIndex(indexName).build();
 
         final CountResult result = JestUtils.execute(jestClient(elasticsearch), count, () -> "Unable to count documents");
-        return result.getCount();
+        return result.getCount().longValue();
     }
 
     @Test

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/FixtureImporterES6.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/FixtureImporterES6.java
@@ -160,9 +160,9 @@ public class FixtureImporterES6 implements FixtureImporter {
         }
     }
 
-    private boolean indexExists(String indexName) {
+    private boolean indexExists(String indexName) throws IOException {
         final IndicesExists.Builder request = new IndicesExists.Builder(indexName);
-        final JestResult result = JestUtils.execute(jestClient, request.build(), () -> "Unable to check if index exists: " + indexName);
+        final JestResult result = jestClient.execute(request.build());
 
         return result.isSucceeded();
     }

--- a/graylog-storage-elasticsearch7/pom.xml
+++ b/graylog-storage-elasticsearch7/pom.xml
@@ -50,6 +50,26 @@
             <artifactId>log4j-core</artifactId>
             <version>${log4j.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.graylog2</groupId>

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/Elasticsearch7Module.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/Elasticsearch7Module.java
@@ -2,6 +2,7 @@ package org.graylog.storage.elasticsearch7;
 
 import com.google.inject.binder.LinkedBindingBuilder;
 import org.graylog2.indexer.counts.CountsAdapter;
+import org.graylog2.indexer.messages.MessagesAdapter;
 import org.graylog2.plugin.VersionAwareModule;
 
 import static org.graylog.storage.elasticsearch7.Elasticsearch7Plugin.SUPPORTED_ES_VERSION;
@@ -10,6 +11,7 @@ public class Elasticsearch7Module extends VersionAwareModule {
     @Override
     protected void configure() {
         bindForSupportedVersion(CountsAdapter.class).to(CountsAdapterES7.class);
+        bindForSupportedVersion(MessagesAdapter.class).to(MessagesAdapterES7.class);
     }
 
     private <T> LinkedBindingBuilder<T> bindForSupportedVersion(Class<T> interfaceClass) {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MessagesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MessagesAdapterES7.java
@@ -69,7 +69,7 @@ public class MessagesAdapterES7 implements MessagesAdapter {
     }
 
     @Override
-    public List<Messages.IndexingError> bulkIndex(List<IndexingRequest> messageList) {
+    public List<Messages.IndexingError> bulkIndex(List<IndexingRequest> messageList) throws IOException {
         return chunkedBulkIndexer.index(messageList, this::bulkIndexChunked);
     }
 

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MessagesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MessagesAdapterES7.java
@@ -1,0 +1,73 @@
+package org.graylog.storage.elasticsearch7;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.bulk.BulkRequest;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.bulk.BulkResponse;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.get.GetRequest;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.get.GetResponse;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.index.IndexRequest;
+import org.graylog2.indexer.IndexFailure;
+import org.graylog2.indexer.messages.DocumentNotFoundException;
+import org.graylog2.indexer.messages.IndexingRequest;
+import org.graylog2.indexer.messages.Messages;
+import org.graylog2.indexer.messages.MessagesAdapter;
+import org.graylog2.indexer.results.ResultMessage;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+public class MessagesAdapterES7 implements MessagesAdapter {
+    private final ElasticsearchClient client;
+    private final Meter invalidTimestampMeter;
+
+    @Inject
+    public MessagesAdapterES7(ElasticsearchClient elasticsearchClient, MetricRegistry metricRegistry) {
+        this.client = elasticsearchClient;
+        this.invalidTimestampMeter = metricRegistry.meter(name(Messages.class, "invalid-timestamps"));
+    }
+
+    @Override
+    public ResultMessage get(String messageId, String index) throws IOException, DocumentNotFoundException {
+        final GetRequest getRequest = new GetRequest(index, messageId);
+
+        final GetResponse result = this.client.execute((c, requestOptions) -> c.get(getRequest, requestOptions));
+
+        if (!result.isExists()) {
+            throw new DocumentNotFoundException(index, messageId);
+        }
+
+        return ResultMessage.parseFromSource(messageId, index, result.getSource());
+    }
+
+    @Override
+    public List<String> analyze(String toAnalyze, String index, String analyzer) throws IOException {
+        return null;
+    }
+
+    @Override
+    public List<IndexFailure> bulkIndex(List<IndexingRequest> messageList) {
+        if (messageList.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        final BulkRequest bulkRequest = new BulkRequest();
+        messageList.forEach(request -> bulkRequest.add(
+                indexRequestFrom(request)
+        ));
+
+        final BulkResponse result = this.client.execute((c, requestOptions) -> c.bulk(bulkRequest, requestOptions));
+
+        return Collections.emptyList();
+    }
+
+    private IndexRequest indexRequestFrom(IndexingRequest request) {
+        return new IndexRequest(request.indexSet().getWriteIndexAlias())
+                .id(request.message().getId())
+                .source(request.message().toElasticSearchObject(this.invalidTimestampMeter));
+    }
+}

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MessagesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MessagesAdapterES7.java
@@ -11,6 +11,8 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.bulk.BulkRespo
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.get.GetRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.get.GetResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.index.IndexRequest;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.AnalyzeRequest;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.AnalyzeResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.rest.RestStatus;
 import org.graylog2.indexer.IndexFailure;
 import org.graylog2.indexer.IndexFailureImpl;
@@ -61,7 +63,12 @@ public class MessagesAdapterES7 implements MessagesAdapter {
 
     @Override
     public List<String> analyze(String toAnalyze, String index, String analyzer) throws IOException {
-        return null;
+        final AnalyzeRequest analyzeRequest = AnalyzeRequest.withIndexAnalyzer(index, analyzer, toAnalyze);
+
+        final AnalyzeResponse result = client.execute((c, requestOptions) -> c.indices().analyze(analyzeRequest, requestOptions));
+        return result.getTokens().stream()
+                .map(AnalyzeResponse.AnalyzeToken::getTerm)
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MessagesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MessagesAdapterES7.java
@@ -40,7 +40,7 @@ public class MessagesAdapterES7 implements MessagesAdapter {
     private static final Logger LOG = LoggerFactory.getLogger(MessagesAdapterES7.class);
     static final String INDEX_BLOCK_ERROR = "cluster_block_exception";
     static final String MAPPER_PARSING_EXCEPTION = "mapper_parsing_exception";
-    static final String INDEX_BLOCK_REASON = "blocked by: [FORBIDDEN/12/index read-only / allow delete (api)];";
+    static final String INDEX_BLOCK_REASON = "blocked by: [TOO_MANY_REQUESTS/12/index read-only / allow delete (api)";
 
     private final ElasticsearchClient client;
     private final Meter invalidTimestampMeter;
@@ -176,7 +176,7 @@ public class MessagesAdapterES7 implements MessagesAdapter {
         final ParsedElasticsearchException exception = ParsedElasticsearchException.from(item.getFailureMessage());
         switch (exception.type()) {
             case MAPPER_PARSING_EXCEPTION: return Messages.IndexingError.ErrorType.MappingError;
-            case INDEX_BLOCK_ERROR: if (exception.reason().equals(INDEX_BLOCK_REASON)) return Messages.IndexingError.ErrorType.IndexBlocked;
+            case INDEX_BLOCK_ERROR: if (exception.reason().contains(INDEX_BLOCK_REASON)) return Messages.IndexingError.ErrorType.IndexBlocked;
             default: return Messages.IndexingError.ErrorType.Unknown;
         }
     }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MessagesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MessagesAdapterES7.java
@@ -54,7 +54,7 @@ public class MessagesAdapterES7 implements MessagesAdapter {
     }
 
     @Override
-    public ResultMessage get(String messageId, String index) throws IOException, DocumentNotFoundException {
+    public ResultMessage get(String messageId, String index) throws DocumentNotFoundException {
         final GetRequest getRequest = new GetRequest(index, messageId);
 
         final GetResponse result = this.client.execute((c, requestOptions) -> c.get(getRequest, requestOptions));
@@ -67,7 +67,7 @@ public class MessagesAdapterES7 implements MessagesAdapter {
     }
 
     @Override
-    public List<String> analyze(String toAnalyze, String index, String analyzer) throws IOException {
+    public List<String> analyze(String toAnalyze, String index, String analyzer) {
         final AnalyzeRequest analyzeRequest = AnalyzeRequest.withIndexAnalyzer(index, analyzer, toAnalyze);
 
         final AnalyzeResponse result = client.execute((c, requestOptions) -> c.indices().analyze(analyzeRequest, requestOptions));

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ParsedElasticsearchException.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ParsedElasticsearchException.java
@@ -2,19 +2,13 @@ package org.graylog.storage.elasticsearch7;
 
 import com.google.auto.value.AutoValue;
 
-import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @AutoValue
 abstract class ParsedElasticsearchException {
-    /*
-    ElasticsearchException[Elasticsearch exception [type=mapper_parsing_exception, reason=failed to parse field [_ourcustomfield]
-    of type [long] in document with id '2f1b81f1-c050-11ea-ad64-d2850321fca4'. Preview of field's value: 'fourty-two']];
-    nested: ElasticsearchException[Elasticsearch exception [type=illegal_argument_exception, reason=For input string: "fourty-two"]];
-     */
     private static final Pattern exceptionPattern = Pattern
-            .compile("^ElasticsearchException\\[Elasticsearch exception \\[type=([\\w_]+), (reason=(.+?)\\]\\];)?");
+            .compile("^ElasticsearchException\\[Elasticsearch exception \\[type=(?<type>[\\w_]+), (?:reason=(?<reason>.+?)\\]\\];)");
 
     abstract String type();
     abstract String reason();
@@ -25,10 +19,9 @@ abstract class ParsedElasticsearchException {
 
     static ParsedElasticsearchException from(String s) {
         final Matcher matcher = exceptionPattern.matcher(s);
-        if (matcher.matches()) {
-            final MatchResult result = matcher.toMatchResult();
-            final String type = result.group(1);
-            final String reason = result.group(3);
+        if (matcher.find()) {
+            final String type = matcher.group("type");
+            final String reason = matcher.group("reason");
 
             return create(type, reason);
         }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ParsedElasticsearchException.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ParsedElasticsearchException.java
@@ -1,0 +1,38 @@
+package org.graylog.storage.elasticsearch7;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.regex.MatchResult;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@AutoValue
+abstract class ParsedElasticsearchException {
+    /*
+    ElasticsearchException[Elasticsearch exception [type=mapper_parsing_exception, reason=failed to parse field [_ourcustomfield]
+    of type [long] in document with id '2f1b81f1-c050-11ea-ad64-d2850321fca4'. Preview of field's value: 'fourty-two']];
+    nested: ElasticsearchException[Elasticsearch exception [type=illegal_argument_exception, reason=For input string: "fourty-two"]];
+     */
+    private static final Pattern exceptionPattern = Pattern
+            .compile("^ElasticsearchException\\[Elasticsearch exception \\[type=([\\w_]+), (reason=(.+?)\\]\\];)?");
+
+    abstract String type();
+    abstract String reason();
+
+    static ParsedElasticsearchException create(String type, String reason) {
+        return new AutoValue_ParsedElasticsearchException(type, reason);
+    }
+
+    static ParsedElasticsearchException from(String s) {
+        final Matcher matcher = exceptionPattern.matcher(s);
+        if (matcher.matches()) {
+            final MatchResult result = matcher.toMatchResult();
+            final String type = result.group(1);
+            final String reason = result.group(3);
+
+            return create(type, reason);
+        }
+
+        throw new IllegalArgumentException("Unable to parse Elasticsearch exception: " + s);
+    }
+}

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ParsedElasticsearchException.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ParsedElasticsearchException.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 @AutoValue
 abstract class ParsedElasticsearchException {
     private static final Pattern exceptionPattern = Pattern
-            .compile("^ElasticsearchException\\[Elasticsearch exception \\[type=(?<type>[\\w_]+), (?:reason=(?<reason>.+?)\\]\\];)");
+            .compile("ElasticsearchException\\[Elasticsearch exception \\[type=(?<type>[\\w_]+), (?:reason=(?<reason>.+?)\\]+;)");
 
     abstract String type();
     abstract String reason();

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/MessagesES7IT.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/MessagesES7IT.java
@@ -1,0 +1,35 @@
+package org.graylog.storage.elasticsearch7;
+
+import com.codahale.metrics.MetricRegistry;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.core.CountRequest;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.core.CountResponse;
+import org.graylog.storage.elasticsearch7.testing.ElasticsearchInstanceES7;
+import org.graylog.testing.elasticsearch.ElasticsearchInstance;
+import org.graylog2.indexer.messages.MessagesAdapter;
+import org.graylog2.indexer.messages.MessagesIT;
+import org.junit.Rule;
+
+public class MessagesES7IT extends MessagesIT {
+    @Rule
+    public final ElasticsearchInstanceES7 elasticsearch = ElasticsearchInstanceES7.create();
+
+    @Override
+    protected ElasticsearchInstance elasticsearch() {
+        return this.elasticsearch;
+    }
+
+    @Override
+    protected MessagesAdapter createMessagesAdapter(MetricRegistry metricRegistry) {
+        return new MessagesAdapterES7(this.elasticsearch.elasticsearchClient(), metricRegistry);
+    }
+
+    @Override
+    protected long messageCount(String indexName) {
+        //this.elasticsearch.elasticsearchClient().execute((c, requestOptions) -> c.indices().refresh(new RefreshRequest(), requestOptions));
+
+        final CountRequest countRequest = new CountRequest(indexName);
+        final CountResponse result = this.elasticsearch.elasticsearchClient().execute((c, requestOptions) -> c.count(countRequest, requestOptions));
+
+        return result.getCount();
+    }
+}

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/MessagesES7IT.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/MessagesES7IT.java
@@ -5,6 +5,7 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.core.CountRequ
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.core.CountResponse;
 import org.graylog.storage.elasticsearch7.testing.ElasticsearchInstanceES7;
 import org.graylog.testing.elasticsearch.ElasticsearchInstance;
+import org.graylog2.indexer.messages.ChunkedBulkIndexer;
 import org.graylog2.indexer.messages.MessagesAdapter;
 import org.graylog2.indexer.messages.MessagesIT;
 import org.junit.Rule;
@@ -20,7 +21,7 @@ public class MessagesES7IT extends MessagesIT {
 
     @Override
     protected MessagesAdapter createMessagesAdapter(MetricRegistry metricRegistry) {
-        return new MessagesAdapterES7(this.elasticsearch.elasticsearchClient(), metricRegistry);
+        return new MessagesAdapterES7(this.elasticsearch.elasticsearchClient(), metricRegistry, new ChunkedBulkIndexer());
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/MessagesES7IT.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/MessagesES7IT.java
@@ -1,14 +1,20 @@
 package org.graylog.storage.elasticsearch7;
 
 import com.codahale.metrics.MetricRegistry;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.index.IndexRequest;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.index.IndexResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.core.CountRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.core.CountResponse;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.rest.RestStatus;
 import org.graylog.storage.elasticsearch7.testing.ElasticsearchInstanceES7;
 import org.graylog.testing.elasticsearch.ElasticsearchInstance;
 import org.graylog2.indexer.messages.ChunkedBulkIndexer;
 import org.graylog2.indexer.messages.MessagesAdapter;
 import org.graylog2.indexer.messages.MessagesIT;
 import org.junit.Rule;
+
+import java.util.Map;
 
 public class MessagesES7IT extends MessagesIT {
     @Rule
@@ -26,11 +32,22 @@ public class MessagesES7IT extends MessagesIT {
 
     @Override
     protected long messageCount(String indexName) {
-        //this.elasticsearch.elasticsearchClient().execute((c, requestOptions) -> c.indices().refresh(new RefreshRequest(), requestOptions));
+        this.elasticsearch.elasticsearchClient().execute((c, requestOptions) -> c.indices().refresh(new RefreshRequest(), requestOptions));
 
         final CountRequest countRequest = new CountRequest(indexName);
         final CountResponse result = this.elasticsearch.elasticsearchClient().execute((c, requestOptions) -> c.count(countRequest, requestOptions));
 
         return result.getCount();
+    }
+
+    @Override
+    protected boolean indexMessage(String index, Map<String, Object> source, String id) {
+        final IndexRequest indexRequest = new IndexRequest(index)
+                .source(source)
+                .id(id);
+
+        final IndexResponse result = this.elasticsearch.elasticsearchClient().execute((c, requestOptions) -> c.index(indexRequest, requestOptions));
+
+        return result.status().equals(RestStatus.CREATED);
     }
 }

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/ParsedElasticsearchExceptionTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/ParsedElasticsearchExceptionTest.java
@@ -20,4 +20,18 @@ class ParsedElasticsearchExceptionTest {
                     "id '2f1b81f1-c050-11ea-ad64-d2850321fca4'. Preview of field's value: 'fourty-two'");
         });
     }
+
+    @Test
+    void parsingIndexReadonlyException() {
+        final String exception = "Elasticsearch exception: ElasticsearchException[Elasticsearch exception " +
+                "[type=cluster_block_exception, reason=index [messages_it_deflector] blocked by: [TOO_MANY_REQUESTS/12/index " +
+                "read-only / allow delete (api)];]]";
+
+        final ParsedElasticsearchException parsed = ParsedElasticsearchException.from(exception);
+
+        assertThat(parsed).satisfies(p -> {
+            assertThat(p.type()).isEqualTo("cluster_block_exception");
+            assertThat(p.reason()).isEqualTo("index [messages_it_deflector] blocked by: [TOO_MANY_REQUESTS/12/index read-only / allow delete (api)");
+        });
+    }
 }

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/ParsedElasticsearchExceptionTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/ParsedElasticsearchExceptionTest.java
@@ -1,0 +1,23 @@
+package org.graylog.storage.elasticsearch7;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ParsedElasticsearchExceptionTest {
+    @Test
+    void parsingMapperParsingException() {
+        final String exception = "ElasticsearchException[Elasticsearch exception [type=mapper_parsing_exception, " +
+                "reason=failed to parse field [_ourcustomfield] of type [long] in document with id '2f1b81f1-c050-11ea-ad64-d2850321fca4'. " +
+                "Preview of field's value: 'fourty-two']]; nested: ElasticsearchException[Elasticsearch exception " +
+                "[type=illegal_argument_exception, reason=For input string: \"fourty-two\"]];";
+
+        final ParsedElasticsearchException parsed = ParsedElasticsearchException.from(exception);
+
+        assertThat(parsed).satisfies(p -> {
+            assertThat(p.type()).isEqualTo("mapper_parsing_exception");
+            assertThat(p.reason()).isEqualTo("failed to parse field [_ourcustomfield] of type [long] in document with " +
+                    "id '2f1b81f1-c050-11ea-ad64-d2850321fca4'. Preview of field's value: 'fourty-two'");
+        });
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/ChunkedBulkIndexer.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/ChunkedBulkIndexer.java
@@ -1,0 +1,86 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.messages;
+
+import org.graylog2.indexer.ElasticsearchException;
+import org.graylog2.indexer.IndexFailure;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ChunkedBulkIndexer {
+    private static final Logger LOG = LoggerFactory.getLogger(ChunkedBulkIndexer.class);
+
+    public interface BulkIndex {
+        List<IndexFailure> apply(Chunk chunk) throws ChunkedBulkIndexer.EntityTooLargeException;
+    }
+
+    public List<IndexFailure> index(List<IndexingRequest> messageList, BulkIndex bulkIndex) {
+        if (messageList.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        int chunkSize = messageList.size();
+        int offset = 0;
+        final List<IndexFailure> failedItems = new ArrayList<>();
+        for (;;) {
+            try {
+                final List<IndexFailure> failures = bulkIndex.apply(new Chunk(messageList, offset, chunkSize));
+                failedItems.addAll(failures);
+                break; // on success
+            } catch (ChunkedBulkIndexer.EntityTooLargeException e) {
+                LOG.warn("Bulk index failed with 'Request Entity Too Large' error. Retrying by splitting up batch size <{}>.", chunkSize);
+                if (chunkSize == messageList.size()) {
+                    LOG.warn("Consider lowering the \"output_batch_size\" setting.");
+                }
+                failedItems.addAll(e.failedItems);
+                offset += e.indexedSuccessfully;
+                chunkSize /= 2;
+            }
+            if (chunkSize == 0) {
+                throw new ElasticsearchException("Bulk index cannot split output batch any further.");
+            }
+        }
+
+        return failedItems;
+    }
+
+    public static class Chunk {
+        public final List<IndexingRequest> requests;
+        public final int offset;
+        public final int size;
+
+        Chunk(List<IndexingRequest> requests, int offset, int size) {
+            this.requests = requests;
+            this.offset = offset;
+            this.size = size;
+        }
+    }
+
+    public static class EntityTooLargeException extends Exception {
+        public final int indexedSuccessfully;
+        public final List<IndexFailure> failedItems;
+
+        public EntityTooLargeException(int indexedSuccessfully, List<IndexFailure> failedItems)  {
+            this.indexedSuccessfully = indexedSuccessfully;
+            this.failedItems = failedItems;
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/ChunkedBulkIndexer.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/ChunkedBulkIndexer.java
@@ -20,6 +20,7 @@ import org.graylog2.indexer.ElasticsearchException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -27,10 +28,10 @@ public class ChunkedBulkIndexer {
     private static final Logger LOG = LoggerFactory.getLogger(ChunkedBulkIndexer.class);
 
     public interface BulkIndex {
-        List<Messages.IndexingError> apply(Chunk chunk) throws ChunkedBulkIndexer.EntityTooLargeException;
+        List<Messages.IndexingError> apply(Chunk chunk) throws ChunkedBulkIndexer.EntityTooLargeException, IOException;
     }
 
-    public List<Messages.IndexingError> index(List<IndexingRequest> messageList, BulkIndex bulkIndex) {
+    public List<Messages.IndexingError> index(List<IndexingRequest> messageList, BulkIndex bulkIndex) throws IOException {
         if (messageList.isEmpty()) {
             return Collections.emptyList();
         }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.indexer.messages;
 
+import org.graylog2.indexer.ElasticsearchException;
 import org.graylog2.indexer.IndexFailure;
 import org.graylog2.indexer.IndexSet;
 import org.graylog2.indexer.results.ResultMessage;
@@ -27,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -180,7 +180,7 @@ public class Messages {
         final Map<String, Object> doc = ImmutableMap.<String, Object>builder()
                 .put("letter_id", message.getId())
                 .put("index", indexError.index())
-                .put("type", indexError.errorType())
+                .put("type", indexError.errorType().toString())
                 .put("message", indexError.errorMessage())
                 .put("timestamp", message.getTimestamp())
                 .build();

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -135,7 +136,7 @@ public class Messages {
         recordTimestamp(successfulRequests);
         accountTotalMessageSizes(indexingRequestList, isSystemTraffic);
 
-        return propagateFailure(indexFailures);
+        return propagateFailure(remainingErrors);
     }
 
     private Set<IndexingError> retryOnlyIndexBlockItemsForever(List<IndexingRequest> messages, List<IndexingError> allFailedItems) {
@@ -225,7 +226,7 @@ public class Messages {
         }
     }
 
-    private List<String> propagateFailure(List<IndexingError> indexingErrors) {
+    private List<String> propagateFailure(Collection<IndexingError> indexingErrors) {
         if (indexingErrors.isEmpty()) {
             return Collections.emptyList();
         }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/Messages.java
@@ -122,9 +122,9 @@ public class Messages {
                 .map(entry -> IndexingRequest.create(entry.getKey(), entry.getValue()))
                 .collect(Collectors.toList());
 
-        final List<IndexingError> indexFailures = runBulkRequest(indexingRequestList, messageList.size());
+        final List<IndexingError> indexingErrors = runBulkRequest(indexingRequestList, messageList.size());
 
-        final Set<IndexingError> remainingErrors = retryOnlyIndexBlockItemsForever(indexingRequestList, indexFailures);
+        final Set<IndexingError> remainingErrors = retryOnlyIndexBlockItemsForever(indexingRequestList, indexingErrors);
 
         final Set<String> failedIds = remainingErrors.stream()
                 .map(indexingError -> indexingError.message().getId())

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/MessagesAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/MessagesAdapter.java
@@ -27,5 +27,5 @@ public interface MessagesAdapter {
 
     List<String> analyze(String toAnalyze, String index, String analyzer) throws IOException;
 
-    List<IndexFailure> bulkIndex(List<IndexingRequest> messageList);
+    List<IndexFailure> bulkIndex(final List<IndexingRequest> messageList);
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/MessagesAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/MessagesAdapter.java
@@ -26,5 +26,5 @@ public interface MessagesAdapter {
 
     List<String> analyze(String toAnalyze, String index, String analyzer) throws IOException;
 
-    List<Messages.IndexingError> bulkIndex(final List<IndexingRequest> messageList);
+    List<Messages.IndexingError> bulkIndex(final List<IndexingRequest> messageList) throws IOException;
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/messages/MessagesAdapter.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/messages/MessagesAdapter.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.indexer.messages;
 
-import org.graylog2.indexer.IndexFailure;
 import org.graylog2.indexer.results.ResultMessage;
 
 import java.io.IOException;
@@ -27,5 +26,5 @@ public interface MessagesAdapter {
 
     List<String> analyze(String toAnalyze, String index, String analyzer) throws IOException;
 
-    List<IndexFailure> bulkIndex(final List<IndexingRequest> messageList);
+    List<Messages.IndexingError> bulkIndex(final List<IndexingRequest> messageList);
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/Client.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/Client.java
@@ -61,4 +61,10 @@ public interface Client {
     void bulkIndex(BulkIndexRequest bulkIndexRequest);
 
     void cleanUp();
+
+    void putSetting(String setting, String value);
+
+    void waitForIndexBlock(String index);
+
+    void resetIndexBlock(String index);
 }

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchInstance.java
@@ -74,7 +74,7 @@ public abstract class ElasticsearchInstance extends ExternalResource {
     private ElasticsearchContainer buildContainer(String image, Network network) {
         return new ElasticsearchContainer(image)
                 .withReuse(true)
-                .withEnv("ES_JAVA_OPTS", "-Xms512m -Xmx512m")
+                .withEnv("ES_JAVA_OPTS", "-Xms1024m -Xmx1024m")
                 .withEnv("discovery.type", "single-node")
                 .withEnv("action.auto_create_index", ".watches,.triggered_watches,.watcher-history-*")
                 .withNetwork(network)

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchInstance.java
@@ -77,6 +77,7 @@ public abstract class ElasticsearchInstance extends ExternalResource {
                 .withEnv("ES_JAVA_OPTS", "-Xms1024m -Xmx1024m")
                 .withEnv("discovery.type", "single-node")
                 .withEnv("action.auto_create_index", ".watches,.triggered_watches,.watcher-history-*")
+                .withEnv("cluster.info.update.interval", "10s")
                 .withNetwork(network)
                 .withNetworkAliases(NETWORK_ALIAS)
                 .waitingFor(Wait.forHttp("/").forPort(ES_PORT));

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesBulkIndexRetryingTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesBulkIndexRetryingTest.java
@@ -180,7 +180,7 @@ class MessagesBulkIndexRetryingTest {
 
     private Messages.IndexingError errorResultItem(String messageId, Messages.IndexingError.ErrorType errorType, String errorReason) {
         final Message message = mock(Message.class);
-        when(message.getTimestamp()).thenReturn(DateTime.now());
+        when(message.getTimestamp()).thenReturn(DateTime.now(DateTimeZone.UTC));
         when(message.getId()).thenReturn(messageId);
 
         return Messages.IndexingError.create(message, "randomIndex", errorType, errorReason);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesBulkIndexRetryingTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesBulkIndexRetryingTest.java
@@ -1,0 +1,188 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.messages;
+
+import com.google.common.collect.ImmutableList;
+import org.graylog2.indexer.IndexSet;
+import org.graylog2.plugin.Message;
+import org.graylog2.system.processing.ProcessingStatusRecorder;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MessagesBulkIndexRetryingTest {
+    private final TrafficAccounting trafficAccounting = mock(TrafficAccounting.class);
+    private final MessagesAdapter messagesAdapter = mock(MessagesAdapter.class);
+    private final ProcessingStatusRecorder processingStatusRecorder = mock(ProcessingStatusRecorder.class);
+
+    private Messages messages;
+
+    @BeforeEach
+    void setUp() {
+        this.messages = new Messages(trafficAccounting, messagesAdapter, processingStatusRecorder);
+    }
+
+    @Test
+    public void bulkIndexingShouldNotDoAnythingForEmptyList() throws Exception {
+        final List<String> result = messages.bulkIndex(Collections.emptyList());
+
+        assertThat(result).isNotNull()
+                .isEmpty();
+
+        verify(messagesAdapter, never()).bulkIndex(any());
+    }
+
+    @Test
+    public void bulkIndexingShouldNotRetryForIndexMappingErrors() throws Exception {
+        final String messageId = "BOOMID";
+
+        final List<Messages.IndexingError> errorResult = ImmutableList.of(
+                errorResultItem(messageId, Messages.IndexingError.ErrorType.MappingError, "failed to parse [http_response_code]")
+        );
+
+        when(messagesAdapter.bulkIndex(any()))
+                .thenReturn(errorResult)
+                .thenThrow(new IllegalStateException("JestResult#execute should not be called twice."));
+
+        final Message mockedMessage = mock(Message.class);
+        when(mockedMessage.getId()).thenReturn(messageId);
+        when(mockedMessage.getTimestamp()).thenReturn(DateTime.now(DateTimeZone.UTC));
+
+        final List<Map.Entry<IndexSet, Message>> messageList = messageListWith(mockedMessage);
+
+        final List<String> result = messages.bulkIndex(messageList);
+
+        assertThat(result).hasSize(1);
+
+        verify(messagesAdapter, times(1)).bulkIndex(any());
+    }
+
+    @Test
+    public void bulkIndexingShouldRetry() throws Exception {
+        when(messagesAdapter.bulkIndex(any()))
+                .thenThrow(new IOException("Boom!"))
+                .thenReturn(Collections.emptyList());
+
+        final List<Map.Entry<IndexSet, Message>> messageList = messageListWith(mock(Message.class));
+
+        final List<String> result = messages.bulkIndex(messageList);
+
+        assertThat(result).isNotNull().isEmpty();
+
+        verify(messagesAdapter, times(2)).bulkIndex(any());
+    }
+
+    @Test
+    public void bulkIndexingShouldRetryIfIndexBlocked() throws IOException {
+        final List<Messages.IndexingError> errorResult = Collections.singletonList(
+                errorResultItem("blocked-id", Messages.IndexingError.ErrorType.IndexBlocked, "Index is read-only")
+        );
+        final List<Messages.IndexingError> successResult = Collections.emptyList();
+
+        when(messagesAdapter.bulkIndex(any()))
+                .thenReturn(errorResult)
+                .thenReturn(successResult);
+
+        final List<String> result = messages.bulkIndex(messagesWithIds("blocked-id"));
+
+        verify(messagesAdapter, times(2)).bulkIndex(any());
+        assertThat(result).isNotNull().isEmpty();
+    }
+
+    @Test
+    public void indexBlockedRetriesShouldOnlyRetryIndexBlockedErrors() throws IOException {
+        final List<Messages.IndexingError> errorResult = ImmutableList.of(
+                errorResultItem("blocked-id", Messages.IndexingError.ErrorType.IndexBlocked, "Index is read-only"),
+                errorResultItem("other-error-id", Messages.IndexingError.ErrorType.Unknown, "Some other error")
+        );
+        final List<Messages.IndexingError> successResult = Collections.emptyList();
+
+        when(messagesAdapter.bulkIndex(any()))
+                .thenReturn(errorResult)
+                .thenReturn(successResult);
+
+        final List<String> result = messages.bulkIndex(messagesWithIds("blocked-id", "other-error-id"));
+
+        verify(messagesAdapter, times(2)).bulkIndex(any());
+        assertThat(result).containsOnly("other-error-id");
+    }
+
+    @Test
+    public void retriedIndexBlockErrorsThatFailWithDifferentErrorsAreTreatedAsPersistentFailures() throws IOException {
+        final List<Messages.IndexingError> errorResult = ImmutableList.of(
+                errorResultItem("blocked-id", Messages.IndexingError.ErrorType.IndexBlocked, "Index is read-only"),
+                errorResultItem("other-error-id", Messages.IndexingError.ErrorType.IndexBlocked, "Index is read-only")
+        );
+        final List<Messages.IndexingError> secondErrorResult = ImmutableList.of(
+                errorResultItem("other-error-id", Messages.IndexingError.ErrorType.Unknown, "Some other error")
+        );
+
+        when(messagesAdapter.bulkIndex(any()))
+                .thenReturn(errorResult)
+                .thenReturn(secondErrorResult);
+
+        final List<String> result = messages.bulkIndex(messagesWithIds("blocked-id", "other-error-id"));
+
+        verify(messagesAdapter, times(2)).bulkIndex(any());
+        assertThat(result).containsOnly("other-error-id");
+    }
+
+    private List<Map.Entry<IndexSet, Message>> messagesWithIds(String... ids) {
+        return Arrays.stream(ids)
+                .map(this::messageWithId)
+                .map(m -> new AbstractMap.SimpleEntry<>(mock(IndexSet.class), m))
+                .collect(Collectors.toList());
+    }
+
+    private Message messageWithId(String id) {
+        final Message mockedMessage = mock(Message.class);
+        when(mockedMessage.getId()).thenReturn(id);
+        when(mockedMessage.getTimestamp()).thenReturn(DateTime.now(DateTimeZone.UTC));
+        return mockedMessage;
+    }
+
+    private List<Map.Entry<IndexSet, Message>> messageListWith(Message mockedMessage) {
+        return ImmutableList.of(
+                new AbstractMap.SimpleEntry<>(mock(IndexSet.class), mockedMessage)
+        );
+    }
+
+    private Messages.IndexingError errorResultItem(String messageId, Messages.IndexingError.ErrorType errorType, String errorReason) {
+        final Message message = mock(Message.class);
+        when(message.getTimestamp()).thenReturn(DateTime.now());
+        when(message.getId()).thenReturn(messageId);
+
+        return Messages.IndexingError.create(message, "randomIndex", errorType, errorReason);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
@@ -36,6 +36,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -108,6 +109,14 @@ public abstract class MessagesIT extends ElasticsearchBaseTest {
         assertThat(message.getMessage()).isEqualTo("This is my message");
         assertThat(message.getSource()).isEqualTo("logsender");
         assertThat(message.getTimestamp()).isEqualTo(DateTime.parse("2017-04-13T15:29:00.000Z"));
+    }
+
+    @Test
+    public void analyzingFieldReturnsTokens() throws IOException {
+        final String randomIndex = client().createRandomIndex("analyze-");
+        final List<String> terms = messages.analyze("The quick brown fox jumps over the lazy dog", randomIndex, "standard");
+
+        assertThat(terms).containsExactlyInAnyOrder("the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog");
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
@@ -100,7 +100,7 @@ public abstract class MessagesIT extends ElasticsearchBaseTest {
         assertThat(messageCount(INDEX_NAME)).isEqualTo(MESSAGECOUNT);
     }
 
-    protected abstract Double messageCount(String indexName);
+    protected abstract long messageCount(String indexName);
 
     @Test
     public void unevenTooLargeBatchesGetSplitUp() throws Exception {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
@@ -199,25 +199,21 @@ public abstract class MessagesIT extends ElasticsearchBaseTest {
 
     @Test
     public void retryIndexingMessagesDuringFloodStage() throws Exception {
-        final String index = "messages_it_deflector";
-
-        client().putSetting("cluster.info.update.interval", "10s");
-
-        triggerFloodStage(index);
+        triggerFloodStage(INDEX_NAME);
 
         final ExecutorService executor = Executors.newFixedThreadPool(1);
 
         final List<Map.Entry<IndexSet, Message>> messageBatch = createMessageBatch(1024 * 1024, 50);
         final Future<List<String>> result = executor.submit(() -> this.messages.bulkIndex(messageBatch));
 
-        resetFloodStage(index);
+        resetFloodStage(INDEX_NAME);
 
         final List<String> failedItems = result.get(3, TimeUnit.MINUTES);
         assertThat(failedItems).isEmpty();
 
         client().refreshNode();
 
-        assertThat(messageCount(index)).isEqualTo(50);
+        assertThat(messageCount(INDEX_NAME)).isEqualTo(50);
     }
 
     private void triggerFloodStage(String index) {

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
@@ -210,7 +210,6 @@ public abstract class MessagesIT extends ElasticsearchBaseTest {
         final List<Map.Entry<IndexSet, Message>> messageBatch = createMessageBatch(1024 * 1024, 50);
         final Future<List<String>> result = executor.submit(() -> this.messages.bulkIndex(messageBatch));
 
-        Thread.sleep(2000);
         resetFloodStage(index);
 
         final List<String> failedItems = result.get(3, TimeUnit.MINUTES);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesRetryWaitTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesRetryWaitTest.java
@@ -14,11 +14,9 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog.storage.elasticsearch6;
+package org.graylog2.indexer.messages;
 
 import com.github.rholder.retry.WaitStrategy;
-import org.graylog2.indexer.messages.IndexBlockRetryAttempt;
-import org.graylog2.indexer.messages.Messages;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 public class MessagesRetryWaitTest {
     @Test
     void secondsBasedRetryWaitsForSecondsStartingWith1() {
-        WaitStrategy waitStrategy = MessagesAdapterES6.exponentialWaitSeconds;
+        WaitStrategy waitStrategy = Messages.exponentialWaitSeconds;
         assertAll(
                 () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(1))).isEqualTo(1000),
                 () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(2))).isEqualTo(2000),
@@ -40,7 +38,7 @@ public class MessagesRetryWaitTest {
     // This test was added to document how the retry strategy actually behaves since this is hard to deduct from the code
     @Test
     void millisecondsBasedRetryWaitsForMillisecondsStartingWith2() {
-        WaitStrategy waitStrategy = MessagesAdapterES6.exponentialWaitMilliseconds;
+        WaitStrategy waitStrategy = Messages.exponentialWaitMilliseconds;
         assertAll(
                 () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(1))).isEqualTo(2),
                 () -> assertThat(waitStrategy.computeSleepTime(new IndexBlockRetryAttempt(2))).isEqualTo(4),

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesTest.java
@@ -27,6 +27,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import java.io.IOException;
 import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.List;
@@ -69,7 +70,7 @@ public class MessagesTest {
     }
 
     @Test
-    public void bulkIndexingShouldAccountMessageSizes() {
+    public void bulkIndexingShouldAccountMessageSizes() throws IOException {
         when(messagesAdapter.bulkIndex(any())).thenReturn(Collections.emptyList());
         final IndexSet indexSet = mock(IndexSet.class);
         final List<Map.Entry<IndexSet, Message>> messageList = ImmutableList.of(
@@ -85,7 +86,7 @@ public class MessagesTest {
     }
 
     @Test
-    public void bulkIndexingShouldAccountMessageSizesForSystemTrafficSeparately() {
+    public void bulkIndexingShouldAccountMessageSizesForSystemTrafficSeparately() throws IOException {
         when(messagesAdapter.bulkIndex(any())).thenReturn(Collections.emptyList());
         final IndexSet indexSet = mock(IndexSet.class);
         final List<Map.Entry<IndexSet, Message>> messageList = ImmutableList.of(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is implementing the `MessagesAdapter` for ES7. It also performs quite extensive refactoring of the `Messages` <-> `MessagesAdapter` relationship. 
Before this PR, retrying logic was buried in the `MessagesAdapter#bulkIndex` call. This change is pulling it upwards into the `Messages` class, which is now retrying `bulkIndex` calls for thrown `IOException`s as well as indexing errors (e.g. index blocks due to target indices being read-only or the node being in flood stage). This is implemented by adding an abstraction for indexing errors (`Messages.IndexingError`) which is instantiated by the adapters but evaluated by the `Messages` class which decides how to proceed based on the error type.

Chunk splitting due to excessive payload sizes is still considered to be a concern of the adapter implementation, as it is related to the way of transport (HTTP). Nevertheless, parts of it are extracted into a shared class (`ChunkedBulkIndexer`) which can be employed by any adapter implementation to provide a strategy that splits chunks into halves until bulk indexing does not fail because of a 413 anymore.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.