### PR TITLE
Fix index stats retrieval for ES7.

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
@@ -303,9 +303,7 @@ public class IndicesAdapterES7 implements IndicesAdapter {
 
     @Override
     public JsonNode getIndexStats(Collection<String> indices) {
-        final JsonNode result = statsApi.indexStatsWithDocsAndStore(indices);
-
-        return result.path("indices");
+        return statsApi.indexStatsWithDocsAndStore(indices);
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
@@ -26,6 +26,7 @@ import org.graylog2.audit.NullAuditEventSender;
 import org.graylog2.indexer.IndexMappingFactory;
 import org.graylog2.indexer.IndexNotFoundException;
 import org.graylog2.indexer.IndexSet;
+import org.graylog2.indexer.IndexSetStatsCreator;
 import org.graylog2.indexer.TestIndexSet;
 import org.graylog2.indexer.cluster.Node;
 import org.graylog2.indexer.cluster.NodeAdapter;
@@ -40,6 +41,7 @@ import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategy;
 import org.graylog2.indexer.rotation.strategies.MessageCountRotationStrategyConfig;
 import org.graylog2.indexer.searches.IndexRangeStats;
 import org.graylog2.plugin.system.NodeId;
+import org.graylog2.rest.resources.system.indexer.responses.IndexSetStats;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Before;
@@ -58,6 +60,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public abstract class IndicesIT extends ElasticsearchBaseTest {
     private static final String INDEX_NAME = "graylog_0";
@@ -412,5 +415,22 @@ public abstract class IndicesIT extends ElasticsearchBaseTest {
         indices.cycleAlias(deflector, index2, index1);
 
         assertThat(indices.aliasTarget(deflector)).hasValue(index2);
+    }
+
+    @Test
+    public void retrievingIndexStatsForWildcard() {
+        final IndexSetStatsCreator indexSetStatsCreator = new IndexSetStatsCreator(indices);
+        final String indexPrefix = "indices_wildcard_";
+        final String wildcard = indexPrefix + "*";
+        final IndexSet indexSet = mock(IndexSet.class);
+        when(indexSet.getIndexWildcard()).thenReturn(wildcard);
+
+        client().createRandomIndex(indexPrefix);
+        client().createRandomIndex(indexPrefix);
+
+        final IndexSetStats indexSetStats = indexSetStatsCreator.getForIndexSet(indexSet);
+
+        assertThat(indexSetStats.indices()).isEqualTo(2L);
+        assertThat(indexSetStats.size()).isNotZero();
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is fixing retrieval of index stats and adds a test case for it. Index stats retrieval was broken, due to returning a json node that got prefixed to the `indices` key twice. This was noticed due to the index set stats page showing no indices.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.