### PR TITLE
Manage singleton for RestHighLevelClient

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/Elasticsearch7Module.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/Elasticsearch7Module.java
@@ -3,6 +3,7 @@ package org.graylog.storage.elasticsearch7;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.binder.LinkedBindingBuilder;
 import org.graylog.events.search.MoreSearchAdapter;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient;
 import org.graylog.storage.elasticsearch7.migrations.V20170607164210_MigrateReopenedIndicesToAliasesClusterStateES7;
 import org.graylog2.indexer.cluster.ClusterAdapter;
 import org.graylog2.indexer.cluster.NodeAdapter;
@@ -30,6 +31,8 @@ public class Elasticsearch7Module extends VersionAwareModule {
         bindForSupportedVersion(V20170607164210_MigrateReopenedIndicesToAliases.ClusterState.class).to(V20170607164210_MigrateReopenedIndicesToAliasesClusterStateES7.class);
 
         install(new FactoryModuleBuilder().build(ScrollResultES7.Factory.class));
+
+        bind(RestHighLevelClient.class).toProvider(RestHighLevelClientProvider.class);
     }
 
     private <T> LinkedBindingBuilder<T> bindForSupportedVersion(Class<T> interfaceClass) {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchClient.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ElasticsearchClient.java
@@ -1,24 +1,16 @@
 package org.graylog.storage.elasticsearch7;
 
-import com.github.joschi.jadconfig.util.Duration;
-import org.graylog.shaded.elasticsearch7.org.apache.http.HttpHost;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.ElasticsearchException;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.MultiSearchRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.MultiSearchResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.search.SearchResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RequestOptions;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestClient;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestClientBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient;
 import org.graylog2.indexer.IndexNotFoundException;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
-import javax.inject.Named;
 import java.io.IOException;
-import java.net.URI;
-import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -26,31 +18,8 @@ public class ElasticsearchClient {
     private final RestHighLevelClient client;
 
     @Inject
-    public ElasticsearchClient(@Named("elasticsearch_hosts") List<URI> elasticsearchHosts,
-                               @Named("elasticsearch_connect_timeout") Duration elasticsearchConnectTimeout,
-                               @Named("elasticsearch_socket_timeout") Duration elasticsearchSocketTimeout,
-                               @Named("elasticsearch_idle_timeout") Duration elasticsearchIdleTimeout,
-                               @Named("elasticsearch_max_total_connections") int elasticsearchMaxTotalConnections,
-                               @Named("elasticsearch_max_total_connections_per_route") int elasticsearchMaxTotalConnectionsPerRoute,
-                               @Named("elasticsearch_max_retries") int elasticsearchMaxRetries,
-                               @Named("elasticsearch_discovery_enabled") boolean discoveryEnabled,
-                               @Named("elasticsearch_discovery_filter") @Nullable String discoveryFilter,
-                               @Named("elasticsearch_discovery_frequency") Duration discoveryFrequency,
-                               @Named("elasticsearch_discovery_default_scheme") String defaultSchemeForDiscoveredNodes,
-                               @Named("elasticsearch_compression_enabled") boolean compressionEnabled) {
-        final HttpHost[] esHosts = elasticsearchHosts.stream().map(uri -> new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme())).toArray(HttpHost[]::new);
-
-        final RestClientBuilder restClientBuilder = RestClient.builder(esHosts)
-                .setRequestConfigCallback(requestConfig -> requestConfig
-                        .setConnectTimeout(Math.toIntExact(elasticsearchConnectTimeout.toMilliseconds()))
-                        .setSocketTimeout(Math.toIntExact(elasticsearchSocketTimeout.toMilliseconds()))
-                )
-                .setHttpClientConfigCallback(httpClientConfig -> httpClientConfig
-                        .setMaxConnTotal(elasticsearchMaxTotalConnections)
-                        .setMaxConnPerRoute(elasticsearchMaxTotalConnectionsPerRoute)
-                );
-
-        this.client = new RestHighLevelClient(restClientBuilder);
+    public ElasticsearchClient(RestHighLevelClient client) {
+        this.client = client;
     }
 
     public SearchResponse search(SearchRequest searchRequest, String errorMessage) {

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/RestHighLevelClientProvider.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/RestHighLevelClientProvider.java
@@ -5,40 +5,50 @@ import org.graylog.shaded.elasticsearch7.org.apache.http.HttpHost;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestClient;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestClientBuilder;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient;
+import org.graylog2.system.shutdown.GracefulShutdownService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
+import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 
 @Singleton
 public class RestHighLevelClientProvider implements Provider<RestHighLevelClient> {
 
+    private static final Logger LOG = LoggerFactory.getLogger(RestHighLevelClientProvider.class);
+
     private final RestHighLevelClient client;
 
     @SuppressWarnings("unused")
     @Inject
-    public RestHighLevelClientProvider(@Named("elasticsearch_hosts") List<URI> hosts,
-                                       @Named("elasticsearch_connect_timeout") Duration connectTimeout,
-                                       @Named("elasticsearch_socket_timeout") Duration socketTimeout,
-                                       @Named("elasticsearch_idle_timeout") Duration elasticsearchIdleTimeout,
-                                       @Named("elasticsearch_max_total_connections") int maxTotalConnections,
-                                       @Named("elasticsearch_max_total_connections_per_route") int maxTotalConnectionsPerRoute,
-                                       @Named("elasticsearch_max_retries") int elasticsearchMaxRetries,
-                                       @Named("elasticsearch_discovery_enabled") boolean discoveryEnabled,
-                                       @Named("elasticsearch_discovery_filter") @Nullable String discoveryFilter,
-                                       @Named("elasticsearch_discovery_frequency") Duration discoveryFrequency,
-                                       @Named("elasticsearch_discovery_default_scheme") String defaultSchemeForDiscoveredNodes,
-                                       @Named("elasticsearch_compression_enabled") boolean compressionEnabled) {
+    public RestHighLevelClientProvider(
+            GracefulShutdownService shutdownService,
+            @Named("elasticsearch_hosts") List<URI> hosts,
+            @Named("elasticsearch_connect_timeout") Duration connectTimeout,
+            @Named("elasticsearch_socket_timeout") Duration socketTimeout,
+            @Named("elasticsearch_idle_timeout") Duration elasticsearchIdleTimeout,
+            @Named("elasticsearch_max_total_connections") int maxTotalConnections,
+            @Named("elasticsearch_max_total_connections_per_route") int maxTotalConnectionsPerRoute,
+            @Named("elasticsearch_max_retries") int elasticsearchMaxRetries,
+            @Named("elasticsearch_discovery_enabled") boolean discoveryEnabled,
+            @Named("elasticsearch_discovery_filter") @Nullable String discoveryFilter,
+            @Named("elasticsearch_discovery_frequency") Duration discoveryFrequency,
+            @Named("elasticsearch_discovery_default_scheme") String defaultSchemeForDiscoveredNodes,
+            @Named("elasticsearch_compression_enabled") boolean compressionEnabled) {
         client = buildClient(
                 hosts,
                 connectTimeout,
                 socketTimeout,
                 maxTotalConnections,
                 maxTotalConnectionsPerRoute);
+
+        registerShutdownHook(shutdownService);
     }
 
     @Override
@@ -65,5 +75,15 @@ public class RestHighLevelClientProvider implements Provider<RestHighLevelClient
                 );
 
         return new RestHighLevelClient(restClientBuilder);
+    }
+
+    private void registerShutdownHook(GracefulShutdownService shutdownService) {
+        shutdownService.register(() -> {
+            try {
+                client.close();
+            } catch (IOException e) {
+                LOG.warn("Failed to close Elasticsearch RestHighLevelClient", e);
+            }
+        });
     }
 }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/RestHighLevelClientProvider.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/RestHighLevelClientProvider.java
@@ -1,0 +1,69 @@
+package org.graylog.storage.elasticsearch7;
+
+import com.github.joschi.jadconfig.util.Duration;
+import org.graylog.shaded.elasticsearch7.org.apache.http.HttpHost;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestClient;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestClientBuilder;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import java.net.URI;
+import java.util.List;
+
+@Singleton
+public class RestHighLevelClientProvider implements Provider<RestHighLevelClient> {
+
+    private final RestHighLevelClient client;
+
+    @SuppressWarnings("unused")
+    @Inject
+    public RestHighLevelClientProvider(@Named("elasticsearch_hosts") List<URI> hosts,
+                                       @Named("elasticsearch_connect_timeout") Duration connectTimeout,
+                                       @Named("elasticsearch_socket_timeout") Duration socketTimeout,
+                                       @Named("elasticsearch_idle_timeout") Duration elasticsearchIdleTimeout,
+                                       @Named("elasticsearch_max_total_connections") int maxTotalConnections,
+                                       @Named("elasticsearch_max_total_connections_per_route") int maxTotalConnectionsPerRoute,
+                                       @Named("elasticsearch_max_retries") int elasticsearchMaxRetries,
+                                       @Named("elasticsearch_discovery_enabled") boolean discoveryEnabled,
+                                       @Named("elasticsearch_discovery_filter") @Nullable String discoveryFilter,
+                                       @Named("elasticsearch_discovery_frequency") Duration discoveryFrequency,
+                                       @Named("elasticsearch_discovery_default_scheme") String defaultSchemeForDiscoveredNodes,
+                                       @Named("elasticsearch_compression_enabled") boolean compressionEnabled) {
+        client = buildClient(
+                hosts,
+                connectTimeout,
+                socketTimeout,
+                maxTotalConnections,
+                maxTotalConnectionsPerRoute);
+    }
+
+    @Override
+    public RestHighLevelClient get() {
+        return client;
+    }
+
+    private RestHighLevelClient buildClient(
+            List<URI> hosts,
+            Duration connectTimeout,
+            Duration socketTimeout,
+            int maxTotalConnections,
+            int maxTotalConnectionsPerRoute) {
+        final HttpHost[] esHosts = hosts.stream().map(uri -> new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme())).toArray(HttpHost[]::new);
+
+        final RestClientBuilder restClientBuilder = RestClient.builder(esHosts)
+                .setRequestConfigCallback(requestConfig -> requestConfig
+                        .setConnectTimeout(Math.toIntExact(connectTimeout.toMilliseconds()))
+                        .setSocketTimeout(Math.toIntExact(socketTimeout.toMilliseconds()))
+                )
+                .setHttpClientConfigCallback(httpClientConfig -> httpClientConfig
+                        .setMaxConnTotal(maxTotalConnections)
+                        .setMaxConnPerRoute(maxTotalConnectionsPerRoute)
+                );
+
+        return new RestHighLevelClient(restClientBuilder);
+    }
+}

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ElasticsearchInstanceES7.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ElasticsearchInstanceES7.java
@@ -4,6 +4,7 @@ import com.github.joschi.jadconfig.util.Duration;
 import com.github.zafarkhaja.semver.Version;
 import com.google.common.collect.ImmutableList;
 import org.graylog.storage.elasticsearch7.ElasticsearchClient;
+import org.graylog.storage.elasticsearch7.RestHighLevelClientProvider;
 import org.graylog.testing.elasticsearch.Client;
 import org.graylog.testing.elasticsearch.ElasticsearchInstance;
 import org.graylog.testing.elasticsearch.FixtureImporter;
@@ -30,7 +31,7 @@ public class ElasticsearchInstanceES7 extends ElasticsearchInstance {
     }
 
     private ElasticsearchClient elasticsearchClientFrom(ElasticsearchContainer container) {
-        return new ElasticsearchClient(
+        final RestHighLevelClientProvider clientProvider = new RestHighLevelClientProvider(
                 ImmutableList.of(URI.create("http://" + container.getHttpHostAddress())),
                 Duration.seconds(60),
                 Duration.seconds(60),
@@ -42,8 +43,9 @@ public class ElasticsearchInstanceES7 extends ElasticsearchInstance {
                 null,
                 Duration.seconds(60),
                 "http",
-                false
-        );
+                false);
+
+        return new ElasticsearchClient(clientProvider.get());
     }
 
     public static ElasticsearchInstanceES7 create() {

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ElasticsearchInstanceES7.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ElasticsearchInstanceES7.java
@@ -8,12 +8,15 @@ import org.graylog.storage.elasticsearch7.RestHighLevelClientProvider;
 import org.graylog.testing.elasticsearch.Client;
 import org.graylog.testing.elasticsearch.ElasticsearchInstance;
 import org.graylog.testing.elasticsearch.FixtureImporter;
+import org.graylog2.system.shutdown.GracefulShutdownService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Network;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 import java.net.URI;
+
+import static org.mockito.Mockito.mock;
 
 public class ElasticsearchInstanceES7 extends ElasticsearchInstance {
     private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchInstanceES7.class);
@@ -32,6 +35,7 @@ public class ElasticsearchInstanceES7 extends ElasticsearchInstance {
 
     private ElasticsearchClient elasticsearchClientFrom(ElasticsearchContainer container) {
         final RestHighLevelClientProvider clientProvider = new RestHighLevelClientProvider(
+                mock(GracefulShutdownService.class),
                 ImmutableList.of(URI.create("http://" + container.getHttpHostAddress())),
                 Duration.seconds(60),
                 Duration.seconds(60),


### PR DESCRIPTION
## Description
Before this PR every instance of `ElasticsearchClient` constructed its own instance of `RestHighLevelClient`. This PR changes that so that `ElasticsearchClient` doesn't have to care about how to construct `RestHighLevelClient`, let alone manage its  lifecycle. Instead a Guice provider was added that is managed as a singleton. That provider also registers a hook on `GracefulShutdownService` to close the client when the server shuts down.

## Motivation and Context
`RestHighLevelClient` should be closed when it's not needed anymore. See https://www.elastic.co/guide/en/elasticsearch/client/java-rest/master/java-rest-high-getting-started-initialization.html
Since it's thread safe and its underlying low level client manages a connection pool, we should only have one instance of it to optimize performance.

## How Has This Been Tested?
Debugged on local instance.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


