### PR TITLE
Exclude sharing user from active shares and refactor capabilities

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/BuiltinCapabilities.java
+++ b/graylog2-server/src/main/java/org/graylog/security/BuiltinCapabilities.java
@@ -19,7 +19,6 @@ package org.graylog.security;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.graylog2.shared.security.RestPermissions;
-import org.graylog2.utilities.GRNRegistry;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -27,11 +26,7 @@ import java.util.Optional;
 
 @Singleton
 public class BuiltinCapabilities {
-    private static ImmutableMap<String, CapabilityDTO> CAPABILITIES;
-
-    public final static String CAPABILITY_ENTITY_VIEWER = "grn::::capability:54e3deadbeefdeadbeef0000";
-    public final static String CAPABILITY_ENTITY_MANAGER = "grn::::capability:54e3deadbeefdeadbeef0001";
-    public final static String CAPABILITY_ENTITY_OWNER = "grn::::capability:54e3deadbeefdeadbeef0002";
+    private static ImmutableMap<Capability, CapabilityDescriptor> CAPABILITIES;
 
     // TODO: Need to be migrated to roles
     public final static String ROLE_COLLECTION_CREATOR = "grn::::role:54e3deadbeefdeadbeef1001";
@@ -39,11 +34,10 @@ public class BuiltinCapabilities {
     public final static String ROLE_STREAM_CREATOR = "grn::::role:54e3deadbeefdeadbeef1003";
 
     @Inject
-    public BuiltinCapabilities(GRNRegistry grnRegistry) {
-
-        CAPABILITIES = ImmutableMap.<String, CapabilityDTO>builder()
-                .put(CAPABILITY_ENTITY_VIEWER, CapabilityDTO.create(
-                        grnRegistry.parse(CAPABILITY_ENTITY_VIEWER).entity(),
+    public BuiltinCapabilities() {
+        CAPABILITIES = ImmutableMap.<Capability, CapabilityDescriptor>builder()
+                .put(Capability.VIEW, CapabilityDescriptor.create(
+                        Capability.VIEW,
                         "Viewer",
                         ImmutableSet.of(
                                 RestPermissions.STREAMS_READ,
@@ -51,8 +45,8 @@ public class BuiltinCapabilities {
                                 // TODO: Add missing collection permissions
                         )
                 ))
-                .put(CAPABILITY_ENTITY_MANAGER, CapabilityDTO.create(
-                        grnRegistry.parse(CAPABILITY_ENTITY_MANAGER).entity(),
+                .put(Capability.MANAGE, CapabilityDescriptor.create(
+                        Capability.MANAGE,
                         "Manager",
                         ImmutableSet.of(
                                 RestPermissions.STREAMS_READ,
@@ -63,8 +57,8 @@ public class BuiltinCapabilities {
                                 // TODO: Add missing collection permissions
                         )
                 ))
-                .put(CAPABILITY_ENTITY_OWNER, CapabilityDTO.create(
-                        grnRegistry.parse(CAPABILITY_ENTITY_OWNER).entity(),
+                .put(Capability.OWN, CapabilityDescriptor.create(
+                        Capability.OWN,
                         "Owner",
                         ImmutableSet.of(
                                 RestPermissions.ENTITY_OWN,
@@ -76,6 +70,7 @@ public class BuiltinCapabilities {
                                 // TODO: Add missing collection permissions
                         )
                 ))
+                /* TODO: Needs to be moved to the actual roles registry
                 .put(ROLE_COLLECTION_CREATOR, CapabilityDTO.create(
                         grnRegistry.parse(ROLE_COLLECTION_CREATOR).entity(),
                         "Collection Creator",
@@ -94,18 +89,19 @@ public class BuiltinCapabilities {
                         "Stream Creator",
                         ImmutableSet.of(RestPermissions.STREAMS_CREATE)
                 ))
+                 */
                 .build();
     }
 
-    public static ImmutableSet<CapabilityDTO> allSharingCapabilities() {
+    public static ImmutableSet<CapabilityDescriptor> allSharingCapabilities() {
         return ImmutableSet.of(
-                CAPABILITIES.get(CAPABILITY_ENTITY_VIEWER),
-                CAPABILITIES.get(CAPABILITY_ENTITY_MANAGER),
-                CAPABILITIES.get(CAPABILITY_ENTITY_OWNER)
+                CAPABILITIES.get(Capability.VIEW),
+                CAPABILITIES.get(Capability.MANAGE),
+                CAPABILITIES.get(Capability.OWN)
         );
     }
 
-    public Optional<CapabilityDTO> get(String grn) {
-        return Optional.ofNullable(CAPABILITIES.get(grn));
+    public Optional<CapabilityDescriptor> get(Capability capability) {
+        return Optional.ofNullable(CAPABILITIES.get(capability));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/security/Capability.java
+++ b/graylog2-server/src/main/java/org/graylog/security/Capability.java
@@ -1,0 +1,34 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.security;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Locale;
+
+public enum Capability {
+    @JsonProperty("view")
+    VIEW,
+    @JsonProperty("manage")
+    MANAGE,
+    @JsonProperty("own")
+    OWN;
+
+    public String toId() {
+        return name().toLowerCase(Locale.US);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/security/CapabilityDescriptor.java
+++ b/graylog2-server/src/main/java/org/graylog/security/CapabilityDescriptor.java
@@ -21,33 +21,33 @@ import com.google.auto.value.AutoValue;
 import java.util.Set;
 
 @AutoValue
-public abstract class CapabilityDTO {
-    public abstract String id();
+public abstract class CapabilityDescriptor {
+    public abstract Capability capability();
 
     public abstract String title();
 
     public abstract Set<String> permissions();
 
-    public static CapabilityDTO create(String id, String title, Set<String> permissions) {
+    public static CapabilityDescriptor create(Capability capability, String title, Set<String> permissions) {
         return builder()
-                .id(id)
+                .capability(capability)
                 .title(title)
                 .permissions(permissions)
                 .build();
     }
 
     public static Builder builder() {
-        return new AutoValue_CapabilityDTO.Builder();
+        return new AutoValue_CapabilityDescriptor.Builder();
     }
 
     @AutoValue.Builder
     public abstract static class Builder {
-        public abstract Builder id(String id);
+        public abstract Builder capability(Capability capability);
 
         public abstract Builder title(String title);
 
         public abstract Builder permissions(Set<String> permissions);
 
-        public abstract CapabilityDTO build();
+        public abstract CapabilityDescriptor build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
@@ -19,6 +19,10 @@ package org.graylog.security;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.mongodb.BasicDBObject;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Updates;
+import org.bson.Document;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.database.PaginatedDbService;
@@ -53,6 +57,21 @@ public class DBGrantService extends PaginatedDbService<GrantDTO> {
         db.createIndex(new BasicDBObject(GrantDTO.FIELD_GRANTEE, 1));
         db.createIndex(new BasicDBObject(GrantDTO.FIELD_TARGET, 1));
         // TODO: Add more indices
+
+        // TODO: Inline migration for development. Must be removed before shipping 4.0 GA!
+        final MongoCollection<Document> collection = mongoConnection.getMongoDatabase().getCollection(COLLECTION_NAME);
+        collection.updateMany(
+                Filters.eq(GrantDTO.FIELD_CAPABILITY, "grn::::capability:54e3deadbeefdeadbeef0000"),
+                Updates.set(GrantDTO.FIELD_CAPABILITY, Capability.VIEW.toId())
+        );
+        collection.updateMany(
+                Filters.eq(GrantDTO.FIELD_CAPABILITY, "grn::::capability:54e3deadbeefdeadbeef0001"),
+                Updates.set(GrantDTO.FIELD_CAPABILITY, Capability.MANAGE.toId())
+        );
+        collection.updateMany(
+                Filters.eq(GrantDTO.FIELD_CAPABILITY, "grn::::capability:54e3deadbeefdeadbeef0002"),
+                Updates.set(GrantDTO.FIELD_CAPABILITY, Capability.OWN.toId())
+        );
     }
 
     public ImmutableSet<GrantDTO> getForGranteesOrGlobal(Set<GRN> grantees) {

--- a/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
@@ -99,7 +99,14 @@ public class DBGrantService extends PaginatedDbService<GrantDTO> {
         }
     }
 
-    public List<GrantDTO> getForTarget(GRN targetGRN) {
-        return db.find(DBQuery.is(GrantDTO.FIELD_TARGET, targetGRN.toString())).toArray();
+    public List<GrantDTO> getForTarget(GRN target) {
+        return db.find(DBQuery.is(GrantDTO.FIELD_TARGET, target.toString())).toArray();
+    }
+
+    public List<GrantDTO> getForTargetExcludingGrantee(GRN target, GRN grantee) {
+        return db.find(DBQuery.and(
+                DBQuery.is(GrantDTO.FIELD_TARGET, target.toString()),
+                DBQuery.notEquals(GrantDTO.FIELD_GRANTEE, grantee.toString())
+        )).toArray();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/security/DefaultGrantPermissionResolver.java
+++ b/graylog2-server/src/main/java/org/graylog/security/DefaultGrantPermissionResolver.java
@@ -78,7 +78,7 @@ public class DefaultGrantPermissionResolver implements GrantPermissionResolver {
         final ImmutableSet.Builder<Permission> permissionsBuilder = ImmutableSet.builder();
 
         for (GrantDTO grant : grants) {
-            final Optional<CapabilityDTO> capability = builtinCapabilities.get(grant.capability());
+            final Optional<CapabilityDescriptor> capability = builtinCapabilities.get(grant.capability());
 
             if (capability.isPresent()) {
                 final Set<GRN> targets = resolveTargets(grant.target());

--- a/graylog2-server/src/main/java/org/graylog/security/GrantDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/security/GrantDTO.java
@@ -40,7 +40,7 @@ import java.util.Optional;
 public abstract class GrantDTO {
     private static final String FIELD_ID = "id";
     static final String FIELD_GRANTEE = "grantee";
-    private static final String FIELD_CAPABILITY = "capability";
+    static final String FIELD_CAPABILITY = "capability";
     public static final String FIELD_TARGET = "target";
     private static final String FIELD_CREATED_BY = "created_by";
     private static final String FIELD_CREATED_AT = "created_at";
@@ -59,7 +59,7 @@ public abstract class GrantDTO {
 
     @NotBlank
     @JsonProperty(FIELD_CAPABILITY)
-    public abstract String capability();
+    public abstract Capability capability();
 
     @NotNull
     @JsonProperty(FIELD_TARGET)
@@ -106,7 +106,7 @@ public abstract class GrantDTO {
         public abstract Builder grantee(GRN grantee);
 
         @JsonProperty(FIELD_CAPABILITY)
-        public abstract Builder capability(String capability);
+        public abstract Builder capability(Capability capability);
 
         @JsonProperty(FIELD_TARGET)
         public abstract Builder target(GRN target);

--- a/graylog2-server/src/main/java/org/graylog/security/rest/EntitySharesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/security/rest/EntitySharesResource.java
@@ -110,9 +110,6 @@ public class EntitySharesResource extends RestResourceWithOwnerCheck {
 
         checkOwnership(grn);
 
-        final String userName = requireNonNull(getCurrentUser()).getName();
-        final GRN currentUser = grnRegistry.newGRN("user", userName);
-
         // TODO: We need to make the return value of this resource more useful to the frontend
         //       (e.g. returning a list of entities with title, etc.)
         final List<GrantDTO> grants = grantService.getForTarget(grn);

--- a/graylog2-server/src/main/java/org/graylog/security/shares/DefaultGranteeService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/DefaultGranteeService.java
@@ -46,6 +46,9 @@ public class DefaultGranteeService implements GranteeService {
         // TODO: We can only expose users that are in the same teams as the sharing user by default. There should
         //       also be a global config setting to allow exposing all existing users in the system.
         return userService.loadAll().stream()
+                // Don't return the sharing user in available grantees until we want to support that sharing users
+                // can remove themselves from an entity.
+                .filter(user -> !sharingUser.getId().equals(user.getId()))
                 .map(user -> AvailableGrantee.create(
                         grnRegistry.newGRN("user", user.getName()).toString(),
                         "user",

--- a/graylog2-server/src/main/java/org/graylog/security/shares/EntitySharePrepareRequest.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/EntitySharePrepareRequest.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
+import org.graylog.security.Capability;
 import org.graylog2.utilities.GRN;
 
 import java.util.Collections;
@@ -30,10 +31,10 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 @AutoValue
 public abstract class EntitySharePrepareRequest {
     @JsonProperty("selected_grantees")
-    public abstract ImmutableMap<GRN, GRN> selectedGrantees();
+    public abstract ImmutableMap<GRN, Capability> selectedGrantees();
 
     @JsonCreator
-    public static EntitySharePrepareRequest create(@JsonProperty("selected_grantees") Map<GRN, GRN> selectedGrantees) {
+    public static EntitySharePrepareRequest create(@JsonProperty("selected_grantees") Map<GRN, Capability> selectedGrantees) {
         return new AutoValue_EntitySharePrepareRequest(ImmutableMap.copyOf(firstNonNull(selectedGrantees, Collections.emptyMap())));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/security/shares/EntitySharePrepareRequest.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/EntitySharePrepareRequest.java
@@ -30,11 +30,11 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 
 @AutoValue
 public abstract class EntitySharePrepareRequest {
-    @JsonProperty("selected_grantees")
-    public abstract ImmutableMap<GRN, Capability> selectedGrantees();
+    @JsonProperty("selected_grantee_capabilities")
+    public abstract ImmutableMap<GRN, Capability> selectedGranteeCapabilities();
 
     @JsonCreator
-    public static EntitySharePrepareRequest create(@JsonProperty("selected_grantees") Map<GRN, Capability> selectedGrantees) {
-        return new AutoValue_EntitySharePrepareRequest(ImmutableMap.copyOf(firstNonNull(selectedGrantees, Collections.emptyMap())));
+    public static EntitySharePrepareRequest create(@JsonProperty("selected_grantee_capabilities") Map<GRN, Capability> selectedGranteeCapabilities) {
+        return new AutoValue_EntitySharePrepareRequest(ImmutableMap.copyOf(firstNonNull(selectedGranteeCapabilities, Collections.emptyMap())));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/security/shares/EntitySharePrepareResponse.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/EntitySharePrepareResponse.java
@@ -48,8 +48,8 @@ public abstract class EntitySharePrepareResponse {
     @JsonProperty("active_shares")
     public abstract ImmutableSet<ActiveShare> activeShares();
 
-    @JsonProperty("selected_grantees")
-    public abstract ImmutableMap<GRN, Capability> selectedGrantees();
+    @JsonProperty("selected_grantee_capabilities")
+    public abstract ImmutableMap<GRN, Capability> selectedGranteeCapabilities();
 
     @JsonProperty("missing_dependencies")
     public abstract ImmutableSet<MissingDependency> missingDependencies();
@@ -64,7 +64,7 @@ public abstract class EntitySharePrepareResponse {
         public static Builder create() {
             return new AutoValue_EntitySharePrepareResponse.Builder()
                     .activeShares(Collections.emptySet())
-                    .selectedGrantees(Collections.emptyMap())
+                    .selectedGranteeCapabilities(Collections.emptyMap())
                     .missingDependencies(Collections.emptySet());
         }
 
@@ -83,8 +83,8 @@ public abstract class EntitySharePrepareResponse {
         @JsonProperty("active_shares")
         public abstract Builder activeShares(Set<ActiveShare> activeShares);
 
-        @JsonProperty("selected_grantees")
-        public abstract Builder selectedGrantees(Map<GRN, Capability> selectedGrantees);
+        @JsonProperty("selected_grantee_capabilities")
+        public abstract Builder selectedGranteeCapabilities(Map<GRN, Capability> selectedGranteeCapabilities);
 
         @JsonProperty("missing_dependencies")
         public abstract Builder missingDependencies(Set<MissingDependency> missingDependencies);

--- a/graylog2-server/src/main/java/org/graylog/security/shares/EntitySharePrepareResponse.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/EntitySharePrepareResponse.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.graylog.security.Capability;
 import org.graylog2.utilities.GRN;
 
 import java.util.Collections;
@@ -48,7 +49,7 @@ public abstract class EntitySharePrepareResponse {
     public abstract ImmutableSet<ActiveShare> activeShares();
 
     @JsonProperty("selected_grantees")
-    public abstract ImmutableMap<GRN, GRN> selectedGrantees();
+    public abstract ImmutableMap<GRN, Capability> selectedGrantees();
 
     @JsonProperty("missing_dependencies")
     public abstract ImmutableSet<MissingDependency> missingDependencies();
@@ -83,7 +84,7 @@ public abstract class EntitySharePrepareResponse {
         public abstract Builder activeShares(Set<ActiveShare> activeShares);
 
         @JsonProperty("selected_grantees")
-        public abstract Builder selectedGrantees(Map<GRN, GRN> selectedGrantees);
+        public abstract Builder selectedGrantees(Map<GRN, Capability> selectedGrantees);
 
         @JsonProperty("missing_dependencies")
         public abstract Builder missingDependencies(Set<MissingDependency> missingDependencies);
@@ -134,12 +135,12 @@ public abstract class EntitySharePrepareResponse {
         public abstract GRN grantee();
 
         @JsonProperty("capability")
-        public abstract String capability();
+        public abstract Capability capability();
 
         @JsonCreator
         public static ActiveShare create(@JsonProperty("grant") String grant,
                                          @JsonProperty("grantee") GRN grantee,
-                                         @JsonProperty("capability") String capability) {
+                                         @JsonProperty("capability") Capability capability) {
             return new AutoValue_EntitySharePrepareResponse_ActiveShare(grant, grantee, capability);
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/security/shares/EntitySharePrepareResponse.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/EntitySharePrepareResponse.java
@@ -35,6 +35,9 @@ public abstract class EntitySharePrepareResponse {
     @JsonProperty("entity")
     public abstract String entity();
 
+    @JsonProperty("sharing_user")
+    public abstract GRN sharingUser();
+
     @JsonProperty("available_grantees")
     public abstract ImmutableSet<AvailableGrantee> availableGrantees();
 
@@ -66,6 +69,9 @@ public abstract class EntitySharePrepareResponse {
 
         @JsonProperty("entity")
         public abstract Builder entity(String entity);
+
+        @JsonProperty("sharing_user")
+        public abstract Builder sharingUser(GRN sharingUser);
 
         @JsonProperty("available_grantees")
         public abstract Builder availableGrantees(Set<AvailableGrantee> availableGrantees);

--- a/graylog2-server/src/main/java/org/graylog/security/shares/EntityShareRequest.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/EntityShareRequest.java
@@ -34,19 +34,19 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 @AutoValue
 @JsonAutoDetect
 public abstract class EntityShareRequest {
-    @JsonProperty("selected_grantees")
-    public abstract ImmutableMap<GRN, Capability> selectedGrantees();
+    @JsonProperty("selected_grantee_capabilities")
+    public abstract ImmutableMap<GRN, Capability> selectedGranteeCapabilities();
 
     public Set<GRN> grantees() {
-        return selectedGrantees().keySet();
+        return selectedGranteeCapabilities().keySet();
     }
 
     public Set<Capability> capabilities() {
-        return ImmutableSet.copyOf(selectedGrantees().values());
+        return ImmutableSet.copyOf(selectedGranteeCapabilities().values());
     }
 
     @JsonCreator
-    public static EntityShareRequest create(@JsonProperty("selected_grantees") Map<GRN, Capability> selectedGrantees) {
-        return new AutoValue_EntityShareRequest(ImmutableMap.copyOf(firstNonNull(selectedGrantees, Collections.emptyMap())));
+    public static EntityShareRequest create(@JsonProperty("selected_grantee_capabilities") Map<GRN, Capability> selectedGranteeCapabilities) {
+        return new AutoValue_EntityShareRequest(ImmutableMap.copyOf(firstNonNull(selectedGranteeCapabilities, Collections.emptyMap())));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/security/shares/EntityShareRequest.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/EntityShareRequest.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.graylog.security.Capability;
 import org.graylog2.utilities.GRN;
 
 import java.util.Collections;
@@ -34,18 +35,18 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 @JsonAutoDetect
 public abstract class EntityShareRequest {
     @JsonProperty("selected_grantees")
-    public abstract ImmutableMap<GRN, GRN> selectedGrantees();
+    public abstract ImmutableMap<GRN, Capability> selectedGrantees();
 
     public Set<GRN> grantees() {
         return selectedGrantees().keySet();
     }
 
-    public Set<GRN> capabilities() {
+    public Set<Capability> capabilities() {
         return ImmutableSet.copyOf(selectedGrantees().values());
     }
 
     @JsonCreator
-    public static EntityShareRequest create(@JsonProperty("selected_grantees") Map<GRN, GRN> selectedGrantees) {
+    public static EntityShareRequest create(@JsonProperty("selected_grantees") Map<GRN, Capability> selectedGrantees) {
         return new AutoValue_EntityShareRequest(ImmutableMap.copyOf(firstNonNull(selectedGrantees, Collections.emptyMap())));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/utilities/GRNRegistry.java
+++ b/graylog2-server/src/main/java/org/graylog2/utilities/GRNRegistry.java
@@ -39,7 +39,6 @@ public class GRNRegistry {
     // TODO find a way to unify these
     private static final ImmutableSet<GRNType> BUILTIN_TYPES = ImmutableSet.<GRNType>builder()
             .add(GRNType.create("collection", "collections:"))
-            .add(GRNType.create("capability", "capabilities:"))
             .add(GRNType.create("dashboard", "dashboards:"))
             .add(GRNType.create("grant", "grants:"))
             .add(GRNType.create("role", "roles:"))

--- a/graylog2-server/src/test/java/org/graylog/security/DBGrantServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/DBGrantServiceTest.java
@@ -64,4 +64,23 @@ public class DBGrantServiceTest {
         assertThat(dbService.getForGranteesOrGlobal(Collections.singleton(jane))).hasSize(3);
         assertThat(dbService.getForGranteesOrGlobal(Collections.singleton(john))).hasSize(2);
     }
+
+    @Test
+    @MongoDBFixtures("grants.json")
+    public void getForTarget() {
+        final GRN stream1 = grnRegistry.parse("grn::::stream:54e3deadbeefdeadbeef0000");
+        final GRN stream2 = grnRegistry.parse("grn::::stream:54e3deadbeefdeadbeef0001");
+
+        assertThat(dbService.getForTarget(stream1)).hasSize(1);
+        assertThat(dbService.getForTarget(stream2)).hasSize(3);
+    }
+
+    @Test
+    @MongoDBFixtures("grants.json")
+    public void getForTargetExcludingGrantee() {
+        final GRN stream = grnRegistry.parse("grn::::stream:54e3deadbeefdeadbeef0001");
+        final GRN grantee = grnRegistry.parse("grn::::user:john");
+
+        assertThat(dbService.getForTargetExcludingGrantee(stream, grantee)).hasSize(2);
+    }
 }

--- a/graylog2-server/src/test/resources/org/graylog/security/grants.json
+++ b/graylog2-server/src/test/resources/org/graylog/security/grants.json
@@ -5,7 +5,7 @@
         "$oid": "54e3deadbeefdeadbeef0000"
       },
       "grantee": "grn::::user:jane",
-      "capability": "grn::::capability:stream-read",
+      "capability": "view",
       "target": "grn::::stream:54e3deadbeefdeadbeef0000",
       "created_by": "admin",
       "created_at": {
@@ -21,7 +21,7 @@
         "$oid": "54e3deadbeefdeadbeef0001"
       },
       "grantee": "grn::::user:jane",
-      "capability": "grn::::capability:stream-manage",
+      "capability": "manage",
       "target": "grn::::stream:54e3deadbeefdeadbeef0001",
       "created_by": "admin",
       "created_at": {
@@ -39,7 +39,7 @@
         "$oid": "54e3deadbeefdeadbeef0002"
       },
       "grantee": "grn::::user:john",
-      "capability": "grn::::capability:stream-read",
+      "capability": "view",
       "target": "grn::::stream:54e3deadbeefdeadbeef0001",
       "created_by": "admin",
       "created_at": {
@@ -57,7 +57,7 @@
         "$oid": "54e3deadbeefdeadbeef0003"
       },
       "grantee": "grn::::builtin-team:everyone",
-      "capability": "grn::::capability:stream-read",
+      "capability": "view",
       "target": "grn::::stream:54e3deadbeefdeadbeef0001",
       "created_by": "admin",
       "created_at": {


### PR DESCRIPTION
- Exclude sharing user in active shares and available grantees. Also add "sharing_user" field to the response.
- Refactor capabilities into an enum and CapabilityDescriptor
  Since capabilities are not dynamic, we don't need to use a GRN for them
  and can use an enum. Permissions for a capability will be pluggable, but
  that's still possible.