### PR TITLE
Fix `Field` component usage for `MessageTable` head (3.3)

### DIFF
--- a/graylog2-web-interface/src/views/components/Field.jsx
+++ b/graylog2-web-interface/src/views/components/Field.jsx
@@ -30,17 +30,7 @@ const Field = ({ children, disabled = false, menuContainer, name, queryId, type 
           {name} = {type.type}
         </FieldActions>
       )
-      : (
-        <span>
-          {name}
-          {children && (
-            <>
-              {' '}
-              {children}
-            </>
-          )}
-        </span>
-      ))}
+      : <span>{children}</span>)}
   </InteractiveContext.Consumer>
 );
 

--- a/graylog2-web-interface/src/views/components/Field.test.jsx
+++ b/graylog2-web-interface/src/views/components/Field.test.jsx
@@ -8,34 +8,38 @@ import InteractiveContext from './contexts/InteractiveContext';
 
 describe('Field', () => {
   describe('handles value action menu depending on interactive context', () => {
-    const component = (interactive) => (props) => (
+    const component = (interactive) => ({ children, ...props }) => (
       <InteractiveContext.Provider value={interactive}>
-        <Field {...props} />
+        <Field {...props}>
+          {children}
+        </Field>
       </InteractiveContext.Provider>
     );
-    it('does not show value actions for field if interactive context is `false`', () => {
+    it('does not show value actions if interactive context is `false`', () => {
       const NoninteractiveComponent = component(false);
-      const wrapper = mount(
-        <NoninteractiveComponent name="Field name"
+      const wrapper = mount((
+        <NoninteractiveComponent name="foo"
                                  queryId="someQueryId"
                                  type={FieldType.Unknown}>
-          Field options like sorting
-        </NoninteractiveComponent>,
-      );
+          Foo
+        </NoninteractiveComponent>
+      ));
       const fieldActions = wrapper.find('FieldActions');
       expect(fieldActions).not.toExist();
-      expect(wrapper).toHaveText('Field name Field options like sorting');
+      expect(wrapper).toHaveText('Foo');
     });
-    it('shows value actions for field if interactive context is `true`', () => {
+    it('shows value actions if interactive context is `true`', () => {
       const InteractiveComponent = component(true);
-      const wrapper = mount(
-        <InteractiveComponent name="Field name"
+      const wrapper = mount((
+        <InteractiveComponent name="foo"
                               queryId="someQueryId"
-                              type={FieldType.Unknown} />,
-      );
+                              type={FieldType.Unknown}>
+          Foo
+        </InteractiveComponent>
+      ));
       const fieldActions = wrapper.find('FieldActions');
       expect(fieldActions).toExist();
-      expect(wrapper).toHaveText('Field name');
+      expect(wrapper).toHaveText('Foo');
     });
   });
 });

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.jsx
@@ -248,7 +248,9 @@ class MessageTable extends React.Component<Props, State> {
                       style={this._columnStyle(selectedFieldName)}>
                     <Field type={this._fieldTypeFor(selectedFieldName, fields)}
                            name={selectedFieldName}
-                           queryId={activeQueryId} />
+                           queryId={activeQueryId}>
+                      {selectedFieldName}
+                    </Field>
                     {editing && (
                       <FieldSortIcon fieldName={selectedFieldName}
                                      onSortChange={onSortChange}

--- a/graylog2-web-interface/src/views/components/widgets/MessageTable.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/MessageTable.test.jsx
@@ -8,6 +8,8 @@ import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import FieldType from 'views/logic/fieldtypes/FieldType';
 import MessagesWidgetConfig from 'views/logic/widgets/MessagesWidgetConfig';
 import MessageTable from './MessageTable';
+
+import InteractiveContext from '../contexts/InteractiveContext';
 import HighlightMessageContext from '../contexts/HighlightMessageContext';
 
 const messages = [
@@ -79,6 +81,26 @@ describe('MessageTable', () => {
                                         selectedFields={Immutable.Set()}
                                         setLoadingState={() => {}}
                                         messages={messages} />);
+
+    const tableHeadFields = wrapper.find('Field').map((field) => field.text());
+
+    expect(tableHeadFields).toEqual(configFields);
+  });
+
+  it('renders config fields in table head in non interactive mode', () => {
+    const configFields = ['gl2_receive_timestamp', 'user_id', 'gl2_source_input'];
+    const configWithFields = MessagesWidgetConfig.builder().fields(configFields).build();
+    const wrapper = mount(
+      <InteractiveContext.Provider value={false}>
+        <MessageTable activeQueryId={activeQueryId}
+                      config={configWithFields}
+                      fields={Immutable.List(fields)}
+                      onSortChange={() => Promise.resolve()}
+                      selectedFields={Immutable.Set()}
+                      setLoadingState={() => {}}
+                      messages={messages} />
+      </InteractiveContext.Provider>,
+    );
 
     const tableHeadFields = wrapper.find('Field').map((field) => field.text());
     expect(tableHeadFields).toEqual(configFields);


### PR DESCRIPTION
**Backport for 3.3 of #8570**

Before https://github.com/Graylog2/graylog2-server/pull/8385 the field names were not being displayed in the message table head, in the non interactive mode. The PR fixed the problem, but introduced a new bug, by displaying the field name twice under some circumstances. (https://github.com/Graylog2/graylog2-server/issues/8500, https://github.com/Graylog2/graylog2-server/issues/8483)

This PR reverts the previous `Field` component changes and fixes the `Field` component usage for the `MessageTable`.

Fixes: #8483

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

