### PR TITLE
Rename missing_dependencies property in JSON response

### DIFF
--- a/graylog2-web-interface/src/logic/permissions/EntityShareState.fixtures.json
+++ b/graylog2-web-interface/src/logic/permissions/EntityShareState.fixtures.json
@@ -48,7 +48,7 @@
     "grn::::user:jane": "grn::::capability:54e3deadbeefdeadbeef0001",
     "grn::::team:security": "grn::::capability:54e3deadbeefdeadbeef0000"
   },
-  "missing_dependencies": {
+  "missing_permissions_on_dependencies": {
     "grn::::user:jane": [
       {
         "id": "grn::::stream:57bc9188e62a2373778d9e03",

--- a/graylog2-web-interface/src/logic/permissions/EntityShareState.js
+++ b/graylog2-web-interface/src/logic/permissions/EntityShareState.js
@@ -79,7 +79,7 @@ export type EntityShareStateJson = {|
   selected_grantee_capabilities: {|
     [grantee: $PropertyType<Grantee, 'id'>]: $PropertyType<Capability, 'id'>,
   |} | {||},
-  missing_dependencies: {[GRN]: Array<MissingDependencyType>},
+  missing_permissions_on_dependencies: {[GRN]: Array<MissingDependencyType>},
 |};
 
 export default class EntityShareState {
@@ -181,7 +181,7 @@ export default class EntityShareState {
       available_capabilities: availableCapabilities,
       active_shares: activeShares,
       selected_grantee_capabilities: selectedGranteeCapabilities,
-      missing_dependencies: missingDependencies,
+      missing_permissions_on_dependencies: missingDependencies,
     };
   }
 
@@ -193,7 +193,7 @@ export default class EntityShareState {
       available_capabilities,
       active_shares,
       selected_grantee_capabilities,
-      missing_dependencies,
+      missing_permissions_on_dependencies,
     } = value;
 
     const availableGrantees = Immutable.fromJS(available_grantees.map((ag) => Grantee.fromJSON(ag)));
@@ -201,7 +201,7 @@ export default class EntityShareState {
     const activeShares = Immutable.fromJS(active_shares.map((as) => ActiveShare.fromJSON(as)));
     const selectedGranteeCapabilities = Immutable.fromJS(selected_grantee_capabilities);
     const missingDependencies = Immutable.fromJS(
-      Object.entries(missing_dependencies).map(
+      Object.entries(missing_permissions_on_dependencies).map(
         ([granteeGRN, dependencyList]) => ({
           // $FlowFixMe: Object entries returns mixed value
           [granteeGRN]: dependencyList.map((dependency) => MissingDependency.fromJSON(dependency)),

--- a/graylog2-web-interface/src/logic/permissions/__snapshots__/EntityShareState.test.js.snap
+++ b/graylog2-web-interface/src/logic/permissions/__snapshots__/EntityShareState.test.js.snap
@@ -46,7 +46,7 @@ Object {
     },
   ],
   "entity": "grn::::dashboard:57bc9188e62a2373778d9e06",
-  "missing_dependencies": Immutable.List [
+  "missing_permissions_on_dependencies": Immutable.List [
     Immutable.Map {
       "grn::::user:jane": Immutable.List [
         Object {


### PR DESCRIPTION
## Motivation
Prior to this change, the JSON response of the prepare
request returned missing_permissions_on_dependencies,
but the JSON converter code still expected missing_dependcies.

## Description
This change will rename the JSON properties.
