### PR TITLE
Remove superfluous es 5 test

### DIFF
--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/IndicesES6IT.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/IndicesES6IT.java
@@ -1,8 +1,6 @@
 package org.graylog.storage.elasticsearch6;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
-import org.graylog.storage.elasticsearch6.testing.ClientES6;
 import org.graylog.storage.elasticsearch6.testing.ElasticsearchInstanceES6;
 import org.graylog.testing.elasticsearch.ElasticsearchInstance;
 import org.graylog2.indexer.cluster.NodeAdapter;
@@ -11,13 +9,10 @@ import org.graylog2.indexer.indices.IndicesAdapter;
 import org.graylog2.indexer.indices.IndicesIT;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.Rule;
-import org.junit.Test;
 
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.graylog.storage.elasticsearch6.testing.TestUtils.jestClient;
-import static org.junit.Assume.assumeTrue;
 
 public class IndicesES6IT extends IndicesIT {
     @Rule
@@ -46,36 +41,5 @@ public class IndicesES6IT extends IndicesIT {
                 "template", indexWildcard,
                 "mappings", ImmutableMap.of(IndexMapping.TYPE_MESSAGE, mapping)
         );
-    }
-
-    @Test
-    public void testIndexTemplateCanBeOverridden_Elasticsearch5() {
-        assumeTrue(elasticsearchVersion().getMajorVersion() == 5);
-
-        final String testIndexName = "graylog_override_template";
-        final String customTemplateName = "custom-template";
-
-        // Create custom index template
-        final Map<String, Object> customMapping = ImmutableMap.of(
-                "_source", ImmutableMap.of("enabled", false),
-                "properties", ImmutableMap.of("source", ImmutableMap.of("type", "text")));
-        final Map<String, Object> templateSource = ImmutableMap.of(
-                "template", indexSet.getIndexWildcard(),
-                "order", 1,
-                "mappings", ImmutableMap.of(IndexMapping.TYPE_MESSAGE, customMapping)
-        );
-
-        client().putTemplate(customTemplateName, templateSource);
-
-        // Validate existing index templates
-        final JsonNode existingTemplate = ((ClientES6)client()).getTemplate(customTemplateName);
-        assertThat(existingTemplate.path(customTemplateName).isObject()).isTrue();
-
-        // Create index with custom template
-        indices.create(testIndexName, indexSet);
-        client().waitForGreenStatus(testIndexName);
-
-        assertThat(client().isSourceEnabled(testIndexName)).isFalse();
-        assertThat(client().fieldType(testIndexName, "source")).isEqualTo("text");
     }
 }

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ClientES6.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ClientES6.java
@@ -128,14 +128,6 @@ public class ClientES6 implements Client {
         return response.getJsonObject();
     }
 
-    public JsonNode getTemplate(String templateName) {
-        final GetTemplate templateRequest = new GetTemplate.Builder(templateName).build();
-        final JestResult templateResponse =
-                executeWithExpectedSuccess(templateRequest, "failed to get template " + templateName);
-
-        return templateResponse.getJsonObject();
-    }
-
     @Override
     public boolean templateExists(String templateName) {
         final GetTemplate templateRequest = new GetTemplate.Builder(templateName).build();
@@ -249,14 +241,6 @@ public class ClientES6 implements Client {
 
     private String[] metadataFieldNamesFor(JsonNode result, String templates) {
         return toArray(result.get("metadata").get(templates).fieldNames(), String.class);
-    }
-
-    @Override
-    public boolean isSourceEnabled(String testIndexName) {
-        final JsonNode indexMappings = getMapping(testIndexName);
-        final JsonNode mapping = indexMappings.path(testIndexName).path("mappings").path(IndexMapping.TYPE_MESSAGE);
-
-        return mapping.path("_source").path("enabled").asBoolean();
     }
 
     @Override

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ClientES7.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ClientES7.java
@@ -100,12 +100,6 @@ public class ClientES7 implements Client {
     }
 
     @Override
-    public boolean isSourceEnabled(String testIndexName) {
-        // TODO: implement
-        return true;
-    }
-
-    @Override
     public String fieldType(String testIndexName, String field) {
         return getMapping(testIndexName).get(field);
     }

--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/Client.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/Client.java
@@ -56,8 +56,6 @@ public interface Client {
 
     void cleanUp();
 
-    boolean isSourceEnabled(String testIndexName);
-
     String fieldType(String testIndexName, String source);
 
     void putSetting(String setting, String value);


### PR DESCRIPTION
## Description
Since we won't support ES 5 anymore after 4.0, we can remove this test.

## Motivation and Context
The test stood out, because it would only run for ES version 5, which would never happen after we bumped the default version for integration tests to 6.8. So we decided to remove it entirely.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

