### PR TITLE
Add missing semicolon for sidebar content column styling.

### DIFF
--- a/graylog2-web-interface/src/views/components/sidebar/ContentColumn.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/ContentColumn.jsx
@@ -21,7 +21,7 @@ type Props = {
 };
 
 export const Container: StyledComponent<{ sidebarIsPinned: boolean }, ThemeInterface, HTMLDivElement> = styled.div(({ theme, sidebarIsPinned }) => css`
-  position: ${sidebarIsPinned ? 'static' : 'fixed'}
+  position: ${sidebarIsPinned ? 'static' : 'fixed'};
   display: grid;
   display: -ms-grid;
   grid-template-columns: 1fr;


### PR DESCRIPTION
The sidebar content column height is currently broken, due to a missing semicolon.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)