### PR TITLE
Bump shaded Elasticsearch version to avoid logging errors

### DIFF
--- a/graylog-storage-elasticsearch6/pom.xml
+++ b/graylog-storage-elasticsearch6/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <it.es.version>6.8.0</it.es.version>
-        <elasticsearch.version>5.6.12</elasticsearch.version>
+        <elasticsearch.version>5.6.16</elasticsearch.version>
         <jest.version>2.4.15+jackson</jest.version>
     </properties>
 

--- a/graylog-storage-elasticsearch7/pom.xml
+++ b/graylog-storage-elasticsearch7/pom.xml
@@ -17,8 +17,8 @@
     <description>Graylog Storage Module for Elasticsearch 7</description>
 
     <properties>
-        <it.es.version>7.6.2</it.es.version>
-        <elasticsearch.version>7.6.2</elasticsearch.version>
+        <it.es.version>7.8.0</it.es.version>
+        <elasticsearch.version>7.8.0</elasticsearch.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Description
This should include the latest version of the shaded dependencies from `graylog-shaded` and thus resolve the logging error described in #8509.

## Motivation and Context
`org.apache.logging` had been relocated in previous versions of `graylog-shaded`. This led to a logged error, because multiple instances of `org.apache.logging.log4j.LogManager` were configured. The configuration happens in a static constructor and due to the relocation we had multiple class definitions in multiple packages, which weren't properly configured.

The relocation was removed so that we should only have one properly configured `LogManager` again: https://github.com/Graylog2/graylog-shaded/pull/1.

## How Has This Been Tested?
Local setup

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


