### PR TITLE
Bump shaded Elasticsearch versions to avoid logging errors

### DIFF
--- a/graylog-storage-elasticsearch6/pom.xml
+++ b/graylog-storage-elasticsearch6/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <it.es.version>6.8.0</it.es.version>
-        <elasticsearch.version>5.6.12</elasticsearch.version>
+        <elasticsearch.version>5.6.16-0</elasticsearch.version>
         <jest.version>2.4.15+jackson</jest.version>
     </properties>
 

--- a/graylog-storage-elasticsearch6/pom.xml
+++ b/graylog-storage-elasticsearch6/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <it.es.version>6.8.0</it.es.version>
-        <elasticsearch.version>5.6.16-0</elasticsearch.version>
+        <elasticsearch.version>5.6.16-1</elasticsearch.version>
         <jest.version>2.4.15+jackson</jest.version>
     </properties>
 

--- a/graylog-storage-elasticsearch7/pom.xml
+++ b/graylog-storage-elasticsearch7/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <it.es.version>7.6.2</it.es.version>
-        <elasticsearch.version>7.8.0-0</elasticsearch.version>
+        <elasticsearch.version>7.8.0-1</elasticsearch.version>
     </properties>
 
     <dependencies>

--- a/graylog-storage-elasticsearch7/pom.xml
+++ b/graylog-storage-elasticsearch7/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <it.es.version>7.6.2</it.es.version>
-        <elasticsearch.version>7.6.2</elasticsearch.version>
+        <elasticsearch.version>7.8.0-0</elasticsearch.version>
     </properties>
 
     <dependencies>

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
@@ -26,7 +26,7 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.CloseI
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.CreateIndexRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.DeleteAliasRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.PutIndexTemplateRequest;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.cluster.metadata.AliasMetaData;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.query.QueryBuilders;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.index.reindex.ReindexRequest;
@@ -250,7 +250,7 @@ public class IndicesAdapterES7 implements IndicesAdapter {
                 .stream()
                 .collect(Collectors.toMap(
                         Map.Entry::getKey,
-                        entry -> entry.getValue().stream().map(AliasMetaData::alias).collect(Collectors.toSet())
+                        entry -> entry.getValue().stream().map(AliasMetadata::alias).collect(Collectors.toSet())
                 ));
     }
 

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ClientES7.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/testing/ClientES7.java
@@ -25,7 +25,7 @@ import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.Create
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.GetIndexRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.GetIndexTemplatesRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.GetIndexTemplatesResponse;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.IndexTemplateMetaData;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.IndexTemplateMetadata;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.PutIndexTemplateRequest;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.common.settings.Settings;
@@ -195,7 +195,7 @@ public class ClientES7 implements Client {
         final GetIndexTemplatesRequest getIndexTemplatesRequest = new GetIndexTemplatesRequest("*");
         final GetIndexTemplatesResponse result = client.execute((c, requestOptions) -> c.indices().getIndexTemplate(getIndexTemplatesRequest, requestOptions));
         return result.getIndexTemplates().stream()
-                .map(IndexTemplateMetaData::name)
+                .map(IndexTemplateMetadata::name)
                 .toArray(String[]::new);
     }
 


### PR DESCRIPTION
## Description
This should include the latest version of the shaded dependencies from `graylog-shaded` and thus resolve the logging error described in #8509.

## Motivation and Context
`org.apache.logging` had been relocated in previous versions of `graylog-shaded`. This led to a logged error, because multiple instances of `org.apache.logging.log4j.LogManager` were configured. The configuration happens in a static constructor and due to the relocation we had multiple class definitions in multiple packages, which weren't properly configured.

The relocation was removed so that we should only have one properly configured `LogManager` again: https://github.com/Graylog2/graylog-shaded/pull/1.

In addition we added a suffix to the shaded dependencies' version so that we can deploy new artifacts without bumping the underlying version for the shaded library.  

## How Has This Been Tested?
Local setup

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


