### PR TITLE
Change initial payload for first prepare request

### DIFF
--- a/graylog2-web-interface/src/components/permissions/EntityShareModal.jsx
+++ b/graylog2-web-interface/src/components/permissions/EntityShareModal.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 
 import { useStore } from 'stores/connect';
 import { Spinner } from 'components/common';
-import { EntityShareStore, EntityShareActions } from 'stores/permissions/EntityShareStore';
+import { EntityShareStore, EntityShareActions, type EntitySharePayload } from 'stores/permissions/EntityShareStore';
 import BootstrapModalConfirm from 'components/bootstrap/BootstrapModalConfirm';
 
 import EntityShareSettings from './EntityShareSettings';
@@ -31,10 +31,11 @@ const EntityShareModal = ({ description, entityId, entityType, entityTitle, onCl
 
   const _handleSave = () => {
     setDisableSubmit(true);
-
-    return EntityShareActions.update(entityGRN, {
+    const payload: EntitySharePayload = {
       selected_grantee_capabilities: entityShareState.selectedGranteeCapabilities,
-    }).then(onClose);
+    };
+
+    return EntityShareActions.update(entityGRN, payload).then(onClose);
   };
 
   return (

--- a/graylog2-web-interface/src/components/permissions/EntityShareSettings.jsx
+++ b/graylog2-web-interface/src/components/permissions/EntityShareSettings.jsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import type { GRN } from 'logic/permissions/types';
 import EntityShareState from 'logic/permissions/EntityShareState';
-import { EntityShareActions } from 'stores/permissions/EntityShareStore';
+import { EntityShareActions, type EntitySharePayload } from 'stores/permissions/EntityShareStore';
 
 import GranteesSelector, { type SelectionRequest } from './GranteesSelector';
 import GranteesList from './GranteesList';
@@ -54,10 +54,11 @@ const EntityShareSettings = ({
 
   const _handleSelection = ({ granteeId, capabilityId }: SelectionRequest) => {
     setDisableSubmit(true);
-
-    return EntityShareActions.prepare(entityGRN, {
+    const payload: EntitySharePayload = {
       selected_grantee_capabilities: selectedGranteeCapabilities.merge({ [granteeId]: capabilityId }),
-    }).then((response) => {
+    };
+
+    return EntityShareActions.prepare(entityGRN, payload).then((response) => {
       setDisableSubmit(false);
 
       return response;
@@ -66,10 +67,11 @@ const EntityShareSettings = ({
 
   const _handleDeletion = (granteeId: GRN) => {
     setDisableSubmit(true);
-
-    return EntityShareActions.prepare(entityGRN, {
+    const payload: EntitySharePayload = {
       selected_grantee_capabilities: selectedGranteeCapabilities.remove(granteeId),
-    }).then((response) => {
+    };
+
+    return EntityShareActions.prepare(entityGRN, payload).then((response) => {
       setDisableSubmit(false);
 
       return response;

--- a/graylog2-web-interface/src/stores/permissions/EntityShareStore.js
+++ b/graylog2-web-interface/src/stores/permissions/EntityShareStore.js
@@ -18,7 +18,7 @@ export type EntitySharePayload = {
 };
 
 type EntityShareActionsType = RefluxActions<{
-  prepare: (GRN, EntitySharePayload) => Promise<EntityShareState>,
+  prepare: (GRN, ?EntitySharePayload) => Promise<EntityShareState>,
   update: (GRN, EntitySharePayload) => Promise<EntityShareState>,
 }>;
 

--- a/graylog2-web-interface/src/stores/permissions/EntityShareStore.js
+++ b/graylog2-web-interface/src/stores/permissions/EntityShareStore.js
@@ -1,6 +1,5 @@
 // @flow strict
 import Reflux from 'reflux';
-import * as Immutable from 'immutable';
 
 import ApiRoutes from 'routing/ApiRoutes';
 import { qualifyUrl } from 'util/URLUtils';
@@ -29,9 +28,7 @@ type EntityShareActionsType = RefluxActions<{
 
 type EntityShareStoreType = Store<EntityShareStoreState>;
 
-const defaultPreparePayload = {
-  selected_grantee_capabilities: Immutable.Map(),
-};
+const defaultPreparePayload = {};
 
 export const EntityShareActions: EntityShareActionsType = singletonActions(
   'permissions.EntityShare',

--- a/graylog2-web-interface/src/stores/permissions/EntityShareStore.js
+++ b/graylog2-web-interface/src/stores/permissions/EntityShareStore.js
@@ -13,17 +13,13 @@ type EntityShareStoreState = {
   state: EntityShareState,
 };
 
-type EntitySharePreparePayload = {|
-  selected_grantee_capabilities?: SelectedGranteeCapabilities,
-|};
-
-type EntityShareUpdatePayload = {|
-  selected_grantee_capabilities?: SelectedGranteeCapabilities,
-|};
+export type EntitySharePayload = {
+  selected_grantee_capabilities: SelectedGranteeCapabilities,
+};
 
 type EntityShareActionsType = RefluxActions<{
-  prepare: (GRN, ?EntitySharePreparePayload) => Promise<EntityShareState>,
-  update: (GRN, EntityShareUpdatePayload) => Promise<EntityShareState>,
+  prepare: (GRN, EntitySharePayload) => Promise<EntityShareState>,
+  update: (GRN, EntitySharePayload) => Promise<EntityShareState>,
 }>;
 
 type EntityShareStoreType = Store<EntityShareStoreState>;
@@ -49,7 +45,7 @@ export const EntityShareStore: EntityShareStoreType = singletonStore(
       return this._state();
     },
 
-    prepare(entityGRN: GRN, payload: EntitySharePreparePayload = defaultPreparePayload): Promise<EntityShareState> {
+    prepare(entityGRN: GRN, payload: EntitySharePayload = defaultPreparePayload): Promise<EntityShareState> {
       const url = qualifyUrl(ApiRoutes.EntityShareController.prepare(entityGRN).url);
       const promise = fetch('POST', url, JSON.stringify(payload)).then(this._handleResponse);
 
@@ -58,7 +54,7 @@ export const EntityShareStore: EntityShareStoreType = singletonStore(
       return promise;
     },
 
-    update(entityGRN: GRN, payload: EntityShareUpdatePayload): Promise<EntityShareState> {
+    update(entityGRN: GRN, payload: EntitySharePayload): Promise<EntityShareState> {
       const url = qualifyUrl(ApiRoutes.EntityShareController.update(entityGRN).url);
       const promise = fetch('POST', url, JSON.stringify(payload)).then(this._handleResponse);
 


### PR DESCRIPTION
Prior to this change, we send the first prepare request with following
payload:

```{ selected_grantee_capabilities: {} }```

But this payload was also send if all grantee where removed, which
mimics the initial prepare request leading to have all removed grantee
back in selected_grantee_capabilities.

This change will adjust the initial request sending a empty object as
payload so the backend can distinguish between "remove all grantee" and
initial prepare request.