### PR TITLE
Update cloud-3.3 with latest 3.3

### DIFF
--- a/graylog2-web-interface/flow-typed/npm/react-router_vx.x.x.js
+++ b/graylog2-web-interface/flow-typed/npm/react-router_vx.x.x.js
@@ -18,4 +18,12 @@ declare module 'react-router' {
   declare export class browserHistory {
     static push: ({pathname: string, state: {}}) => void,
   }
+  declare export class Link extends React$Component<Props> {
+    to: (string | { [key: string]: any } | () => {}),
+    activeStyle?: any,
+    activeClassName?: string,
+    onlyActiveOnIndex: boolean,
+    onClick?: () => void,
+    target?: string,
+  }
 }

--- a/graylog2-web-interface/src/util/DocsHelper.js
+++ b/graylog2-web-interface/src/util/DocsHelper.js
@@ -17,6 +17,7 @@ class DocsHelper {
     INDEXER_FAILURES: 'indexer_failures.html',
     INDEX_MODEL: 'configuration/index_model.html',
     LOAD_BALANCERS: 'configuration/load_balancers.html',
+    LOOKUPTABLES: 'lookuptables.html',
     PAGE_FLEXIBLE_DATE_CONVERTER: 'extractors.html#the-flexible-date-converter',
     PAGE_STANDARD_DATE_CONVERTER: 'extractors.html#the-standard-date-converter',
     PIPELINE_FUNCTIONS: 'pipelines/functions.html',


### PR DESCRIPTION
Merge the latest changes in `3.3` into `cloud-3.3` (especially https://github.com/Graylog2/graylog2-server/pull/8464, which is required for the Forwarder UI)

@ousmaneo It looks like the backport was the only new 3.3 commit that we needed to merge in. 