### PR TITLE
Unconditionally include time range filter in created search for ES7.

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/SearchRequestFactory.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/SearchRequestFactory.java
@@ -53,17 +53,17 @@ public class SearchRequestFactory {
                 : queryStringQuery(query).allowLeadingWildcard(allowLeadingWildcardSearches);
 
         final Optional<BoolQueryBuilder> rangeQueryBuilder = searchCommand.range()
-                .map(range -> boolQuery()
-                        .must(TimeRangeQueryFactory.create(range)));
+                .map(TimeRangeQueryFactory::create)
+                .map(rangeQuery -> boolQuery().must(rangeQuery));
         final Optional<BoolQueryBuilder> filterQueryBuilder = searchCommand.filter()
                 .filter(filter -> !isWildcardQuery(filter))
                 .map(QueryBuilders::queryStringQuery)
-                .map(filter -> rangeQueryBuilder.orElse(boolQuery())
-                        .must(filter));
+                .map(queryStringQuery -> boolQuery().must(queryStringQuery));
 
         final BoolQueryBuilder filteredQueryBuilder = boolQuery()
                 .must(queryBuilder);
         filterQueryBuilder.ifPresent(filteredQueryBuilder::filter);
+        rangeQueryBuilder.ifPresent(filteredQueryBuilder::filter);
 
         applyStreamsFilter(filteredQueryBuilder, searchCommand);
 

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/SearchRequestFactoryTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/SearchRequestFactoryTest.java
@@ -2,11 +2,8 @@ package org.graylog.storage.elasticsearch7;
 
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.graylog2.indexer.searches.ScrollCommand;
-import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
-import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.graylog2.plugin.indexer.searches.timeranges.AbsoluteRange;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeUtils;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -22,18 +19,14 @@ class SearchRequestFactoryTest {
         this.searchRequestFactory = new SearchRequestFactory(new SortOrderMapper(), true, true);
     }
 
-    @AfterEach
-    public void tearDown() {
-        DateTimeUtils.setCurrentMillisSystem();
-    }
-
     @Test
-    void searchIncludesTimerange() throws InvalidRangeParametersException {
-        DateTimeUtils.setCurrentMillisFixed(DateTime.parse("2020-07-23T11:08:32.243Z").getMillis());
-
+    void searchIncludesTimerange() {
         final SearchSourceBuilder search = this.searchRequestFactory.create(ScrollCommand.builder()
                 .indices(Collections.singleton("graylog_0"))
-                .range(RelativeRange.create(300))
+                .range(AbsoluteRange.create(
+                        DateTime.parse("2020-07-23T11:03:32.243Z"),
+                        DateTime.parse("2020-07-23T11:08:32.243Z")
+                ))
                 .build());
 
         assertJsonPath(search, request -> {

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/SearchRequestFactoryTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/SearchRequestFactoryTest.java
@@ -1,0 +1,46 @@
+package org.graylog.storage.elasticsearch7;
+
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.graylog2.indexer.searches.ScrollCommand;
+import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
+import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.graylog2.utilities.AssertJsonPath.assertJsonPath;
+
+class SearchRequestFactoryTest {
+    private SearchRequestFactory searchRequestFactory;
+
+    @BeforeEach
+    void setUp() {
+        this.searchRequestFactory = new SearchRequestFactory(new SortOrderMapper(), true, true);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        DateTimeUtils.setCurrentMillisSystem();
+    }
+
+    @Test
+    void searchIncludesTimerange() throws InvalidRangeParametersException {
+        DateTimeUtils.setCurrentMillisFixed(DateTime.parse("2020-07-23T11:08:32.243Z").getMillis());
+
+        final SearchSourceBuilder search = this.searchRequestFactory.create(ScrollCommand.builder()
+                .indices(Collections.singleton("graylog_0"))
+                .range(RelativeRange.create(300))
+                .build());
+
+        assertJsonPath(search, request -> {
+            request.jsonPathAsListOf("$.query.bool.filter..range.timestamp.from", String.class)
+                    .containsExactly("2020-07-23 11:03:32.243");
+            request.jsonPathAsListOf("$.query.bool.filter..range.timestamp.to", String.class)
+                    .containsExactly("2020-07-23 11:08:32.243");
+        });
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/EventsIndexMappingTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/EventsIndexMappingTest.java
@@ -18,18 +18,10 @@ package org.graylog2.indexer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.zafarkhaja.semver.Version;
-import com.jayway.jsonpath.Configuration;
-import com.jayway.jsonpath.DocumentContext;
-import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.Option;
-import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
-import com.jayway.jsonpath.spi.json.JsonProvider;
-import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
-import com.jayway.jsonpath.spi.mapper.MappingProvider;
 import com.revinate.assertj.json.JsonPathAssert;
 import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
-import org.junit.BeforeClass;
+import org.graylog2.utilities.AssertJsonPath;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -37,9 +29,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -53,34 +43,8 @@ public class EventsIndexMappingTest {
 
     private static final ObjectMapper objectMapper = new ObjectMapperProvider().get();
 
-    @BeforeClass
-    public static void classSetUp() {
-        Configuration.setDefaults(new Configuration.Defaults() {
-            private final JsonProvider jsonProvider = new JacksonJsonProvider(objectMapper);
-            private final MappingProvider mappingProvider = new JacksonMappingProvider(objectMapper);
-
-            @Override
-            public JsonProvider jsonProvider() {
-                return jsonProvider;
-            }
-
-            @Override
-            public Set<Option> options() {
-                return EnumSet.noneOf(Option.class);
-            }
-
-            @Override
-            public MappingProvider mappingProvider() {
-                return mappingProvider;
-            }
-        });
-    }
-
     private void assertJsonPath(Map<String, Object> map, Consumer<JsonPathAssert> consumer) throws Exception {
-        final DocumentContext context = JsonPath.parse(objectMapper.writeValueAsString(map));
-        final JsonPathAssert jsonPathAssert = JsonPathAssert.assertThat(context);
-
-        consumer.accept(jsonPathAssert);
+        AssertJsonPath.assertJsonPath(objectMapper.writeValueAsString(map), consumer);
     }
 
     private void assertStandardMappingValues(JsonPathAssert at) {

--- a/graylog2-server/src/test/java/org/graylog2/utilities/AssertJsonPath.java
+++ b/graylog2-server/src/test/java/org/graylog2/utilities/AssertJsonPath.java
@@ -1,0 +1,48 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.utilities;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import com.revinate.assertj.json.JsonPathAssert;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+
+import java.util.function.Consumer;
+
+public class AssertJsonPath {
+    private static final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+    private static final Configuration configuration = Configuration.builder()
+            .mappingProvider(new JacksonMappingProvider(objectMapper))
+            .jsonProvider(new JacksonJsonProvider(objectMapper))
+            .build();
+
+
+    public static void assertJsonPath(Object obj, Consumer<JsonPathAssert> consumer) {
+        assertJsonPath(obj.toString(), consumer);
+    }
+
+    public static void assertJsonPath(String json, Consumer<JsonPathAssert> consumer) {
+        final DocumentContext context = JsonPath.parse(json, configuration);
+        final JsonPathAssert jsonPathAssert = JsonPathAssert.assertThat(context);
+
+        consumer.accept(jsonPathAssert);
+    }
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, a subtle bug was introduced by wrong optional chaining. The effect was that the time range was included in a created search only if the filter query string is present and not a wildcard.

This change is fixing that by streamlining filter creation and addition to the search source builder.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.