### PR TITLE
Reflect that ScrollChunk was turned into an interface in ScrollChunkWriter#isWritable 

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/rest/ScrollChunkWriter.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/ScrollChunkWriter.java
@@ -44,7 +44,7 @@ public class ScrollChunkWriter implements MessageBodyWriter<ScrollResult.ScrollC
 
     @Override
     public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
-        return ScrollResult.ScrollChunk.class.equals(type) && MoreMediaTypes.TEXT_CSV_TYPE.isCompatible(mediaType);
+        return ScrollResult.ScrollChunk.class.isAssignableFrom(type) && MoreMediaTypes.TEXT_CSV_TYPE.isCompatible(mediaType);
 
     }
 


### PR DESCRIPTION
Since `ScrollChunk` is an interface now, `ScrollChunkWriter#isWritable` has to check, if the passed type *implements* `ScrollChunk` instead of checking that it *is* `ScrollChunk`

#8336 turned `ScrollChunk` into an interface, but we forgot to reflect that in `ScrollChunkWriter#isWritable`.