### PR TITLE
Further improvements for entity share modal

### DIFF
--- a/graylog2-web-interface/src/components/common/PageSizeSelect.jsx
+++ b/graylog2-web-interface/src/components/common/PageSizeSelect.jsx
@@ -1,7 +1,10 @@
 // @flow strict
 import * as React from 'react';
+import PropTypes from 'prop-types';
 
 import { Input } from 'components/bootstrap';
+
+const PAGE_SIZES = [10, 50, 100];
 
 type Props = {
   className?: string,
@@ -18,8 +21,18 @@ const PageSizeSelect = ({ pageSizes, pageSize, onChange, className }: Props) => 
   </div>
 );
 
+PageSizeSelect.propTypes = {
+  className: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  pageSize: PropTypes.number.isRequired,
+  pageSizes: PropTypes.arrayOf(PropTypes.number),
+};
+
 PageSizeSelect.defaultProps = {
   className: undefined,
+  pageSizes: PAGE_SIZES,
 };
+
+PageSizeSelect.defaultPageSizes = PAGE_SIZES;
 
 export default PageSizeSelect;

--- a/graylog2-web-interface/src/components/permissions/EntityShareModal.jsx
+++ b/graylog2-web-interface/src/components/permissions/EntityShareModal.jsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
+import { createGRN } from 'logic/permissions/GRN';
 import { useStore } from 'stores/connect';
 import { Spinner } from 'components/common';
 import { EntityShareStore, EntityShareActions } from 'stores/permissions/EntityShareStore';
@@ -18,12 +19,10 @@ type Props = {
   onClose: () => void,
 };
 
-const _generateGRN = (id, type) => `grn::::${type}:${id}`;
-
 const EntityShareModal = ({ description, entityId, entityType, entityTitle, onClose }: Props) => {
   const { state: entityShareState } = useStore(EntityShareStore);
   const [disableSubmit, setDisableSubmit] = useState(false);
-  const entityGRN = _generateGRN(entityId, entityType);
+  const entityGRN = createGRN(entityId, entityType);
 
   useEffect(() => {
     EntityShareActions.prepare(entityGRN);

--- a/graylog2-web-interface/src/components/permissions/EntityShareModal.jsx
+++ b/graylog2-web-interface/src/components/permissions/EntityShareModal.jsx
@@ -39,6 +39,7 @@ const EntityShareModal = ({ description, entityId, entityType, entityTitle, onCl
   return (
     <BootstrapModalConfirm confirmButtonDisabled={disableSubmit}
                            confirmButtonText="Save"
+                           cancelButtonText="Discard changes"
                            onConfirm={_handleSave}
                            onModalClose={onClose}
                            showModal

--- a/graylog2-web-interface/src/components/permissions/EntityShareModal.test.jsx
+++ b/graylog2-web-interface/src/components/permissions/EntityShareModal.test.jsx
@@ -75,7 +75,7 @@ describe('EntityShareModal', () => {
     const onClose = jest.fn();
     const { getByText } = render(<SimpleEntityShareModal onClose={onClose} />);
 
-    const cancelButton = getByText('Cancel');
+    const cancelButton = getByText('Discard changes');
 
     fireEvent.click(cancelButton);
 
@@ -237,7 +237,7 @@ describe('EntityShareModal', () => {
       const deleteGrantee = async ({ grantee }) => {
         const { getByTitle } = render(<SimpleEntityShareModal />);
 
-        const deleteButton = getByTitle(`Delete sharing for ${grantee.title}`);
+        const deleteButton = getByTitle(`Remove sharing for ${grantee.title}`);
 
         fireEvent.click(deleteButton);
 

--- a/graylog2-web-interface/src/components/permissions/GranteesList.jsx
+++ b/graylog2-web-interface/src/components/permissions/GranteesList.jsx
@@ -66,17 +66,21 @@ const _paginatedGrantees = (selectedGrantees: SelectedGrantees, pageSize: number
 };
 
 const GranteesList = ({ activeShares, onDelete, onCapabilityChange, entityGRN, availableCapabilities, selectedGrantees, className, title }: Props) => {
-  const pageSizes = [10, 50, 100];
-  const [pageSize, setPageSize] = useState(pageSizes[0]);
+  const initialPageSize = PageSizeSelect.defaultPageSizes[0];
+  const [pageSize, setPageSize] = useState(initialPageSize);
   const [currentPage, setCurrentPage] = useState(1);
   const paginatedGrantees = _paginatedGrantees(selectedGrantees, pageSize, currentPage);
-  const numberPages = Math.ceil(selectedGrantees.size / pageSize);
+  const totalGrantees = selectedGrantees.size;
+  const totalPages = Math.ceil(totalGrantees / pageSize);
+  const showPageSizeSelect = totalGrantees > initialPageSize;
 
   return (
     <div className={className}>
       <Header>
         <h5>{title}</h5>
-        <StyledPageSizeSelect onChange={(event) => setPageSize(Number(event.target.value))} pageSize={pageSize} pageSizes={pageSizes} />
+        {showPageSizeSelect && (
+          <StyledPageSizeSelect onChange={(event) => setPageSize(Number(event.target.value))} pageSize={pageSize} />
+        )}
       </Header>
       <List>
         {paginatedGrantees.map((grantee) => {
@@ -94,7 +98,7 @@ const GranteesList = ({ activeShares, onDelete, onCapabilityChange, entityGRN, a
         })}
       </List>
       <PaginationWrapper>
-        <StyledPagination totalPages={numberPages}
+        <StyledPagination totalPages={totalPages}
                           currentPage={currentPage}
                           onChange={setCurrentPage} />
       </PaginationWrapper>

--- a/graylog2-web-interface/src/components/permissions/GranteesListItem.jsx
+++ b/graylog2-web-interface/src/components/permissions/GranteesListItem.jsx
@@ -99,7 +99,7 @@ const GranteesListItem = ({ availableCapabilities, currentGranteeState, grantee:
             {isDeleting ? (
               <Spinner text="" />
             ) : (
-              <IconButton name="trash" onClick={handleDelete} title={`Delete sharing for ${title}`} />
+              <IconButton name="trash" onClick={handleDelete} title={`Remove sharing for ${title}`} />
             )}
           </Actions>
         </Container>

--- a/graylog2-web-interface/src/logic/permissions/GRN.js
+++ b/graylog2-web-interface/src/logic/permissions/GRN.js
@@ -1,0 +1,4 @@
+// @flow strict
+
+// eslint-disable-next-line import/prefer-default-export
+export const createGRN = (id: string, type: string) => `grn::::${type}:${id}`;


### PR DESCRIPTION
This PR contains the following improvements for the entity share modal:
- rename modal cancel button to "Discard changes'
- rename grantee delete button to "Remove sharing for user x"
- create separate file for GRN generation
- display page size select for grantees list, depending on grantees amount

