### PR TITLE
Add new creator roles

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/authzroles/BuiltinRole.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authzroles/BuiltinRole.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.security.authzroles;
 
 import com.google.auto.value.AutoValue;

--- a/graylog2-server/src/main/java/org/graylog/security/authzroles/BuiltinRole.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authzroles/BuiltinRole.java
@@ -1,0 +1,17 @@
+package org.graylog.security.authzroles;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.Set;
+
+@AutoValue
+public abstract class BuiltinRole {
+
+    public static BuiltinRole create(String name, String description, Set<String> permissions) {
+        return new AutoValue_BuiltinRole(name, description, permissions);
+    }
+
+    public abstract String name();
+    public abstract String description();
+    public abstract Set<String> permissions();
+}

--- a/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
@@ -46,5 +46,6 @@ public class MigrationsModule extends PluginModule {
         addMigration(V20191219090834_AddSourcesPage.class);
         addMigration(V20200102140000_UnifyEventSeriesId.class);
         addMigration(V20200226181600_EncryptAccessTokensMigration.class);
+        addMigration(V20200722110800_AddBuiltinRoles.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20200722110800_AddBuiltinRoles.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20200722110800_AddBuiltinRoles.java
@@ -1,0 +1,47 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.migrations;
+
+import org.graylog2.plugin.security.PluginPermissions;
+
+import javax.inject.Inject;
+import java.time.ZonedDateTime;
+import java.util.Set;
+
+public class V20200722110800_AddBuiltinRoles extends Migration {
+    private final MigrationHelpers helpers;
+    private final Set<PluginPermissions> pluginPermissions;
+
+    @Inject
+    public V20200722110800_AddBuiltinRoles(MigrationHelpers helpers,
+                                           Set<PluginPermissions> pluginPermissions) {
+        this.helpers = helpers;
+        this.pluginPermissions = pluginPermissions;
+    }
+
+    @Override
+    public ZonedDateTime createdAt() {
+        return ZonedDateTime.parse("2020-07-22T11:08:00Z");
+    }
+
+    @Override
+    public void upgrade() {
+        for (PluginPermissions permission: pluginPermissions) {
+            permission.builtinRoles().forEach(r -> helpers.ensureBuiltinRole(r.name(), r.description(), r.permissions()));
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/plugin/security/PluginPermissions.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/security/PluginPermissions.java
@@ -16,10 +16,21 @@
  */
 package org.graylog2.plugin.security;
 
+import com.google.common.collect.ImmutableSet;
+import org.graylog.security.authzroles.BuiltinRole;
+
 import java.util.Set;
 
 public interface PluginPermissions {
     Set<Permission> permissions();
 
     Set<Permission> readerBasePermissions();
+
+    /**
+     * A set of built-in roles that should be added to every graylog setup.
+     * @return The roles that this plugin provides
+     */
+    default Set<BuiltinRole> builtinRoles() {
+        return ImmutableSet.of();
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
@@ -115,9 +115,6 @@ public class RestPermissions implements PluginPermissions {
     public static final String ROLES_DELETE = "roles:delete";
     public static final String ROLES_EDIT = "roles:edit";
     public static final String ROLES_READ = "roles:read";
-    public static final String SAVEDSEARCHES_CREATE = "savedsearches:create";
-    public static final String SAVEDSEARCHES_EDIT = "savedsearches:edit";
-    public static final String SAVEDSEARCHES_READ = "savedsearches:read";
     public static final String SEARCHES_ABSOLUTE = "searches:absolute";
     public static final String SEARCHES_KEYWORD = "searches:keyword";
     public static final String SEARCHES_RELATIVE = "searches:relative";
@@ -237,9 +234,6 @@ public class RestPermissions implements PluginPermissions {
             .add(create(ROLES_DELETE, ""))
             .add(create(ROLES_EDIT, ""))
             .add(create(ROLES_READ, ""))
-            .add(create(SAVEDSEARCHES_CREATE, ""))
-            .add(create(SAVEDSEARCHES_EDIT, ""))
-            .add(create(SAVEDSEARCHES_READ, ""))
             .add(create(SEARCHES_ABSOLUTE, ""))
             .add(create(SEARCHES_KEYWORD, ""))
             .add(create(SEARCHES_RELATIVE, ""))
@@ -286,9 +280,6 @@ public class RestPermissions implements PluginPermissions {
             MESSAGES_ANALYZE,
             MESSAGES_READ,
             METRICS_READ,
-            SAVEDSEARCHES_CREATE,
-            SAVEDSEARCHES_EDIT,
-            SAVEDSEARCHES_READ,
             SYSTEM_READ,
             THROUGHPUT_READ
     ).build();

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
@@ -17,6 +17,7 @@
 package org.graylog2.shared.security;
 
 import com.google.common.collect.ImmutableSet;
+import org.graylog.security.authzroles.BuiltinRole;
 import org.graylog2.plugin.security.Permission;
 import org.graylog2.plugin.security.PluginPermissions;
 
@@ -288,6 +289,18 @@ public class RestPermissions implements PluginPermissions {
             .filter(permission -> READER_BASE_PERMISSION_SELECTION.contains(permission.permission()))
             .collect(Collectors.toSet());
 
+    protected static final ImmutableSet<BuiltinRole> BUILTIN_ROLES = ImmutableSet.<BuiltinRole>builder().add(
+            BuiltinRole.create("Dashboard Creator", "Allows creation of Dashboards (built-in)", ImmutableSet.of(
+                    RestPermissions.DASHBOARDS_CREATE
+            )),
+            BuiltinRole.create("Event Definition Creator", "Allows creation of Event Definitions (built-in)", ImmutableSet.of(
+                    RestPermissions.EVENT_DEFINITIONS_CREATE
+            )),
+            BuiltinRole.create("Event Notification Creator", "Allows creation of Event Notifications (built-in)", ImmutableSet.of(
+                    RestPermissions.EVENT_NOTIFICATIONS_CREATE
+            ))
+    ).build();
+
     @Override
     public Set<Permission> readerBasePermissions() {
         return READER_BASE_PERMISSIONS;
@@ -296,5 +309,10 @@ public class RestPermissions implements PluginPermissions {
     @Override
     public Set<Permission> permissions() {
         return PERMISSIONS;
+    }
+
+    @Override
+    public Set<BuiltinRole> builtinRoles() {
+        return BUILTIN_ROLES;
     }
 }


### PR DESCRIPTION
The new permissions system requires a way to
create entities, before they can be shared via grants.

These roles are meant to provide creation rights for
topics that are currently covered with the new grants system.