### PR TITLE
Use correct setting name for ES template target.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
@@ -45,6 +45,10 @@ public abstract class IndexMapping implements IndexMappingTemplate {
         final Map<String, Object> settings = ImmutableMap.of("analysis", analysis);
         final Map<String, Object> mappings = mapping(analyzer);
 
+        return createTemplate(template, order, settings, mappings);
+    }
+
+    Map<String, Object> createTemplate(String template, int order, Map<String, Object> settings, Map<String, Object> mappings) {
         return ImmutableMap.of(
                 "template", template,
                 "order", order,

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping7.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping7.java
@@ -33,4 +33,14 @@ public class IndexMapping7 extends IndexMapping {
                 "mapping", notAnalyzedString()
         );
     }
+
+    @Override
+    Map<String, Object> createTemplate(String template, int order, Map<String, Object> settings, Map<String, Object> mappings) {
+        return ImmutableMap.of(
+                "index_patterns", template,
+                "order", order,
+                "settings", settings,
+                "mappings", mappings
+        );
+    }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In ES7, the `template` field in an index mapping template is deprecated.
This results in these errors whenever a template is created for ES7:

```
2020-07-09 14:46:08,160 WARN : org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestClient - request [PUT http://localhost:33319/_template/graylog-test-internal?master_timeout=30s] returned 1 warnings: [299 Elasticsearch-7.8.0-757314695644ea9a1dc2fecd26d1a43856725e65 "Deprecated field [template] used, replaced by [index_patterns]"
```

This change is using the correct field name `index_patterns` instead.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.