### PR TITLE
Fix scroll arguments in old search resources

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/searches/Searches.java
@@ -103,10 +103,6 @@ public class Searches {
         return result;
     }
 
-    public ScrollResult scroll(String query, TimeRange range, int limit, int offset, List<String> fields, String filter) {
-        return scroll(query, range, limit, offset, fields, filter, ScrollCommand.NO_BATCHSIZE);
-    }
-
     public ScrollResult scroll(String query, TimeRange range, int limit, int offset, List<String> fields, String filter, int batchSize) {
         final Set<String> affectedIndices = determineAffectedIndices(range, filter);
         final Set<String> indexWildcards = indexSetRegistry.getForIndices(affectedIndices).stream()

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/AbsoluteSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/AbsoluteSearchResource.java
@@ -137,7 +137,7 @@ public class AbsoluteSearchResource extends SearchResource {
 
         final ScrollResult scroll = searches
                 .scroll(query, timeRange, limit, offset, fieldList, filter, batchSize);
-        return buildChunkedOutput(scroll, limit);
+        return buildChunkedOutput(scroll);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/AbsoluteSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/AbsoluteSearchResource.java
@@ -136,7 +136,7 @@ public class AbsoluteSearchResource extends SearchResource {
         final TimeRange timeRange = buildAbsoluteTimeRange(from, to);
 
         final ScrollResult scroll = searches
-                .scroll(query, timeRange, batchSize, offset, fieldList, filter);
+                .scroll(query, timeRange, limit, offset, fieldList, filter, batchSize);
         return buildChunkedOutput(scroll, limit);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/KeywordSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/KeywordSearchResource.java
@@ -131,7 +131,7 @@ public class KeywordSearchResource extends SearchResource {
 
         final ScrollResult scroll = searches
                 .scroll(query, timeRange, limit, offset, fieldList, filter, batchSize);
-        return buildChunkedOutput(scroll, limit);
+        return buildChunkedOutput(scroll);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/KeywordSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/KeywordSearchResource.java
@@ -130,7 +130,7 @@ public class KeywordSearchResource extends SearchResource {
         final TimeRange timeRange = buildKeywordTimeRange(keyword);
 
         final ScrollResult scroll = searches
-                .scroll(query, timeRange, batchSize, offset, fieldList, filter);
+                .scroll(query, timeRange, limit, offset, fieldList, filter, batchSize);
         return buildChunkedOutput(scroll, limit);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
@@ -135,7 +135,7 @@ public class RelativeSearchResource extends SearchResource {
 
         final ScrollResult scroll = searches
                 .scroll(query, timeRange, limit, offset, fieldList, filter, batchSize);
-        return buildChunkedOutput(scroll, limit);
+        return buildChunkedOutput(scroll);
     }
 
     @GET

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/search/RelativeSearchResource.java
@@ -134,7 +134,7 @@ public class RelativeSearchResource extends SearchResource {
         final TimeRange timeRange = buildRelativeTimeRange(range);
 
         final ScrollResult scroll = searches
-                .scroll(query, timeRange, batchSize, offset, fieldList, filter);
+                .scroll(query, timeRange, limit, offset, fieldList, filter, batchSize);
         return buildChunkedOutput(scroll, limit);
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/searches/SearchesIT.java
@@ -67,6 +67,7 @@ import java.util.SortedSet;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.graylog2.indexer.searches.ScrollCommand.NO_BATCHSIZE;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
@@ -492,7 +493,7 @@ public abstract class SearchesIT extends ElasticsearchBaseTest {
 
         when(indexSetRegistry.getForIndices(Collections.singleton("graylog_0"))).thenReturn(Collections.singleton(indexSet));
         final AbsoluteRange range = AbsoluteRange.create(new DateTime(2015, 1, 1, 0, 0, DateTimeZone.UTC).withZone(UTC), new DateTime(2015, 1, 2, 0, 0, DateTimeZone.UTC).withZone(UTC));
-        final ScrollResult scrollResult = searches.scroll("*", range, 5, 0, Collections.singletonList("source"), null);
+        final ScrollResult scrollResult = searches.scroll("*", range, 5, 0, Collections.singletonList("source"), null, NO_BATCHSIZE);
 
         assertThat(scrollResult).isNotNull();
         assertThat(scrollResult.getQueryHash()).isNotEmpty();


### PR DESCRIPTION
Fixes #8550 and gets rid of old code responsible for liimiting chunked results for scroll requests. This was made redundant by #8488, which implemented a more precise limiting in the Elasticsearch adapter code.

In order to test this, #8580 should be merged first.