### PR TITLE
Improve naming

### DIFF
--- a/graylog2-web-interface/src/components/ldap/LdapComponent.jsx
+++ b/graylog2-web-interface/src/components/ldap/LdapComponent.jsx
@@ -416,7 +416,7 @@ class LdapComponent extends React.Component {
                            id="trust-all-certificates"
                            checked={ldapSettings.trust_all_certificates}
                            onChange={this._bindChecked}
-                           disabled={disabled} /> Allow self-signed certificates
+                           disabled={disabled} /> Allow untrusted certificates
                   </label>
                 </>
               </Input>


### PR DESCRIPTION
`untrusted` is closer to the truth
