### PR TITLE
Implement `CurrentUserContext` for `IfPermitted` and `Navigation` component

### DIFF
--- a/graylog2-web-interface/src/components/common/IfPermitted.jsx
+++ b/graylog2-web-interface/src/components/common/IfPermitted.jsx
@@ -1,17 +1,22 @@
+// @flow strict
+import * as React from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
-import React from 'react';
 
-import connect from 'stores/connect';
-import StoreProvider from 'injection/StoreProvider';
-import PermissionsMixin from 'util/PermissionsMixin';
-
-const CurrentUserStore = StoreProvider.getStore('CurrentUser');
-const { isPermitted, isAnyPermitted } = PermissionsMixin;
+import CurrentUserContext from 'contexts/CurrentUserContext';
+import { isPermitted, isAnyPermitted } from 'util/PermissionsMixin';
 
 /**
  * Wrapper component that renders its children only if the current user fulfills certain permissions.
  * Current user's permissions are fetched from the server.
  */
+
+type Props = {
+  children: React.Node,
+  permissions: string | Array<string>,
+  anyPermissions?: boolean,
+};
+
 const _checkPermissions = (permissions, anyPermissions, currentUser) => {
   if (anyPermissions) {
     return isAnyPermitted(currentUser.permissions, permissions);
@@ -20,7 +25,9 @@ const _checkPermissions = (permissions, anyPermissions, currentUser) => {
   return isPermitted(currentUser.permissions, permissions);
 };
 
-const IfPermitted = ({ children, currentUser, permissions, anyPermissions, ...rest }) => {
+const IfPermitted = ({ children, permissions, anyPermissions, ...rest }: Props) => {
+  const currentUser = useContext(CurrentUserContext);
+
   if ((!permissions || permissions.length === 0) || (currentUser && _checkPermissions(permissions, anyPermissions, currentUser))) {
     return React.Children.map(children, (child) => {
       if (React.isValidElement(child)) {
@@ -57,4 +64,4 @@ IfPermitted.defaultProps = {
 };
 
 /** @component */
-export default connect(IfPermitted, { currentUser: CurrentUserStore }, ({ currentUser }) => ({ currentUser: currentUser ? currentUser.currentUser : currentUser }));
+export default IfPermitted;

--- a/graylog2-web-interface/src/components/common/IfPermitted.test.jsx
+++ b/graylog2-web-interface/src/components/common/IfPermitted.test.jsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { mount, shallow } from 'wrappedEnzyme';
 import { viewsManager } from 'fixtures/users';
 import mockComponent from 'helpers/mocking/MockComponent';
@@ -11,7 +10,7 @@ import IfPermitted from './IfPermitted';
 jest.mock('stores/connect', () => (x) => x);
 jest.mock('injection/StoreProvider', () => ({ getStore: () => {} }));
 
-describe('SimpleIfPermitted', () => {
+describe('IfPermitted', () => {
   let element;
 
   // We can't use prop types here, they don't work well together with mount and require
@@ -30,7 +29,7 @@ describe('SimpleIfPermitted', () => {
     let wrapper;
 
     afterEach(() => {
-      expect(wrapper.find('SimpleIfPermitted')).toBeEmptyRender();
+      expect(wrapper.find('IfPermitted')).toBeEmptyRender();
     });
 
     it('no user is present', () => {

--- a/graylog2-web-interface/src/components/common/IfPermitted.test.jsx
+++ b/graylog2-web-interface/src/components/common/IfPermitted.test.jsx
@@ -13,7 +13,7 @@ jest.mock('injection/StoreProvider', () => ({ getStore: () => {} }));
 describe('IfPermitted', () => {
   let element;
 
-  // We can't use prop types here, they don't work well together with mount and require
+  // We can't use prop types here, they are not compatible with mount and require in this case
   // eslint-disable-next-line react/prop-types
   const SimpleIfPermitted = ({ children, currentUser, ...props }) => (
     <CurrentUserContext.Provider value={{ ...viewsManager, ...currentUser }}>

--- a/graylog2-web-interface/src/components/common/IfPermitted.test.jsx
+++ b/graylog2-web-interface/src/components/common/IfPermitted.test.jsx
@@ -1,14 +1,26 @@
-import React from 'react';
+import * as React from 'react';
+import PropTypes from 'prop-types';
 import { mount, shallow } from 'wrappedEnzyme';
+import { viewsManager } from 'fixtures/users';
 import mockComponent from 'helpers/mocking/MockComponent';
+
+import CurrentUserContext from 'contexts/CurrentUserContext';
 
 import IfPermitted from './IfPermitted';
 
 jest.mock('stores/connect', () => (x) => x);
 jest.mock('injection/StoreProvider', () => ({ getStore: () => {} }));
 
-describe('IfPermitted', () => {
+describe('SimpleIfPermitted', () => {
   let element;
+
+  // We can't use prop types here, they don't work well together with mount and require
+  // eslint-disable-next-line react/prop-types
+  const SimpleIfPermitted = ({ children, currentUser, ...props }) => (
+    <CurrentUserContext.Provider value={{ ...viewsManager, ...currentUser }}>
+      <IfPermitted {...props}>{children}</IfPermitted>
+    </CurrentUserContext.Provider>
+  );
 
   beforeEach(() => {
     element = <p>Something!</p>;
@@ -18,78 +30,78 @@ describe('IfPermitted', () => {
     let wrapper;
 
     afterEach(() => {
-      expect(wrapper.find('IfPermitted')).toBeEmptyRender();
+      expect(wrapper.find('SimpleIfPermitted')).toBeEmptyRender();
     });
 
     it('no user is present', () => {
       wrapper = mount((
-        <IfPermitted permissions={['somepermission']}>
+        <SimpleIfPermitted permissions={['somepermission']}>
           {element}
-        </IfPermitted>
+        </SimpleIfPermitted>
       ));
     });
 
     it('user does not have permissions', () => {
       wrapper = mount((
-        <IfPermitted permissions={['somepermission']} currentUser={{}}>
+        <SimpleIfPermitted permissions={['somepermission']} currentUser={{}}>
           {element}
-        </IfPermitted>
+        </SimpleIfPermitted>
       ));
     });
 
     it('user has empty permissions', () => {
       wrapper = mount((
-        <IfPermitted permissions={['somepermission']} currentUser={{ permissions: [] }}>
+        <SimpleIfPermitted permissions={['somepermission']} currentUser={{ permissions: [] }}>
           {element}
-        </IfPermitted>
+        </SimpleIfPermitted>
       ));
     });
 
     it('user has undefined permissions', () => {
       wrapper = mount((
-        <IfPermitted permissions={['somepermission']} currentUser={{ permissions: undefined }}>
+        <SimpleIfPermitted permissions={['somepermission']} currentUser={{ permissions: undefined }}>
           {element}
-        </IfPermitted>
+        </SimpleIfPermitted>
       ));
     });
 
     it('user has different permissions', () => {
       wrapper = mount((
-        <IfPermitted permissions={['somepermission']} currentUser={{ permissions: ['someotherpermission'] }}>
+        <SimpleIfPermitted permissions={['somepermission']} currentUser={{ permissions: ['someotherpermission'] }}>
           {element}
-        </IfPermitted>
+        </SimpleIfPermitted>
       ));
     });
 
     it('user is missing one permission', () => {
       wrapper = mount((
-        <IfPermitted permissions={['somepermission', 'someotherpermission']} currentUser={{ permissions: ['someotherpermission'] }}>
+        <SimpleIfPermitted permissions={['somepermission', 'someotherpermission']} currentUser={{ permissions: ['someotherpermission'] }}>
           {element}
-        </IfPermitted>
+        </SimpleIfPermitted>
       ));
     });
 
     it('user is missing permission for specific id', () => {
       wrapper = mount((
-        <IfPermitted permissions={['entity:action:id']} currentUser={{ permissions: ['entity:action:otherid'] }}>
+        <SimpleIfPermitted permissions={['entity:action:id']} currentUser={{ permissions: ['entity:action:otherid'] }}>
           {element}
-        </IfPermitted>
+        </SimpleIfPermitted>
       ));
     });
 
     it('user has permission for different action', () => {
       wrapper = mount((
-        <IfPermitted permissions={['entity:action']} currentUser={{ permissions: ['entity:otheraction'] }}>
+        <SimpleIfPermitted permissions={['entity:action']} currentUser={{ permissions: ['entity:otheraction'] }}>
           {element}
-        </IfPermitted>
+        </SimpleIfPermitted>
       ));
     });
 
     it('user has permission for id only', () => {
       wrapper = mount((
-        <IfPermitted permissions={['entity:action']} currentUser={{ permissions: ['entity:action:id'] }}>
+        <SimpleIfPermitted permissions={['entity:action']} currentUser={{ permissions: ['entity:action:id'] }}>
           {element}
-        </IfPermitted>
+        </SimpleIfPermitted>
       ));
     });
   });
@@ -103,89 +115,89 @@ describe('IfPermitted', () => {
 
     it('empty permissions were passed', () => {
       wrapper = mount((
-        <IfPermitted permissions={[]} currentUser={{ permissions: [] }}>
+        <SimpleIfPermitted permissions={[]} currentUser={{ permissions: [] }}>
           {element}
-        </IfPermitted>
+        </SimpleIfPermitted>
       ));
     });
 
     it('empty permissions were passed and no user is present', () => {
       wrapper = mount((
-        <IfPermitted permissions={[]}>
+        <SimpleIfPermitted permissions={[]}>
           {element}
-        </IfPermitted>
+        </SimpleIfPermitted>
       ));
     });
 
     it('undefined permissions were passed and no user is present', () => {
       wrapper = mount((
-        <IfPermitted permissions={[]}>
+        <SimpleIfPermitted permissions={[]}>
           {element}
-        </IfPermitted>
+        </SimpleIfPermitted>
       ));
     });
 
     it('user has exact required permissions', () => {
       wrapper = mount((
-        <IfPermitted permissions={['something']} currentUser={{ permissions: ['something'] }}>
+        <SimpleIfPermitted permissions={['something']} currentUser={{ permissions: ['something'] }}>
           {element}
-        </IfPermitted>
+        </SimpleIfPermitted>
       ));
     });
 
     it('user has any exact required permission', () => {
       wrapper = mount((
-        <IfPermitted permissions={['something', 'someother']} currentUser={{ permissions: ['something'] }} anyPermissions>
+        <SimpleIfPermitted permissions={['something', 'someother']} currentUser={{ permissions: ['something'] }} anyPermissions>
           {element}
-        </IfPermitted>
+        </SimpleIfPermitted>
       ));
     });
 
     it('user has exact required permission for action with entity id', () => {
       wrapper = mount((
-        <IfPermitted permissions={['entity:action:id']} currentUser={{ permissions: ['entity:action:id'] }}>
+        <SimpleIfPermitted permissions={['entity:action:id']} currentUser={{ permissions: ['entity:action:id'] }}>
           {element}
-        </IfPermitted>
+        </SimpleIfPermitted>
       ));
     });
 
     it('user has wildcard permission', () => {
       wrapper = mount((
-        <IfPermitted permissions={['something']} currentUser={{ permissions: ['*'] }}>
+        <SimpleIfPermitted permissions={['something']} currentUser={{ permissions: ['*'] }}>
           {element}
-        </IfPermitted>
+        </SimpleIfPermitted>
       ));
     });
 
     it('user has wildcard permission for action', () => {
       wrapper = mount((
-        <IfPermitted permissions={['entity:action:id']} currentUser={{ permissions: ['entity:action'] }}>
+        <SimpleIfPermitted permissions={['entity:action:id']} currentUser={{ permissions: ['entity:action'] }}>
           {element}
-        </IfPermitted>
+        </SimpleIfPermitted>
       ));
     });
 
     it('user has wildcard permission for id', () => {
       wrapper = mount((
-        <IfPermitted permissions={['entity:action:id']} currentUser={{ permissions: ['entity:action:*'] }}>
+        <SimpleIfPermitted permissions={['entity:action:id']} currentUser={{ permissions: ['entity:action:*'] }}>
           {element}
-        </IfPermitted>
+        </SimpleIfPermitted>
       ));
     });
 
     it('user has wildcard permission for entity', () => {
       wrapper = mount((
-        <IfPermitted permissions={['entity:action']} currentUser={{ permissions: ['entity:*'] }}>
+        <SimpleIfPermitted permissions={['entity:action']} currentUser={{ permissions: ['entity:*'] }}>
           {element}
-        </IfPermitted>
+        </SimpleIfPermitted>
       ));
     });
 
     it('user has wildcard permission for entity when permission for id is required', () => {
       wrapper = mount((
-        <IfPermitted permissions={['entity:action:id']} currentUser={{ permissions: ['entity:*'] }}>
+        <SimpleIfPermitted permissions={['entity:action:id']} currentUser={{ permissions: ['entity:*'] }}>
           {element}
-        </IfPermitted>
+        </SimpleIfPermitted>
       ));
     });
   });

--- a/graylog2-web-interface/src/components/configurations/__snapshots__/UrlWhiteListConfig.test.jsx.snap
+++ b/graylog2-web-interface/src/components/configurations/__snapshots__/UrlWhiteListConfig.test.jsx.snap
@@ -156,14 +156,10 @@ exports[`UrlWhiteListConfig render the UrlWhiteListConfig component should creat
         </Table>
       </StyledComponent>
     </Table>
-    <ConnectStoresWrapper[IfPermitted] stores=currentUser
+    <IfPermitted
+      anyPermissions={false}
       permissions="urlwhitelist:write"
-    >
-      <IfPermitted
-        anyPermissions={false}
-        permissions="urlwhitelist:write"
-      />
-    </ConnectStoresWrapper[IfPermitted] stores=currentUser>
+    />
     <BootstrapModalForm
       bsSize="lg"
       cancelButtonText="Cancel"

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -1,18 +1,19 @@
+// @flow strict
+import * as React from 'react';
+import { useContext } from 'react';
 import PropTypes from 'prop-types';
-import React from 'react';
 import { withRouter } from 'react-router';
 import { LinkContainer } from 'react-router-bootstrap';
 import naturalSort from 'javascript-natural-sort';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
-import { Navbar, Nav, NavItem, NavDropdown } from 'components/graylog';
-import connect from 'stores/connect';
-import StoreProvider from 'injection/StoreProvider';
-import { isPermitted } from 'util/PermissionsMixin';
-import Routes from 'routing/Routes';
 import { appPrefixed } from 'util/URLUtils';
-import GlobalThroughput from 'components/throughput/GlobalThroughput';
 import { IfPermitted } from 'components/common';
+import { isPermitted } from 'util/PermissionsMixin';
+import { Navbar, Nav, NavItem, NavDropdown } from 'components/graylog';
+import CurrentUserContext from 'contexts/CurrentUserContext';
+import GlobalThroughput from 'components/throughput/GlobalThroughput';
+import Routes from 'routing/Routes';
 
 import UserMenu from './UserMenu';
 import HelpMenu from './HelpMenu';
@@ -24,8 +25,6 @@ import SystemMenu from './SystemMenu';
 import InactiveNavItem from './InactiveNavItem';
 import ScratchpadToggle from './ScratchpadToggle';
 import StyledNavbar from './Navigation.styles';
-
-const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
 const _isActive = (requestPath, prefix) => {
   return requestPath.indexOf(appPrefixed(prefix)) === 0;
@@ -61,7 +60,10 @@ const formatPluginRoute = (pluginRoute, permissions, location) => {
   return formatSinglePluginRoute(pluginRoute, true);
 };
 
-const Navigation = ({ permissions, fullName, location, loginName }) => {
+const Navigation = ({ location }) => {
+  const currentUser = useContext(CurrentUserContext);
+  const { permissions, username, full_name: fullName } = currentUser || {};
+
   const pluginExports = PluginStore.exports('navigation');
 
   if (!pluginExports.find((value) => value.description.toLowerCase() === 'enterprise')) {
@@ -128,7 +130,7 @@ const Navigation = ({ permissions, fullName, location, loginName }) => {
           </LinkContainer>
           <ScratchpadToggle />
           <HelpMenu active={_isActive(location.pathname, Routes.GETTING_STARTED)} />
-          <UserMenu fullName={fullName} loginName={loginName} />
+          <UserMenu fullName={fullName} loginName={username} />
         </Nav>
       </Navbar.Collapse>
     </StyledNavbar>
@@ -139,17 +141,6 @@ Navigation.propTypes = {
   location: PropTypes.shape({
     pathname: PropTypes.string.isRequired,
   }).isRequired,
-  loginName: PropTypes.string.isRequired,
-  fullName: PropTypes.string.isRequired,
-  permissions: PropTypes.arrayOf(PropTypes.string),
 };
 
-Navigation.defaultProps = {
-  permissions: undefined,
-};
-
-export default connect(
-  withRouter(Navigation),
-  { currentUser: CurrentUserStore },
-  ({ currentUser }) => ({ permissions: currentUser ? currentUser.currentUser.permissions : undefined }),
-);
+export default withRouter(Navigation);

--- a/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
@@ -1,10 +1,13 @@
-import React from 'react';
+import * as React from 'react';
+import PropTypes from 'prop-types';
 import { mount } from 'wrappedEnzyme';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import mockComponent from 'helpers/mocking/MockComponent';
+import { admin } from 'fixtures/users';
 
 import Routes from 'routing/Routes';
 import AppConfig from 'util/AppConfig';
+import CurrentUserContext from 'contexts/CurrentUserContext';
 
 jest.mock('./SystemMenu', () => mockComponent('SystemMenu'));
 jest.mock('./NavigationBrand', () => mockComponent('NavigationBrand'));
@@ -26,30 +29,32 @@ const findLink = (wrapper, title) => wrapper.find(`NavigationLink[description="$
 jest.mock('./DevelopmentHeaderBadge', () => () => <span />);
 
 describe('Navigation', () => {
-  let currentUser;
   let Navigation;
 
-  beforeEach(() => {
-    currentUser = { permissions: [] };
-    const CurrentUserStore = {
-      getInitialState: jest.fn(() => ({ currentUser })),
-      listen: jest.fn(),
-      get: jest.fn(),
-    };
+  // We can't use prop types here, they don't work well together with mount and require
+  // eslint-disable-next-line react/prop-types
+  const SimpleNavigation = ({ component: Component, permissions, ...props }) => (
+    <CurrentUserContext.Provider value={{ ...admin, permissions }}>
+      <Component {...props} />
+    </CurrentUserContext.Provider>
+  );
 
-    jest.doMock('injection/StoreProvider', () => ({ getStore: () => CurrentUserStore }));
+  SimpleNavigation.defaultProps = {
+    location: { pathname: '/' },
+    permissions: [],
+  };
+
+  beforeEach(() => {
     // eslint-disable-next-line global-require
     Navigation = require('./Navigation');
+    setTimeout(() => {}, 0);
   });
 
   describe('has common elements', () => {
     let wrapper;
 
     beforeEach(() => {
-      wrapper = mount(<Navigation permissions={[]}
-                                  fullName="Sam Lowry"
-                                  location={{ pathname: '/' }}
-                                  loginName="slowry" />);
+      wrapper = mount(<SimpleNavigation component={Navigation} />);
     });
 
     it('contains brand icon', () => {
@@ -63,8 +68,8 @@ describe('Navigation', () => {
     it('contains user menu including correct username', () => {
       const usermenu = wrapper.find('UserMenu');
 
-      expect(usermenu).toHaveProp('loginName', 'slowry');
-      expect(usermenu).toHaveProp('fullName', 'Sam Lowry');
+      expect(usermenu).toHaveProp('loginName', admin.username);
+      expect(usermenu).toHaveProp('fullName', admin.full_name);
     });
 
     it('contains help menu', () => {
@@ -108,66 +113,44 @@ describe('Navigation', () => {
     });
 
     it('contains top-level navigation element', () => {
-      const wrapper = mount(<Navigation permissions={[]}
-                                        fullName="Sam Lowry"
-                                        location={{ pathname: '/' }}
-                                        loginName="slowry" />);
+      const wrapper = mount(<SimpleNavigation component={Navigation} />);
 
       expect(findLink(wrapper, 'Perpetuum Mobile')).toExist();
     });
 
     it('prefix plugin navigation item paths with app prefix', () => {
       AppConfig.gl2AppPathPrefix.mockReturnValue('/my/crazy/prefix');
-      const wrapper = mount(<Navigation permissions={[]}
-                                        fullName="Sam Lowry"
-                                        location={{ pathname: '/' }}
-                                        loginName="slowry" />);
+      const wrapper = mount(<SimpleNavigation component={Navigation} />);
 
       expect(findLink(wrapper, 'Perpetuum Mobile')).toHaveProp('path', '/my/crazy/prefix/something');
     });
 
     it('does not contain navigation elements from plugins where permissions are missing', () => {
-      const wrapper = mount(<Navigation permissions={[]}
-                                        fullName="Sam Lowry"
-                                        location={{ pathname: '/' }}
-                                        loginName="slowry" />);
+      const wrapper = mount(<SimpleNavigation component={Navigation} />);
 
       expect(findLink(wrapper, 'Archives')).not.toExist();
     });
 
     it('contains restricted navigation elements from plugins if permissions are present', () => {
-      currentUser.permissions = ['archive:read'];
-      const wrapper = mount(<Navigation permissions={[]}
-                                        fullName="Sam Lowry"
-                                        location={{ pathname: '/' }}
-                                        loginName="slowry" />);
+      const wrapper = mount(<SimpleNavigation component={Navigation} permissions={['archive:read']} />);
 
       expect(findLink(wrapper, 'Archives')).toExist();
     });
 
     it('does not render dropdown contributed by plugin if permissions for all elements are missing', () => {
-      const wrapper = mount(<Navigation permissions={[]}
-                                        fullName="Sam Lowry"
-                                        location={{ pathname: '/' }}
-                                        loginName="slowry" />);
+      const wrapper = mount(<SimpleNavigation component={Navigation} />);
 
       expect(wrapper.find('NavDropdown[title="Neat Stuff"]')).not.toExist();
     });
 
     it('renders dropdown contributed by plugin if permissions are sufficient', () => {
-      currentUser.permissions = ['somethingelse', 'completelydifferent'];
-      const wrapper = mount(<Navigation fullName="Sam Lowry"
-                                        location={{ pathname: '/' }}
-                                        loginName="slowry" />);
+      const wrapper = mount(<SimpleNavigation component={Navigation} permissions={['somethingelse', 'completelydifferent']} />);
 
       expect(wrapper.find('NavDropdown[title="Neat Stuff"]')).toExist();
     });
 
     it('sets dropdown title based on match', () => {
-      currentUser.permissions = ['somethingelse', 'completelydifferent'];
-      const wrapper = mount(<Navigation fullName="Sam Lowry"
-                                        location={{ pathname: '/somethingelse' }}
-                                        loginName="slowry" />);
+      const wrapper = mount(<SimpleNavigation component={Navigation} location={{ pathname: '/somethingelse' }} permissions={['somethingelse', 'completelydifferent']} />);
 
       expect(wrapper.find('NavDropdown[title="Neat Stuff / Something Else"]')).toExist();
     });
@@ -175,8 +158,7 @@ describe('Navigation', () => {
 
   describe('uses correct permissions:', () => {
     const verifyPermissions = ({ permissions, count, links }) => {
-      currentUser.permissions = permissions;
-      const wrapper = mount(<Navigation location={{ pathname: '/' }} fullName="Sam Lowry" loginName="slowry" />);
+      const wrapper = mount(<SimpleNavigation component={Navigation} permissions={permissions} />);
       const navigationLinks = wrapper.find('NavItem');
 
       expect(navigationLinks).toHaveLength(count);

--- a/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import { mount } from 'wrappedEnzyme';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import mockComponent from 'helpers/mocking/MockComponent';
-import { admin } from 'fixtures/users';
+import { viewsManager } from 'fixtures/users';
 
 import Routes from 'routing/Routes';
 import AppConfig from 'util/AppConfig';
@@ -24,6 +23,7 @@ jest.mock('util/AppConfig', () => ({
   isFeatureEnabled: jest.fn(() => false),
 }));
 
+const currentUser = viewsManager;
 const findLink = (wrapper, title) => wrapper.find(`NavigationLink[description="${title}"]`);
 
 jest.mock('./DevelopmentHeaderBadge', () => () => <span />);
@@ -34,7 +34,7 @@ describe('Navigation', () => {
   // We can't use prop types here, they don't work well together with mount and require
   // eslint-disable-next-line react/prop-types
   const SimpleNavigation = ({ component: Component, permissions, ...props }) => (
-    <CurrentUserContext.Provider value={{ ...admin, permissions }}>
+    <CurrentUserContext.Provider value={{ ...currentUser, permissions }}>
       <Component {...props} />
     </CurrentUserContext.Provider>
   );
@@ -47,7 +47,6 @@ describe('Navigation', () => {
   beforeEach(() => {
     // eslint-disable-next-line global-require
     Navigation = require('./Navigation');
-    setTimeout(() => {}, 0);
   });
 
   describe('has common elements', () => {
@@ -68,8 +67,8 @@ describe('Navigation', () => {
     it('contains user menu including correct username', () => {
       const usermenu = wrapper.find('UserMenu');
 
-      expect(usermenu).toHaveProp('loginName', admin.username);
-      expect(usermenu).toHaveProp('fullName', admin.full_name);
+      expect(usermenu).toHaveProp('loginName', currentUser.username);
+      expect(usermenu).toHaveProp('fullName', currentUser.full_name);
     });
 
     it('contains help menu', () => {
@@ -132,7 +131,8 @@ describe('Navigation', () => {
     });
 
     it('contains restricted navigation elements from plugins if permissions are present', () => {
-      const wrapper = mount(<SimpleNavigation component={Navigation} permissions={['archive:read']} />);
+      const wrapper = mount(<SimpleNavigation component={Navigation}
+                                              permissions={['archive:read']} />);
 
       expect(findLink(wrapper, 'Archives')).toExist();
     });
@@ -144,13 +144,16 @@ describe('Navigation', () => {
     });
 
     it('renders dropdown contributed by plugin if permissions are sufficient', () => {
-      const wrapper = mount(<SimpleNavigation component={Navigation} permissions={['somethingelse', 'completelydifferent']} />);
+      const wrapper = mount(<SimpleNavigation component={Navigation}
+                                              permissions={['somethingelse', 'completelydifferent']} />);
 
       expect(wrapper.find('NavDropdown[title="Neat Stuff"]')).toExist();
     });
 
     it('sets dropdown title based on match', () => {
-      const wrapper = mount(<SimpleNavigation component={Navigation} location={{ pathname: '/somethingelse' }} permissions={['somethingelse', 'completelydifferent']} />);
+      const wrapper = mount(<SimpleNavigation component={Navigation}
+                                              location={{ pathname: '/somethingelse' }}
+                                              permissions={['somethingelse', 'completelydifferent']} />);
 
       expect(wrapper.find('NavDropdown[title="Neat Stuff / Something Else"]')).toExist();
     });
@@ -158,7 +161,8 @@ describe('Navigation', () => {
 
   describe('uses correct permissions:', () => {
     const verifyPermissions = ({ permissions, count, links }) => {
-      const wrapper = mount(<SimpleNavigation component={Navigation} permissions={permissions} />);
+      const wrapper = mount(<SimpleNavigation component={Navigation}
+                                              permissions={permissions} />);
       const navigationLinks = wrapper.find('NavItem');
 
       expect(navigationLinks).toHaveLength(count);

--- a/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
@@ -31,7 +31,7 @@ jest.mock('./DevelopmentHeaderBadge', () => () => <span />);
 describe('Navigation', () => {
   let Navigation;
 
-  // We can't use prop types here, they don't work well together with mount and require
+  // We can't use prop types here, they are not compatible with mount and require in this case
   // eslint-disable-next-line react/prop-types
   const SimpleNavigation = ({ component: Component, permissions, ...props }) => (
     <CurrentUserContext.Provider value={{ ...currentUser, permissions }}>

--- a/graylog2-web-interface/src/components/navigation/SystemMenu.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/SystemMenu.test.jsx
@@ -1,5 +1,9 @@
-import React from 'react';
+// @flow strict
+import * as React from 'react';
 import { mount } from 'wrappedEnzyme';
+import { admin } from 'fixtures/users';
+
+import CurrentUserContext from 'contexts/CurrentUserContext';
 
 import AppConfig from '../../util/AppConfig';
 
@@ -14,17 +18,9 @@ jest.mock('util/AppConfig', () => ({
 }));
 
 describe('SystemMenu', () => {
-  let currentUser;
   let exports;
 
   beforeEach(() => {
-    currentUser = { permissions: [] };
-    const CurrentUserStore = {
-      getInitialState: jest.fn(() => ({ currentUser })),
-      listen: jest.fn(),
-    };
-
-    jest.doMock('injection/StoreProvider', () => ({ getStore: () => CurrentUserStore }));
     exports = {};
 
     const PluginStore = { exports: jest.fn((key) => exports[key] || []) };
@@ -32,6 +28,17 @@ describe('SystemMenu', () => {
     jest.doMock('graylog-web-plugin/plugin', () => ({ PluginStore }));
     AppConfig.gl2AppPathPrefix = jest.fn(() => '');
   });
+
+  const SimpleSystemMenu = ({ permissions, component: Component, location }: { permissions?: Array<string>, component: any, location?: { pathname: string }}) => (
+    <CurrentUserContext.Provider value={{ ...admin, permissions: permissions ?? [] }}>
+      <Component location={location} />
+    </CurrentUserContext.Provider>
+  );
+
+  SimpleSystemMenu.defaultProps = {
+    permissions: [],
+    location: { pathname: '/' },
+  };
 
   describe('uses correct permissions:', () => {
     let SystemMenu;
@@ -42,8 +49,7 @@ describe('SystemMenu', () => {
     });
 
     const verifyPermissions = ({ permissions, count, links }) => {
-      currentUser.permissions = permissions;
-      const wrapper = mount(<SystemMenu location={{ pathname: '/' }} />);
+      const wrapper = mount(<SimpleSystemMenu component={SystemMenu} permissions={permissions} />);
       const navigationLinks = wrapper.find('NavigationLink');
 
       expect(navigationLinks).toHaveLength(count);
@@ -85,8 +91,7 @@ describe('SystemMenu', () => {
     });
 
     it('includes plugin item in system navigation', () => {
-      const wrapper = mount(<SystemMenu location={{ pathname: '/' }} />);
-
+      const wrapper = mount(<SimpleSystemMenu component={SystemMenu} />);
       containsLink(wrapper, 'Audit Log');
 
       expect(findLink(wrapper, 'Audit Log')).toHaveProp('path', '/system/auditlog');
@@ -94,23 +99,21 @@ describe('SystemMenu', () => {
     });
 
     it('includes plugin item in system navigation if required permissions are present', () => {
-      currentUser.permissions = ['inputs:create'];
-      const wrapper = mount(<SystemMenu location={{ pathname: '/' }} />);
+      const wrapper = mount(<SimpleSystemMenu component={SystemMenu} permissions={['inputs:create']} />);
 
       containsLink(wrapper, 'Audit Log');
       containsLink(wrapper, 'Licenses');
     });
 
     it('does not include plugin item in system navigation if required permissions are not present', () => {
-      currentUser.permissions = [];
-      const wrapper = mount(<SystemMenu location={{ pathname: '/' }} />);
+      const wrapper = mount(<SimpleSystemMenu component={SystemMenu} permissions={[]} />);
 
       expect(findLink(wrapper, 'Licenses')).not.toExist();
     });
 
     it('prefixes plugin path with current application path prefix', () => {
       AppConfig.gl2AppPathPrefix = jest.fn(() => '/my/fancy/prefix');
-      const wrapper = mount(<SystemMenu location={{ pathname: '/' }} />);
+      const wrapper = mount(<SimpleSystemMenu component={SystemMenu} />);
 
       expect(findLink(wrapper, 'Audit Log')).toHaveProp('path', '/my/fancy/prefix/system/auditlog');
     });
@@ -134,19 +137,19 @@ describe('SystemMenu', () => {
     });
 
     it('uses a default title if location is not matched', () => {
-      const wrapper = mount(<SystemMenu location={{ pathname: '/' }} />);
+      const wrapper = mount(<SimpleSystemMenu component={SystemMenu} />);
 
       expect(wrapper.find('NavDropdown').at(1)).toHaveProp('title', 'System');
     });
 
     it('uses a custom title if location is matched', () => {
-      const wrapper = mount(<SystemMenu location={{ pathname: '/system/overview' }} />);
+      const wrapper = mount(<SimpleSystemMenu component={SystemMenu} location={{ pathname: '/system/overview' }} />);
 
       expect(wrapper.find('NavDropdown').at(1)).toHaveProp('title', 'System / Overview');
     });
 
     it('uses a custom title for a plugin route if location is matched', () => {
-      const wrapper = mount(<SystemMenu location={{ pathname: '/system/licenses' }} />);
+      const wrapper = mount(<SimpleSystemMenu component={SystemMenu} location={{ pathname: '/system/licenses' }} />);
 
       expect(wrapper.find('NavDropdown').at(1)).toHaveProp('title', 'System / Licenses');
     });

--- a/graylog2-web-interface/src/routing/App.jsx
+++ b/graylog2-web-interface/src/routing/App.jsx
@@ -29,7 +29,7 @@ const ScrollToHint = styled.div(({ theme }) => css`
   background: ${chroma(theme.colors.brand.tertiary).alpha(0.8).css()};
 `);
 
-const App = ({ children, location }) => (
+const App = ({ children }) => (
   <CurrentUserContext.Consumer>
     {(currentUser) => {
       if (!currentUser) {
@@ -38,10 +38,7 @@ const App = ({ children, location }) => (
 
       return (
         <ScratchpadProvider loginName={currentUser.username}>
-          <Navigation requestPath={location.pathname}
-                      fullName={currentUser.full_name}
-                      loginName={currentUser.username}
-                      permissions={currentUser.permissions} />
+          <Navigation />
           <ScrollToHint id="scroll-to-hint">
             <Icon name="arrow-up" />
           </ScrollToHint>
@@ -62,7 +59,6 @@ App.propTypes = {
     PropTypes.arrayOf(PropTypes.element),
     PropTypes.element,
   ]).isRequired,
-  location: PropTypes.object.isRequired,
 };
 
 export default App;


### PR DESCRIPTION
_We need to merge the related enterprise PR first_

This PR implements the `CurrentUserContext` for the `IfPermitted` and `Navigation` component.

## Motivation and Context
We should replace the usage of `CurrentUserStore` step by step. Using the `CurrentUserContext` in `IfPermitted` makes is easier to test components which use `IfPermitted` and the `CurrentUserContext`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

