### PR TITLE
Implementing SSL certificate validation for LDAP authentication. (3.3)

### DIFF
--- a/UPGRADING.rst
+++ b/UPGRADING.rst
@@ -4,6 +4,13 @@ Upgrading to Graylog 3.3.x
 
 .. _upgrade-from-32-to-33:
 
+Fixing certificate validation for LDAP servers used for authentication
+======================================================================
+
+Prior to v3.3.3, the certificates of LDAP servers which are connected to using a secure connection (SSL or TLS) were not validated, even if the "Allow self-signed certificates" option was unchecked. Starting with v3.3.3, certificates are validated against the local default keystore. This might introduce a breaking change, depending on your local LDAP settings and the validity of the certificates used (if any). Please ensure that all certificates used are valid and your local keystore contains all CA/intermediate certs required for validation.
+
+A `CVE <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15813>`_ is tracked for this issue.
+
 Deprecating legacy Aggregation API endpoints
 ============================================
 

--- a/graylog2-server/pom.xml
+++ b/graylog2-server/pom.xml
@@ -415,6 +415,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jukito</groupId>
             <artifactId>jukito</artifactId>
         </dependency>

--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ldap/LdapResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/system/ldap/LdapResource.java
@@ -61,8 +61,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.net.URI;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -127,14 +125,12 @@ public class LdapResource extends RestResource {
     @Produces(MediaType.APPLICATION_JSON)
     @NoAuditEvent("only used to test LDAP configuration")
     public LdapTestConfigResponse testLdapConfiguration(@ApiParam(name = "Configuration to test", required = true)
-                                                        @Valid @NotNull LdapTestConfigRequest request) throws KeyStoreException, NoSuchAlgorithmException {
-
-        final LdapConnectionConfig config = ldapConnector.createConfig(request);
+                                                        @Valid @NotNull LdapTestConfigRequest request) {
 
         LdapNetworkConnection connection = null;
         try {
             try {
-                connection = ldapConnector.connect(config);
+                connection = ldapConnector.connect(request);
             } catch (Exception e) {
                 Throwable rootCause = e;
                 while (rootCause.getCause() != null && rootCause.getCause().getMessage() != null) {

--- a/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
@@ -57,6 +57,7 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Locale;
@@ -458,12 +459,10 @@ public class LdapConnector {
                 .getInstance(TrustManagerFactory.getDefaultAlgorithm());
         tmf.init((KeyStore) null);
 
-        for (TrustManager tm : tmf.getTrustManagers()) {
-            if (tm instanceof X509TrustManager) {
-                return tm;
-            }
-        }
-        throw new IllegalStateException("Unable to initialize default X509 trust manager.");
+        return Arrays.stream(tmf.getTrustManagers())
+                .filter(trustManager -> trustManager instanceof X509TrustManager)
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Unable to initialize default X509 trust manager."));
     }
 
     public LdapConnectionConfig createConfig(LdapSettings ldapSettings) throws KeyStoreException, NoSuchAlgorithmException {

--- a/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
@@ -108,16 +108,14 @@ public class LdapConnector {
 
         // this will perform an anonymous bind if there were no system credentials
         final ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("ldap-connector-%d").build();
+        @SuppressWarnings("UnstableApiUsage")
         final SimpleTimeLimiter timeLimiter = SimpleTimeLimiter.create(Executors.newSingleThreadExecutor(threadFactory));
-        @SuppressWarnings("unchecked")
+        @SuppressWarnings({"unchecked", "UnstableApiUsage"})
         final Callable<Boolean> timeLimitedConnection = timeLimiter.newProxy(
-                new Callable<Boolean>() {
-                    @Override
-                    public Boolean call() throws Exception {
-                        return connection.connect();
-                    }
-                }, Callable.class,
-                connectionTimeout, TimeUnit.MILLISECONDS);
+                connection::connect,
+                Callable.class,
+                connectionTimeout,
+                TimeUnit.MILLISECONDS);
         try {
             final Boolean connected = timeLimitedConnection.call();
             if (!connected) {

--- a/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
@@ -87,6 +87,16 @@ public class LdapConnector {
         this.ldapSettingsService = ldapSettingsService;
     }
 
+    public LdapNetworkConnection connect(LdapSettings settings) throws KeyStoreException, LdapException, NoSuchAlgorithmException {
+        final LdapConnectionConfig config = createConfig(settings);
+        return connect(config);
+    }
+
+    public LdapNetworkConnection connect(LdapTestConfigRequest request) throws KeyStoreException, LdapException, NoSuchAlgorithmException {
+        final LdapConnectionConfig config = createConfig(request);
+        return connect(config);
+    }
+
     public LdapNetworkConnection connect(LdapConnectionConfig config) throws LdapException {
         final LdapNetworkConnection connection = new LdapNetworkConnection(config);
         connection.setTimeOut(connectionTimeout);
@@ -420,7 +430,7 @@ public class LdapConnector {
         return connection.isAuthenticated();
     }
 
-    public LdapConnectionConfig createConfig(LdapTestConfigRequest request) throws KeyStoreException, NoSuchAlgorithmException {
+    private LdapConnectionConfig createConfig(LdapTestConfigRequest request) throws KeyStoreException, NoSuchAlgorithmException {
         final LdapConnectionConfig config = new LdapConnectionConfig();
         final URI ldapUri = request.ldapUri();
         config.setLdapHost(ldapUri.getHost());
@@ -465,7 +475,7 @@ public class LdapConnector {
                 .orElseThrow(() -> new IllegalStateException("Unable to initialize default X509 trust manager."));
     }
 
-    public LdapConnectionConfig createConfig(LdapSettings ldapSettings) throws KeyStoreException, NoSuchAlgorithmException {
+    private LdapConnectionConfig createConfig(LdapSettings ldapSettings) throws KeyStoreException, NoSuchAlgorithmException {
         final LdapConnectionConfig config = new LdapConnectionConfig();
         config.setLdapHost(ldapSettings.getUri().getHost());
         config.setLdapPort(ldapSettings.getUri().getPort());

--- a/graylog2-server/src/main/java/org/graylog2/security/realm/LdapUserAuthenticator.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/realm/LdapUserAuthenticator.java
@@ -32,7 +32,6 @@ import org.apache.shiro.realm.AuthenticatingRealm;
 import org.graylog2.database.NotFoundException;
 import org.graylog2.plugin.database.ValidationException;
 import org.graylog2.plugin.database.users.User;
-import org.graylog2.security.TrustAllX509TrustManager;
 import org.graylog2.security.ldap.LdapConnector;
 import org.graylog2.security.ldap.LdapSettingsService;
 import org.graylog2.shared.security.ldap.LdapEntry;
@@ -48,6 +47,8 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -142,17 +143,8 @@ public class LdapUserAuthenticator extends AuthenticatingRealm {
         return null;
     }
 
-    protected LdapNetworkConnection openLdapConnection(LdapSettings ldapSettings) throws LdapException {
-        final LdapConnectionConfig config = new LdapConnectionConfig();
-        config.setLdapHost(ldapSettings.getUri().getHost());
-        config.setLdapPort(ldapSettings.getUri().getPort());
-        config.setUseSsl(ldapSettings.getUri().getScheme().startsWith("ldaps"));
-        config.setUseTls(ldapSettings.isUseStartTls());
-        if (ldapSettings.isTrustAllCertificates()) {
-            config.setTrustManagers(new TrustAllX509TrustManager());
-        }
-        config.setName(ldapSettings.getSystemUserName());
-        config.setCredentials(ldapSettings.getSystemPassword());
+    protected LdapNetworkConnection openLdapConnection(LdapSettings ldapSettings) throws LdapException, KeyStoreException, NoSuchAlgorithmException {
+        final LdapConnectionConfig config = ldapConnector.createConfig(ldapSettings);
         return ldapConnector.connect(config);
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/security/realm/LdapUserAuthenticator.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/realm/LdapUserAuthenticator.java
@@ -20,7 +20,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
 import org.apache.directory.api.ldap.model.cursor.CursorException;
 import org.apache.directory.api.ldap.model.exception.LdapException;
-import org.apache.directory.ldap.client.api.LdapConnectionConfig;
 import org.apache.directory.ldap.client.api.LdapNetworkConnection;
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationInfo;
@@ -144,8 +143,7 @@ public class LdapUserAuthenticator extends AuthenticatingRealm {
     }
 
     protected LdapNetworkConnection openLdapConnection(LdapSettings ldapSettings) throws LdapException, KeyStoreException, NoSuchAlgorithmException {
-        final LdapConnectionConfig config = ldapConnector.createConfig(ldapSettings);
-        return ldapConnector.connect(config);
+        return ldapConnector.connect(ldapSettings);
     }
 
     protected LdapEntry searchLdapUser(LdapNetworkConnection connection, String principal, LdapSettings ldapSettings) throws LdapException, CursorException {

--- a/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorSSLTLSIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorSSLTLSIT.java
@@ -18,6 +18,7 @@ package org.graylog2.security.ldap;
 
 import org.apache.directory.api.ldap.model.exception.LdapException;
 import org.apache.directory.api.ldap.model.exception.LdapOperationException;
+import org.apache.directory.api.ldap.model.exception.LdapProtocolErrorException;
 import org.apache.directory.ldap.client.api.LdapNetworkConnection;
 import org.assertj.core.api.Assertions;
 import org.graylog2.rest.models.system.ldap.requests.LdapTestConfigRequest;
@@ -36,6 +37,7 @@ import static org.mockito.Mockito.mock;
 
 @Testcontainers
 public class LdapConnectorSSLTLSIT {
+    private static final int DEFAULT_TIMEOUT = 60 * 1000;
     private static final String NETWORK_ALIAS = "ldapserver";
     private static final Integer PORT = 389;
     private static final Integer SSL_PORT = 636;
@@ -62,7 +64,7 @@ public class LdapConnectorSSLTLSIT {
     @Test
     void shouldNotConnectViaTLSToSelfSignedCertIfValidationIsRequested() throws Exception {
         final LdapSettingsService ldapSettingsService = mock(LdapSettingsService.class);
-        final LdapConnector ldapConnector = new LdapConnector(60, ldapSettingsService);
+        final LdapConnector ldapConnector = new LdapConnector(DEFAULT_TIMEOUT, ldapSettingsService);
 
         final LdapTestConfigRequest request = createTLSTestRequest(false);
 
@@ -75,7 +77,7 @@ public class LdapConnectorSSLTLSIT {
     @Test
     void shouldConnectViaTLSToSelfSignedCertIfValidationIsNotRequested() throws Exception {
         final LdapSettingsService ldapSettingsService = mock(LdapSettingsService.class);
-        final LdapConnector ldapConnector = new LdapConnector(60, ldapSettingsService);
+        final LdapConnector ldapConnector = new LdapConnector(DEFAULT_TIMEOUT, ldapSettingsService);
 
         final LdapTestConfigRequest request = createTLSTestRequest(true);
 
@@ -109,21 +111,19 @@ public class LdapConnectorSSLTLSIT {
     @Test
     void shouldNotConnectViaSSLToSelfSignedCertIfValidationIsRequested() throws Exception {
         final LdapSettingsService ldapSettingsService = mock(LdapSettingsService.class);
-        final LdapConnector ldapConnector = new LdapConnector(60, ldapSettingsService);
+        final LdapConnector ldapConnector = new LdapConnector(DEFAULT_TIMEOUT, ldapSettingsService);
 
         final LdapTestConfigRequest request = createSSLTestRequest(false);
 
         Assertions.assertThatThrownBy(() -> ldapConnector.connect(request))
-                .satisfies(e -> assertThat(e).isNotNull())
-                .isInstanceOf(LdapException.class)
-                .hasRootCauseInstanceOf(LdapOperationException.class)
-                .hasMessage("Failed to initialize the SSL context");
+                .isInstanceOf(LdapProtocolErrorException.class)
+                .hasMessage("PROTOCOL_ERROR: The server will disconnect!");
     }
 
     @Test
     void shouldConnectViaSSLToSelfSignedCertIfValidationIsNotRequested() throws Exception {
         final LdapSettingsService ldapSettingsService = mock(LdapSettingsService.class);
-        final LdapConnector ldapConnector = new LdapConnector(60, ldapSettingsService);
+        final LdapConnector ldapConnector = new LdapConnector(DEFAULT_TIMEOUT, ldapSettingsService);
 
         final LdapTestConfigRequest request = createSSLTestRequest(true);
 

--- a/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorSSLTLSIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorSSLTLSIT.java
@@ -40,6 +40,7 @@ public class LdapConnectorSSLTLSIT {
     private static final Integer PORT = 389;
     private static final Integer SSL_PORT = 636;
 
+    @SuppressWarnings("rawtypes")
     @Container
     private final GenericContainer topLevelContainer = new GenericContainer("rroemhild/test-openldap:latest")
             .waitingFor(Wait.forLogMessage(".*slapd starting.*", 1))
@@ -113,9 +114,7 @@ public class LdapConnectorSSLTLSIT {
         final LdapTestConfigRequest request = createSSLTestRequest(false);
 
         Assertions.assertThatThrownBy(() -> ldapConnector.connect(request))
-                .satisfies(e -> {
-                    assertThat(e).isNotNull();
-                })
+                .satisfies(e -> assertThat(e).isNotNull())
                 .isInstanceOf(LdapException.class)
                 .hasRootCauseInstanceOf(LdapOperationException.class)
                 .hasMessage("Failed to initialize the SSL context");

--- a/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorSSLTLSIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorSSLTLSIT.java
@@ -1,0 +1,157 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.security.ldap;
+
+import org.apache.directory.api.ldap.model.exception.LdapException;
+import org.apache.directory.api.ldap.model.exception.LdapOperationException;
+import org.apache.directory.ldap.client.api.LdapNetworkConnection;
+import org.assertj.core.api.Assertions;
+import org.graylog2.rest.models.system.ldap.requests.LdapTestConfigRequest;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.net.URI;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@Testcontainers
+public class LdapConnectorSSLTLSIT {
+    private static final String NETWORK_ALIAS = "ldapserver";
+    private static final Integer PORT = 389;
+    private static final Integer SSL_PORT = 636;
+
+    @Container
+    private final GenericContainer topLevelContainer = new GenericContainer("rroemhild/test-openldap:latest")
+            .waitingFor(Wait.forLogMessage(".*slapd starting.*", 1))
+            .withNetworkAliases(NETWORK_ALIAS)
+            .withExposedPorts(PORT, SSL_PORT);
+
+    private URI internalUri() {
+        return URI.create(String.format(Locale.US, "ldap://%s:%d",
+                topLevelContainer.getContainerIpAddress(),
+                topLevelContainer.getMappedPort(PORT)));
+    }
+
+    private URI internalSSLUri() {
+        return URI.create(String.format(Locale.US, "ldaps://%s:%d",
+                topLevelContainer.getContainerIpAddress(),
+                topLevelContainer.getMappedPort(SSL_PORT)));
+    }
+
+    @Test
+    void shouldNotConnectViaTLSToSelfSignedCertIfValidationIsRequested() throws Exception {
+        final LdapSettingsService ldapSettingsService = mock(LdapSettingsService.class);
+        final LdapConnector ldapConnector = new LdapConnector(60, ldapSettingsService);
+
+        final LdapTestConfigRequest request = createTLSTestRequest(false);
+
+        Assertions.assertThatThrownBy(() -> ldapConnector.connect(request))
+                .isInstanceOf(LdapException.class)
+                .hasRootCauseInstanceOf(LdapOperationException.class)
+                .hasMessage("Failed to initialize the SSL context");
+    }
+
+    @Test
+    void shouldConnectViaTLSToSelfSignedCertIfValidationIsNotRequested() throws Exception {
+        final LdapSettingsService ldapSettingsService = mock(LdapSettingsService.class);
+        final LdapConnector ldapConnector = new LdapConnector(60, ldapSettingsService);
+
+        final LdapTestConfigRequest request = createTLSTestRequest(true);
+
+        final LdapNetworkConnection connection = ldapConnector.connect(request);
+
+        assertThat(connection.isAuthenticated()).isTrue();
+        assertThat(connection.isConnected()).isTrue();
+        assertThat(connection.isSecured()).isTrue();
+    }
+
+    @NotNull
+    private LdapTestConfigRequest createTLSTestRequest(boolean trustAllCertificates) {
+        return LdapTestConfigRequest.create(
+                "cn=admin,dc=planetexpress,dc=com",
+                "GoodNewsEveryone",
+                internalUri(),
+                true,
+                trustAllCertificates,
+                false,
+                null,
+                null,
+                null,
+                null,
+                true,
+                null,
+                null,
+                null
+        );
+    }
+
+    @Test
+    void shouldNotConnectViaSSLToSelfSignedCertIfValidationIsRequested() throws Exception {
+        final LdapSettingsService ldapSettingsService = mock(LdapSettingsService.class);
+        final LdapConnector ldapConnector = new LdapConnector(60, ldapSettingsService);
+
+        final LdapTestConfigRequest request = createSSLTestRequest(false);
+
+        Assertions.assertThatThrownBy(() -> ldapConnector.connect(request))
+                .satisfies(e -> {
+                    assertThat(e).isNotNull();
+                })
+                .isInstanceOf(LdapException.class)
+                .hasRootCauseInstanceOf(LdapOperationException.class)
+                .hasMessage("Failed to initialize the SSL context");
+    }
+
+    @Test
+    void shouldConnectViaSSLToSelfSignedCertIfValidationIsNotRequested() throws Exception {
+        final LdapSettingsService ldapSettingsService = mock(LdapSettingsService.class);
+        final LdapConnector ldapConnector = new LdapConnector(60, ldapSettingsService);
+
+        final LdapTestConfigRequest request = createSSLTestRequest(true);
+
+        final LdapNetworkConnection connection = ldapConnector.connect(request);
+
+        assertThat(connection.isAuthenticated()).isTrue();
+        assertThat(connection.isConnected()).isTrue();
+        assertThat(connection.isSecured()).isTrue();
+    }
+
+    @NotNull
+    private LdapTestConfigRequest createSSLTestRequest(boolean trustAllCertificates) {
+        return LdapTestConfigRequest.create(
+                "cn=admin,dc=planetexpress,dc=com",
+                "GoodNewsEveryone",
+                internalSSLUri(),
+                false,
+                trustAllCertificates,
+                false,
+                null,
+                null,
+                null,
+                null,
+                true,
+                null,
+                null,
+                null
+        );
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorTest.java
@@ -44,6 +44,7 @@ import org.junit.runner.RunWith;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 @RunWith(FrameworkRunner.class)
 @CreateLdapServer(transports = {
@@ -97,7 +98,7 @@ public class LdapConnectorTest extends AbstractLdapTestUnit {
         config.setName(ADMIN_DN);
         config.setCredentials(ADMIN_PASSWORD);
 
-        connector = new LdapConnector(10000);
+        connector = new LdapConnector(10000, mock(LdapSettingsService.class));
         connection = connector.connect(config);
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/security/realm/LdapUserAuthenticatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/realm/LdapUserAuthenticatorTest.java
@@ -121,8 +121,8 @@ public class LdapUserAuthenticatorTest extends AbstractLdapTestUnit {
         configuration = mock(Configuration.class);
         when(configuration.getPasswordSecret()).thenReturn(PASSWORD_SECRET);
 
-        ldapConnector = new LdapConnector(10000);
         ldapSettingsService = mock(LdapSettingsService.class);
+        ldapConnector = new LdapConnector(10000, ldapSettingsService);
         userService = mock(UserService.class);
 
         ldapSettings = new LdapSettingsImpl(configuration, mock(RoleService.class));

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
         <nosqlunit.version>1.0.0-rc.5</nosqlunit.version>
         <restassured.version>4.2.0</restassured.version>
         <system-rules.version>1.19.0</system-rules.version>
-        <testcontainers.version>1.12.5</testcontainers.version>
+        <testcontainers.version>1.14.3</testcontainers.version>
 
         <!-- Nodejs dependencies -->
         <nodejs.version>v12.13.1</nodejs.version>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note: This is a backport of #8569 for `3.3`.**

Before this change, SSL certificates used to secure the connection between Graylog and an LDAP server used for authentication over a SSL/TLS-secured connection were not validated, even if the `Allow self-signed certificates` option was left unchecked.

This change is implementing SSL certificate validation by configuring a trust manager that uses the default keystore to validate certificates against. In addition, it consolidates different places where the `LdapConnectionConfig` was created.

Fixes #5906.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.