### PR TITLE
Create a basic AuthzRole resource

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRoleDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRoleDTO.java
@@ -1,0 +1,77 @@
+package org.graylog.security.authzroles;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.value.AutoValue;
+import org.mongojack.Id;
+import org.mongojack.ObjectId;
+
+import javax.annotation.Nullable;
+import java.util.Set;
+
+@AutoValue
+@JsonDeserialize(builder = AuthzRoleDTO.Builder.class)
+public abstract class AuthzRoleDTO {
+
+    private static final String FIELD_ID = "id";
+    public static final String FIELD_NAME = "name";
+    public static final String FIELD_DESCRIPTION = "description";
+    private static final String FIELD_PERMISSIONS = "permissions";
+    private static final String FIELD_READ_ONLY = "read_only";
+
+    @Id
+    @ObjectId
+    @Nullable
+    @JsonProperty(FIELD_ID)
+    public abstract String id();
+
+    @JsonProperty(FIELD_NAME)
+    public abstract String name();
+
+    @JsonProperty(FIELD_DESCRIPTION)
+    public abstract String description();
+
+    @JsonProperty(FIELD_PERMISSIONS)
+    public abstract Set<String> permissions();
+
+    @JsonProperty(FIELD_READ_ONLY)
+    public abstract boolean readOnly();
+
+    public static Builder builder() {
+        return Builder.create();
+    }
+
+    public abstract Builder toBuilder();
+
+    @AutoValue.Builder
+    @JsonIgnoreProperties({"name_lower"})
+    public static abstract class Builder {
+
+        @JsonCreator
+        public static Builder create() {
+            return new AutoValue_AuthzRoleDTO.Builder();
+        }
+
+        @Id
+        @ObjectId
+        @JsonProperty(FIELD_ID)
+        public abstract Builder id(String id);
+
+        @JsonProperty(FIELD_NAME)
+        public abstract Builder name(String name);
+
+        @JsonProperty(FIELD_DESCRIPTION)
+        public abstract Builder description(String description);
+
+        @JsonProperty(FIELD_PERMISSIONS)
+        public abstract Builder permissions(Set<String> permissions);
+
+        @JsonProperty(FIELD_READ_ONLY)
+        public abstract Builder readOnly(boolean readOnly);
+
+        public abstract AuthzRoleDTO build();
+    }
+}
+

--- a/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRoleDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRoleDTO.java
@@ -80,7 +80,7 @@ public abstract class AuthzRoleDTO {
         public abstract Builder name(String name);
 
         @JsonProperty(FIELD_DESCRIPTION)
-        public abstract Builder description(String description);
+        public abstract Builder description(@Nullable String description);
 
         @JsonProperty(FIELD_PERMISSIONS)
         public abstract Builder permissions(Set<String> permissions);

--- a/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRoleDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRoleDTO.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.security.authzroles;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRoleDTO.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRoleDTO.java
@@ -47,6 +47,7 @@ public abstract class AuthzRoleDTO {
     public abstract String name();
 
     @JsonProperty(FIELD_DESCRIPTION)
+    @Nullable
     public abstract String description();
 
     @JsonProperty(FIELD_PERMISSIONS)
@@ -90,4 +91,3 @@ public abstract class AuthzRoleDTO {
         public abstract AuthzRoleDTO build();
     }
 }
-

--- a/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRolesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRolesResource.java
@@ -1,0 +1,104 @@
+package org.graylog.security.authzroles;
+
+import com.codahale.metrics.annotation.Timed;
+import com.google.common.collect.ImmutableMap;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.graylog2.database.PaginatedList;
+import org.graylog2.rest.models.PaginatedResponse;
+import org.graylog2.search.SearchQuery;
+import org.graylog2.search.SearchQueryField;
+import org.graylog2.search.SearchQueryParser;
+import org.graylog2.shared.rest.resources.RestResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.validation.constraints.NotEmpty;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+@RequiresAuthentication
+@Api(value = "AuthzRoles", description = "Read Roles")
+@Path("/authzRoles")
+public class AuthzRolesResource extends RestResource {
+    private static final Logger LOG = LoggerFactory.getLogger(AuthzRolesResource.class);
+
+
+    protected static final ImmutableMap<String, SearchQueryField> SEARCH_FIELD_MAPPING = ImmutableMap.<String, SearchQueryField>builder()
+            .put(AuthzRoleDTO.FIELD_NAME, SearchQueryField.create(AuthzRoleDTO.FIELD_NAME))
+            .put(AuthzRoleDTO.FIELD_DESCRIPTION, SearchQueryField.create(AuthzRoleDTO.FIELD_DESCRIPTION))
+            .build();
+
+    private final PaginatedAuthzRolesService authzRolesService;
+    private final SearchQueryParser searchQueryParser;
+
+    @Inject
+    public AuthzRolesResource(PaginatedAuthzRolesService authzRolesService) {
+        this.authzRolesService = authzRolesService;
+
+        this.searchQueryParser = new SearchQueryParser(AuthzRoleDTO.FIELD_NAME, SEARCH_FIELD_MAPPING);
+    }
+
+    @GET
+    @Timed
+    @ApiOperation(value = "Get a paginated list of all roles")
+    @Produces(MediaType.APPLICATION_JSON)
+    public PaginatedResponse<AuthzRoleDTO> getList(@ApiParam(name = "page") @QueryParam("page") @DefaultValue("1") int page,
+        @ApiParam(name = "per_page") @QueryParam("per_page") @DefaultValue("50") int perPage,
+        @ApiParam(name = "query") @QueryParam("query") @DefaultValue("") String query,
+        @ApiParam(name = "sort",
+                value = "The field to sort the result on",
+                required = true,
+                allowableValues = "name,description")
+        @DefaultValue(AuthzRoleDTO.FIELD_NAME) @QueryParam("sort") String sort,
+        @ApiParam(name = "order", value = "The sort direction", allowableValues = "asc, desc")
+        @DefaultValue("asc") @QueryParam("order") String order) {
+
+        SearchQuery searchQuery;
+        try {
+            searchQuery = searchQueryParser.parse(query);
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException("Invalid argument in search query: " + e.getMessage());
+        }
+
+        final PaginatedList<AuthzRoleDTO> result = authzRolesService.findPaginated(searchQuery, page, perPage,sort, order);
+        return PaginatedResponse.create("roles", result, query);
+    }
+
+    @GET
+    @ApiOperation(value = "Get a paginated list roles for a user")
+    @Path("/{username}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public PaginatedResponse<AuthzRoleDTO> getListForUser(
+        @ApiParam(name = "username") @PathParam("username") @NotEmpty String username,
+        @ApiParam(name = "page") @QueryParam("page") @DefaultValue("1") int page,
+        @ApiParam(name = "per_page") @QueryParam("per_page") @DefaultValue("50") int perPage,
+        @ApiParam(name = "query") @QueryParam("query") @DefaultValue("") String query,
+        @ApiParam(name = "sort",
+                value = "The field to sort the result on",
+                required = true,
+                allowableValues = "name,description")
+        @DefaultValue(AuthzRoleDTO.FIELD_NAME) @QueryParam("sort") String sort,
+        @ApiParam(name = "order", value = "The sort direction", allowableValues = "asc, desc")
+        @DefaultValue("asc") @QueryParam("order") String order) {
+
+        SearchQuery searchQuery;
+        try {
+            searchQuery = searchQueryParser.parse(query);
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException("Invalid argument in search query: " + e.getMessage());
+        }
+
+        final PaginatedList<AuthzRoleDTO> result = authzRolesService.findPaginatedForUser(searchQuery, page, perPage,sort, order, username);
+        return PaginatedResponse.create("roles", result, query);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRolesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRolesResource.java
@@ -22,14 +22,14 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
+import org.apache.shiro.authz.annotation.RequiresPermissions;
 import org.graylog2.database.PaginatedList;
 import org.graylog2.rest.models.PaginatedResponse;
 import org.graylog2.search.SearchQuery;
 import org.graylog2.search.SearchQueryField;
 import org.graylog2.search.SearchQueryParser;
 import org.graylog2.shared.rest.resources.RestResource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.graylog2.shared.security.RestPermissions;
 
 import javax.inject.Inject;
 import javax.validation.constraints.NotEmpty;
@@ -46,9 +46,6 @@ import javax.ws.rs.core.MediaType;
 @Api(value = "AuthzRoles", description = "Read Roles")
 @Path("/authzRoles")
 public class AuthzRolesResource extends RestResource {
-    private static final Logger LOG = LoggerFactory.getLogger(AuthzRolesResource.class);
-
-
     protected static final ImmutableMap<String, SearchQueryField> SEARCH_FIELD_MAPPING = ImmutableMap.<String, SearchQueryField>builder()
             .put(AuthzRoleDTO.FIELD_NAME, SearchQueryField.create(AuthzRoleDTO.FIELD_NAME))
             .put(AuthzRoleDTO.FIELD_DESCRIPTION, SearchQueryField.create(AuthzRoleDTO.FIELD_DESCRIPTION))
@@ -68,6 +65,7 @@ public class AuthzRolesResource extends RestResource {
     @Timed
     @ApiOperation(value = "Get a paginated list of all roles")
     @Produces(MediaType.APPLICATION_JSON)
+    @RequiresPermissions(RestPermissions.ROLES_READ)
     public PaginatedResponse<AuthzRoleDTO> getList(@ApiParam(name = "page") @QueryParam("page") @DefaultValue("1") int page,
         @ApiParam(name = "per_page") @QueryParam("per_page") @DefaultValue("50") int perPage,
         @ApiParam(name = "query") @QueryParam("query") @DefaultValue("") String query,
@@ -94,6 +92,7 @@ public class AuthzRolesResource extends RestResource {
     @ApiOperation(value = "Get a paginated list roles for a user")
     @Path("/{username}")
     @Produces(MediaType.APPLICATION_JSON)
+    @RequiresPermissions(RestPermissions.ROLES_READ)
     public PaginatedResponse<AuthzRoleDTO> getListForUser(
         @ApiParam(name = "username") @PathParam("username") @NotEmpty String username,
         @ApiParam(name = "page") @QueryParam("page") @DefaultValue("1") int page,

--- a/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRolesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRolesResource.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.security.authzroles;
 
 import com.codahale.metrics.annotation.Timed;

--- a/graylog2-server/src/main/java/org/graylog/security/authzroles/PaginatedAuthzRolesService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authzroles/PaginatedAuthzRolesService.java
@@ -1,0 +1,51 @@
+package org.graylog.security.authzroles;
+
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.database.PaginatedDbService;
+import org.graylog2.database.PaginatedList;
+import org.graylog2.plugin.database.users.User;
+import org.graylog2.search.SearchQuery;
+import org.graylog2.shared.users.UserService;
+import org.mongojack.DBQuery;
+import org.mongojack.DBSort;
+
+import javax.inject.Inject;
+import javax.ws.rs.NotFoundException;
+
+public class PaginatedAuthzRolesService extends PaginatedDbService<AuthzRoleDTO> {
+    private static final String COLLECTION_NAME = "roles";
+
+    private UserService userService;
+
+    @Inject
+    public PaginatedAuthzRolesService(MongoConnection mongoConnection,
+                                      UserService userService,
+                                      MongoJackObjectMapperProvider mapper) {
+        super(mongoConnection, mapper, AuthzRoleDTO.class, COLLECTION_NAME);
+        this.userService = userService;
+    }
+
+    public long count() {
+        return db.count();
+    }
+
+    public PaginatedList<AuthzRoleDTO> findPaginated(SearchQuery searchQuery, int page,
+                                                     int perPage, String sortField, String order) {
+        final DBQuery.Query dbQuery = searchQuery.toDBQuery();
+        final DBSort.SortBuilder sortBuilder = getSortBuilder(order, sortField);
+        return findPaginatedWithQueryAndSort(dbQuery, sortBuilder, page, perPage);
+    }
+
+    public PaginatedList<AuthzRoleDTO> findPaginatedForUser(SearchQuery searchQuery, int page,
+                                                     int perPage, String sortField, String order, String username) {
+        final User user = userService.load(username);
+        if (user == null) {
+            throw new NotFoundException("Could not find user: " + username);
+        }
+        final DBQuery.Query dbQuery = searchQuery.toDBQuery()
+                .in("_id", user.getRoleIds());
+        final DBSort.SortBuilder sortBuilder = getSortBuilder(order, sortField);
+        return findPaginatedWithQueryAndSort(dbQuery, sortBuilder, page, perPage);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/security/authzroles/PaginatedAuthzRolesService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authzroles/PaginatedAuthzRolesService.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.security.authzroles;
 
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;


### PR DESCRIPTION
Prior to this change, we did not have a paginated access
to all roles and to the roles of a user.

This change is adding a new resource which will query all
roles and the roles of a user.