### PR TITLE
Fixing remove alias action during deflector cycle for ES7.

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
@@ -350,8 +350,7 @@ public class IndicesAdapterES7 implements IndicesAdapter {
                 .index(targetIndex)
                 .alias(aliasName);
         final IndicesAliasesRequest.AliasActions removeAlias = new IndicesAliasesRequest.AliasActions(IndicesAliasesRequest.AliasActions.Type.REMOVE_INDEX)
-                .index(oldIndex)
-                .alias(aliasName);
+                .index(oldIndex);
         final IndicesAliasesRequest indicesAliasesRequest = new IndicesAliasesRequest()
                 .addAliasAction(removeAlias)
                 .addAliasAction(addAlias);

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
@@ -397,4 +397,20 @@ public abstract class IndicesIT extends ElasticsearchBaseTest {
 
         assertThat(indicesStats).isNotEmpty();
     }
+
+    @Test
+    public void cyclingDeflectorMovesAliasFromOldToNewTarget() {
+        final String deflector = "indices_it_deflector";
+
+        final String index1 = client().createRandomIndex("indices_it_");
+        final String index2 = client().createRandomIndex("indices_it_");
+
+        client().addAliasMapping(index1, deflector);
+
+        assertThat(indices.aliasTarget(deflector)).hasValue(index1);
+
+        indices.cycleAlias(deflector, index2, index1);
+
+        assertThat(indices.aliasTarget(deflector)).hasValue(index2);
+    }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, a disallowed parameter (alias) was used for remove alias actions during the deflector cycle on ES7. This change removes it and adds a test making sure that deflector cycling works for all storage driver modules.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.