### PR TITLE
Adding ES7 adapter for reopened indices migration.

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/Elasticsearch7Module.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/Elasticsearch7Module.java
@@ -3,12 +3,14 @@ package org.graylog.storage.elasticsearch7;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.binder.LinkedBindingBuilder;
 import org.graylog.events.search.MoreSearchAdapter;
+import org.graylog.storage.elasticsearch7.migrations.V20170607164210_MigrateReopenedIndicesToAliasesClusterStateES7;
 import org.graylog2.indexer.cluster.ClusterAdapter;
 import org.graylog2.indexer.cluster.NodeAdapter;
 import org.graylog2.indexer.counts.CountsAdapter;
 import org.graylog2.indexer.indices.IndicesAdapter;
 import org.graylog2.indexer.messages.MessagesAdapter;
 import org.graylog2.indexer.searches.SearchesAdapter;
+import org.graylog2.migrations.V20170607164210_MigrateReopenedIndicesToAliases;
 import org.graylog2.plugin.VersionAwareModule;
 
 import static org.graylog.storage.elasticsearch7.Elasticsearch7Plugin.SUPPORTED_ES_VERSION;
@@ -23,6 +25,7 @@ public class Elasticsearch7Module extends VersionAwareModule {
         bindForSupportedVersion(MoreSearchAdapter.class).to(MoreSearchAdapterES7.class);
         bindForSupportedVersion(NodeAdapter.class).to(NodeAdapterES7.class);
         bindForSupportedVersion(SearchesAdapter.class).to(SearchesAdapterES7.class);
+        bindForSupportedVersion(V20170607164210_MigrateReopenedIndicesToAliases.ClusterState.class).to(V20170607164210_MigrateReopenedIndicesToAliasesClusterStateES7.class);
 
         install(new FactoryModuleBuilder().build(ScrollResultES7.Factory.class));
     }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/cluster/ClusterStateApi.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/cluster/ClusterStateApi.java
@@ -38,8 +38,6 @@ public class ClusterStateApi {
             return objectMapper.readTree(response.getEntity().getContent());
         }, "Unable to retrieve fields from indices: " + String.join(",", indices));
 
-
-
         //noinspection UnstableApiUsage
         return Streams.stream(jsonResponse.path("metadata").path("indices").fields())
                 .flatMap(index -> allFieldsFromIndex(index.getKey(), index.getValue()))
@@ -68,5 +66,4 @@ public class ClusterStateApi {
 
         return new Request("GET", apiEndpoint.toString());
     }
-
 }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/migrations/V20170607164210_MigrateReopenedIndicesToAliasesClusterStateES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/migrations/V20170607164210_MigrateReopenedIndicesToAliasesClusterStateES7.java
@@ -1,0 +1,35 @@
+package org.graylog.storage.elasticsearch7.migrations;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.Request;
+import org.graylog.storage.elasticsearch7.PlainJsonApi;
+import org.graylog2.migrations.V20170607164210_MigrateReopenedIndicesToAliases;
+
+import javax.inject.Inject;
+import java.util.Collection;
+
+public class V20170607164210_MigrateReopenedIndicesToAliasesClusterStateES7 implements V20170607164210_MigrateReopenedIndicesToAliases.ClusterState {
+    private final PlainJsonApi plainJsonApi;
+
+    @Inject
+    public V20170607164210_MigrateReopenedIndicesToAliasesClusterStateES7(PlainJsonApi plainJsonApi) {
+        this.plainJsonApi = plainJsonApi;
+    }
+
+    @Override
+    public JsonNode getForIndices(Collection<String> indices) {
+        return plainJsonApi.perform(request(indices),
+                "Couldn't read cluster state for reopened indices " + indices);
+    }
+
+    private Request request(Collection<String> indices) {
+        final StringBuilder apiEndpoint = new StringBuilder("/_cluster/state/metadata");
+        if (!indices.isEmpty()) {
+            final String joinedIndices = String.join(",", indices);
+            apiEndpoint.append("/");
+            apiEndpoint.append(joinedIndices);
+        }
+
+        return new Request("GET", apiEndpoint.toString());
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20170607164210_MigrateReopenedIndicesToAliases.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20170607164210_MigrateReopenedIndicesToAliases.java
@@ -119,7 +119,7 @@ public class V20170607164210_MigrateReopenedIndicesToAliases extends Migration {
         final JsonNode settings;
         if (elasticsearchVersion.satisfies(">=2.1.0 & <5.0.0")) {
             settings = indexSettings;
-        } else if (elasticsearchVersion.satisfies("^5.0.0 | ^6.0.0")) {
+        } else if (elasticsearchVersion.satisfies("^5.0.0 | ^6.0.0 | ^7.0.0")) {
             settings = indexSettings.path("archived");
         } else {
             throw new ElasticsearchException("Unsupported Elasticsearch version: " + elasticsearchVersion);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In one of our migrations, we are using ES-specific code to determine reopened indices which need migration. We have extracted the ES-specifics into an interface that needs to be implemented by each storage driver module. This PR is adding it for the ES7 module.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.