### PR TITLE
Add missing CountsAdapterProvider

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/storage/VersionAwareStorageModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/VersionAwareStorageModule.java
@@ -22,12 +22,14 @@ import org.graylog.events.search.MoreSearchAdapter;
 import org.graylog2.indexer.IndexToolsAdapter;
 import org.graylog2.indexer.cluster.ClusterAdapter;
 import org.graylog2.indexer.cluster.NodeAdapter;
+import org.graylog2.indexer.counts.CountsAdapter;
 import org.graylog2.indexer.fieldtypes.IndexFieldTypePollerAdapter;
 import org.graylog2.indexer.indices.IndicesAdapter;
 import org.graylog2.indexer.messages.MessagesAdapter;
 import org.graylog2.indexer.searches.SearchesAdapter;
 import org.graylog2.migrations.V20170607164210_MigrateReopenedIndicesToAliases;
 import org.graylog2.storage.providers.ClusterAdapterProvider;
+import org.graylog2.storage.providers.CountsAdapterProvider;
 import org.graylog2.storage.providers.EventIndexerAdapterProvider;
 import org.graylog2.storage.providers.IndexFieldTypePollerAdapterProvider;
 import org.graylog2.storage.providers.IndexToolsAdapterProvider;
@@ -41,6 +43,7 @@ import org.graylog2.storage.providers.V20170607164210_MigrateReopenedIndicesToAl
 public class VersionAwareStorageModule extends AbstractModule {
     @Override
     protected void configure() {
+        bind(CountsAdapter.class).toProvider(CountsAdapterProvider.class);
         bind(IndicesAdapter.class).toProvider(IndicesAdapterProvider.class);
         bind(SearchesAdapter.class).toProvider(SearchesAdapterProvider.class);
         bind(MoreSearchAdapter.class).toProvider(MoreSearchAdapterProvider.class);

--- a/graylog2-server/src/main/java/org/graylog2/storage/providers/CountsAdapterProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/providers/CountsAdapterProvider.java
@@ -1,0 +1,33 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.storage.providers;
+
+import org.graylog2.indexer.counts.CountsAdapter;
+import org.graylog2.plugin.Version;
+import org.graylog2.storage.VersionAwareProvider;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import java.util.Map;
+
+public class CountsAdapterProvider extends VersionAwareProvider<CountsAdapter> {
+    @Inject
+    public CountsAdapterProvider(@Named("elasticsearch_version") String elasticsearchMajorVersion, Map<Version, Provider<CountsAdapter>> pluginBindings) {
+        super(elasticsearchMajorVersion, pluginBindings);
+    }
+}


### PR DESCRIPTION
`Counts` couldn't be injected into `IndexerOverviewResource`, because we forgot to add a version-aware provider implementation for `CountsAdapter`.