### PR TITLE
Enhance Button render performance

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/__snapshots__/Input.test.jsx.snap
+++ b/graylog2-web-interface/src/components/bootstrap/__snapshots__/Input.test.jsx.snap
@@ -104,7 +104,7 @@ exports[`Input renders a button after the input if buttonAfter is passed 1`] = `
 <Input
   addonAfter={null}
   bsStyle={null}
-  buttonAfter={<ForwardRef />}
+  buttonAfter={<Button />}
   help=""
   id="inputWithButton"
   label=""
@@ -176,24 +176,22 @@ exports[`Input renders a button after the input if buttonAfter is passed 1`] = `
                         <span
                           className="input-group-btn"
                         >
-                          <ForwardRef>
-                            <Button__StyledButton>
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="default"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH"
+                          <Button>
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
+                              bsStyle="default"
+                              className="Button-c9cbmb-0 bNulii"
+                              disabled={false}
+                            >
+                              <button
+                                className="Button-c9cbmb-0 bNulii btn btn-default"
                                 disabled={false}
-                              >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                  disabled={false}
-                                  type="button"
-                                />
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
+                                type="button"
+                              />
+                            </Button>
+                          </Button>
                         </span>
                       </InputGroupButton>
                     </Button>

--- a/graylog2-web-interface/src/components/common/__snapshots__/Wizard.test.jsx.snap
+++ b/graylog2-web-interface/src/components/common/__snapshots__/Wizard.test.jsx.snap
@@ -476,102 +476,89 @@ exports[`<Wizard /> should render in horizontal mode with 3 steps 1`] = `
                       className="c2 btn-toolbar"
                       role="toolbar"
                     >
-                      <ForwardRef
+                      <Button
                         bsSize="xsmall"
                         bsStyle="info"
                         disabled={true}
                         onClick={[Function]}
                       >
-                        <Button__StyledButton
+                        <Button
+                          active={false}
+                          block={false}
+                          bsClass="btn"
                           bsSize="xsmall"
                           bsStyle="info"
+                          className="c3"
                           disabled={true}
                           onClick={[Function]}
                         >
-                          <Button
-                            active={false}
-                            block={false}
-                            bsClass="btn"
-                            bsSize="xsmall"
-                            bsStyle="info"
-                            className="c3"
+                          <button
+                            className="c3 btn btn-xs btn-info"
                             disabled={true}
                             onClick={[Function]}
+                            type="button"
                           >
-                            <button
-                              className="c3 btn btn-xs btn-info"
-                              disabled={true}
-                              onClick={[Function]}
-                              type="button"
+                            <Icon
+                              name="caret-left"
+                              type="solid"
                             >
-                              <Icon
-                                name="caret-left"
-                                type="solid"
-                              >
-                                <FontAwesomeIcon
-                                  icon={
-                                    Object {
-                                      "iconName": "caret-left",
-                                      "prefix": "fas",
-                                    }
+                              <FontAwesomeIcon
+                                icon={
+                                  Object {
+                                    "iconName": "caret-left",
+                                    "prefix": "fas",
                                   }
-                                >
-                                  <svg
-                                    className="svg-inline--fa fa-caret-left"
-                                  />
-                                </FontAwesomeIcon>
-                              </Icon>
-                            </button>
-                          </Button>
-                        </Button__StyledButton>
-                      </ForwardRef>
-                      <ForwardRef
+                                }
+                              >
+                                <svg
+                                  className="svg-inline--fa fa-caret-left"
+                                />
+                              </FontAwesomeIcon>
+                            </Icon>
+                          </button>
+                        </Button>
+                      </Button>
+                      <Button
                         bsSize="xsmall"
                         bsStyle="info"
                         onClick={[Function]}
                       >
-                        <Button__StyledButton
+                        <Button
+                          active={false}
+                          block={false}
+                          bsClass="btn"
                           bsSize="xsmall"
                           bsStyle="info"
+                          className="c3"
+                          disabled={false}
                           onClick={[Function]}
                         >
-                          <Button
-                            active={false}
-                            block={false}
-                            bsClass="btn"
-                            bsSize="xsmall"
-                            bsStyle="info"
-                            className="c3"
+                          <button
+                            className="c3 btn btn-xs btn-info"
                             disabled={false}
                             onClick={[Function]}
+                            type="button"
                           >
-                            <button
-                              className="c3 btn btn-xs btn-info"
-                              disabled={false}
-                              onClick={[Function]}
-                              type="button"
+                            <Icon
+                              name="caret-right"
+                              type="solid"
                             >
-                              <Icon
-                                name="caret-right"
-                                type="solid"
-                              >
-                                <FontAwesomeIcon
-                                  icon={
-                                    Object {
-                                      "iconName": "caret-right",
-                                      "prefix": "fas",
-                                    }
+                              <FontAwesomeIcon
+                                icon={
+                                  Object {
+                                    "iconName": "caret-right",
+                                    "prefix": "fas",
                                   }
-                                >
-                                  <svg
-                                    className="svg-inline--fa fa-caret-right"
-                                  />
-                                </FontAwesomeIcon>
-                              </Icon>
-                            </button>
-                          </Button>
-                        </Button__StyledButton>
-                      </ForwardRef>
+                                }
+                              >
+                                <svg
+                                  className="svg-inline--fa fa-caret-right"
+                                />
+                              </FontAwesomeIcon>
+                            </Icon>
+                          </button>
+                        </Button>
+                      </Button>
                     </div>
                   </ButtonToolbar>
                 </Wizard__HorizontalButtonToolbar>
@@ -1182,102 +1169,89 @@ exports[`<Wizard /> should render in horizontal mode with 3 steps and children 1
                       className="c2 btn-toolbar"
                       role="toolbar"
                     >
-                      <ForwardRef
+                      <Button
                         bsSize="xsmall"
                         bsStyle="info"
                         disabled={true}
                         onClick={[Function]}
                       >
-                        <Button__StyledButton
+                        <Button
+                          active={false}
+                          block={false}
+                          bsClass="btn"
                           bsSize="xsmall"
                           bsStyle="info"
+                          className="c3"
                           disabled={true}
                           onClick={[Function]}
                         >
-                          <Button
-                            active={false}
-                            block={false}
-                            bsClass="btn"
-                            bsSize="xsmall"
-                            bsStyle="info"
-                            className="c3"
+                          <button
+                            className="c3 btn btn-xs btn-info"
                             disabled={true}
                             onClick={[Function]}
+                            type="button"
                           >
-                            <button
-                              className="c3 btn btn-xs btn-info"
-                              disabled={true}
-                              onClick={[Function]}
-                              type="button"
+                            <Icon
+                              name="caret-left"
+                              type="solid"
                             >
-                              <Icon
-                                name="caret-left"
-                                type="solid"
-                              >
-                                <FontAwesomeIcon
-                                  icon={
-                                    Object {
-                                      "iconName": "caret-left",
-                                      "prefix": "fas",
-                                    }
+                              <FontAwesomeIcon
+                                icon={
+                                  Object {
+                                    "iconName": "caret-left",
+                                    "prefix": "fas",
                                   }
-                                >
-                                  <svg
-                                    className="svg-inline--fa fa-caret-left"
-                                  />
-                                </FontAwesomeIcon>
-                              </Icon>
-                            </button>
-                          </Button>
-                        </Button__StyledButton>
-                      </ForwardRef>
-                      <ForwardRef
+                                }
+                              >
+                                <svg
+                                  className="svg-inline--fa fa-caret-left"
+                                />
+                              </FontAwesomeIcon>
+                            </Icon>
+                          </button>
+                        </Button>
+                      </Button>
+                      <Button
                         bsSize="xsmall"
                         bsStyle="info"
                         onClick={[Function]}
                       >
-                        <Button__StyledButton
+                        <Button
+                          active={false}
+                          block={false}
+                          bsClass="btn"
                           bsSize="xsmall"
                           bsStyle="info"
+                          className="c3"
+                          disabled={false}
                           onClick={[Function]}
                         >
-                          <Button
-                            active={false}
-                            block={false}
-                            bsClass="btn"
-                            bsSize="xsmall"
-                            bsStyle="info"
-                            className="c3"
+                          <button
+                            className="c3 btn btn-xs btn-info"
                             disabled={false}
                             onClick={[Function]}
+                            type="button"
                           >
-                            <button
-                              className="c3 btn btn-xs btn-info"
-                              disabled={false}
-                              onClick={[Function]}
-                              type="button"
+                            <Icon
+                              name="caret-right"
+                              type="solid"
                             >
-                              <Icon
-                                name="caret-right"
-                                type="solid"
-                              >
-                                <FontAwesomeIcon
-                                  icon={
-                                    Object {
-                                      "iconName": "caret-right",
-                                      "prefix": "fas",
-                                    }
+                              <FontAwesomeIcon
+                                icon={
+                                  Object {
+                                    "iconName": "caret-right",
+                                    "prefix": "fas",
                                   }
-                                >
-                                  <svg
-                                    className="svg-inline--fa fa-caret-right"
-                                  />
-                                </FontAwesomeIcon>
-                              </Icon>
-                            </button>
-                          </Button>
-                        </Button__StyledButton>
-                      </ForwardRef>
+                                }
+                              >
+                                <svg
+                                  className="svg-inline--fa fa-caret-right"
+                                />
+                              </FontAwesomeIcon>
+                            </Icon>
+                          </button>
+                        </Button>
+                      </Button>
                     </div>
                   </ButtonToolbar>
                 </Wizard__HorizontalButtonToolbar>
@@ -2012,39 +1986,32 @@ exports[`<Wizard /> should render with 3 steps 1`] = `
                       <div
                         className="col-xs-6"
                       >
-                        <ForwardRef
+                        <Button
                           bsSize="small"
                           bsStyle="info"
                           disabled={true}
                           onClick={[Function]}
                         >
-                          <Button__StyledButton
+                          <Button
+                            active={false}
+                            block={false}
+                            bsClass="btn"
                             bsSize="small"
                             bsStyle="info"
+                            className="c3"
                             disabled={true}
                             onClick={[Function]}
                           >
-                            <Button
-                              active={false}
-                              block={false}
-                              bsClass="btn"
-                              bsSize="small"
-                              bsStyle="info"
-                              className="c3"
+                            <button
+                              className="c3 btn btn-sm btn-info"
                               disabled={true}
                               onClick={[Function]}
+                              type="button"
                             >
-                              <button
-                                className="c3 btn btn-sm btn-info"
-                                disabled={true}
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                Previous
-                              </button>
-                            </Button>
-                          </Button__StyledButton>
-                        </ForwardRef>
+                              Previous
+                            </button>
+                          </Button>
+                        </Button>
                       </div>
                     </Col>
                     <Col
@@ -2056,37 +2023,31 @@ exports[`<Wizard /> should render with 3 steps 1`] = `
                       <div
                         className="text-right col-xs-6"
                       >
-                        <ForwardRef
+                        <Button
                           bsSize="small"
                           bsStyle="info"
                           onClick={[Function]}
                         >
-                          <Button__StyledButton
+                          <Button
+                            active={false}
+                            block={false}
+                            bsClass="btn"
                             bsSize="small"
                             bsStyle="info"
+                            className="c3"
+                            disabled={false}
                             onClick={[Function]}
                           >
-                            <Button
-                              active={false}
-                              block={false}
-                              bsClass="btn"
-                              bsSize="small"
-                              bsStyle="info"
-                              className="c3"
+                            <button
+                              className="c3 btn btn-sm btn-info"
                               disabled={false}
                               onClick={[Function]}
+                              type="button"
                             >
-                              <button
-                                className="c3 btn btn-sm btn-info"
-                                disabled={false}
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                Next
-                              </button>
-                            </Button>
-                          </Button__StyledButton>
-                        </ForwardRef>
+                              Next
+                            </button>
+                          </Button>
+                        </Button>
                       </div>
                     </Col>
                   </div>
@@ -2701,39 +2662,32 @@ exports[`<Wizard /> should render with 3 steps and children 1`] = `
                       <div
                         className="col-xs-6"
                       >
-                        <ForwardRef
+                        <Button
                           bsSize="small"
                           bsStyle="info"
                           disabled={true}
                           onClick={[Function]}
                         >
-                          <Button__StyledButton
+                          <Button
+                            active={false}
+                            block={false}
+                            bsClass="btn"
                             bsSize="small"
                             bsStyle="info"
+                            className="c3"
                             disabled={true}
                             onClick={[Function]}
                           >
-                            <Button
-                              active={false}
-                              block={false}
-                              bsClass="btn"
-                              bsSize="small"
-                              bsStyle="info"
-                              className="c3"
+                            <button
+                              className="c3 btn btn-sm btn-info"
                               disabled={true}
                               onClick={[Function]}
+                              type="button"
                             >
-                              <button
-                                className="c3 btn btn-sm btn-info"
-                                disabled={true}
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                Previous
-                              </button>
-                            </Button>
-                          </Button__StyledButton>
-                        </ForwardRef>
+                              Previous
+                            </button>
+                          </Button>
+                        </Button>
                       </div>
                     </Col>
                     <Col
@@ -2745,37 +2699,31 @@ exports[`<Wizard /> should render with 3 steps and children 1`] = `
                       <div
                         className="text-right col-xs-6"
                       >
-                        <ForwardRef
+                        <Button
                           bsSize="small"
                           bsStyle="info"
                           onClick={[Function]}
                         >
-                          <Button__StyledButton
+                          <Button
+                            active={false}
+                            block={false}
+                            bsClass="btn"
                             bsSize="small"
                             bsStyle="info"
+                            className="c3"
+                            disabled={false}
                             onClick={[Function]}
                           >
-                            <Button
-                              active={false}
-                              block={false}
-                              bsClass="btn"
-                              bsSize="small"
-                              bsStyle="info"
-                              className="c3"
+                            <button
+                              className="c3 btn btn-sm btn-info"
                               disabled={false}
                               onClick={[Function]}
+                              type="button"
                             >
-                              <button
-                                className="c3 btn btn-sm btn-info"
-                                disabled={false}
-                                onClick={[Function]}
-                                type="button"
-                              >
-                                Next
-                              </button>
-                            </Button>
-                          </Button__StyledButton>
-                        </ForwardRef>
+                              Next
+                            </button>
+                          </Button>
+                        </Button>
                       </div>
                     </Col>
                   </div>

--- a/graylog2-web-interface/src/components/configurations/__snapshots__/UrlWhiteListForm.test.jsx.snap
+++ b/graylog2-web-interface/src/components/configurations/__snapshots__/UrlWhiteListForm.test.jsx.snap
@@ -109,35 +109,30 @@ exports[`UrlWhitelistForm render the UrlWhitelistForm component should create ne
       </FormGroup__StyledFormGroup>
     </Component>
   </Input>
-  <ForwardRef
+  <Button
     bsSize="sm"
     onClick={[Function]}
   >
-    <Button__StyledButton
+    <Button
+      active={false}
+      block={false}
+      bsClass="btn"
       bsSize="sm"
+      bsStyle="default"
+      className="Button-c9cbmb-0 bNulii"
+      disabled={false}
       onClick={[Function]}
     >
-      <Button
-        active={false}
-        block={false}
-        bsClass="btn"
-        bsSize="sm"
-        bsStyle="default"
-        className="Button__StyledButton-c9cbmb-0 laZUlH"
+      <button
+        className="Button-c9cbmb-0 bNulii btn btn-sm btn-default"
         disabled={false}
         onClick={[Function]}
+        type="button"
       >
-        <button
-          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-default"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-        >
-          Add Url
-        </button>
-      </Button>
-    </Button__StyledButton>
-  </ForwardRef>
+        Add Url
+      </button>
+    </Button>
+  </Button>
   <UrlWhiteListForm__StyledTable
     bordered={true}
     striped={true}
@@ -615,25 +610,291 @@ exports[`UrlWhitelistForm render the UrlWhitelistForm component should create ne
                                       ],
                                       "button": Array [
                                         Array [
-                                          [Function],
+                                          "&.btn-",
+                                          "danger",
+                                          "{background-color:",
+                                          "#ad0707",
+                                          ";border-color:",
+                                          "#b23939",
+                                          ";color:",
+                                          "rgb(252,249,249)",
+                                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                                          "#a00e0e",
+                                          ";border-color:",
+                                          "#a53636",
+                                          ";color:",
+                                          "#e9e6e6",
+                                          ";}&.active{background-color:",
+                                          "#b75151",
+                                          ";border-color:",
+                                          "#bc6363",
+                                          ";color:",
+                                          "rgb(252,249,249)",
+                                          ";:hover{background-color:",
+                                          "#a94c4c",
+                                          ";border-color:",
+                                          "#ad5c5c",
+                                          ";color:",
+                                          "#e9e6e6",
+                                          ";}}&[disabled],&.disabled{background-color:",
+                                          "#c07272",
+                                          ";border-color:",
+                                          "#bc6363",
+                                          ";color:",
+                                          "rgb(252,250,250)",
+                                          ";:hover{background-color:",
+                                          "#c07272",
+                                          ";border-color:",
+                                          "#bc6363",
+                                          ";color:",
+                                          "rgb(252,250,250)",
+                                          ";}}}",
                                         ],
                                         Array [
-                                          [Function],
+                                          "&.btn-",
+                                          "default",
+                                          "{background-color:",
+                                          "#e6e6e6",
+                                          ";border-color:",
+                                          "#e0e0e0",
+                                          ";color:",
+                                          "rgb(73,73,73)",
+                                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                                          "#d4d4d4",
+                                          ";border-color:",
+                                          "#cfcfcf",
+                                          ";color:",
+                                          "#444444",
+                                          ";}&.active{background-color:",
+                                          "#dadada",
+                                          ";border-color:",
+                                          "#d4d4d4",
+                                          ";color:",
+                                          "rgb(49,49,49)",
+                                          ";:hover{background-color:",
+                                          "#cacaca",
+                                          ";border-color:",
+                                          "#c4c4c4",
+                                          ";color:",
+                                          "#2f2f2f",
+                                          ";}}&[disabled],&.disabled{background-color:",
+                                          "#cecece",
+                                          ";border-color:",
+                                          "#d4d4d4",
+                                          ";color:",
+                                          "rgb(80,80,80)",
+                                          ";:hover{background-color:",
+                                          "#cecece",
+                                          ";border-color:",
+                                          "#d4d4d4",
+                                          ";color:",
+                                          "rgb(80,80,80)",
+                                          ";}}}",
                                         ],
                                         Array [
-                                          [Function],
+                                          "&.btn-",
+                                          "info",
+                                          "{background-color:",
+                                          "#0063be",
+                                          ";border-color:",
+                                          "#3970c2",
+                                          ";color:",
+                                          "rgb(249,250,252)",
+                                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                                          "#0c5cb0",
+                                          ";border-color:",
+                                          "#3668b3",
+                                          ";color:",
+                                          "#e6e7e9",
+                                          ";}&.active{background-color:",
+                                          "#517cc5",
+                                          ";border-color:",
+                                          "#6386c9",
+                                          ";color:",
+                                          "rgb(249,250,252)",
+                                          ";:hover{background-color:",
+                                          "#4b73b6",
+                                          ";border-color:",
+                                          "#5c7dba",
+                                          ";color:",
+                                          "#e6e7e9",
+                                          ";}}&[disabled],&.disabled{background-color:",
+                                          "#7290cd",
+                                          ";border-color:",
+                                          "#6386c9",
+                                          ";color:",
+                                          "rgb(250,251,253)",
+                                          ";:hover{background-color:",
+                                          "#7290cd",
+                                          ";border-color:",
+                                          "#6386c9",
+                                          ";color:",
+                                          "rgb(250,251,253)",
+                                          ";}}}",
                                         ],
                                         Array [
-                                          [Function],
+                                          "&.btn-",
+                                          "link",
+                                          "{background-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";border-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";color:",
+                                          "#702785",
+                                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                                          "#ebebeb26",
+                                          ";border-color:",
+                                          "#ebebeb26",
+                                          ";color:",
+                                          "#68267b",
+                                          ";}&.active{background-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";border-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";color:",
+                                          "#410057",
+                                          ";:hover{background-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";border-color:",
+                                          "#ebebeb26",
+                                          ";color:",
+                                          "#3d0c51",
+                                          ";}}&[disabled],&.disabled{background-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";border-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";color:",
+                                          "#702785",
+                                          ";:hover{background-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";border-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";color:",
+                                          "#702785",
+                                          ";}}}",
                                         ],
                                         Array [
-                                          [Function],
+                                          "&.btn-",
+                                          "primary",
+                                          "{background-color:",
+                                          "#702785",
+                                          ";border-color:",
+                                          "#7b458e",
+                                          ";color:",
+                                          "rgb(234,229,236)",
+                                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                                          "#68267b",
+                                          ";border-color:",
+                                          "#724083",
+                                          ";color:",
+                                          "#d8d3da",
+                                          ";}&.active{background-color:",
+                                          "#855996",
+                                          ";border-color:",
+                                          "#8f699d",
+                                          ";color:",
+                                          "rgb(250,249,251)",
+                                          ";:hover{background-color:",
+                                          "#7c538b",
+                                          ";border-color:",
+                                          "#846292",
+                                          ";color:",
+                                          "#e7e6e8",
+                                          ";}}&[disabled],&.disabled{background-color:",
+                                          "#9877a5",
+                                          ";border-color:",
+                                          "#8f699d",
+                                          ";color:",
+                                          "rgb(251,250,251)",
+                                          ";:hover{background-color:",
+                                          "#9877a5",
+                                          ";border-color:",
+                                          "#8f699d",
+                                          ";color:",
+                                          "rgb(251,250,251)",
+                                          ";}}}",
                                         ],
                                         Array [
-                                          [Function],
+                                          "&.btn-",
+                                          "success",
+                                          "{background-color:",
+                                          "#00ae42",
+                                          ";border-color:",
+                                          "#39b356",
+                                          ";color:",
+                                          "rgb(249,252,249)",
+                                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                                          "#0ca13e",
+                                          ";border-color:",
+                                          "#36a550",
+                                          ";color:",
+                                          "#e6e9e6",
+                                          ";}&.active{background-color:",
+                                          "#51b866",
+                                          ";border-color:",
+                                          "#63bc74",
+                                          ";color:",
+                                          "rgb(249,252,250)",
+                                          ";:hover{background-color:",
+                                          "#4baa5f",
+                                          ";border-color:",
+                                          "#5cae6c",
+                                          ";color:",
+                                          "#e6e9e7",
+                                          ";}}&[disabled],&.disabled{background-color:",
+                                          "#72c180",
+                                          ";border-color:",
+                                          "#63bc74",
+                                          ";color:",
+                                          "rgb(250,252,250)",
+                                          ";:hover{background-color:",
+                                          "#72c180",
+                                          ";border-color:",
+                                          "#63bc74",
+                                          ";color:",
+                                          "rgb(250,252,250)",
+                                          ";}}}",
                                         ],
                                         Array [
-                                          [Function],
+                                          "&.btn-",
+                                          "warning",
+                                          "{background-color:",
+                                          "#ffd200",
+                                          ";border-color:",
+                                          "#f9cd07",
+                                          ";color:",
+                                          "rgb(57,47,0)",
+                                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                                          "#ebc20c",
+                                          ";border-color:",
+                                          "#e6bd0e",
+                                          ";color:",
+                                          "#362d0c",
+                                          ";}&.active{background-color:",
+                                          "#f2c70a",
+                                          ";border-color:",
+                                          "#ebc20c",
+                                          ";color:",
+                                          "rgb(54,45,2)",
+                                          ";:hover{background-color:",
+                                          "#e0b80f",
+                                          ";border-color:",
+                                          "#d9b310",
+                                          ";color:",
+                                          "#332b0c",
+                                          ";}}&[disabled],&.disabled{background-color:",
+                                          "#e4bc0e",
+                                          ";border-color:",
+                                          "#ebc20c",
+                                          ";color:",
+                                          "rgb(88,73,5)",
+                                          ";:hover{background-color:",
+                                          "#e4bc0e",
+                                          ";border-color:",
+                                          "#ebc20c",
+                                          ";color:",
+                                          "rgb(88,73,5)",
+                                          ";}}}",
                                         ],
                                       ],
                                     },
@@ -2130,48 +2391,44 @@ exports[`UrlWhitelistForm render the UrlWhitelistForm component should create ne
               </Input>
             </td>
             <td>
-              <ForwardRef
+              <Button
                 onClick={[Function]}
               >
-                <Button__StyledButton
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="Button-c9cbmb-0 bNulii"
+                  disabled={false}
                   onClick={[Function]}
                 >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="default"
-                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                  <button
+                    className="Button-c9cbmb-0 bNulii btn btn-default"
                     disabled={false}
                     onClick={[Function]}
+                    type="button"
                   >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                      disabled={false}
-                      onClick={[Function]}
-                      type="button"
+                    <Icon
+                      name="trash-alt"
+                      type="solid"
                     >
-                      <Icon
-                        name="trash-alt"
-                        type="solid"
-                      >
-                        <FontAwesomeIcon
-                          icon={
-                            Object {
-                              "iconName": "trash-alt",
-                              "prefix": "fas",
-                            }
+                      <FontAwesomeIcon
+                        icon={
+                          Object {
+                            "iconName": "trash-alt",
+                            "prefix": "fas",
                           }
-                        >
-                          <svg
-                            className="svg-inline--fa fa-trash-alt"
-                          />
-                        </FontAwesomeIcon>
-                      </Icon>
-                    </button>
-                  </Button>
-                </Button__StyledButton>
-              </ForwardRef>
+                        }
+                      >
+                        <svg
+                          className="svg-inline--fa fa-trash-alt"
+                        />
+                      </FontAwesomeIcon>
+                    </Icon>
+                  </button>
+                </Button>
+              </Button>
             </td>
           </tr>
           <tr
@@ -2615,25 +2872,291 @@ exports[`UrlWhitelistForm render the UrlWhitelistForm component should create ne
                                       ],
                                       "button": Array [
                                         Array [
-                                          [Function],
+                                          "&.btn-",
+                                          "danger",
+                                          "{background-color:",
+                                          "#ad0707",
+                                          ";border-color:",
+                                          "#b23939",
+                                          ";color:",
+                                          "rgb(252,249,249)",
+                                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                                          "#a00e0e",
+                                          ";border-color:",
+                                          "#a53636",
+                                          ";color:",
+                                          "#e9e6e6",
+                                          ";}&.active{background-color:",
+                                          "#b75151",
+                                          ";border-color:",
+                                          "#bc6363",
+                                          ";color:",
+                                          "rgb(252,249,249)",
+                                          ";:hover{background-color:",
+                                          "#a94c4c",
+                                          ";border-color:",
+                                          "#ad5c5c",
+                                          ";color:",
+                                          "#e9e6e6",
+                                          ";}}&[disabled],&.disabled{background-color:",
+                                          "#c07272",
+                                          ";border-color:",
+                                          "#bc6363",
+                                          ";color:",
+                                          "rgb(252,250,250)",
+                                          ";:hover{background-color:",
+                                          "#c07272",
+                                          ";border-color:",
+                                          "#bc6363",
+                                          ";color:",
+                                          "rgb(252,250,250)",
+                                          ";}}}",
                                         ],
                                         Array [
-                                          [Function],
+                                          "&.btn-",
+                                          "default",
+                                          "{background-color:",
+                                          "#e6e6e6",
+                                          ";border-color:",
+                                          "#e0e0e0",
+                                          ";color:",
+                                          "rgb(73,73,73)",
+                                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                                          "#d4d4d4",
+                                          ";border-color:",
+                                          "#cfcfcf",
+                                          ";color:",
+                                          "#444444",
+                                          ";}&.active{background-color:",
+                                          "#dadada",
+                                          ";border-color:",
+                                          "#d4d4d4",
+                                          ";color:",
+                                          "rgb(49,49,49)",
+                                          ";:hover{background-color:",
+                                          "#cacaca",
+                                          ";border-color:",
+                                          "#c4c4c4",
+                                          ";color:",
+                                          "#2f2f2f",
+                                          ";}}&[disabled],&.disabled{background-color:",
+                                          "#cecece",
+                                          ";border-color:",
+                                          "#d4d4d4",
+                                          ";color:",
+                                          "rgb(80,80,80)",
+                                          ";:hover{background-color:",
+                                          "#cecece",
+                                          ";border-color:",
+                                          "#d4d4d4",
+                                          ";color:",
+                                          "rgb(80,80,80)",
+                                          ";}}}",
                                         ],
                                         Array [
-                                          [Function],
+                                          "&.btn-",
+                                          "info",
+                                          "{background-color:",
+                                          "#0063be",
+                                          ";border-color:",
+                                          "#3970c2",
+                                          ";color:",
+                                          "rgb(249,250,252)",
+                                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                                          "#0c5cb0",
+                                          ";border-color:",
+                                          "#3668b3",
+                                          ";color:",
+                                          "#e6e7e9",
+                                          ";}&.active{background-color:",
+                                          "#517cc5",
+                                          ";border-color:",
+                                          "#6386c9",
+                                          ";color:",
+                                          "rgb(249,250,252)",
+                                          ";:hover{background-color:",
+                                          "#4b73b6",
+                                          ";border-color:",
+                                          "#5c7dba",
+                                          ";color:",
+                                          "#e6e7e9",
+                                          ";}}&[disabled],&.disabled{background-color:",
+                                          "#7290cd",
+                                          ";border-color:",
+                                          "#6386c9",
+                                          ";color:",
+                                          "rgb(250,251,253)",
+                                          ";:hover{background-color:",
+                                          "#7290cd",
+                                          ";border-color:",
+                                          "#6386c9",
+                                          ";color:",
+                                          "rgb(250,251,253)",
+                                          ";}}}",
                                         ],
                                         Array [
-                                          [Function],
+                                          "&.btn-",
+                                          "link",
+                                          "{background-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";border-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";color:",
+                                          "#702785",
+                                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                                          "#ebebeb26",
+                                          ";border-color:",
+                                          "#ebebeb26",
+                                          ";color:",
+                                          "#68267b",
+                                          ";}&.active{background-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";border-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";color:",
+                                          "#410057",
+                                          ";:hover{background-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";border-color:",
+                                          "#ebebeb26",
+                                          ";color:",
+                                          "#3d0c51",
+                                          ";}}&[disabled],&.disabled{background-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";border-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";color:",
+                                          "#702785",
+                                          ";:hover{background-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";border-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";color:",
+                                          "#702785",
+                                          ";}}}",
                                         ],
                                         Array [
-                                          [Function],
+                                          "&.btn-",
+                                          "primary",
+                                          "{background-color:",
+                                          "#702785",
+                                          ";border-color:",
+                                          "#7b458e",
+                                          ";color:",
+                                          "rgb(234,229,236)",
+                                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                                          "#68267b",
+                                          ";border-color:",
+                                          "#724083",
+                                          ";color:",
+                                          "#d8d3da",
+                                          ";}&.active{background-color:",
+                                          "#855996",
+                                          ";border-color:",
+                                          "#8f699d",
+                                          ";color:",
+                                          "rgb(250,249,251)",
+                                          ";:hover{background-color:",
+                                          "#7c538b",
+                                          ";border-color:",
+                                          "#846292",
+                                          ";color:",
+                                          "#e7e6e8",
+                                          ";}}&[disabled],&.disabled{background-color:",
+                                          "#9877a5",
+                                          ";border-color:",
+                                          "#8f699d",
+                                          ";color:",
+                                          "rgb(251,250,251)",
+                                          ";:hover{background-color:",
+                                          "#9877a5",
+                                          ";border-color:",
+                                          "#8f699d",
+                                          ";color:",
+                                          "rgb(251,250,251)",
+                                          ";}}}",
                                         ],
                                         Array [
-                                          [Function],
+                                          "&.btn-",
+                                          "success",
+                                          "{background-color:",
+                                          "#00ae42",
+                                          ";border-color:",
+                                          "#39b356",
+                                          ";color:",
+                                          "rgb(249,252,249)",
+                                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                                          "#0ca13e",
+                                          ";border-color:",
+                                          "#36a550",
+                                          ";color:",
+                                          "#e6e9e6",
+                                          ";}&.active{background-color:",
+                                          "#51b866",
+                                          ";border-color:",
+                                          "#63bc74",
+                                          ";color:",
+                                          "rgb(249,252,250)",
+                                          ";:hover{background-color:",
+                                          "#4baa5f",
+                                          ";border-color:",
+                                          "#5cae6c",
+                                          ";color:",
+                                          "#e6e9e7",
+                                          ";}}&[disabled],&.disabled{background-color:",
+                                          "#72c180",
+                                          ";border-color:",
+                                          "#63bc74",
+                                          ";color:",
+                                          "rgb(250,252,250)",
+                                          ";:hover{background-color:",
+                                          "#72c180",
+                                          ";border-color:",
+                                          "#63bc74",
+                                          ";color:",
+                                          "rgb(250,252,250)",
+                                          ";}}}",
                                         ],
                                         Array [
-                                          [Function],
+                                          "&.btn-",
+                                          "warning",
+                                          "{background-color:",
+                                          "#ffd200",
+                                          ";border-color:",
+                                          "#f9cd07",
+                                          ";color:",
+                                          "rgb(57,47,0)",
+                                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                                          "#ebc20c",
+                                          ";border-color:",
+                                          "#e6bd0e",
+                                          ";color:",
+                                          "#362d0c",
+                                          ";}&.active{background-color:",
+                                          "#f2c70a",
+                                          ";border-color:",
+                                          "#ebc20c",
+                                          ";color:",
+                                          "rgb(54,45,2)",
+                                          ";:hover{background-color:",
+                                          "#e0b80f",
+                                          ";border-color:",
+                                          "#d9b310",
+                                          ";color:",
+                                          "#332b0c",
+                                          ";}}&[disabled],&.disabled{background-color:",
+                                          "#e4bc0e",
+                                          ";border-color:",
+                                          "#ebc20c",
+                                          ";color:",
+                                          "rgb(88,73,5)",
+                                          ";:hover{background-color:",
+                                          "#e4bc0e",
+                                          ";border-color:",
+                                          "#ebc20c",
+                                          ";color:",
+                                          "rgb(88,73,5)",
+                                          ";}}}",
                                         ],
                                       ],
                                     },
@@ -4130,48 +4653,44 @@ exports[`UrlWhitelistForm render the UrlWhitelistForm component should create ne
               </Input>
             </td>
             <td>
-              <ForwardRef
+              <Button
                 onClick={[Function]}
               >
-                <Button__StyledButton
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="Button-c9cbmb-0 bNulii"
+                  disabled={false}
                   onClick={[Function]}
                 >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="default"
-                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                  <button
+                    className="Button-c9cbmb-0 bNulii btn btn-default"
                     disabled={false}
                     onClick={[Function]}
+                    type="button"
                   >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                      disabled={false}
-                      onClick={[Function]}
-                      type="button"
+                    <Icon
+                      name="trash-alt"
+                      type="solid"
                     >
-                      <Icon
-                        name="trash-alt"
-                        type="solid"
-                      >
-                        <FontAwesomeIcon
-                          icon={
-                            Object {
-                              "iconName": "trash-alt",
-                              "prefix": "fas",
-                            }
+                      <FontAwesomeIcon
+                        icon={
+                          Object {
+                            "iconName": "trash-alt",
+                            "prefix": "fas",
                           }
-                        >
-                          <svg
-                            className="svg-inline--fa fa-trash-alt"
-                          />
-                        </FontAwesomeIcon>
-                      </Icon>
-                    </button>
-                  </Button>
-                </Button__StyledButton>
-              </ForwardRef>
+                        }
+                      >
+                        <svg
+                          className="svg-inline--fa fa-trash-alt"
+                        />
+                      </FontAwesomeIcon>
+                    </Icon>
+                  </button>
+                </Button>
+              </Button>
             </td>
           </tr>
           <tr
@@ -4615,25 +5134,291 @@ exports[`UrlWhitelistForm render the UrlWhitelistForm component should create ne
                                       ],
                                       "button": Array [
                                         Array [
-                                          [Function],
+                                          "&.btn-",
+                                          "danger",
+                                          "{background-color:",
+                                          "#ad0707",
+                                          ";border-color:",
+                                          "#b23939",
+                                          ";color:",
+                                          "rgb(252,249,249)",
+                                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                                          "#a00e0e",
+                                          ";border-color:",
+                                          "#a53636",
+                                          ";color:",
+                                          "#e9e6e6",
+                                          ";}&.active{background-color:",
+                                          "#b75151",
+                                          ";border-color:",
+                                          "#bc6363",
+                                          ";color:",
+                                          "rgb(252,249,249)",
+                                          ";:hover{background-color:",
+                                          "#a94c4c",
+                                          ";border-color:",
+                                          "#ad5c5c",
+                                          ";color:",
+                                          "#e9e6e6",
+                                          ";}}&[disabled],&.disabled{background-color:",
+                                          "#c07272",
+                                          ";border-color:",
+                                          "#bc6363",
+                                          ";color:",
+                                          "rgb(252,250,250)",
+                                          ";:hover{background-color:",
+                                          "#c07272",
+                                          ";border-color:",
+                                          "#bc6363",
+                                          ";color:",
+                                          "rgb(252,250,250)",
+                                          ";}}}",
                                         ],
                                         Array [
-                                          [Function],
+                                          "&.btn-",
+                                          "default",
+                                          "{background-color:",
+                                          "#e6e6e6",
+                                          ";border-color:",
+                                          "#e0e0e0",
+                                          ";color:",
+                                          "rgb(73,73,73)",
+                                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                                          "#d4d4d4",
+                                          ";border-color:",
+                                          "#cfcfcf",
+                                          ";color:",
+                                          "#444444",
+                                          ";}&.active{background-color:",
+                                          "#dadada",
+                                          ";border-color:",
+                                          "#d4d4d4",
+                                          ";color:",
+                                          "rgb(49,49,49)",
+                                          ";:hover{background-color:",
+                                          "#cacaca",
+                                          ";border-color:",
+                                          "#c4c4c4",
+                                          ";color:",
+                                          "#2f2f2f",
+                                          ";}}&[disabled],&.disabled{background-color:",
+                                          "#cecece",
+                                          ";border-color:",
+                                          "#d4d4d4",
+                                          ";color:",
+                                          "rgb(80,80,80)",
+                                          ";:hover{background-color:",
+                                          "#cecece",
+                                          ";border-color:",
+                                          "#d4d4d4",
+                                          ";color:",
+                                          "rgb(80,80,80)",
+                                          ";}}}",
                                         ],
                                         Array [
-                                          [Function],
+                                          "&.btn-",
+                                          "info",
+                                          "{background-color:",
+                                          "#0063be",
+                                          ";border-color:",
+                                          "#3970c2",
+                                          ";color:",
+                                          "rgb(249,250,252)",
+                                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                                          "#0c5cb0",
+                                          ";border-color:",
+                                          "#3668b3",
+                                          ";color:",
+                                          "#e6e7e9",
+                                          ";}&.active{background-color:",
+                                          "#517cc5",
+                                          ";border-color:",
+                                          "#6386c9",
+                                          ";color:",
+                                          "rgb(249,250,252)",
+                                          ";:hover{background-color:",
+                                          "#4b73b6",
+                                          ";border-color:",
+                                          "#5c7dba",
+                                          ";color:",
+                                          "#e6e7e9",
+                                          ";}}&[disabled],&.disabled{background-color:",
+                                          "#7290cd",
+                                          ";border-color:",
+                                          "#6386c9",
+                                          ";color:",
+                                          "rgb(250,251,253)",
+                                          ";:hover{background-color:",
+                                          "#7290cd",
+                                          ";border-color:",
+                                          "#6386c9",
+                                          ";color:",
+                                          "rgb(250,251,253)",
+                                          ";}}}",
                                         ],
                                         Array [
-                                          [Function],
+                                          "&.btn-",
+                                          "link",
+                                          "{background-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";border-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";color:",
+                                          "#702785",
+                                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                                          "#ebebeb26",
+                                          ";border-color:",
+                                          "#ebebeb26",
+                                          ";color:",
+                                          "#68267b",
+                                          ";}&.active{background-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";border-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";color:",
+                                          "#410057",
+                                          ";:hover{background-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";border-color:",
+                                          "#ebebeb26",
+                                          ";color:",
+                                          "#3d0c51",
+                                          ";}}&[disabled],&.disabled{background-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";border-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";color:",
+                                          "#702785",
+                                          ";:hover{background-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";border-color:",
+                                          "rgba(255, 255, 255, 0)",
+                                          ";color:",
+                                          "#702785",
+                                          ";}}}",
                                         ],
                                         Array [
-                                          [Function],
+                                          "&.btn-",
+                                          "primary",
+                                          "{background-color:",
+                                          "#702785",
+                                          ";border-color:",
+                                          "#7b458e",
+                                          ";color:",
+                                          "rgb(234,229,236)",
+                                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                                          "#68267b",
+                                          ";border-color:",
+                                          "#724083",
+                                          ";color:",
+                                          "#d8d3da",
+                                          ";}&.active{background-color:",
+                                          "#855996",
+                                          ";border-color:",
+                                          "#8f699d",
+                                          ";color:",
+                                          "rgb(250,249,251)",
+                                          ";:hover{background-color:",
+                                          "#7c538b",
+                                          ";border-color:",
+                                          "#846292",
+                                          ";color:",
+                                          "#e7e6e8",
+                                          ";}}&[disabled],&.disabled{background-color:",
+                                          "#9877a5",
+                                          ";border-color:",
+                                          "#8f699d",
+                                          ";color:",
+                                          "rgb(251,250,251)",
+                                          ";:hover{background-color:",
+                                          "#9877a5",
+                                          ";border-color:",
+                                          "#8f699d",
+                                          ";color:",
+                                          "rgb(251,250,251)",
+                                          ";}}}",
                                         ],
                                         Array [
-                                          [Function],
+                                          "&.btn-",
+                                          "success",
+                                          "{background-color:",
+                                          "#00ae42",
+                                          ";border-color:",
+                                          "#39b356",
+                                          ";color:",
+                                          "rgb(249,252,249)",
+                                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                                          "#0ca13e",
+                                          ";border-color:",
+                                          "#36a550",
+                                          ";color:",
+                                          "#e6e9e6",
+                                          ";}&.active{background-color:",
+                                          "#51b866",
+                                          ";border-color:",
+                                          "#63bc74",
+                                          ";color:",
+                                          "rgb(249,252,250)",
+                                          ";:hover{background-color:",
+                                          "#4baa5f",
+                                          ";border-color:",
+                                          "#5cae6c",
+                                          ";color:",
+                                          "#e6e9e7",
+                                          ";}}&[disabled],&.disabled{background-color:",
+                                          "#72c180",
+                                          ";border-color:",
+                                          "#63bc74",
+                                          ";color:",
+                                          "rgb(250,252,250)",
+                                          ";:hover{background-color:",
+                                          "#72c180",
+                                          ";border-color:",
+                                          "#63bc74",
+                                          ";color:",
+                                          "rgb(250,252,250)",
+                                          ";}}}",
                                         ],
                                         Array [
-                                          [Function],
+                                          "&.btn-",
+                                          "warning",
+                                          "{background-color:",
+                                          "#ffd200",
+                                          ";border-color:",
+                                          "#f9cd07",
+                                          ";color:",
+                                          "rgb(57,47,0)",
+                                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                                          "#ebc20c",
+                                          ";border-color:",
+                                          "#e6bd0e",
+                                          ";color:",
+                                          "#362d0c",
+                                          ";}&.active{background-color:",
+                                          "#f2c70a",
+                                          ";border-color:",
+                                          "#ebc20c",
+                                          ";color:",
+                                          "rgb(54,45,2)",
+                                          ";:hover{background-color:",
+                                          "#e0b80f",
+                                          ";border-color:",
+                                          "#d9b310",
+                                          ";color:",
+                                          "#332b0c",
+                                          ";}}&[disabled],&.disabled{background-color:",
+                                          "#e4bc0e",
+                                          ";border-color:",
+                                          "#ebc20c",
+                                          ";color:",
+                                          "rgb(88,73,5)",
+                                          ";:hover{background-color:",
+                                          "#e4bc0e",
+                                          ";border-color:",
+                                          "#ebc20c",
+                                          ";color:",
+                                          "rgb(88,73,5)",
+                                          ";}}}",
                                         ],
                                       ],
                                     },
@@ -6130,82 +6915,73 @@ exports[`UrlWhitelistForm render the UrlWhitelistForm component should create ne
               </Input>
             </td>
             <td>
-              <ForwardRef
+              <Button
                 onClick={[Function]}
               >
-                <Button__StyledButton
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="Button-c9cbmb-0 bNulii"
+                  disabled={false}
                   onClick={[Function]}
                 >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="default"
-                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                  <button
+                    className="Button-c9cbmb-0 bNulii btn btn-default"
                     disabled={false}
                     onClick={[Function]}
+                    type="button"
                   >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                      disabled={false}
-                      onClick={[Function]}
-                      type="button"
+                    <Icon
+                      name="trash-alt"
+                      type="solid"
                     >
-                      <Icon
-                        name="trash-alt"
-                        type="solid"
-                      >
-                        <FontAwesomeIcon
-                          icon={
-                            Object {
-                              "iconName": "trash-alt",
-                              "prefix": "fas",
-                            }
+                      <FontAwesomeIcon
+                        icon={
+                          Object {
+                            "iconName": "trash-alt",
+                            "prefix": "fas",
                           }
-                        >
-                          <svg
-                            className="svg-inline--fa fa-trash-alt"
-                          />
-                        </FontAwesomeIcon>
-                      </Icon>
-                    </button>
-                  </Button>
-                </Button__StyledButton>
-              </ForwardRef>
+                        }
+                      >
+                        <svg
+                          className="svg-inline--fa fa-trash-alt"
+                        />
+                      </FontAwesomeIcon>
+                    </Icon>
+                  </button>
+                </Button>
+              </Button>
             </td>
           </tr>
         </tbody>
       </table>
     </Table>
   </UrlWhiteListForm__StyledTable>
-  <ForwardRef
+  <Button
     bsSize="sm"
     onClick={[Function]}
   >
-    <Button__StyledButton
+    <Button
+      active={false}
+      block={false}
+      bsClass="btn"
       bsSize="sm"
+      bsStyle="default"
+      className="Button-c9cbmb-0 bNulii"
+      disabled={false}
       onClick={[Function]}
     >
-      <Button
-        active={false}
-        block={false}
-        bsClass="btn"
-        bsSize="sm"
-        bsStyle="default"
-        className="Button__StyledButton-c9cbmb-0 laZUlH"
+      <button
+        className="Button-c9cbmb-0 bNulii btn btn-sm btn-default"
         disabled={false}
         onClick={[Function]}
+        type="button"
       >
-        <button
-          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-default"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-        >
-          Add Url
-        </button>
-      </Button>
-    </Button__StyledButton>
-  </ForwardRef>
+        Add Url
+      </button>
+    </Button>
+  </Button>
 </UrlWhiteListForm>
 `;

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackApplyParameter.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackApplyParameter.test.jsx.snap
@@ -342,35 +342,29 @@ exports[`<ContentPackApplyParameter /> should render with full props 1`] = `
               <div
                 className="col-sm-2 col-sm-offset-10"
               >
-                <ForwardRef
+                <Button
                   bsStyle="primary"
                   disabled={true}
                   type="submit"
                 >
-                  <Button__StyledButton
+                  <Button
+                    active={false}
+                    block={false}
+                    bsClass="btn"
                     bsStyle="primary"
+                    className="Button-c9cbmb-0 bNulii"
                     disabled={true}
                     type="submit"
                   >
-                    <Button
-                      active={false}
-                      block={false}
-                      bsClass="btn"
-                      bsStyle="primary"
-                      className="Button__StyledButton-c9cbmb-0 laZUlH"
+                    <button
+                      className="Button-c9cbmb-0 bNulii btn btn-primary"
                       disabled={true}
                       type="submit"
                     >
-                      <button
-                        className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-primary"
-                        disabled={true}
-                        type="submit"
-                      >
-                        Apply
-                      </button>
-                    </Button>
-                  </Button__StyledButton>
-                </ForwardRef>
+                      Apply
+                    </button>
+                  </Button>
+                </Button>
               </div>
             </Col>
           </div>
@@ -497,37 +491,31 @@ exports[`<ContentPackApplyParameter /> should render with full props 1`] = `
                                     PORT
                                   </td>
                                   <td>
-                                    <ForwardRef
+                                    <Button
                                       bsSize="small"
                                       bsStyle="info"
                                       onClick={[Function]}
                                     >
-                                      <Button__StyledButton
+                                      <Button
+                                        active={false}
+                                        block={false}
+                                        bsClass="btn"
                                         bsSize="small"
                                         bsStyle="info"
+                                        className="Button-c9cbmb-0 bNulii"
+                                        disabled={false}
                                         onClick={[Function]}
                                       >
-                                        <Button
-                                          active={false}
-                                          block={false}
-                                          bsClass="btn"
-                                          bsSize="small"
-                                          bsStyle="info"
-                                          className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                        <button
+                                          className="Button-c9cbmb-0 bNulii btn btn-sm btn-info"
                                           disabled={false}
                                           onClick={[Function]}
+                                          type="button"
                                         >
-                                          <button
-                                            className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-info"
-                                            disabled={false}
-                                            onClick={[Function]}
-                                            type="button"
-                                          >
-                                            Clear
-                                          </button>
-                                        </Button>
-                                      </Button__StyledButton>
-                                    </ForwardRef>
+                                          Clear
+                                        </button>
+                                      </Button>
+                                    </Button>
                                   </td>
                                 </tr>
                               </DataTableElement>
@@ -871,35 +859,29 @@ exports[`<ContentPackApplyParameter /> should render with minimal props 1`] = `
               <div
                 className="col-sm-2 col-sm-offset-10"
               >
-                <ForwardRef
+                <Button
                   bsStyle="primary"
                   disabled={true}
                   type="submit"
                 >
-                  <Button__StyledButton
+                  <Button
+                    active={false}
+                    block={false}
+                    bsClass="btn"
                     bsStyle="primary"
+                    className="Button-c9cbmb-0 bNulii"
                     disabled={true}
                     type="submit"
                   >
-                    <Button
-                      active={false}
-                      block={false}
-                      bsClass="btn"
-                      bsStyle="primary"
-                      className="Button__StyledButton-c9cbmb-0 laZUlH"
+                    <button
+                      className="Button-c9cbmb-0 bNulii btn btn-primary"
                       disabled={true}
                       type="submit"
                     >
-                      <button
-                        className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-primary"
-                        disabled={true}
-                        type="submit"
-                      >
-                        Apply
-                      </button>
-                    </Button>
-                  </Button__StyledButton>
-                </ForwardRef>
+                      Apply
+                    </button>
+                  </Button>
+                </Button>
               </div>
             </Col>
           </div>
@@ -1317,35 +1299,29 @@ exports[`<ContentPackApplyParameter /> should render with readOnly 1`] = `
               <div
                 className="col-sm-2 col-sm-offset-10"
               >
-                <ForwardRef
+                <Button
                   bsStyle="primary"
                   disabled={true}
                   type="submit"
                 >
-                  <Button__StyledButton
+                  <Button
+                    active={false}
+                    block={false}
+                    bsClass="btn"
                     bsStyle="primary"
+                    className="Button-c9cbmb-0 bNulii"
                     disabled={true}
                     type="submit"
                   >
-                    <Button
-                      active={false}
-                      block={false}
-                      bsClass="btn"
-                      bsStyle="primary"
-                      className="Button__StyledButton-c9cbmb-0 laZUlH"
+                    <button
+                      className="Button-c9cbmb-0 bNulii btn btn-primary"
                       disabled={true}
                       type="submit"
                     >
-                      <button
-                        className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-primary"
-                        disabled={true}
-                        type="submit"
-                      >
-                        Apply
-                      </button>
-                    </Button>
-                  </Button__StyledButton>
-                </ForwardRef>
+                      Apply
+                    </button>
+                  </Button>
+                </Button>
               </div>
             </Col>
           </div>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
@@ -297,39 +297,32 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                           <div
                             className="col-xs-6"
                           >
-                            <ForwardRef
+                            <Button
                               bsSize="small"
                               bsStyle="info"
                               disabled={true}
                               onClick={[Function]}
                             >
-                              <Button__StyledButton
+                              <Button
+                                active={false}
+                                block={false}
+                                bsClass="btn"
                                 bsSize="small"
                                 bsStyle="info"
+                                className="Button-c9cbmb-0 bNulii"
                                 disabled={true}
                                 onClick={[Function]}
                               >
-                                <Button
-                                  active={false}
-                                  block={false}
-                                  bsClass="btn"
-                                  bsSize="small"
-                                  bsStyle="info"
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                <button
+                                  className="Button-c9cbmb-0 bNulii btn btn-sm btn-info"
                                   disabled={true}
                                   onClick={[Function]}
+                                  type="button"
                                 >
-                                  <button
-                                    className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-info"
-                                    disabled={true}
-                                    onClick={[Function]}
-                                    type="button"
-                                  >
-                                    Previous
-                                  </button>
-                                </Button>
-                              </Button__StyledButton>
-                            </ForwardRef>
+                                  Previous
+                                </button>
+                              </Button>
+                            </Button>
                           </div>
                         </Col>
                         <Col
@@ -341,39 +334,32 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                           <div
                             className="text-right col-xs-6"
                           >
-                            <ForwardRef
+                            <Button
                               bsSize="small"
                               bsStyle="info"
                               disabled={true}
                               onClick={[Function]}
                             >
-                              <Button__StyledButton
+                              <Button
+                                active={false}
+                                block={false}
+                                bsClass="btn"
                                 bsSize="small"
                                 bsStyle="info"
+                                className="Button-c9cbmb-0 bNulii"
                                 disabled={true}
                                 onClick={[Function]}
                               >
-                                <Button
-                                  active={false}
-                                  block={false}
-                                  bsClass="btn"
-                                  bsSize="small"
-                                  bsStyle="info"
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                <button
+                                  className="Button-c9cbmb-0 bNulii btn btn-sm btn-info"
                                   disabled={true}
                                   onClick={[Function]}
+                                  type="button"
                                 >
-                                  <button
-                                    className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-info"
-                                    disabled={true}
-                                    onClick={[Function]}
-                                    type="button"
-                                  >
-                                    Next
-                                  </button>
-                                </Button>
-                              </Button__StyledButton>
-                            </ForwardRef>
+                                  Next
+                                </button>
+                              </Button>
+                            </Button>
                           </div>
                         </Col>
                       </div>
@@ -1077,37 +1063,30 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                                         }
                                       }
                                     >
-                                      <ForwardRef
+                                      <Button
                                         bsStyle="default"
                                         className="submit-button"
                                         disabled={false}
                                         type="submit"
                                       >
-                                        <Button__StyledButton
+                                        <Button
+                                          active={false}
+                                          block={false}
+                                          bsClass="btn"
                                           bsStyle="default"
-                                          className="submit-button"
+                                          className="Button-c9cbmb-0 bNulii submit-button"
                                           disabled={false}
                                           type="submit"
                                         >
-                                          <Button
-                                            active={false}
-                                            block={false}
-                                            bsClass="btn"
-                                            bsStyle="default"
-                                            className="Button__StyledButton-c9cbmb-0 laZUlH submit-button"
+                                          <button
+                                            className="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                                             disabled={false}
                                             type="submit"
                                           >
-                                            <button
-                                              className="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
-                                              disabled={false}
-                                              type="submit"
-                                            >
-                                              Filter
-                                            </button>
-                                          </Button>
-                                        </Button__StyledButton>
-                                      </ForwardRef>
+                                            Filter
+                                          </button>
+                                        </Button>
+                                      </Button>
                                     </div>
                                     <div
                                       className="form-group"
@@ -1117,37 +1096,31 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                                         }
                                       }
                                     >
-                                      <ForwardRef
+                                      <Button
                                         className="reset-button"
                                         onClick={[Function]}
                                         type="reset"
                                       >
-                                        <Button__StyledButton
-                                          className="reset-button"
+                                        <Button
+                                          active={false}
+                                          block={false}
+                                          bsClass="btn"
+                                          bsStyle="default"
+                                          className="Button-c9cbmb-0 bNulii reset-button"
+                                          disabled={false}
                                           onClick={[Function]}
                                           type="reset"
                                         >
-                                          <Button
-                                            active={false}
-                                            block={false}
-                                            bsClass="btn"
-                                            bsStyle="default"
-                                            className="Button__StyledButton-c9cbmb-0 laZUlH reset-button"
+                                          <button
+                                            className="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                                             disabled={false}
                                             onClick={[Function]}
                                             type="reset"
                                           >
-                                            <button
-                                              className="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
-                                              disabled={false}
-                                              onClick={[Function]}
-                                              type="reset"
-                                            >
-                                              Reset
-                                            </button>
-                                          </Button>
-                                        </Button__StyledButton>
-                                      </ForwardRef>
+                                            Reset
+                                          </button>
+                                        </Button>
+                                      </Button>
                                     </div>
                                   </form>
                                 </div>
@@ -1806,39 +1779,32 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
                           <div
                             className="col-xs-6"
                           >
-                            <ForwardRef
+                            <Button
                               bsSize="small"
                               bsStyle="info"
                               disabled={true}
                               onClick={[Function]}
                             >
-                              <Button__StyledButton
+                              <Button
+                                active={false}
+                                block={false}
+                                bsClass="btn"
                                 bsSize="small"
                                 bsStyle="info"
+                                className="Button-c9cbmb-0 bNulii"
                                 disabled={true}
                                 onClick={[Function]}
                               >
-                                <Button
-                                  active={false}
-                                  block={false}
-                                  bsClass="btn"
-                                  bsSize="small"
-                                  bsStyle="info"
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                <button
+                                  className="Button-c9cbmb-0 bNulii btn btn-sm btn-info"
                                   disabled={true}
                                   onClick={[Function]}
+                                  type="button"
                                 >
-                                  <button
-                                    className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-info"
-                                    disabled={true}
-                                    onClick={[Function]}
-                                    type="button"
-                                  >
-                                    Previous
-                                  </button>
-                                </Button>
-                              </Button__StyledButton>
-                            </ForwardRef>
+                                  Previous
+                                </button>
+                              </Button>
+                            </Button>
                           </div>
                         </Col>
                         <Col
@@ -1850,39 +1816,32 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
                           <div
                             className="text-right col-xs-6"
                           >
-                            <ForwardRef
+                            <Button
                               bsSize="small"
                               bsStyle="info"
                               disabled={false}
                               onClick={[Function]}
                             >
-                              <Button__StyledButton
+                              <Button
+                                active={false}
+                                block={false}
+                                bsClass="btn"
                                 bsSize="small"
                                 bsStyle="info"
+                                className="Button-c9cbmb-0 bNulii"
                                 disabled={false}
                                 onClick={[Function]}
                               >
-                                <Button
-                                  active={false}
-                                  block={false}
-                                  bsClass="btn"
-                                  bsSize="small"
-                                  bsStyle="info"
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                <button
+                                  className="Button-c9cbmb-0 bNulii btn btn-sm btn-info"
                                   disabled={false}
                                   onClick={[Function]}
+                                  type="button"
                                 >
-                                  <button
-                                    className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-info"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    type="button"
-                                  >
-                                    Next
-                                  </button>
-                                </Button>
-                              </Button__StyledButton>
-                            </ForwardRef>
+                                  Next
+                                </button>
+                              </Button>
+                            </Button>
                           </div>
                         </Col>
                       </div>
@@ -2627,37 +2586,30 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
                                         }
                                       }
                                     >
-                                      <ForwardRef
+                                      <Button
                                         bsStyle="default"
                                         className="submit-button"
                                         disabled={false}
                                         type="submit"
                                       >
-                                        <Button__StyledButton
+                                        <Button
+                                          active={false}
+                                          block={false}
+                                          bsClass="btn"
                                           bsStyle="default"
-                                          className="submit-button"
+                                          className="Button-c9cbmb-0 bNulii submit-button"
                                           disabled={false}
                                           type="submit"
                                         >
-                                          <Button
-                                            active={false}
-                                            block={false}
-                                            bsClass="btn"
-                                            bsStyle="default"
-                                            className="Button__StyledButton-c9cbmb-0 laZUlH submit-button"
+                                          <button
+                                            className="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                                             disabled={false}
                                             type="submit"
                                           >
-                                            <button
-                                              className="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
-                                              disabled={false}
-                                              type="submit"
-                                            >
-                                              Filter
-                                            </button>
-                                          </Button>
-                                        </Button__StyledButton>
-                                      </ForwardRef>
+                                            Filter
+                                          </button>
+                                        </Button>
+                                      </Button>
                                     </div>
                                     <div
                                       className="form-group"
@@ -2667,37 +2619,31 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
                                         }
                                       }
                                     >
-                                      <ForwardRef
+                                      <Button
                                         className="reset-button"
                                         onClick={[Function]}
                                         type="reset"
                                       >
-                                        <Button__StyledButton
-                                          className="reset-button"
+                                        <Button
+                                          active={false}
+                                          block={false}
+                                          bsClass="btn"
+                                          bsStyle="default"
+                                          className="Button-c9cbmb-0 bNulii reset-button"
+                                          disabled={false}
                                           onClick={[Function]}
                                           type="reset"
                                         >
-                                          <Button
-                                            active={false}
-                                            block={false}
-                                            bsClass="btn"
-                                            bsStyle="default"
-                                            className="Button__StyledButton-c9cbmb-0 laZUlH reset-button"
+                                          <button
+                                            className="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                                             disabled={false}
                                             onClick={[Function]}
                                             type="reset"
                                           >
-                                            <button
-                                              className="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
-                                              disabled={false}
-                                              onClick={[Function]}
-                                              type="reset"
-                                            >
-                                              Reset
-                                            </button>
-                                          </Button>
-                                        </Button__StyledButton>
-                                      </ForwardRef>
+                                            Reset
+                                          </button>
+                                        </Button>
+                                      </Button>
                                     </div>
                                   </form>
                                 </div>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntitiesList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntitiesList.test.jsx.snap
@@ -76,37 +76,30 @@ exports[`<ContentPackEntitiesList /> should render with empty entities 1`] = `
               }
             }
           >
-            <ForwardRef
+            <Button
               bsStyle="default"
               className="submit-button"
               disabled={false}
               type="submit"
             >
-              <Button__StyledButton
+              <Button
+                active={false}
+                block={false}
+                bsClass="btn"
                 bsStyle="default"
-                className="submit-button"
+                className="Button-c9cbmb-0 bNulii submit-button"
                 disabled={false}
                 type="submit"
               >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 laZUlH submit-button"
+                <button
+                  className="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                   disabled={false}
                   type="submit"
                 >
-                  <button
-                    className="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
-                    disabled={false}
-                    type="submit"
-                  >
-                    Filter
-                  </button>
-                </Button>
-              </Button__StyledButton>
-            </ForwardRef>
+                  Filter
+                </button>
+              </Button>
+            </Button>
           </div>
           <div
             className="form-group"
@@ -116,37 +109,31 @@ exports[`<ContentPackEntitiesList /> should render with empty entities 1`] = `
               }
             }
           >
-            <ForwardRef
+            <Button
               className="reset-button"
               onClick={[Function]}
               type="reset"
             >
-              <Button__StyledButton
-                className="reset-button"
+              <Button
+                active={false}
+                block={false}
+                bsClass="btn"
+                bsStyle="default"
+                className="Button-c9cbmb-0 bNulii reset-button"
+                disabled={false}
                 onClick={[Function]}
                 type="reset"
               >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 laZUlH reset-button"
+                <button
+                  className="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                   disabled={false}
                   onClick={[Function]}
                   type="reset"
                 >
-                  <button
-                    className="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
-                    disabled={false}
-                    onClick={[Function]}
-                    type="reset"
-                  >
-                    Reset
-                  </button>
-                </Button>
-              </Button__StyledButton>
-            </ForwardRef>
+                  Reset
+                </button>
+              </Button>
+            </Button>
           </div>
         </form>
       </div>
@@ -355,37 +342,30 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
               }
             }
           >
-            <ForwardRef
+            <Button
               bsStyle="default"
               className="submit-button"
               disabled={false}
               type="submit"
             >
-              <Button__StyledButton
+              <Button
+                active={false}
+                block={false}
+                bsClass="btn"
                 bsStyle="default"
-                className="submit-button"
+                className="Button-c9cbmb-0 bNulii submit-button"
                 disabled={false}
                 type="submit"
               >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 laZUlH submit-button"
+                <button
+                  className="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                   disabled={false}
                   type="submit"
                 >
-                  <button
-                    className="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
-                    disabled={false}
-                    type="submit"
-                  >
-                    Filter
-                  </button>
-                </Button>
-              </Button__StyledButton>
-            </ForwardRef>
+                  Filter
+                </button>
+              </Button>
+            </Button>
           </div>
           <div
             className="form-group"
@@ -395,37 +375,31 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
               }
             }
           >
-            <ForwardRef
+            <Button
               className="reset-button"
               onClick={[Function]}
               type="reset"
             >
-              <Button__StyledButton
-                className="reset-button"
+              <Button
+                active={false}
+                block={false}
+                bsClass="btn"
+                bsStyle="default"
+                className="Button-c9cbmb-0 bNulii reset-button"
+                disabled={false}
                 onClick={[Function]}
                 type="reset"
               >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 laZUlH reset-button"
+                <button
+                  className="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                   disabled={false}
                   onClick={[Function]}
                   type="reset"
                 >
-                  <button
-                    className="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
-                    disabled={false}
-                    onClick={[Function]}
-                    type="reset"
-                  >
-                    Reset
-                  </button>
-                </Button>
-              </Button__StyledButton>
-            </ForwardRef>
+                  Reset
+                </button>
+              </Button>
+            </Button>
           </div>
         </form>
       </div>
@@ -677,70 +651,57 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
                               className="btn-toolbar"
                               role="toolbar"
                             >
-                              <ForwardRef
+                              <Button
                                 bsSize="xs"
                                 bsStyle="primary"
                                 disabled={false}
                                 onClick={[Function]}
                               >
-                                <Button__StyledButton
+                                <Button
+                                  active={false}
+                                  block={false}
+                                  bsClass="btn"
                                   bsSize="xs"
                                   bsStyle="primary"
+                                  className="Button-c9cbmb-0 bNulii"
                                   disabled={false}
                                   onClick={[Function]}
                                 >
-                                  <Button
-                                    active={false}
-                                    block={false}
-                                    bsClass="btn"
-                                    bsSize="xs"
-                                    bsStyle="primary"
-                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                  <button
+                                    className="Button-c9cbmb-0 bNulii btn btn-xs btn-primary"
                                     disabled={false}
                                     onClick={[Function]}
+                                    type="button"
                                   >
-                                    <button
-                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-xs btn-primary"
-                                      disabled={false}
-                                      onClick={[Function]}
-                                      type="button"
-                                    >
-                                      Edit
-                                    </button>
-                                  </Button>
-                                </Button__StyledButton>
-                              </ForwardRef>
-                              <ForwardRef
+                                    Edit
+                                  </button>
+                                </Button>
+                              </Button>
+                              <Button
                                 bsSize="xs"
                                 bsStyle="info"
                                 onClick={[Function]}
                               >
-                                <Button__StyledButton
+                                <Button
+                                  active={false}
+                                  block={false}
+                                  bsClass="btn"
                                   bsSize="xs"
                                   bsStyle="info"
+                                  className="Button-c9cbmb-0 bNulii"
+                                  disabled={false}
                                   onClick={[Function]}
                                 >
-                                  <Button
-                                    active={false}
-                                    block={false}
-                                    bsClass="btn"
-                                    bsSize="xs"
-                                    bsStyle="info"
-                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                  <button
+                                    className="Button-c9cbmb-0 bNulii btn btn-xs btn-info"
                                     disabled={false}
                                     onClick={[Function]}
+                                    type="button"
                                   >
-                                    <button
-                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-xs btn-info"
-                                      disabled={false}
-                                      onClick={[Function]}
-                                      type="button"
-                                    >
-                                      Show
-                                    </button>
-                                  </Button>
-                                </Button__StyledButton>
-                              </ForwardRef>
+                                    Show
+                                  </button>
+                                </Button>
+                              </Button>
                             </div>
                           </ButtonToolbar>
                         </td>
@@ -976,70 +937,57 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
                               className="btn-toolbar"
                               role="toolbar"
                             >
-                              <ForwardRef
+                              <Button
                                 bsSize="xs"
                                 bsStyle="primary"
                                 disabled={false}
                                 onClick={[Function]}
                               >
-                                <Button__StyledButton
+                                <Button
+                                  active={false}
+                                  block={false}
+                                  bsClass="btn"
                                   bsSize="xs"
                                   bsStyle="primary"
+                                  className="Button-c9cbmb-0 bNulii"
                                   disabled={false}
                                   onClick={[Function]}
                                 >
-                                  <Button
-                                    active={false}
-                                    block={false}
-                                    bsClass="btn"
-                                    bsSize="xs"
-                                    bsStyle="primary"
-                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                  <button
+                                    className="Button-c9cbmb-0 bNulii btn btn-xs btn-primary"
                                     disabled={false}
                                     onClick={[Function]}
+                                    type="button"
                                   >
-                                    <button
-                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-xs btn-primary"
-                                      disabled={false}
-                                      onClick={[Function]}
-                                      type="button"
-                                    >
-                                      Edit
-                                    </button>
-                                  </Button>
-                                </Button__StyledButton>
-                              </ForwardRef>
-                              <ForwardRef
+                                    Edit
+                                  </button>
+                                </Button>
+                              </Button>
+                              <Button
                                 bsSize="xs"
                                 bsStyle="info"
                                 onClick={[Function]}
                               >
-                                <Button__StyledButton
+                                <Button
+                                  active={false}
+                                  block={false}
+                                  bsClass="btn"
                                   bsSize="xs"
                                   bsStyle="info"
+                                  className="Button-c9cbmb-0 bNulii"
+                                  disabled={false}
                                   onClick={[Function]}
                                 >
-                                  <Button
-                                    active={false}
-                                    block={false}
-                                    bsClass="btn"
-                                    bsSize="xs"
-                                    bsStyle="info"
-                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                  <button
+                                    className="Button-c9cbmb-0 bNulii btn btn-xs btn-info"
                                     disabled={false}
                                     onClick={[Function]}
+                                    type="button"
                                   >
-                                    <button
-                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-xs btn-info"
-                                      disabled={false}
-                                      onClick={[Function]}
-                                      type="button"
-                                    >
-                                      Show
-                                    </button>
-                                  </Button>
-                                </Button__StyledButton>
-                              </ForwardRef>
+                                    Show
+                                  </button>
+                                </Button>
+                              </Button>
                             </div>
                           </ButtonToolbar>
                         </td>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstall.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstall.test.jsx.snap
@@ -434,37 +434,30 @@ exports[`<ContentPackInstall /> should render a install 1`] = `
                             }
                           }
                         >
-                          <ForwardRef
+                          <Button
                             bsStyle="default"
                             className="submit-button"
                             disabled={false}
                             type="submit"
                           >
-                            <Button__StyledButton
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
                               bsStyle="default"
-                              className="submit-button"
+                              className="Button-c9cbmb-0 bNulii submit-button"
                               disabled={false}
                               type="submit"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="default"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH submit-button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                                 disabled={false}
                                 type="submit"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
-                                  disabled={false}
-                                  type="submit"
-                                >
-                                  Filter
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
+                                Filter
+                              </button>
+                            </Button>
+                          </Button>
                         </div>
                         <div
                           className="form-group"
@@ -474,37 +467,31 @@ exports[`<ContentPackInstall /> should render a install 1`] = `
                             }
                           }
                         >
-                          <ForwardRef
+                          <Button
                             className="reset-button"
                             onClick={[Function]}
                             type="reset"
                           >
-                            <Button__StyledButton
-                              className="reset-button"
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
+                              bsStyle="default"
+                              className="Button-c9cbmb-0 bNulii reset-button"
+                              disabled={false}
                               onClick={[Function]}
                               type="reset"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="default"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH reset-button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                                 disabled={false}
                                 onClick={[Function]}
                                 type="reset"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  type="reset"
-                                >
-                                  Reset
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
+                                Reset
+                              </button>
+                            </Button>
+                          </Button>
                         </div>
                       </form>
                     </div>
@@ -663,37 +650,31 @@ exports[`<ContentPackInstall /> should render a install 1`] = `
                                             className="btn-toolbar"
                                             role="toolbar"
                                           >
-                                            <ForwardRef
+                                            <Button
                                               bsSize="xs"
                                               bsStyle="info"
                                               onClick={[Function]}
                                             >
-                                              <Button__StyledButton
+                                              <Button
+                                                active={false}
+                                                block={false}
+                                                bsClass="btn"
                                                 bsSize="xs"
                                                 bsStyle="info"
+                                                className="Button-c9cbmb-0 bNulii"
+                                                disabled={false}
                                                 onClick={[Function]}
                                               >
-                                                <Button
-                                                  active={false}
-                                                  block={false}
-                                                  bsClass="btn"
-                                                  bsSize="xs"
-                                                  bsStyle="info"
-                                                  className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                <button
+                                                  className="Button-c9cbmb-0 bNulii btn btn-xs btn-info"
                                                   disabled={false}
                                                   onClick={[Function]}
+                                                  type="button"
                                                 >
-                                                  <button
-                                                    className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-xs btn-info"
-                                                    disabled={false}
-                                                    onClick={[Function]}
-                                                    type="button"
-                                                  >
-                                                    Show
-                                                  </button>
-                                                </Button>
-                                              </Button__StyledButton>
-                                            </ForwardRef>
+                                                  Show
+                                                </button>
+                                              </Button>
+                                            </Button>
                                           </div>
                                         </ButtonToolbar>
                                       </td>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstallations.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstallations.test.jsx.snap
@@ -190,68 +190,56 @@ exports[`<ContentPackInstallations /> should render with a installation 1`] = `
                               className="btn-toolbar"
                               role="toolbar"
                             >
-                              <ForwardRef
+                              <Button
                                 bsSize="small"
                                 bsStyle="primary"
                                 onClick={[Function]}
                               >
-                                <Button__StyledButton
+                                <Button
+                                  active={false}
+                                  block={false}
+                                  bsClass="btn"
                                   bsSize="small"
                                   bsStyle="primary"
+                                  className="Button-c9cbmb-0 bNulii"
+                                  disabled={false}
                                   onClick={[Function]}
                                 >
-                                  <Button
-                                    active={false}
-                                    block={false}
-                                    bsClass="btn"
-                                    bsSize="small"
-                                    bsStyle="primary"
-                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                  <button
+                                    className="Button-c9cbmb-0 bNulii btn btn-sm btn-primary"
                                     disabled={false}
                                     onClick={[Function]}
+                                    type="button"
                                   >
-                                    <button
-                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-primary"
-                                      disabled={false}
-                                      onClick={[Function]}
-                                      type="button"
-                                    >
-                                      Uninstall
-                                    </button>
-                                  </Button>
-                                </Button__StyledButton>
-                              </ForwardRef>
-                              <ForwardRef
+                                    Uninstall
+                                  </button>
+                                </Button>
+                              </Button>
+                              <Button
                                 bsSize="small"
                                 bsStyle="info"
                                 onClick={[Function]}
                               >
-                                <Button__StyledButton
+                                <Button
+                                  active={false}
+                                  block={false}
+                                  bsClass="btn"
                                   bsSize="small"
                                   bsStyle="info"
+                                  className="Button-c9cbmb-0 bNulii"
+                                  disabled={false}
                                   onClick={[Function]}
                                 >
-                                  <Button
-                                    active={false}
-                                    block={false}
-                                    bsClass="btn"
-                                    bsSize="small"
-                                    bsStyle="info"
-                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                  <button
+                                    className="Button-c9cbmb-0 bNulii btn btn-sm btn-info"
                                     disabled={false}
                                     onClick={[Function]}
+                                    type="button"
                                   >
-                                    <button
-                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-info"
-                                      disabled={false}
-                                      onClick={[Function]}
-                                      type="button"
-                                    >
-                                      View
-                                    </button>
-                                  </Button>
-                                </Button__StyledButton>
-                              </ForwardRef>
+                                    View
+                                  </button>
+                                </Button>
+                              </Button>
                               <BootstrapModalWrapper
                                 backdrop="static"
                                 bsSize="large"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameterList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameterList.test.jsx.snap
@@ -85,37 +85,30 @@ exports[`<ContentPackParameterList /> should render with empty parameters with r
               }
             }
           >
-            <ForwardRef
+            <Button
               bsStyle="default"
               className="submit-button"
               disabled={false}
               type="submit"
             >
-              <Button__StyledButton
+              <Button
+                active={false}
+                block={false}
+                bsClass="btn"
                 bsStyle="default"
-                className="submit-button"
+                className="Button-c9cbmb-0 bNulii submit-button"
                 disabled={false}
                 type="submit"
               >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 laZUlH submit-button"
+                <button
+                  className="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                   disabled={false}
                   type="submit"
                 >
-                  <button
-                    className="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
-                    disabled={false}
-                    type="submit"
-                  >
-                    Filter
-                  </button>
-                </Button>
-              </Button__StyledButton>
-            </ForwardRef>
+                  Filter
+                </button>
+              </Button>
+            </Button>
           </div>
           <div
             className="form-group"
@@ -125,37 +118,31 @@ exports[`<ContentPackParameterList /> should render with empty parameters with r
               }
             }
           >
-            <ForwardRef
+            <Button
               className="reset-button"
               onClick={[Function]}
               type="reset"
             >
-              <Button__StyledButton
-                className="reset-button"
+              <Button
+                active={false}
+                block={false}
+                bsClass="btn"
+                bsStyle="default"
+                className="Button-c9cbmb-0 bNulii reset-button"
+                disabled={false}
                 onClick={[Function]}
                 type="reset"
               >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 laZUlH reset-button"
+                <button
+                  className="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                   disabled={false}
                   onClick={[Function]}
                   type="reset"
                 >
-                  <button
-                    className="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
-                    disabled={false}
-                    onClick={[Function]}
-                    type="reset"
-                  >
-                    Reset
-                  </button>
-                </Button>
-              </Button__StyledButton>
-            </ForwardRef>
+                  Reset
+                </button>
+              </Button>
+            </Button>
           </div>
         </form>
       </div>
@@ -235,41 +222,34 @@ exports[`<ContentPackParameterList /> should render with empty parameters withou
       Parameters list
     </h2>
     <br />
-    <ForwardRef
+    <Button
       bsSize="small"
       bsStyle="info"
       onClick={[Function]}
       title="Edit Modal"
     >
-      <Button__StyledButton
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
         bsSize="small"
         bsStyle="info"
+        className="Button-c9cbmb-0 bNulii"
+        disabled={false}
         onClick={[Function]}
         title="Edit Modal"
       >
-        <Button
-          active={false}
-          block={false}
-          bsClass="btn"
-          bsSize="small"
-          bsStyle="info"
-          className="Button__StyledButton-c9cbmb-0 laZUlH"
+        <button
+          className="Button-c9cbmb-0 bNulii btn btn-sm btn-info"
           disabled={false}
           onClick={[Function]}
           title="Edit Modal"
+          type="button"
         >
-          <button
-            className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-info"
-            disabled={false}
-            onClick={[Function]}
-            title="Edit Modal"
-            type="button"
-          >
-            Create parameter
-          </button>
-        </Button>
-      </Button__StyledButton>
-    </ForwardRef>
+          Create parameter
+        </button>
+      </Button>
+    </Button>
     <BootstrapModalWrapper
       backdrop="static"
       bsSize="large"
@@ -406,37 +386,30 @@ exports[`<ContentPackParameterList /> should render with empty parameters withou
               }
             }
           >
-            <ForwardRef
+            <Button
               bsStyle="default"
               className="submit-button"
               disabled={false}
               type="submit"
             >
-              <Button__StyledButton
+              <Button
+                active={false}
+                block={false}
+                bsClass="btn"
                 bsStyle="default"
-                className="submit-button"
+                className="Button-c9cbmb-0 bNulii submit-button"
                 disabled={false}
                 type="submit"
               >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 laZUlH submit-button"
+                <button
+                  className="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                   disabled={false}
                   type="submit"
                 >
-                  <button
-                    className="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
-                    disabled={false}
-                    type="submit"
-                  >
-                    Filter
-                  </button>
-                </Button>
-              </Button__StyledButton>
-            </ForwardRef>
+                  Filter
+                </button>
+              </Button>
+            </Button>
           </div>
           <div
             className="form-group"
@@ -446,37 +419,31 @@ exports[`<ContentPackParameterList /> should render with empty parameters withou
               }
             }
           >
-            <ForwardRef
+            <Button
               className="reset-button"
               onClick={[Function]}
               type="reset"
             >
-              <Button__StyledButton
-                className="reset-button"
+              <Button
+                active={false}
+                block={false}
+                bsClass="btn"
+                bsStyle="default"
+                className="Button-c9cbmb-0 bNulii reset-button"
+                disabled={false}
                 onClick={[Function]}
                 type="reset"
               >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 laZUlH reset-button"
+                <button
+                  className="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                   disabled={false}
                   onClick={[Function]}
                   type="reset"
                 >
-                  <button
-                    className="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
-                    disabled={false}
-                    onClick={[Function]}
-                    type="reset"
-                  >
-                    Reset
-                  </button>
-                </Button>
-              </Button__StyledButton>
-            </ForwardRef>
+                  Reset
+                </button>
+              </Button>
+            </Button>
           </div>
         </form>
       </div>
@@ -624,37 +591,30 @@ exports[`<ContentPackParameterList /> should render with parameters with readOnl
               }
             }
           >
-            <ForwardRef
+            <Button
               bsStyle="default"
               className="submit-button"
               disabled={false}
               type="submit"
             >
-              <Button__StyledButton
+              <Button
+                active={false}
+                block={false}
+                bsClass="btn"
                 bsStyle="default"
-                className="submit-button"
+                className="Button-c9cbmb-0 bNulii submit-button"
                 disabled={false}
                 type="submit"
               >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 laZUlH submit-button"
+                <button
+                  className="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                   disabled={false}
                   type="submit"
                 >
-                  <button
-                    className="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
-                    disabled={false}
-                    type="submit"
-                  >
-                    Filter
-                  </button>
-                </Button>
-              </Button__StyledButton>
-            </ForwardRef>
+                  Filter
+                </button>
+              </Button>
+            </Button>
           </div>
           <div
             className="form-group"
@@ -664,37 +624,31 @@ exports[`<ContentPackParameterList /> should render with parameters with readOnl
               }
             }
           >
-            <ForwardRef
+            <Button
               className="reset-button"
               onClick={[Function]}
               type="reset"
             >
-              <Button__StyledButton
-                className="reset-button"
+              <Button
+                active={false}
+                block={false}
+                bsClass="btn"
+                bsStyle="default"
+                className="Button-c9cbmb-0 bNulii reset-button"
+                disabled={false}
                 onClick={[Function]}
                 type="reset"
               >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 laZUlH reset-button"
+                <button
+                  className="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                   disabled={false}
                   onClick={[Function]}
                   type="reset"
                 >
-                  <button
-                    className="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
-                    disabled={false}
-                    onClick={[Function]}
-                    type="reset"
-                  >
-                    Reset
-                  </button>
-                </Button>
-              </Button__StyledButton>
-            </ForwardRef>
+                  Reset
+                </button>
+              </Button>
+            </Button>
           </div>
         </form>
       </div>
@@ -938,41 +892,34 @@ exports[`<ContentPackParameterList /> should render with parameters without read
       Parameters list
     </h2>
     <br />
-    <ForwardRef
+    <Button
       bsSize="small"
       bsStyle="info"
       onClick={[Function]}
       title="Edit Modal"
     >
-      <Button__StyledButton
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
         bsSize="small"
         bsStyle="info"
+        className="Button-c9cbmb-0 bNulii"
+        disabled={false}
         onClick={[Function]}
         title="Edit Modal"
       >
-        <Button
-          active={false}
-          block={false}
-          bsClass="btn"
-          bsSize="small"
-          bsStyle="info"
-          className="Button__StyledButton-c9cbmb-0 laZUlH"
+        <button
+          className="Button-c9cbmb-0 bNulii btn btn-sm btn-info"
           disabled={false}
           onClick={[Function]}
           title="Edit Modal"
+          type="button"
         >
-          <button
-            className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-info"
-            disabled={false}
-            onClick={[Function]}
-            title="Edit Modal"
-            type="button"
-          >
-            Create parameter
-          </button>
-        </Button>
-      </Button__StyledButton>
-    </ForwardRef>
+          Create parameter
+        </button>
+      </Button>
+    </Button>
     <BootstrapModalWrapper
       backdrop="static"
       bsSize="large"
@@ -1109,37 +1056,30 @@ exports[`<ContentPackParameterList /> should render with parameters without read
               }
             }
           >
-            <ForwardRef
+            <Button
               bsStyle="default"
               className="submit-button"
               disabled={false}
               type="submit"
             >
-              <Button__StyledButton
+              <Button
+                active={false}
+                block={false}
+                bsClass="btn"
                 bsStyle="default"
-                className="submit-button"
+                className="Button-c9cbmb-0 bNulii submit-button"
                 disabled={false}
                 type="submit"
               >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 laZUlH submit-button"
+                <button
+                  className="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                   disabled={false}
                   type="submit"
                 >
-                  <button
-                    className="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
-                    disabled={false}
-                    type="submit"
-                  >
-                    Filter
-                  </button>
-                </Button>
-              </Button__StyledButton>
-            </ForwardRef>
+                  Filter
+                </button>
+              </Button>
+            </Button>
           </div>
           <div
             className="form-group"
@@ -1149,37 +1089,31 @@ exports[`<ContentPackParameterList /> should render with parameters without read
               }
             }
           >
-            <ForwardRef
+            <Button
               className="reset-button"
               onClick={[Function]}
               type="reset"
             >
-              <Button__StyledButton
-                className="reset-button"
+              <Button
+                active={false}
+                block={false}
+                bsClass="btn"
+                bsStyle="default"
+                className="Button-c9cbmb-0 bNulii reset-button"
+                disabled={false}
                 onClick={[Function]}
                 type="reset"
               >
-                <Button
-                  active={false}
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
-                  className="Button__StyledButton-c9cbmb-0 laZUlH reset-button"
+                <button
+                  className="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                   disabled={false}
                   onClick={[Function]}
                   type="reset"
                 >
-                  <button
-                    className="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
-                    disabled={false}
-                    onClick={[Function]}
-                    type="reset"
-                  >
-                    Reset
-                  </button>
-                </Button>
-              </Button__StyledButton>
-            </ForwardRef>
+                  Reset
+                </button>
+              </Button>
+            </Button>
           </div>
         </form>
       </div>
@@ -1394,78 +1328,63 @@ exports[`<ContentPackParameterList /> should render with parameters without read
                               className="btn-toolbar"
                               role="toolbar"
                             >
-                              <ForwardRef
+                              <Button
                                 bsSize="xs"
                                 bsStyle="primary"
                                 disabled={false}
                                 onClick={[Function]}
                                 title="Delete Parameter"
                               >
-                                <Button__StyledButton
+                                <Button
+                                  active={false}
+                                  block={false}
+                                  bsClass="btn"
                                   bsSize="xs"
                                   bsStyle="primary"
+                                  className="Button-c9cbmb-0 bNulii"
                                   disabled={false}
                                   onClick={[Function]}
                                   title="Delete Parameter"
                                 >
-                                  <Button
-                                    active={false}
-                                    block={false}
-                                    bsClass="btn"
-                                    bsSize="xs"
-                                    bsStyle="primary"
-                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                  <button
+                                    className="Button-c9cbmb-0 bNulii btn btn-xs btn-primary"
                                     disabled={false}
                                     onClick={[Function]}
                                     title="Delete Parameter"
+                                    type="button"
                                   >
-                                    <button
-                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-xs btn-primary"
-                                      disabled={false}
-                                      onClick={[Function]}
-                                      title="Delete Parameter"
-                                      type="button"
-                                    >
-                                      Delete
-                                    </button>
-                                  </Button>
-                                </Button__StyledButton>
-                              </ForwardRef>
-                              <ForwardRef
+                                    Delete
+                                  </button>
+                                </Button>
+                              </Button>
+                              <Button
                                 bsSize="xsmall"
                                 bsStyle="info"
                                 onClick={[Function]}
                                 title="Edit Modal"
                               >
-                                <Button__StyledButton
+                                <Button
+                                  active={false}
+                                  block={false}
+                                  bsClass="btn"
                                   bsSize="xsmall"
                                   bsStyle="info"
+                                  className="Button-c9cbmb-0 bNulii"
+                                  disabled={false}
                                   onClick={[Function]}
                                   title="Edit Modal"
                                 >
-                                  <Button
-                                    active={false}
-                                    block={false}
-                                    bsClass="btn"
-                                    bsSize="xsmall"
-                                    bsStyle="info"
-                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                  <button
+                                    className="Button-c9cbmb-0 bNulii btn btn-xs btn-info"
                                     disabled={false}
                                     onClick={[Function]}
                                     title="Edit Modal"
+                                    type="button"
                                   >
-                                    <button
-                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-xs btn-info"
-                                      disabled={false}
-                                      onClick={[Function]}
-                                      title="Edit Modal"
-                                      type="button"
-                                    >
-                                      Edit
-                                    </button>
-                                  </Button>
-                                </Button__StyledButton>
-                              </ForwardRef>
+                                    Edit
+                                  </button>
+                                </Button>
+                              </Button>
                               <BootstrapModalWrapper
                                 backdrop="static"
                                 bsSize="large"

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameters.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameters.test.jsx.snap
@@ -139,41 +139,34 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                     Parameters list
                   </h2>
                   <br />
-                  <ForwardRef
+                  <Button
                     bsSize="small"
                     bsStyle="info"
                     onClick={[Function]}
                     title="Edit Modal"
                   >
-                    <Button__StyledButton
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
                       bsSize="small"
                       bsStyle="info"
+                      className="Button-c9cbmb-0 bNulii"
+                      disabled={false}
                       onClick={[Function]}
                       title="Edit Modal"
                     >
-                      <Button
-                        active={false}
-                        block={false}
-                        bsClass="btn"
-                        bsSize="small"
-                        bsStyle="info"
-                        className="Button__StyledButton-c9cbmb-0 laZUlH"
+                      <button
+                        className="Button-c9cbmb-0 bNulii btn btn-sm btn-info"
                         disabled={false}
                         onClick={[Function]}
                         title="Edit Modal"
+                        type="button"
                       >
-                        <button
-                          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-info"
-                          disabled={false}
-                          onClick={[Function]}
-                          title="Edit Modal"
-                          type="button"
-                        >
-                          Create parameter
-                        </button>
-                      </Button>
-                    </Button__StyledButton>
-                  </ForwardRef>
+                        Create parameter
+                      </button>
+                    </Button>
+                  </Button>
                   <BootstrapModalWrapper
                     backdrop="static"
                     bsSize="large"
@@ -310,37 +303,30 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                             }
                           }
                         >
-                          <ForwardRef
+                          <Button
                             bsStyle="default"
                             className="submit-button"
                             disabled={false}
                             type="submit"
                           >
-                            <Button__StyledButton
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
                               bsStyle="default"
-                              className="submit-button"
+                              className="Button-c9cbmb-0 bNulii submit-button"
                               disabled={false}
                               type="submit"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="default"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH submit-button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                                 disabled={false}
                                 type="submit"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
-                                  disabled={false}
-                                  type="submit"
-                                >
-                                  Filter
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
+                                Filter
+                              </button>
+                            </Button>
+                          </Button>
                         </div>
                         <div
                           className="form-group"
@@ -350,37 +336,31 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                             }
                           }
                         >
-                          <ForwardRef
+                          <Button
                             className="reset-button"
                             onClick={[Function]}
                             type="reset"
                           >
-                            <Button__StyledButton
-                              className="reset-button"
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
+                              bsStyle="default"
+                              className="Button-c9cbmb-0 bNulii reset-button"
+                              disabled={false}
                               onClick={[Function]}
                               type="reset"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="default"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH reset-button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                                 disabled={false}
                                 onClick={[Function]}
                                 type="reset"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  type="reset"
-                                >
-                                  Reset
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
+                                Reset
+                              </button>
+                            </Button>
+                          </Button>
                         </div>
                       </form>
                     </div>
@@ -595,78 +575,63 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                                             className="btn-toolbar"
                                             role="toolbar"
                                           >
-                                            <ForwardRef
+                                            <Button
                                               bsSize="xs"
                                               bsStyle="primary"
                                               disabled={false}
                                               onClick={[Function]}
                                               title="Delete Parameter"
                                             >
-                                              <Button__StyledButton
+                                              <Button
+                                                active={false}
+                                                block={false}
+                                                bsClass="btn"
                                                 bsSize="xs"
                                                 bsStyle="primary"
+                                                className="Button-c9cbmb-0 bNulii"
                                                 disabled={false}
                                                 onClick={[Function]}
                                                 title="Delete Parameter"
                                               >
-                                                <Button
-                                                  active={false}
-                                                  block={false}
-                                                  bsClass="btn"
-                                                  bsSize="xs"
-                                                  bsStyle="primary"
-                                                  className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                <button
+                                                  className="Button-c9cbmb-0 bNulii btn btn-xs btn-primary"
                                                   disabled={false}
                                                   onClick={[Function]}
                                                   title="Delete Parameter"
+                                                  type="button"
                                                 >
-                                                  <button
-                                                    className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-xs btn-primary"
-                                                    disabled={false}
-                                                    onClick={[Function]}
-                                                    title="Delete Parameter"
-                                                    type="button"
-                                                  >
-                                                    Delete
-                                                  </button>
-                                                </Button>
-                                              </Button__StyledButton>
-                                            </ForwardRef>
-                                            <ForwardRef
+                                                  Delete
+                                                </button>
+                                              </Button>
+                                            </Button>
+                                            <Button
                                               bsSize="xsmall"
                                               bsStyle="info"
                                               onClick={[Function]}
                                               title="Edit Modal"
                                             >
-                                              <Button__StyledButton
+                                              <Button
+                                                active={false}
+                                                block={false}
+                                                bsClass="btn"
                                                 bsSize="xsmall"
                                                 bsStyle="info"
+                                                className="Button-c9cbmb-0 bNulii"
+                                                disabled={false}
                                                 onClick={[Function]}
                                                 title="Edit Modal"
                                               >
-                                                <Button
-                                                  active={false}
-                                                  block={false}
-                                                  bsClass="btn"
-                                                  bsSize="xsmall"
-                                                  bsStyle="info"
-                                                  className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                <button
+                                                  className="Button-c9cbmb-0 bNulii btn btn-xs btn-info"
                                                   disabled={false}
                                                   onClick={[Function]}
                                                   title="Edit Modal"
+                                                  type="button"
                                                 >
-                                                  <button
-                                                    className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-xs btn-info"
-                                                    disabled={false}
-                                                    onClick={[Function]}
-                                                    title="Edit Modal"
-                                                    type="button"
-                                                  >
-                                                    Edit
-                                                  </button>
-                                                </Button>
-                                              </Button__StyledButton>
-                                            </ForwardRef>
+                                                  Edit
+                                                </button>
+                                              </Button>
+                                            </Button>
                                             <BootstrapModalWrapper
                                               backdrop="static"
                                               bsSize="large"
@@ -983,37 +948,30 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                             }
                           }
                         >
-                          <ForwardRef
+                          <Button
                             bsStyle="default"
                             className="submit-button"
                             disabled={false}
                             type="submit"
                           >
-                            <Button__StyledButton
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
                               bsStyle="default"
-                              className="submit-button"
+                              className="Button-c9cbmb-0 bNulii submit-button"
                               disabled={false}
                               type="submit"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="default"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH submit-button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                                 disabled={false}
                                 type="submit"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
-                                  disabled={false}
-                                  type="submit"
-                                >
-                                  Filter
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
+                                Filter
+                              </button>
+                            </Button>
+                          </Button>
                         </div>
                         <div
                           className="form-group"
@@ -1023,37 +981,31 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                             }
                           }
                         >
-                          <ForwardRef
+                          <Button
                             className="reset-button"
                             onClick={[Function]}
                             type="reset"
                           >
-                            <Button__StyledButton
-                              className="reset-button"
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
+                              bsStyle="default"
+                              className="Button-c9cbmb-0 bNulii reset-button"
+                              disabled={false}
                               onClick={[Function]}
                               type="reset"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="default"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH reset-button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                                 disabled={false}
                                 onClick={[Function]}
                                 type="reset"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  type="reset"
-                                >
-                                  Reset
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
+                                Reset
+                              </button>
+                            </Button>
+                          </Button>
                         </div>
                       </form>
                     </div>
@@ -1284,70 +1236,57 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                                             className="btn-toolbar"
                                             role="toolbar"
                                           >
-                                            <ForwardRef
+                                            <Button
                                               bsSize="xs"
                                               bsStyle="primary"
                                               disabled={false}
                                               onClick={[Function]}
                                             >
-                                              <Button__StyledButton
+                                              <Button
+                                                active={false}
+                                                block={false}
+                                                bsClass="btn"
                                                 bsSize="xs"
                                                 bsStyle="primary"
+                                                className="Button-c9cbmb-0 bNulii"
                                                 disabled={false}
                                                 onClick={[Function]}
                                               >
-                                                <Button
-                                                  active={false}
-                                                  block={false}
-                                                  bsClass="btn"
-                                                  bsSize="xs"
-                                                  bsStyle="primary"
-                                                  className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                <button
+                                                  className="Button-c9cbmb-0 bNulii btn btn-xs btn-primary"
                                                   disabled={false}
                                                   onClick={[Function]}
+                                                  type="button"
                                                 >
-                                                  <button
-                                                    className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-xs btn-primary"
-                                                    disabled={false}
-                                                    onClick={[Function]}
-                                                    type="button"
-                                                  >
-                                                    Edit
-                                                  </button>
-                                                </Button>
-                                              </Button__StyledButton>
-                                            </ForwardRef>
-                                            <ForwardRef
+                                                  Edit
+                                                </button>
+                                              </Button>
+                                            </Button>
+                                            <Button
                                               bsSize="xs"
                                               bsStyle="info"
                                               onClick={[Function]}
                                             >
-                                              <Button__StyledButton
+                                              <Button
+                                                active={false}
+                                                block={false}
+                                                bsClass="btn"
                                                 bsSize="xs"
                                                 bsStyle="info"
+                                                className="Button-c9cbmb-0 bNulii"
+                                                disabled={false}
                                                 onClick={[Function]}
                                               >
-                                                <Button
-                                                  active={false}
-                                                  block={false}
-                                                  bsClass="btn"
-                                                  bsSize="xs"
-                                                  bsStyle="info"
-                                                  className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                <button
+                                                  className="Button-c9cbmb-0 bNulii btn btn-xs btn-info"
                                                   disabled={false}
                                                   onClick={[Function]}
+                                                  type="button"
                                                 >
-                                                  <button
-                                                    className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-xs btn-info"
-                                                    disabled={false}
-                                                    onClick={[Function]}
-                                                    type="button"
-                                                  >
-                                                    Show
-                                                  </button>
-                                                </Button>
-                                              </Button__StyledButton>
-                                            </ForwardRef>
+                                                  Show
+                                                </button>
+                                              </Button>
+                                            </Button>
                                           </div>
                                         </ButtonToolbar>
                                       </td>
@@ -1565,41 +1504,34 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
                     Parameters list
                   </h2>
                   <br />
-                  <ForwardRef
+                  <Button
                     bsSize="small"
                     bsStyle="info"
                     onClick={[Function]}
                     title="Edit Modal"
                   >
-                    <Button__StyledButton
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
                       bsSize="small"
                       bsStyle="info"
+                      className="Button-c9cbmb-0 bNulii"
+                      disabled={false}
                       onClick={[Function]}
                       title="Edit Modal"
                     >
-                      <Button
-                        active={false}
-                        block={false}
-                        bsClass="btn"
-                        bsSize="small"
-                        bsStyle="info"
-                        className="Button__StyledButton-c9cbmb-0 laZUlH"
+                      <button
+                        className="Button-c9cbmb-0 bNulii btn btn-sm btn-info"
                         disabled={false}
                         onClick={[Function]}
                         title="Edit Modal"
+                        type="button"
                       >
-                        <button
-                          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-info"
-                          disabled={false}
-                          onClick={[Function]}
-                          title="Edit Modal"
-                          type="button"
-                        >
-                          Create parameter
-                        </button>
-                      </Button>
-                    </Button__StyledButton>
-                  </ForwardRef>
+                        Create parameter
+                      </button>
+                    </Button>
+                  </Button>
                   <BootstrapModalWrapper
                     backdrop="static"
                     bsSize="large"
@@ -1736,37 +1668,30 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
                             }
                           }
                         >
-                          <ForwardRef
+                          <Button
                             bsStyle="default"
                             className="submit-button"
                             disabled={false}
                             type="submit"
                           >
-                            <Button__StyledButton
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
                               bsStyle="default"
-                              className="submit-button"
+                              className="Button-c9cbmb-0 bNulii submit-button"
                               disabled={false}
                               type="submit"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="default"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH submit-button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                                 disabled={false}
                                 type="submit"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
-                                  disabled={false}
-                                  type="submit"
-                                >
-                                  Filter
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
+                                Filter
+                              </button>
+                            </Button>
+                          </Button>
                         </div>
                         <div
                           className="form-group"
@@ -1776,37 +1701,31 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
                             }
                           }
                         >
-                          <ForwardRef
+                          <Button
                             className="reset-button"
                             onClick={[Function]}
                             type="reset"
                           >
-                            <Button__StyledButton
-                              className="reset-button"
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
+                              bsStyle="default"
+                              className="Button-c9cbmb-0 bNulii reset-button"
+                              disabled={false}
                               onClick={[Function]}
                               type="reset"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="default"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH reset-button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                                 disabled={false}
                                 onClick={[Function]}
                                 type="reset"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  type="reset"
-                                >
-                                  Reset
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
+                                Reset
+                              </button>
+                            </Button>
+                          </Button>
                         </div>
                       </form>
                     </div>
@@ -2041,37 +1960,30 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
                             }
                           }
                         >
-                          <ForwardRef
+                          <Button
                             bsStyle="default"
                             className="submit-button"
                             disabled={false}
                             type="submit"
                           >
-                            <Button__StyledButton
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
                               bsStyle="default"
-                              className="submit-button"
+                              className="Button-c9cbmb-0 bNulii submit-button"
                               disabled={false}
                               type="submit"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="default"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH submit-button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                                 disabled={false}
                                 type="submit"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
-                                  disabled={false}
-                                  type="submit"
-                                >
-                                  Filter
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
+                                Filter
+                              </button>
+                            </Button>
+                          </Button>
                         </div>
                         <div
                           className="form-group"
@@ -2081,37 +1993,31 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
                             }
                           }
                         >
-                          <ForwardRef
+                          <Button
                             className="reset-button"
                             onClick={[Function]}
                             type="reset"
                           >
-                            <Button__StyledButton
-                              className="reset-button"
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
+                              bsStyle="default"
+                              className="Button-c9cbmb-0 bNulii reset-button"
+                              disabled={false}
                               onClick={[Function]}
                               type="reset"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="default"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH reset-button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                                 disabled={false}
                                 onClick={[Function]}
                                 type="reset"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  type="reset"
-                                >
-                                  Reset
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
+                                Reset
+                              </button>
+                            </Button>
+                          </Button>
                         </div>
                       </form>
                     </div>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackPreview.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackPreview.test.jsx.snap
@@ -310,37 +310,30 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
                             }
                           }
                         >
-                          <ForwardRef
+                          <Button
                             bsStyle="default"
                             className="submit-button"
                             disabled={false}
                             type="submit"
                           >
-                            <Button__StyledButton
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
                               bsStyle="default"
-                              className="submit-button"
+                              className="Button-c9cbmb-0 bNulii submit-button"
                               disabled={false}
                               type="submit"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="default"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH submit-button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                                 disabled={false}
                                 type="submit"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
-                                  disabled={false}
-                                  type="submit"
-                                >
-                                  Filter
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
+                                Filter
+                              </button>
+                            </Button>
+                          </Button>
                         </div>
                         <div
                           className="form-group"
@@ -350,37 +343,31 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
                             }
                           }
                         >
-                          <ForwardRef
+                          <Button
                             className="reset-button"
                             onClick={[Function]}
                             type="reset"
                           >
-                            <Button__StyledButton
-                              className="reset-button"
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
+                              bsStyle="default"
+                              className="Button-c9cbmb-0 bNulii reset-button"
+                              disabled={false}
                               onClick={[Function]}
                               type="reset"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="default"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH reset-button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                                 disabled={false}
                                 onClick={[Function]}
                                 type="reset"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  type="reset"
-                                >
-                                  Reset
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
+                                Reset
+                              </button>
+                            </Button>
+                          </Button>
                         </div>
                       </form>
                     </div>
@@ -514,37 +501,30 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
                             }
                           }
                         >
-                          <ForwardRef
+                          <Button
                             bsStyle="default"
                             className="submit-button"
                             disabled={false}
                             type="submit"
                           >
-                            <Button__StyledButton
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
                               bsStyle="default"
-                              className="submit-button"
+                              className="Button-c9cbmb-0 bNulii submit-button"
                               disabled={false}
                               type="submit"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="default"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH submit-button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                                 disabled={false}
                                 type="submit"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
-                                  disabled={false}
-                                  type="submit"
-                                >
-                                  Filter
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
+                                Filter
+                              </button>
+                            </Button>
+                          </Button>
                         </div>
                         <div
                           className="form-group"
@@ -554,37 +534,31 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
                             }
                           }
                         >
-                          <ForwardRef
+                          <Button
                             className="reset-button"
                             onClick={[Function]}
                             type="reset"
                           >
-                            <Button__StyledButton
-                              className="reset-button"
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
+                              bsStyle="default"
+                              className="Button-c9cbmb-0 bNulii reset-button"
+                              disabled={false}
                               onClick={[Function]}
                               type="reset"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="default"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH reset-button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                                 disabled={false}
                                 onClick={[Function]}
                                 type="reset"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  type="reset"
-                                >
-                                  Reset
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
+                                Reset
+                              </button>
+                            </Button>
+                          </Button>
                         </div>
                       </form>
                     </div>
@@ -658,75 +632,63 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
             <div
               className="col-sm-6"
             >
-              <ForwardRef
+              <Button
                 bsStyle="primary"
                 id="create"
                 onClick={[Function]}
               >
-                <Button__StyledButton
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
                   bsStyle="primary"
+                  className="Button-c9cbmb-0 bNulii"
+                  disabled={false}
                   id="create"
+                  onClick={[Function]}
+                >
+                  <button
+                    className="Button-c9cbmb-0 bNulii btn btn-primary"
+                    disabled={false}
+                    id="create"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Create
+                  </button>
+                </Button>
+              </Button>
+               
+              <a
+                download="content-pack-dead-beef-1.json"
+                href="data:text/plain;charset=utf-8,%7B%0A%20%20%22v%22%3A%201%2C%0A%20%20%22id%22%3A%20%22dead-beef%22%2C%0A%20%20%22rev%22%3A%201%2C%0A%20%20%22name%22%3A%20%22%22%2C%0A%20%20%22summary%22%3A%20%22%22%2C%0A%20%20%22description%22%3A%20%22%22%2C%0A%20%20%22vendor%22%3A%20%22%22%2C%0A%20%20%22url%22%3A%20%22%22%2C%0A%20%20%22parameters%22%3A%20%5B%5D%2C%0A%20%20%22entities%22%3A%20%5B%5D%0A%7D"
+              >
+                <Button
+                  bsStyle="info"
+                  id="download"
                   onClick={[Function]}
                 >
                   <Button
                     active={false}
                     block={false}
                     bsClass="btn"
-                    bsStyle="primary"
-                    className="Button__StyledButton-c9cbmb-0 laZUlH"
-                    disabled={false}
-                    id="create"
-                    onClick={[Function]}
-                  >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-primary"
-                      disabled={false}
-                      id="create"
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      Create
-                    </button>
-                  </Button>
-                </Button__StyledButton>
-              </ForwardRef>
-               
-              <a
-                download="content-pack-dead-beef-1.json"
-                href="data:text/plain;charset=utf-8,%7B%0A%20%20%22v%22%3A%201%2C%0A%20%20%22id%22%3A%20%22dead-beef%22%2C%0A%20%20%22rev%22%3A%201%2C%0A%20%20%22name%22%3A%20%22%22%2C%0A%20%20%22summary%22%3A%20%22%22%2C%0A%20%20%22description%22%3A%20%22%22%2C%0A%20%20%22vendor%22%3A%20%22%22%2C%0A%20%20%22url%22%3A%20%22%22%2C%0A%20%20%22parameters%22%3A%20%5B%5D%2C%0A%20%20%22entities%22%3A%20%5B%5D%0A%7D"
-              >
-                <ForwardRef
-                  bsStyle="info"
-                  id="download"
-                  onClick={[Function]}
-                >
-                  <Button__StyledButton
                     bsStyle="info"
+                    className="Button-c9cbmb-0 bNulii"
+                    disabled={false}
                     id="download"
                     onClick={[Function]}
                   >
-                    <Button
-                      active={false}
-                      block={false}
-                      bsClass="btn"
-                      bsStyle="info"
-                      className="Button__StyledButton-c9cbmb-0 laZUlH"
+                    <button
+                      className="Button-c9cbmb-0 bNulii btn btn-info"
                       disabled={false}
                       id="download"
                       onClick={[Function]}
+                      type="button"
                     >
-                      <button
-                        className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-info"
-                        disabled={false}
-                        id="download"
-                        onClick={[Function]}
-                        type="button"
-                      >
-                        Create and Download
-                      </button>
-                    </Button>
-                  </Button__StyledButton>
-                </ForwardRef>
+                      Create and Download
+                    </button>
+                  </Button>
+                </Button>
               </a>
             </div>
           </Col>
@@ -1080,37 +1042,30 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
                             }
                           }
                         >
-                          <ForwardRef
+                          <Button
                             bsStyle="default"
                             className="submit-button"
                             disabled={false}
                             type="submit"
                           >
-                            <Button__StyledButton
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
                               bsStyle="default"
-                              className="submit-button"
+                              className="Button-c9cbmb-0 bNulii submit-button"
                               disabled={false}
                               type="submit"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="default"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH submit-button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                                 disabled={false}
                                 type="submit"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
-                                  disabled={false}
-                                  type="submit"
-                                >
-                                  Filter
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
+                                Filter
+                              </button>
+                            </Button>
+                          </Button>
                         </div>
                         <div
                           className="form-group"
@@ -1120,37 +1075,31 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
                             }
                           }
                         >
-                          <ForwardRef
+                          <Button
                             className="reset-button"
                             onClick={[Function]}
                             type="reset"
                           >
-                            <Button__StyledButton
-                              className="reset-button"
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
+                              bsStyle="default"
+                              className="Button-c9cbmb-0 bNulii reset-button"
+                              disabled={false}
                               onClick={[Function]}
                               type="reset"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="default"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH reset-button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                                 disabled={false}
                                 onClick={[Function]}
                                 type="reset"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  type="reset"
-                                >
-                                  Reset
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
+                                Reset
+                              </button>
+                            </Button>
+                          </Button>
                         </div>
                       </form>
                     </div>
@@ -1284,37 +1233,30 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
                             }
                           }
                         >
-                          <ForwardRef
+                          <Button
                             bsStyle="default"
                             className="submit-button"
                             disabled={false}
                             type="submit"
                           >
-                            <Button__StyledButton
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
                               bsStyle="default"
-                              className="submit-button"
+                              className="Button-c9cbmb-0 bNulii submit-button"
                               disabled={false}
                               type="submit"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="default"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH submit-button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                                 disabled={false}
                                 type="submit"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
-                                  disabled={false}
-                                  type="submit"
-                                >
-                                  Filter
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
+                                Filter
+                              </button>
+                            </Button>
+                          </Button>
                         </div>
                         <div
                           className="form-group"
@@ -1324,37 +1266,31 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
                             }
                           }
                         >
-                          <ForwardRef
+                          <Button
                             className="reset-button"
                             onClick={[Function]}
                             type="reset"
                           >
-                            <Button__StyledButton
-                              className="reset-button"
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
+                              bsStyle="default"
+                              className="Button-c9cbmb-0 bNulii reset-button"
+                              disabled={false}
                               onClick={[Function]}
                               type="reset"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="default"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH reset-button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                                 disabled={false}
                                 onClick={[Function]}
                                 type="reset"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  type="reset"
-                                >
-                                  Reset
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
+                                Reset
+                              </button>
+                            </Button>
+                          </Button>
                         </div>
                       </form>
                     </div>
@@ -1428,75 +1364,63 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
             <div
               className="col-sm-6"
             >
-              <ForwardRef
+              <Button
                 bsStyle="primary"
                 id="create"
                 onClick={[Function]}
               >
-                <Button__StyledButton
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
                   bsStyle="primary"
+                  className="Button-c9cbmb-0 bNulii"
+                  disabled={false}
                   id="create"
+                  onClick={[Function]}
+                >
+                  <button
+                    className="Button-c9cbmb-0 bNulii btn btn-primary"
+                    disabled={false}
+                    id="create"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Create
+                  </button>
+                </Button>
+              </Button>
+               
+              <a
+                download="content-pack-dead-beef-1.json"
+                href="data:text/plain;charset=utf-8,%7B%0A%20%20%22v%22%3A%201%2C%0A%20%20%22id%22%3A%20%22dead-beef%22%2C%0A%20%20%22rev%22%3A%201%2C%0A%20%20%22name%22%3A%20%22name%22%2C%0A%20%20%22summary%22%3A%20%22summary%22%2C%0A%20%20%22description%22%3A%20%22descr%22%2C%0A%20%20%22vendor%22%3A%20%22vendor%22%2C%0A%20%20%22url%22%3A%20%22http%3A%2F%2Fexample.com%22%2C%0A%20%20%22parameters%22%3A%20%5B%5D%2C%0A%20%20%22entities%22%3A%20%5B%5D%0A%7D"
+              >
+                <Button
+                  bsStyle="info"
+                  id="download"
                   onClick={[Function]}
                 >
                   <Button
                     active={false}
                     block={false}
                     bsClass="btn"
-                    bsStyle="primary"
-                    className="Button__StyledButton-c9cbmb-0 laZUlH"
-                    disabled={false}
-                    id="create"
-                    onClick={[Function]}
-                  >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-primary"
-                      disabled={false}
-                      id="create"
-                      onClick={[Function]}
-                      type="button"
-                    >
-                      Create
-                    </button>
-                  </Button>
-                </Button__StyledButton>
-              </ForwardRef>
-               
-              <a
-                download="content-pack-dead-beef-1.json"
-                href="data:text/plain;charset=utf-8,%7B%0A%20%20%22v%22%3A%201%2C%0A%20%20%22id%22%3A%20%22dead-beef%22%2C%0A%20%20%22rev%22%3A%201%2C%0A%20%20%22name%22%3A%20%22name%22%2C%0A%20%20%22summary%22%3A%20%22summary%22%2C%0A%20%20%22description%22%3A%20%22descr%22%2C%0A%20%20%22vendor%22%3A%20%22vendor%22%2C%0A%20%20%22url%22%3A%20%22http%3A%2F%2Fexample.com%22%2C%0A%20%20%22parameters%22%3A%20%5B%5D%2C%0A%20%20%22entities%22%3A%20%5B%5D%0A%7D"
-              >
-                <ForwardRef
-                  bsStyle="info"
-                  id="download"
-                  onClick={[Function]}
-                >
-                  <Button__StyledButton
                     bsStyle="info"
+                    className="Button-c9cbmb-0 bNulii"
+                    disabled={false}
                     id="download"
                     onClick={[Function]}
                   >
-                    <Button
-                      active={false}
-                      block={false}
-                      bsClass="btn"
-                      bsStyle="info"
-                      className="Button__StyledButton-c9cbmb-0 laZUlH"
+                    <button
+                      className="Button-c9cbmb-0 bNulii btn btn-info"
                       disabled={false}
                       id="download"
                       onClick={[Function]}
+                      type="button"
                     >
-                      <button
-                        className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-info"
-                        disabled={false}
-                        id="download"
-                        onClick={[Function]}
-                        type="button"
-                      >
-                        Create and Download
-                      </button>
-                    </Button>
-                  </Button__StyledButton>
-                </ForwardRef>
+                      Create and Download
+                    </button>
+                  </Button>
+                </Button>
               </a>
             </div>
           </Col>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
@@ -688,37 +688,30 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
                         }
                       }
                     >
-                      <ForwardRef
+                      <Button
                         bsStyle="default"
                         className="submit-button"
                         disabled={false}
                         type="submit"
                       >
-                        <Button__StyledButton
+                        <Button
+                          active={false}
+                          block={false}
+                          bsClass="btn"
                           bsStyle="default"
-                          className="submit-button"
+                          className="Button-c9cbmb-0 bNulii submit-button"
                           disabled={false}
                           type="submit"
                         >
-                          <Button
-                            active={false}
-                            block={false}
-                            bsClass="btn"
-                            bsStyle="default"
-                            className="Button__StyledButton-c9cbmb-0 laZUlH submit-button"
+                          <button
+                            className="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                             disabled={false}
                             type="submit"
                           >
-                            <button
-                              className="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
-                              disabled={false}
-                              type="submit"
-                            >
-                              Filter
-                            </button>
-                          </Button>
-                        </Button__StyledButton>
-                      </ForwardRef>
+                            Filter
+                          </button>
+                        </Button>
+                      </Button>
                     </div>
                     <div
                       className="form-group"
@@ -728,37 +721,31 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
                         }
                       }
                     >
-                      <ForwardRef
+                      <Button
                         className="reset-button"
                         onClick={[Function]}
                         type="reset"
                       >
-                        <Button__StyledButton
-                          className="reset-button"
+                        <Button
+                          active={false}
+                          block={false}
+                          bsClass="btn"
+                          bsStyle="default"
+                          className="Button-c9cbmb-0 bNulii reset-button"
+                          disabled={false}
                           onClick={[Function]}
                           type="reset"
                         >
-                          <Button
-                            active={false}
-                            block={false}
-                            bsClass="btn"
-                            bsStyle="default"
-                            className="Button__StyledButton-c9cbmb-0 laZUlH reset-button"
+                          <button
+                            className="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                             disabled={false}
                             onClick={[Function]}
                             type="reset"
                           >
-                            <button
-                              className="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
-                              disabled={false}
-                              onClick={[Function]}
-                              type="reset"
-                            >
-                              Reset
-                            </button>
-                          </Button>
-                        </Button__StyledButton>
-                      </ForwardRef>
+                            Reset
+                          </button>
+                        </Button>
+                      </Button>
                     </div>
                   </form>
                 </div>
@@ -1559,37 +1546,30 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
                         }
                       }
                     >
-                      <ForwardRef
+                      <Button
                         bsStyle="default"
                         className="submit-button"
                         disabled={false}
                         type="submit"
                       >
-                        <Button__StyledButton
+                        <Button
+                          active={false}
+                          block={false}
+                          bsClass="btn"
                           bsStyle="default"
-                          className="submit-button"
+                          className="Button-c9cbmb-0 bNulii submit-button"
                           disabled={false}
                           type="submit"
                         >
-                          <Button
-                            active={false}
-                            block={false}
-                            bsClass="btn"
-                            bsStyle="default"
-                            className="Button__StyledButton-c9cbmb-0 laZUlH submit-button"
+                          <button
+                            className="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                             disabled={false}
                             type="submit"
                           >
-                            <button
-                              className="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
-                              disabled={false}
-                              type="submit"
-                            >
-                              Filter
-                            </button>
-                          </Button>
-                        </Button__StyledButton>
-                      </ForwardRef>
+                            Filter
+                          </button>
+                        </Button>
+                      </Button>
                     </div>
                     <div
                       className="form-group"
@@ -1599,37 +1579,31 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
                         }
                       }
                     >
-                      <ForwardRef
+                      <Button
                         className="reset-button"
                         onClick={[Function]}
                         type="reset"
                       >
-                        <Button__StyledButton
-                          className="reset-button"
+                        <Button
+                          active={false}
+                          block={false}
+                          bsClass="btn"
+                          bsStyle="default"
+                          className="Button-c9cbmb-0 bNulii reset-button"
+                          disabled={false}
                           onClick={[Function]}
                           type="reset"
                         >
-                          <Button
-                            active={false}
-                            block={false}
-                            bsClass="btn"
-                            bsStyle="default"
-                            className="Button__StyledButton-c9cbmb-0 laZUlH reset-button"
+                          <button
+                            className="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                             disabled={false}
                             onClick={[Function]}
                             type="reset"
                           >
-                            <button
-                              className="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
-                              disabled={false}
-                              onClick={[Function]}
-                              type="reset"
-                            >
-                              Reset
-                            </button>
-                          </Button>
-                        </Button__StyledButton>
-                      </ForwardRef>
+                            Reset
+                          </button>
+                        </Button>
+                      </Button>
                     </div>
                   </form>
                 </div>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackUploadControls.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackUploadControls.test.jsx.snap
@@ -3,42 +3,34 @@
 exports[`<ContentPackUploadControls /> should render 1`] = `
 <ContentPackUploadControls>
   <span>
-    <ForwardRef
+    <Button
       active={false}
       bsStyle="success"
       className="button"
       id="upload-content-pack-button"
       onClick={[Function]}
     >
-      <Button__StyledButton
+      <Button
         active={false}
+        block={false}
+        bsClass="btn"
         bsStyle="success"
-        className="button"
+        className="Button-c9cbmb-0 bNulii button"
+        disabled={false}
         id="upload-content-pack-button"
         onClick={[Function]}
       >
-        <Button
-          active={false}
-          block={false}
-          bsClass="btn"
-          bsStyle="success"
-          className="Button__StyledButton-c9cbmb-0 laZUlH button"
+        <button
+          className="Button-c9cbmb-0 bNulii button btn btn-success"
           disabled={false}
           id="upload-content-pack-button"
           onClick={[Function]}
+          type="button"
         >
-          <button
-            className="Button__StyledButton-c9cbmb-0 laZUlH button btn btn-success"
-            disabled={false}
-            id="upload-content-pack-button"
-            onClick={[Function]}
-            type="button"
-          >
-            Upload
-          </button>
-        </Button>
-      </Button__StyledButton>
-    </ForwardRef>
+          Upload
+        </button>
+      </Button>
+    </Button>
     <BootstrapModalForm
       cancelButtonText="Cancel"
       formProps={Object {}}

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackVersions.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackVersions.test.jsx.snap
@@ -232,251 +232,188 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                             className="pull-right btn-toolbar"
                             role="toolbar"
                           >
-                            <ForwardRef
+                            <Button
                               bsSize="small"
                               bsStyle="success"
                               onClick={[Function]}
                             >
-                              <Button__StyledButton
+                              <Button
+                                active={false}
+                                block={false}
+                                bsClass="btn"
                                 bsSize="small"
                                 bsStyle="success"
+                                className="Button-c9cbmb-0 bNulii"
+                                disabled={false}
                                 onClick={[Function]}
                               >
-                                <Button
-                                  active={false}
-                                  block={false}
-                                  bsClass="btn"
-                                  bsSize="small"
-                                  bsStyle="success"
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                <button
+                                  className="Button-c9cbmb-0 bNulii btn btn-sm btn-success"
                                   disabled={false}
                                   onClick={[Function]}
+                                  type="button"
                                 >
-                                  <button
-                                    className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-success"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    type="button"
-                                  >
-                                    Download
-                                  </button>
-                                </Button>
-                              </Button__StyledButton>
-                            </ForwardRef>
-                            <ForwardRef
+                                  Download
+                                </button>
+                              </Button>
+                            </Button>
+                            <DropdownButton
                               bsSize="small"
                               bsStyle="info"
                               id="action-1"
                               title="Actions"
                             >
-                              <DropdownButton__StyledDropdownButton
+                              <DropdownButton
                                 bsSize="small"
                                 bsStyle="info"
+                                className="DropdownButton-sc-1343dcx-0 jHYVsD"
                                 id="action-1"
                                 title="Actions"
                               >
-                                <DropdownButton
+                                <ForwardRef
                                   bsSize="small"
                                   bsStyle="info"
-                                  className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
                                   id="action-1"
-                                  title="Actions"
                                 >
-                                  <ForwardRef
+                                  <Uncontrolled(Dropdown)
                                     bsSize="small"
                                     bsStyle="info"
                                     id="action-1"
+                                    innerRef={null}
                                   >
-                                    <Uncontrolled(Dropdown)
+                                    <Dropdown
+                                      bsClass="dropdown"
                                       bsSize="small"
                                       bsStyle="info"
+                                      componentClass={[Function]}
                                       id="action-1"
-                                      innerRef={null}
+                                      onToggle={[Function]}
                                     >
-                                      <Dropdown
-                                        bsClass="dropdown"
+                                      <ButtonGroup
+                                        block={false}
+                                        bsClass="btn-group"
                                         bsSize="small"
                                         bsStyle="info"
-                                        componentClass={[Function]}
-                                        id="action-1"
-                                        onToggle={[Function]}
+                                        className="dropdown"
+                                        justified={false}
+                                        vertical={false}
                                       >
-                                        <ButtonGroup
-                                          block={false}
-                                          bsClass="btn-group"
-                                          bsSize="small"
-                                          bsStyle="info"
-                                          className="dropdown"
-                                          justified={false}
-                                          vertical={false}
+                                        <div
+                                          className="dropdown btn-group btn-group-sm btn-group-info"
                                         >
-                                          <div
-                                            className="dropdown btn-group btn-group-sm btn-group-info"
+                                          <DropdownToggle
+                                            bsClass="dropdown-toggle"
+                                            bsRole="toggle"
+                                            bsSize="small"
+                                            bsStyle="info"
+                                            className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                                            id="action-1"
+                                            key=".0"
+                                            onClick={[Function]}
+                                            onKeyDown={[Function]}
+                                            open={false}
+                                            useAnchor={false}
                                           >
-                                            <DropdownToggle
-                                              bsClass="dropdown-toggle"
-                                              bsRole="toggle"
+                                            <Button
+                                              active={false}
+                                              aria-expanded={false}
+                                              aria-haspopup={true}
+                                              block={false}
+                                              bsClass="btn"
                                               bsSize="small"
                                               bsStyle="info"
-                                              className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                                              className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                              disabled={false}
                                               id="action-1"
-                                              key=".0"
                                               onClick={[Function]}
                                               onKeyDown={[Function]}
-                                              open={false}
-                                              useAnchor={false}
+                                              role="button"
                                             >
-                                              <Button
-                                                active={false}
+                                              <button
                                                 aria-expanded={false}
                                                 aria-haspopup={true}
-                                                block={false}
-                                                bsClass="btn"
-                                                bsSize="small"
-                                                bsStyle="info"
-                                                className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                                className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-sm btn-info"
                                                 disabled={false}
                                                 id="action-1"
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
                                                 role="button"
+                                                type="button"
                                               >
-                                                <button
-                                                  aria-expanded={false}
-                                                  aria-haspopup={true}
-                                                  className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-sm btn-info"
+                                                Actions
+                                                 
+                                                <span
+                                                  className="caret"
+                                                />
+                                              </button>
+                                            </Button>
+                                          </DropdownToggle>
+                                          <DropdownMenu
+                                            bsClass="dropdown-menu"
+                                            bsRole="menu"
+                                            key=".1"
+                                            labelledBy="action-1"
+                                            onClose={[Function]}
+                                            onSelect={[Function]}
+                                            pullRight={false}
+                                          >
+                                            <RootCloseWrapper
+                                              disabled={true}
+                                              event="click"
+                                              onRootClose={[Function]}
+                                            >
+                                              <ul
+                                                aria-labelledby="action-1"
+                                                className="dropdown-menu"
+                                                role="menu"
+                                              >
+                                                <MenuItem
+                                                  bsClass="dropdown"
                                                   disabled={false}
-                                                  id="action-1"
+                                                  divider={false}
+                                                  header={false}
+                                                  key=".0"
                                                   onClick={[Function]}
                                                   onKeyDown={[Function]}
-                                                  role="button"
-                                                  type="button"
+                                                  onSelect={[Function]}
                                                 >
-                                                  Actions
-                                                   
-                                                  <span
-                                                    className="caret"
-                                                  />
-                                                </button>
-                                              </Button>
-                                            </DropdownToggle>
-                                            <DropdownMenu
-                                              bsClass="dropdown-menu"
-                                              bsRole="menu"
-                                              key=".1"
-                                              labelledBy="action-1"
-                                              onClose={[Function]}
-                                              onSelect={[Function]}
-                                              pullRight={false}
-                                            >
-                                              <RootCloseWrapper
-                                                disabled={true}
-                                                event="click"
-                                                onRootClose={[Function]}
-                                              >
-                                                <ul
-                                                  aria-labelledby="action-1"
-                                                  className="dropdown-menu"
-                                                  role="menu"
-                                                >
-                                                  <MenuItem
-                                                    bsClass="dropdown"
-                                                    disabled={false}
-                                                    divider={false}
-                                                    header={false}
-                                                    key=".0"
-                                                    onClick={[Function]}
-                                                    onKeyDown={[Function]}
-                                                    onSelect={[Function]}
+                                                  <li
+                                                    className=""
+                                                    role="presentation"
                                                   >
-                                                    <li
-                                                      className=""
-                                                      role="presentation"
-                                                    >
-                                                      <SafeAnchor
-                                                        componentClass="a"
-                                                        onClick={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        role="menuitem"
-                                                        tabIndex="-1"
-                                                      >
-                                                        <a
-                                                          href="#"
-                                                          onClick={[Function]}
-                                                          onKeyDown={[Function]}
-                                                          role="menuitem"
-                                                          tabIndex="-1"
-                                                        >
-                                                          Install
-                                                        </a>
-                                                      </SafeAnchor>
-                                                    </li>
-                                                  </MenuItem>
-                                                  <LinkContainer
-                                                    action="push"
-                                                    key=".1"
-                                                    onKeyDown={[Function]}
-                                                    onSelect={[Function]}
-                                                    onlyActiveOnIndex={false}
-                                                    to="/system/contentpacks/1/1/edit"
-                                                  >
-                                                    <MenuItem
-                                                      action="push"
-                                                      bsClass="dropdown"
-                                                      disabled={false}
-                                                      divider={false}
-                                                      header={false}
+                                                    <SafeAnchor
+                                                      componentClass="a"
                                                       onClick={[Function]}
                                                       onKeyDown={[Function]}
-                                                      onSelect={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex="-1"
                                                     >
-                                                      <li
-                                                        className=""
-                                                        role="presentation"
+                                                      <a
+                                                        href="#"
+                                                        onClick={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex="-1"
                                                       >
-                                                        <SafeAnchor
-                                                          action="push"
-                                                          componentClass="a"
-                                                          onClick={[Function]}
-                                                          onKeyDown={[Function]}
-                                                          role="menuitem"
-                                                          tabIndex="-1"
-                                                        >
-                                                          <a
-                                                            action="push"
-                                                            href="#"
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            role="menuitem"
-                                                            tabIndex="-1"
-                                                          >
-                                                            Create New From Revision
-                                                          </a>
-                                                        </SafeAnchor>
-                                                      </li>
-                                                    </MenuItem>
-                                                  </LinkContainer>
+                                                        Install
+                                                      </a>
+                                                    </SafeAnchor>
+                                                  </li>
+                                                </MenuItem>
+                                                <LinkContainer
+                                                  action="push"
+                                                  key=".1"
+                                                  onKeyDown={[Function]}
+                                                  onSelect={[Function]}
+                                                  onlyActiveOnIndex={false}
+                                                  to="/system/contentpacks/1/1/edit"
+                                                >
                                                   <MenuItem
-                                                    bsClass="dropdown"
-                                                    disabled={false}
-                                                    divider={true}
-                                                    header={false}
-                                                    key=".2"
-                                                    onKeyDown={[Function]}
-                                                    onSelect={[Function]}
-                                                  >
-                                                    <li
-                                                      className="divider"
-                                                      onKeyDown={[Function]}
-                                                      role="separator"
-                                                    />
-                                                  </MenuItem>
-                                                  <MenuItem
+                                                    action="push"
                                                     bsClass="dropdown"
                                                     disabled={false}
                                                     divider={false}
                                                     header={false}
-                                                    key=".3"
                                                     onClick={[Function]}
                                                     onKeyDown={[Function]}
                                                     onSelect={[Function]}
@@ -486,6 +423,7 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                                                       role="presentation"
                                                     >
                                                       <SafeAnchor
+                                                        action="push"
                                                         componentClass="a"
                                                         onClick={[Function]}
                                                         onKeyDown={[Function]}
@@ -493,42 +431,117 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                                                         tabIndex="-1"
                                                       >
                                                         <a
+                                                          action="push"
                                                           href="#"
                                                           onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           role="menuitem"
                                                           tabIndex="-1"
                                                         >
-                                                          Delete
+                                                          Create New From Revision
                                                         </a>
                                                       </SafeAnchor>
                                                     </li>
                                                   </MenuItem>
-                                                  <BootstrapModalWrapper
+                                                </LinkContainer>
+                                                <MenuItem
+                                                  bsClass="dropdown"
+                                                  disabled={false}
+                                                  divider={true}
+                                                  header={false}
+                                                  key=".2"
+                                                  onKeyDown={[Function]}
+                                                  onSelect={[Function]}
+                                                >
+                                                  <li
+                                                    className="divider"
+                                                    onKeyDown={[Function]}
+                                                    role="separator"
+                                                  />
+                                                </MenuItem>
+                                                <MenuItem
+                                                  bsClass="dropdown"
+                                                  disabled={false}
+                                                  divider={false}
+                                                  header={false}
+                                                  key=".3"
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  onSelect={[Function]}
+                                                >
+                                                  <li
+                                                    className=""
+                                                    role="presentation"
+                                                  >
+                                                    <SafeAnchor
+                                                      componentClass="a"
+                                                      onClick={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex="-1"
+                                                    >
+                                                      <a
+                                                        href="#"
+                                                        onClick={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex="-1"
+                                                      >
+                                                        Delete
+                                                      </a>
+                                                    </SafeAnchor>
+                                                  </li>
+                                                </MenuItem>
+                                                <BootstrapModalWrapper
+                                                  backdrop="static"
+                                                  bsSize="large"
+                                                  key=".4"
+                                                  onClose={[Function]}
+                                                  onHide={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  onOpen={[Function]}
+                                                  onSelect={[Function]}
+                                                  showModal={false}
+                                                >
+                                                  <Modal
                                                     backdrop="static"
                                                     bsSize="large"
-                                                    key=".4"
-                                                    onClose={[Function]}
                                                     onHide={[Function]}
-                                                    onKeyDown={[Function]}
-                                                    onOpen={[Function]}
-                                                    onSelect={[Function]}
-                                                    showModal={false}
+                                                    show={false}
                                                   >
                                                     <Modal
+                                                      animation={true}
+                                                      autoFocus={true}
                                                       backdrop="static"
+                                                      bsClass="modal"
                                                       bsSize="large"
+                                                      className="Modal-nuree8-0 hMPgsT"
+                                                      dialogComponentClass={[Function]}
+                                                      enforceFocus={true}
+                                                      keyboard={true}
+                                                      manager={
+                                                        ModalManager {
+                                                          "add": [Function],
+                                                          "containers": Array [],
+                                                          "data": Array [],
+                                                          "handleContainerOverflow": true,
+                                                          "hideSiblingNodes": true,
+                                                          "isTopModal": [Function],
+                                                          "modals": Array [],
+                                                          "remove": [Function],
+                                                        }
+                                                      }
                                                       onHide={[Function]}
+                                                      renderBackdrop={[Function]}
+                                                      restoreFocus={true}
                                                       show={false}
                                                     >
                                                       <Modal
-                                                        animation={true}
                                                         autoFocus={true}
                                                         backdrop="static"
-                                                        bsClass="modal"
-                                                        bsSize="large"
-                                                        className="Modal-nuree8-0 hMPgsT"
-                                                        dialogComponentClass={[Function]}
+                                                        backdropClassName="modal-backdrop"
+                                                        backdropTransition={[Function]}
+                                                        containerClassName="modal-open"
                                                         enforceFocus={true}
                                                         keyboard={true}
                                                         manager={
@@ -543,54 +556,28 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                                                             "remove": [Function],
                                                           }
                                                         }
+                                                        onEntering={[Function]}
+                                                        onExited={[Function]}
                                                         onHide={[Function]}
+                                                        onMouseUp={[Function]}
                                                         renderBackdrop={[Function]}
                                                         restoreFocus={true}
                                                         show={false}
-                                                      >
-                                                        <Modal
-                                                          autoFocus={true}
-                                                          backdrop="static"
-                                                          backdropClassName="modal-backdrop"
-                                                          backdropTransition={[Function]}
-                                                          containerClassName="modal-open"
-                                                          enforceFocus={true}
-                                                          keyboard={true}
-                                                          manager={
-                                                            ModalManager {
-                                                              "add": [Function],
-                                                              "containers": Array [],
-                                                              "data": Array [],
-                                                              "handleContainerOverflow": true,
-                                                              "hideSiblingNodes": true,
-                                                              "isTopModal": [Function],
-                                                              "modals": Array [],
-                                                              "remove": [Function],
-                                                            }
-                                                          }
-                                                          onEntering={[Function]}
-                                                          onExited={[Function]}
-                                                          onHide={[Function]}
-                                                          onMouseUp={[Function]}
-                                                          renderBackdrop={[Function]}
-                                                          restoreFocus={true}
-                                                          show={false}
-                                                          transition={[Function]}
-                                                        />
-                                                      </Modal>
+                                                        transition={[Function]}
+                                                      />
                                                     </Modal>
-                                                  </BootstrapModalWrapper>
-                                                </ul>
-                                              </RootCloseWrapper>
-                                            </DropdownMenu>
-                                          </div>
-                                        </ButtonGroup>
-                                      </Dropdown>
-                                    </Uncontrolled(Dropdown)>
-                                  </ForwardRef>
-                                </DropdownButton>
-                              </DropdownButton__StyledDropdownButton>
-                            </ForwardRef>
+                                                  </Modal>
+                                                </BootstrapModalWrapper>
+                                              </ul>
+                                            </RootCloseWrapper>
+                                          </DropdownMenu>
+                                        </div>
+                                      </ButtonGroup>
+                                    </Dropdown>
+                                  </Uncontrolled(Dropdown)>
+                                </ForwardRef>
+                              </DropdownButton>
+                            </DropdownButton>
                           </div>
                         </ButtonToolbar>
                       </td>
@@ -718,251 +705,188 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                             className="pull-right btn-toolbar"
                             role="toolbar"
                           >
-                            <ForwardRef
+                            <Button
                               bsSize="small"
                               bsStyle="success"
                               onClick={[Function]}
                             >
-                              <Button__StyledButton
+                              <Button
+                                active={false}
+                                block={false}
+                                bsClass="btn"
                                 bsSize="small"
                                 bsStyle="success"
+                                className="Button-c9cbmb-0 bNulii"
+                                disabled={false}
                                 onClick={[Function]}
                               >
-                                <Button
-                                  active={false}
-                                  block={false}
-                                  bsClass="btn"
-                                  bsSize="small"
-                                  bsStyle="success"
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                <button
+                                  className="Button-c9cbmb-0 bNulii btn btn-sm btn-success"
                                   disabled={false}
                                   onClick={[Function]}
+                                  type="button"
                                 >
-                                  <button
-                                    className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-success"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    type="button"
-                                  >
-                                    Download
-                                  </button>
-                                </Button>
-                              </Button__StyledButton>
-                            </ForwardRef>
-                            <ForwardRef
+                                  Download
+                                </button>
+                              </Button>
+                            </Button>
+                            <DropdownButton
                               bsSize="small"
                               bsStyle="info"
                               id="action-2"
                               title="Actions"
                             >
-                              <DropdownButton__StyledDropdownButton
+                              <DropdownButton
                                 bsSize="small"
                                 bsStyle="info"
+                                className="DropdownButton-sc-1343dcx-0 jHYVsD"
                                 id="action-2"
                                 title="Actions"
                               >
-                                <DropdownButton
+                                <ForwardRef
                                   bsSize="small"
                                   bsStyle="info"
-                                  className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
                                   id="action-2"
-                                  title="Actions"
                                 >
-                                  <ForwardRef
+                                  <Uncontrolled(Dropdown)
                                     bsSize="small"
                                     bsStyle="info"
                                     id="action-2"
+                                    innerRef={null}
                                   >
-                                    <Uncontrolled(Dropdown)
+                                    <Dropdown
+                                      bsClass="dropdown"
                                       bsSize="small"
                                       bsStyle="info"
+                                      componentClass={[Function]}
                                       id="action-2"
-                                      innerRef={null}
+                                      onToggle={[Function]}
                                     >
-                                      <Dropdown
-                                        bsClass="dropdown"
+                                      <ButtonGroup
+                                        block={false}
+                                        bsClass="btn-group"
                                         bsSize="small"
                                         bsStyle="info"
-                                        componentClass={[Function]}
-                                        id="action-2"
-                                        onToggle={[Function]}
+                                        className="dropdown"
+                                        justified={false}
+                                        vertical={false}
                                       >
-                                        <ButtonGroup
-                                          block={false}
-                                          bsClass="btn-group"
-                                          bsSize="small"
-                                          bsStyle="info"
-                                          className="dropdown"
-                                          justified={false}
-                                          vertical={false}
+                                        <div
+                                          className="dropdown btn-group btn-group-sm btn-group-info"
                                         >
-                                          <div
-                                            className="dropdown btn-group btn-group-sm btn-group-info"
+                                          <DropdownToggle
+                                            bsClass="dropdown-toggle"
+                                            bsRole="toggle"
+                                            bsSize="small"
+                                            bsStyle="info"
+                                            className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                                            id="action-2"
+                                            key=".0"
+                                            onClick={[Function]}
+                                            onKeyDown={[Function]}
+                                            open={false}
+                                            useAnchor={false}
                                           >
-                                            <DropdownToggle
-                                              bsClass="dropdown-toggle"
-                                              bsRole="toggle"
+                                            <Button
+                                              active={false}
+                                              aria-expanded={false}
+                                              aria-haspopup={true}
+                                              block={false}
+                                              bsClass="btn"
                                               bsSize="small"
                                               bsStyle="info"
-                                              className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                                              className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                              disabled={false}
                                               id="action-2"
-                                              key=".0"
                                               onClick={[Function]}
                                               onKeyDown={[Function]}
-                                              open={false}
-                                              useAnchor={false}
+                                              role="button"
                                             >
-                                              <Button
-                                                active={false}
+                                              <button
                                                 aria-expanded={false}
                                                 aria-haspopup={true}
-                                                block={false}
-                                                bsClass="btn"
-                                                bsSize="small"
-                                                bsStyle="info"
-                                                className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                                className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-sm btn-info"
                                                 disabled={false}
                                                 id="action-2"
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
                                                 role="button"
+                                                type="button"
                                               >
-                                                <button
-                                                  aria-expanded={false}
-                                                  aria-haspopup={true}
-                                                  className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-sm btn-info"
+                                                Actions
+                                                 
+                                                <span
+                                                  className="caret"
+                                                />
+                                              </button>
+                                            </Button>
+                                          </DropdownToggle>
+                                          <DropdownMenu
+                                            bsClass="dropdown-menu"
+                                            bsRole="menu"
+                                            key=".1"
+                                            labelledBy="action-2"
+                                            onClose={[Function]}
+                                            onSelect={[Function]}
+                                            pullRight={false}
+                                          >
+                                            <RootCloseWrapper
+                                              disabled={true}
+                                              event="click"
+                                              onRootClose={[Function]}
+                                            >
+                                              <ul
+                                                aria-labelledby="action-2"
+                                                className="dropdown-menu"
+                                                role="menu"
+                                              >
+                                                <MenuItem
+                                                  bsClass="dropdown"
                                                   disabled={false}
-                                                  id="action-2"
+                                                  divider={false}
+                                                  header={false}
+                                                  key=".0"
                                                   onClick={[Function]}
                                                   onKeyDown={[Function]}
-                                                  role="button"
-                                                  type="button"
+                                                  onSelect={[Function]}
                                                 >
-                                                  Actions
-                                                   
-                                                  <span
-                                                    className="caret"
-                                                  />
-                                                </button>
-                                              </Button>
-                                            </DropdownToggle>
-                                            <DropdownMenu
-                                              bsClass="dropdown-menu"
-                                              bsRole="menu"
-                                              key=".1"
-                                              labelledBy="action-2"
-                                              onClose={[Function]}
-                                              onSelect={[Function]}
-                                              pullRight={false}
-                                            >
-                                              <RootCloseWrapper
-                                                disabled={true}
-                                                event="click"
-                                                onRootClose={[Function]}
-                                              >
-                                                <ul
-                                                  aria-labelledby="action-2"
-                                                  className="dropdown-menu"
-                                                  role="menu"
-                                                >
-                                                  <MenuItem
-                                                    bsClass="dropdown"
-                                                    disabled={false}
-                                                    divider={false}
-                                                    header={false}
-                                                    key=".0"
-                                                    onClick={[Function]}
-                                                    onKeyDown={[Function]}
-                                                    onSelect={[Function]}
+                                                  <li
+                                                    className=""
+                                                    role="presentation"
                                                   >
-                                                    <li
-                                                      className=""
-                                                      role="presentation"
-                                                    >
-                                                      <SafeAnchor
-                                                        componentClass="a"
-                                                        onClick={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        role="menuitem"
-                                                        tabIndex="-1"
-                                                      >
-                                                        <a
-                                                          href="#"
-                                                          onClick={[Function]}
-                                                          onKeyDown={[Function]}
-                                                          role="menuitem"
-                                                          tabIndex="-1"
-                                                        >
-                                                          Install
-                                                        </a>
-                                                      </SafeAnchor>
-                                                    </li>
-                                                  </MenuItem>
-                                                  <LinkContainer
-                                                    action="push"
-                                                    key=".1"
-                                                    onKeyDown={[Function]}
-                                                    onSelect={[Function]}
-                                                    onlyActiveOnIndex={false}
-                                                    to="/system/contentpacks/1/2/edit"
-                                                  >
-                                                    <MenuItem
-                                                      action="push"
-                                                      bsClass="dropdown"
-                                                      disabled={false}
-                                                      divider={false}
-                                                      header={false}
+                                                    <SafeAnchor
+                                                      componentClass="a"
                                                       onClick={[Function]}
                                                       onKeyDown={[Function]}
-                                                      onSelect={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex="-1"
                                                     >
-                                                      <li
-                                                        className=""
-                                                        role="presentation"
+                                                      <a
+                                                        href="#"
+                                                        onClick={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex="-1"
                                                       >
-                                                        <SafeAnchor
-                                                          action="push"
-                                                          componentClass="a"
-                                                          onClick={[Function]}
-                                                          onKeyDown={[Function]}
-                                                          role="menuitem"
-                                                          tabIndex="-1"
-                                                        >
-                                                          <a
-                                                            action="push"
-                                                            href="#"
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            role="menuitem"
-                                                            tabIndex="-1"
-                                                          >
-                                                            Create New From Revision
-                                                          </a>
-                                                        </SafeAnchor>
-                                                      </li>
-                                                    </MenuItem>
-                                                  </LinkContainer>
+                                                        Install
+                                                      </a>
+                                                    </SafeAnchor>
+                                                  </li>
+                                                </MenuItem>
+                                                <LinkContainer
+                                                  action="push"
+                                                  key=".1"
+                                                  onKeyDown={[Function]}
+                                                  onSelect={[Function]}
+                                                  onlyActiveOnIndex={false}
+                                                  to="/system/contentpacks/1/2/edit"
+                                                >
                                                   <MenuItem
-                                                    bsClass="dropdown"
-                                                    disabled={false}
-                                                    divider={true}
-                                                    header={false}
-                                                    key=".2"
-                                                    onKeyDown={[Function]}
-                                                    onSelect={[Function]}
-                                                  >
-                                                    <li
-                                                      className="divider"
-                                                      onKeyDown={[Function]}
-                                                      role="separator"
-                                                    />
-                                                  </MenuItem>
-                                                  <MenuItem
+                                                    action="push"
                                                     bsClass="dropdown"
                                                     disabled={false}
                                                     divider={false}
                                                     header={false}
-                                                    key=".3"
                                                     onClick={[Function]}
                                                     onKeyDown={[Function]}
                                                     onSelect={[Function]}
@@ -972,6 +896,7 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                                                       role="presentation"
                                                     >
                                                       <SafeAnchor
+                                                        action="push"
                                                         componentClass="a"
                                                         onClick={[Function]}
                                                         onKeyDown={[Function]}
@@ -979,42 +904,117 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                                                         tabIndex="-1"
                                                       >
                                                         <a
+                                                          action="push"
                                                           href="#"
                                                           onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           role="menuitem"
                                                           tabIndex="-1"
                                                         >
-                                                          Delete
+                                                          Create New From Revision
                                                         </a>
                                                       </SafeAnchor>
                                                     </li>
                                                   </MenuItem>
-                                                  <BootstrapModalWrapper
+                                                </LinkContainer>
+                                                <MenuItem
+                                                  bsClass="dropdown"
+                                                  disabled={false}
+                                                  divider={true}
+                                                  header={false}
+                                                  key=".2"
+                                                  onKeyDown={[Function]}
+                                                  onSelect={[Function]}
+                                                >
+                                                  <li
+                                                    className="divider"
+                                                    onKeyDown={[Function]}
+                                                    role="separator"
+                                                  />
+                                                </MenuItem>
+                                                <MenuItem
+                                                  bsClass="dropdown"
+                                                  disabled={false}
+                                                  divider={false}
+                                                  header={false}
+                                                  key=".3"
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  onSelect={[Function]}
+                                                >
+                                                  <li
+                                                    className=""
+                                                    role="presentation"
+                                                  >
+                                                    <SafeAnchor
+                                                      componentClass="a"
+                                                      onClick={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex="-1"
+                                                    >
+                                                      <a
+                                                        href="#"
+                                                        onClick={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex="-1"
+                                                      >
+                                                        Delete
+                                                      </a>
+                                                    </SafeAnchor>
+                                                  </li>
+                                                </MenuItem>
+                                                <BootstrapModalWrapper
+                                                  backdrop="static"
+                                                  bsSize="large"
+                                                  key=".4"
+                                                  onClose={[Function]}
+                                                  onHide={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  onOpen={[Function]}
+                                                  onSelect={[Function]}
+                                                  showModal={false}
+                                                >
+                                                  <Modal
                                                     backdrop="static"
                                                     bsSize="large"
-                                                    key=".4"
-                                                    onClose={[Function]}
                                                     onHide={[Function]}
-                                                    onKeyDown={[Function]}
-                                                    onOpen={[Function]}
-                                                    onSelect={[Function]}
-                                                    showModal={false}
+                                                    show={false}
                                                   >
                                                     <Modal
+                                                      animation={true}
+                                                      autoFocus={true}
                                                       backdrop="static"
+                                                      bsClass="modal"
                                                       bsSize="large"
+                                                      className="Modal-nuree8-0 hMPgsT"
+                                                      dialogComponentClass={[Function]}
+                                                      enforceFocus={true}
+                                                      keyboard={true}
+                                                      manager={
+                                                        ModalManager {
+                                                          "add": [Function],
+                                                          "containers": Array [],
+                                                          "data": Array [],
+                                                          "handleContainerOverflow": true,
+                                                          "hideSiblingNodes": true,
+                                                          "isTopModal": [Function],
+                                                          "modals": Array [],
+                                                          "remove": [Function],
+                                                        }
+                                                      }
                                                       onHide={[Function]}
+                                                      renderBackdrop={[Function]}
+                                                      restoreFocus={true}
                                                       show={false}
                                                     >
                                                       <Modal
-                                                        animation={true}
                                                         autoFocus={true}
                                                         backdrop="static"
-                                                        bsClass="modal"
-                                                        bsSize="large"
-                                                        className="Modal-nuree8-0 hMPgsT"
-                                                        dialogComponentClass={[Function]}
+                                                        backdropClassName="modal-backdrop"
+                                                        backdropTransition={[Function]}
+                                                        containerClassName="modal-open"
                                                         enforceFocus={true}
                                                         keyboard={true}
                                                         manager={
@@ -1029,54 +1029,28 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                                                             "remove": [Function],
                                                           }
                                                         }
+                                                        onEntering={[Function]}
+                                                        onExited={[Function]}
                                                         onHide={[Function]}
+                                                        onMouseUp={[Function]}
                                                         renderBackdrop={[Function]}
                                                         restoreFocus={true}
                                                         show={false}
-                                                      >
-                                                        <Modal
-                                                          autoFocus={true}
-                                                          backdrop="static"
-                                                          backdropClassName="modal-backdrop"
-                                                          backdropTransition={[Function]}
-                                                          containerClassName="modal-open"
-                                                          enforceFocus={true}
-                                                          keyboard={true}
-                                                          manager={
-                                                            ModalManager {
-                                                              "add": [Function],
-                                                              "containers": Array [],
-                                                              "data": Array [],
-                                                              "handleContainerOverflow": true,
-                                                              "hideSiblingNodes": true,
-                                                              "isTopModal": [Function],
-                                                              "modals": Array [],
-                                                              "remove": [Function],
-                                                            }
-                                                          }
-                                                          onEntering={[Function]}
-                                                          onExited={[Function]}
-                                                          onHide={[Function]}
-                                                          onMouseUp={[Function]}
-                                                          renderBackdrop={[Function]}
-                                                          restoreFocus={true}
-                                                          show={false}
-                                                          transition={[Function]}
-                                                        />
-                                                      </Modal>
+                                                        transition={[Function]}
+                                                      />
                                                     </Modal>
-                                                  </BootstrapModalWrapper>
-                                                </ul>
-                                              </RootCloseWrapper>
-                                            </DropdownMenu>
-                                          </div>
-                                        </ButtonGroup>
-                                      </Dropdown>
-                                    </Uncontrolled(Dropdown)>
-                                  </ForwardRef>
-                                </DropdownButton>
-                              </DropdownButton__StyledDropdownButton>
-                            </ForwardRef>
+                                                  </Modal>
+                                                </BootstrapModalWrapper>
+                                              </ul>
+                                            </RootCloseWrapper>
+                                          </DropdownMenu>
+                                        </div>
+                                      </ButtonGroup>
+                                    </Dropdown>
+                                  </Uncontrolled(Dropdown)>
+                                </ForwardRef>
+                              </DropdownButton>
+                            </DropdownButton>
                           </div>
                         </ButtonToolbar>
                       </td>
@@ -1204,251 +1178,188 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                             className="pull-right btn-toolbar"
                             role="toolbar"
                           >
-                            <ForwardRef
+                            <Button
                               bsSize="small"
                               bsStyle="success"
                               onClick={[Function]}
                             >
-                              <Button__StyledButton
+                              <Button
+                                active={false}
+                                block={false}
+                                bsClass="btn"
                                 bsSize="small"
                                 bsStyle="success"
+                                className="Button-c9cbmb-0 bNulii"
+                                disabled={false}
                                 onClick={[Function]}
                               >
-                                <Button
-                                  active={false}
-                                  block={false}
-                                  bsClass="btn"
-                                  bsSize="small"
-                                  bsStyle="success"
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                <button
+                                  className="Button-c9cbmb-0 bNulii btn btn-sm btn-success"
                                   disabled={false}
                                   onClick={[Function]}
+                                  type="button"
                                 >
-                                  <button
-                                    className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-success"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    type="button"
-                                  >
-                                    Download
-                                  </button>
-                                </Button>
-                              </Button__StyledButton>
-                            </ForwardRef>
-                            <ForwardRef
+                                  Download
+                                </button>
+                              </Button>
+                            </Button>
+                            <DropdownButton
                               bsSize="small"
                               bsStyle="info"
                               id="action-3"
                               title="Actions"
                             >
-                              <DropdownButton__StyledDropdownButton
+                              <DropdownButton
                                 bsSize="small"
                                 bsStyle="info"
+                                className="DropdownButton-sc-1343dcx-0 jHYVsD"
                                 id="action-3"
                                 title="Actions"
                               >
-                                <DropdownButton
+                                <ForwardRef
                                   bsSize="small"
                                   bsStyle="info"
-                                  className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
                                   id="action-3"
-                                  title="Actions"
                                 >
-                                  <ForwardRef
+                                  <Uncontrolled(Dropdown)
                                     bsSize="small"
                                     bsStyle="info"
                                     id="action-3"
+                                    innerRef={null}
                                   >
-                                    <Uncontrolled(Dropdown)
+                                    <Dropdown
+                                      bsClass="dropdown"
                                       bsSize="small"
                                       bsStyle="info"
+                                      componentClass={[Function]}
                                       id="action-3"
-                                      innerRef={null}
+                                      onToggle={[Function]}
                                     >
-                                      <Dropdown
-                                        bsClass="dropdown"
+                                      <ButtonGroup
+                                        block={false}
+                                        bsClass="btn-group"
                                         bsSize="small"
                                         bsStyle="info"
-                                        componentClass={[Function]}
-                                        id="action-3"
-                                        onToggle={[Function]}
+                                        className="dropdown"
+                                        justified={false}
+                                        vertical={false}
                                       >
-                                        <ButtonGroup
-                                          block={false}
-                                          bsClass="btn-group"
-                                          bsSize="small"
-                                          bsStyle="info"
-                                          className="dropdown"
-                                          justified={false}
-                                          vertical={false}
+                                        <div
+                                          className="dropdown btn-group btn-group-sm btn-group-info"
                                         >
-                                          <div
-                                            className="dropdown btn-group btn-group-sm btn-group-info"
+                                          <DropdownToggle
+                                            bsClass="dropdown-toggle"
+                                            bsRole="toggle"
+                                            bsSize="small"
+                                            bsStyle="info"
+                                            className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                                            id="action-3"
+                                            key=".0"
+                                            onClick={[Function]}
+                                            onKeyDown={[Function]}
+                                            open={false}
+                                            useAnchor={false}
                                           >
-                                            <DropdownToggle
-                                              bsClass="dropdown-toggle"
-                                              bsRole="toggle"
+                                            <Button
+                                              active={false}
+                                              aria-expanded={false}
+                                              aria-haspopup={true}
+                                              block={false}
+                                              bsClass="btn"
                                               bsSize="small"
                                               bsStyle="info"
-                                              className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                                              className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                              disabled={false}
                                               id="action-3"
-                                              key=".0"
                                               onClick={[Function]}
                                               onKeyDown={[Function]}
-                                              open={false}
-                                              useAnchor={false}
+                                              role="button"
                                             >
-                                              <Button
-                                                active={false}
+                                              <button
                                                 aria-expanded={false}
                                                 aria-haspopup={true}
-                                                block={false}
-                                                bsClass="btn"
-                                                bsSize="small"
-                                                bsStyle="info"
-                                                className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                                className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-sm btn-info"
                                                 disabled={false}
                                                 id="action-3"
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
                                                 role="button"
+                                                type="button"
                                               >
-                                                <button
-                                                  aria-expanded={false}
-                                                  aria-haspopup={true}
-                                                  className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-sm btn-info"
+                                                Actions
+                                                 
+                                                <span
+                                                  className="caret"
+                                                />
+                                              </button>
+                                            </Button>
+                                          </DropdownToggle>
+                                          <DropdownMenu
+                                            bsClass="dropdown-menu"
+                                            bsRole="menu"
+                                            key=".1"
+                                            labelledBy="action-3"
+                                            onClose={[Function]}
+                                            onSelect={[Function]}
+                                            pullRight={false}
+                                          >
+                                            <RootCloseWrapper
+                                              disabled={true}
+                                              event="click"
+                                              onRootClose={[Function]}
+                                            >
+                                              <ul
+                                                aria-labelledby="action-3"
+                                                className="dropdown-menu"
+                                                role="menu"
+                                              >
+                                                <MenuItem
+                                                  bsClass="dropdown"
                                                   disabled={false}
-                                                  id="action-3"
+                                                  divider={false}
+                                                  header={false}
+                                                  key=".0"
                                                   onClick={[Function]}
                                                   onKeyDown={[Function]}
-                                                  role="button"
-                                                  type="button"
+                                                  onSelect={[Function]}
                                                 >
-                                                  Actions
-                                                   
-                                                  <span
-                                                    className="caret"
-                                                  />
-                                                </button>
-                                              </Button>
-                                            </DropdownToggle>
-                                            <DropdownMenu
-                                              bsClass="dropdown-menu"
-                                              bsRole="menu"
-                                              key=".1"
-                                              labelledBy="action-3"
-                                              onClose={[Function]}
-                                              onSelect={[Function]}
-                                              pullRight={false}
-                                            >
-                                              <RootCloseWrapper
-                                                disabled={true}
-                                                event="click"
-                                                onRootClose={[Function]}
-                                              >
-                                                <ul
-                                                  aria-labelledby="action-3"
-                                                  className="dropdown-menu"
-                                                  role="menu"
-                                                >
-                                                  <MenuItem
-                                                    bsClass="dropdown"
-                                                    disabled={false}
-                                                    divider={false}
-                                                    header={false}
-                                                    key=".0"
-                                                    onClick={[Function]}
-                                                    onKeyDown={[Function]}
-                                                    onSelect={[Function]}
+                                                  <li
+                                                    className=""
+                                                    role="presentation"
                                                   >
-                                                    <li
-                                                      className=""
-                                                      role="presentation"
-                                                    >
-                                                      <SafeAnchor
-                                                        componentClass="a"
-                                                        onClick={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        role="menuitem"
-                                                        tabIndex="-1"
-                                                      >
-                                                        <a
-                                                          href="#"
-                                                          onClick={[Function]}
-                                                          onKeyDown={[Function]}
-                                                          role="menuitem"
-                                                          tabIndex="-1"
-                                                        >
-                                                          Install
-                                                        </a>
-                                                      </SafeAnchor>
-                                                    </li>
-                                                  </MenuItem>
-                                                  <LinkContainer
-                                                    action="push"
-                                                    key=".1"
-                                                    onKeyDown={[Function]}
-                                                    onSelect={[Function]}
-                                                    onlyActiveOnIndex={false}
-                                                    to="/system/contentpacks/1/3/edit"
-                                                  >
-                                                    <MenuItem
-                                                      action="push"
-                                                      bsClass="dropdown"
-                                                      disabled={false}
-                                                      divider={false}
-                                                      header={false}
+                                                    <SafeAnchor
+                                                      componentClass="a"
                                                       onClick={[Function]}
                                                       onKeyDown={[Function]}
-                                                      onSelect={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex="-1"
                                                     >
-                                                      <li
-                                                        className=""
-                                                        role="presentation"
+                                                      <a
+                                                        href="#"
+                                                        onClick={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex="-1"
                                                       >
-                                                        <SafeAnchor
-                                                          action="push"
-                                                          componentClass="a"
-                                                          onClick={[Function]}
-                                                          onKeyDown={[Function]}
-                                                          role="menuitem"
-                                                          tabIndex="-1"
-                                                        >
-                                                          <a
-                                                            action="push"
-                                                            href="#"
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            role="menuitem"
-                                                            tabIndex="-1"
-                                                          >
-                                                            Create New From Revision
-                                                          </a>
-                                                        </SafeAnchor>
-                                                      </li>
-                                                    </MenuItem>
-                                                  </LinkContainer>
+                                                        Install
+                                                      </a>
+                                                    </SafeAnchor>
+                                                  </li>
+                                                </MenuItem>
+                                                <LinkContainer
+                                                  action="push"
+                                                  key=".1"
+                                                  onKeyDown={[Function]}
+                                                  onSelect={[Function]}
+                                                  onlyActiveOnIndex={false}
+                                                  to="/system/contentpacks/1/3/edit"
+                                                >
                                                   <MenuItem
-                                                    bsClass="dropdown"
-                                                    disabled={false}
-                                                    divider={true}
-                                                    header={false}
-                                                    key=".2"
-                                                    onKeyDown={[Function]}
-                                                    onSelect={[Function]}
-                                                  >
-                                                    <li
-                                                      className="divider"
-                                                      onKeyDown={[Function]}
-                                                      role="separator"
-                                                    />
-                                                  </MenuItem>
-                                                  <MenuItem
+                                                    action="push"
                                                     bsClass="dropdown"
                                                     disabled={false}
                                                     divider={false}
                                                     header={false}
-                                                    key=".3"
                                                     onClick={[Function]}
                                                     onKeyDown={[Function]}
                                                     onSelect={[Function]}
@@ -1458,6 +1369,7 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                                                       role="presentation"
                                                     >
                                                       <SafeAnchor
+                                                        action="push"
                                                         componentClass="a"
                                                         onClick={[Function]}
                                                         onKeyDown={[Function]}
@@ -1465,42 +1377,117 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                                                         tabIndex="-1"
                                                       >
                                                         <a
+                                                          action="push"
                                                           href="#"
                                                           onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           role="menuitem"
                                                           tabIndex="-1"
                                                         >
-                                                          Delete
+                                                          Create New From Revision
                                                         </a>
                                                       </SafeAnchor>
                                                     </li>
                                                   </MenuItem>
-                                                  <BootstrapModalWrapper
+                                                </LinkContainer>
+                                                <MenuItem
+                                                  bsClass="dropdown"
+                                                  disabled={false}
+                                                  divider={true}
+                                                  header={false}
+                                                  key=".2"
+                                                  onKeyDown={[Function]}
+                                                  onSelect={[Function]}
+                                                >
+                                                  <li
+                                                    className="divider"
+                                                    onKeyDown={[Function]}
+                                                    role="separator"
+                                                  />
+                                                </MenuItem>
+                                                <MenuItem
+                                                  bsClass="dropdown"
+                                                  disabled={false}
+                                                  divider={false}
+                                                  header={false}
+                                                  key=".3"
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  onSelect={[Function]}
+                                                >
+                                                  <li
+                                                    className=""
+                                                    role="presentation"
+                                                  >
+                                                    <SafeAnchor
+                                                      componentClass="a"
+                                                      onClick={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex="-1"
+                                                    >
+                                                      <a
+                                                        href="#"
+                                                        onClick={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex="-1"
+                                                      >
+                                                        Delete
+                                                      </a>
+                                                    </SafeAnchor>
+                                                  </li>
+                                                </MenuItem>
+                                                <BootstrapModalWrapper
+                                                  backdrop="static"
+                                                  bsSize="large"
+                                                  key=".4"
+                                                  onClose={[Function]}
+                                                  onHide={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  onOpen={[Function]}
+                                                  onSelect={[Function]}
+                                                  showModal={false}
+                                                >
+                                                  <Modal
                                                     backdrop="static"
                                                     bsSize="large"
-                                                    key=".4"
-                                                    onClose={[Function]}
                                                     onHide={[Function]}
-                                                    onKeyDown={[Function]}
-                                                    onOpen={[Function]}
-                                                    onSelect={[Function]}
-                                                    showModal={false}
+                                                    show={false}
                                                   >
                                                     <Modal
+                                                      animation={true}
+                                                      autoFocus={true}
                                                       backdrop="static"
+                                                      bsClass="modal"
                                                       bsSize="large"
+                                                      className="Modal-nuree8-0 hMPgsT"
+                                                      dialogComponentClass={[Function]}
+                                                      enforceFocus={true}
+                                                      keyboard={true}
+                                                      manager={
+                                                        ModalManager {
+                                                          "add": [Function],
+                                                          "containers": Array [],
+                                                          "data": Array [],
+                                                          "handleContainerOverflow": true,
+                                                          "hideSiblingNodes": true,
+                                                          "isTopModal": [Function],
+                                                          "modals": Array [],
+                                                          "remove": [Function],
+                                                        }
+                                                      }
                                                       onHide={[Function]}
+                                                      renderBackdrop={[Function]}
+                                                      restoreFocus={true}
                                                       show={false}
                                                     >
                                                       <Modal
-                                                        animation={true}
                                                         autoFocus={true}
                                                         backdrop="static"
-                                                        bsClass="modal"
-                                                        bsSize="large"
-                                                        className="Modal-nuree8-0 hMPgsT"
-                                                        dialogComponentClass={[Function]}
+                                                        backdropClassName="modal-backdrop"
+                                                        backdropTransition={[Function]}
+                                                        containerClassName="modal-open"
                                                         enforceFocus={true}
                                                         keyboard={true}
                                                         manager={
@@ -1515,54 +1502,28 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                                                             "remove": [Function],
                                                           }
                                                         }
+                                                        onEntering={[Function]}
+                                                        onExited={[Function]}
                                                         onHide={[Function]}
+                                                        onMouseUp={[Function]}
                                                         renderBackdrop={[Function]}
                                                         restoreFocus={true}
                                                         show={false}
-                                                      >
-                                                        <Modal
-                                                          autoFocus={true}
-                                                          backdrop="static"
-                                                          backdropClassName="modal-backdrop"
-                                                          backdropTransition={[Function]}
-                                                          containerClassName="modal-open"
-                                                          enforceFocus={true}
-                                                          keyboard={true}
-                                                          manager={
-                                                            ModalManager {
-                                                              "add": [Function],
-                                                              "containers": Array [],
-                                                              "data": Array [],
-                                                              "handleContainerOverflow": true,
-                                                              "hideSiblingNodes": true,
-                                                              "isTopModal": [Function],
-                                                              "modals": Array [],
-                                                              "remove": [Function],
-                                                            }
-                                                          }
-                                                          onEntering={[Function]}
-                                                          onExited={[Function]}
-                                                          onHide={[Function]}
-                                                          onMouseUp={[Function]}
-                                                          renderBackdrop={[Function]}
-                                                          restoreFocus={true}
-                                                          show={false}
-                                                          transition={[Function]}
-                                                        />
-                                                      </Modal>
+                                                        transition={[Function]}
+                                                      />
                                                     </Modal>
-                                                  </BootstrapModalWrapper>
-                                                </ul>
-                                              </RootCloseWrapper>
-                                            </DropdownMenu>
-                                          </div>
-                                        </ButtonGroup>
-                                      </Dropdown>
-                                    </Uncontrolled(Dropdown)>
-                                  </ForwardRef>
-                                </DropdownButton>
-                              </DropdownButton__StyledDropdownButton>
-                            </ForwardRef>
+                                                  </Modal>
+                                                </BootstrapModalWrapper>
+                                              </ul>
+                                            </RootCloseWrapper>
+                                          </DropdownMenu>
+                                        </div>
+                                      </ButtonGroup>
+                                    </Dropdown>
+                                  </Uncontrolled(Dropdown)>
+                                </ForwardRef>
+                              </DropdownButton>
+                            </DropdownButton>
                           </div>
                         </ButtonToolbar>
                       </td>
@@ -1690,251 +1651,188 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                             className="pull-right btn-toolbar"
                             role="toolbar"
                           >
-                            <ForwardRef
+                            <Button
                               bsSize="small"
                               bsStyle="success"
                               onClick={[Function]}
                             >
-                              <Button__StyledButton
+                              <Button
+                                active={false}
+                                block={false}
+                                bsClass="btn"
                                 bsSize="small"
                                 bsStyle="success"
+                                className="Button-c9cbmb-0 bNulii"
+                                disabled={false}
                                 onClick={[Function]}
                               >
-                                <Button
-                                  active={false}
-                                  block={false}
-                                  bsClass="btn"
-                                  bsSize="small"
-                                  bsStyle="success"
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                <button
+                                  className="Button-c9cbmb-0 bNulii btn btn-sm btn-success"
                                   disabled={false}
                                   onClick={[Function]}
+                                  type="button"
                                 >
-                                  <button
-                                    className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-success"
-                                    disabled={false}
-                                    onClick={[Function]}
-                                    type="button"
-                                  >
-                                    Download
-                                  </button>
-                                </Button>
-                              </Button__StyledButton>
-                            </ForwardRef>
-                            <ForwardRef
+                                  Download
+                                </button>
+                              </Button>
+                            </Button>
+                            <DropdownButton
                               bsSize="small"
                               bsStyle="info"
                               id="action-4"
                               title="Actions"
                             >
-                              <DropdownButton__StyledDropdownButton
+                              <DropdownButton
                                 bsSize="small"
                                 bsStyle="info"
+                                className="DropdownButton-sc-1343dcx-0 jHYVsD"
                                 id="action-4"
                                 title="Actions"
                               >
-                                <DropdownButton
+                                <ForwardRef
                                   bsSize="small"
                                   bsStyle="info"
-                                  className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
                                   id="action-4"
-                                  title="Actions"
                                 >
-                                  <ForwardRef
+                                  <Uncontrolled(Dropdown)
                                     bsSize="small"
                                     bsStyle="info"
                                     id="action-4"
+                                    innerRef={null}
                                   >
-                                    <Uncontrolled(Dropdown)
+                                    <Dropdown
+                                      bsClass="dropdown"
                                       bsSize="small"
                                       bsStyle="info"
+                                      componentClass={[Function]}
                                       id="action-4"
-                                      innerRef={null}
+                                      onToggle={[Function]}
                                     >
-                                      <Dropdown
-                                        bsClass="dropdown"
+                                      <ButtonGroup
+                                        block={false}
+                                        bsClass="btn-group"
                                         bsSize="small"
                                         bsStyle="info"
-                                        componentClass={[Function]}
-                                        id="action-4"
-                                        onToggle={[Function]}
+                                        className="dropdown"
+                                        justified={false}
+                                        vertical={false}
                                       >
-                                        <ButtonGroup
-                                          block={false}
-                                          bsClass="btn-group"
-                                          bsSize="small"
-                                          bsStyle="info"
-                                          className="dropdown"
-                                          justified={false}
-                                          vertical={false}
+                                        <div
+                                          className="dropdown btn-group btn-group-sm btn-group-info"
                                         >
-                                          <div
-                                            className="dropdown btn-group btn-group-sm btn-group-info"
+                                          <DropdownToggle
+                                            bsClass="dropdown-toggle"
+                                            bsRole="toggle"
+                                            bsSize="small"
+                                            bsStyle="info"
+                                            className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                                            id="action-4"
+                                            key=".0"
+                                            onClick={[Function]}
+                                            onKeyDown={[Function]}
+                                            open={false}
+                                            useAnchor={false}
                                           >
-                                            <DropdownToggle
-                                              bsClass="dropdown-toggle"
-                                              bsRole="toggle"
+                                            <Button
+                                              active={false}
+                                              aria-expanded={false}
+                                              aria-haspopup={true}
+                                              block={false}
+                                              bsClass="btn"
                                               bsSize="small"
                                               bsStyle="info"
-                                              className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                                              className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                              disabled={false}
                                               id="action-4"
-                                              key=".0"
                                               onClick={[Function]}
                                               onKeyDown={[Function]}
-                                              open={false}
-                                              useAnchor={false}
+                                              role="button"
                                             >
-                                              <Button
-                                                active={false}
+                                              <button
                                                 aria-expanded={false}
                                                 aria-haspopup={true}
-                                                block={false}
-                                                bsClass="btn"
-                                                bsSize="small"
-                                                bsStyle="info"
-                                                className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                                className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-sm btn-info"
                                                 disabled={false}
                                                 id="action-4"
                                                 onClick={[Function]}
                                                 onKeyDown={[Function]}
                                                 role="button"
+                                                type="button"
                                               >
-                                                <button
-                                                  aria-expanded={false}
-                                                  aria-haspopup={true}
-                                                  className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-sm btn-info"
+                                                Actions
+                                                 
+                                                <span
+                                                  className="caret"
+                                                />
+                                              </button>
+                                            </Button>
+                                          </DropdownToggle>
+                                          <DropdownMenu
+                                            bsClass="dropdown-menu"
+                                            bsRole="menu"
+                                            key=".1"
+                                            labelledBy="action-4"
+                                            onClose={[Function]}
+                                            onSelect={[Function]}
+                                            pullRight={false}
+                                          >
+                                            <RootCloseWrapper
+                                              disabled={true}
+                                              event="click"
+                                              onRootClose={[Function]}
+                                            >
+                                              <ul
+                                                aria-labelledby="action-4"
+                                                className="dropdown-menu"
+                                                role="menu"
+                                              >
+                                                <MenuItem
+                                                  bsClass="dropdown"
                                                   disabled={false}
-                                                  id="action-4"
+                                                  divider={false}
+                                                  header={false}
+                                                  key=".0"
                                                   onClick={[Function]}
                                                   onKeyDown={[Function]}
-                                                  role="button"
-                                                  type="button"
+                                                  onSelect={[Function]}
                                                 >
-                                                  Actions
-                                                   
-                                                  <span
-                                                    className="caret"
-                                                  />
-                                                </button>
-                                              </Button>
-                                            </DropdownToggle>
-                                            <DropdownMenu
-                                              bsClass="dropdown-menu"
-                                              bsRole="menu"
-                                              key=".1"
-                                              labelledBy="action-4"
-                                              onClose={[Function]}
-                                              onSelect={[Function]}
-                                              pullRight={false}
-                                            >
-                                              <RootCloseWrapper
-                                                disabled={true}
-                                                event="click"
-                                                onRootClose={[Function]}
-                                              >
-                                                <ul
-                                                  aria-labelledby="action-4"
-                                                  className="dropdown-menu"
-                                                  role="menu"
-                                                >
-                                                  <MenuItem
-                                                    bsClass="dropdown"
-                                                    disabled={false}
-                                                    divider={false}
-                                                    header={false}
-                                                    key=".0"
-                                                    onClick={[Function]}
-                                                    onKeyDown={[Function]}
-                                                    onSelect={[Function]}
+                                                  <li
+                                                    className=""
+                                                    role="presentation"
                                                   >
-                                                    <li
-                                                      className=""
-                                                      role="presentation"
-                                                    >
-                                                      <SafeAnchor
-                                                        componentClass="a"
-                                                        onClick={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        role="menuitem"
-                                                        tabIndex="-1"
-                                                      >
-                                                        <a
-                                                          href="#"
-                                                          onClick={[Function]}
-                                                          onKeyDown={[Function]}
-                                                          role="menuitem"
-                                                          tabIndex="-1"
-                                                        >
-                                                          Install
-                                                        </a>
-                                                      </SafeAnchor>
-                                                    </li>
-                                                  </MenuItem>
-                                                  <LinkContainer
-                                                    action="push"
-                                                    key=".1"
-                                                    onKeyDown={[Function]}
-                                                    onSelect={[Function]}
-                                                    onlyActiveOnIndex={false}
-                                                    to="/system/contentpacks/1/4/edit"
-                                                  >
-                                                    <MenuItem
-                                                      action="push"
-                                                      bsClass="dropdown"
-                                                      disabled={false}
-                                                      divider={false}
-                                                      header={false}
+                                                    <SafeAnchor
+                                                      componentClass="a"
                                                       onClick={[Function]}
                                                       onKeyDown={[Function]}
-                                                      onSelect={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex="-1"
                                                     >
-                                                      <li
-                                                        className=""
-                                                        role="presentation"
+                                                      <a
+                                                        href="#"
+                                                        onClick={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex="-1"
                                                       >
-                                                        <SafeAnchor
-                                                          action="push"
-                                                          componentClass="a"
-                                                          onClick={[Function]}
-                                                          onKeyDown={[Function]}
-                                                          role="menuitem"
-                                                          tabIndex="-1"
-                                                        >
-                                                          <a
-                                                            action="push"
-                                                            href="#"
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            role="menuitem"
-                                                            tabIndex="-1"
-                                                          >
-                                                            Create New From Revision
-                                                          </a>
-                                                        </SafeAnchor>
-                                                      </li>
-                                                    </MenuItem>
-                                                  </LinkContainer>
+                                                        Install
+                                                      </a>
+                                                    </SafeAnchor>
+                                                  </li>
+                                                </MenuItem>
+                                                <LinkContainer
+                                                  action="push"
+                                                  key=".1"
+                                                  onKeyDown={[Function]}
+                                                  onSelect={[Function]}
+                                                  onlyActiveOnIndex={false}
+                                                  to="/system/contentpacks/1/4/edit"
+                                                >
                                                   <MenuItem
-                                                    bsClass="dropdown"
-                                                    disabled={false}
-                                                    divider={true}
-                                                    header={false}
-                                                    key=".2"
-                                                    onKeyDown={[Function]}
-                                                    onSelect={[Function]}
-                                                  >
-                                                    <li
-                                                      className="divider"
-                                                      onKeyDown={[Function]}
-                                                      role="separator"
-                                                    />
-                                                  </MenuItem>
-                                                  <MenuItem
+                                                    action="push"
                                                     bsClass="dropdown"
                                                     disabled={false}
                                                     divider={false}
                                                     header={false}
-                                                    key=".3"
                                                     onClick={[Function]}
                                                     onKeyDown={[Function]}
                                                     onSelect={[Function]}
@@ -1944,6 +1842,7 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                                                       role="presentation"
                                                     >
                                                       <SafeAnchor
+                                                        action="push"
                                                         componentClass="a"
                                                         onClick={[Function]}
                                                         onKeyDown={[Function]}
@@ -1951,42 +1850,117 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                                                         tabIndex="-1"
                                                       >
                                                         <a
+                                                          action="push"
                                                           href="#"
                                                           onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           role="menuitem"
                                                           tabIndex="-1"
                                                         >
-                                                          Delete
+                                                          Create New From Revision
                                                         </a>
                                                       </SafeAnchor>
                                                     </li>
                                                   </MenuItem>
-                                                  <BootstrapModalWrapper
+                                                </LinkContainer>
+                                                <MenuItem
+                                                  bsClass="dropdown"
+                                                  disabled={false}
+                                                  divider={true}
+                                                  header={false}
+                                                  key=".2"
+                                                  onKeyDown={[Function]}
+                                                  onSelect={[Function]}
+                                                >
+                                                  <li
+                                                    className="divider"
+                                                    onKeyDown={[Function]}
+                                                    role="separator"
+                                                  />
+                                                </MenuItem>
+                                                <MenuItem
+                                                  bsClass="dropdown"
+                                                  disabled={false}
+                                                  divider={false}
+                                                  header={false}
+                                                  key=".3"
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  onSelect={[Function]}
+                                                >
+                                                  <li
+                                                    className=""
+                                                    role="presentation"
+                                                  >
+                                                    <SafeAnchor
+                                                      componentClass="a"
+                                                      onClick={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex="-1"
+                                                    >
+                                                      <a
+                                                        href="#"
+                                                        onClick={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex="-1"
+                                                      >
+                                                        Delete
+                                                      </a>
+                                                    </SafeAnchor>
+                                                  </li>
+                                                </MenuItem>
+                                                <BootstrapModalWrapper
+                                                  backdrop="static"
+                                                  bsSize="large"
+                                                  key=".4"
+                                                  onClose={[Function]}
+                                                  onHide={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  onOpen={[Function]}
+                                                  onSelect={[Function]}
+                                                  showModal={false}
+                                                >
+                                                  <Modal
                                                     backdrop="static"
                                                     bsSize="large"
-                                                    key=".4"
-                                                    onClose={[Function]}
                                                     onHide={[Function]}
-                                                    onKeyDown={[Function]}
-                                                    onOpen={[Function]}
-                                                    onSelect={[Function]}
-                                                    showModal={false}
+                                                    show={false}
                                                   >
                                                     <Modal
+                                                      animation={true}
+                                                      autoFocus={true}
                                                       backdrop="static"
+                                                      bsClass="modal"
                                                       bsSize="large"
+                                                      className="Modal-nuree8-0 hMPgsT"
+                                                      dialogComponentClass={[Function]}
+                                                      enforceFocus={true}
+                                                      keyboard={true}
+                                                      manager={
+                                                        ModalManager {
+                                                          "add": [Function],
+                                                          "containers": Array [],
+                                                          "data": Array [],
+                                                          "handleContainerOverflow": true,
+                                                          "hideSiblingNodes": true,
+                                                          "isTopModal": [Function],
+                                                          "modals": Array [],
+                                                          "remove": [Function],
+                                                        }
+                                                      }
                                                       onHide={[Function]}
+                                                      renderBackdrop={[Function]}
+                                                      restoreFocus={true}
                                                       show={false}
                                                     >
                                                       <Modal
-                                                        animation={true}
                                                         autoFocus={true}
                                                         backdrop="static"
-                                                        bsClass="modal"
-                                                        bsSize="large"
-                                                        className="Modal-nuree8-0 hMPgsT"
-                                                        dialogComponentClass={[Function]}
+                                                        backdropClassName="modal-backdrop"
+                                                        backdropTransition={[Function]}
+                                                        containerClassName="modal-open"
                                                         enforceFocus={true}
                                                         keyboard={true}
                                                         manager={
@@ -2001,54 +1975,28 @@ exports[`<ContentPackVersions /> should render with content pack versions 1`] = 
                                                             "remove": [Function],
                                                           }
                                                         }
+                                                        onEntering={[Function]}
+                                                        onExited={[Function]}
                                                         onHide={[Function]}
+                                                        onMouseUp={[Function]}
                                                         renderBackdrop={[Function]}
                                                         restoreFocus={true}
                                                         show={false}
-                                                      >
-                                                        <Modal
-                                                          autoFocus={true}
-                                                          backdrop="static"
-                                                          backdropClassName="modal-backdrop"
-                                                          backdropTransition={[Function]}
-                                                          containerClassName="modal-open"
-                                                          enforceFocus={true}
-                                                          keyboard={true}
-                                                          manager={
-                                                            ModalManager {
-                                                              "add": [Function],
-                                                              "containers": Array [],
-                                                              "data": Array [],
-                                                              "handleContainerOverflow": true,
-                                                              "hideSiblingNodes": true,
-                                                              "isTopModal": [Function],
-                                                              "modals": Array [],
-                                                              "remove": [Function],
-                                                            }
-                                                          }
-                                                          onEntering={[Function]}
-                                                          onExited={[Function]}
-                                                          onHide={[Function]}
-                                                          onMouseUp={[Function]}
-                                                          renderBackdrop={[Function]}
-                                                          restoreFocus={true}
-                                                          show={false}
-                                                          transition={[Function]}
-                                                        />
-                                                      </Modal>
+                                                        transition={[Function]}
+                                                      />
                                                     </Modal>
-                                                  </BootstrapModalWrapper>
-                                                </ul>
-                                              </RootCloseWrapper>
-                                            </DropdownMenu>
-                                          </div>
-                                        </ButtonGroup>
-                                      </Dropdown>
-                                    </Uncontrolled(Dropdown)>
-                                  </ForwardRef>
-                                </DropdownButton>
-                              </DropdownButton__StyledDropdownButton>
-                            </ForwardRef>
+                                                  </Modal>
+                                                </BootstrapModalWrapper>
+                                              </ul>
+                                            </RootCloseWrapper>
+                                          </DropdownMenu>
+                                        </div>
+                                      </ButtonGroup>
+                                    </Dropdown>
+                                  </Uncontrolled(Dropdown)>
+                                </ForwardRef>
+                              </DropdownButton>
+                            </DropdownButton>
                           </div>
                         </ButtonToolbar>
                       </td>

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPacksList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPacksList.test.jsx.snap
@@ -382,7 +382,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         </Component>
                       </Input>
                     </TypeAheadInput>
-                    <ForwardRef
+                    <Button
                       style={
                         Object {
                           "marginLeft": 5,
@@ -390,7 +390,13 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                       }
                       type="submit"
                     >
-                      <Button__StyledButton
+                      <Button
+                        active={false}
+                        block={false}
+                        bsClass="btn"
+                        bsStyle="default"
+                        className="Button-c9cbmb-0 bNulii"
+                        disabled={false}
                         style={
                           Object {
                             "marginLeft": 5,
@@ -398,12 +404,8 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         }
                         type="submit"
                       >
-                        <Button
-                          active={false}
-                          block={false}
-                          bsClass="btn"
-                          bsStyle="default"
-                          className="Button__StyledButton-c9cbmb-0 laZUlH"
+                        <button
+                          className="Button-c9cbmb-0 bNulii btn btn-default"
                           disabled={false}
                           style={
                             Object {
@@ -412,22 +414,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                           }
                           type="submit"
                         >
-                          <button
-                            className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                            disabled={false}
-                            style={
-                              Object {
-                                "marginLeft": 5,
-                              }
-                            }
-                            type="submit"
-                          >
-                            Filter
-                          </button>
-                        </Button>
-                      </Button__StyledButton>
-                    </ForwardRef>
-                    <ForwardRef
+                          Filter
+                        </button>
+                      </Button>
+                    </Button>
+                    <Button
                       disabled={true}
                       onClick={[Function]}
                       style={
@@ -437,7 +428,12 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                       }
                       type="button"
                     >
-                      <Button__StyledButton
+                      <Button
+                        active={false}
+                        block={false}
+                        bsClass="btn"
+                        bsStyle="default"
+                        className="Button-c9cbmb-0 bNulii"
                         disabled={true}
                         onClick={[Function]}
                         style={
@@ -447,12 +443,8 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                         }
                         type="button"
                       >
-                        <Button
-                          active={false}
-                          block={false}
-                          bsClass="btn"
-                          bsStyle="default"
-                          className="Button__StyledButton-c9cbmb-0 laZUlH"
+                        <button
+                          className="Button-c9cbmb-0 bNulii btn btn-default"
                           disabled={true}
                           onClick={[Function]}
                           style={
@@ -462,22 +454,10 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                           }
                           type="button"
                         >
-                          <button
-                            className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                            disabled={true}
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "marginLeft": 5,
-                              }
-                            }
-                            type="button"
-                          >
-                            Reset
-                          </button>
-                        </Button>
-                      </Button__StyledButton>
-                    </ForwardRef>
+                          Reset
+                        </button>
+                      </Button>
+                    </Button>
                   </form>
                   <ul
                     className="pill-list"
@@ -950,37 +930,31 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                   className="text-right col-md-3"
                                 >
                                    
-                                  <ForwardRef
+                                  <Button
                                     bsSize="small"
                                     bsStyle="info"
                                     onClick={[Function]}
                                   >
-                                    <Button__StyledButton
+                                    <Button
+                                      active={false}
+                                      block={false}
+                                      bsClass="btn"
                                       bsSize="small"
                                       bsStyle="info"
+                                      className="Button-c9cbmb-0 bNulii"
+                                      disabled={false}
                                       onClick={[Function]}
                                     >
-                                      <Button
-                                        active={false}
-                                        block={false}
-                                        bsClass="btn"
-                                        bsSize="small"
-                                        bsStyle="info"
-                                        className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                      <button
+                                        className="Button-c9cbmb-0 bNulii btn btn-sm btn-info"
                                         disabled={false}
                                         onClick={[Function]}
+                                        type="button"
                                       >
-                                        <button
-                                          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-info"
-                                          disabled={false}
-                                          onClick={[Function]}
-                                          type="button"
-                                        >
-                                          Install
-                                        </button>
-                                      </Button>
-                                    </Button__StyledButton>
-                                  </ForwardRef>
+                                        Install
+                                      </button>
+                                    </Button>
+                                  </Button>
                                   <BootstrapModalWrapper
                                     backdrop="static"
                                     bsSize="large"
@@ -1055,214 +1029,129 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                     </Modal>
                                   </BootstrapModalWrapper>
                                    
-                                  <ForwardRef
+                                  <DropdownButton
                                     bsSize="small"
                                     id="more-actions-1"
                                     pullRight={true}
                                     title="More Actions"
                                   >
-                                    <DropdownButton__StyledDropdownButton
+                                    <DropdownButton
                                       bsSize="small"
+                                      className="DropdownButton-sc-1343dcx-0 jHYVsD"
                                       id="more-actions-1"
                                       pullRight={true}
                                       title="More Actions"
                                     >
-                                      <DropdownButton
+                                      <ForwardRef
                                         bsSize="small"
-                                        className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
                                         id="more-actions-1"
                                         pullRight={true}
-                                        title="More Actions"
                                       >
-                                        <ForwardRef
+                                        <Uncontrolled(Dropdown)
                                           bsSize="small"
                                           id="more-actions-1"
+                                          innerRef={null}
                                           pullRight={true}
                                         >
-                                          <Uncontrolled(Dropdown)
+                                          <Dropdown
+                                            bsClass="dropdown"
                                             bsSize="small"
+                                            componentClass={[Function]}
                                             id="more-actions-1"
-                                            innerRef={null}
+                                            onToggle={[Function]}
                                             pullRight={true}
                                           >
-                                            <Dropdown
-                                              bsClass="dropdown"
+                                            <ButtonGroup
+                                              block={false}
+                                              bsClass="btn-group"
                                               bsSize="small"
-                                              componentClass={[Function]}
-                                              id="more-actions-1"
-                                              onToggle={[Function]}
-                                              pullRight={true}
+                                              className="dropdown"
+                                              justified={false}
+                                              vertical={false}
                                             >
-                                              <ButtonGroup
-                                                block={false}
-                                                bsClass="btn-group"
-                                                bsSize="small"
-                                                className="dropdown"
-                                                justified={false}
-                                                vertical={false}
+                                              <div
+                                                className="dropdown btn-group btn-group-sm"
                                               >
-                                                <div
-                                                  className="dropdown btn-group btn-group-sm"
+                                                <DropdownToggle
+                                                  bsClass="dropdown-toggle"
+                                                  bsRole="toggle"
+                                                  bsSize="small"
+                                                  className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                                                  id="more-actions-1"
+                                                  key=".0"
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  open={false}
+                                                  useAnchor={false}
                                                 >
-                                                  <DropdownToggle
-                                                    bsClass="dropdown-toggle"
-                                                    bsRole="toggle"
+                                                  <Button
+                                                    active={false}
+                                                    aria-expanded={false}
+                                                    aria-haspopup={true}
+                                                    block={false}
+                                                    bsClass="btn"
                                                     bsSize="small"
-                                                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                                                    bsStyle="default"
+                                                    className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                                    disabled={false}
                                                     id="more-actions-1"
-                                                    key=".0"
                                                     onClick={[Function]}
                                                     onKeyDown={[Function]}
-                                                    open={false}
-                                                    useAnchor={false}
+                                                    role="button"
                                                   >
-                                                    <Button
-                                                      active={false}
+                                                    <button
                                                       aria-expanded={false}
                                                       aria-haspopup={true}
-                                                      block={false}
-                                                      bsClass="btn"
-                                                      bsSize="small"
-                                                      bsStyle="default"
-                                                      className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                                      className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-sm btn-default"
                                                       disabled={false}
                                                       id="more-actions-1"
                                                       onClick={[Function]}
                                                       onKeyDown={[Function]}
                                                       role="button"
+                                                      type="button"
                                                     >
-                                                      <button
-                                                        aria-expanded={false}
-                                                        aria-haspopup={true}
-                                                        className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-sm btn-default"
-                                                        disabled={false}
-                                                        id="more-actions-1"
-                                                        onClick={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        role="button"
-                                                        type="button"
-                                                      >
-                                                        More Actions
-                                                         
-                                                        <span
-                                                          className="caret"
-                                                        />
-                                                      </button>
-                                                    </Button>
-                                                  </DropdownToggle>
-                                                  <DropdownMenu
-                                                    bsClass="dropdown-menu"
-                                                    bsRole="menu"
-                                                    key=".1"
-                                                    labelledBy="more-actions-1"
-                                                    onClose={[Function]}
-                                                    onSelect={[Function]}
-                                                    pullRight={true}
+                                                      More Actions
+                                                       
+                                                      <span
+                                                        className="caret"
+                                                      />
+                                                    </button>
+                                                  </Button>
+                                                </DropdownToggle>
+                                                <DropdownMenu
+                                                  bsClass="dropdown-menu"
+                                                  bsRole="menu"
+                                                  key=".1"
+                                                  labelledBy="more-actions-1"
+                                                  onClose={[Function]}
+                                                  onSelect={[Function]}
+                                                  pullRight={true}
+                                                >
+                                                  <RootCloseWrapper
+                                                    disabled={true}
+                                                    event="click"
+                                                    onRootClose={[Function]}
                                                   >
-                                                    <RootCloseWrapper
-                                                      disabled={true}
-                                                      event="click"
-                                                      onRootClose={[Function]}
+                                                    <ul
+                                                      aria-labelledby="more-actions-1"
+                                                      className="dropdown-menu dropdown-menu-right"
+                                                      role="menu"
                                                     >
-                                                      <ul
-                                                        aria-labelledby="more-actions-1"
-                                                        className="dropdown-menu dropdown-menu-right"
-                                                        role="menu"
+                                                      <LinkContainer
+                                                        action="push"
+                                                        key=".0"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                        onlyActiveOnIndex={false}
+                                                        to="/system/contentpacks/1"
                                                       >
-                                                        <LinkContainer
-                                                          action="push"
-                                                          key=".0"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                          onlyActiveOnIndex={false}
-                                                          to="/system/contentpacks/1"
-                                                        >
-                                                          <MenuItem
-                                                            action="push"
-                                                            bsClass="dropdown"
-                                                            disabled={false}
-                                                            divider={false}
-                                                            header={false}
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            onSelect={[Function]}
-                                                          >
-                                                            <li
-                                                              className=""
-                                                              role="presentation"
-                                                            >
-                                                              <SafeAnchor
-                                                                action="push"
-                                                                componentClass="a"
-                                                                onClick={[Function]}
-                                                                onKeyDown={[Function]}
-                                                                role="menuitem"
-                                                                tabIndex="-1"
-                                                              >
-                                                                <a
-                                                                  action="push"
-                                                                  href="#"
-                                                                  onClick={[Function]}
-                                                                  onKeyDown={[Function]}
-                                                                  role="menuitem"
-                                                                  tabIndex="-1"
-                                                                >
-                                                                  Show
-                                                                </a>
-                                                              </SafeAnchor>
-                                                            </li>
-                                                          </MenuItem>
-                                                        </LinkContainer>
-                                                        <LinkContainer
-                                                          action="push"
-                                                          key=".1"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                          onlyActiveOnIndex={false}
-                                                          to="/system/contentpacks/1/1/edit"
-                                                        >
-                                                          <MenuItem
-                                                            action="push"
-                                                            bsClass="dropdown"
-                                                            disabled={false}
-                                                            divider={false}
-                                                            header={false}
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            onSelect={[Function]}
-                                                          >
-                                                            <li
-                                                              className=""
-                                                              role="presentation"
-                                                            >
-                                                              <SafeAnchor
-                                                                action="push"
-                                                                componentClass="a"
-                                                                onClick={[Function]}
-                                                                onKeyDown={[Function]}
-                                                                role="menuitem"
-                                                                tabIndex="-1"
-                                                              >
-                                                                <a
-                                                                  action="push"
-                                                                  href="#"
-                                                                  onClick={[Function]}
-                                                                  onKeyDown={[Function]}
-                                                                  role="menuitem"
-                                                                  tabIndex="-1"
-                                                                >
-                                                                  Create New Version
-                                                                </a>
-                                                              </SafeAnchor>
-                                                            </li>
-                                                          </MenuItem>
-                                                        </LinkContainer>
                                                         <MenuItem
+                                                          action="push"
                                                           bsClass="dropdown"
                                                           disabled={false}
                                                           divider={false}
                                                           header={false}
-                                                          key=".2"
+                                                          onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           onSelect={[Function]}
                                                         >
@@ -1271,6 +1160,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                             role="presentation"
                                                           >
                                                             <SafeAnchor
+                                                              action="push"
                                                               componentClass="a"
                                                               onClick={[Function]}
                                                               onKeyDown={[Function]}
@@ -1278,38 +1168,34 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                               tabIndex="-1"
                                                             >
                                                               <a
+                                                                action="push"
                                                                 href="#"
                                                                 onClick={[Function]}
                                                                 onKeyDown={[Function]}
                                                                 role="menuitem"
                                                                 tabIndex="-1"
                                                               >
-                                                                Download
+                                                                Show
                                                               </a>
                                                             </SafeAnchor>
                                                           </li>
                                                         </MenuItem>
+                                                      </LinkContainer>
+                                                      <LinkContainer
+                                                        action="push"
+                                                        key=".1"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                        onlyActiveOnIndex={false}
+                                                        to="/system/contentpacks/1/1/edit"
+                                                      >
                                                         <MenuItem
-                                                          bsClass="dropdown"
-                                                          disabled={false}
-                                                          divider={true}
-                                                          header={false}
-                                                          key=".3"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                        >
-                                                          <li
-                                                            className="divider"
-                                                            onKeyDown={[Function]}
-                                                            role="separator"
-                                                          />
-                                                        </MenuItem>
-                                                        <MenuItem
+                                                          action="push"
                                                           bsClass="dropdown"
                                                           disabled={false}
                                                           divider={false}
                                                           header={false}
-                                                          key=".4"
+                                                          onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           onSelect={[Function]}
                                                         >
@@ -1318,6 +1204,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                             role="presentation"
                                                           >
                                                             <SafeAnchor
+                                                              action="push"
                                                               componentClass="a"
                                                               onClick={[Function]}
                                                               onKeyDown={[Function]}
@@ -1325,28 +1212,108 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                               tabIndex="-1"
                                                             >
                                                               <a
+                                                                action="push"
                                                                 href="#"
                                                                 onClick={[Function]}
                                                                 onKeyDown={[Function]}
                                                                 role="menuitem"
                                                                 tabIndex="-1"
                                                               >
-                                                                Delete All Versions
+                                                                Create New Version
                                                               </a>
                                                             </SafeAnchor>
                                                           </li>
                                                         </MenuItem>
-                                                      </ul>
-                                                    </RootCloseWrapper>
-                                                  </DropdownMenu>
-                                                </div>
-                                              </ButtonGroup>
-                                            </Dropdown>
-                                          </Uncontrolled(Dropdown)>
-                                        </ForwardRef>
-                                      </DropdownButton>
-                                    </DropdownButton__StyledDropdownButton>
-                                  </ForwardRef>
+                                                      </LinkContainer>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={false}
+                                                        header={false}
+                                                        key=".2"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className=""
+                                                          role="presentation"
+                                                        >
+                                                          <SafeAnchor
+                                                            componentClass="a"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            role="menuitem"
+                                                            tabIndex="-1"
+                                                          >
+                                                            <a
+                                                              href="#"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              role="menuitem"
+                                                              tabIndex="-1"
+                                                            >
+                                                              Download
+                                                            </a>
+                                                          </SafeAnchor>
+                                                        </li>
+                                                      </MenuItem>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={true}
+                                                        header={false}
+                                                        key=".3"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className="divider"
+                                                          onKeyDown={[Function]}
+                                                          role="separator"
+                                                        />
+                                                      </MenuItem>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={false}
+                                                        header={false}
+                                                        key=".4"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className=""
+                                                          role="presentation"
+                                                        >
+                                                          <SafeAnchor
+                                                            componentClass="a"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            role="menuitem"
+                                                            tabIndex="-1"
+                                                          >
+                                                            <a
+                                                              href="#"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              role="menuitem"
+                                                              tabIndex="-1"
+                                                            >
+                                                              Delete All Versions
+                                                            </a>
+                                                          </SafeAnchor>
+                                                        </li>
+                                                      </MenuItem>
+                                                    </ul>
+                                                  </RootCloseWrapper>
+                                                </DropdownMenu>
+                                              </div>
+                                            </ButtonGroup>
+                                          </Dropdown>
+                                        </Uncontrolled(Dropdown)>
+                                      </ForwardRef>
+                                    </DropdownButton>
+                                  </DropdownButton>
                                   <ContentPackDownloadControl
                                     contentPackId="1"
                                     revision={1}
@@ -1564,37 +1531,31 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                   className="text-right col-md-3"
                                 >
                                    
-                                  <ForwardRef
+                                  <Button
                                     bsSize="small"
                                     bsStyle="info"
                                     onClick={[Function]}
                                   >
-                                    <Button__StyledButton
+                                    <Button
+                                      active={false}
+                                      block={false}
+                                      bsClass="btn"
                                       bsSize="small"
                                       bsStyle="info"
+                                      className="Button-c9cbmb-0 bNulii"
+                                      disabled={false}
                                       onClick={[Function]}
                                     >
-                                      <Button
-                                        active={false}
-                                        block={false}
-                                        bsClass="btn"
-                                        bsSize="small"
-                                        bsStyle="info"
-                                        className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                      <button
+                                        className="Button-c9cbmb-0 bNulii btn btn-sm btn-info"
                                         disabled={false}
                                         onClick={[Function]}
+                                        type="button"
                                       >
-                                        <button
-                                          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-info"
-                                          disabled={false}
-                                          onClick={[Function]}
-                                          type="button"
-                                        >
-                                          Install
-                                        </button>
-                                      </Button>
-                                    </Button__StyledButton>
-                                  </ForwardRef>
+                                        Install
+                                      </button>
+                                    </Button>
+                                  </Button>
                                   <BootstrapModalWrapper
                                     backdrop="static"
                                     bsSize="large"
@@ -1669,214 +1630,129 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                     </Modal>
                                   </BootstrapModalWrapper>
                                    
-                                  <ForwardRef
+                                  <DropdownButton
                                     bsSize="small"
                                     id="more-actions-2"
                                     pullRight={true}
                                     title="More Actions"
                                   >
-                                    <DropdownButton__StyledDropdownButton
+                                    <DropdownButton
                                       bsSize="small"
+                                      className="DropdownButton-sc-1343dcx-0 jHYVsD"
                                       id="more-actions-2"
                                       pullRight={true}
                                       title="More Actions"
                                     >
-                                      <DropdownButton
+                                      <ForwardRef
                                         bsSize="small"
-                                        className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
                                         id="more-actions-2"
                                         pullRight={true}
-                                        title="More Actions"
                                       >
-                                        <ForwardRef
+                                        <Uncontrolled(Dropdown)
                                           bsSize="small"
                                           id="more-actions-2"
+                                          innerRef={null}
                                           pullRight={true}
                                         >
-                                          <Uncontrolled(Dropdown)
+                                          <Dropdown
+                                            bsClass="dropdown"
                                             bsSize="small"
+                                            componentClass={[Function]}
                                             id="more-actions-2"
-                                            innerRef={null}
+                                            onToggle={[Function]}
                                             pullRight={true}
                                           >
-                                            <Dropdown
-                                              bsClass="dropdown"
+                                            <ButtonGroup
+                                              block={false}
+                                              bsClass="btn-group"
                                               bsSize="small"
-                                              componentClass={[Function]}
-                                              id="more-actions-2"
-                                              onToggle={[Function]}
-                                              pullRight={true}
+                                              className="dropdown"
+                                              justified={false}
+                                              vertical={false}
                                             >
-                                              <ButtonGroup
-                                                block={false}
-                                                bsClass="btn-group"
-                                                bsSize="small"
-                                                className="dropdown"
-                                                justified={false}
-                                                vertical={false}
+                                              <div
+                                                className="dropdown btn-group btn-group-sm"
                                               >
-                                                <div
-                                                  className="dropdown btn-group btn-group-sm"
+                                                <DropdownToggle
+                                                  bsClass="dropdown-toggle"
+                                                  bsRole="toggle"
+                                                  bsSize="small"
+                                                  className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                                                  id="more-actions-2"
+                                                  key=".0"
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  open={false}
+                                                  useAnchor={false}
                                                 >
-                                                  <DropdownToggle
-                                                    bsClass="dropdown-toggle"
-                                                    bsRole="toggle"
+                                                  <Button
+                                                    active={false}
+                                                    aria-expanded={false}
+                                                    aria-haspopup={true}
+                                                    block={false}
+                                                    bsClass="btn"
                                                     bsSize="small"
-                                                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                                                    bsStyle="default"
+                                                    className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                                    disabled={false}
                                                     id="more-actions-2"
-                                                    key=".0"
                                                     onClick={[Function]}
                                                     onKeyDown={[Function]}
-                                                    open={false}
-                                                    useAnchor={false}
+                                                    role="button"
                                                   >
-                                                    <Button
-                                                      active={false}
+                                                    <button
                                                       aria-expanded={false}
                                                       aria-haspopup={true}
-                                                      block={false}
-                                                      bsClass="btn"
-                                                      bsSize="small"
-                                                      bsStyle="default"
-                                                      className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                                      className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-sm btn-default"
                                                       disabled={false}
                                                       id="more-actions-2"
                                                       onClick={[Function]}
                                                       onKeyDown={[Function]}
                                                       role="button"
+                                                      type="button"
                                                     >
-                                                      <button
-                                                        aria-expanded={false}
-                                                        aria-haspopup={true}
-                                                        className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-sm btn-default"
-                                                        disabled={false}
-                                                        id="more-actions-2"
-                                                        onClick={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        role="button"
-                                                        type="button"
-                                                      >
-                                                        More Actions
-                                                         
-                                                        <span
-                                                          className="caret"
-                                                        />
-                                                      </button>
-                                                    </Button>
-                                                  </DropdownToggle>
-                                                  <DropdownMenu
-                                                    bsClass="dropdown-menu"
-                                                    bsRole="menu"
-                                                    key=".1"
-                                                    labelledBy="more-actions-2"
-                                                    onClose={[Function]}
-                                                    onSelect={[Function]}
-                                                    pullRight={true}
+                                                      More Actions
+                                                       
+                                                      <span
+                                                        className="caret"
+                                                      />
+                                                    </button>
+                                                  </Button>
+                                                </DropdownToggle>
+                                                <DropdownMenu
+                                                  bsClass="dropdown-menu"
+                                                  bsRole="menu"
+                                                  key=".1"
+                                                  labelledBy="more-actions-2"
+                                                  onClose={[Function]}
+                                                  onSelect={[Function]}
+                                                  pullRight={true}
+                                                >
+                                                  <RootCloseWrapper
+                                                    disabled={true}
+                                                    event="click"
+                                                    onRootClose={[Function]}
                                                   >
-                                                    <RootCloseWrapper
-                                                      disabled={true}
-                                                      event="click"
-                                                      onRootClose={[Function]}
+                                                    <ul
+                                                      aria-labelledby="more-actions-2"
+                                                      className="dropdown-menu dropdown-menu-right"
+                                                      role="menu"
                                                     >
-                                                      <ul
-                                                        aria-labelledby="more-actions-2"
-                                                        className="dropdown-menu dropdown-menu-right"
-                                                        role="menu"
+                                                      <LinkContainer
+                                                        action="push"
+                                                        key=".0"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                        onlyActiveOnIndex={false}
+                                                        to="/system/contentpacks/2"
                                                       >
-                                                        <LinkContainer
-                                                          action="push"
-                                                          key=".0"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                          onlyActiveOnIndex={false}
-                                                          to="/system/contentpacks/2"
-                                                        >
-                                                          <MenuItem
-                                                            action="push"
-                                                            bsClass="dropdown"
-                                                            disabled={false}
-                                                            divider={false}
-                                                            header={false}
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            onSelect={[Function]}
-                                                          >
-                                                            <li
-                                                              className=""
-                                                              role="presentation"
-                                                            >
-                                                              <SafeAnchor
-                                                                action="push"
-                                                                componentClass="a"
-                                                                onClick={[Function]}
-                                                                onKeyDown={[Function]}
-                                                                role="menuitem"
-                                                                tabIndex="-1"
-                                                              >
-                                                                <a
-                                                                  action="push"
-                                                                  href="#"
-                                                                  onClick={[Function]}
-                                                                  onKeyDown={[Function]}
-                                                                  role="menuitem"
-                                                                  tabIndex="-1"
-                                                                >
-                                                                  Show
-                                                                </a>
-                                                              </SafeAnchor>
-                                                            </li>
-                                                          </MenuItem>
-                                                        </LinkContainer>
-                                                        <LinkContainer
-                                                          action="push"
-                                                          key=".1"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                          onlyActiveOnIndex={false}
-                                                          to="/system/contentpacks/2/1/edit"
-                                                        >
-                                                          <MenuItem
-                                                            action="push"
-                                                            bsClass="dropdown"
-                                                            disabled={false}
-                                                            divider={false}
-                                                            header={false}
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            onSelect={[Function]}
-                                                          >
-                                                            <li
-                                                              className=""
-                                                              role="presentation"
-                                                            >
-                                                              <SafeAnchor
-                                                                action="push"
-                                                                componentClass="a"
-                                                                onClick={[Function]}
-                                                                onKeyDown={[Function]}
-                                                                role="menuitem"
-                                                                tabIndex="-1"
-                                                              >
-                                                                <a
-                                                                  action="push"
-                                                                  href="#"
-                                                                  onClick={[Function]}
-                                                                  onKeyDown={[Function]}
-                                                                  role="menuitem"
-                                                                  tabIndex="-1"
-                                                                >
-                                                                  Create New Version
-                                                                </a>
-                                                              </SafeAnchor>
-                                                            </li>
-                                                          </MenuItem>
-                                                        </LinkContainer>
                                                         <MenuItem
+                                                          action="push"
                                                           bsClass="dropdown"
                                                           disabled={false}
                                                           divider={false}
                                                           header={false}
-                                                          key=".2"
+                                                          onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           onSelect={[Function]}
                                                         >
@@ -1885,6 +1761,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                             role="presentation"
                                                           >
                                                             <SafeAnchor
+                                                              action="push"
                                                               componentClass="a"
                                                               onClick={[Function]}
                                                               onKeyDown={[Function]}
@@ -1892,38 +1769,34 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                               tabIndex="-1"
                                                             >
                                                               <a
+                                                                action="push"
                                                                 href="#"
                                                                 onClick={[Function]}
                                                                 onKeyDown={[Function]}
                                                                 role="menuitem"
                                                                 tabIndex="-1"
                                                               >
-                                                                Download
+                                                                Show
                                                               </a>
                                                             </SafeAnchor>
                                                           </li>
                                                         </MenuItem>
+                                                      </LinkContainer>
+                                                      <LinkContainer
+                                                        action="push"
+                                                        key=".1"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                        onlyActiveOnIndex={false}
+                                                        to="/system/contentpacks/2/1/edit"
+                                                      >
                                                         <MenuItem
-                                                          bsClass="dropdown"
-                                                          disabled={false}
-                                                          divider={true}
-                                                          header={false}
-                                                          key=".3"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                        >
-                                                          <li
-                                                            className="divider"
-                                                            onKeyDown={[Function]}
-                                                            role="separator"
-                                                          />
-                                                        </MenuItem>
-                                                        <MenuItem
+                                                          action="push"
                                                           bsClass="dropdown"
                                                           disabled={false}
                                                           divider={false}
                                                           header={false}
-                                                          key=".4"
+                                                          onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           onSelect={[Function]}
                                                         >
@@ -1932,6 +1805,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                             role="presentation"
                                                           >
                                                             <SafeAnchor
+                                                              action="push"
                                                               componentClass="a"
                                                               onClick={[Function]}
                                                               onKeyDown={[Function]}
@@ -1939,28 +1813,108 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                               tabIndex="-1"
                                                             >
                                                               <a
+                                                                action="push"
                                                                 href="#"
                                                                 onClick={[Function]}
                                                                 onKeyDown={[Function]}
                                                                 role="menuitem"
                                                                 tabIndex="-1"
                                                               >
-                                                                Delete All Versions
+                                                                Create New Version
                                                               </a>
                                                             </SafeAnchor>
                                                           </li>
                                                         </MenuItem>
-                                                      </ul>
-                                                    </RootCloseWrapper>
-                                                  </DropdownMenu>
-                                                </div>
-                                              </ButtonGroup>
-                                            </Dropdown>
-                                          </Uncontrolled(Dropdown)>
-                                        </ForwardRef>
-                                      </DropdownButton>
-                                    </DropdownButton__StyledDropdownButton>
-                                  </ForwardRef>
+                                                      </LinkContainer>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={false}
+                                                        header={false}
+                                                        key=".2"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className=""
+                                                          role="presentation"
+                                                        >
+                                                          <SafeAnchor
+                                                            componentClass="a"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            role="menuitem"
+                                                            tabIndex="-1"
+                                                          >
+                                                            <a
+                                                              href="#"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              role="menuitem"
+                                                              tabIndex="-1"
+                                                            >
+                                                              Download
+                                                            </a>
+                                                          </SafeAnchor>
+                                                        </li>
+                                                      </MenuItem>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={true}
+                                                        header={false}
+                                                        key=".3"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className="divider"
+                                                          onKeyDown={[Function]}
+                                                          role="separator"
+                                                        />
+                                                      </MenuItem>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={false}
+                                                        header={false}
+                                                        key=".4"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className=""
+                                                          role="presentation"
+                                                        >
+                                                          <SafeAnchor
+                                                            componentClass="a"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            role="menuitem"
+                                                            tabIndex="-1"
+                                                          >
+                                                            <a
+                                                              href="#"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              role="menuitem"
+                                                              tabIndex="-1"
+                                                            >
+                                                              Delete All Versions
+                                                            </a>
+                                                          </SafeAnchor>
+                                                        </li>
+                                                      </MenuItem>
+                                                    </ul>
+                                                  </RootCloseWrapper>
+                                                </DropdownMenu>
+                                              </div>
+                                            </ButtonGroup>
+                                          </Dropdown>
+                                        </Uncontrolled(Dropdown)>
+                                      </ForwardRef>
+                                    </DropdownButton>
+                                  </DropdownButton>
                                   <ContentPackDownloadControl
                                     contentPackId="2"
                                     revision={1}
@@ -2144,37 +2098,31 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                   className="text-right col-md-3"
                                 >
                                    
-                                  <ForwardRef
+                                  <Button
                                     bsSize="small"
                                     bsStyle="info"
                                     onClick={[Function]}
                                   >
-                                    <Button__StyledButton
+                                    <Button
+                                      active={false}
+                                      block={false}
+                                      bsClass="btn"
                                       bsSize="small"
                                       bsStyle="info"
+                                      className="Button-c9cbmb-0 bNulii"
+                                      disabled={false}
                                       onClick={[Function]}
                                     >
-                                      <Button
-                                        active={false}
-                                        block={false}
-                                        bsClass="btn"
-                                        bsSize="small"
-                                        bsStyle="info"
-                                        className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                      <button
+                                        className="Button-c9cbmb-0 bNulii btn btn-sm btn-info"
                                         disabled={false}
                                         onClick={[Function]}
+                                        type="button"
                                       >
-                                        <button
-                                          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-info"
-                                          disabled={false}
-                                          onClick={[Function]}
-                                          type="button"
-                                        >
-                                          Install
-                                        </button>
-                                      </Button>
-                                    </Button__StyledButton>
-                                  </ForwardRef>
+                                        Install
+                                      </button>
+                                    </Button>
+                                  </Button>
                                   <BootstrapModalWrapper
                                     backdrop="static"
                                     bsSize="large"
@@ -2249,214 +2197,129 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                     </Modal>
                                   </BootstrapModalWrapper>
                                    
-                                  <ForwardRef
+                                  <DropdownButton
                                     bsSize="small"
                                     id="more-actions-3"
                                     pullRight={true}
                                     title="More Actions"
                                   >
-                                    <DropdownButton__StyledDropdownButton
+                                    <DropdownButton
                                       bsSize="small"
+                                      className="DropdownButton-sc-1343dcx-0 jHYVsD"
                                       id="more-actions-3"
                                       pullRight={true}
                                       title="More Actions"
                                     >
-                                      <DropdownButton
+                                      <ForwardRef
                                         bsSize="small"
-                                        className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
                                         id="more-actions-3"
                                         pullRight={true}
-                                        title="More Actions"
                                       >
-                                        <ForwardRef
+                                        <Uncontrolled(Dropdown)
                                           bsSize="small"
                                           id="more-actions-3"
+                                          innerRef={null}
                                           pullRight={true}
                                         >
-                                          <Uncontrolled(Dropdown)
+                                          <Dropdown
+                                            bsClass="dropdown"
                                             bsSize="small"
+                                            componentClass={[Function]}
                                             id="more-actions-3"
-                                            innerRef={null}
+                                            onToggle={[Function]}
                                             pullRight={true}
                                           >
-                                            <Dropdown
-                                              bsClass="dropdown"
+                                            <ButtonGroup
+                                              block={false}
+                                              bsClass="btn-group"
                                               bsSize="small"
-                                              componentClass={[Function]}
-                                              id="more-actions-3"
-                                              onToggle={[Function]}
-                                              pullRight={true}
+                                              className="dropdown"
+                                              justified={false}
+                                              vertical={false}
                                             >
-                                              <ButtonGroup
-                                                block={false}
-                                                bsClass="btn-group"
-                                                bsSize="small"
-                                                className="dropdown"
-                                                justified={false}
-                                                vertical={false}
+                                              <div
+                                                className="dropdown btn-group btn-group-sm"
                                               >
-                                                <div
-                                                  className="dropdown btn-group btn-group-sm"
+                                                <DropdownToggle
+                                                  bsClass="dropdown-toggle"
+                                                  bsRole="toggle"
+                                                  bsSize="small"
+                                                  className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                                                  id="more-actions-3"
+                                                  key=".0"
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  open={false}
+                                                  useAnchor={false}
                                                 >
-                                                  <DropdownToggle
-                                                    bsClass="dropdown-toggle"
-                                                    bsRole="toggle"
+                                                  <Button
+                                                    active={false}
+                                                    aria-expanded={false}
+                                                    aria-haspopup={true}
+                                                    block={false}
+                                                    bsClass="btn"
                                                     bsSize="small"
-                                                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                                                    bsStyle="default"
+                                                    className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                                    disabled={false}
                                                     id="more-actions-3"
-                                                    key=".0"
                                                     onClick={[Function]}
                                                     onKeyDown={[Function]}
-                                                    open={false}
-                                                    useAnchor={false}
+                                                    role="button"
                                                   >
-                                                    <Button
-                                                      active={false}
+                                                    <button
                                                       aria-expanded={false}
                                                       aria-haspopup={true}
-                                                      block={false}
-                                                      bsClass="btn"
-                                                      bsSize="small"
-                                                      bsStyle="default"
-                                                      className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                                      className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-sm btn-default"
                                                       disabled={false}
                                                       id="more-actions-3"
                                                       onClick={[Function]}
                                                       onKeyDown={[Function]}
                                                       role="button"
+                                                      type="button"
                                                     >
-                                                      <button
-                                                        aria-expanded={false}
-                                                        aria-haspopup={true}
-                                                        className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-sm btn-default"
-                                                        disabled={false}
-                                                        id="more-actions-3"
-                                                        onClick={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        role="button"
-                                                        type="button"
-                                                      >
-                                                        More Actions
-                                                         
-                                                        <span
-                                                          className="caret"
-                                                        />
-                                                      </button>
-                                                    </Button>
-                                                  </DropdownToggle>
-                                                  <DropdownMenu
-                                                    bsClass="dropdown-menu"
-                                                    bsRole="menu"
-                                                    key=".1"
-                                                    labelledBy="more-actions-3"
-                                                    onClose={[Function]}
-                                                    onSelect={[Function]}
-                                                    pullRight={true}
+                                                      More Actions
+                                                       
+                                                      <span
+                                                        className="caret"
+                                                      />
+                                                    </button>
+                                                  </Button>
+                                                </DropdownToggle>
+                                                <DropdownMenu
+                                                  bsClass="dropdown-menu"
+                                                  bsRole="menu"
+                                                  key=".1"
+                                                  labelledBy="more-actions-3"
+                                                  onClose={[Function]}
+                                                  onSelect={[Function]}
+                                                  pullRight={true}
+                                                >
+                                                  <RootCloseWrapper
+                                                    disabled={true}
+                                                    event="click"
+                                                    onRootClose={[Function]}
                                                   >
-                                                    <RootCloseWrapper
-                                                      disabled={true}
-                                                      event="click"
-                                                      onRootClose={[Function]}
+                                                    <ul
+                                                      aria-labelledby="more-actions-3"
+                                                      className="dropdown-menu dropdown-menu-right"
+                                                      role="menu"
                                                     >
-                                                      <ul
-                                                        aria-labelledby="more-actions-3"
-                                                        className="dropdown-menu dropdown-menu-right"
-                                                        role="menu"
+                                                      <LinkContainer
+                                                        action="push"
+                                                        key=".0"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                        onlyActiveOnIndex={false}
+                                                        to="/system/contentpacks/3"
                                                       >
-                                                        <LinkContainer
-                                                          action="push"
-                                                          key=".0"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                          onlyActiveOnIndex={false}
-                                                          to="/system/contentpacks/3"
-                                                        >
-                                                          <MenuItem
-                                                            action="push"
-                                                            bsClass="dropdown"
-                                                            disabled={false}
-                                                            divider={false}
-                                                            header={false}
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            onSelect={[Function]}
-                                                          >
-                                                            <li
-                                                              className=""
-                                                              role="presentation"
-                                                            >
-                                                              <SafeAnchor
-                                                                action="push"
-                                                                componentClass="a"
-                                                                onClick={[Function]}
-                                                                onKeyDown={[Function]}
-                                                                role="menuitem"
-                                                                tabIndex="-1"
-                                                              >
-                                                                <a
-                                                                  action="push"
-                                                                  href="#"
-                                                                  onClick={[Function]}
-                                                                  onKeyDown={[Function]}
-                                                                  role="menuitem"
-                                                                  tabIndex="-1"
-                                                                >
-                                                                  Show
-                                                                </a>
-                                                              </SafeAnchor>
-                                                            </li>
-                                                          </MenuItem>
-                                                        </LinkContainer>
-                                                        <LinkContainer
-                                                          action="push"
-                                                          key=".1"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                          onlyActiveOnIndex={false}
-                                                          to="/system/contentpacks/3/1/edit"
-                                                        >
-                                                          <MenuItem
-                                                            action="push"
-                                                            bsClass="dropdown"
-                                                            disabled={false}
-                                                            divider={false}
-                                                            header={false}
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            onSelect={[Function]}
-                                                          >
-                                                            <li
-                                                              className=""
-                                                              role="presentation"
-                                                            >
-                                                              <SafeAnchor
-                                                                action="push"
-                                                                componentClass="a"
-                                                                onClick={[Function]}
-                                                                onKeyDown={[Function]}
-                                                                role="menuitem"
-                                                                tabIndex="-1"
-                                                              >
-                                                                <a
-                                                                  action="push"
-                                                                  href="#"
-                                                                  onClick={[Function]}
-                                                                  onKeyDown={[Function]}
-                                                                  role="menuitem"
-                                                                  tabIndex="-1"
-                                                                >
-                                                                  Create New Version
-                                                                </a>
-                                                              </SafeAnchor>
-                                                            </li>
-                                                          </MenuItem>
-                                                        </LinkContainer>
                                                         <MenuItem
+                                                          action="push"
                                                           bsClass="dropdown"
                                                           disabled={false}
                                                           divider={false}
                                                           header={false}
-                                                          key=".2"
+                                                          onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           onSelect={[Function]}
                                                         >
@@ -2465,6 +2328,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                             role="presentation"
                                                           >
                                                             <SafeAnchor
+                                                              action="push"
                                                               componentClass="a"
                                                               onClick={[Function]}
                                                               onKeyDown={[Function]}
@@ -2472,38 +2336,34 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                               tabIndex="-1"
                                                             >
                                                               <a
+                                                                action="push"
                                                                 href="#"
                                                                 onClick={[Function]}
                                                                 onKeyDown={[Function]}
                                                                 role="menuitem"
                                                                 tabIndex="-1"
                                                               >
-                                                                Download
+                                                                Show
                                                               </a>
                                                             </SafeAnchor>
                                                           </li>
                                                         </MenuItem>
+                                                      </LinkContainer>
+                                                      <LinkContainer
+                                                        action="push"
+                                                        key=".1"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                        onlyActiveOnIndex={false}
+                                                        to="/system/contentpacks/3/1/edit"
+                                                      >
                                                         <MenuItem
-                                                          bsClass="dropdown"
-                                                          disabled={false}
-                                                          divider={true}
-                                                          header={false}
-                                                          key=".3"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                        >
-                                                          <li
-                                                            className="divider"
-                                                            onKeyDown={[Function]}
-                                                            role="separator"
-                                                          />
-                                                        </MenuItem>
-                                                        <MenuItem
+                                                          action="push"
                                                           bsClass="dropdown"
                                                           disabled={false}
                                                           divider={false}
                                                           header={false}
-                                                          key=".4"
+                                                          onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           onSelect={[Function]}
                                                         >
@@ -2512,6 +2372,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                             role="presentation"
                                                           >
                                                             <SafeAnchor
+                                                              action="push"
                                                               componentClass="a"
                                                               onClick={[Function]}
                                                               onKeyDown={[Function]}
@@ -2519,28 +2380,108 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                               tabIndex="-1"
                                                             >
                                                               <a
+                                                                action="push"
                                                                 href="#"
                                                                 onClick={[Function]}
                                                                 onKeyDown={[Function]}
                                                                 role="menuitem"
                                                                 tabIndex="-1"
                                                               >
-                                                                Delete All Versions
+                                                                Create New Version
                                                               </a>
                                                             </SafeAnchor>
                                                           </li>
                                                         </MenuItem>
-                                                      </ul>
-                                                    </RootCloseWrapper>
-                                                  </DropdownMenu>
-                                                </div>
-                                              </ButtonGroup>
-                                            </Dropdown>
-                                          </Uncontrolled(Dropdown)>
-                                        </ForwardRef>
-                                      </DropdownButton>
-                                    </DropdownButton__StyledDropdownButton>
-                                  </ForwardRef>
+                                                      </LinkContainer>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={false}
+                                                        header={false}
+                                                        key=".2"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className=""
+                                                          role="presentation"
+                                                        >
+                                                          <SafeAnchor
+                                                            componentClass="a"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            role="menuitem"
+                                                            tabIndex="-1"
+                                                          >
+                                                            <a
+                                                              href="#"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              role="menuitem"
+                                                              tabIndex="-1"
+                                                            >
+                                                              Download
+                                                            </a>
+                                                          </SafeAnchor>
+                                                        </li>
+                                                      </MenuItem>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={true}
+                                                        header={false}
+                                                        key=".3"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className="divider"
+                                                          onKeyDown={[Function]}
+                                                          role="separator"
+                                                        />
+                                                      </MenuItem>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={false}
+                                                        header={false}
+                                                        key=".4"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className=""
+                                                          role="presentation"
+                                                        >
+                                                          <SafeAnchor
+                                                            componentClass="a"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            role="menuitem"
+                                                            tabIndex="-1"
+                                                          >
+                                                            <a
+                                                              href="#"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              role="menuitem"
+                                                              tabIndex="-1"
+                                                            >
+                                                              Delete All Versions
+                                                            </a>
+                                                          </SafeAnchor>
+                                                        </li>
+                                                      </MenuItem>
+                                                    </ul>
+                                                  </RootCloseWrapper>
+                                                </DropdownMenu>
+                                              </div>
+                                            </ButtonGroup>
+                                          </Dropdown>
+                                        </Uncontrolled(Dropdown)>
+                                      </ForwardRef>
+                                    </DropdownButton>
+                                  </DropdownButton>
                                   <ContentPackDownloadControl
                                     contentPackId="3"
                                     revision={1}
@@ -2723,37 +2664,31 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                   className="text-right col-md-3"
                                 >
                                    
-                                  <ForwardRef
+                                  <Button
                                     bsSize="small"
                                     bsStyle="info"
                                     onClick={[Function]}
                                   >
-                                    <Button__StyledButton
+                                    <Button
+                                      active={false}
+                                      block={false}
+                                      bsClass="btn"
                                       bsSize="small"
                                       bsStyle="info"
+                                      className="Button-c9cbmb-0 bNulii"
+                                      disabled={false}
                                       onClick={[Function]}
                                     >
-                                      <Button
-                                        active={false}
-                                        block={false}
-                                        bsClass="btn"
-                                        bsSize="small"
-                                        bsStyle="info"
-                                        className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                      <button
+                                        className="Button-c9cbmb-0 bNulii btn btn-sm btn-info"
                                         disabled={false}
                                         onClick={[Function]}
+                                        type="button"
                                       >
-                                        <button
-                                          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-info"
-                                          disabled={false}
-                                          onClick={[Function]}
-                                          type="button"
-                                        >
-                                          Install
-                                        </button>
-                                      </Button>
-                                    </Button__StyledButton>
-                                  </ForwardRef>
+                                        Install
+                                      </button>
+                                    </Button>
+                                  </Button>
                                   <BootstrapModalWrapper
                                     backdrop="static"
                                     bsSize="large"
@@ -2828,214 +2763,129 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                     </Modal>
                                   </BootstrapModalWrapper>
                                    
-                                  <ForwardRef
+                                  <DropdownButton
                                     bsSize="small"
                                     id="more-actions-4"
                                     pullRight={true}
                                     title="More Actions"
                                   >
-                                    <DropdownButton__StyledDropdownButton
+                                    <DropdownButton
                                       bsSize="small"
+                                      className="DropdownButton-sc-1343dcx-0 jHYVsD"
                                       id="more-actions-4"
                                       pullRight={true}
                                       title="More Actions"
                                     >
-                                      <DropdownButton
+                                      <ForwardRef
                                         bsSize="small"
-                                        className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
                                         id="more-actions-4"
                                         pullRight={true}
-                                        title="More Actions"
                                       >
-                                        <ForwardRef
+                                        <Uncontrolled(Dropdown)
                                           bsSize="small"
                                           id="more-actions-4"
+                                          innerRef={null}
                                           pullRight={true}
                                         >
-                                          <Uncontrolled(Dropdown)
+                                          <Dropdown
+                                            bsClass="dropdown"
                                             bsSize="small"
+                                            componentClass={[Function]}
                                             id="more-actions-4"
-                                            innerRef={null}
+                                            onToggle={[Function]}
                                             pullRight={true}
                                           >
-                                            <Dropdown
-                                              bsClass="dropdown"
+                                            <ButtonGroup
+                                              block={false}
+                                              bsClass="btn-group"
                                               bsSize="small"
-                                              componentClass={[Function]}
-                                              id="more-actions-4"
-                                              onToggle={[Function]}
-                                              pullRight={true}
+                                              className="dropdown"
+                                              justified={false}
+                                              vertical={false}
                                             >
-                                              <ButtonGroup
-                                                block={false}
-                                                bsClass="btn-group"
-                                                bsSize="small"
-                                                className="dropdown"
-                                                justified={false}
-                                                vertical={false}
+                                              <div
+                                                className="dropdown btn-group btn-group-sm"
                                               >
-                                                <div
-                                                  className="dropdown btn-group btn-group-sm"
+                                                <DropdownToggle
+                                                  bsClass="dropdown-toggle"
+                                                  bsRole="toggle"
+                                                  bsSize="small"
+                                                  className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                                                  id="more-actions-4"
+                                                  key=".0"
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  open={false}
+                                                  useAnchor={false}
                                                 >
-                                                  <DropdownToggle
-                                                    bsClass="dropdown-toggle"
-                                                    bsRole="toggle"
+                                                  <Button
+                                                    active={false}
+                                                    aria-expanded={false}
+                                                    aria-haspopup={true}
+                                                    block={false}
+                                                    bsClass="btn"
                                                     bsSize="small"
-                                                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                                                    bsStyle="default"
+                                                    className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                                    disabled={false}
                                                     id="more-actions-4"
-                                                    key=".0"
                                                     onClick={[Function]}
                                                     onKeyDown={[Function]}
-                                                    open={false}
-                                                    useAnchor={false}
+                                                    role="button"
                                                   >
-                                                    <Button
-                                                      active={false}
+                                                    <button
                                                       aria-expanded={false}
                                                       aria-haspopup={true}
-                                                      block={false}
-                                                      bsClass="btn"
-                                                      bsSize="small"
-                                                      bsStyle="default"
-                                                      className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                                      className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-sm btn-default"
                                                       disabled={false}
                                                       id="more-actions-4"
                                                       onClick={[Function]}
                                                       onKeyDown={[Function]}
                                                       role="button"
+                                                      type="button"
                                                     >
-                                                      <button
-                                                        aria-expanded={false}
-                                                        aria-haspopup={true}
-                                                        className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-sm btn-default"
-                                                        disabled={false}
-                                                        id="more-actions-4"
-                                                        onClick={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        role="button"
-                                                        type="button"
-                                                      >
-                                                        More Actions
-                                                         
-                                                        <span
-                                                          className="caret"
-                                                        />
-                                                      </button>
-                                                    </Button>
-                                                  </DropdownToggle>
-                                                  <DropdownMenu
-                                                    bsClass="dropdown-menu"
-                                                    bsRole="menu"
-                                                    key=".1"
-                                                    labelledBy="more-actions-4"
-                                                    onClose={[Function]}
-                                                    onSelect={[Function]}
-                                                    pullRight={true}
+                                                      More Actions
+                                                       
+                                                      <span
+                                                        className="caret"
+                                                      />
+                                                    </button>
+                                                  </Button>
+                                                </DropdownToggle>
+                                                <DropdownMenu
+                                                  bsClass="dropdown-menu"
+                                                  bsRole="menu"
+                                                  key=".1"
+                                                  labelledBy="more-actions-4"
+                                                  onClose={[Function]}
+                                                  onSelect={[Function]}
+                                                  pullRight={true}
+                                                >
+                                                  <RootCloseWrapper
+                                                    disabled={true}
+                                                    event="click"
+                                                    onRootClose={[Function]}
                                                   >
-                                                    <RootCloseWrapper
-                                                      disabled={true}
-                                                      event="click"
-                                                      onRootClose={[Function]}
+                                                    <ul
+                                                      aria-labelledby="more-actions-4"
+                                                      className="dropdown-menu dropdown-menu-right"
+                                                      role="menu"
                                                     >
-                                                      <ul
-                                                        aria-labelledby="more-actions-4"
-                                                        className="dropdown-menu dropdown-menu-right"
-                                                        role="menu"
+                                                      <LinkContainer
+                                                        action="push"
+                                                        key=".0"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                        onlyActiveOnIndex={false}
+                                                        to="/system/contentpacks/4"
                                                       >
-                                                        <LinkContainer
-                                                          action="push"
-                                                          key=".0"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                          onlyActiveOnIndex={false}
-                                                          to="/system/contentpacks/4"
-                                                        >
-                                                          <MenuItem
-                                                            action="push"
-                                                            bsClass="dropdown"
-                                                            disabled={false}
-                                                            divider={false}
-                                                            header={false}
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            onSelect={[Function]}
-                                                          >
-                                                            <li
-                                                              className=""
-                                                              role="presentation"
-                                                            >
-                                                              <SafeAnchor
-                                                                action="push"
-                                                                componentClass="a"
-                                                                onClick={[Function]}
-                                                                onKeyDown={[Function]}
-                                                                role="menuitem"
-                                                                tabIndex="-1"
-                                                              >
-                                                                <a
-                                                                  action="push"
-                                                                  href="#"
-                                                                  onClick={[Function]}
-                                                                  onKeyDown={[Function]}
-                                                                  role="menuitem"
-                                                                  tabIndex="-1"
-                                                                >
-                                                                  Show
-                                                                </a>
-                                                              </SafeAnchor>
-                                                            </li>
-                                                          </MenuItem>
-                                                        </LinkContainer>
-                                                        <LinkContainer
-                                                          action="push"
-                                                          key=".1"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                          onlyActiveOnIndex={false}
-                                                          to="/system/contentpacks/4/1/edit"
-                                                        >
-                                                          <MenuItem
-                                                            action="push"
-                                                            bsClass="dropdown"
-                                                            disabled={false}
-                                                            divider={false}
-                                                            header={false}
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            onSelect={[Function]}
-                                                          >
-                                                            <li
-                                                              className=""
-                                                              role="presentation"
-                                                            >
-                                                              <SafeAnchor
-                                                                action="push"
-                                                                componentClass="a"
-                                                                onClick={[Function]}
-                                                                onKeyDown={[Function]}
-                                                                role="menuitem"
-                                                                tabIndex="-1"
-                                                              >
-                                                                <a
-                                                                  action="push"
-                                                                  href="#"
-                                                                  onClick={[Function]}
-                                                                  onKeyDown={[Function]}
-                                                                  role="menuitem"
-                                                                  tabIndex="-1"
-                                                                >
-                                                                  Create New Version
-                                                                </a>
-                                                              </SafeAnchor>
-                                                            </li>
-                                                          </MenuItem>
-                                                        </LinkContainer>
                                                         <MenuItem
+                                                          action="push"
                                                           bsClass="dropdown"
                                                           disabled={false}
                                                           divider={false}
                                                           header={false}
-                                                          key=".2"
+                                                          onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           onSelect={[Function]}
                                                         >
@@ -3044,6 +2894,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                             role="presentation"
                                                           >
                                                             <SafeAnchor
+                                                              action="push"
                                                               componentClass="a"
                                                               onClick={[Function]}
                                                               onKeyDown={[Function]}
@@ -3051,38 +2902,34 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                               tabIndex="-1"
                                                             >
                                                               <a
+                                                                action="push"
                                                                 href="#"
                                                                 onClick={[Function]}
                                                                 onKeyDown={[Function]}
                                                                 role="menuitem"
                                                                 tabIndex="-1"
                                                               >
-                                                                Download
+                                                                Show
                                                               </a>
                                                             </SafeAnchor>
                                                           </li>
                                                         </MenuItem>
+                                                      </LinkContainer>
+                                                      <LinkContainer
+                                                        action="push"
+                                                        key=".1"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                        onlyActiveOnIndex={false}
+                                                        to="/system/contentpacks/4/1/edit"
+                                                      >
                                                         <MenuItem
-                                                          bsClass="dropdown"
-                                                          disabled={false}
-                                                          divider={true}
-                                                          header={false}
-                                                          key=".3"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                        >
-                                                          <li
-                                                            className="divider"
-                                                            onKeyDown={[Function]}
-                                                            role="separator"
-                                                          />
-                                                        </MenuItem>
-                                                        <MenuItem
+                                                          action="push"
                                                           bsClass="dropdown"
                                                           disabled={false}
                                                           divider={false}
                                                           header={false}
-                                                          key=".4"
+                                                          onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           onSelect={[Function]}
                                                         >
@@ -3091,6 +2938,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                             role="presentation"
                                                           >
                                                             <SafeAnchor
+                                                              action="push"
                                                               componentClass="a"
                                                               onClick={[Function]}
                                                               onKeyDown={[Function]}
@@ -3098,28 +2946,108 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                               tabIndex="-1"
                                                             >
                                                               <a
+                                                                action="push"
                                                                 href="#"
                                                                 onClick={[Function]}
                                                                 onKeyDown={[Function]}
                                                                 role="menuitem"
                                                                 tabIndex="-1"
                                                               >
-                                                                Delete All Versions
+                                                                Create New Version
                                                               </a>
                                                             </SafeAnchor>
                                                           </li>
                                                         </MenuItem>
-                                                      </ul>
-                                                    </RootCloseWrapper>
-                                                  </DropdownMenu>
-                                                </div>
-                                              </ButtonGroup>
-                                            </Dropdown>
-                                          </Uncontrolled(Dropdown)>
-                                        </ForwardRef>
-                                      </DropdownButton>
-                                    </DropdownButton__StyledDropdownButton>
-                                  </ForwardRef>
+                                                      </LinkContainer>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={false}
+                                                        header={false}
+                                                        key=".2"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className=""
+                                                          role="presentation"
+                                                        >
+                                                          <SafeAnchor
+                                                            componentClass="a"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            role="menuitem"
+                                                            tabIndex="-1"
+                                                          >
+                                                            <a
+                                                              href="#"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              role="menuitem"
+                                                              tabIndex="-1"
+                                                            >
+                                                              Download
+                                                            </a>
+                                                          </SafeAnchor>
+                                                        </li>
+                                                      </MenuItem>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={true}
+                                                        header={false}
+                                                        key=".3"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className="divider"
+                                                          onKeyDown={[Function]}
+                                                          role="separator"
+                                                        />
+                                                      </MenuItem>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={false}
+                                                        header={false}
+                                                        key=".4"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className=""
+                                                          role="presentation"
+                                                        >
+                                                          <SafeAnchor
+                                                            componentClass="a"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            role="menuitem"
+                                                            tabIndex="-1"
+                                                          >
+                                                            <a
+                                                              href="#"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              role="menuitem"
+                                                              tabIndex="-1"
+                                                            >
+                                                              Delete All Versions
+                                                            </a>
+                                                          </SafeAnchor>
+                                                        </li>
+                                                      </MenuItem>
+                                                    </ul>
+                                                  </RootCloseWrapper>
+                                                </DropdownMenu>
+                                              </div>
+                                            </ButtonGroup>
+                                          </Dropdown>
+                                        </Uncontrolled(Dropdown)>
+                                      </ForwardRef>
+                                    </DropdownButton>
+                                  </DropdownButton>
                                   <ContentPackDownloadControl
                                     contentPackId="4"
                                     revision={1}
@@ -3303,37 +3231,31 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                   className="text-right col-md-3"
                                 >
                                    
-                                  <ForwardRef
+                                  <Button
                                     bsSize="small"
                                     bsStyle="info"
                                     onClick={[Function]}
                                   >
-                                    <Button__StyledButton
+                                    <Button
+                                      active={false}
+                                      block={false}
+                                      bsClass="btn"
                                       bsSize="small"
                                       bsStyle="info"
+                                      className="Button-c9cbmb-0 bNulii"
+                                      disabled={false}
                                       onClick={[Function]}
                                     >
-                                      <Button
-                                        active={false}
-                                        block={false}
-                                        bsClass="btn"
-                                        bsSize="small"
-                                        bsStyle="info"
-                                        className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                      <button
+                                        className="Button-c9cbmb-0 bNulii btn btn-sm btn-info"
                                         disabled={false}
                                         onClick={[Function]}
+                                        type="button"
                                       >
-                                        <button
-                                          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-info"
-                                          disabled={false}
-                                          onClick={[Function]}
-                                          type="button"
-                                        >
-                                          Install
-                                        </button>
-                                      </Button>
-                                    </Button__StyledButton>
-                                  </ForwardRef>
+                                        Install
+                                      </button>
+                                    </Button>
+                                  </Button>
                                   <BootstrapModalWrapper
                                     backdrop="static"
                                     bsSize="large"
@@ -3408,214 +3330,129 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                     </Modal>
                                   </BootstrapModalWrapper>
                                    
-                                  <ForwardRef
+                                  <DropdownButton
                                     bsSize="small"
                                     id="more-actions-5"
                                     pullRight={true}
                                     title="More Actions"
                                   >
-                                    <DropdownButton__StyledDropdownButton
+                                    <DropdownButton
                                       bsSize="small"
+                                      className="DropdownButton-sc-1343dcx-0 jHYVsD"
                                       id="more-actions-5"
                                       pullRight={true}
                                       title="More Actions"
                                     >
-                                      <DropdownButton
+                                      <ForwardRef
                                         bsSize="small"
-                                        className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
                                         id="more-actions-5"
                                         pullRight={true}
-                                        title="More Actions"
                                       >
-                                        <ForwardRef
+                                        <Uncontrolled(Dropdown)
                                           bsSize="small"
                                           id="more-actions-5"
+                                          innerRef={null}
                                           pullRight={true}
                                         >
-                                          <Uncontrolled(Dropdown)
+                                          <Dropdown
+                                            bsClass="dropdown"
                                             bsSize="small"
+                                            componentClass={[Function]}
                                             id="more-actions-5"
-                                            innerRef={null}
+                                            onToggle={[Function]}
                                             pullRight={true}
                                           >
-                                            <Dropdown
-                                              bsClass="dropdown"
+                                            <ButtonGroup
+                                              block={false}
+                                              bsClass="btn-group"
                                               bsSize="small"
-                                              componentClass={[Function]}
-                                              id="more-actions-5"
-                                              onToggle={[Function]}
-                                              pullRight={true}
+                                              className="dropdown"
+                                              justified={false}
+                                              vertical={false}
                                             >
-                                              <ButtonGroup
-                                                block={false}
-                                                bsClass="btn-group"
-                                                bsSize="small"
-                                                className="dropdown"
-                                                justified={false}
-                                                vertical={false}
+                                              <div
+                                                className="dropdown btn-group btn-group-sm"
                                               >
-                                                <div
-                                                  className="dropdown btn-group btn-group-sm"
+                                                <DropdownToggle
+                                                  bsClass="dropdown-toggle"
+                                                  bsRole="toggle"
+                                                  bsSize="small"
+                                                  className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                                                  id="more-actions-5"
+                                                  key=".0"
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  open={false}
+                                                  useAnchor={false}
                                                 >
-                                                  <DropdownToggle
-                                                    bsClass="dropdown-toggle"
-                                                    bsRole="toggle"
+                                                  <Button
+                                                    active={false}
+                                                    aria-expanded={false}
+                                                    aria-haspopup={true}
+                                                    block={false}
+                                                    bsClass="btn"
                                                     bsSize="small"
-                                                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                                                    bsStyle="default"
+                                                    className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                                    disabled={false}
                                                     id="more-actions-5"
-                                                    key=".0"
                                                     onClick={[Function]}
                                                     onKeyDown={[Function]}
-                                                    open={false}
-                                                    useAnchor={false}
+                                                    role="button"
                                                   >
-                                                    <Button
-                                                      active={false}
+                                                    <button
                                                       aria-expanded={false}
                                                       aria-haspopup={true}
-                                                      block={false}
-                                                      bsClass="btn"
-                                                      bsSize="small"
-                                                      bsStyle="default"
-                                                      className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                                      className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-sm btn-default"
                                                       disabled={false}
                                                       id="more-actions-5"
                                                       onClick={[Function]}
                                                       onKeyDown={[Function]}
                                                       role="button"
+                                                      type="button"
                                                     >
-                                                      <button
-                                                        aria-expanded={false}
-                                                        aria-haspopup={true}
-                                                        className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-sm btn-default"
-                                                        disabled={false}
-                                                        id="more-actions-5"
-                                                        onClick={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        role="button"
-                                                        type="button"
-                                                      >
-                                                        More Actions
-                                                         
-                                                        <span
-                                                          className="caret"
-                                                        />
-                                                      </button>
-                                                    </Button>
-                                                  </DropdownToggle>
-                                                  <DropdownMenu
-                                                    bsClass="dropdown-menu"
-                                                    bsRole="menu"
-                                                    key=".1"
-                                                    labelledBy="more-actions-5"
-                                                    onClose={[Function]}
-                                                    onSelect={[Function]}
-                                                    pullRight={true}
+                                                      More Actions
+                                                       
+                                                      <span
+                                                        className="caret"
+                                                      />
+                                                    </button>
+                                                  </Button>
+                                                </DropdownToggle>
+                                                <DropdownMenu
+                                                  bsClass="dropdown-menu"
+                                                  bsRole="menu"
+                                                  key=".1"
+                                                  labelledBy="more-actions-5"
+                                                  onClose={[Function]}
+                                                  onSelect={[Function]}
+                                                  pullRight={true}
+                                                >
+                                                  <RootCloseWrapper
+                                                    disabled={true}
+                                                    event="click"
+                                                    onRootClose={[Function]}
                                                   >
-                                                    <RootCloseWrapper
-                                                      disabled={true}
-                                                      event="click"
-                                                      onRootClose={[Function]}
+                                                    <ul
+                                                      aria-labelledby="more-actions-5"
+                                                      className="dropdown-menu dropdown-menu-right"
+                                                      role="menu"
                                                     >
-                                                      <ul
-                                                        aria-labelledby="more-actions-5"
-                                                        className="dropdown-menu dropdown-menu-right"
-                                                        role="menu"
+                                                      <LinkContainer
+                                                        action="push"
+                                                        key=".0"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                        onlyActiveOnIndex={false}
+                                                        to="/system/contentpacks/5"
                                                       >
-                                                        <LinkContainer
-                                                          action="push"
-                                                          key=".0"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                          onlyActiveOnIndex={false}
-                                                          to="/system/contentpacks/5"
-                                                        >
-                                                          <MenuItem
-                                                            action="push"
-                                                            bsClass="dropdown"
-                                                            disabled={false}
-                                                            divider={false}
-                                                            header={false}
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            onSelect={[Function]}
-                                                          >
-                                                            <li
-                                                              className=""
-                                                              role="presentation"
-                                                            >
-                                                              <SafeAnchor
-                                                                action="push"
-                                                                componentClass="a"
-                                                                onClick={[Function]}
-                                                                onKeyDown={[Function]}
-                                                                role="menuitem"
-                                                                tabIndex="-1"
-                                                              >
-                                                                <a
-                                                                  action="push"
-                                                                  href="#"
-                                                                  onClick={[Function]}
-                                                                  onKeyDown={[Function]}
-                                                                  role="menuitem"
-                                                                  tabIndex="-1"
-                                                                >
-                                                                  Show
-                                                                </a>
-                                                              </SafeAnchor>
-                                                            </li>
-                                                          </MenuItem>
-                                                        </LinkContainer>
-                                                        <LinkContainer
-                                                          action="push"
-                                                          key=".1"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                          onlyActiveOnIndex={false}
-                                                          to="/system/contentpacks/5/1/edit"
-                                                        >
-                                                          <MenuItem
-                                                            action="push"
-                                                            bsClass="dropdown"
-                                                            disabled={false}
-                                                            divider={false}
-                                                            header={false}
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            onSelect={[Function]}
-                                                          >
-                                                            <li
-                                                              className=""
-                                                              role="presentation"
-                                                            >
-                                                              <SafeAnchor
-                                                                action="push"
-                                                                componentClass="a"
-                                                                onClick={[Function]}
-                                                                onKeyDown={[Function]}
-                                                                role="menuitem"
-                                                                tabIndex="-1"
-                                                              >
-                                                                <a
-                                                                  action="push"
-                                                                  href="#"
-                                                                  onClick={[Function]}
-                                                                  onKeyDown={[Function]}
-                                                                  role="menuitem"
-                                                                  tabIndex="-1"
-                                                                >
-                                                                  Create New Version
-                                                                </a>
-                                                              </SafeAnchor>
-                                                            </li>
-                                                          </MenuItem>
-                                                        </LinkContainer>
                                                         <MenuItem
+                                                          action="push"
                                                           bsClass="dropdown"
                                                           disabled={false}
                                                           divider={false}
                                                           header={false}
-                                                          key=".2"
+                                                          onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           onSelect={[Function]}
                                                         >
@@ -3624,6 +3461,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                             role="presentation"
                                                           >
                                                             <SafeAnchor
+                                                              action="push"
                                                               componentClass="a"
                                                               onClick={[Function]}
                                                               onKeyDown={[Function]}
@@ -3631,38 +3469,34 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                               tabIndex="-1"
                                                             >
                                                               <a
+                                                                action="push"
                                                                 href="#"
                                                                 onClick={[Function]}
                                                                 onKeyDown={[Function]}
                                                                 role="menuitem"
                                                                 tabIndex="-1"
                                                               >
-                                                                Download
+                                                                Show
                                                               </a>
                                                             </SafeAnchor>
                                                           </li>
                                                         </MenuItem>
+                                                      </LinkContainer>
+                                                      <LinkContainer
+                                                        action="push"
+                                                        key=".1"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                        onlyActiveOnIndex={false}
+                                                        to="/system/contentpacks/5/1/edit"
+                                                      >
                                                         <MenuItem
-                                                          bsClass="dropdown"
-                                                          disabled={false}
-                                                          divider={true}
-                                                          header={false}
-                                                          key=".3"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                        >
-                                                          <li
-                                                            className="divider"
-                                                            onKeyDown={[Function]}
-                                                            role="separator"
-                                                          />
-                                                        </MenuItem>
-                                                        <MenuItem
+                                                          action="push"
                                                           bsClass="dropdown"
                                                           disabled={false}
                                                           divider={false}
                                                           header={false}
-                                                          key=".4"
+                                                          onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           onSelect={[Function]}
                                                         >
@@ -3671,6 +3505,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                             role="presentation"
                                                           >
                                                             <SafeAnchor
+                                                              action="push"
                                                               componentClass="a"
                                                               onClick={[Function]}
                                                               onKeyDown={[Function]}
@@ -3678,28 +3513,108 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                               tabIndex="-1"
                                                             >
                                                               <a
+                                                                action="push"
                                                                 href="#"
                                                                 onClick={[Function]}
                                                                 onKeyDown={[Function]}
                                                                 role="menuitem"
                                                                 tabIndex="-1"
                                                               >
-                                                                Delete All Versions
+                                                                Create New Version
                                                               </a>
                                                             </SafeAnchor>
                                                           </li>
                                                         </MenuItem>
-                                                      </ul>
-                                                    </RootCloseWrapper>
-                                                  </DropdownMenu>
-                                                </div>
-                                              </ButtonGroup>
-                                            </Dropdown>
-                                          </Uncontrolled(Dropdown)>
-                                        </ForwardRef>
-                                      </DropdownButton>
-                                    </DropdownButton__StyledDropdownButton>
-                                  </ForwardRef>
+                                                      </LinkContainer>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={false}
+                                                        header={false}
+                                                        key=".2"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className=""
+                                                          role="presentation"
+                                                        >
+                                                          <SafeAnchor
+                                                            componentClass="a"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            role="menuitem"
+                                                            tabIndex="-1"
+                                                          >
+                                                            <a
+                                                              href="#"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              role="menuitem"
+                                                              tabIndex="-1"
+                                                            >
+                                                              Download
+                                                            </a>
+                                                          </SafeAnchor>
+                                                        </li>
+                                                      </MenuItem>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={true}
+                                                        header={false}
+                                                        key=".3"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className="divider"
+                                                          onKeyDown={[Function]}
+                                                          role="separator"
+                                                        />
+                                                      </MenuItem>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={false}
+                                                        header={false}
+                                                        key=".4"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className=""
+                                                          role="presentation"
+                                                        >
+                                                          <SafeAnchor
+                                                            componentClass="a"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            role="menuitem"
+                                                            tabIndex="-1"
+                                                          >
+                                                            <a
+                                                              href="#"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              role="menuitem"
+                                                              tabIndex="-1"
+                                                            >
+                                                              Delete All Versions
+                                                            </a>
+                                                          </SafeAnchor>
+                                                        </li>
+                                                      </MenuItem>
+                                                    </ul>
+                                                  </RootCloseWrapper>
+                                                </DropdownMenu>
+                                              </div>
+                                            </ButtonGroup>
+                                          </Dropdown>
+                                        </Uncontrolled(Dropdown)>
+                                      </ForwardRef>
+                                    </DropdownButton>
+                                  </DropdownButton>
                                   <ContentPackDownloadControl
                                     contentPackId="5"
                                     revision={1}
@@ -3883,37 +3798,31 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                   className="text-right col-md-3"
                                 >
                                    
-                                  <ForwardRef
+                                  <Button
                                     bsSize="small"
                                     bsStyle="info"
                                     onClick={[Function]}
                                   >
-                                    <Button__StyledButton
+                                    <Button
+                                      active={false}
+                                      block={false}
+                                      bsClass="btn"
                                       bsSize="small"
                                       bsStyle="info"
+                                      className="Button-c9cbmb-0 bNulii"
+                                      disabled={false}
                                       onClick={[Function]}
                                     >
-                                      <Button
-                                        active={false}
-                                        block={false}
-                                        bsClass="btn"
-                                        bsSize="small"
-                                        bsStyle="info"
-                                        className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                      <button
+                                        className="Button-c9cbmb-0 bNulii btn btn-sm btn-info"
                                         disabled={false}
                                         onClick={[Function]}
+                                        type="button"
                                       >
-                                        <button
-                                          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-info"
-                                          disabled={false}
-                                          onClick={[Function]}
-                                          type="button"
-                                        >
-                                          Install
-                                        </button>
-                                      </Button>
-                                    </Button__StyledButton>
-                                  </ForwardRef>
+                                        Install
+                                      </button>
+                                    </Button>
+                                  </Button>
                                   <BootstrapModalWrapper
                                     backdrop="static"
                                     bsSize="large"
@@ -3988,214 +3897,129 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                     </Modal>
                                   </BootstrapModalWrapper>
                                    
-                                  <ForwardRef
+                                  <DropdownButton
                                     bsSize="small"
                                     id="more-actions-6"
                                     pullRight={true}
                                     title="More Actions"
                                   >
-                                    <DropdownButton__StyledDropdownButton
+                                    <DropdownButton
                                       bsSize="small"
+                                      className="DropdownButton-sc-1343dcx-0 jHYVsD"
                                       id="more-actions-6"
                                       pullRight={true}
                                       title="More Actions"
                                     >
-                                      <DropdownButton
+                                      <ForwardRef
                                         bsSize="small"
-                                        className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
                                         id="more-actions-6"
                                         pullRight={true}
-                                        title="More Actions"
                                       >
-                                        <ForwardRef
+                                        <Uncontrolled(Dropdown)
                                           bsSize="small"
                                           id="more-actions-6"
+                                          innerRef={null}
                                           pullRight={true}
                                         >
-                                          <Uncontrolled(Dropdown)
+                                          <Dropdown
+                                            bsClass="dropdown"
                                             bsSize="small"
+                                            componentClass={[Function]}
                                             id="more-actions-6"
-                                            innerRef={null}
+                                            onToggle={[Function]}
                                             pullRight={true}
                                           >
-                                            <Dropdown
-                                              bsClass="dropdown"
+                                            <ButtonGroup
+                                              block={false}
+                                              bsClass="btn-group"
                                               bsSize="small"
-                                              componentClass={[Function]}
-                                              id="more-actions-6"
-                                              onToggle={[Function]}
-                                              pullRight={true}
+                                              className="dropdown"
+                                              justified={false}
+                                              vertical={false}
                                             >
-                                              <ButtonGroup
-                                                block={false}
-                                                bsClass="btn-group"
-                                                bsSize="small"
-                                                className="dropdown"
-                                                justified={false}
-                                                vertical={false}
+                                              <div
+                                                className="dropdown btn-group btn-group-sm"
                                               >
-                                                <div
-                                                  className="dropdown btn-group btn-group-sm"
+                                                <DropdownToggle
+                                                  bsClass="dropdown-toggle"
+                                                  bsRole="toggle"
+                                                  bsSize="small"
+                                                  className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                                                  id="more-actions-6"
+                                                  key=".0"
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  open={false}
+                                                  useAnchor={false}
                                                 >
-                                                  <DropdownToggle
-                                                    bsClass="dropdown-toggle"
-                                                    bsRole="toggle"
+                                                  <Button
+                                                    active={false}
+                                                    aria-expanded={false}
+                                                    aria-haspopup={true}
+                                                    block={false}
+                                                    bsClass="btn"
                                                     bsSize="small"
-                                                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                                                    bsStyle="default"
+                                                    className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                                    disabled={false}
                                                     id="more-actions-6"
-                                                    key=".0"
                                                     onClick={[Function]}
                                                     onKeyDown={[Function]}
-                                                    open={false}
-                                                    useAnchor={false}
+                                                    role="button"
                                                   >
-                                                    <Button
-                                                      active={false}
+                                                    <button
                                                       aria-expanded={false}
                                                       aria-haspopup={true}
-                                                      block={false}
-                                                      bsClass="btn"
-                                                      bsSize="small"
-                                                      bsStyle="default"
-                                                      className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                                      className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-sm btn-default"
                                                       disabled={false}
                                                       id="more-actions-6"
                                                       onClick={[Function]}
                                                       onKeyDown={[Function]}
                                                       role="button"
+                                                      type="button"
                                                     >
-                                                      <button
-                                                        aria-expanded={false}
-                                                        aria-haspopup={true}
-                                                        className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-sm btn-default"
-                                                        disabled={false}
-                                                        id="more-actions-6"
-                                                        onClick={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        role="button"
-                                                        type="button"
-                                                      >
-                                                        More Actions
-                                                         
-                                                        <span
-                                                          className="caret"
-                                                        />
-                                                      </button>
-                                                    </Button>
-                                                  </DropdownToggle>
-                                                  <DropdownMenu
-                                                    bsClass="dropdown-menu"
-                                                    bsRole="menu"
-                                                    key=".1"
-                                                    labelledBy="more-actions-6"
-                                                    onClose={[Function]}
-                                                    onSelect={[Function]}
-                                                    pullRight={true}
+                                                      More Actions
+                                                       
+                                                      <span
+                                                        className="caret"
+                                                      />
+                                                    </button>
+                                                  </Button>
+                                                </DropdownToggle>
+                                                <DropdownMenu
+                                                  bsClass="dropdown-menu"
+                                                  bsRole="menu"
+                                                  key=".1"
+                                                  labelledBy="more-actions-6"
+                                                  onClose={[Function]}
+                                                  onSelect={[Function]}
+                                                  pullRight={true}
+                                                >
+                                                  <RootCloseWrapper
+                                                    disabled={true}
+                                                    event="click"
+                                                    onRootClose={[Function]}
                                                   >
-                                                    <RootCloseWrapper
-                                                      disabled={true}
-                                                      event="click"
-                                                      onRootClose={[Function]}
+                                                    <ul
+                                                      aria-labelledby="more-actions-6"
+                                                      className="dropdown-menu dropdown-menu-right"
+                                                      role="menu"
                                                     >
-                                                      <ul
-                                                        aria-labelledby="more-actions-6"
-                                                        className="dropdown-menu dropdown-menu-right"
-                                                        role="menu"
+                                                      <LinkContainer
+                                                        action="push"
+                                                        key=".0"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                        onlyActiveOnIndex={false}
+                                                        to="/system/contentpacks/6"
                                                       >
-                                                        <LinkContainer
-                                                          action="push"
-                                                          key=".0"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                          onlyActiveOnIndex={false}
-                                                          to="/system/contentpacks/6"
-                                                        >
-                                                          <MenuItem
-                                                            action="push"
-                                                            bsClass="dropdown"
-                                                            disabled={false}
-                                                            divider={false}
-                                                            header={false}
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            onSelect={[Function]}
-                                                          >
-                                                            <li
-                                                              className=""
-                                                              role="presentation"
-                                                            >
-                                                              <SafeAnchor
-                                                                action="push"
-                                                                componentClass="a"
-                                                                onClick={[Function]}
-                                                                onKeyDown={[Function]}
-                                                                role="menuitem"
-                                                                tabIndex="-1"
-                                                              >
-                                                                <a
-                                                                  action="push"
-                                                                  href="#"
-                                                                  onClick={[Function]}
-                                                                  onKeyDown={[Function]}
-                                                                  role="menuitem"
-                                                                  tabIndex="-1"
-                                                                >
-                                                                  Show
-                                                                </a>
-                                                              </SafeAnchor>
-                                                            </li>
-                                                          </MenuItem>
-                                                        </LinkContainer>
-                                                        <LinkContainer
-                                                          action="push"
-                                                          key=".1"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                          onlyActiveOnIndex={false}
-                                                          to="/system/contentpacks/6/1/edit"
-                                                        >
-                                                          <MenuItem
-                                                            action="push"
-                                                            bsClass="dropdown"
-                                                            disabled={false}
-                                                            divider={false}
-                                                            header={false}
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            onSelect={[Function]}
-                                                          >
-                                                            <li
-                                                              className=""
-                                                              role="presentation"
-                                                            >
-                                                              <SafeAnchor
-                                                                action="push"
-                                                                componentClass="a"
-                                                                onClick={[Function]}
-                                                                onKeyDown={[Function]}
-                                                                role="menuitem"
-                                                                tabIndex="-1"
-                                                              >
-                                                                <a
-                                                                  action="push"
-                                                                  href="#"
-                                                                  onClick={[Function]}
-                                                                  onKeyDown={[Function]}
-                                                                  role="menuitem"
-                                                                  tabIndex="-1"
-                                                                >
-                                                                  Create New Version
-                                                                </a>
-                                                              </SafeAnchor>
-                                                            </li>
-                                                          </MenuItem>
-                                                        </LinkContainer>
                                                         <MenuItem
+                                                          action="push"
                                                           bsClass="dropdown"
                                                           disabled={false}
                                                           divider={false}
                                                           header={false}
-                                                          key=".2"
+                                                          onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           onSelect={[Function]}
                                                         >
@@ -4204,6 +4028,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                             role="presentation"
                                                           >
                                                             <SafeAnchor
+                                                              action="push"
                                                               componentClass="a"
                                                               onClick={[Function]}
                                                               onKeyDown={[Function]}
@@ -4211,38 +4036,34 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                               tabIndex="-1"
                                                             >
                                                               <a
+                                                                action="push"
                                                                 href="#"
                                                                 onClick={[Function]}
                                                                 onKeyDown={[Function]}
                                                                 role="menuitem"
                                                                 tabIndex="-1"
                                                               >
-                                                                Download
+                                                                Show
                                                               </a>
                                                             </SafeAnchor>
                                                           </li>
                                                         </MenuItem>
+                                                      </LinkContainer>
+                                                      <LinkContainer
+                                                        action="push"
+                                                        key=".1"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                        onlyActiveOnIndex={false}
+                                                        to="/system/contentpacks/6/1/edit"
+                                                      >
                                                         <MenuItem
-                                                          bsClass="dropdown"
-                                                          disabled={false}
-                                                          divider={true}
-                                                          header={false}
-                                                          key=".3"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                        >
-                                                          <li
-                                                            className="divider"
-                                                            onKeyDown={[Function]}
-                                                            role="separator"
-                                                          />
-                                                        </MenuItem>
-                                                        <MenuItem
+                                                          action="push"
                                                           bsClass="dropdown"
                                                           disabled={false}
                                                           divider={false}
                                                           header={false}
-                                                          key=".4"
+                                                          onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           onSelect={[Function]}
                                                         >
@@ -4251,6 +4072,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                             role="presentation"
                                                           >
                                                             <SafeAnchor
+                                                              action="push"
                                                               componentClass="a"
                                                               onClick={[Function]}
                                                               onKeyDown={[Function]}
@@ -4258,28 +4080,108 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                               tabIndex="-1"
                                                             >
                                                               <a
+                                                                action="push"
                                                                 href="#"
                                                                 onClick={[Function]}
                                                                 onKeyDown={[Function]}
                                                                 role="menuitem"
                                                                 tabIndex="-1"
                                                               >
-                                                                Delete All Versions
+                                                                Create New Version
                                                               </a>
                                                             </SafeAnchor>
                                                           </li>
                                                         </MenuItem>
-                                                      </ul>
-                                                    </RootCloseWrapper>
-                                                  </DropdownMenu>
-                                                </div>
-                                              </ButtonGroup>
-                                            </Dropdown>
-                                          </Uncontrolled(Dropdown)>
-                                        </ForwardRef>
-                                      </DropdownButton>
-                                    </DropdownButton__StyledDropdownButton>
-                                  </ForwardRef>
+                                                      </LinkContainer>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={false}
+                                                        header={false}
+                                                        key=".2"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className=""
+                                                          role="presentation"
+                                                        >
+                                                          <SafeAnchor
+                                                            componentClass="a"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            role="menuitem"
+                                                            tabIndex="-1"
+                                                          >
+                                                            <a
+                                                              href="#"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              role="menuitem"
+                                                              tabIndex="-1"
+                                                            >
+                                                              Download
+                                                            </a>
+                                                          </SafeAnchor>
+                                                        </li>
+                                                      </MenuItem>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={true}
+                                                        header={false}
+                                                        key=".3"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className="divider"
+                                                          onKeyDown={[Function]}
+                                                          role="separator"
+                                                        />
+                                                      </MenuItem>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={false}
+                                                        header={false}
+                                                        key=".4"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className=""
+                                                          role="presentation"
+                                                        >
+                                                          <SafeAnchor
+                                                            componentClass="a"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            role="menuitem"
+                                                            tabIndex="-1"
+                                                          >
+                                                            <a
+                                                              href="#"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              role="menuitem"
+                                                              tabIndex="-1"
+                                                            >
+                                                              Delete All Versions
+                                                            </a>
+                                                          </SafeAnchor>
+                                                        </li>
+                                                      </MenuItem>
+                                                    </ul>
+                                                  </RootCloseWrapper>
+                                                </DropdownMenu>
+                                              </div>
+                                            </ButtonGroup>
+                                          </Dropdown>
+                                        </Uncontrolled(Dropdown)>
+                                      </ForwardRef>
+                                    </DropdownButton>
+                                  </DropdownButton>
                                   <ContentPackDownloadControl
                                     contentPackId="6"
                                     revision={1}
@@ -4463,37 +4365,31 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                   className="text-right col-md-3"
                                 >
                                    
-                                  <ForwardRef
+                                  <Button
                                     bsSize="small"
                                     bsStyle="info"
                                     onClick={[Function]}
                                   >
-                                    <Button__StyledButton
+                                    <Button
+                                      active={false}
+                                      block={false}
+                                      bsClass="btn"
                                       bsSize="small"
                                       bsStyle="info"
+                                      className="Button-c9cbmb-0 bNulii"
+                                      disabled={false}
                                       onClick={[Function]}
                                     >
-                                      <Button
-                                        active={false}
-                                        block={false}
-                                        bsClass="btn"
-                                        bsSize="small"
-                                        bsStyle="info"
-                                        className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                      <button
+                                        className="Button-c9cbmb-0 bNulii btn btn-sm btn-info"
                                         disabled={false}
                                         onClick={[Function]}
+                                        type="button"
                                       >
-                                        <button
-                                          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-info"
-                                          disabled={false}
-                                          onClick={[Function]}
-                                          type="button"
-                                        >
-                                          Install
-                                        </button>
-                                      </Button>
-                                    </Button__StyledButton>
-                                  </ForwardRef>
+                                        Install
+                                      </button>
+                                    </Button>
+                                  </Button>
                                   <BootstrapModalWrapper
                                     backdrop="static"
                                     bsSize="large"
@@ -4568,214 +4464,129 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                     </Modal>
                                   </BootstrapModalWrapper>
                                    
-                                  <ForwardRef
+                                  <DropdownButton
                                     bsSize="small"
                                     id="more-actions-7"
                                     pullRight={true}
                                     title="More Actions"
                                   >
-                                    <DropdownButton__StyledDropdownButton
+                                    <DropdownButton
                                       bsSize="small"
+                                      className="DropdownButton-sc-1343dcx-0 jHYVsD"
                                       id="more-actions-7"
                                       pullRight={true}
                                       title="More Actions"
                                     >
-                                      <DropdownButton
+                                      <ForwardRef
                                         bsSize="small"
-                                        className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
                                         id="more-actions-7"
                                         pullRight={true}
-                                        title="More Actions"
                                       >
-                                        <ForwardRef
+                                        <Uncontrolled(Dropdown)
                                           bsSize="small"
                                           id="more-actions-7"
+                                          innerRef={null}
                                           pullRight={true}
                                         >
-                                          <Uncontrolled(Dropdown)
+                                          <Dropdown
+                                            bsClass="dropdown"
                                             bsSize="small"
+                                            componentClass={[Function]}
                                             id="more-actions-7"
-                                            innerRef={null}
+                                            onToggle={[Function]}
                                             pullRight={true}
                                           >
-                                            <Dropdown
-                                              bsClass="dropdown"
+                                            <ButtonGroup
+                                              block={false}
+                                              bsClass="btn-group"
                                               bsSize="small"
-                                              componentClass={[Function]}
-                                              id="more-actions-7"
-                                              onToggle={[Function]}
-                                              pullRight={true}
+                                              className="dropdown"
+                                              justified={false}
+                                              vertical={false}
                                             >
-                                              <ButtonGroup
-                                                block={false}
-                                                bsClass="btn-group"
-                                                bsSize="small"
-                                                className="dropdown"
-                                                justified={false}
-                                                vertical={false}
+                                              <div
+                                                className="dropdown btn-group btn-group-sm"
                                               >
-                                                <div
-                                                  className="dropdown btn-group btn-group-sm"
+                                                <DropdownToggle
+                                                  bsClass="dropdown-toggle"
+                                                  bsRole="toggle"
+                                                  bsSize="small"
+                                                  className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                                                  id="more-actions-7"
+                                                  key=".0"
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  open={false}
+                                                  useAnchor={false}
                                                 >
-                                                  <DropdownToggle
-                                                    bsClass="dropdown-toggle"
-                                                    bsRole="toggle"
+                                                  <Button
+                                                    active={false}
+                                                    aria-expanded={false}
+                                                    aria-haspopup={true}
+                                                    block={false}
+                                                    bsClass="btn"
                                                     bsSize="small"
-                                                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                                                    bsStyle="default"
+                                                    className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                                    disabled={false}
                                                     id="more-actions-7"
-                                                    key=".0"
                                                     onClick={[Function]}
                                                     onKeyDown={[Function]}
-                                                    open={false}
-                                                    useAnchor={false}
+                                                    role="button"
                                                   >
-                                                    <Button
-                                                      active={false}
+                                                    <button
                                                       aria-expanded={false}
                                                       aria-haspopup={true}
-                                                      block={false}
-                                                      bsClass="btn"
-                                                      bsSize="small"
-                                                      bsStyle="default"
-                                                      className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                                      className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-sm btn-default"
                                                       disabled={false}
                                                       id="more-actions-7"
                                                       onClick={[Function]}
                                                       onKeyDown={[Function]}
                                                       role="button"
+                                                      type="button"
                                                     >
-                                                      <button
-                                                        aria-expanded={false}
-                                                        aria-haspopup={true}
-                                                        className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-sm btn-default"
-                                                        disabled={false}
-                                                        id="more-actions-7"
-                                                        onClick={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        role="button"
-                                                        type="button"
-                                                      >
-                                                        More Actions
-                                                         
-                                                        <span
-                                                          className="caret"
-                                                        />
-                                                      </button>
-                                                    </Button>
-                                                  </DropdownToggle>
-                                                  <DropdownMenu
-                                                    bsClass="dropdown-menu"
-                                                    bsRole="menu"
-                                                    key=".1"
-                                                    labelledBy="more-actions-7"
-                                                    onClose={[Function]}
-                                                    onSelect={[Function]}
-                                                    pullRight={true}
+                                                      More Actions
+                                                       
+                                                      <span
+                                                        className="caret"
+                                                      />
+                                                    </button>
+                                                  </Button>
+                                                </DropdownToggle>
+                                                <DropdownMenu
+                                                  bsClass="dropdown-menu"
+                                                  bsRole="menu"
+                                                  key=".1"
+                                                  labelledBy="more-actions-7"
+                                                  onClose={[Function]}
+                                                  onSelect={[Function]}
+                                                  pullRight={true}
+                                                >
+                                                  <RootCloseWrapper
+                                                    disabled={true}
+                                                    event="click"
+                                                    onRootClose={[Function]}
                                                   >
-                                                    <RootCloseWrapper
-                                                      disabled={true}
-                                                      event="click"
-                                                      onRootClose={[Function]}
+                                                    <ul
+                                                      aria-labelledby="more-actions-7"
+                                                      className="dropdown-menu dropdown-menu-right"
+                                                      role="menu"
                                                     >
-                                                      <ul
-                                                        aria-labelledby="more-actions-7"
-                                                        className="dropdown-menu dropdown-menu-right"
-                                                        role="menu"
+                                                      <LinkContainer
+                                                        action="push"
+                                                        key=".0"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                        onlyActiveOnIndex={false}
+                                                        to="/system/contentpacks/7"
                                                       >
-                                                        <LinkContainer
-                                                          action="push"
-                                                          key=".0"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                          onlyActiveOnIndex={false}
-                                                          to="/system/contentpacks/7"
-                                                        >
-                                                          <MenuItem
-                                                            action="push"
-                                                            bsClass="dropdown"
-                                                            disabled={false}
-                                                            divider={false}
-                                                            header={false}
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            onSelect={[Function]}
-                                                          >
-                                                            <li
-                                                              className=""
-                                                              role="presentation"
-                                                            >
-                                                              <SafeAnchor
-                                                                action="push"
-                                                                componentClass="a"
-                                                                onClick={[Function]}
-                                                                onKeyDown={[Function]}
-                                                                role="menuitem"
-                                                                tabIndex="-1"
-                                                              >
-                                                                <a
-                                                                  action="push"
-                                                                  href="#"
-                                                                  onClick={[Function]}
-                                                                  onKeyDown={[Function]}
-                                                                  role="menuitem"
-                                                                  tabIndex="-1"
-                                                                >
-                                                                  Show
-                                                                </a>
-                                                              </SafeAnchor>
-                                                            </li>
-                                                          </MenuItem>
-                                                        </LinkContainer>
-                                                        <LinkContainer
-                                                          action="push"
-                                                          key=".1"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                          onlyActiveOnIndex={false}
-                                                          to="/system/contentpacks/7/1/edit"
-                                                        >
-                                                          <MenuItem
-                                                            action="push"
-                                                            bsClass="dropdown"
-                                                            disabled={false}
-                                                            divider={false}
-                                                            header={false}
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            onSelect={[Function]}
-                                                          >
-                                                            <li
-                                                              className=""
-                                                              role="presentation"
-                                                            >
-                                                              <SafeAnchor
-                                                                action="push"
-                                                                componentClass="a"
-                                                                onClick={[Function]}
-                                                                onKeyDown={[Function]}
-                                                                role="menuitem"
-                                                                tabIndex="-1"
-                                                              >
-                                                                <a
-                                                                  action="push"
-                                                                  href="#"
-                                                                  onClick={[Function]}
-                                                                  onKeyDown={[Function]}
-                                                                  role="menuitem"
-                                                                  tabIndex="-1"
-                                                                >
-                                                                  Create New Version
-                                                                </a>
-                                                              </SafeAnchor>
-                                                            </li>
-                                                          </MenuItem>
-                                                        </LinkContainer>
                                                         <MenuItem
+                                                          action="push"
                                                           bsClass="dropdown"
                                                           disabled={false}
                                                           divider={false}
                                                           header={false}
-                                                          key=".2"
+                                                          onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           onSelect={[Function]}
                                                         >
@@ -4784,6 +4595,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                             role="presentation"
                                                           >
                                                             <SafeAnchor
+                                                              action="push"
                                                               componentClass="a"
                                                               onClick={[Function]}
                                                               onKeyDown={[Function]}
@@ -4791,38 +4603,34 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                               tabIndex="-1"
                                                             >
                                                               <a
+                                                                action="push"
                                                                 href="#"
                                                                 onClick={[Function]}
                                                                 onKeyDown={[Function]}
                                                                 role="menuitem"
                                                                 tabIndex="-1"
                                                               >
-                                                                Download
+                                                                Show
                                                               </a>
                                                             </SafeAnchor>
                                                           </li>
                                                         </MenuItem>
+                                                      </LinkContainer>
+                                                      <LinkContainer
+                                                        action="push"
+                                                        key=".1"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                        onlyActiveOnIndex={false}
+                                                        to="/system/contentpacks/7/1/edit"
+                                                      >
                                                         <MenuItem
-                                                          bsClass="dropdown"
-                                                          disabled={false}
-                                                          divider={true}
-                                                          header={false}
-                                                          key=".3"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                        >
-                                                          <li
-                                                            className="divider"
-                                                            onKeyDown={[Function]}
-                                                            role="separator"
-                                                          />
-                                                        </MenuItem>
-                                                        <MenuItem
+                                                          action="push"
                                                           bsClass="dropdown"
                                                           disabled={false}
                                                           divider={false}
                                                           header={false}
-                                                          key=".4"
+                                                          onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           onSelect={[Function]}
                                                         >
@@ -4831,6 +4639,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                             role="presentation"
                                                           >
                                                             <SafeAnchor
+                                                              action="push"
                                                               componentClass="a"
                                                               onClick={[Function]}
                                                               onKeyDown={[Function]}
@@ -4838,28 +4647,108 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                               tabIndex="-1"
                                                             >
                                                               <a
+                                                                action="push"
                                                                 href="#"
                                                                 onClick={[Function]}
                                                                 onKeyDown={[Function]}
                                                                 role="menuitem"
                                                                 tabIndex="-1"
                                                               >
-                                                                Delete All Versions
+                                                                Create New Version
                                                               </a>
                                                             </SafeAnchor>
                                                           </li>
                                                         </MenuItem>
-                                                      </ul>
-                                                    </RootCloseWrapper>
-                                                  </DropdownMenu>
-                                                </div>
-                                              </ButtonGroup>
-                                            </Dropdown>
-                                          </Uncontrolled(Dropdown)>
-                                        </ForwardRef>
-                                      </DropdownButton>
-                                    </DropdownButton__StyledDropdownButton>
-                                  </ForwardRef>
+                                                      </LinkContainer>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={false}
+                                                        header={false}
+                                                        key=".2"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className=""
+                                                          role="presentation"
+                                                        >
+                                                          <SafeAnchor
+                                                            componentClass="a"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            role="menuitem"
+                                                            tabIndex="-1"
+                                                          >
+                                                            <a
+                                                              href="#"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              role="menuitem"
+                                                              tabIndex="-1"
+                                                            >
+                                                              Download
+                                                            </a>
+                                                          </SafeAnchor>
+                                                        </li>
+                                                      </MenuItem>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={true}
+                                                        header={false}
+                                                        key=".3"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className="divider"
+                                                          onKeyDown={[Function]}
+                                                          role="separator"
+                                                        />
+                                                      </MenuItem>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={false}
+                                                        header={false}
+                                                        key=".4"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className=""
+                                                          role="presentation"
+                                                        >
+                                                          <SafeAnchor
+                                                            componentClass="a"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            role="menuitem"
+                                                            tabIndex="-1"
+                                                          >
+                                                            <a
+                                                              href="#"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              role="menuitem"
+                                                              tabIndex="-1"
+                                                            >
+                                                              Delete All Versions
+                                                            </a>
+                                                          </SafeAnchor>
+                                                        </li>
+                                                      </MenuItem>
+                                                    </ul>
+                                                  </RootCloseWrapper>
+                                                </DropdownMenu>
+                                              </div>
+                                            </ButtonGroup>
+                                          </Dropdown>
+                                        </Uncontrolled(Dropdown)>
+                                      </ForwardRef>
+                                    </DropdownButton>
+                                  </DropdownButton>
                                   <ContentPackDownloadControl
                                     contentPackId="7"
                                     revision={1}
@@ -5043,37 +4932,31 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                   className="text-right col-md-3"
                                 >
                                    
-                                  <ForwardRef
+                                  <Button
                                     bsSize="small"
                                     bsStyle="info"
                                     onClick={[Function]}
                                   >
-                                    <Button__StyledButton
+                                    <Button
+                                      active={false}
+                                      block={false}
+                                      bsClass="btn"
                                       bsSize="small"
                                       bsStyle="info"
+                                      className="Button-c9cbmb-0 bNulii"
+                                      disabled={false}
                                       onClick={[Function]}
                                     >
-                                      <Button
-                                        active={false}
-                                        block={false}
-                                        bsClass="btn"
-                                        bsSize="small"
-                                        bsStyle="info"
-                                        className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                      <button
+                                        className="Button-c9cbmb-0 bNulii btn btn-sm btn-info"
                                         disabled={false}
                                         onClick={[Function]}
+                                        type="button"
                                       >
-                                        <button
-                                          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-info"
-                                          disabled={false}
-                                          onClick={[Function]}
-                                          type="button"
-                                        >
-                                          Install
-                                        </button>
-                                      </Button>
-                                    </Button__StyledButton>
-                                  </ForwardRef>
+                                        Install
+                                      </button>
+                                    </Button>
+                                  </Button>
                                   <BootstrapModalWrapper
                                     backdrop="static"
                                     bsSize="large"
@@ -5148,214 +5031,129 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                     </Modal>
                                   </BootstrapModalWrapper>
                                    
-                                  <ForwardRef
+                                  <DropdownButton
                                     bsSize="small"
                                     id="more-actions-8"
                                     pullRight={true}
                                     title="More Actions"
                                   >
-                                    <DropdownButton__StyledDropdownButton
+                                    <DropdownButton
                                       bsSize="small"
+                                      className="DropdownButton-sc-1343dcx-0 jHYVsD"
                                       id="more-actions-8"
                                       pullRight={true}
                                       title="More Actions"
                                     >
-                                      <DropdownButton
+                                      <ForwardRef
                                         bsSize="small"
-                                        className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
                                         id="more-actions-8"
                                         pullRight={true}
-                                        title="More Actions"
                                       >
-                                        <ForwardRef
+                                        <Uncontrolled(Dropdown)
                                           bsSize="small"
                                           id="more-actions-8"
+                                          innerRef={null}
                                           pullRight={true}
                                         >
-                                          <Uncontrolled(Dropdown)
+                                          <Dropdown
+                                            bsClass="dropdown"
                                             bsSize="small"
+                                            componentClass={[Function]}
                                             id="more-actions-8"
-                                            innerRef={null}
+                                            onToggle={[Function]}
                                             pullRight={true}
                                           >
-                                            <Dropdown
-                                              bsClass="dropdown"
+                                            <ButtonGroup
+                                              block={false}
+                                              bsClass="btn-group"
                                               bsSize="small"
-                                              componentClass={[Function]}
-                                              id="more-actions-8"
-                                              onToggle={[Function]}
-                                              pullRight={true}
+                                              className="dropdown"
+                                              justified={false}
+                                              vertical={false}
                                             >
-                                              <ButtonGroup
-                                                block={false}
-                                                bsClass="btn-group"
-                                                bsSize="small"
-                                                className="dropdown"
-                                                justified={false}
-                                                vertical={false}
+                                              <div
+                                                className="dropdown btn-group btn-group-sm"
                                               >
-                                                <div
-                                                  className="dropdown btn-group btn-group-sm"
+                                                <DropdownToggle
+                                                  bsClass="dropdown-toggle"
+                                                  bsRole="toggle"
+                                                  bsSize="small"
+                                                  className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                                                  id="more-actions-8"
+                                                  key=".0"
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  open={false}
+                                                  useAnchor={false}
                                                 >
-                                                  <DropdownToggle
-                                                    bsClass="dropdown-toggle"
-                                                    bsRole="toggle"
+                                                  <Button
+                                                    active={false}
+                                                    aria-expanded={false}
+                                                    aria-haspopup={true}
+                                                    block={false}
+                                                    bsClass="btn"
                                                     bsSize="small"
-                                                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                                                    bsStyle="default"
+                                                    className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                                    disabled={false}
                                                     id="more-actions-8"
-                                                    key=".0"
                                                     onClick={[Function]}
                                                     onKeyDown={[Function]}
-                                                    open={false}
-                                                    useAnchor={false}
+                                                    role="button"
                                                   >
-                                                    <Button
-                                                      active={false}
+                                                    <button
                                                       aria-expanded={false}
                                                       aria-haspopup={true}
-                                                      block={false}
-                                                      bsClass="btn"
-                                                      bsSize="small"
-                                                      bsStyle="default"
-                                                      className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                                      className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-sm btn-default"
                                                       disabled={false}
                                                       id="more-actions-8"
                                                       onClick={[Function]}
                                                       onKeyDown={[Function]}
                                                       role="button"
+                                                      type="button"
                                                     >
-                                                      <button
-                                                        aria-expanded={false}
-                                                        aria-haspopup={true}
-                                                        className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-sm btn-default"
-                                                        disabled={false}
-                                                        id="more-actions-8"
-                                                        onClick={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        role="button"
-                                                        type="button"
-                                                      >
-                                                        More Actions
-                                                         
-                                                        <span
-                                                          className="caret"
-                                                        />
-                                                      </button>
-                                                    </Button>
-                                                  </DropdownToggle>
-                                                  <DropdownMenu
-                                                    bsClass="dropdown-menu"
-                                                    bsRole="menu"
-                                                    key=".1"
-                                                    labelledBy="more-actions-8"
-                                                    onClose={[Function]}
-                                                    onSelect={[Function]}
-                                                    pullRight={true}
+                                                      More Actions
+                                                       
+                                                      <span
+                                                        className="caret"
+                                                      />
+                                                    </button>
+                                                  </Button>
+                                                </DropdownToggle>
+                                                <DropdownMenu
+                                                  bsClass="dropdown-menu"
+                                                  bsRole="menu"
+                                                  key=".1"
+                                                  labelledBy="more-actions-8"
+                                                  onClose={[Function]}
+                                                  onSelect={[Function]}
+                                                  pullRight={true}
+                                                >
+                                                  <RootCloseWrapper
+                                                    disabled={true}
+                                                    event="click"
+                                                    onRootClose={[Function]}
                                                   >
-                                                    <RootCloseWrapper
-                                                      disabled={true}
-                                                      event="click"
-                                                      onRootClose={[Function]}
+                                                    <ul
+                                                      aria-labelledby="more-actions-8"
+                                                      className="dropdown-menu dropdown-menu-right"
+                                                      role="menu"
                                                     >
-                                                      <ul
-                                                        aria-labelledby="more-actions-8"
-                                                        className="dropdown-menu dropdown-menu-right"
-                                                        role="menu"
+                                                      <LinkContainer
+                                                        action="push"
+                                                        key=".0"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                        onlyActiveOnIndex={false}
+                                                        to="/system/contentpacks/8"
                                                       >
-                                                        <LinkContainer
-                                                          action="push"
-                                                          key=".0"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                          onlyActiveOnIndex={false}
-                                                          to="/system/contentpacks/8"
-                                                        >
-                                                          <MenuItem
-                                                            action="push"
-                                                            bsClass="dropdown"
-                                                            disabled={false}
-                                                            divider={false}
-                                                            header={false}
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            onSelect={[Function]}
-                                                          >
-                                                            <li
-                                                              className=""
-                                                              role="presentation"
-                                                            >
-                                                              <SafeAnchor
-                                                                action="push"
-                                                                componentClass="a"
-                                                                onClick={[Function]}
-                                                                onKeyDown={[Function]}
-                                                                role="menuitem"
-                                                                tabIndex="-1"
-                                                              >
-                                                                <a
-                                                                  action="push"
-                                                                  href="#"
-                                                                  onClick={[Function]}
-                                                                  onKeyDown={[Function]}
-                                                                  role="menuitem"
-                                                                  tabIndex="-1"
-                                                                >
-                                                                  Show
-                                                                </a>
-                                                              </SafeAnchor>
-                                                            </li>
-                                                          </MenuItem>
-                                                        </LinkContainer>
-                                                        <LinkContainer
-                                                          action="push"
-                                                          key=".1"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                          onlyActiveOnIndex={false}
-                                                          to="/system/contentpacks/8/1/edit"
-                                                        >
-                                                          <MenuItem
-                                                            action="push"
-                                                            bsClass="dropdown"
-                                                            disabled={false}
-                                                            divider={false}
-                                                            header={false}
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            onSelect={[Function]}
-                                                          >
-                                                            <li
-                                                              className=""
-                                                              role="presentation"
-                                                            >
-                                                              <SafeAnchor
-                                                                action="push"
-                                                                componentClass="a"
-                                                                onClick={[Function]}
-                                                                onKeyDown={[Function]}
-                                                                role="menuitem"
-                                                                tabIndex="-1"
-                                                              >
-                                                                <a
-                                                                  action="push"
-                                                                  href="#"
-                                                                  onClick={[Function]}
-                                                                  onKeyDown={[Function]}
-                                                                  role="menuitem"
-                                                                  tabIndex="-1"
-                                                                >
-                                                                  Create New Version
-                                                                </a>
-                                                              </SafeAnchor>
-                                                            </li>
-                                                          </MenuItem>
-                                                        </LinkContainer>
                                                         <MenuItem
+                                                          action="push"
                                                           bsClass="dropdown"
                                                           disabled={false}
                                                           divider={false}
                                                           header={false}
-                                                          key=".2"
+                                                          onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           onSelect={[Function]}
                                                         >
@@ -5364,6 +5162,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                             role="presentation"
                                                           >
                                                             <SafeAnchor
+                                                              action="push"
                                                               componentClass="a"
                                                               onClick={[Function]}
                                                               onKeyDown={[Function]}
@@ -5371,38 +5170,34 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                               tabIndex="-1"
                                                             >
                                                               <a
+                                                                action="push"
                                                                 href="#"
                                                                 onClick={[Function]}
                                                                 onKeyDown={[Function]}
                                                                 role="menuitem"
                                                                 tabIndex="-1"
                                                               >
-                                                                Download
+                                                                Show
                                                               </a>
                                                             </SafeAnchor>
                                                           </li>
                                                         </MenuItem>
+                                                      </LinkContainer>
+                                                      <LinkContainer
+                                                        action="push"
+                                                        key=".1"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                        onlyActiveOnIndex={false}
+                                                        to="/system/contentpacks/8/1/edit"
+                                                      >
                                                         <MenuItem
-                                                          bsClass="dropdown"
-                                                          disabled={false}
-                                                          divider={true}
-                                                          header={false}
-                                                          key=".3"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                        >
-                                                          <li
-                                                            className="divider"
-                                                            onKeyDown={[Function]}
-                                                            role="separator"
-                                                          />
-                                                        </MenuItem>
-                                                        <MenuItem
+                                                          action="push"
                                                           bsClass="dropdown"
                                                           disabled={false}
                                                           divider={false}
                                                           header={false}
-                                                          key=".4"
+                                                          onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           onSelect={[Function]}
                                                         >
@@ -5411,6 +5206,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                             role="presentation"
                                                           >
                                                             <SafeAnchor
+                                                              action="push"
                                                               componentClass="a"
                                                               onClick={[Function]}
                                                               onKeyDown={[Function]}
@@ -5418,28 +5214,108 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                               tabIndex="-1"
                                                             >
                                                               <a
+                                                                action="push"
                                                                 href="#"
                                                                 onClick={[Function]}
                                                                 onKeyDown={[Function]}
                                                                 role="menuitem"
                                                                 tabIndex="-1"
                                                               >
-                                                                Delete All Versions
+                                                                Create New Version
                                                               </a>
                                                             </SafeAnchor>
                                                           </li>
                                                         </MenuItem>
-                                                      </ul>
-                                                    </RootCloseWrapper>
-                                                  </DropdownMenu>
-                                                </div>
-                                              </ButtonGroup>
-                                            </Dropdown>
-                                          </Uncontrolled(Dropdown)>
-                                        </ForwardRef>
-                                      </DropdownButton>
-                                    </DropdownButton__StyledDropdownButton>
-                                  </ForwardRef>
+                                                      </LinkContainer>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={false}
+                                                        header={false}
+                                                        key=".2"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className=""
+                                                          role="presentation"
+                                                        >
+                                                          <SafeAnchor
+                                                            componentClass="a"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            role="menuitem"
+                                                            tabIndex="-1"
+                                                          >
+                                                            <a
+                                                              href="#"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              role="menuitem"
+                                                              tabIndex="-1"
+                                                            >
+                                                              Download
+                                                            </a>
+                                                          </SafeAnchor>
+                                                        </li>
+                                                      </MenuItem>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={true}
+                                                        header={false}
+                                                        key=".3"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className="divider"
+                                                          onKeyDown={[Function]}
+                                                          role="separator"
+                                                        />
+                                                      </MenuItem>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={false}
+                                                        header={false}
+                                                        key=".4"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className=""
+                                                          role="presentation"
+                                                        >
+                                                          <SafeAnchor
+                                                            componentClass="a"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            role="menuitem"
+                                                            tabIndex="-1"
+                                                          >
+                                                            <a
+                                                              href="#"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              role="menuitem"
+                                                              tabIndex="-1"
+                                                            >
+                                                              Delete All Versions
+                                                            </a>
+                                                          </SafeAnchor>
+                                                        </li>
+                                                      </MenuItem>
+                                                    </ul>
+                                                  </RootCloseWrapper>
+                                                </DropdownMenu>
+                                              </div>
+                                            </ButtonGroup>
+                                          </Dropdown>
+                                        </Uncontrolled(Dropdown)>
+                                      </ForwardRef>
+                                    </DropdownButton>
+                                  </DropdownButton>
                                   <ContentPackDownloadControl
                                     contentPackId="8"
                                     revision={1}
@@ -5622,37 +5498,31 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                   className="text-right col-md-3"
                                 >
                                    
-                                  <ForwardRef
+                                  <Button
                                     bsSize="small"
                                     bsStyle="info"
                                     onClick={[Function]}
                                   >
-                                    <Button__StyledButton
+                                    <Button
+                                      active={false}
+                                      block={false}
+                                      bsClass="btn"
                                       bsSize="small"
                                       bsStyle="info"
+                                      className="Button-c9cbmb-0 bNulii"
+                                      disabled={false}
                                       onClick={[Function]}
                                     >
-                                      <Button
-                                        active={false}
-                                        block={false}
-                                        bsClass="btn"
-                                        bsSize="small"
-                                        bsStyle="info"
-                                        className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                      <button
+                                        className="Button-c9cbmb-0 bNulii btn btn-sm btn-info"
                                         disabled={false}
                                         onClick={[Function]}
+                                        type="button"
                                       >
-                                        <button
-                                          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-info"
-                                          disabled={false}
-                                          onClick={[Function]}
-                                          type="button"
-                                        >
-                                          Install
-                                        </button>
-                                      </Button>
-                                    </Button__StyledButton>
-                                  </ForwardRef>
+                                        Install
+                                      </button>
+                                    </Button>
+                                  </Button>
                                   <BootstrapModalWrapper
                                     backdrop="static"
                                     bsSize="large"
@@ -5727,214 +5597,129 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                     </Modal>
                                   </BootstrapModalWrapper>
                                    
-                                  <ForwardRef
+                                  <DropdownButton
                                     bsSize="small"
                                     id="more-actions-9"
                                     pullRight={true}
                                     title="More Actions"
                                   >
-                                    <DropdownButton__StyledDropdownButton
+                                    <DropdownButton
                                       bsSize="small"
+                                      className="DropdownButton-sc-1343dcx-0 jHYVsD"
                                       id="more-actions-9"
                                       pullRight={true}
                                       title="More Actions"
                                     >
-                                      <DropdownButton
+                                      <ForwardRef
                                         bsSize="small"
-                                        className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
                                         id="more-actions-9"
                                         pullRight={true}
-                                        title="More Actions"
                                       >
-                                        <ForwardRef
+                                        <Uncontrolled(Dropdown)
                                           bsSize="small"
                                           id="more-actions-9"
+                                          innerRef={null}
                                           pullRight={true}
                                         >
-                                          <Uncontrolled(Dropdown)
+                                          <Dropdown
+                                            bsClass="dropdown"
                                             bsSize="small"
+                                            componentClass={[Function]}
                                             id="more-actions-9"
-                                            innerRef={null}
+                                            onToggle={[Function]}
                                             pullRight={true}
                                           >
-                                            <Dropdown
-                                              bsClass="dropdown"
+                                            <ButtonGroup
+                                              block={false}
+                                              bsClass="btn-group"
                                               bsSize="small"
-                                              componentClass={[Function]}
-                                              id="more-actions-9"
-                                              onToggle={[Function]}
-                                              pullRight={true}
+                                              className="dropdown"
+                                              justified={false}
+                                              vertical={false}
                                             >
-                                              <ButtonGroup
-                                                block={false}
-                                                bsClass="btn-group"
-                                                bsSize="small"
-                                                className="dropdown"
-                                                justified={false}
-                                                vertical={false}
+                                              <div
+                                                className="dropdown btn-group btn-group-sm"
                                               >
-                                                <div
-                                                  className="dropdown btn-group btn-group-sm"
+                                                <DropdownToggle
+                                                  bsClass="dropdown-toggle"
+                                                  bsRole="toggle"
+                                                  bsSize="small"
+                                                  className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                                                  id="more-actions-9"
+                                                  key=".0"
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  open={false}
+                                                  useAnchor={false}
                                                 >
-                                                  <DropdownToggle
-                                                    bsClass="dropdown-toggle"
-                                                    bsRole="toggle"
+                                                  <Button
+                                                    active={false}
+                                                    aria-expanded={false}
+                                                    aria-haspopup={true}
+                                                    block={false}
+                                                    bsClass="btn"
                                                     bsSize="small"
-                                                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                                                    bsStyle="default"
+                                                    className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                                    disabled={false}
                                                     id="more-actions-9"
-                                                    key=".0"
                                                     onClick={[Function]}
                                                     onKeyDown={[Function]}
-                                                    open={false}
-                                                    useAnchor={false}
+                                                    role="button"
                                                   >
-                                                    <Button
-                                                      active={false}
+                                                    <button
                                                       aria-expanded={false}
                                                       aria-haspopup={true}
-                                                      block={false}
-                                                      bsClass="btn"
-                                                      bsSize="small"
-                                                      bsStyle="default"
-                                                      className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                                      className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-sm btn-default"
                                                       disabled={false}
                                                       id="more-actions-9"
                                                       onClick={[Function]}
                                                       onKeyDown={[Function]}
                                                       role="button"
+                                                      type="button"
                                                     >
-                                                      <button
-                                                        aria-expanded={false}
-                                                        aria-haspopup={true}
-                                                        className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-sm btn-default"
-                                                        disabled={false}
-                                                        id="more-actions-9"
-                                                        onClick={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        role="button"
-                                                        type="button"
-                                                      >
-                                                        More Actions
-                                                         
-                                                        <span
-                                                          className="caret"
-                                                        />
-                                                      </button>
-                                                    </Button>
-                                                  </DropdownToggle>
-                                                  <DropdownMenu
-                                                    bsClass="dropdown-menu"
-                                                    bsRole="menu"
-                                                    key=".1"
-                                                    labelledBy="more-actions-9"
-                                                    onClose={[Function]}
-                                                    onSelect={[Function]}
-                                                    pullRight={true}
+                                                      More Actions
+                                                       
+                                                      <span
+                                                        className="caret"
+                                                      />
+                                                    </button>
+                                                  </Button>
+                                                </DropdownToggle>
+                                                <DropdownMenu
+                                                  bsClass="dropdown-menu"
+                                                  bsRole="menu"
+                                                  key=".1"
+                                                  labelledBy="more-actions-9"
+                                                  onClose={[Function]}
+                                                  onSelect={[Function]}
+                                                  pullRight={true}
+                                                >
+                                                  <RootCloseWrapper
+                                                    disabled={true}
+                                                    event="click"
+                                                    onRootClose={[Function]}
                                                   >
-                                                    <RootCloseWrapper
-                                                      disabled={true}
-                                                      event="click"
-                                                      onRootClose={[Function]}
+                                                    <ul
+                                                      aria-labelledby="more-actions-9"
+                                                      className="dropdown-menu dropdown-menu-right"
+                                                      role="menu"
                                                     >
-                                                      <ul
-                                                        aria-labelledby="more-actions-9"
-                                                        className="dropdown-menu dropdown-menu-right"
-                                                        role="menu"
+                                                      <LinkContainer
+                                                        action="push"
+                                                        key=".0"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                        onlyActiveOnIndex={false}
+                                                        to="/system/contentpacks/9"
                                                       >
-                                                        <LinkContainer
-                                                          action="push"
-                                                          key=".0"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                          onlyActiveOnIndex={false}
-                                                          to="/system/contentpacks/9"
-                                                        >
-                                                          <MenuItem
-                                                            action="push"
-                                                            bsClass="dropdown"
-                                                            disabled={false}
-                                                            divider={false}
-                                                            header={false}
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            onSelect={[Function]}
-                                                          >
-                                                            <li
-                                                              className=""
-                                                              role="presentation"
-                                                            >
-                                                              <SafeAnchor
-                                                                action="push"
-                                                                componentClass="a"
-                                                                onClick={[Function]}
-                                                                onKeyDown={[Function]}
-                                                                role="menuitem"
-                                                                tabIndex="-1"
-                                                              >
-                                                                <a
-                                                                  action="push"
-                                                                  href="#"
-                                                                  onClick={[Function]}
-                                                                  onKeyDown={[Function]}
-                                                                  role="menuitem"
-                                                                  tabIndex="-1"
-                                                                >
-                                                                  Show
-                                                                </a>
-                                                              </SafeAnchor>
-                                                            </li>
-                                                          </MenuItem>
-                                                        </LinkContainer>
-                                                        <LinkContainer
-                                                          action="push"
-                                                          key=".1"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                          onlyActiveOnIndex={false}
-                                                          to="/system/contentpacks/9/1/edit"
-                                                        >
-                                                          <MenuItem
-                                                            action="push"
-                                                            bsClass="dropdown"
-                                                            disabled={false}
-                                                            divider={false}
-                                                            header={false}
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            onSelect={[Function]}
-                                                          >
-                                                            <li
-                                                              className=""
-                                                              role="presentation"
-                                                            >
-                                                              <SafeAnchor
-                                                                action="push"
-                                                                componentClass="a"
-                                                                onClick={[Function]}
-                                                                onKeyDown={[Function]}
-                                                                role="menuitem"
-                                                                tabIndex="-1"
-                                                              >
-                                                                <a
-                                                                  action="push"
-                                                                  href="#"
-                                                                  onClick={[Function]}
-                                                                  onKeyDown={[Function]}
-                                                                  role="menuitem"
-                                                                  tabIndex="-1"
-                                                                >
-                                                                  Create New Version
-                                                                </a>
-                                                              </SafeAnchor>
-                                                            </li>
-                                                          </MenuItem>
-                                                        </LinkContainer>
                                                         <MenuItem
+                                                          action="push"
                                                           bsClass="dropdown"
                                                           disabled={false}
                                                           divider={false}
                                                           header={false}
-                                                          key=".2"
+                                                          onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           onSelect={[Function]}
                                                         >
@@ -5943,6 +5728,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                             role="presentation"
                                                           >
                                                             <SafeAnchor
+                                                              action="push"
                                                               componentClass="a"
                                                               onClick={[Function]}
                                                               onKeyDown={[Function]}
@@ -5950,38 +5736,34 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                               tabIndex="-1"
                                                             >
                                                               <a
+                                                                action="push"
                                                                 href="#"
                                                                 onClick={[Function]}
                                                                 onKeyDown={[Function]}
                                                                 role="menuitem"
                                                                 tabIndex="-1"
                                                               >
-                                                                Download
+                                                                Show
                                                               </a>
                                                             </SafeAnchor>
                                                           </li>
                                                         </MenuItem>
+                                                      </LinkContainer>
+                                                      <LinkContainer
+                                                        action="push"
+                                                        key=".1"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                        onlyActiveOnIndex={false}
+                                                        to="/system/contentpacks/9/1/edit"
+                                                      >
                                                         <MenuItem
-                                                          bsClass="dropdown"
-                                                          disabled={false}
-                                                          divider={true}
-                                                          header={false}
-                                                          key=".3"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                        >
-                                                          <li
-                                                            className="divider"
-                                                            onKeyDown={[Function]}
-                                                            role="separator"
-                                                          />
-                                                        </MenuItem>
-                                                        <MenuItem
+                                                          action="push"
                                                           bsClass="dropdown"
                                                           disabled={false}
                                                           divider={false}
                                                           header={false}
-                                                          key=".4"
+                                                          onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           onSelect={[Function]}
                                                         >
@@ -5990,6 +5772,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                             role="presentation"
                                                           >
                                                             <SafeAnchor
+                                                              action="push"
                                                               componentClass="a"
                                                               onClick={[Function]}
                                                               onKeyDown={[Function]}
@@ -5997,28 +5780,108 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                               tabIndex="-1"
                                                             >
                                                               <a
+                                                                action="push"
                                                                 href="#"
                                                                 onClick={[Function]}
                                                                 onKeyDown={[Function]}
                                                                 role="menuitem"
                                                                 tabIndex="-1"
                                                               >
-                                                                Delete All Versions
+                                                                Create New Version
                                                               </a>
                                                             </SafeAnchor>
                                                           </li>
                                                         </MenuItem>
-                                                      </ul>
-                                                    </RootCloseWrapper>
-                                                  </DropdownMenu>
-                                                </div>
-                                              </ButtonGroup>
-                                            </Dropdown>
-                                          </Uncontrolled(Dropdown)>
-                                        </ForwardRef>
-                                      </DropdownButton>
-                                    </DropdownButton__StyledDropdownButton>
-                                  </ForwardRef>
+                                                      </LinkContainer>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={false}
+                                                        header={false}
+                                                        key=".2"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className=""
+                                                          role="presentation"
+                                                        >
+                                                          <SafeAnchor
+                                                            componentClass="a"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            role="menuitem"
+                                                            tabIndex="-1"
+                                                          >
+                                                            <a
+                                                              href="#"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              role="menuitem"
+                                                              tabIndex="-1"
+                                                            >
+                                                              Download
+                                                            </a>
+                                                          </SafeAnchor>
+                                                        </li>
+                                                      </MenuItem>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={true}
+                                                        header={false}
+                                                        key=".3"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className="divider"
+                                                          onKeyDown={[Function]}
+                                                          role="separator"
+                                                        />
+                                                      </MenuItem>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={false}
+                                                        header={false}
+                                                        key=".4"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className=""
+                                                          role="presentation"
+                                                        >
+                                                          <SafeAnchor
+                                                            componentClass="a"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            role="menuitem"
+                                                            tabIndex="-1"
+                                                          >
+                                                            <a
+                                                              href="#"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              role="menuitem"
+                                                              tabIndex="-1"
+                                                            >
+                                                              Delete All Versions
+                                                            </a>
+                                                          </SafeAnchor>
+                                                        </li>
+                                                      </MenuItem>
+                                                    </ul>
+                                                  </RootCloseWrapper>
+                                                </DropdownMenu>
+                                              </div>
+                                            </ButtonGroup>
+                                          </Dropdown>
+                                        </Uncontrolled(Dropdown)>
+                                      </ForwardRef>
+                                    </DropdownButton>
+                                  </DropdownButton>
                                   <ContentPackDownloadControl
                                     contentPackId="9"
                                     revision={1}
@@ -6202,37 +6065,31 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                   className="text-right col-md-3"
                                 >
                                    
-                                  <ForwardRef
+                                  <Button
                                     bsSize="small"
                                     bsStyle="info"
                                     onClick={[Function]}
                                   >
-                                    <Button__StyledButton
+                                    <Button
+                                      active={false}
+                                      block={false}
+                                      bsClass="btn"
                                       bsSize="small"
                                       bsStyle="info"
+                                      className="Button-c9cbmb-0 bNulii"
+                                      disabled={false}
                                       onClick={[Function]}
                                     >
-                                      <Button
-                                        active={false}
-                                        block={false}
-                                        bsClass="btn"
-                                        bsSize="small"
-                                        bsStyle="info"
-                                        className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                      <button
+                                        className="Button-c9cbmb-0 bNulii btn btn-sm btn-info"
                                         disabled={false}
                                         onClick={[Function]}
+                                        type="button"
                                       >
-                                        <button
-                                          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-info"
-                                          disabled={false}
-                                          onClick={[Function]}
-                                          type="button"
-                                        >
-                                          Install
-                                        </button>
-                                      </Button>
-                                    </Button__StyledButton>
-                                  </ForwardRef>
+                                        Install
+                                      </button>
+                                    </Button>
+                                  </Button>
                                   <BootstrapModalWrapper
                                     backdrop="static"
                                     bsSize="large"
@@ -6307,214 +6164,129 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                     </Modal>
                                   </BootstrapModalWrapper>
                                    
-                                  <ForwardRef
+                                  <DropdownButton
                                     bsSize="small"
                                     id="more-actions-10"
                                     pullRight={true}
                                     title="More Actions"
                                   >
-                                    <DropdownButton__StyledDropdownButton
+                                    <DropdownButton
                                       bsSize="small"
+                                      className="DropdownButton-sc-1343dcx-0 jHYVsD"
                                       id="more-actions-10"
                                       pullRight={true}
                                       title="More Actions"
                                     >
-                                      <DropdownButton
+                                      <ForwardRef
                                         bsSize="small"
-                                        className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
                                         id="more-actions-10"
                                         pullRight={true}
-                                        title="More Actions"
                                       >
-                                        <ForwardRef
+                                        <Uncontrolled(Dropdown)
                                           bsSize="small"
                                           id="more-actions-10"
+                                          innerRef={null}
                                           pullRight={true}
                                         >
-                                          <Uncontrolled(Dropdown)
+                                          <Dropdown
+                                            bsClass="dropdown"
                                             bsSize="small"
+                                            componentClass={[Function]}
                                             id="more-actions-10"
-                                            innerRef={null}
+                                            onToggle={[Function]}
                                             pullRight={true}
                                           >
-                                            <Dropdown
-                                              bsClass="dropdown"
+                                            <ButtonGroup
+                                              block={false}
+                                              bsClass="btn-group"
                                               bsSize="small"
-                                              componentClass={[Function]}
-                                              id="more-actions-10"
-                                              onToggle={[Function]}
-                                              pullRight={true}
+                                              className="dropdown"
+                                              justified={false}
+                                              vertical={false}
                                             >
-                                              <ButtonGroup
-                                                block={false}
-                                                bsClass="btn-group"
-                                                bsSize="small"
-                                                className="dropdown"
-                                                justified={false}
-                                                vertical={false}
+                                              <div
+                                                className="dropdown btn-group btn-group-sm"
                                               >
-                                                <div
-                                                  className="dropdown btn-group btn-group-sm"
+                                                <DropdownToggle
+                                                  bsClass="dropdown-toggle"
+                                                  bsRole="toggle"
+                                                  bsSize="small"
+                                                  className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                                                  id="more-actions-10"
+                                                  key=".0"
+                                                  onClick={[Function]}
+                                                  onKeyDown={[Function]}
+                                                  open={false}
+                                                  useAnchor={false}
                                                 >
-                                                  <DropdownToggle
-                                                    bsClass="dropdown-toggle"
-                                                    bsRole="toggle"
+                                                  <Button
+                                                    active={false}
+                                                    aria-expanded={false}
+                                                    aria-haspopup={true}
+                                                    block={false}
+                                                    bsClass="btn"
                                                     bsSize="small"
-                                                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                                                    bsStyle="default"
+                                                    className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                                    disabled={false}
                                                     id="more-actions-10"
-                                                    key=".0"
                                                     onClick={[Function]}
                                                     onKeyDown={[Function]}
-                                                    open={false}
-                                                    useAnchor={false}
+                                                    role="button"
                                                   >
-                                                    <Button
-                                                      active={false}
+                                                    <button
                                                       aria-expanded={false}
                                                       aria-haspopup={true}
-                                                      block={false}
-                                                      bsClass="btn"
-                                                      bsSize="small"
-                                                      bsStyle="default"
-                                                      className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                                      className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-sm btn-default"
                                                       disabled={false}
                                                       id="more-actions-10"
                                                       onClick={[Function]}
                                                       onKeyDown={[Function]}
                                                       role="button"
+                                                      type="button"
                                                     >
-                                                      <button
-                                                        aria-expanded={false}
-                                                        aria-haspopup={true}
-                                                        className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-sm btn-default"
-                                                        disabled={false}
-                                                        id="more-actions-10"
-                                                        onClick={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        role="button"
-                                                        type="button"
-                                                      >
-                                                        More Actions
-                                                         
-                                                        <span
-                                                          className="caret"
-                                                        />
-                                                      </button>
-                                                    </Button>
-                                                  </DropdownToggle>
-                                                  <DropdownMenu
-                                                    bsClass="dropdown-menu"
-                                                    bsRole="menu"
-                                                    key=".1"
-                                                    labelledBy="more-actions-10"
-                                                    onClose={[Function]}
-                                                    onSelect={[Function]}
-                                                    pullRight={true}
+                                                      More Actions
+                                                       
+                                                      <span
+                                                        className="caret"
+                                                      />
+                                                    </button>
+                                                  </Button>
+                                                </DropdownToggle>
+                                                <DropdownMenu
+                                                  bsClass="dropdown-menu"
+                                                  bsRole="menu"
+                                                  key=".1"
+                                                  labelledBy="more-actions-10"
+                                                  onClose={[Function]}
+                                                  onSelect={[Function]}
+                                                  pullRight={true}
+                                                >
+                                                  <RootCloseWrapper
+                                                    disabled={true}
+                                                    event="click"
+                                                    onRootClose={[Function]}
                                                   >
-                                                    <RootCloseWrapper
-                                                      disabled={true}
-                                                      event="click"
-                                                      onRootClose={[Function]}
+                                                    <ul
+                                                      aria-labelledby="more-actions-10"
+                                                      className="dropdown-menu dropdown-menu-right"
+                                                      role="menu"
                                                     >
-                                                      <ul
-                                                        aria-labelledby="more-actions-10"
-                                                        className="dropdown-menu dropdown-menu-right"
-                                                        role="menu"
+                                                      <LinkContainer
+                                                        action="push"
+                                                        key=".0"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                        onlyActiveOnIndex={false}
+                                                        to="/system/contentpacks/10"
                                                       >
-                                                        <LinkContainer
-                                                          action="push"
-                                                          key=".0"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                          onlyActiveOnIndex={false}
-                                                          to="/system/contentpacks/10"
-                                                        >
-                                                          <MenuItem
-                                                            action="push"
-                                                            bsClass="dropdown"
-                                                            disabled={false}
-                                                            divider={false}
-                                                            header={false}
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            onSelect={[Function]}
-                                                          >
-                                                            <li
-                                                              className=""
-                                                              role="presentation"
-                                                            >
-                                                              <SafeAnchor
-                                                                action="push"
-                                                                componentClass="a"
-                                                                onClick={[Function]}
-                                                                onKeyDown={[Function]}
-                                                                role="menuitem"
-                                                                tabIndex="-1"
-                                                              >
-                                                                <a
-                                                                  action="push"
-                                                                  href="#"
-                                                                  onClick={[Function]}
-                                                                  onKeyDown={[Function]}
-                                                                  role="menuitem"
-                                                                  tabIndex="-1"
-                                                                >
-                                                                  Show
-                                                                </a>
-                                                              </SafeAnchor>
-                                                            </li>
-                                                          </MenuItem>
-                                                        </LinkContainer>
-                                                        <LinkContainer
-                                                          action="push"
-                                                          key=".1"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                          onlyActiveOnIndex={false}
-                                                          to="/system/contentpacks/10/1/edit"
-                                                        >
-                                                          <MenuItem
-                                                            action="push"
-                                                            bsClass="dropdown"
-                                                            disabled={false}
-                                                            divider={false}
-                                                            header={false}
-                                                            onClick={[Function]}
-                                                            onKeyDown={[Function]}
-                                                            onSelect={[Function]}
-                                                          >
-                                                            <li
-                                                              className=""
-                                                              role="presentation"
-                                                            >
-                                                              <SafeAnchor
-                                                                action="push"
-                                                                componentClass="a"
-                                                                onClick={[Function]}
-                                                                onKeyDown={[Function]}
-                                                                role="menuitem"
-                                                                tabIndex="-1"
-                                                              >
-                                                                <a
-                                                                  action="push"
-                                                                  href="#"
-                                                                  onClick={[Function]}
-                                                                  onKeyDown={[Function]}
-                                                                  role="menuitem"
-                                                                  tabIndex="-1"
-                                                                >
-                                                                  Create New Version
-                                                                </a>
-                                                              </SafeAnchor>
-                                                            </li>
-                                                          </MenuItem>
-                                                        </LinkContainer>
                                                         <MenuItem
+                                                          action="push"
                                                           bsClass="dropdown"
                                                           disabled={false}
                                                           divider={false}
                                                           header={false}
-                                                          key=".2"
+                                                          onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           onSelect={[Function]}
                                                         >
@@ -6523,6 +6295,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                             role="presentation"
                                                           >
                                                             <SafeAnchor
+                                                              action="push"
                                                               componentClass="a"
                                                               onClick={[Function]}
                                                               onKeyDown={[Function]}
@@ -6530,38 +6303,34 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                               tabIndex="-1"
                                                             >
                                                               <a
+                                                                action="push"
                                                                 href="#"
                                                                 onClick={[Function]}
                                                                 onKeyDown={[Function]}
                                                                 role="menuitem"
                                                                 tabIndex="-1"
                                                               >
-                                                                Download
+                                                                Show
                                                               </a>
                                                             </SafeAnchor>
                                                           </li>
                                                         </MenuItem>
+                                                      </LinkContainer>
+                                                      <LinkContainer
+                                                        action="push"
+                                                        key=".1"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                        onlyActiveOnIndex={false}
+                                                        to="/system/contentpacks/10/1/edit"
+                                                      >
                                                         <MenuItem
-                                                          bsClass="dropdown"
-                                                          disabled={false}
-                                                          divider={true}
-                                                          header={false}
-                                                          key=".3"
-                                                          onKeyDown={[Function]}
-                                                          onSelect={[Function]}
-                                                        >
-                                                          <li
-                                                            className="divider"
-                                                            onKeyDown={[Function]}
-                                                            role="separator"
-                                                          />
-                                                        </MenuItem>
-                                                        <MenuItem
+                                                          action="push"
                                                           bsClass="dropdown"
                                                           disabled={false}
                                                           divider={false}
                                                           header={false}
-                                                          key=".4"
+                                                          onClick={[Function]}
                                                           onKeyDown={[Function]}
                                                           onSelect={[Function]}
                                                         >
@@ -6570,6 +6339,7 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                             role="presentation"
                                                           >
                                                             <SafeAnchor
+                                                              action="push"
                                                               componentClass="a"
                                                               onClick={[Function]}
                                                               onKeyDown={[Function]}
@@ -6577,28 +6347,108 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                                                               tabIndex="-1"
                                                             >
                                                               <a
+                                                                action="push"
                                                                 href="#"
                                                                 onClick={[Function]}
                                                                 onKeyDown={[Function]}
                                                                 role="menuitem"
                                                                 tabIndex="-1"
                                                               >
-                                                                Delete All Versions
+                                                                Create New Version
                                                               </a>
                                                             </SafeAnchor>
                                                           </li>
                                                         </MenuItem>
-                                                      </ul>
-                                                    </RootCloseWrapper>
-                                                  </DropdownMenu>
-                                                </div>
-                                              </ButtonGroup>
-                                            </Dropdown>
-                                          </Uncontrolled(Dropdown)>
-                                        </ForwardRef>
-                                      </DropdownButton>
-                                    </DropdownButton__StyledDropdownButton>
-                                  </ForwardRef>
+                                                      </LinkContainer>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={false}
+                                                        header={false}
+                                                        key=".2"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className=""
+                                                          role="presentation"
+                                                        >
+                                                          <SafeAnchor
+                                                            componentClass="a"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            role="menuitem"
+                                                            tabIndex="-1"
+                                                          >
+                                                            <a
+                                                              href="#"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              role="menuitem"
+                                                              tabIndex="-1"
+                                                            >
+                                                              Download
+                                                            </a>
+                                                          </SafeAnchor>
+                                                        </li>
+                                                      </MenuItem>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={true}
+                                                        header={false}
+                                                        key=".3"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className="divider"
+                                                          onKeyDown={[Function]}
+                                                          role="separator"
+                                                        />
+                                                      </MenuItem>
+                                                      <MenuItem
+                                                        bsClass="dropdown"
+                                                        disabled={false}
+                                                        divider={false}
+                                                        header={false}
+                                                        key=".4"
+                                                        onKeyDown={[Function]}
+                                                        onSelect={[Function]}
+                                                      >
+                                                        <li
+                                                          className=""
+                                                          role="presentation"
+                                                        >
+                                                          <SafeAnchor
+                                                            componentClass="a"
+                                                            onClick={[Function]}
+                                                            onKeyDown={[Function]}
+                                                            role="menuitem"
+                                                            tabIndex="-1"
+                                                          >
+                                                            <a
+                                                              href="#"
+                                                              onClick={[Function]}
+                                                              onKeyDown={[Function]}
+                                                              role="menuitem"
+                                                              tabIndex="-1"
+                                                            >
+                                                              Delete All Versions
+                                                            </a>
+                                                          </SafeAnchor>
+                                                        </li>
+                                                      </MenuItem>
+                                                    </ul>
+                                                  </RootCloseWrapper>
+                                                </DropdownMenu>
+                                              </div>
+                                            </ButtonGroup>
+                                          </Dropdown>
+                                        </Uncontrolled(Dropdown)>
+                                      </ForwardRef>
+                                    </DropdownButton>
+                                  </DropdownButton>
                                   <ContentPackDownloadControl
                                     contentPackId="10"
                                     revision={1}
@@ -7212,7 +7062,7 @@ exports[`<ContentPacksList /> should render with empty content packs 1`] = `
                         </Component>
                       </Input>
                     </TypeAheadInput>
-                    <ForwardRef
+                    <Button
                       style={
                         Object {
                           "marginLeft": 5,
@@ -7220,7 +7070,13 @@ exports[`<ContentPacksList /> should render with empty content packs 1`] = `
                       }
                       type="submit"
                     >
-                      <Button__StyledButton
+                      <Button
+                        active={false}
+                        block={false}
+                        bsClass="btn"
+                        bsStyle="default"
+                        className="Button-c9cbmb-0 bNulii"
+                        disabled={false}
                         style={
                           Object {
                             "marginLeft": 5,
@@ -7228,12 +7084,8 @@ exports[`<ContentPacksList /> should render with empty content packs 1`] = `
                         }
                         type="submit"
                       >
-                        <Button
-                          active={false}
-                          block={false}
-                          bsClass="btn"
-                          bsStyle="default"
-                          className="Button__StyledButton-c9cbmb-0 laZUlH"
+                        <button
+                          className="Button-c9cbmb-0 bNulii btn btn-default"
                           disabled={false}
                           style={
                             Object {
@@ -7242,22 +7094,11 @@ exports[`<ContentPacksList /> should render with empty content packs 1`] = `
                           }
                           type="submit"
                         >
-                          <button
-                            className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                            disabled={false}
-                            style={
-                              Object {
-                                "marginLeft": 5,
-                              }
-                            }
-                            type="submit"
-                          >
-                            Filter
-                          </button>
-                        </Button>
-                      </Button__StyledButton>
-                    </ForwardRef>
-                    <ForwardRef
+                          Filter
+                        </button>
+                      </Button>
+                    </Button>
+                    <Button
                       disabled={true}
                       onClick={[Function]}
                       style={
@@ -7267,7 +7108,12 @@ exports[`<ContentPacksList /> should render with empty content packs 1`] = `
                       }
                       type="button"
                     >
-                      <Button__StyledButton
+                      <Button
+                        active={false}
+                        block={false}
+                        bsClass="btn"
+                        bsStyle="default"
+                        className="Button-c9cbmb-0 bNulii"
                         disabled={true}
                         onClick={[Function]}
                         style={
@@ -7277,12 +7123,8 @@ exports[`<ContentPacksList /> should render with empty content packs 1`] = `
                         }
                         type="button"
                       >
-                        <Button
-                          active={false}
-                          block={false}
-                          bsClass="btn"
-                          bsStyle="default"
-                          className="Button__StyledButton-c9cbmb-0 laZUlH"
+                        <button
+                          className="Button-c9cbmb-0 bNulii btn btn-default"
                           disabled={true}
                           onClick={[Function]}
                           style={
@@ -7292,22 +7134,10 @@ exports[`<ContentPacksList /> should render with empty content packs 1`] = `
                           }
                           type="button"
                         >
-                          <button
-                            className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                            disabled={true}
-                            onClick={[Function]}
-                            style={
-                              Object {
-                                "marginLeft": 5,
-                              }
-                            }
-                            type="button"
-                          >
-                            Reset
-                          </button>
-                        </Button>
-                      </Button__StyledButton>
-                    </ForwardRef>
+                          Reset
+                        </button>
+                      </Button>
+                    </Button>
                   </form>
                   <ul
                     className="pill-list"

--- a/graylog2-web-interface/src/components/graylog/Button.jsx
+++ b/graylog2-web-interface/src/components/graylog/Button.jsx
@@ -1,13 +1,10 @@
-import React, { forwardRef } from 'react';
+import React from 'react';
 import styled, { css } from 'styled-components';
 // eslint-disable-next-line no-restricted-imports
 import { Button as BootstrapButton } from 'react-bootstrap';
 
-const StyledButton = styled(BootstrapButton)(({ theme }) => css`
+const Button = styled(BootstrapButton)(({ theme }) => css`
   ${theme.components.button}
 `);
 
-const Button = forwardRef((props, ref) => <StyledButton {...props} ref={ref} />);
-
 export default Button;
-export { StyledButton };

--- a/graylog2-web-interface/src/components/graylog/Button.jsx
+++ b/graylog2-web-interface/src/components/graylog/Button.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled, { css } from 'styled-components';
 // eslint-disable-next-line no-restricted-imports
 import { Button as BootstrapButton } from 'react-bootstrap';

--- a/graylog2-web-interface/src/components/graylog/DropdownButton.jsx
+++ b/graylog2-web-interface/src/components/graylog/DropdownButton.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { DropdownButton as BootstrapDropdownButton } from 'react-bootstrap';
 import styled, { css } from 'styled-components';

--- a/graylog2-web-interface/src/components/graylog/DropdownButton.jsx
+++ b/graylog2-web-interface/src/components/graylog/DropdownButton.jsx
@@ -1,19 +1,16 @@
-import React, { forwardRef } from 'react';
+import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { DropdownButton as BootstrapDropdownButton } from 'react-bootstrap';
 import styled, { css } from 'styled-components';
 
 import menuItemStyles from './styles/menuItem';
 
-const StyledDropdownButton = styled(BootstrapDropdownButton)(({ theme }) => css`
+const DropdownButton = styled(BootstrapDropdownButton)(({ theme }) => css`
   ${theme.components.button}
   & ~ {
     ${menuItemStyles}
   }
 `);
 
-const DropdownButton = forwardRef((props, ref) => <StyledDropdownButton {...props} ref={ref} />);
-
 /** @component */
 export default DropdownButton;
-export { StyledDropdownButton };

--- a/graylog2-web-interface/src/components/graylog/SplitButton.jsx
+++ b/graylog2-web-interface/src/components/graylog/SplitButton.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { SplitButton as BootstrapSplitButton } from 'react-bootstrap';
 import styled, { css } from 'styled-components';

--- a/graylog2-web-interface/src/components/graylog/SplitButton.jsx
+++ b/graylog2-web-interface/src/components/graylog/SplitButton.jsx
@@ -1,11 +1,11 @@
-import React, { forwardRef } from 'react';
+import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { SplitButton as BootstrapSplitButton } from 'react-bootstrap';
 import styled, { css } from 'styled-components';
 
 import menuItemStyles from './styles/menuItem';
 
-const StyledSplitButton = styled(BootstrapSplitButton)(({ theme }) => css`
+const SplitButton = styled(BootstrapSplitButton)(({ theme }) => css`
   ${theme.components.button}
   ~ .btn.dropdown-toggle {
     ${theme.components.button}
@@ -15,8 +15,5 @@ const StyledSplitButton = styled(BootstrapSplitButton)(({ theme }) => css`
   }
 `);
 
-const SplitButton = forwardRef((props, ref) => <StyledSplitButton {...props} ref={ref} />);
-
 /** @component */
 export default SplitButton;
-export { StyledSplitButton };

--- a/graylog2-web-interface/src/components/graylog/styles/buttonStyles.js
+++ b/graylog2-web-interface/src/components/graylog/styles/buttonStyles.js
@@ -1,7 +1,7 @@
 import chroma from 'chroma-js';
 import { css } from 'styled-components';
 
-const buttonStyles = ({ colors }) => {
+const buttonStyles = ({ colors, utils }) => {
   const variants = {
     danger: colors.variant.danger,
     default: colors.gray[90],
@@ -14,7 +14,7 @@ const buttonStyles = ({ colors }) => {
 
   const mixColor = (originalColor) => chroma.mix(originalColor, colors.global.textDefault, 0.15);
 
-  return Object.keys(variants).map((variant) => css(({ theme }) => {
+  return Object.keys(variants).map((variant) => {
     const variantColor = variants[variant];
     const isLink = variant === 'link';
 
@@ -22,15 +22,23 @@ const buttonStyles = ({ colors }) => {
 
     const defaultBackground = variantColor;
     const defaultBorder = isLink ? variants.link : chroma.mix(variantColor, buttonAdjustColor, 0.05);
-    const defaultColor = isLink ? colors.global.link : theme.utils.contrastingColor(defaultBackground);
+    const defaultColor = isLink ? colors.global.link : utils.contrastingColor(defaultBackground);
 
     const activeBackground = isLink ? variants.link : chroma.mix(variantColor, buttonAdjustColor, 0.10);
     const activeBorder = isLink ? variants.link : chroma.mix(variantColor, buttonAdjustColor, 0.15);
-    const activeColor = isLink ? colors.global.linkHover : theme.utils.contrastingColor(activeBackground);
+    const activeColor = isLink ? colors.global.linkHover : utils.contrastingColor(activeBackground);
 
     const disabledBackground = isLink ? variants.link : chroma.mix(variantColor, buttonAdjustColor, 0.20);
     const disabledBorder = isLink ? variants.link : chroma.mix(variantColor, buttonAdjustColor, 0.15);
-    const disabledColor = isLink ? colors.global.link : theme.utils.contrastingColor(disabledBackground, 'AA');
+    const disabledColor = isLink ? colors.global.link : utils.contrastingColor(disabledBackground, 'AA');
+
+    const hoverBackground = mixColor(defaultBackground);
+    const hoverBorderColor = mixColor(defaultBorder);
+    const hoverColor = mixColor(defaultBorder);
+
+    const activeHoverBackground = mixColor(activeBackground);
+    const activeHoverBorderColor = mixColor(activeBorder);
+    const activeHoverColor = mixColor(activeBorder);
 
     return css`
       &.btn-${variant} {
@@ -42,9 +50,9 @@ const buttonStyles = ({ colors }) => {
           color 150ms ease-in-out;
 
         :hover {
-          background-color: ${mixColor(defaultBackground)};
-          border-color: ${mixColor(defaultBorder)};
-          color: ${mixColor(defaultColor)};
+          background-color: ${hoverBackground};
+          border-color: ${hoverBorderColor};
+          color: ${hoverColor};
         }
 
         &.active {
@@ -53,9 +61,9 @@ const buttonStyles = ({ colors }) => {
           color: ${activeColor};
 
           :hover {
-            background-color: ${isLink ? variants.link : mixColor(activeBackground)};
-            border-color: ${mixColor(activeBorder)};
-            color: ${mixColor(activeColor)};
+            background-color: ${isLink ? variants.link : activeHoverBackground};
+            border-color: ${activeHoverBorderColor};
+            color: ${activeHoverColor};
           }
         }
 
@@ -73,7 +81,7 @@ const buttonStyles = ({ colors }) => {
         }
       }
     `;
-  }));
+  });
 };
 
 export default buttonStyles;

--- a/graylog2-web-interface/src/components/graylog/styles/buttonStyles.js
+++ b/graylog2-web-interface/src/components/graylog/styles/buttonStyles.js
@@ -34,11 +34,11 @@ const buttonStyles = ({ colors, utils }) => {
 
     const hoverBackground = mixColor(defaultBackground);
     const hoverBorderColor = mixColor(defaultBorder);
-    const hoverColor = mixColor(defaultBorder);
+    const hoverColor = mixColor(defaultColor);
 
     const activeHoverBackground = mixColor(activeBackground);
     const activeHoverBorderColor = mixColor(activeBorder);
-    const activeHoverColor = mixColor(activeBorder);
+    const activeHoverColor = mixColor(activeColor);
 
     return css`
       &.btn-${variant} {

--- a/graylog2-web-interface/src/components/grok-patterns/__snapshots__/EditPatternModal.test.jsx.snap
+++ b/graylog2-web-interface/src/components/grok-patterns/__snapshots__/EditPatternModal.test.jsx.snap
@@ -13,34 +13,29 @@ exports[`<EditPatternModal /> should render a modal button with as create 1`] = 
   validPatternName={[Function]}
 >
   <span>
-    <ForwardRef
+    <Button
       bsStyle="success"
       onClick={[Function]}
     >
-      <Button__StyledButton
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
         bsStyle="success"
+        className="Button-c9cbmb-0 bNulii"
+        disabled={false}
         onClick={[Function]}
       >
-        <Button
-          active={false}
-          block={false}
-          bsClass="btn"
-          bsStyle="success"
-          className="Button__StyledButton-c9cbmb-0 laZUlH"
+        <button
+          className="Button-c9cbmb-0 bNulii btn btn-success"
           disabled={false}
           onClick={[Function]}
+          type="button"
         >
-          <button
-            className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-success"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
-          >
-            Create pattern
-          </button>
-        </Button>
-      </Button__StyledButton>
-    </ForwardRef>
+          Create pattern
+        </button>
+      </Button>
+    </Button>
     <BootstrapModalForm
       bsSize="large"
       cancelButtonText="Cancel"
@@ -145,39 +140,33 @@ exports[`<EditPatternModal /> should render a modal button with as edit 1`] = `
   validPatternName={[Function]}
 >
   <span>
-    <ForwardRef
+    <Button
       bsSize="xs"
       bsStyle="info"
       onClick={[Function]}
     >
-      <Button__StyledButton
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
         bsSize="xs"
         bsStyle="info"
+        className="Button-c9cbmb-0 bNulii"
+        disabled={false}
         onClick={[Function]}
       >
-        <Button
-          active={false}
-          block={false}
-          bsClass="btn"
-          bsSize="xs"
-          bsStyle="info"
-          className="Button__StyledButton-c9cbmb-0 laZUlH"
+        <button
+          className="Button-c9cbmb-0 bNulii btn btn-xs btn-info"
           disabled={false}
           onClick={[Function]}
+          type="button"
         >
-          <button
-            className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-xs btn-info"
-            disabled={false}
-            onClick={[Function]}
-            type="button"
-          >
-            <span>
-              Edit
-            </span>
-          </button>
-        </Button>
-      </Button__StyledButton>
-    </ForwardRef>
+          <span>
+            Edit
+          </span>
+        </button>
+      </Button>
+    </Button>
     <BootstrapModalForm
       bsSize="large"
       cancelButtonText="Cancel"

--- a/graylog2-web-interface/src/components/grok-patterns/__snapshots__/GrokPatternFilter.test.jsx.snap
+++ b/graylog2-web-interface/src/components/grok-patterns/__snapshots__/GrokPatternFilter.test.jsx.snap
@@ -166,37 +166,31 @@ exports[`<GrokPatternFilter /> should render grok pattern input with patterns 1`
                   <span
                     className="addButton"
                   >
-                    <ForwardRef
+                    <Button
                       bsSize="xsmall"
                       bsStyle="primary"
                       onClick={[Function]}
                     >
-                      <Button__StyledButton
+                      <Button
+                        active={false}
+                        block={false}
+                        bsClass="btn"
                         bsSize="xsmall"
                         bsStyle="primary"
+                        className="Button-c9cbmb-0 bNulii"
+                        disabled={false}
                         onClick={[Function]}
                       >
-                        <Button
-                          active={false}
-                          block={false}
-                          bsClass="btn"
-                          bsSize="xsmall"
-                          bsStyle="primary"
-                          className="Button__StyledButton-c9cbmb-0 laZUlH"
+                        <button
+                          className="Button-c9cbmb-0 bNulii btn btn-xs btn-primary"
                           disabled={false}
                           onClick={[Function]}
+                          type="button"
                         >
-                          <button
-                            className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-xs btn-primary"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="button"
-                          >
-                            Add
-                          </button>
-                        </Button>
-                      </Button__StyledButton>
-                    </ForwardRef>
+                          Add
+                        </button>
+                      </Button>
+                    </Button>
                   </span>
                 </p>
               </span>
@@ -243,37 +237,31 @@ exports[`<GrokPatternFilter /> should render grok pattern input with patterns 1`
                   <span
                     className="addButton"
                   >
-                    <ForwardRef
+                    <Button
                       bsSize="xsmall"
                       bsStyle="primary"
                       onClick={[Function]}
                     >
-                      <Button__StyledButton
+                      <Button
+                        active={false}
+                        block={false}
+                        bsClass="btn"
                         bsSize="xsmall"
                         bsStyle="primary"
+                        className="Button-c9cbmb-0 bNulii"
+                        disabled={false}
                         onClick={[Function]}
                       >
-                        <Button
-                          active={false}
-                          block={false}
-                          bsClass="btn"
-                          bsSize="xsmall"
-                          bsStyle="primary"
-                          className="Button__StyledButton-c9cbmb-0 laZUlH"
+                        <button
+                          className="Button-c9cbmb-0 bNulii btn btn-xs btn-primary"
                           disabled={false}
                           onClick={[Function]}
+                          type="button"
                         >
-                          <button
-                            className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-xs btn-primary"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="button"
-                          >
-                            Add
-                          </button>
-                        </Button>
-                      </Button__StyledButton>
-                    </ForwardRef>
+                          Add
+                        </button>
+                      </Button>
+                    </Button>
                   </span>
                 </p>
               </span>
@@ -320,37 +308,31 @@ exports[`<GrokPatternFilter /> should render grok pattern input with patterns 1`
                   <span
                     className="addButton"
                   >
-                    <ForwardRef
+                    <Button
                       bsSize="xsmall"
                       bsStyle="primary"
                       onClick={[Function]}
                     >
-                      <Button__StyledButton
+                      <Button
+                        active={false}
+                        block={false}
+                        bsClass="btn"
                         bsSize="xsmall"
                         bsStyle="primary"
+                        className="Button-c9cbmb-0 bNulii"
+                        disabled={false}
                         onClick={[Function]}
                       >
-                        <Button
-                          active={false}
-                          block={false}
-                          bsClass="btn"
-                          bsSize="xsmall"
-                          bsStyle="primary"
-                          className="Button__StyledButton-c9cbmb-0 laZUlH"
+                        <button
+                          className="Button-c9cbmb-0 bNulii btn btn-xs btn-primary"
                           disabled={false}
                           onClick={[Function]}
+                          type="button"
                         >
-                          <button
-                            className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-xs btn-primary"
-                            disabled={false}
-                            onClick={[Function]}
-                            type="button"
-                          >
-                            Add
-                          </button>
-                        </Button>
-                      </Button__StyledButton>
-                    </ForwardRef>
+                          Add
+                        </button>
+                      </Button>
+                    </Button>
                   </span>
                 </p>
               </span>

--- a/graylog2-web-interface/src/components/grok-patterns/__snapshots__/GrokPatternInput.test.jsx.snap
+++ b/graylog2-web-interface/src/components/grok-patterns/__snapshots__/GrokPatternInput.test.jsx.snap
@@ -322,37 +322,31 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
                               <span
                                 className="addButton"
                               >
-                                <ForwardRef
+                                <Button
                                   bsSize="xsmall"
                                   bsStyle="primary"
                                   onClick={[Function]}
                                 >
-                                  <Button__StyledButton
+                                  <Button
+                                    active={false}
+                                    block={false}
+                                    bsClass="btn"
                                     bsSize="xsmall"
                                     bsStyle="primary"
+                                    className="Button-c9cbmb-0 bNulii"
+                                    disabled={false}
                                     onClick={[Function]}
                                   >
-                                    <Button
-                                      active={false}
-                                      block={false}
-                                      bsClass="btn"
-                                      bsSize="xsmall"
-                                      bsStyle="primary"
-                                      className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                    <button
+                                      className="Button-c9cbmb-0 bNulii btn btn-xs btn-primary"
                                       disabled={false}
                                       onClick={[Function]}
+                                      type="button"
                                     >
-                                      <button
-                                        className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-xs btn-primary"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        Add
-                                      </button>
-                                    </Button>
-                                  </Button__StyledButton>
-                                </ForwardRef>
+                                      Add
+                                    </button>
+                                  </Button>
+                                </Button>
                               </span>
                             </p>
                           </span>
@@ -399,37 +393,31 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
                               <span
                                 className="addButton"
                               >
-                                <ForwardRef
+                                <Button
                                   bsSize="xsmall"
                                   bsStyle="primary"
                                   onClick={[Function]}
                                 >
-                                  <Button__StyledButton
+                                  <Button
+                                    active={false}
+                                    block={false}
+                                    bsClass="btn"
                                     bsSize="xsmall"
                                     bsStyle="primary"
+                                    className="Button-c9cbmb-0 bNulii"
+                                    disabled={false}
                                     onClick={[Function]}
                                   >
-                                    <Button
-                                      active={false}
-                                      block={false}
-                                      bsClass="btn"
-                                      bsSize="xsmall"
-                                      bsStyle="primary"
-                                      className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                    <button
+                                      className="Button-c9cbmb-0 bNulii btn btn-xs btn-primary"
                                       disabled={false}
                                       onClick={[Function]}
+                                      type="button"
                                     >
-                                      <button
-                                        className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-xs btn-primary"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        Add
-                                      </button>
-                                    </Button>
-                                  </Button__StyledButton>
-                                </ForwardRef>
+                                      Add
+                                    </button>
+                                  </Button>
+                                </Button>
                               </span>
                             </p>
                           </span>
@@ -476,37 +464,31 @@ exports[`<GrokPatternInput /> should render grok pattern input with patterns 1`]
                               <span
                                 className="addButton"
                               >
-                                <ForwardRef
+                                <Button
                                   bsSize="xsmall"
                                   bsStyle="primary"
                                   onClick={[Function]}
                                 >
-                                  <Button__StyledButton
+                                  <Button
+                                    active={false}
+                                    block={false}
+                                    bsClass="btn"
                                     bsSize="xsmall"
                                     bsStyle="primary"
+                                    className="Button-c9cbmb-0 bNulii"
+                                    disabled={false}
                                     onClick={[Function]}
                                   >
-                                    <Button
-                                      active={false}
-                                      block={false}
-                                      bsClass="btn"
-                                      bsSize="xsmall"
-                                      bsStyle="primary"
-                                      className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                    <button
+                                      className="Button-c9cbmb-0 bNulii btn btn-xs btn-primary"
                                       disabled={false}
                                       onClick={[Function]}
+                                      type="button"
                                     >
-                                      <button
-                                        className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-xs btn-primary"
-                                        disabled={false}
-                                        onClick={[Function]}
-                                        type="button"
-                                      >
-                                        Add
-                                      </button>
-                                    </Button>
-                                  </Button__StyledButton>
-                                </ForwardRef>
+                                      Add
+                                    </button>
+                                  </Button>
+                                </Button>
                               </span>
                             </p>
                           </span>

--- a/graylog2-web-interface/src/components/lookup-tables/adapters/__snapshots__/HTTPJSONPathAdapterFieldSet.test.jsx.snap
+++ b/graylog2-web-interface/src/components/lookup-tables/adapters/__snapshots__/HTTPJSONPathAdapterFieldSet.test.jsx.snap
@@ -158,7 +158,7 @@ exports[`HTTPJSONPathAdapterFieldSet should render the field set 1`] = `
                   </td>
                   <td>
                     <button
-                      class="Button__StyledButton-c9cbmb-0 laZUlH btn btn-xs btn-danger"
+                      class="Button-c9cbmb-0 bNulii btn btn-xs btn-danger"
                       type="button"
                     >
                       Delete
@@ -208,7 +208,7 @@ exports[`HTTPJSONPathAdapterFieldSet should render the field set 1`] = `
                   </td>
                   <td>
                     <button
-                      class="Button__StyledButton-c9cbmb-0 laZUlH btn btn-sm btn-success"
+                      class="Button-c9cbmb-0 bNulii btn btn-sm btn-success"
                       disabled=""
                       type="button"
                     >

--- a/graylog2-web-interface/src/components/streamrules/__snapshots__/StreamRuleForm.test.jsx.snap
+++ b/graylog2-web-interface/src/components/streamrules/__snapshots__/StreamRuleForm.test.jsx.snap
@@ -258,13 +258,13 @@ Object {
                 class="modal-footer"
               >
                 <button
-                  class="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
+                  class="Button-c9cbmb-0 bNulii btn btn-default"
                   type="button"
                 >
                   Cancel
                 </button>
                 <button
-                  class="Button__StyledButton-c9cbmb-0 laZUlH btn btn-primary"
+                  class="Button-c9cbmb-0 bNulii btn btn-primary"
                   type="submit"
                 >
                   Save
@@ -595,13 +595,13 @@ Object {
                 class="modal-footer"
               >
                 <button
-                  class="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
+                  class="Button-c9cbmb-0 bNulii btn btn-default"
                   type="button"
                 >
                   Cancel
                 </button>
                 <button
-                  class="Button__StyledButton-c9cbmb-0 laZUlH btn btn-primary"
+                  class="Button-c9cbmb-0 bNulii btn btn-primary"
                   type="submit"
                 >
                   Save

--- a/graylog2-web-interface/src/components/users/__snapshots__/PermissionSelector.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/PermissionSelector.test.jsx.snap
@@ -380,7 +380,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                       </Component>
                                                     </Input>
                                                   </TypeAheadInput>
-                                                  <ForwardRef
+                                                  <Button
                                                     style={
                                                       Object {
                                                         "marginLeft": 5,
@@ -388,7 +388,13 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                     }
                                                     type="submit"
                                                   >
-                                                    <Button__StyledButton
+                                                    <Button
+                                                      active={false}
+                                                      block={false}
+                                                      bsClass="btn"
+                                                      bsStyle="default"
+                                                      className="Button-c9cbmb-0 bNulii"
+                                                      disabled={false}
                                                       style={
                                                         Object {
                                                           "marginLeft": 5,
@@ -396,12 +402,8 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                       }
                                                       type="submit"
                                                     >
-                                                      <Button
-                                                        active={false}
-                                                        block={false}
-                                                        bsClass="btn"
-                                                        bsStyle="default"
-                                                        className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                      <button
+                                                        className="Button-c9cbmb-0 bNulii btn btn-default"
                                                         disabled={false}
                                                         style={
                                                           Object {
@@ -410,22 +412,11 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                         }
                                                         type="submit"
                                                       >
-                                                        <button
-                                                          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                                          disabled={false}
-                                                          style={
-                                                            Object {
-                                                              "marginLeft": 5,
-                                                            }
-                                                          }
-                                                          type="submit"
-                                                        >
-                                                          Filter
-                                                        </button>
-                                                      </Button>
-                                                    </Button__StyledButton>
-                                                  </ForwardRef>
-                                                  <ForwardRef
+                                                        Filter
+                                                      </button>
+                                                    </Button>
+                                                  </Button>
+                                                  <Button
                                                     disabled={true}
                                                     onClick={[Function]}
                                                     style={
@@ -435,7 +426,12 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                     }
                                                     type="button"
                                                   >
-                                                    <Button__StyledButton
+                                                    <Button
+                                                      active={false}
+                                                      block={false}
+                                                      bsClass="btn"
+                                                      bsStyle="default"
+                                                      className="Button-c9cbmb-0 bNulii"
                                                       disabled={true}
                                                       onClick={[Function]}
                                                       style={
@@ -445,12 +441,8 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                       }
                                                       type="button"
                                                     >
-                                                      <Button
-                                                        active={false}
-                                                        block={false}
-                                                        bsClass="btn"
-                                                        bsStyle="default"
-                                                        className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                      <button
+                                                        className="Button-c9cbmb-0 bNulii btn btn-default"
                                                         disabled={true}
                                                         onClick={[Function]}
                                                         style={
@@ -460,22 +452,10 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                         }
                                                         type="button"
                                                       >
-                                                        <button
-                                                          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                                          disabled={true}
-                                                          onClick={[Function]}
-                                                          style={
-                                                            Object {
-                                                              "marginLeft": 5,
-                                                            }
-                                                          }
-                                                          type="button"
-                                                        >
-                                                          Reset
-                                                        </button>
-                                                      </Button>
-                                                    </Button__StyledButton>
-                                                  </ForwardRef>
+                                                        Reset
+                                                      </button>
+                                                    </Button>
+                                                  </Button>
                                                 </form>
                                                 <ul
                                                   className="pill-list"
@@ -625,66 +605,54 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                             <div
                                                               className="btn-group btn-group-sm"
                                                             >
-                                                              <ForwardRef
+                                                              <Button
                                                                 active={false}
                                                                 bsStyle="default"
                                                                 onClick={[Function]}
                                                               >
-                                                                <Button__StyledButton
+                                                                <Button
                                                                   active={false}
+                                                                  block={false}
+                                                                  bsClass="btn"
                                                                   bsStyle="default"
+                                                                  className="Button-c9cbmb-0 bNulii"
+                                                                  disabled={false}
                                                                   onClick={[Function]}
                                                                 >
-                                                                  <Button
-                                                                    active={false}
-                                                                    block={false}
-                                                                    bsClass="btn"
-                                                                    bsStyle="default"
-                                                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                                  <button
+                                                                    className="Button-c9cbmb-0 bNulii btn btn-default"
                                                                     disabled={false}
                                                                     onClick={[Function]}
+                                                                    type="button"
                                                                   >
-                                                                    <button
-                                                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                                                      disabled={false}
-                                                                      onClick={[Function]}
-                                                                      type="button"
-                                                                    >
-                                                                      Allow reading
-                                                                    </button>
-                                                                  </Button>
-                                                                </Button__StyledButton>
-                                                              </ForwardRef>
-                                                              <ForwardRef
+                                                                    Allow reading
+                                                                  </button>
+                                                                </Button>
+                                                              </Button>
+                                                              <Button
                                                                 active={false}
                                                                 bsStyle="default"
                                                                 onClick={[Function]}
                                                               >
-                                                                <Button__StyledButton
+                                                                <Button
                                                                   active={false}
+                                                                  block={false}
+                                                                  bsClass="btn"
                                                                   bsStyle="default"
+                                                                  className="Button-c9cbmb-0 bNulii"
+                                                                  disabled={false}
                                                                   onClick={[Function]}
                                                                 >
-                                                                  <Button
-                                                                    active={false}
-                                                                    block={false}
-                                                                    bsClass="btn"
-                                                                    bsStyle="default"
-                                                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                                  <button
+                                                                    className="Button-c9cbmb-0 bNulii btn btn-default"
                                                                     disabled={false}
                                                                     onClick={[Function]}
+                                                                    type="button"
                                                                   >
-                                                                    <button
-                                                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                                                      disabled={false}
-                                                                      onClick={[Function]}
-                                                                      type="button"
-                                                                    >
-                                                                      Allow editing
-                                                                    </button>
-                                                                  </Button>
-                                                                </Button__StyledButton>
-                                                              </ForwardRef>
+                                                                    Allow editing
+                                                                  </button>
+                                                                </Button>
+                                                              </Button>
                                                             </div>
                                                           </ButtonGroup>
                                                         </div>
@@ -802,66 +770,54 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                             <div
                                                               className="btn-group btn-group-sm"
                                                             >
-                                                              <ForwardRef
+                                                              <Button
                                                                 active={false}
                                                                 bsStyle="default"
                                                                 onClick={[Function]}
                                                               >
-                                                                <Button__StyledButton
+                                                                <Button
                                                                   active={false}
+                                                                  block={false}
+                                                                  bsClass="btn"
                                                                   bsStyle="default"
+                                                                  className="Button-c9cbmb-0 bNulii"
+                                                                  disabled={false}
                                                                   onClick={[Function]}
                                                                 >
-                                                                  <Button
-                                                                    active={false}
-                                                                    block={false}
-                                                                    bsClass="btn"
-                                                                    bsStyle="default"
-                                                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                                  <button
+                                                                    className="Button-c9cbmb-0 bNulii btn btn-default"
                                                                     disabled={false}
                                                                     onClick={[Function]}
+                                                                    type="button"
                                                                   >
-                                                                    <button
-                                                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                                                      disabled={false}
-                                                                      onClick={[Function]}
-                                                                      type="button"
-                                                                    >
-                                                                      Allow reading
-                                                                    </button>
-                                                                  </Button>
-                                                                </Button__StyledButton>
-                                                              </ForwardRef>
-                                                              <ForwardRef
+                                                                    Allow reading
+                                                                  </button>
+                                                                </Button>
+                                                              </Button>
+                                                              <Button
                                                                 active={false}
                                                                 bsStyle="default"
                                                                 onClick={[Function]}
                                                               >
-                                                                <Button__StyledButton
+                                                                <Button
                                                                   active={false}
+                                                                  block={false}
+                                                                  bsClass="btn"
                                                                   bsStyle="default"
+                                                                  className="Button-c9cbmb-0 bNulii"
+                                                                  disabled={false}
                                                                   onClick={[Function]}
                                                                 >
-                                                                  <Button
-                                                                    active={false}
-                                                                    block={false}
-                                                                    bsClass="btn"
-                                                                    bsStyle="default"
-                                                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                                  <button
+                                                                    className="Button-c9cbmb-0 bNulii btn btn-default"
                                                                     disabled={false}
                                                                     onClick={[Function]}
+                                                                    type="button"
                                                                   >
-                                                                    <button
-                                                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                                                      disabled={false}
-                                                                      onClick={[Function]}
-                                                                      type="button"
-                                                                    >
-                                                                      Allow editing
-                                                                    </button>
-                                                                  </Button>
-                                                                </Button__StyledButton>
-                                                              </ForwardRef>
+                                                                    Allow editing
+                                                                  </button>
+                                                                </Button>
+                                                              </Button>
                                                             </div>
                                                           </ButtonGroup>
                                                         </div>
@@ -1165,7 +1121,7 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                       </Component>
                                                     </Input>
                                                   </TypeAheadInput>
-                                                  <ForwardRef
+                                                  <Button
                                                     style={
                                                       Object {
                                                         "marginLeft": 5,
@@ -1173,7 +1129,13 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                     }
                                                     type="submit"
                                                   >
-                                                    <Button__StyledButton
+                                                    <Button
+                                                      active={false}
+                                                      block={false}
+                                                      bsClass="btn"
+                                                      bsStyle="default"
+                                                      className="Button-c9cbmb-0 bNulii"
+                                                      disabled={false}
                                                       style={
                                                         Object {
                                                           "marginLeft": 5,
@@ -1181,12 +1143,8 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                       }
                                                       type="submit"
                                                     >
-                                                      <Button
-                                                        active={false}
-                                                        block={false}
-                                                        bsClass="btn"
-                                                        bsStyle="default"
-                                                        className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                      <button
+                                                        className="Button-c9cbmb-0 bNulii btn btn-default"
                                                         disabled={false}
                                                         style={
                                                           Object {
@@ -1195,22 +1153,11 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                         }
                                                         type="submit"
                                                       >
-                                                        <button
-                                                          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                                          disabled={false}
-                                                          style={
-                                                            Object {
-                                                              "marginLeft": 5,
-                                                            }
-                                                          }
-                                                          type="submit"
-                                                        >
-                                                          Filter
-                                                        </button>
-                                                      </Button>
-                                                    </Button__StyledButton>
-                                                  </ForwardRef>
-                                                  <ForwardRef
+                                                        Filter
+                                                      </button>
+                                                    </Button>
+                                                  </Button>
+                                                  <Button
                                                     disabled={true}
                                                     onClick={[Function]}
                                                     style={
@@ -1220,7 +1167,12 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                     }
                                                     type="button"
                                                   >
-                                                    <Button__StyledButton
+                                                    <Button
+                                                      active={false}
+                                                      block={false}
+                                                      bsClass="btn"
+                                                      bsStyle="default"
+                                                      className="Button-c9cbmb-0 bNulii"
                                                       disabled={true}
                                                       onClick={[Function]}
                                                       style={
@@ -1230,12 +1182,8 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                       }
                                                       type="button"
                                                     >
-                                                      <Button
-                                                        active={false}
-                                                        block={false}
-                                                        bsClass="btn"
-                                                        bsStyle="default"
-                                                        className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                      <button
+                                                        className="Button-c9cbmb-0 bNulii btn btn-default"
                                                         disabled={true}
                                                         onClick={[Function]}
                                                         style={
@@ -1245,22 +1193,10 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                         }
                                                         type="button"
                                                       >
-                                                        <button
-                                                          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                                          disabled={true}
-                                                          onClick={[Function]}
-                                                          style={
-                                                            Object {
-                                                              "marginLeft": 5,
-                                                            }
-                                                          }
-                                                          type="button"
-                                                        >
-                                                          Reset
-                                                        </button>
-                                                      </Button>
-                                                    </Button__StyledButton>
-                                                  </ForwardRef>
+                                                        Reset
+                                                      </button>
+                                                    </Button>
+                                                  </Button>
                                                 </form>
                                                 <ul
                                                   className="pill-list"
@@ -1410,66 +1346,54 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                             <div
                                                               className="btn-group btn-group-sm"
                                                             >
-                                                              <ForwardRef
+                                                              <Button
                                                                 active={false}
                                                                 bsStyle="default"
                                                                 onClick={[Function]}
                                                               >
-                                                                <Button__StyledButton
+                                                                <Button
                                                                   active={false}
+                                                                  block={false}
+                                                                  bsClass="btn"
                                                                   bsStyle="default"
+                                                                  className="Button-c9cbmb-0 bNulii"
+                                                                  disabled={false}
                                                                   onClick={[Function]}
                                                                 >
-                                                                  <Button
-                                                                    active={false}
-                                                                    block={false}
-                                                                    bsClass="btn"
-                                                                    bsStyle="default"
-                                                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                                  <button
+                                                                    className="Button-c9cbmb-0 bNulii btn btn-default"
                                                                     disabled={false}
                                                                     onClick={[Function]}
+                                                                    type="button"
                                                                   >
-                                                                    <button
-                                                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                                                      disabled={false}
-                                                                      onClick={[Function]}
-                                                                      type="button"
-                                                                    >
-                                                                      Allow reading
-                                                                    </button>
-                                                                  </Button>
-                                                                </Button__StyledButton>
-                                                              </ForwardRef>
-                                                              <ForwardRef
+                                                                    Allow reading
+                                                                  </button>
+                                                                </Button>
+                                                              </Button>
+                                                              <Button
                                                                 active={false}
                                                                 bsStyle="default"
                                                                 onClick={[Function]}
                                                               >
-                                                                <Button__StyledButton
+                                                                <Button
                                                                   active={false}
+                                                                  block={false}
+                                                                  bsClass="btn"
                                                                   bsStyle="default"
+                                                                  className="Button-c9cbmb-0 bNulii"
+                                                                  disabled={false}
                                                                   onClick={[Function]}
                                                                 >
-                                                                  <Button
-                                                                    active={false}
-                                                                    block={false}
-                                                                    bsClass="btn"
-                                                                    bsStyle="default"
-                                                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                                  <button
+                                                                    className="Button-c9cbmb-0 bNulii btn btn-default"
                                                                     disabled={false}
                                                                     onClick={[Function]}
+                                                                    type="button"
                                                                   >
-                                                                    <button
-                                                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                                                      disabled={false}
-                                                                      onClick={[Function]}
-                                                                      type="button"
-                                                                    >
-                                                                      Allow editing
-                                                                    </button>
-                                                                  </Button>
-                                                                </Button__StyledButton>
-                                                              </ForwardRef>
+                                                                    Allow editing
+                                                                  </button>
+                                                                </Button>
+                                                              </Button>
                                                             </div>
                                                           </ButtonGroup>
                                                         </div>
@@ -1587,66 +1511,54 @@ exports[`<PermissionSelector /> should render with empty permissions 1`] = `
                                                             <div
                                                               className="btn-group btn-group-sm"
                                                             >
-                                                              <ForwardRef
+                                                              <Button
                                                                 active={false}
                                                                 bsStyle="default"
                                                                 onClick={[Function]}
                                                               >
-                                                                <Button__StyledButton
+                                                                <Button
                                                                   active={false}
+                                                                  block={false}
+                                                                  bsClass="btn"
                                                                   bsStyle="default"
+                                                                  className="Button-c9cbmb-0 bNulii"
+                                                                  disabled={false}
                                                                   onClick={[Function]}
                                                                 >
-                                                                  <Button
-                                                                    active={false}
-                                                                    block={false}
-                                                                    bsClass="btn"
-                                                                    bsStyle="default"
-                                                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                                  <button
+                                                                    className="Button-c9cbmb-0 bNulii btn btn-default"
                                                                     disabled={false}
                                                                     onClick={[Function]}
+                                                                    type="button"
                                                                   >
-                                                                    <button
-                                                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                                                      disabled={false}
-                                                                      onClick={[Function]}
-                                                                      type="button"
-                                                                    >
-                                                                      Allow reading
-                                                                    </button>
-                                                                  </Button>
-                                                                </Button__StyledButton>
-                                                              </ForwardRef>
-                                                              <ForwardRef
+                                                                    Allow reading
+                                                                  </button>
+                                                                </Button>
+                                                              </Button>
+                                                              <Button
                                                                 active={false}
                                                                 bsStyle="default"
                                                                 onClick={[Function]}
                                                               >
-                                                                <Button__StyledButton
+                                                                <Button
                                                                   active={false}
+                                                                  block={false}
+                                                                  bsClass="btn"
                                                                   bsStyle="default"
+                                                                  className="Button-c9cbmb-0 bNulii"
+                                                                  disabled={false}
                                                                   onClick={[Function]}
                                                                 >
-                                                                  <Button
-                                                                    active={false}
-                                                                    block={false}
-                                                                    bsClass="btn"
-                                                                    bsStyle="default"
-                                                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                                  <button
+                                                                    className="Button-c9cbmb-0 bNulii btn btn-default"
                                                                     disabled={false}
                                                                     onClick={[Function]}
+                                                                    type="button"
                                                                   >
-                                                                    <button
-                                                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                                                      disabled={false}
-                                                                      onClick={[Function]}
-                                                                      type="button"
-                                                                    >
-                                                                      Allow editing
-                                                                    </button>
-                                                                  </Button>
-                                                                </Button__StyledButton>
-                                                              </ForwardRef>
+                                                                    Allow editing
+                                                                  </button>
+                                                                </Button>
+                                                              </Button>
                                                             </div>
                                                           </ButtonGroup>
                                                         </div>
@@ -2145,7 +2057,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                       </Component>
                                                     </Input>
                                                   </TypeAheadInput>
-                                                  <ForwardRef
+                                                  <Button
                                                     style={
                                                       Object {
                                                         "marginLeft": 5,
@@ -2153,7 +2065,13 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                     }
                                                     type="submit"
                                                   >
-                                                    <Button__StyledButton
+                                                    <Button
+                                                      active={false}
+                                                      block={false}
+                                                      bsClass="btn"
+                                                      bsStyle="default"
+                                                      className="Button-c9cbmb-0 bNulii"
+                                                      disabled={false}
                                                       style={
                                                         Object {
                                                           "marginLeft": 5,
@@ -2161,12 +2079,8 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                       }
                                                       type="submit"
                                                     >
-                                                      <Button
-                                                        active={false}
-                                                        block={false}
-                                                        bsClass="btn"
-                                                        bsStyle="default"
-                                                        className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                      <button
+                                                        className="Button-c9cbmb-0 bNulii btn btn-default"
                                                         disabled={false}
                                                         style={
                                                           Object {
@@ -2175,22 +2089,11 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                         }
                                                         type="submit"
                                                       >
-                                                        <button
-                                                          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                                          disabled={false}
-                                                          style={
-                                                            Object {
-                                                              "marginLeft": 5,
-                                                            }
-                                                          }
-                                                          type="submit"
-                                                        >
-                                                          Filter
-                                                        </button>
-                                                      </Button>
-                                                    </Button__StyledButton>
-                                                  </ForwardRef>
-                                                  <ForwardRef
+                                                        Filter
+                                                      </button>
+                                                    </Button>
+                                                  </Button>
+                                                  <Button
                                                     disabled={true}
                                                     onClick={[Function]}
                                                     style={
@@ -2200,7 +2103,12 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                     }
                                                     type="button"
                                                   >
-                                                    <Button__StyledButton
+                                                    <Button
+                                                      active={false}
+                                                      block={false}
+                                                      bsClass="btn"
+                                                      bsStyle="default"
+                                                      className="Button-c9cbmb-0 bNulii"
                                                       disabled={true}
                                                       onClick={[Function]}
                                                       style={
@@ -2210,12 +2118,8 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                       }
                                                       type="button"
                                                     >
-                                                      <Button
-                                                        active={false}
-                                                        block={false}
-                                                        bsClass="btn"
-                                                        bsStyle="default"
-                                                        className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                      <button
+                                                        className="Button-c9cbmb-0 bNulii btn btn-default"
                                                         disabled={true}
                                                         onClick={[Function]}
                                                         style={
@@ -2225,22 +2129,10 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                         }
                                                         type="button"
                                                       >
-                                                        <button
-                                                          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                                          disabled={true}
-                                                          onClick={[Function]}
-                                                          style={
-                                                            Object {
-                                                              "marginLeft": 5,
-                                                            }
-                                                          }
-                                                          type="button"
-                                                        >
-                                                          Reset
-                                                        </button>
-                                                      </Button>
-                                                    </Button__StyledButton>
-                                                  </ForwardRef>
+                                                        Reset
+                                                      </button>
+                                                    </Button>
+                                                  </Button>
                                                 </form>
                                                 <ul
                                                   className="pill-list"
@@ -2390,66 +2282,54 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                             <div
                                                               className="btn-group btn-group-sm"
                                                             >
-                                                              <ForwardRef
+                                                              <Button
                                                                 active={true}
                                                                 bsStyle="info"
                                                                 onClick={[Function]}
                                                               >
-                                                                <Button__StyledButton
+                                                                <Button
                                                                   active={true}
+                                                                  block={false}
+                                                                  bsClass="btn"
                                                                   bsStyle="info"
+                                                                  className="Button-c9cbmb-0 bNulii"
+                                                                  disabled={false}
                                                                   onClick={[Function]}
                                                                 >
-                                                                  <Button
-                                                                    active={true}
-                                                                    block={false}
-                                                                    bsClass="btn"
-                                                                    bsStyle="info"
-                                                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                                  <button
+                                                                    className="Button-c9cbmb-0 bNulii btn btn-info active"
                                                                     disabled={false}
                                                                     onClick={[Function]}
+                                                                    type="button"
                                                                   >
-                                                                    <button
-                                                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-info active"
-                                                                      disabled={false}
-                                                                      onClick={[Function]}
-                                                                      type="button"
-                                                                    >
-                                                                      Allow reading
-                                                                    </button>
-                                                                  </Button>
-                                                                </Button__StyledButton>
-                                                              </ForwardRef>
-                                                              <ForwardRef
+                                                                    Allow reading
+                                                                  </button>
+                                                                </Button>
+                                                              </Button>
+                                                              <Button
                                                                 active={false}
                                                                 bsStyle="default"
                                                                 onClick={[Function]}
                                                               >
-                                                                <Button__StyledButton
+                                                                <Button
                                                                   active={false}
+                                                                  block={false}
+                                                                  bsClass="btn"
                                                                   bsStyle="default"
+                                                                  className="Button-c9cbmb-0 bNulii"
+                                                                  disabled={false}
                                                                   onClick={[Function]}
                                                                 >
-                                                                  <Button
-                                                                    active={false}
-                                                                    block={false}
-                                                                    bsClass="btn"
-                                                                    bsStyle="default"
-                                                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                                  <button
+                                                                    className="Button-c9cbmb-0 bNulii btn btn-default"
                                                                     disabled={false}
                                                                     onClick={[Function]}
+                                                                    type="button"
                                                                   >
-                                                                    <button
-                                                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                                                      disabled={false}
-                                                                      onClick={[Function]}
-                                                                      type="button"
-                                                                    >
-                                                                      Allow editing
-                                                                    </button>
-                                                                  </Button>
-                                                                </Button__StyledButton>
-                                                              </ForwardRef>
+                                                                    Allow editing
+                                                                  </button>
+                                                                </Button>
+                                                              </Button>
                                                             </div>
                                                           </ButtonGroup>
                                                         </div>
@@ -2567,66 +2447,54 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                             <div
                                                               className="btn-group btn-group-sm"
                                                             >
-                                                              <ForwardRef
+                                                              <Button
                                                                 active={false}
                                                                 bsStyle="default"
                                                                 onClick={[Function]}
                                                               >
-                                                                <Button__StyledButton
+                                                                <Button
                                                                   active={false}
+                                                                  block={false}
+                                                                  bsClass="btn"
                                                                   bsStyle="default"
+                                                                  className="Button-c9cbmb-0 bNulii"
+                                                                  disabled={false}
                                                                   onClick={[Function]}
                                                                 >
-                                                                  <Button
-                                                                    active={false}
-                                                                    block={false}
-                                                                    bsClass="btn"
-                                                                    bsStyle="default"
-                                                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                                  <button
+                                                                    className="Button-c9cbmb-0 bNulii btn btn-default"
                                                                     disabled={false}
                                                                     onClick={[Function]}
+                                                                    type="button"
                                                                   >
-                                                                    <button
-                                                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                                                      disabled={false}
-                                                                      onClick={[Function]}
-                                                                      type="button"
-                                                                    >
-                                                                      Allow reading
-                                                                    </button>
-                                                                  </Button>
-                                                                </Button__StyledButton>
-                                                              </ForwardRef>
-                                                              <ForwardRef
+                                                                    Allow reading
+                                                                  </button>
+                                                                </Button>
+                                                              </Button>
+                                                              <Button
                                                                 active={true}
                                                                 bsStyle="info"
                                                                 onClick={[Function]}
                                                               >
-                                                                <Button__StyledButton
+                                                                <Button
                                                                   active={true}
+                                                                  block={false}
+                                                                  bsClass="btn"
                                                                   bsStyle="info"
+                                                                  className="Button-c9cbmb-0 bNulii"
+                                                                  disabled={false}
                                                                   onClick={[Function]}
                                                                 >
-                                                                  <Button
-                                                                    active={true}
-                                                                    block={false}
-                                                                    bsClass="btn"
-                                                                    bsStyle="info"
-                                                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                                  <button
+                                                                    className="Button-c9cbmb-0 bNulii btn btn-info active"
                                                                     disabled={false}
                                                                     onClick={[Function]}
+                                                                    type="button"
                                                                   >
-                                                                    <button
-                                                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-info active"
-                                                                      disabled={false}
-                                                                      onClick={[Function]}
-                                                                      type="button"
-                                                                    >
-                                                                      Allow editing
-                                                                    </button>
-                                                                  </Button>
-                                                                </Button__StyledButton>
-                                                              </ForwardRef>
+                                                                    Allow editing
+                                                                  </button>
+                                                                </Button>
+                                                              </Button>
                                                             </div>
                                                           </ButtonGroup>
                                                         </div>
@@ -2930,7 +2798,7 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                       </Component>
                                                     </Input>
                                                   </TypeAheadInput>
-                                                  <ForwardRef
+                                                  <Button
                                                     style={
                                                       Object {
                                                         "marginLeft": 5,
@@ -2938,7 +2806,13 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                     }
                                                     type="submit"
                                                   >
-                                                    <Button__StyledButton
+                                                    <Button
+                                                      active={false}
+                                                      block={false}
+                                                      bsClass="btn"
+                                                      bsStyle="default"
+                                                      className="Button-c9cbmb-0 bNulii"
+                                                      disabled={false}
                                                       style={
                                                         Object {
                                                           "marginLeft": 5,
@@ -2946,12 +2820,8 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                       }
                                                       type="submit"
                                                     >
-                                                      <Button
-                                                        active={false}
-                                                        block={false}
-                                                        bsClass="btn"
-                                                        bsStyle="default"
-                                                        className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                      <button
+                                                        className="Button-c9cbmb-0 bNulii btn btn-default"
                                                         disabled={false}
                                                         style={
                                                           Object {
@@ -2960,22 +2830,11 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                         }
                                                         type="submit"
                                                       >
-                                                        <button
-                                                          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                                          disabled={false}
-                                                          style={
-                                                            Object {
-                                                              "marginLeft": 5,
-                                                            }
-                                                          }
-                                                          type="submit"
-                                                        >
-                                                          Filter
-                                                        </button>
-                                                      </Button>
-                                                    </Button__StyledButton>
-                                                  </ForwardRef>
-                                                  <ForwardRef
+                                                        Filter
+                                                      </button>
+                                                    </Button>
+                                                  </Button>
+                                                  <Button
                                                     disabled={true}
                                                     onClick={[Function]}
                                                     style={
@@ -2985,7 +2844,12 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                     }
                                                     type="button"
                                                   >
-                                                    <Button__StyledButton
+                                                    <Button
+                                                      active={false}
+                                                      block={false}
+                                                      bsClass="btn"
+                                                      bsStyle="default"
+                                                      className="Button-c9cbmb-0 bNulii"
                                                       disabled={true}
                                                       onClick={[Function]}
                                                       style={
@@ -2995,12 +2859,8 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                       }
                                                       type="button"
                                                     >
-                                                      <Button
-                                                        active={false}
-                                                        block={false}
-                                                        bsClass="btn"
-                                                        bsStyle="default"
-                                                        className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                      <button
+                                                        className="Button-c9cbmb-0 bNulii btn btn-default"
                                                         disabled={true}
                                                         onClick={[Function]}
                                                         style={
@@ -3010,22 +2870,10 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                         }
                                                         type="button"
                                                       >
-                                                        <button
-                                                          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                                          disabled={true}
-                                                          onClick={[Function]}
-                                                          style={
-                                                            Object {
-                                                              "marginLeft": 5,
-                                                            }
-                                                          }
-                                                          type="button"
-                                                        >
-                                                          Reset
-                                                        </button>
-                                                      </Button>
-                                                    </Button__StyledButton>
-                                                  </ForwardRef>
+                                                        Reset
+                                                      </button>
+                                                    </Button>
+                                                  </Button>
                                                 </form>
                                                 <ul
                                                   className="pill-list"
@@ -3175,66 +3023,54 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                             <div
                                                               className="btn-group btn-group-sm"
                                                             >
-                                                              <ForwardRef
+                                                              <Button
                                                                 active={false}
                                                                 bsStyle="default"
                                                                 onClick={[Function]}
                                                               >
-                                                                <Button__StyledButton
+                                                                <Button
                                                                   active={false}
+                                                                  block={false}
+                                                                  bsClass="btn"
                                                                   bsStyle="default"
+                                                                  className="Button-c9cbmb-0 bNulii"
+                                                                  disabled={false}
                                                                   onClick={[Function]}
                                                                 >
-                                                                  <Button
-                                                                    active={false}
-                                                                    block={false}
-                                                                    bsClass="btn"
-                                                                    bsStyle="default"
-                                                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                                  <button
+                                                                    className="Button-c9cbmb-0 bNulii btn btn-default"
                                                                     disabled={false}
                                                                     onClick={[Function]}
+                                                                    type="button"
                                                                   >
-                                                                    <button
-                                                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                                                      disabled={false}
-                                                                      onClick={[Function]}
-                                                                      type="button"
-                                                                    >
-                                                                      Allow reading
-                                                                    </button>
-                                                                  </Button>
-                                                                </Button__StyledButton>
-                                                              </ForwardRef>
-                                                              <ForwardRef
+                                                                    Allow reading
+                                                                  </button>
+                                                                </Button>
+                                                              </Button>
+                                                              <Button
                                                                 active={false}
                                                                 bsStyle="default"
                                                                 onClick={[Function]}
                                                               >
-                                                                <Button__StyledButton
+                                                                <Button
                                                                   active={false}
+                                                                  block={false}
+                                                                  bsClass="btn"
                                                                   bsStyle="default"
+                                                                  className="Button-c9cbmb-0 bNulii"
+                                                                  disabled={false}
                                                                   onClick={[Function]}
                                                                 >
-                                                                  <Button
-                                                                    active={false}
-                                                                    block={false}
-                                                                    bsClass="btn"
-                                                                    bsStyle="default"
-                                                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                                  <button
+                                                                    className="Button-c9cbmb-0 bNulii btn btn-default"
                                                                     disabled={false}
                                                                     onClick={[Function]}
+                                                                    type="button"
                                                                   >
-                                                                    <button
-                                                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                                                      disabled={false}
-                                                                      onClick={[Function]}
-                                                                      type="button"
-                                                                    >
-                                                                      Allow editing
-                                                                    </button>
-                                                                  </Button>
-                                                                </Button__StyledButton>
-                                                              </ForwardRef>
+                                                                    Allow editing
+                                                                  </button>
+                                                                </Button>
+                                                              </Button>
                                                             </div>
                                                           </ButtonGroup>
                                                         </div>
@@ -3352,66 +3188,54 @@ exports[`<PermissionSelector /> should render with set permissions 1`] = `
                                                             <div
                                                               className="btn-group btn-group-sm"
                                                             >
-                                                              <ForwardRef
+                                                              <Button
                                                                 active={true}
                                                                 bsStyle="info"
                                                                 onClick={[Function]}
                                                               >
-                                                                <Button__StyledButton
+                                                                <Button
                                                                   active={true}
+                                                                  block={false}
+                                                                  bsClass="btn"
                                                                   bsStyle="info"
+                                                                  className="Button-c9cbmb-0 bNulii"
+                                                                  disabled={false}
                                                                   onClick={[Function]}
                                                                 >
-                                                                  <Button
-                                                                    active={true}
-                                                                    block={false}
-                                                                    bsClass="btn"
-                                                                    bsStyle="info"
-                                                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                                  <button
+                                                                    className="Button-c9cbmb-0 bNulii btn btn-info active"
                                                                     disabled={false}
                                                                     onClick={[Function]}
+                                                                    type="button"
                                                                   >
-                                                                    <button
-                                                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-info active"
-                                                                      disabled={false}
-                                                                      onClick={[Function]}
-                                                                      type="button"
-                                                                    >
-                                                                      Allow reading
-                                                                    </button>
-                                                                  </Button>
-                                                                </Button__StyledButton>
-                                                              </ForwardRef>
-                                                              <ForwardRef
+                                                                    Allow reading
+                                                                  </button>
+                                                                </Button>
+                                                              </Button>
+                                                              <Button
                                                                 active={false}
                                                                 bsStyle="default"
                                                                 onClick={[Function]}
                                                               >
-                                                                <Button__StyledButton
+                                                                <Button
                                                                   active={false}
+                                                                  block={false}
+                                                                  bsClass="btn"
                                                                   bsStyle="default"
+                                                                  className="Button-c9cbmb-0 bNulii"
+                                                                  disabled={false}
                                                                   onClick={[Function]}
                                                                 >
-                                                                  <Button
-                                                                    active={false}
-                                                                    block={false}
-                                                                    bsClass="btn"
-                                                                    bsStyle="default"
-                                                                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                                                  <button
+                                                                    className="Button-c9cbmb-0 bNulii btn btn-default"
                                                                     disabled={false}
                                                                     onClick={[Function]}
+                                                                    type="button"
                                                                   >
-                                                                    <button
-                                                                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                                                      disabled={false}
-                                                                      onClick={[Function]}
-                                                                      type="button"
-                                                                    >
-                                                                      Allow editing
-                                                                    </button>
-                                                                  </Button>
-                                                                </Button__StyledButton>
-                                                              </ForwardRef>
+                                                                    Allow editing
+                                                                  </button>
+                                                                </Button>
+                                                              </Button>
                                                             </div>
                                                           </ButtonGroup>
                                                         </div>

--- a/graylog2-web-interface/src/components/users/__snapshots__/TokenList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/TokenList.test.jsx.snap
@@ -93,39 +93,32 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
                 <div
                   className="col-sm-2"
                 >
-                  <ForwardRef
+                  <Button
                     bsStyle="primary"
                     disabled={true}
                     id="create-token"
                     type="submit"
                   >
-                    <Button__StyledButton
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
                       bsStyle="primary"
+                      className="Button-c9cbmb-0 bNulii"
                       disabled={true}
                       id="create-token"
                       type="submit"
                     >
-                      <Button
-                        active={false}
-                        block={false}
-                        bsClass="btn"
-                        bsStyle="primary"
-                        className="Button__StyledButton-c9cbmb-0 laZUlH"
+                      <button
+                        className="Button-c9cbmb-0 bNulii btn btn-primary"
                         disabled={true}
                         id="create-token"
                         type="submit"
                       >
-                        <button
-                          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-primary"
-                          disabled={true}
-                          id="create-token"
-                          type="submit"
-                        >
-                          Create Token
-                        </button>
-                      </Button>
-                    </Button__StyledButton>
-                  </ForwardRef>
+                        Create Token
+                      </button>
+                    </Button>
+                  </Button>
                 </div>
               </Col>
             </div>
@@ -290,7 +283,7 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
                             </Component>
                           </Input>
                         </TypeAheadInput>
-                        <ForwardRef
+                        <Button
                           style={
                             Object {
                               "marginLeft": 5,
@@ -298,7 +291,13 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
                           }
                           type="submit"
                         >
-                          <Button__StyledButton
+                          <Button
+                            active={false}
+                            block={false}
+                            bsClass="btn"
+                            bsStyle="default"
+                            className="Button-c9cbmb-0 bNulii"
+                            disabled={false}
                             style={
                               Object {
                                 "marginLeft": 5,
@@ -306,12 +305,8 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
                             }
                             type="submit"
                           >
-                            <Button
-                              active={false}
-                              block={false}
-                              bsClass="btn"
-                              bsStyle="default"
-                              className="Button__StyledButton-c9cbmb-0 laZUlH"
+                            <button
+                              className="Button-c9cbmb-0 bNulii btn btn-default"
                               disabled={false}
                               style={
                                 Object {
@@ -320,22 +315,11 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
                               }
                               type="submit"
                             >
-                              <button
-                                className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                disabled={false}
-                                style={
-                                  Object {
-                                    "marginLeft": 5,
-                                  }
-                                }
-                                type="submit"
-                              >
-                                Filter
-                              </button>
-                            </Button>
-                          </Button__StyledButton>
-                        </ForwardRef>
-                        <ForwardRef
+                              Filter
+                            </button>
+                          </Button>
+                        </Button>
+                        <Button
                           disabled={true}
                           onClick={[Function]}
                           style={
@@ -345,7 +329,12 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
                           }
                           type="button"
                         >
-                          <Button__StyledButton
+                          <Button
+                            active={false}
+                            block={false}
+                            bsClass="btn"
+                            bsStyle="default"
+                            className="Button-c9cbmb-0 bNulii"
                             disabled={true}
                             onClick={[Function]}
                             style={
@@ -355,12 +344,8 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
                             }
                             type="button"
                           >
-                            <Button
-                              active={false}
-                              block={false}
-                              bsClass="btn"
-                              bsStyle="default"
-                              className="Button__StyledButton-c9cbmb-0 laZUlH"
+                            <button
+                              className="Button-c9cbmb-0 bNulii btn btn-default"
                               disabled={true}
                               onClick={[Function]}
                               style={
@@ -370,22 +355,10 @@ exports[`<TokenList /> should render with empty tokens 1`] = `
                               }
                               type="button"
                             >
-                              <button
-                                className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                disabled={true}
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "marginLeft": 5,
-                                  }
-                                }
-                                type="button"
-                              >
-                                Reset
-                              </button>
-                            </Button>
-                          </Button__StyledButton>
-                        </ForwardRef>
+                              Reset
+                            </button>
+                          </Button>
+                        </Button>
                       </form>
                       <ul
                         className="pill-list"
@@ -595,39 +568,32 @@ exports[`<TokenList /> should render with tokens 1`] = `
                 <div
                   className="col-sm-2"
                 >
-                  <ForwardRef
+                  <Button
                     bsStyle="primary"
                     disabled={true}
                     id="create-token"
                     type="submit"
                   >
-                    <Button__StyledButton
+                    <Button
+                      active={false}
+                      block={false}
+                      bsClass="btn"
                       bsStyle="primary"
+                      className="Button-c9cbmb-0 bNulii"
                       disabled={true}
                       id="create-token"
                       type="submit"
                     >
-                      <Button
-                        active={false}
-                        block={false}
-                        bsClass="btn"
-                        bsStyle="primary"
-                        className="Button__StyledButton-c9cbmb-0 laZUlH"
+                      <button
+                        className="Button-c9cbmb-0 bNulii btn btn-primary"
                         disabled={true}
                         id="create-token"
                         type="submit"
                       >
-                        <button
-                          className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-primary"
-                          disabled={true}
-                          id="create-token"
-                          type="submit"
-                        >
-                          Create Token
-                        </button>
-                      </Button>
-                    </Button__StyledButton>
-                  </ForwardRef>
+                        Create Token
+                      </button>
+                    </Button>
+                  </Button>
                 </div>
               </Col>
             </div>
@@ -818,7 +784,7 @@ exports[`<TokenList /> should render with tokens 1`] = `
                             </Component>
                           </Input>
                         </TypeAheadInput>
-                        <ForwardRef
+                        <Button
                           style={
                             Object {
                               "marginLeft": 5,
@@ -826,7 +792,13 @@ exports[`<TokenList /> should render with tokens 1`] = `
                           }
                           type="submit"
                         >
-                          <Button__StyledButton
+                          <Button
+                            active={false}
+                            block={false}
+                            bsClass="btn"
+                            bsStyle="default"
+                            className="Button-c9cbmb-0 bNulii"
+                            disabled={false}
                             style={
                               Object {
                                 "marginLeft": 5,
@@ -834,12 +806,8 @@ exports[`<TokenList /> should render with tokens 1`] = `
                             }
                             type="submit"
                           >
-                            <Button
-                              active={false}
-                              block={false}
-                              bsClass="btn"
-                              bsStyle="default"
-                              className="Button__StyledButton-c9cbmb-0 laZUlH"
+                            <button
+                              className="Button-c9cbmb-0 bNulii btn btn-default"
                               disabled={false}
                               style={
                                 Object {
@@ -848,22 +816,11 @@ exports[`<TokenList /> should render with tokens 1`] = `
                               }
                               type="submit"
                             >
-                              <button
-                                className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                disabled={false}
-                                style={
-                                  Object {
-                                    "marginLeft": 5,
-                                  }
-                                }
-                                type="submit"
-                              >
-                                Filter
-                              </button>
-                            </Button>
-                          </Button__StyledButton>
-                        </ForwardRef>
-                        <ForwardRef
+                              Filter
+                            </button>
+                          </Button>
+                        </Button>
+                        <Button
                           disabled={true}
                           onClick={[Function]}
                           style={
@@ -873,7 +830,12 @@ exports[`<TokenList /> should render with tokens 1`] = `
                           }
                           type="button"
                         >
-                          <Button__StyledButton
+                          <Button
+                            active={false}
+                            block={false}
+                            bsClass="btn"
+                            bsStyle="default"
+                            className="Button-c9cbmb-0 bNulii"
                             disabled={true}
                             onClick={[Function]}
                             style={
@@ -883,12 +845,8 @@ exports[`<TokenList /> should render with tokens 1`] = `
                             }
                             type="button"
                           >
-                            <Button
-                              active={false}
-                              block={false}
-                              bsClass="btn"
-                              bsStyle="default"
-                              className="Button__StyledButton-c9cbmb-0 laZUlH"
+                            <button
+                              className="Button-c9cbmb-0 bNulii btn btn-default"
                               disabled={true}
                               onClick={[Function]}
                               style={
@@ -898,22 +856,10 @@ exports[`<TokenList /> should render with tokens 1`] = `
                               }
                               type="button"
                             >
-                              <button
-                                className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                                disabled={true}
-                                onClick={[Function]}
-                                style={
-                                  Object {
-                                    "marginLeft": 5,
-                                  }
-                                }
-                                type="button"
-                              >
-                                Reset
-                              </button>
-                            </Button>
-                          </Button__StyledButton>
-                        </ForwardRef>
+                              Reset
+                            </button>
+                          </Button>
+                        </Button>
                       </form>
                       <ul
                         className="pill-list"
@@ -996,39 +942,32 @@ exports[`<TokenList /> should render with tokens 1`] = `
                                       text="beef2001"
                                       title="Copy to clipboard"
                                     />
-                                    <ForwardRef
+                                    <Button
                                       bsSize="xsmall"
                                       bsStyle="primary"
                                       disabled={false}
                                       onClick={[Function]}
                                     >
-                                      <Button__StyledButton
+                                      <Button
+                                        active={false}
+                                        block={false}
+                                        bsClass="btn"
                                         bsSize="xsmall"
                                         bsStyle="primary"
+                                        className="Button-c9cbmb-0 bNulii"
                                         disabled={false}
                                         onClick={[Function]}
                                       >
-                                        <Button
-                                          active={false}
-                                          block={false}
-                                          bsClass="btn"
-                                          bsSize="xsmall"
-                                          bsStyle="primary"
-                                          className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                        <button
+                                          className="Button-c9cbmb-0 bNulii btn btn-xs btn-primary"
                                           disabled={false}
                                           onClick={[Function]}
+                                          type="button"
                                         >
-                                          <button
-                                            className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-xs btn-primary"
-                                            disabled={false}
-                                            onClick={[Function]}
-                                            type="button"
-                                          >
-                                            Delete
-                                          </button>
-                                        </Button>
-                                      </Button__StyledButton>
-                                    </ForwardRef>
+                                          Delete
+                                        </button>
+                                      </Button>
+                                    </Button>
                                   </div>
                                 </ButtonGroup>
                               </div>
@@ -1077,39 +1016,32 @@ exports[`<TokenList /> should render with tokens 1`] = `
                                       text="beef2002"
                                       title="Copy to clipboard"
                                     />
-                                    <ForwardRef
+                                    <Button
                                       bsSize="xsmall"
                                       bsStyle="primary"
                                       disabled={false}
                                       onClick={[Function]}
                                     >
-                                      <Button__StyledButton
+                                      <Button
+                                        active={false}
+                                        block={false}
+                                        bsClass="btn"
                                         bsSize="xsmall"
                                         bsStyle="primary"
+                                        className="Button-c9cbmb-0 bNulii"
                                         disabled={false}
                                         onClick={[Function]}
                                       >
-                                        <Button
-                                          active={false}
-                                          block={false}
-                                          bsClass="btn"
-                                          bsSize="xsmall"
-                                          bsStyle="primary"
-                                          className="Button__StyledButton-c9cbmb-0 laZUlH"
+                                        <button
+                                          className="Button-c9cbmb-0 bNulii btn btn-xs btn-primary"
                                           disabled={false}
                                           onClick={[Function]}
+                                          type="button"
                                         >
-                                          <button
-                                            className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-xs btn-primary"
-                                            disabled={false}
-                                            onClick={[Function]}
-                                            type="button"
-                                          >
-                                            Delete
-                                          </button>
-                                        </Button>
-                                      </Button__StyledButton>
-                                    </ForwardRef>
+                                          Delete
+                                        </button>
+                                      </Button>
+                                    </Button>
                                   </div>
                                 </ButtonGroup>
                               </div>

--- a/graylog2-web-interface/src/components/users/__snapshots__/UserPreferencesButton.test.jsx.snap
+++ b/graylog2-web-interface/src/components/users/__snapshots__/UserPreferencesButton.test.jsx.snap
@@ -4,7 +4,7 @@ exports[`UserPreferencesButton should load user data when user clicks edit butto
 <div>
   <span>
     <button
-      class="Button__StyledButton-c9cbmb-0 laZUlH btn btn-success"
+      class="Button-c9cbmb-0 bNulii btn btn-success"
       data-testid="user-preferences-button"
       type="button"
     >

--- a/graylog2-web-interface/src/theme/GraylogThemeProvider.jsx
+++ b/graylog2-web-interface/src/theme/GraylogThemeProvider.jsx
@@ -17,7 +17,7 @@ const GraylogThemeProvider = ({ children }) => {
       colors,
       fonts,
       components: {
-        button: buttonStyles({ colors }),
+        button: buttonStyles({ colors, utils }),
         aceEditor: aceEditorStyles({ colors }),
       },
       utils,

--- a/graylog2-web-interface/src/views/components/__snapshots__/WidgetQueryControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/__snapshots__/WidgetQueryControls.test.jsx.snap
@@ -21,7 +21,7 @@ exports[`WidgetQueryControls should do something 1`] = `
             <button
               aria-expanded="false"
               aria-haspopup="true"
-              class="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt TimeRangeDropdownButton__StyledDropdownButton-sc-1rmks06-0 cVrRCV dropdown-toggle btn btn-info"
+              class="DropdownButton-sc-1343dcx-0 TimeRangeDropdownButton__StyledDropdownButton-sc-1rmks06-0 dsvoeu dropdown-toggle btn btn-info"
               id="timerange-type"
               role="button"
               type="button"
@@ -196,7 +196,7 @@ exports[`WidgetQueryControls should do something 1`] = `
           </a>
         </div>
         <button
-          class="Button__StyledButton-c9cbmb-0 laZUlH SearchButton__StyledButton-mm3q5z-0 feYjNC pull-left btn btn-success"
+          class="Button-c9cbmb-0 SearchButton__StyledButton-mm3q5z-0 WuJdQ pull-left btn btn-success"
           title="Perform search"
           type="submit"
         >

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/ColumnPivotConfiguration.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/ColumnPivotConfiguration.test.jsx.snap
@@ -101,34 +101,29 @@ exports[`<ColumnPivotConfiguraiton /> should render as expected 1`] = `
         }
       }
     >
-      <ForwardRef
+      <Button
         bsStyle="success"
         onClick={[Function]}
       >
-        <Button__StyledButton
+        <Button
+          active={false}
+          block={false}
+          bsClass="btn"
           bsStyle="success"
+          className="Button-c9cbmb-0 bNulii"
+          disabled={false}
           onClick={[Function]}
         >
-          <Button
-            active={false}
-            block={false}
-            bsClass="btn"
-            bsStyle="success"
-            className="Button__StyledButton-c9cbmb-0 laZUlH"
+          <button
+            className="Button-c9cbmb-0 bNulii btn btn-success"
             disabled={false}
             onClick={[Function]}
+            type="button"
           >
-            <button
-              className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-success"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
-            >
-              Done
-            </button>
-          </Button>
-        </Button__StyledButton>
-      </ForwardRef>
+            Done
+          </button>
+        </Button>
+      </Button>
     </div>
   </div>
 </ColumnPivotConfiguration>

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/SeriesConfiguration.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/SeriesConfiguration.test.jsx.snap
@@ -86,36 +86,30 @@ exports[`SeriesConfiguration renders the configuration dialog 1`] = `
         }
       }
     >
-      <ForwardRef
+      <Button
         bsStyle="success"
         disabled={false}
         onClick={[Function]}
       >
-        <Button__StyledButton
+        <Button
+          active={false}
+          block={false}
+          bsClass="btn"
           bsStyle="success"
+          className="Button-c9cbmb-0 bNulii"
           disabled={false}
           onClick={[Function]}
         >
-          <Button
-            active={false}
-            block={false}
-            bsClass="btn"
-            bsStyle="success"
-            className="Button__StyledButton-c9cbmb-0 laZUlH"
+          <button
+            className="Button-c9cbmb-0 bNulii btn btn-success"
             disabled={false}
             onClick={[Function]}
+            type="button"
           >
-            <button
-              className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-success"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
-            >
-              Done
-            </button>
-          </Button>
-        </Button__StyledButton>
-      </ForwardRef>
+            Done
+          </button>
+        </Button>
+      </Button>
     </div>
   </span>
 </SeriesConfiguration>

--- a/graylog2-web-interface/src/views/components/searchbar/__snapshots__/RefreshControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/__snapshots__/RefreshControls.test.jsx.snap
@@ -34,49 +34,45 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: fa
             <div
               className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 rpAER btn-group"
             >
-              <ForwardRef
+              <Button
                 onClick={[Function]}
               >
-                <Button__StyledButton
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="Button-c9cbmb-0 bNulii"
+                  disabled={false}
                   onClick={[Function]}
                 >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="default"
-                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                  <button
+                    className="Button-c9cbmb-0 bNulii btn btn-default"
                     disabled={false}
                     onClick={[Function]}
+                    type="button"
                   >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                      disabled={false}
-                      onClick={[Function]}
-                      type="button"
+                    <Icon
+                      name="play"
+                      type="solid"
                     >
-                      <Icon
-                        name="play"
-                        type="solid"
-                      >
-                        <FontAwesomeIcon
-                          icon={
-                            Object {
-                              "iconName": "play",
-                              "prefix": "fas",
-                            }
+                      <FontAwesomeIcon
+                        icon={
+                          Object {
+                            "iconName": "play",
+                            "prefix": "fas",
                           }
-                        >
-                          <svg
-                            className="svg-inline--fa fa-play"
-                          />
-                        </FontAwesomeIcon>
-                      </Icon>
-                    </button>
-                  </Button>
-                </Button__StyledButton>
-              </ForwardRef>
-              <ForwardRef
+                        }
+                      >
+                        <svg
+                          className="svg-inline--fa fa-play"
+                        />
+                      </FontAwesomeIcon>
+                    </Icon>
+                  </button>
+                </Button>
+              </Button>
+              <DropdownButton
                 id="refresh-options-dropdown"
                 title={
                   <RefreshControls__ButtonLabel>
@@ -84,7 +80,8 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: fa
                   </RefreshControls__ButtonLabel>
                 }
               >
-                <DropdownButton__StyledDropdownButton
+                <DropdownButton
+                  className="DropdownButton-sc-1343dcx-0 jHYVsD"
                   id="refresh-options-dropdown"
                   title={
                     <RefreshControls__ButtonLabel>
@@ -92,349 +89,339 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: fa
                     </RefreshControls__ButtonLabel>
                   }
                 >
-                  <DropdownButton
-                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                  <ForwardRef
                     id="refresh-options-dropdown"
-                    title={
-                      <RefreshControls__ButtonLabel>
-                        Not updating
-                      </RefreshControls__ButtonLabel>
-                    }
                   >
-                    <ForwardRef
+                    <Uncontrolled(Dropdown)
                       id="refresh-options-dropdown"
+                      innerRef={null}
                     >
-                      <Uncontrolled(Dropdown)
+                      <Dropdown
+                        bsClass="dropdown"
+                        componentClass={[Function]}
                         id="refresh-options-dropdown"
-                        innerRef={null}
+                        onToggle={[Function]}
                       >
-                        <Dropdown
-                          bsClass="dropdown"
-                          componentClass={[Function]}
-                          id="refresh-options-dropdown"
-                          onToggle={[Function]}
+                        <ButtonGroup
+                          block={false}
+                          bsClass="btn-group"
+                          className="dropdown"
+                          justified={false}
+                          vertical={false}
                         >
-                          <ButtonGroup
-                            block={false}
-                            bsClass="btn-group"
-                            className="dropdown"
-                            justified={false}
-                            vertical={false}
+                          <div
+                            className="dropdown btn-group"
                           >
-                            <div
-                              className="dropdown btn-group"
+                            <DropdownToggle
+                              bsClass="dropdown-toggle"
+                              bsRole="toggle"
+                              className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                              id="refresh-options-dropdown"
+                              key=".0"
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              open={false}
+                              useAnchor={false}
                             >
-                              <DropdownToggle
-                                bsClass="dropdown-toggle"
-                                bsRole="toggle"
-                                className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                              <Button
+                                active={false}
+                                aria-expanded={false}
+                                aria-haspopup={true}
+                                block={false}
+                                bsClass="btn"
+                                bsStyle="default"
+                                className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                disabled={false}
                                 id="refresh-options-dropdown"
-                                key=".0"
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
-                                open={false}
-                                useAnchor={false}
+                                role="button"
                               >
-                                <Button
-                                  active={false}
+                                <button
                                   aria-expanded={false}
                                   aria-haspopup={true}
-                                  block={false}
-                                  bsClass="btn"
-                                  bsStyle="default"
-                                  className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                  className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-default"
                                   disabled={false}
                                   id="refresh-options-dropdown"
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
                                   role="button"
+                                  type="button"
                                 >
-                                  <button
-                                    aria-expanded={false}
-                                    aria-haspopup={true}
-                                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-default"
+                                  <RefreshControls__ButtonLabel>
+                                    <div
+                                      className="RefreshControls__ButtonLabel-sc-1pygk8n-2 eWVOVO"
+                                    >
+                                      Not updating
+                                    </div>
+                                  </RefreshControls__ButtonLabel>
+                                   
+                                  <span
+                                    className="caret"
+                                  />
+                                </button>
+                              </Button>
+                            </DropdownToggle>
+                            <DropdownMenu
+                              bsClass="dropdown-menu"
+                              bsRole="menu"
+                              key=".1"
+                              labelledBy="refresh-options-dropdown"
+                              onClose={[Function]}
+                              onSelect={[Function]}
+                              pullRight={false}
+                            >
+                              <RootCloseWrapper
+                                disabled={true}
+                                event="click"
+                                onRootClose={[Function]}
+                              >
+                                <ul
+                                  aria-labelledby="refresh-options-dropdown"
+                                  className="dropdown-menu"
+                                  role="menu"
+                                >
+                                  <MenuItem
+                                    bsClass="dropdown"
                                     disabled={false}
-                                    id="refresh-options-dropdown"
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-1 Second"
                                     onClick={[Function]}
                                     onKeyDown={[Function]}
-                                    role="button"
-                                    type="button"
+                                    onSelect={[Function]}
                                   >
-                                    <RefreshControls__ButtonLabel>
-                                      <div
-                                        className="RefreshControls__ButtonLabel-sc-1pygk8n-2 eWVOVO"
+                                    <li
+                                      className=""
+                                      role="presentation"
+                                    >
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        Not updating
-                                      </div>
-                                    </RefreshControls__ButtonLabel>
-                                     
-                                    <span
-                                      className="caret"
-                                    />
-                                  </button>
-                                </Button>
-                              </DropdownToggle>
-                              <DropdownMenu
-                                bsClass="dropdown-menu"
-                                bsRole="menu"
-                                key=".1"
-                                labelledBy="refresh-options-dropdown"
-                                onClose={[Function]}
-                                onSelect={[Function]}
-                                pullRight={false}
-                              >
-                                <RootCloseWrapper
-                                  disabled={true}
-                                  event="click"
-                                  onRootClose={[Function]}
-                                >
-                                  <ul
-                                    aria-labelledby="refresh-options-dropdown"
-                                    className="dropdown-menu"
-                                    role="menu"
+                                        <a
+                                          href="#"
+                                          onClick={[Function]}
+                                          onKeyDown={[Function]}
+                                          role="menuitem"
+                                          tabIndex="-1"
+                                        >
+                                          1 Second
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-2 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
                                   >
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-1 Second"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            1 Second
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-2 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          2 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-5 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            2 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-5 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          5 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-10 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            5 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-10 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          10 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-30 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            10 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-30 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          30 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-1 Minute"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            30 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-1 Minute"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          1 Minute
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-5 Minutes"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            1 Minute
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-5 Minutes"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
-                                    >
-                                      <li
-                                        className=""
-                                        role="presentation"
-                                      >
-                                        <SafeAnchor
-                                          componentClass="a"
-                                          onClick={[Function]}
-                                          onKeyDown={[Function]}
-                                          role="menuitem"
-                                          tabIndex="-1"
-                                        >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            5 Minutes
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                  </ul>
-                                </RootCloseWrapper>
-                              </DropdownMenu>
-                            </div>
-                          </ButtonGroup>
-                        </Dropdown>
-                      </Uncontrolled(Dropdown)>
-                    </ForwardRef>
-                  </DropdownButton>
-                </DropdownButton__StyledDropdownButton>
-              </ForwardRef>
+                                          5 Minutes
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                </ul>
+                              </RootCloseWrapper>
+                            </DropdownMenu>
+                          </div>
+                        </ButtonGroup>
+                      </Dropdown>
+                    </Uncontrolled(Dropdown)>
+                  </ForwardRef>
+                </DropdownButton>
+              </DropdownButton>
             </div>
           </ButtonGroup>
         </RefreshControls__FlexibleButtonGroup>
@@ -478,49 +465,45 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: fa
             <div
               className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 rpAER btn-group"
             >
-              <ForwardRef
+              <Button
                 onClick={[Function]}
               >
-                <Button__StyledButton
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="Button-c9cbmb-0 bNulii"
+                  disabled={false}
                   onClick={[Function]}
                 >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="default"
-                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                  <button
+                    className="Button-c9cbmb-0 bNulii btn btn-default"
                     disabled={false}
                     onClick={[Function]}
+                    type="button"
                   >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                      disabled={false}
-                      onClick={[Function]}
-                      type="button"
+                    <Icon
+                      name="play"
+                      type="solid"
                     >
-                      <Icon
-                        name="play"
-                        type="solid"
-                      >
-                        <FontAwesomeIcon
-                          icon={
-                            Object {
-                              "iconName": "play",
-                              "prefix": "fas",
-                            }
+                      <FontAwesomeIcon
+                        icon={
+                          Object {
+                            "iconName": "play",
+                            "prefix": "fas",
                           }
-                        >
-                          <svg
-                            className="svg-inline--fa fa-play"
-                          />
-                        </FontAwesomeIcon>
-                      </Icon>
-                    </button>
-                  </Button>
-                </Button__StyledButton>
-              </ForwardRef>
-              <ForwardRef
+                        }
+                      >
+                        <svg
+                          className="svg-inline--fa fa-play"
+                        />
+                      </FontAwesomeIcon>
+                    </Icon>
+                  </button>
+                </Button>
+              </Button>
+              <DropdownButton
                 id="refresh-options-dropdown"
                 title={
                   <RefreshControls__ButtonLabel>
@@ -528,7 +511,8 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: fa
                   </RefreshControls__ButtonLabel>
                 }
               >
-                <DropdownButton__StyledDropdownButton
+                <DropdownButton
+                  className="DropdownButton-sc-1343dcx-0 jHYVsD"
                   id="refresh-options-dropdown"
                   title={
                     <RefreshControls__ButtonLabel>
@@ -536,349 +520,339 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: fa
                     </RefreshControls__ButtonLabel>
                   }
                 >
-                  <DropdownButton
-                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                  <ForwardRef
                     id="refresh-options-dropdown"
-                    title={
-                      <RefreshControls__ButtonLabel>
-                        Not updating
-                      </RefreshControls__ButtonLabel>
-                    }
                   >
-                    <ForwardRef
+                    <Uncontrolled(Dropdown)
                       id="refresh-options-dropdown"
+                      innerRef={null}
                     >
-                      <Uncontrolled(Dropdown)
+                      <Dropdown
+                        bsClass="dropdown"
+                        componentClass={[Function]}
                         id="refresh-options-dropdown"
-                        innerRef={null}
+                        onToggle={[Function]}
                       >
-                        <Dropdown
-                          bsClass="dropdown"
-                          componentClass={[Function]}
-                          id="refresh-options-dropdown"
-                          onToggle={[Function]}
+                        <ButtonGroup
+                          block={false}
+                          bsClass="btn-group"
+                          className="dropdown"
+                          justified={false}
+                          vertical={false}
                         >
-                          <ButtonGroup
-                            block={false}
-                            bsClass="btn-group"
-                            className="dropdown"
-                            justified={false}
-                            vertical={false}
+                          <div
+                            className="dropdown btn-group"
                           >
-                            <div
-                              className="dropdown btn-group"
+                            <DropdownToggle
+                              bsClass="dropdown-toggle"
+                              bsRole="toggle"
+                              className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                              id="refresh-options-dropdown"
+                              key=".0"
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              open={false}
+                              useAnchor={false}
                             >
-                              <DropdownToggle
-                                bsClass="dropdown-toggle"
-                                bsRole="toggle"
-                                className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                              <Button
+                                active={false}
+                                aria-expanded={false}
+                                aria-haspopup={true}
+                                block={false}
+                                bsClass="btn"
+                                bsStyle="default"
+                                className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                disabled={false}
                                 id="refresh-options-dropdown"
-                                key=".0"
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
-                                open={false}
-                                useAnchor={false}
+                                role="button"
                               >
-                                <Button
-                                  active={false}
+                                <button
                                   aria-expanded={false}
                                   aria-haspopup={true}
-                                  block={false}
-                                  bsClass="btn"
-                                  bsStyle="default"
-                                  className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                  className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-default"
                                   disabled={false}
                                   id="refresh-options-dropdown"
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
                                   role="button"
+                                  type="button"
                                 >
-                                  <button
-                                    aria-expanded={false}
-                                    aria-haspopup={true}
-                                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-default"
+                                  <RefreshControls__ButtonLabel>
+                                    <div
+                                      className="RefreshControls__ButtonLabel-sc-1pygk8n-2 eWVOVO"
+                                    >
+                                      Not updating
+                                    </div>
+                                  </RefreshControls__ButtonLabel>
+                                   
+                                  <span
+                                    className="caret"
+                                  />
+                                </button>
+                              </Button>
+                            </DropdownToggle>
+                            <DropdownMenu
+                              bsClass="dropdown-menu"
+                              bsRole="menu"
+                              key=".1"
+                              labelledBy="refresh-options-dropdown"
+                              onClose={[Function]}
+                              onSelect={[Function]}
+                              pullRight={false}
+                            >
+                              <RootCloseWrapper
+                                disabled={true}
+                                event="click"
+                                onRootClose={[Function]}
+                              >
+                                <ul
+                                  aria-labelledby="refresh-options-dropdown"
+                                  className="dropdown-menu"
+                                  role="menu"
+                                >
+                                  <MenuItem
+                                    bsClass="dropdown"
                                     disabled={false}
-                                    id="refresh-options-dropdown"
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-1 Second"
                                     onClick={[Function]}
                                     onKeyDown={[Function]}
-                                    role="button"
-                                    type="button"
+                                    onSelect={[Function]}
                                   >
-                                    <RefreshControls__ButtonLabel>
-                                      <div
-                                        className="RefreshControls__ButtonLabel-sc-1pygk8n-2 eWVOVO"
+                                    <li
+                                      className=""
+                                      role="presentation"
+                                    >
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        Not updating
-                                      </div>
-                                    </RefreshControls__ButtonLabel>
-                                     
-                                    <span
-                                      className="caret"
-                                    />
-                                  </button>
-                                </Button>
-                              </DropdownToggle>
-                              <DropdownMenu
-                                bsClass="dropdown-menu"
-                                bsRole="menu"
-                                key=".1"
-                                labelledBy="refresh-options-dropdown"
-                                onClose={[Function]}
-                                onSelect={[Function]}
-                                pullRight={false}
-                              >
-                                <RootCloseWrapper
-                                  disabled={true}
-                                  event="click"
-                                  onRootClose={[Function]}
-                                >
-                                  <ul
-                                    aria-labelledby="refresh-options-dropdown"
-                                    className="dropdown-menu"
-                                    role="menu"
+                                        <a
+                                          href="#"
+                                          onClick={[Function]}
+                                          onKeyDown={[Function]}
+                                          role="menuitem"
+                                          tabIndex="-1"
+                                        >
+                                          1 Second
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-2 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
                                   >
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-1 Second"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            1 Second
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-2 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          2 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-5 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            2 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-5 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          5 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-10 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            5 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-10 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          10 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-30 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            10 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-30 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          30 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-1 Minute"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            30 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-1 Minute"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          1 Minute
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-5 Minutes"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            1 Minute
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-5 Minutes"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
-                                    >
-                                      <li
-                                        className=""
-                                        role="presentation"
-                                      >
-                                        <SafeAnchor
-                                          componentClass="a"
-                                          onClick={[Function]}
-                                          onKeyDown={[Function]}
-                                          role="menuitem"
-                                          tabIndex="-1"
-                                        >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            5 Minutes
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                  </ul>
-                                </RootCloseWrapper>
-                              </DropdownMenu>
-                            </div>
-                          </ButtonGroup>
-                        </Dropdown>
-                      </Uncontrolled(Dropdown)>
-                    </ForwardRef>
-                  </DropdownButton>
-                </DropdownButton__StyledDropdownButton>
-              </ForwardRef>
+                                          5 Minutes
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                </ul>
+                              </RootCloseWrapper>
+                            </DropdownMenu>
+                          </div>
+                        </ButtonGroup>
+                      </Dropdown>
+                    </Uncontrolled(Dropdown)>
+                  </ForwardRef>
+                </DropdownButton>
+              </DropdownButton>
             </div>
           </ButtonGroup>
         </RefreshControls__FlexibleButtonGroup>
@@ -922,49 +896,45 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
             <div
               className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 rpAER btn-group"
             >
-              <ForwardRef
+              <Button
                 onClick={[Function]}
               >
-                <Button__StyledButton
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="Button-c9cbmb-0 bNulii"
+                  disabled={false}
                   onClick={[Function]}
                 >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="default"
-                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                  <button
+                    className="Button-c9cbmb-0 bNulii btn btn-default"
                     disabled={false}
                     onClick={[Function]}
+                    type="button"
                   >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                      disabled={false}
-                      onClick={[Function]}
-                      type="button"
+                    <Icon
+                      name="pause"
+                      type="solid"
                     >
-                      <Icon
-                        name="pause"
-                        type="solid"
-                      >
-                        <FontAwesomeIcon
-                          icon={
-                            Object {
-                              "iconName": "pause",
-                              "prefix": "fas",
-                            }
+                      <FontAwesomeIcon
+                        icon={
+                          Object {
+                            "iconName": "pause",
+                            "prefix": "fas",
                           }
-                        >
-                          <svg
-                            className="svg-inline--fa fa-pause"
-                          />
-                        </FontAwesomeIcon>
-                      </Icon>
-                    </button>
-                  </Button>
-                </Button__StyledButton>
-              </ForwardRef>
-              <ForwardRef
+                        }
+                      >
+                        <svg
+                          className="svg-inline--fa fa-pause"
+                        />
+                      </FontAwesomeIcon>
+                    </Icon>
+                  </button>
+                </Button>
+              </Button>
+              <DropdownButton
                 id="refresh-options-dropdown"
                 title={
                   <RefreshControls__ButtonLabel>
@@ -983,7 +953,8 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
                   </RefreshControls__ButtonLabel>
                 }
               >
-                <DropdownButton__StyledDropdownButton
+                <DropdownButton
+                  className="DropdownButton-sc-1343dcx-0 jHYVsD"
                   id="refresh-options-dropdown"
                   title={
                     <RefreshControls__ButtonLabel>
@@ -1002,373 +973,352 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
                     </RefreshControls__ButtonLabel>
                   }
                 >
-                  <DropdownButton
-                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                  <ForwardRef
                     id="refresh-options-dropdown"
-                    title={
-                      <RefreshControls__ButtonLabel>
-                        <React.Fragment>
-                          Update every 
-                          <span>
-                            1
-                             
-                            <Pluralize
-                              plural="seconds"
-                              singular="second"
-                              value={1}
-                            />
-                          </span>
-                        </React.Fragment>
-                      </RefreshControls__ButtonLabel>
-                    }
                   >
-                    <ForwardRef
+                    <Uncontrolled(Dropdown)
                       id="refresh-options-dropdown"
+                      innerRef={null}
                     >
-                      <Uncontrolled(Dropdown)
+                      <Dropdown
+                        bsClass="dropdown"
+                        componentClass={[Function]}
                         id="refresh-options-dropdown"
-                        innerRef={null}
+                        onToggle={[Function]}
                       >
-                        <Dropdown
-                          bsClass="dropdown"
-                          componentClass={[Function]}
-                          id="refresh-options-dropdown"
-                          onToggle={[Function]}
+                        <ButtonGroup
+                          block={false}
+                          bsClass="btn-group"
+                          className="dropdown"
+                          justified={false}
+                          vertical={false}
                         >
-                          <ButtonGroup
-                            block={false}
-                            bsClass="btn-group"
-                            className="dropdown"
-                            justified={false}
-                            vertical={false}
+                          <div
+                            className="dropdown btn-group"
                           >
-                            <div
-                              className="dropdown btn-group"
+                            <DropdownToggle
+                              bsClass="dropdown-toggle"
+                              bsRole="toggle"
+                              className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                              id="refresh-options-dropdown"
+                              key=".0"
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              open={false}
+                              useAnchor={false}
                             >
-                              <DropdownToggle
-                                bsClass="dropdown-toggle"
-                                bsRole="toggle"
-                                className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                              <Button
+                                active={false}
+                                aria-expanded={false}
+                                aria-haspopup={true}
+                                block={false}
+                                bsClass="btn"
+                                bsStyle="default"
+                                className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                disabled={false}
                                 id="refresh-options-dropdown"
-                                key=".0"
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
-                                open={false}
-                                useAnchor={false}
+                                role="button"
                               >
-                                <Button
-                                  active={false}
+                                <button
                                   aria-expanded={false}
                                   aria-haspopup={true}
-                                  block={false}
-                                  bsClass="btn"
-                                  bsStyle="default"
-                                  className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                  className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-default"
                                   disabled={false}
                                   id="refresh-options-dropdown"
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
                                   role="button"
+                                  type="button"
                                 >
-                                  <button
-                                    aria-expanded={false}
-                                    aria-haspopup={true}
-                                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-default"
+                                  <RefreshControls__ButtonLabel>
+                                    <div
+                                      className="RefreshControls__ButtonLabel-sc-1pygk8n-2 eWVOVO"
+                                    >
+                                      Update every 
+                                      <span>
+                                        1
+                                         
+                                        <Pluralize
+                                          plural="seconds"
+                                          singular="second"
+                                          value={1}
+                                        >
+                                          <span>
+                                            second
+                                          </span>
+                                        </Pluralize>
+                                      </span>
+                                    </div>
+                                  </RefreshControls__ButtonLabel>
+                                   
+                                  <span
+                                    className="caret"
+                                  />
+                                </button>
+                              </Button>
+                            </DropdownToggle>
+                            <DropdownMenu
+                              bsClass="dropdown-menu"
+                              bsRole="menu"
+                              key=".1"
+                              labelledBy="refresh-options-dropdown"
+                              onClose={[Function]}
+                              onSelect={[Function]}
+                              pullRight={false}
+                            >
+                              <RootCloseWrapper
+                                disabled={true}
+                                event="click"
+                                onRootClose={[Function]}
+                              >
+                                <ul
+                                  aria-labelledby="refresh-options-dropdown"
+                                  className="dropdown-menu"
+                                  role="menu"
+                                >
+                                  <MenuItem
+                                    bsClass="dropdown"
                                     disabled={false}
-                                    id="refresh-options-dropdown"
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-1 Second"
                                     onClick={[Function]}
                                     onKeyDown={[Function]}
-                                    role="button"
-                                    type="button"
+                                    onSelect={[Function]}
                                   >
-                                    <RefreshControls__ButtonLabel>
-                                      <div
-                                        className="RefreshControls__ButtonLabel-sc-1pygk8n-2 eWVOVO"
+                                    <li
+                                      className=""
+                                      role="presentation"
+                                    >
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        Update every 
-                                        <span>
-                                          1
-                                           
-                                          <Pluralize
-                                            plural="seconds"
-                                            singular="second"
-                                            value={1}
-                                          >
-                                            <span>
-                                              second
-                                            </span>
-                                          </Pluralize>
-                                        </span>
-                                      </div>
-                                    </RefreshControls__ButtonLabel>
-                                     
-                                    <span
-                                      className="caret"
-                                    />
-                                  </button>
-                                </Button>
-                              </DropdownToggle>
-                              <DropdownMenu
-                                bsClass="dropdown-menu"
-                                bsRole="menu"
-                                key=".1"
-                                labelledBy="refresh-options-dropdown"
-                                onClose={[Function]}
-                                onSelect={[Function]}
-                                pullRight={false}
-                              >
-                                <RootCloseWrapper
-                                  disabled={true}
-                                  event="click"
-                                  onRootClose={[Function]}
-                                >
-                                  <ul
-                                    aria-labelledby="refresh-options-dropdown"
-                                    className="dropdown-menu"
-                                    role="menu"
+                                        <a
+                                          href="#"
+                                          onClick={[Function]}
+                                          onKeyDown={[Function]}
+                                          role="menuitem"
+                                          tabIndex="-1"
+                                        >
+                                          1 Second
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-2 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
                                   >
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-1 Second"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            1 Second
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-2 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          2 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-5 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            2 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-5 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          5 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-10 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            5 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-10 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          10 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-30 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            10 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-30 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          30 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-1 Minute"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            30 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-1 Minute"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          1 Minute
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-5 Minutes"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            1 Minute
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-5 Minutes"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
-                                    >
-                                      <li
-                                        className=""
-                                        role="presentation"
-                                      >
-                                        <SafeAnchor
-                                          componentClass="a"
-                                          onClick={[Function]}
-                                          onKeyDown={[Function]}
-                                          role="menuitem"
-                                          tabIndex="-1"
-                                        >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            5 Minutes
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                  </ul>
-                                </RootCloseWrapper>
-                              </DropdownMenu>
-                            </div>
-                          </ButtonGroup>
-                        </Dropdown>
-                      </Uncontrolled(Dropdown)>
-                    </ForwardRef>
-                  </DropdownButton>
-                </DropdownButton__StyledDropdownButton>
-              </ForwardRef>
+                                          5 Minutes
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                </ul>
+                              </RootCloseWrapper>
+                            </DropdownMenu>
+                          </div>
+                        </ButtonGroup>
+                      </Dropdown>
+                    </Uncontrolled(Dropdown)>
+                  </ForwardRef>
+                </DropdownButton>
+              </DropdownButton>
             </div>
           </ButtonGroup>
         </RefreshControls__FlexibleButtonGroup>
@@ -1412,49 +1362,45 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
             <div
               className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 rpAER btn-group"
             >
-              <ForwardRef
+              <Button
                 onClick={[Function]}
               >
-                <Button__StyledButton
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="Button-c9cbmb-0 bNulii"
+                  disabled={false}
                   onClick={[Function]}
                 >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="default"
-                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                  <button
+                    className="Button-c9cbmb-0 bNulii btn btn-default"
                     disabled={false}
                     onClick={[Function]}
+                    type="button"
                   >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                      disabled={false}
-                      onClick={[Function]}
-                      type="button"
+                    <Icon
+                      name="pause"
+                      type="solid"
                     >
-                      <Icon
-                        name="pause"
-                        type="solid"
-                      >
-                        <FontAwesomeIcon
-                          icon={
-                            Object {
-                              "iconName": "pause",
-                              "prefix": "fas",
-                            }
+                      <FontAwesomeIcon
+                        icon={
+                          Object {
+                            "iconName": "pause",
+                            "prefix": "fas",
                           }
-                        >
-                          <svg
-                            className="svg-inline--fa fa-pause"
-                          />
-                        </FontAwesomeIcon>
-                      </Icon>
-                    </button>
-                  </Button>
-                </Button__StyledButton>
-              </ForwardRef>
-              <ForwardRef
+                        }
+                      >
+                        <svg
+                          className="svg-inline--fa fa-pause"
+                        />
+                      </FontAwesomeIcon>
+                    </Icon>
+                  </button>
+                </Button>
+              </Button>
+              <DropdownButton
                 id="refresh-options-dropdown"
                 title={
                   <RefreshControls__ButtonLabel>
@@ -1473,7 +1419,8 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
                   </RefreshControls__ButtonLabel>
                 }
               >
-                <DropdownButton__StyledDropdownButton
+                <DropdownButton
+                  className="DropdownButton-sc-1343dcx-0 jHYVsD"
                   id="refresh-options-dropdown"
                   title={
                     <RefreshControls__ButtonLabel>
@@ -1492,373 +1439,352 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
                     </RefreshControls__ButtonLabel>
                   }
                 >
-                  <DropdownButton
-                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                  <ForwardRef
                     id="refresh-options-dropdown"
-                    title={
-                      <RefreshControls__ButtonLabel>
-                        <React.Fragment>
-                          Update every 
-                          <span>
-                            2
-                             
-                            <Pluralize
-                              plural="seconds"
-                              singular="second"
-                              value={2}
-                            />
-                          </span>
-                        </React.Fragment>
-                      </RefreshControls__ButtonLabel>
-                    }
                   >
-                    <ForwardRef
+                    <Uncontrolled(Dropdown)
                       id="refresh-options-dropdown"
+                      innerRef={null}
                     >
-                      <Uncontrolled(Dropdown)
+                      <Dropdown
+                        bsClass="dropdown"
+                        componentClass={[Function]}
                         id="refresh-options-dropdown"
-                        innerRef={null}
+                        onToggle={[Function]}
                       >
-                        <Dropdown
-                          bsClass="dropdown"
-                          componentClass={[Function]}
-                          id="refresh-options-dropdown"
-                          onToggle={[Function]}
+                        <ButtonGroup
+                          block={false}
+                          bsClass="btn-group"
+                          className="dropdown"
+                          justified={false}
+                          vertical={false}
                         >
-                          <ButtonGroup
-                            block={false}
-                            bsClass="btn-group"
-                            className="dropdown"
-                            justified={false}
-                            vertical={false}
+                          <div
+                            className="dropdown btn-group"
                           >
-                            <div
-                              className="dropdown btn-group"
+                            <DropdownToggle
+                              bsClass="dropdown-toggle"
+                              bsRole="toggle"
+                              className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                              id="refresh-options-dropdown"
+                              key=".0"
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              open={false}
+                              useAnchor={false}
                             >
-                              <DropdownToggle
-                                bsClass="dropdown-toggle"
-                                bsRole="toggle"
-                                className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                              <Button
+                                active={false}
+                                aria-expanded={false}
+                                aria-haspopup={true}
+                                block={false}
+                                bsClass="btn"
+                                bsStyle="default"
+                                className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                disabled={false}
                                 id="refresh-options-dropdown"
-                                key=".0"
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
-                                open={false}
-                                useAnchor={false}
+                                role="button"
                               >
-                                <Button
-                                  active={false}
+                                <button
                                   aria-expanded={false}
                                   aria-haspopup={true}
-                                  block={false}
-                                  bsClass="btn"
-                                  bsStyle="default"
-                                  className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                  className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-default"
                                   disabled={false}
                                   id="refresh-options-dropdown"
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
                                   role="button"
+                                  type="button"
                                 >
-                                  <button
-                                    aria-expanded={false}
-                                    aria-haspopup={true}
-                                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-default"
+                                  <RefreshControls__ButtonLabel>
+                                    <div
+                                      className="RefreshControls__ButtonLabel-sc-1pygk8n-2 eWVOVO"
+                                    >
+                                      Update every 
+                                      <span>
+                                        2
+                                         
+                                        <Pluralize
+                                          plural="seconds"
+                                          singular="second"
+                                          value={2}
+                                        >
+                                          <span>
+                                            seconds
+                                          </span>
+                                        </Pluralize>
+                                      </span>
+                                    </div>
+                                  </RefreshControls__ButtonLabel>
+                                   
+                                  <span
+                                    className="caret"
+                                  />
+                                </button>
+                              </Button>
+                            </DropdownToggle>
+                            <DropdownMenu
+                              bsClass="dropdown-menu"
+                              bsRole="menu"
+                              key=".1"
+                              labelledBy="refresh-options-dropdown"
+                              onClose={[Function]}
+                              onSelect={[Function]}
+                              pullRight={false}
+                            >
+                              <RootCloseWrapper
+                                disabled={true}
+                                event="click"
+                                onRootClose={[Function]}
+                              >
+                                <ul
+                                  aria-labelledby="refresh-options-dropdown"
+                                  className="dropdown-menu"
+                                  role="menu"
+                                >
+                                  <MenuItem
+                                    bsClass="dropdown"
                                     disabled={false}
-                                    id="refresh-options-dropdown"
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-1 Second"
                                     onClick={[Function]}
                                     onKeyDown={[Function]}
-                                    role="button"
-                                    type="button"
+                                    onSelect={[Function]}
                                   >
-                                    <RefreshControls__ButtonLabel>
-                                      <div
-                                        className="RefreshControls__ButtonLabel-sc-1pygk8n-2 eWVOVO"
+                                    <li
+                                      className=""
+                                      role="presentation"
+                                    >
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        Update every 
-                                        <span>
-                                          2
-                                           
-                                          <Pluralize
-                                            plural="seconds"
-                                            singular="second"
-                                            value={2}
-                                          >
-                                            <span>
-                                              seconds
-                                            </span>
-                                          </Pluralize>
-                                        </span>
-                                      </div>
-                                    </RefreshControls__ButtonLabel>
-                                     
-                                    <span
-                                      className="caret"
-                                    />
-                                  </button>
-                                </Button>
-                              </DropdownToggle>
-                              <DropdownMenu
-                                bsClass="dropdown-menu"
-                                bsRole="menu"
-                                key=".1"
-                                labelledBy="refresh-options-dropdown"
-                                onClose={[Function]}
-                                onSelect={[Function]}
-                                pullRight={false}
-                              >
-                                <RootCloseWrapper
-                                  disabled={true}
-                                  event="click"
-                                  onRootClose={[Function]}
-                                >
-                                  <ul
-                                    aria-labelledby="refresh-options-dropdown"
-                                    className="dropdown-menu"
-                                    role="menu"
+                                        <a
+                                          href="#"
+                                          onClick={[Function]}
+                                          onKeyDown={[Function]}
+                                          role="menuitem"
+                                          tabIndex="-1"
+                                        >
+                                          1 Second
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-2 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
                                   >
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-1 Second"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            1 Second
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-2 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          2 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-5 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            2 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-5 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          5 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-10 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            5 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-10 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          10 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-30 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            10 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-30 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          30 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-1 Minute"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            30 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-1 Minute"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          1 Minute
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-5 Minutes"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            1 Minute
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-5 Minutes"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
-                                    >
-                                      <li
-                                        className=""
-                                        role="presentation"
-                                      >
-                                        <SafeAnchor
-                                          componentClass="a"
-                                          onClick={[Function]}
-                                          onKeyDown={[Function]}
-                                          role="menuitem"
-                                          tabIndex="-1"
-                                        >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            5 Minutes
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                  </ul>
-                                </RootCloseWrapper>
-                              </DropdownMenu>
-                            </div>
-                          </ButtonGroup>
-                        </Dropdown>
-                      </Uncontrolled(Dropdown)>
-                    </ForwardRef>
-                  </DropdownButton>
-                </DropdownButton__StyledDropdownButton>
-              </ForwardRef>
+                                          5 Minutes
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                </ul>
+                              </RootCloseWrapper>
+                            </DropdownMenu>
+                          </div>
+                        </ButtonGroup>
+                      </Dropdown>
+                    </Uncontrolled(Dropdown)>
+                  </ForwardRef>
+                </DropdownButton>
+              </DropdownButton>
             </div>
           </ButtonGroup>
         </RefreshControls__FlexibleButtonGroup>
@@ -1902,49 +1828,45 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
             <div
               className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 rpAER btn-group"
             >
-              <ForwardRef
+              <Button
                 onClick={[Function]}
               >
-                <Button__StyledButton
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="Button-c9cbmb-0 bNulii"
+                  disabled={false}
                   onClick={[Function]}
                 >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="default"
-                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                  <button
+                    className="Button-c9cbmb-0 bNulii btn btn-default"
                     disabled={false}
                     onClick={[Function]}
+                    type="button"
                   >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                      disabled={false}
-                      onClick={[Function]}
-                      type="button"
+                    <Icon
+                      name="pause"
+                      type="solid"
                     >
-                      <Icon
-                        name="pause"
-                        type="solid"
-                      >
-                        <FontAwesomeIcon
-                          icon={
-                            Object {
-                              "iconName": "pause",
-                              "prefix": "fas",
-                            }
+                      <FontAwesomeIcon
+                        icon={
+                          Object {
+                            "iconName": "pause",
+                            "prefix": "fas",
                           }
-                        >
-                          <svg
-                            className="svg-inline--fa fa-pause"
-                          />
-                        </FontAwesomeIcon>
-                      </Icon>
-                    </button>
-                  </Button>
-                </Button__StyledButton>
-              </ForwardRef>
-              <ForwardRef
+                        }
+                      >
+                        <svg
+                          className="svg-inline--fa fa-pause"
+                        />
+                      </FontAwesomeIcon>
+                    </Icon>
+                  </button>
+                </Button>
+              </Button>
+              <DropdownButton
                 id="refresh-options-dropdown"
                 title={
                   <RefreshControls__ButtonLabel>
@@ -1963,7 +1885,8 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
                   </RefreshControls__ButtonLabel>
                 }
               >
-                <DropdownButton__StyledDropdownButton
+                <DropdownButton
+                  className="DropdownButton-sc-1343dcx-0 jHYVsD"
                   id="refresh-options-dropdown"
                   title={
                     <RefreshControls__ButtonLabel>
@@ -1982,373 +1905,352 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
                     </RefreshControls__ButtonLabel>
                   }
                 >
-                  <DropdownButton
-                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                  <ForwardRef
                     id="refresh-options-dropdown"
-                    title={
-                      <RefreshControls__ButtonLabel>
-                        <React.Fragment>
-                          Update every 
-                          <span>
-                            5
-                             
-                            <Pluralize
-                              plural="seconds"
-                              singular="second"
-                              value={5}
-                            />
-                          </span>
-                        </React.Fragment>
-                      </RefreshControls__ButtonLabel>
-                    }
                   >
-                    <ForwardRef
+                    <Uncontrolled(Dropdown)
                       id="refresh-options-dropdown"
+                      innerRef={null}
                     >
-                      <Uncontrolled(Dropdown)
+                      <Dropdown
+                        bsClass="dropdown"
+                        componentClass={[Function]}
                         id="refresh-options-dropdown"
-                        innerRef={null}
+                        onToggle={[Function]}
                       >
-                        <Dropdown
-                          bsClass="dropdown"
-                          componentClass={[Function]}
-                          id="refresh-options-dropdown"
-                          onToggle={[Function]}
+                        <ButtonGroup
+                          block={false}
+                          bsClass="btn-group"
+                          className="dropdown"
+                          justified={false}
+                          vertical={false}
                         >
-                          <ButtonGroup
-                            block={false}
-                            bsClass="btn-group"
-                            className="dropdown"
-                            justified={false}
-                            vertical={false}
+                          <div
+                            className="dropdown btn-group"
                           >
-                            <div
-                              className="dropdown btn-group"
+                            <DropdownToggle
+                              bsClass="dropdown-toggle"
+                              bsRole="toggle"
+                              className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                              id="refresh-options-dropdown"
+                              key=".0"
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              open={false}
+                              useAnchor={false}
                             >
-                              <DropdownToggle
-                                bsClass="dropdown-toggle"
-                                bsRole="toggle"
-                                className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                              <Button
+                                active={false}
+                                aria-expanded={false}
+                                aria-haspopup={true}
+                                block={false}
+                                bsClass="btn"
+                                bsStyle="default"
+                                className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                disabled={false}
                                 id="refresh-options-dropdown"
-                                key=".0"
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
-                                open={false}
-                                useAnchor={false}
+                                role="button"
                               >
-                                <Button
-                                  active={false}
+                                <button
                                   aria-expanded={false}
                                   aria-haspopup={true}
-                                  block={false}
-                                  bsClass="btn"
-                                  bsStyle="default"
-                                  className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                  className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-default"
                                   disabled={false}
                                   id="refresh-options-dropdown"
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
                                   role="button"
+                                  type="button"
                                 >
-                                  <button
-                                    aria-expanded={false}
-                                    aria-haspopup={true}
-                                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-default"
+                                  <RefreshControls__ButtonLabel>
+                                    <div
+                                      className="RefreshControls__ButtonLabel-sc-1pygk8n-2 eWVOVO"
+                                    >
+                                      Update every 
+                                      <span>
+                                        5
+                                         
+                                        <Pluralize
+                                          plural="seconds"
+                                          singular="second"
+                                          value={5}
+                                        >
+                                          <span>
+                                            seconds
+                                          </span>
+                                        </Pluralize>
+                                      </span>
+                                    </div>
+                                  </RefreshControls__ButtonLabel>
+                                   
+                                  <span
+                                    className="caret"
+                                  />
+                                </button>
+                              </Button>
+                            </DropdownToggle>
+                            <DropdownMenu
+                              bsClass="dropdown-menu"
+                              bsRole="menu"
+                              key=".1"
+                              labelledBy="refresh-options-dropdown"
+                              onClose={[Function]}
+                              onSelect={[Function]}
+                              pullRight={false}
+                            >
+                              <RootCloseWrapper
+                                disabled={true}
+                                event="click"
+                                onRootClose={[Function]}
+                              >
+                                <ul
+                                  aria-labelledby="refresh-options-dropdown"
+                                  className="dropdown-menu"
+                                  role="menu"
+                                >
+                                  <MenuItem
+                                    bsClass="dropdown"
                                     disabled={false}
-                                    id="refresh-options-dropdown"
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-1 Second"
                                     onClick={[Function]}
                                     onKeyDown={[Function]}
-                                    role="button"
-                                    type="button"
+                                    onSelect={[Function]}
                                   >
-                                    <RefreshControls__ButtonLabel>
-                                      <div
-                                        className="RefreshControls__ButtonLabel-sc-1pygk8n-2 eWVOVO"
+                                    <li
+                                      className=""
+                                      role="presentation"
+                                    >
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        Update every 
-                                        <span>
-                                          5
-                                           
-                                          <Pluralize
-                                            plural="seconds"
-                                            singular="second"
-                                            value={5}
-                                          >
-                                            <span>
-                                              seconds
-                                            </span>
-                                          </Pluralize>
-                                        </span>
-                                      </div>
-                                    </RefreshControls__ButtonLabel>
-                                     
-                                    <span
-                                      className="caret"
-                                    />
-                                  </button>
-                                </Button>
-                              </DropdownToggle>
-                              <DropdownMenu
-                                bsClass="dropdown-menu"
-                                bsRole="menu"
-                                key=".1"
-                                labelledBy="refresh-options-dropdown"
-                                onClose={[Function]}
-                                onSelect={[Function]}
-                                pullRight={false}
-                              >
-                                <RootCloseWrapper
-                                  disabled={true}
-                                  event="click"
-                                  onRootClose={[Function]}
-                                >
-                                  <ul
-                                    aria-labelledby="refresh-options-dropdown"
-                                    className="dropdown-menu"
-                                    role="menu"
+                                        <a
+                                          href="#"
+                                          onClick={[Function]}
+                                          onKeyDown={[Function]}
+                                          role="menuitem"
+                                          tabIndex="-1"
+                                        >
+                                          1 Second
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-2 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
                                   >
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-1 Second"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            1 Second
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-2 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          2 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-5 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            2 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-5 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          5 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-10 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            5 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-10 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          10 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-30 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            10 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-30 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          30 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-1 Minute"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            30 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-1 Minute"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          1 Minute
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-5 Minutes"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            1 Minute
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-5 Minutes"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
-                                    >
-                                      <li
-                                        className=""
-                                        role="presentation"
-                                      >
-                                        <SafeAnchor
-                                          componentClass="a"
-                                          onClick={[Function]}
-                                          onKeyDown={[Function]}
-                                          role="menuitem"
-                                          tabIndex="-1"
-                                        >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            5 Minutes
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                  </ul>
-                                </RootCloseWrapper>
-                              </DropdownMenu>
-                            </div>
-                          </ButtonGroup>
-                        </Dropdown>
-                      </Uncontrolled(Dropdown)>
-                    </ForwardRef>
-                  </DropdownButton>
-                </DropdownButton__StyledDropdownButton>
-              </ForwardRef>
+                                          5 Minutes
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                </ul>
+                              </RootCloseWrapper>
+                            </DropdownMenu>
+                          </div>
+                        </ButtonGroup>
+                      </Dropdown>
+                    </Uncontrolled(Dropdown)>
+                  </ForwardRef>
+                </DropdownButton>
+              </DropdownButton>
             </div>
           </ButtonGroup>
         </RefreshControls__FlexibleButtonGroup>
@@ -2392,49 +2294,45 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
             <div
               className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 rpAER btn-group"
             >
-              <ForwardRef
+              <Button
                 onClick={[Function]}
               >
-                <Button__StyledButton
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="Button-c9cbmb-0 bNulii"
+                  disabled={false}
                   onClick={[Function]}
                 >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="default"
-                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                  <button
+                    className="Button-c9cbmb-0 bNulii btn btn-default"
                     disabled={false}
                     onClick={[Function]}
+                    type="button"
                   >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                      disabled={false}
-                      onClick={[Function]}
-                      type="button"
+                    <Icon
+                      name="pause"
+                      type="solid"
                     >
-                      <Icon
-                        name="pause"
-                        type="solid"
-                      >
-                        <FontAwesomeIcon
-                          icon={
-                            Object {
-                              "iconName": "pause",
-                              "prefix": "fas",
-                            }
+                      <FontAwesomeIcon
+                        icon={
+                          Object {
+                            "iconName": "pause",
+                            "prefix": "fas",
                           }
-                        >
-                          <svg
-                            className="svg-inline--fa fa-pause"
-                          />
-                        </FontAwesomeIcon>
-                      </Icon>
-                    </button>
-                  </Button>
-                </Button__StyledButton>
-              </ForwardRef>
-              <ForwardRef
+                        }
+                      >
+                        <svg
+                          className="svg-inline--fa fa-pause"
+                        />
+                      </FontAwesomeIcon>
+                    </Icon>
+                  </button>
+                </Button>
+              </Button>
+              <DropdownButton
                 id="refresh-options-dropdown"
                 title={
                   <RefreshControls__ButtonLabel>
@@ -2453,7 +2351,8 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
                   </RefreshControls__ButtonLabel>
                 }
               >
-                <DropdownButton__StyledDropdownButton
+                <DropdownButton
+                  className="DropdownButton-sc-1343dcx-0 jHYVsD"
                   id="refresh-options-dropdown"
                   title={
                     <RefreshControls__ButtonLabel>
@@ -2472,373 +2371,352 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
                     </RefreshControls__ButtonLabel>
                   }
                 >
-                  <DropdownButton
-                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                  <ForwardRef
                     id="refresh-options-dropdown"
-                    title={
-                      <RefreshControls__ButtonLabel>
-                        <React.Fragment>
-                          Update every 
-                          <span>
-                            10
-                             
-                            <Pluralize
-                              plural="seconds"
-                              singular="second"
-                              value={10}
-                            />
-                          </span>
-                        </React.Fragment>
-                      </RefreshControls__ButtonLabel>
-                    }
                   >
-                    <ForwardRef
+                    <Uncontrolled(Dropdown)
                       id="refresh-options-dropdown"
+                      innerRef={null}
                     >
-                      <Uncontrolled(Dropdown)
+                      <Dropdown
+                        bsClass="dropdown"
+                        componentClass={[Function]}
                         id="refresh-options-dropdown"
-                        innerRef={null}
+                        onToggle={[Function]}
                       >
-                        <Dropdown
-                          bsClass="dropdown"
-                          componentClass={[Function]}
-                          id="refresh-options-dropdown"
-                          onToggle={[Function]}
+                        <ButtonGroup
+                          block={false}
+                          bsClass="btn-group"
+                          className="dropdown"
+                          justified={false}
+                          vertical={false}
                         >
-                          <ButtonGroup
-                            block={false}
-                            bsClass="btn-group"
-                            className="dropdown"
-                            justified={false}
-                            vertical={false}
+                          <div
+                            className="dropdown btn-group"
                           >
-                            <div
-                              className="dropdown btn-group"
+                            <DropdownToggle
+                              bsClass="dropdown-toggle"
+                              bsRole="toggle"
+                              className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                              id="refresh-options-dropdown"
+                              key=".0"
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              open={false}
+                              useAnchor={false}
                             >
-                              <DropdownToggle
-                                bsClass="dropdown-toggle"
-                                bsRole="toggle"
-                                className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                              <Button
+                                active={false}
+                                aria-expanded={false}
+                                aria-haspopup={true}
+                                block={false}
+                                bsClass="btn"
+                                bsStyle="default"
+                                className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                disabled={false}
                                 id="refresh-options-dropdown"
-                                key=".0"
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
-                                open={false}
-                                useAnchor={false}
+                                role="button"
                               >
-                                <Button
-                                  active={false}
+                                <button
                                   aria-expanded={false}
                                   aria-haspopup={true}
-                                  block={false}
-                                  bsClass="btn"
-                                  bsStyle="default"
-                                  className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                  className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-default"
                                   disabled={false}
                                   id="refresh-options-dropdown"
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
                                   role="button"
+                                  type="button"
                                 >
-                                  <button
-                                    aria-expanded={false}
-                                    aria-haspopup={true}
-                                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-default"
+                                  <RefreshControls__ButtonLabel>
+                                    <div
+                                      className="RefreshControls__ButtonLabel-sc-1pygk8n-2 eWVOVO"
+                                    >
+                                      Update every 
+                                      <span>
+                                        10
+                                         
+                                        <Pluralize
+                                          plural="seconds"
+                                          singular="second"
+                                          value={10}
+                                        >
+                                          <span>
+                                            seconds
+                                          </span>
+                                        </Pluralize>
+                                      </span>
+                                    </div>
+                                  </RefreshControls__ButtonLabel>
+                                   
+                                  <span
+                                    className="caret"
+                                  />
+                                </button>
+                              </Button>
+                            </DropdownToggle>
+                            <DropdownMenu
+                              bsClass="dropdown-menu"
+                              bsRole="menu"
+                              key=".1"
+                              labelledBy="refresh-options-dropdown"
+                              onClose={[Function]}
+                              onSelect={[Function]}
+                              pullRight={false}
+                            >
+                              <RootCloseWrapper
+                                disabled={true}
+                                event="click"
+                                onRootClose={[Function]}
+                              >
+                                <ul
+                                  aria-labelledby="refresh-options-dropdown"
+                                  className="dropdown-menu"
+                                  role="menu"
+                                >
+                                  <MenuItem
+                                    bsClass="dropdown"
                                     disabled={false}
-                                    id="refresh-options-dropdown"
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-1 Second"
                                     onClick={[Function]}
                                     onKeyDown={[Function]}
-                                    role="button"
-                                    type="button"
+                                    onSelect={[Function]}
                                   >
-                                    <RefreshControls__ButtonLabel>
-                                      <div
-                                        className="RefreshControls__ButtonLabel-sc-1pygk8n-2 eWVOVO"
+                                    <li
+                                      className=""
+                                      role="presentation"
+                                    >
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        Update every 
-                                        <span>
-                                          10
-                                           
-                                          <Pluralize
-                                            plural="seconds"
-                                            singular="second"
-                                            value={10}
-                                          >
-                                            <span>
-                                              seconds
-                                            </span>
-                                          </Pluralize>
-                                        </span>
-                                      </div>
-                                    </RefreshControls__ButtonLabel>
-                                     
-                                    <span
-                                      className="caret"
-                                    />
-                                  </button>
-                                </Button>
-                              </DropdownToggle>
-                              <DropdownMenu
-                                bsClass="dropdown-menu"
-                                bsRole="menu"
-                                key=".1"
-                                labelledBy="refresh-options-dropdown"
-                                onClose={[Function]}
-                                onSelect={[Function]}
-                                pullRight={false}
-                              >
-                                <RootCloseWrapper
-                                  disabled={true}
-                                  event="click"
-                                  onRootClose={[Function]}
-                                >
-                                  <ul
-                                    aria-labelledby="refresh-options-dropdown"
-                                    className="dropdown-menu"
-                                    role="menu"
+                                        <a
+                                          href="#"
+                                          onClick={[Function]}
+                                          onKeyDown={[Function]}
+                                          role="menuitem"
+                                          tabIndex="-1"
+                                        >
+                                          1 Second
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-2 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
                                   >
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-1 Second"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            1 Second
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-2 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          2 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-5 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            2 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-5 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          5 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-10 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            5 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-10 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          10 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-30 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            10 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-30 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          30 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-1 Minute"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            30 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-1 Minute"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          1 Minute
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-5 Minutes"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            1 Minute
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-5 Minutes"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
-                                    >
-                                      <li
-                                        className=""
-                                        role="presentation"
-                                      >
-                                        <SafeAnchor
-                                          componentClass="a"
-                                          onClick={[Function]}
-                                          onKeyDown={[Function]}
-                                          role="menuitem"
-                                          tabIndex="-1"
-                                        >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            5 Minutes
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                  </ul>
-                                </RootCloseWrapper>
-                              </DropdownMenu>
-                            </div>
-                          </ButtonGroup>
-                        </Dropdown>
-                      </Uncontrolled(Dropdown)>
-                    </ForwardRef>
-                  </DropdownButton>
-                </DropdownButton__StyledDropdownButton>
-              </ForwardRef>
+                                          5 Minutes
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                </ul>
+                              </RootCloseWrapper>
+                            </DropdownMenu>
+                          </div>
+                        </ButtonGroup>
+                      </Dropdown>
+                    </Uncontrolled(Dropdown)>
+                  </ForwardRef>
+                </DropdownButton>
+              </DropdownButton>
             </div>
           </ButtonGroup>
         </RefreshControls__FlexibleButtonGroup>
@@ -2882,49 +2760,45 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
             <div
               className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 rpAER btn-group"
             >
-              <ForwardRef
+              <Button
                 onClick={[Function]}
               >
-                <Button__StyledButton
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="Button-c9cbmb-0 bNulii"
+                  disabled={false}
                   onClick={[Function]}
                 >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="default"
-                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                  <button
+                    className="Button-c9cbmb-0 bNulii btn btn-default"
                     disabled={false}
                     onClick={[Function]}
+                    type="button"
                   >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                      disabled={false}
-                      onClick={[Function]}
-                      type="button"
+                    <Icon
+                      name="pause"
+                      type="solid"
                     >
-                      <Icon
-                        name="pause"
-                        type="solid"
-                      >
-                        <FontAwesomeIcon
-                          icon={
-                            Object {
-                              "iconName": "pause",
-                              "prefix": "fas",
-                            }
+                      <FontAwesomeIcon
+                        icon={
+                          Object {
+                            "iconName": "pause",
+                            "prefix": "fas",
                           }
-                        >
-                          <svg
-                            className="svg-inline--fa fa-pause"
-                          />
-                        </FontAwesomeIcon>
-                      </Icon>
-                    </button>
-                  </Button>
-                </Button__StyledButton>
-              </ForwardRef>
-              <ForwardRef
+                        }
+                      >
+                        <svg
+                          className="svg-inline--fa fa-pause"
+                        />
+                      </FontAwesomeIcon>
+                    </Icon>
+                  </button>
+                </Button>
+              </Button>
+              <DropdownButton
                 id="refresh-options-dropdown"
                 title={
                   <RefreshControls__ButtonLabel>
@@ -2943,7 +2817,8 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
                   </RefreshControls__ButtonLabel>
                 }
               >
-                <DropdownButton__StyledDropdownButton
+                <DropdownButton
+                  className="DropdownButton-sc-1343dcx-0 jHYVsD"
                   id="refresh-options-dropdown"
                   title={
                     <RefreshControls__ButtonLabel>
@@ -2962,373 +2837,352 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
                     </RefreshControls__ButtonLabel>
                   }
                 >
-                  <DropdownButton
-                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                  <ForwardRef
                     id="refresh-options-dropdown"
-                    title={
-                      <RefreshControls__ButtonLabel>
-                        <React.Fragment>
-                          Update every 
-                          <span>
-                            30
-                             
-                            <Pluralize
-                              plural="seconds"
-                              singular="second"
-                              value={30}
-                            />
-                          </span>
-                        </React.Fragment>
-                      </RefreshControls__ButtonLabel>
-                    }
                   >
-                    <ForwardRef
+                    <Uncontrolled(Dropdown)
                       id="refresh-options-dropdown"
+                      innerRef={null}
                     >
-                      <Uncontrolled(Dropdown)
+                      <Dropdown
+                        bsClass="dropdown"
+                        componentClass={[Function]}
                         id="refresh-options-dropdown"
-                        innerRef={null}
+                        onToggle={[Function]}
                       >
-                        <Dropdown
-                          bsClass="dropdown"
-                          componentClass={[Function]}
-                          id="refresh-options-dropdown"
-                          onToggle={[Function]}
+                        <ButtonGroup
+                          block={false}
+                          bsClass="btn-group"
+                          className="dropdown"
+                          justified={false}
+                          vertical={false}
                         >
-                          <ButtonGroup
-                            block={false}
-                            bsClass="btn-group"
-                            className="dropdown"
-                            justified={false}
-                            vertical={false}
+                          <div
+                            className="dropdown btn-group"
                           >
-                            <div
-                              className="dropdown btn-group"
+                            <DropdownToggle
+                              bsClass="dropdown-toggle"
+                              bsRole="toggle"
+                              className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                              id="refresh-options-dropdown"
+                              key=".0"
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              open={false}
+                              useAnchor={false}
                             >
-                              <DropdownToggle
-                                bsClass="dropdown-toggle"
-                                bsRole="toggle"
-                                className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                              <Button
+                                active={false}
+                                aria-expanded={false}
+                                aria-haspopup={true}
+                                block={false}
+                                bsClass="btn"
+                                bsStyle="default"
+                                className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                disabled={false}
                                 id="refresh-options-dropdown"
-                                key=".0"
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
-                                open={false}
-                                useAnchor={false}
+                                role="button"
                               >
-                                <Button
-                                  active={false}
+                                <button
                                   aria-expanded={false}
                                   aria-haspopup={true}
-                                  block={false}
-                                  bsClass="btn"
-                                  bsStyle="default"
-                                  className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                  className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-default"
                                   disabled={false}
                                   id="refresh-options-dropdown"
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
                                   role="button"
+                                  type="button"
                                 >
-                                  <button
-                                    aria-expanded={false}
-                                    aria-haspopup={true}
-                                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-default"
+                                  <RefreshControls__ButtonLabel>
+                                    <div
+                                      className="RefreshControls__ButtonLabel-sc-1pygk8n-2 eWVOVO"
+                                    >
+                                      Update every 
+                                      <span>
+                                        30
+                                         
+                                        <Pluralize
+                                          plural="seconds"
+                                          singular="second"
+                                          value={30}
+                                        >
+                                          <span>
+                                            seconds
+                                          </span>
+                                        </Pluralize>
+                                      </span>
+                                    </div>
+                                  </RefreshControls__ButtonLabel>
+                                   
+                                  <span
+                                    className="caret"
+                                  />
+                                </button>
+                              </Button>
+                            </DropdownToggle>
+                            <DropdownMenu
+                              bsClass="dropdown-menu"
+                              bsRole="menu"
+                              key=".1"
+                              labelledBy="refresh-options-dropdown"
+                              onClose={[Function]}
+                              onSelect={[Function]}
+                              pullRight={false}
+                            >
+                              <RootCloseWrapper
+                                disabled={true}
+                                event="click"
+                                onRootClose={[Function]}
+                              >
+                                <ul
+                                  aria-labelledby="refresh-options-dropdown"
+                                  className="dropdown-menu"
+                                  role="menu"
+                                >
+                                  <MenuItem
+                                    bsClass="dropdown"
                                     disabled={false}
-                                    id="refresh-options-dropdown"
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-1 Second"
                                     onClick={[Function]}
                                     onKeyDown={[Function]}
-                                    role="button"
-                                    type="button"
+                                    onSelect={[Function]}
                                   >
-                                    <RefreshControls__ButtonLabel>
-                                      <div
-                                        className="RefreshControls__ButtonLabel-sc-1pygk8n-2 eWVOVO"
+                                    <li
+                                      className=""
+                                      role="presentation"
+                                    >
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        Update every 
-                                        <span>
-                                          30
-                                           
-                                          <Pluralize
-                                            plural="seconds"
-                                            singular="second"
-                                            value={30}
-                                          >
-                                            <span>
-                                              seconds
-                                            </span>
-                                          </Pluralize>
-                                        </span>
-                                      </div>
-                                    </RefreshControls__ButtonLabel>
-                                     
-                                    <span
-                                      className="caret"
-                                    />
-                                  </button>
-                                </Button>
-                              </DropdownToggle>
-                              <DropdownMenu
-                                bsClass="dropdown-menu"
-                                bsRole="menu"
-                                key=".1"
-                                labelledBy="refresh-options-dropdown"
-                                onClose={[Function]}
-                                onSelect={[Function]}
-                                pullRight={false}
-                              >
-                                <RootCloseWrapper
-                                  disabled={true}
-                                  event="click"
-                                  onRootClose={[Function]}
-                                >
-                                  <ul
-                                    aria-labelledby="refresh-options-dropdown"
-                                    className="dropdown-menu"
-                                    role="menu"
+                                        <a
+                                          href="#"
+                                          onClick={[Function]}
+                                          onKeyDown={[Function]}
+                                          role="menuitem"
+                                          tabIndex="-1"
+                                        >
+                                          1 Second
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-2 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
                                   >
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-1 Second"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            1 Second
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-2 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          2 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-5 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            2 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-5 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          5 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-10 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            5 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-10 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          10 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-30 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            10 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-30 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          30 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-1 Minute"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            30 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-1 Minute"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          1 Minute
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-5 Minutes"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            1 Minute
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-5 Minutes"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
-                                    >
-                                      <li
-                                        className=""
-                                        role="presentation"
-                                      >
-                                        <SafeAnchor
-                                          componentClass="a"
-                                          onClick={[Function]}
-                                          onKeyDown={[Function]}
-                                          role="menuitem"
-                                          tabIndex="-1"
-                                        >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            5 Minutes
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                  </ul>
-                                </RootCloseWrapper>
-                              </DropdownMenu>
-                            </div>
-                          </ButtonGroup>
-                        </Dropdown>
-                      </Uncontrolled(Dropdown)>
-                    </ForwardRef>
-                  </DropdownButton>
-                </DropdownButton__StyledDropdownButton>
-              </ForwardRef>
+                                          5 Minutes
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                </ul>
+                              </RootCloseWrapper>
+                            </DropdownMenu>
+                          </div>
+                        </ButtonGroup>
+                      </Dropdown>
+                    </Uncontrolled(Dropdown)>
+                  </ForwardRef>
+                </DropdownButton>
+              </DropdownButton>
             </div>
           </ButtonGroup>
         </RefreshControls__FlexibleButtonGroup>
@@ -3372,49 +3226,45 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
             <div
               className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 rpAER btn-group"
             >
-              <ForwardRef
+              <Button
                 onClick={[Function]}
               >
-                <Button__StyledButton
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="Button-c9cbmb-0 bNulii"
+                  disabled={false}
                   onClick={[Function]}
                 >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="default"
-                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                  <button
+                    className="Button-c9cbmb-0 bNulii btn btn-default"
                     disabled={false}
                     onClick={[Function]}
+                    type="button"
                   >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                      disabled={false}
-                      onClick={[Function]}
-                      type="button"
+                    <Icon
+                      name="pause"
+                      type="solid"
                     >
-                      <Icon
-                        name="pause"
-                        type="solid"
-                      >
-                        <FontAwesomeIcon
-                          icon={
-                            Object {
-                              "iconName": "pause",
-                              "prefix": "fas",
-                            }
+                      <FontAwesomeIcon
+                        icon={
+                          Object {
+                            "iconName": "pause",
+                            "prefix": "fas",
                           }
-                        >
-                          <svg
-                            className="svg-inline--fa fa-pause"
-                          />
-                        </FontAwesomeIcon>
-                      </Icon>
-                    </button>
-                  </Button>
-                </Button__StyledButton>
-              </ForwardRef>
-              <ForwardRef
+                        }
+                      >
+                        <svg
+                          className="svg-inline--fa fa-pause"
+                        />
+                      </FontAwesomeIcon>
+                    </Icon>
+                  </button>
+                </Button>
+              </Button>
+              <DropdownButton
                 id="refresh-options-dropdown"
                 title={
                   <RefreshControls__ButtonLabel>
@@ -3433,7 +3283,8 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
                   </RefreshControls__ButtonLabel>
                 }
               >
-                <DropdownButton__StyledDropdownButton
+                <DropdownButton
+                  className="DropdownButton-sc-1343dcx-0 jHYVsD"
                   id="refresh-options-dropdown"
                   title={
                     <RefreshControls__ButtonLabel>
@@ -3452,373 +3303,352 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
                     </RefreshControls__ButtonLabel>
                   }
                 >
-                  <DropdownButton
-                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                  <ForwardRef
                     id="refresh-options-dropdown"
-                    title={
-                      <RefreshControls__ButtonLabel>
-                        <React.Fragment>
-                          Update every 
-                          <span>
-                            1
-                             
-                            <Pluralize
-                              plural="minutes"
-                              singular="minute"
-                              value={1}
-                            />
-                          </span>
-                        </React.Fragment>
-                      </RefreshControls__ButtonLabel>
-                    }
                   >
-                    <ForwardRef
+                    <Uncontrolled(Dropdown)
                       id="refresh-options-dropdown"
+                      innerRef={null}
                     >
-                      <Uncontrolled(Dropdown)
+                      <Dropdown
+                        bsClass="dropdown"
+                        componentClass={[Function]}
                         id="refresh-options-dropdown"
-                        innerRef={null}
+                        onToggle={[Function]}
                       >
-                        <Dropdown
-                          bsClass="dropdown"
-                          componentClass={[Function]}
-                          id="refresh-options-dropdown"
-                          onToggle={[Function]}
+                        <ButtonGroup
+                          block={false}
+                          bsClass="btn-group"
+                          className="dropdown"
+                          justified={false}
+                          vertical={false}
                         >
-                          <ButtonGroup
-                            block={false}
-                            bsClass="btn-group"
-                            className="dropdown"
-                            justified={false}
-                            vertical={false}
+                          <div
+                            className="dropdown btn-group"
                           >
-                            <div
-                              className="dropdown btn-group"
+                            <DropdownToggle
+                              bsClass="dropdown-toggle"
+                              bsRole="toggle"
+                              className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                              id="refresh-options-dropdown"
+                              key=".0"
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              open={false}
+                              useAnchor={false}
                             >
-                              <DropdownToggle
-                                bsClass="dropdown-toggle"
-                                bsRole="toggle"
-                                className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                              <Button
+                                active={false}
+                                aria-expanded={false}
+                                aria-haspopup={true}
+                                block={false}
+                                bsClass="btn"
+                                bsStyle="default"
+                                className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                disabled={false}
                                 id="refresh-options-dropdown"
-                                key=".0"
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
-                                open={false}
-                                useAnchor={false}
+                                role="button"
                               >
-                                <Button
-                                  active={false}
+                                <button
                                   aria-expanded={false}
                                   aria-haspopup={true}
-                                  block={false}
-                                  bsClass="btn"
-                                  bsStyle="default"
-                                  className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                  className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-default"
                                   disabled={false}
                                   id="refresh-options-dropdown"
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
                                   role="button"
+                                  type="button"
                                 >
-                                  <button
-                                    aria-expanded={false}
-                                    aria-haspopup={true}
-                                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-default"
+                                  <RefreshControls__ButtonLabel>
+                                    <div
+                                      className="RefreshControls__ButtonLabel-sc-1pygk8n-2 eWVOVO"
+                                    >
+                                      Update every 
+                                      <span>
+                                        1
+                                         
+                                        <Pluralize
+                                          plural="minutes"
+                                          singular="minute"
+                                          value={1}
+                                        >
+                                          <span>
+                                            minute
+                                          </span>
+                                        </Pluralize>
+                                      </span>
+                                    </div>
+                                  </RefreshControls__ButtonLabel>
+                                   
+                                  <span
+                                    className="caret"
+                                  />
+                                </button>
+                              </Button>
+                            </DropdownToggle>
+                            <DropdownMenu
+                              bsClass="dropdown-menu"
+                              bsRole="menu"
+                              key=".1"
+                              labelledBy="refresh-options-dropdown"
+                              onClose={[Function]}
+                              onSelect={[Function]}
+                              pullRight={false}
+                            >
+                              <RootCloseWrapper
+                                disabled={true}
+                                event="click"
+                                onRootClose={[Function]}
+                              >
+                                <ul
+                                  aria-labelledby="refresh-options-dropdown"
+                                  className="dropdown-menu"
+                                  role="menu"
+                                >
+                                  <MenuItem
+                                    bsClass="dropdown"
                                     disabled={false}
-                                    id="refresh-options-dropdown"
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-1 Second"
                                     onClick={[Function]}
                                     onKeyDown={[Function]}
-                                    role="button"
-                                    type="button"
+                                    onSelect={[Function]}
                                   >
-                                    <RefreshControls__ButtonLabel>
-                                      <div
-                                        className="RefreshControls__ButtonLabel-sc-1pygk8n-2 eWVOVO"
+                                    <li
+                                      className=""
+                                      role="presentation"
+                                    >
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        Update every 
-                                        <span>
-                                          1
-                                           
-                                          <Pluralize
-                                            plural="minutes"
-                                            singular="minute"
-                                            value={1}
-                                          >
-                                            <span>
-                                              minute
-                                            </span>
-                                          </Pluralize>
-                                        </span>
-                                      </div>
-                                    </RefreshControls__ButtonLabel>
-                                     
-                                    <span
-                                      className="caret"
-                                    />
-                                  </button>
-                                </Button>
-                              </DropdownToggle>
-                              <DropdownMenu
-                                bsClass="dropdown-menu"
-                                bsRole="menu"
-                                key=".1"
-                                labelledBy="refresh-options-dropdown"
-                                onClose={[Function]}
-                                onSelect={[Function]}
-                                pullRight={false}
-                              >
-                                <RootCloseWrapper
-                                  disabled={true}
-                                  event="click"
-                                  onRootClose={[Function]}
-                                >
-                                  <ul
-                                    aria-labelledby="refresh-options-dropdown"
-                                    className="dropdown-menu"
-                                    role="menu"
+                                        <a
+                                          href="#"
+                                          onClick={[Function]}
+                                          onKeyDown={[Function]}
+                                          role="menuitem"
+                                          tabIndex="-1"
+                                        >
+                                          1 Second
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-2 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
                                   >
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-1 Second"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            1 Second
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-2 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          2 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-5 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            2 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-5 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          5 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-10 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            5 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-10 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          10 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-30 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            10 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-30 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          30 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-1 Minute"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            30 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-1 Minute"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          1 Minute
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-5 Minutes"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            1 Minute
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-5 Minutes"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
-                                    >
-                                      <li
-                                        className=""
-                                        role="presentation"
-                                      >
-                                        <SafeAnchor
-                                          componentClass="a"
-                                          onClick={[Function]}
-                                          onKeyDown={[Function]}
-                                          role="menuitem"
-                                          tabIndex="-1"
-                                        >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            5 Minutes
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                  </ul>
-                                </RootCloseWrapper>
-                              </DropdownMenu>
-                            </div>
-                          </ButtonGroup>
-                        </Dropdown>
-                      </Uncontrolled(Dropdown)>
-                    </ForwardRef>
-                  </DropdownButton>
-                </DropdownButton__StyledDropdownButton>
-              </ForwardRef>
+                                          5 Minutes
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                </ul>
+                              </RootCloseWrapper>
+                            </DropdownMenu>
+                          </div>
+                        </ButtonGroup>
+                      </Dropdown>
+                    </Uncontrolled(Dropdown)>
+                  </ForwardRef>
+                </DropdownButton>
+              </DropdownButton>
             </div>
           </ButtonGroup>
         </RefreshControls__FlexibleButtonGroup>
@@ -3862,49 +3692,45 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
             <div
               className="RefreshControls__FlexibleButtonGroup-sc-1pygk8n-1 rpAER btn-group"
             >
-              <ForwardRef
+              <Button
                 onClick={[Function]}
               >
-                <Button__StyledButton
+                <Button
+                  active={false}
+                  block={false}
+                  bsClass="btn"
+                  bsStyle="default"
+                  className="Button-c9cbmb-0 bNulii"
+                  disabled={false}
                   onClick={[Function]}
                 >
-                  <Button
-                    active={false}
-                    block={false}
-                    bsClass="btn"
-                    bsStyle="default"
-                    className="Button__StyledButton-c9cbmb-0 laZUlH"
+                  <button
+                    className="Button-c9cbmb-0 bNulii btn btn-default"
                     disabled={false}
                     onClick={[Function]}
+                    type="button"
                   >
-                    <button
-                      className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
-                      disabled={false}
-                      onClick={[Function]}
-                      type="button"
+                    <Icon
+                      name="pause"
+                      type="solid"
                     >
-                      <Icon
-                        name="pause"
-                        type="solid"
-                      >
-                        <FontAwesomeIcon
-                          icon={
-                            Object {
-                              "iconName": "pause",
-                              "prefix": "fas",
-                            }
+                      <FontAwesomeIcon
+                        icon={
+                          Object {
+                            "iconName": "pause",
+                            "prefix": "fas",
                           }
-                        >
-                          <svg
-                            className="svg-inline--fa fa-pause"
-                          />
-                        </FontAwesomeIcon>
-                      </Icon>
-                    </button>
-                  </Button>
-                </Button__StyledButton>
-              </ForwardRef>
-              <ForwardRef
+                        }
+                      >
+                        <svg
+                          className="svg-inline--fa fa-pause"
+                        />
+                      </FontAwesomeIcon>
+                    </Icon>
+                  </button>
+                </Button>
+              </Button>
+              <DropdownButton
                 id="refresh-options-dropdown"
                 title={
                   <RefreshControls__ButtonLabel>
@@ -3923,7 +3749,8 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
                   </RefreshControls__ButtonLabel>
                 }
               >
-                <DropdownButton__StyledDropdownButton
+                <DropdownButton
+                  className="DropdownButton-sc-1343dcx-0 jHYVsD"
                   id="refresh-options-dropdown"
                   title={
                     <RefreshControls__ButtonLabel>
@@ -3942,373 +3769,352 @@ exports[`RefreshControls rendering it renders refresh controlls with enabled: tr
                     </RefreshControls__ButtonLabel>
                   }
                 >
-                  <DropdownButton
-                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                  <ForwardRef
                     id="refresh-options-dropdown"
-                    title={
-                      <RefreshControls__ButtonLabel>
-                        <React.Fragment>
-                          Update every 
-                          <span>
-                            5
-                             
-                            <Pluralize
-                              plural="minutes"
-                              singular="minute"
-                              value={5}
-                            />
-                          </span>
-                        </React.Fragment>
-                      </RefreshControls__ButtonLabel>
-                    }
                   >
-                    <ForwardRef
+                    <Uncontrolled(Dropdown)
                       id="refresh-options-dropdown"
+                      innerRef={null}
                     >
-                      <Uncontrolled(Dropdown)
+                      <Dropdown
+                        bsClass="dropdown"
+                        componentClass={[Function]}
                         id="refresh-options-dropdown"
-                        innerRef={null}
+                        onToggle={[Function]}
                       >
-                        <Dropdown
-                          bsClass="dropdown"
-                          componentClass={[Function]}
-                          id="refresh-options-dropdown"
-                          onToggle={[Function]}
+                        <ButtonGroup
+                          block={false}
+                          bsClass="btn-group"
+                          className="dropdown"
+                          justified={false}
+                          vertical={false}
                         >
-                          <ButtonGroup
-                            block={false}
-                            bsClass="btn-group"
-                            className="dropdown"
-                            justified={false}
-                            vertical={false}
+                          <div
+                            className="dropdown btn-group"
                           >
-                            <div
-                              className="dropdown btn-group"
+                            <DropdownToggle
+                              bsClass="dropdown-toggle"
+                              bsRole="toggle"
+                              className="DropdownButton-sc-1343dcx-0 jHYVsD"
+                              id="refresh-options-dropdown"
+                              key=".0"
+                              onClick={[Function]}
+                              onKeyDown={[Function]}
+                              open={false}
+                              useAnchor={false}
                             >
-                              <DropdownToggle
-                                bsClass="dropdown-toggle"
-                                bsRole="toggle"
-                                className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt"
+                              <Button
+                                active={false}
+                                aria-expanded={false}
+                                aria-haspopup={true}
+                                block={false}
+                                bsClass="btn"
+                                bsStyle="default"
+                                className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle"
+                                disabled={false}
                                 id="refresh-options-dropdown"
-                                key=".0"
                                 onClick={[Function]}
                                 onKeyDown={[Function]}
-                                open={false}
-                                useAnchor={false}
+                                role="button"
                               >
-                                <Button
-                                  active={false}
+                                <button
                                   aria-expanded={false}
                                   aria-haspopup={true}
-                                  block={false}
-                                  bsClass="btn"
-                                  bsStyle="default"
-                                  className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle"
+                                  className="DropdownButton-sc-1343dcx-0 jHYVsD dropdown-toggle btn btn-default"
                                   disabled={false}
                                   id="refresh-options-dropdown"
                                   onClick={[Function]}
                                   onKeyDown={[Function]}
                                   role="button"
+                                  type="button"
                                 >
-                                  <button
-                                    aria-expanded={false}
-                                    aria-haspopup={true}
-                                    className="DropdownButton__StyledDropdownButton-sc-1343dcx-0 iEHPAt dropdown-toggle btn btn-default"
+                                  <RefreshControls__ButtonLabel>
+                                    <div
+                                      className="RefreshControls__ButtonLabel-sc-1pygk8n-2 eWVOVO"
+                                    >
+                                      Update every 
+                                      <span>
+                                        5
+                                         
+                                        <Pluralize
+                                          plural="minutes"
+                                          singular="minute"
+                                          value={5}
+                                        >
+                                          <span>
+                                            minutes
+                                          </span>
+                                        </Pluralize>
+                                      </span>
+                                    </div>
+                                  </RefreshControls__ButtonLabel>
+                                   
+                                  <span
+                                    className="caret"
+                                  />
+                                </button>
+                              </Button>
+                            </DropdownToggle>
+                            <DropdownMenu
+                              bsClass="dropdown-menu"
+                              bsRole="menu"
+                              key=".1"
+                              labelledBy="refresh-options-dropdown"
+                              onClose={[Function]}
+                              onSelect={[Function]}
+                              pullRight={false}
+                            >
+                              <RootCloseWrapper
+                                disabled={true}
+                                event="click"
+                                onRootClose={[Function]}
+                              >
+                                <ul
+                                  aria-labelledby="refresh-options-dropdown"
+                                  className="dropdown-menu"
+                                  role="menu"
+                                >
+                                  <MenuItem
+                                    bsClass="dropdown"
                                     disabled={false}
-                                    id="refresh-options-dropdown"
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-1 Second"
                                     onClick={[Function]}
                                     onKeyDown={[Function]}
-                                    role="button"
-                                    type="button"
+                                    onSelect={[Function]}
                                   >
-                                    <RefreshControls__ButtonLabel>
-                                      <div
-                                        className="RefreshControls__ButtonLabel-sc-1pygk8n-2 eWVOVO"
+                                    <li
+                                      className=""
+                                      role="presentation"
+                                    >
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        Update every 
-                                        <span>
-                                          5
-                                           
-                                          <Pluralize
-                                            plural="minutes"
-                                            singular="minute"
-                                            value={5}
-                                          >
-                                            <span>
-                                              minutes
-                                            </span>
-                                          </Pluralize>
-                                        </span>
-                                      </div>
-                                    </RefreshControls__ButtonLabel>
-                                     
-                                    <span
-                                      className="caret"
-                                    />
-                                  </button>
-                                </Button>
-                              </DropdownToggle>
-                              <DropdownMenu
-                                bsClass="dropdown-menu"
-                                bsRole="menu"
-                                key=".1"
-                                labelledBy="refresh-options-dropdown"
-                                onClose={[Function]}
-                                onSelect={[Function]}
-                                pullRight={false}
-                              >
-                                <RootCloseWrapper
-                                  disabled={true}
-                                  event="click"
-                                  onRootClose={[Function]}
-                                >
-                                  <ul
-                                    aria-labelledby="refresh-options-dropdown"
-                                    className="dropdown-menu"
-                                    role="menu"
+                                        <a
+                                          href="#"
+                                          onClick={[Function]}
+                                          onKeyDown={[Function]}
+                                          role="menuitem"
+                                          tabIndex="-1"
+                                        >
+                                          1 Second
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-2 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
                                   >
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-1 Second"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            1 Second
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-2 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          2 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-5 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            2 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-5 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          5 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-10 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            5 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-10 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          10 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-30 Seconds"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            10 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-30 Seconds"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          30 Seconds
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-1 Minute"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            30 Seconds
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-1 Minute"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
+                                          1 Minute
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                  <MenuItem
+                                    bsClass="dropdown"
+                                    disabled={false}
+                                    divider={false}
+                                    header={false}
+                                    key=".$RefreshControls-5 Minutes"
+                                    onClick={[Function]}
+                                    onKeyDown={[Function]}
+                                    onSelect={[Function]}
+                                  >
+                                    <li
+                                      className=""
+                                      role="presentation"
                                     >
-                                      <li
-                                        className=""
-                                        role="presentation"
+                                      <SafeAnchor
+                                        componentClass="a"
+                                        onClick={[Function]}
+                                        onKeyDown={[Function]}
+                                        role="menuitem"
+                                        tabIndex="-1"
                                       >
-                                        <SafeAnchor
-                                          componentClass="a"
+                                        <a
+                                          href="#"
                                           onClick={[Function]}
                                           onKeyDown={[Function]}
                                           role="menuitem"
                                           tabIndex="-1"
                                         >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            1 Minute
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                    <MenuItem
-                                      bsClass="dropdown"
-                                      disabled={false}
-                                      divider={false}
-                                      header={false}
-                                      key=".$RefreshControls-5 Minutes"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      onSelect={[Function]}
-                                    >
-                                      <li
-                                        className=""
-                                        role="presentation"
-                                      >
-                                        <SafeAnchor
-                                          componentClass="a"
-                                          onClick={[Function]}
-                                          onKeyDown={[Function]}
-                                          role="menuitem"
-                                          tabIndex="-1"
-                                        >
-                                          <a
-                                            href="#"
-                                            onClick={[Function]}
-                                            onKeyDown={[Function]}
-                                            role="menuitem"
-                                            tabIndex="-1"
-                                          >
-                                            5 Minutes
-                                          </a>
-                                        </SafeAnchor>
-                                      </li>
-                                    </MenuItem>
-                                  </ul>
-                                </RootCloseWrapper>
-                              </DropdownMenu>
-                            </div>
-                          </ButtonGroup>
-                        </Dropdown>
-                      </Uncontrolled(Dropdown)>
-                    </ForwardRef>
-                  </DropdownButton>
-                </DropdownButton__StyledDropdownButton>
-              </ForwardRef>
+                                          5 Minutes
+                                        </a>
+                                      </SafeAnchor>
+                                    </li>
+                                  </MenuItem>
+                                </ul>
+                              </RootCloseWrapper>
+                            </DropdownMenu>
+                          </div>
+                        </ButtonGroup>
+                      </Dropdown>
+                    </Uncontrolled(Dropdown)>
+                  </ForwardRef>
+                </DropdownButton>
+              </DropdownButton>
             </div>
           </ButtonGroup>
         </RefreshControls__FlexibleButtonGroup>

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/__snapshots__/SavedSearchControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/__snapshots__/SavedSearchControls.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`SavedSearchControls render the SavedSearchControls should render dirty 1`] = `
 <button
-  className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
+  className="Button-c9cbmb-0 bNulii btn btn-default"
   disabled={false}
   onClick={[Function]}
   title="Unsaved changes"
@@ -41,7 +41,7 @@ exports[`SavedSearchControls render the SavedSearchControls should render dirty 
 
 exports[`SavedSearchControls render the SavedSearchControls should render not dirty 1`] = `
 <button
-  className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
+  className="Button-c9cbmb-0 bNulii btn btn-default"
   disabled={false}
   onClick={[Function]}
   title="Saved search"
@@ -80,7 +80,7 @@ exports[`SavedSearchControls render the SavedSearchControls should render not di
 
 exports[`SavedSearchControls render the SavedSearchControls should render not dirty with unsaved view 1`] = `
 <button
-  className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
+  className="Button-c9cbmb-0 bNulii btn btn-default"
   disabled={false}
   onClick={[Function]}
   title="Save search"

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/__snapshots__/SavedSearchForm.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/__snapshots__/SavedSearchForm.test.jsx.snap
@@ -223,25 +223,291 @@ exports[`SavedSearchForm render the SavedSearchForm should render create new 1`]
                       ],
                       "button": Array [
                         Array [
-                          [Function],
+                          "&.btn-",
+                          "danger",
+                          "{background-color:",
+                          "#ad0707",
+                          ";border-color:",
+                          "#b23939",
+                          ";color:",
+                          "rgb(252,249,249)",
+                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                          "#a00e0e",
+                          ";border-color:",
+                          "#a53636",
+                          ";color:",
+                          "#e9e6e6",
+                          ";}&.active{background-color:",
+                          "#b75151",
+                          ";border-color:",
+                          "#bc6363",
+                          ";color:",
+                          "rgb(252,249,249)",
+                          ";:hover{background-color:",
+                          "#a94c4c",
+                          ";border-color:",
+                          "#ad5c5c",
+                          ";color:",
+                          "#e9e6e6",
+                          ";}}&[disabled],&.disabled{background-color:",
+                          "#c07272",
+                          ";border-color:",
+                          "#bc6363",
+                          ";color:",
+                          "rgb(252,250,250)",
+                          ";:hover{background-color:",
+                          "#c07272",
+                          ";border-color:",
+                          "#bc6363",
+                          ";color:",
+                          "rgb(252,250,250)",
+                          ";}}}",
                         ],
                         Array [
-                          [Function],
+                          "&.btn-",
+                          "default",
+                          "{background-color:",
+                          "#e6e6e6",
+                          ";border-color:",
+                          "#e0e0e0",
+                          ";color:",
+                          "rgb(73,73,73)",
+                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                          "#d4d4d4",
+                          ";border-color:",
+                          "#cfcfcf",
+                          ";color:",
+                          "#444444",
+                          ";}&.active{background-color:",
+                          "#dadada",
+                          ";border-color:",
+                          "#d4d4d4",
+                          ";color:",
+                          "rgb(49,49,49)",
+                          ";:hover{background-color:",
+                          "#cacaca",
+                          ";border-color:",
+                          "#c4c4c4",
+                          ";color:",
+                          "#2f2f2f",
+                          ";}}&[disabled],&.disabled{background-color:",
+                          "#cecece",
+                          ";border-color:",
+                          "#d4d4d4",
+                          ";color:",
+                          "rgb(80,80,80)",
+                          ";:hover{background-color:",
+                          "#cecece",
+                          ";border-color:",
+                          "#d4d4d4",
+                          ";color:",
+                          "rgb(80,80,80)",
+                          ";}}}",
                         ],
                         Array [
-                          [Function],
+                          "&.btn-",
+                          "info",
+                          "{background-color:",
+                          "#0063be",
+                          ";border-color:",
+                          "#3970c2",
+                          ";color:",
+                          "rgb(249,250,252)",
+                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                          "#0c5cb0",
+                          ";border-color:",
+                          "#3668b3",
+                          ";color:",
+                          "#e6e7e9",
+                          ";}&.active{background-color:",
+                          "#517cc5",
+                          ";border-color:",
+                          "#6386c9",
+                          ";color:",
+                          "rgb(249,250,252)",
+                          ";:hover{background-color:",
+                          "#4b73b6",
+                          ";border-color:",
+                          "#5c7dba",
+                          ";color:",
+                          "#e6e7e9",
+                          ";}}&[disabled],&.disabled{background-color:",
+                          "#7290cd",
+                          ";border-color:",
+                          "#6386c9",
+                          ";color:",
+                          "rgb(250,251,253)",
+                          ";:hover{background-color:",
+                          "#7290cd",
+                          ";border-color:",
+                          "#6386c9",
+                          ";color:",
+                          "rgb(250,251,253)",
+                          ";}}}",
                         ],
                         Array [
-                          [Function],
+                          "&.btn-",
+                          "link",
+                          "{background-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";border-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";color:",
+                          "#702785",
+                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                          "#ebebeb26",
+                          ";border-color:",
+                          "#ebebeb26",
+                          ";color:",
+                          "#68267b",
+                          ";}&.active{background-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";border-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";color:",
+                          "#410057",
+                          ";:hover{background-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";border-color:",
+                          "#ebebeb26",
+                          ";color:",
+                          "#3d0c51",
+                          ";}}&[disabled],&.disabled{background-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";border-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";color:",
+                          "#702785",
+                          ";:hover{background-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";border-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";color:",
+                          "#702785",
+                          ";}}}",
                         ],
                         Array [
-                          [Function],
+                          "&.btn-",
+                          "primary",
+                          "{background-color:",
+                          "#702785",
+                          ";border-color:",
+                          "#7b458e",
+                          ";color:",
+                          "rgb(234,229,236)",
+                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                          "#68267b",
+                          ";border-color:",
+                          "#724083",
+                          ";color:",
+                          "#d8d3da",
+                          ";}&.active{background-color:",
+                          "#855996",
+                          ";border-color:",
+                          "#8f699d",
+                          ";color:",
+                          "rgb(250,249,251)",
+                          ";:hover{background-color:",
+                          "#7c538b",
+                          ";border-color:",
+                          "#846292",
+                          ";color:",
+                          "#e7e6e8",
+                          ";}}&[disabled],&.disabled{background-color:",
+                          "#9877a5",
+                          ";border-color:",
+                          "#8f699d",
+                          ";color:",
+                          "rgb(251,250,251)",
+                          ";:hover{background-color:",
+                          "#9877a5",
+                          ";border-color:",
+                          "#8f699d",
+                          ";color:",
+                          "rgb(251,250,251)",
+                          ";}}}",
                         ],
                         Array [
-                          [Function],
+                          "&.btn-",
+                          "success",
+                          "{background-color:",
+                          "#00ae42",
+                          ";border-color:",
+                          "#39b356",
+                          ";color:",
+                          "rgb(249,252,249)",
+                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                          "#0ca13e",
+                          ";border-color:",
+                          "#36a550",
+                          ";color:",
+                          "#e6e9e6",
+                          ";}&.active{background-color:",
+                          "#51b866",
+                          ";border-color:",
+                          "#63bc74",
+                          ";color:",
+                          "rgb(249,252,250)",
+                          ";:hover{background-color:",
+                          "#4baa5f",
+                          ";border-color:",
+                          "#5cae6c",
+                          ";color:",
+                          "#e6e9e7",
+                          ";}}&[disabled],&.disabled{background-color:",
+                          "#72c180",
+                          ";border-color:",
+                          "#63bc74",
+                          ";color:",
+                          "rgb(250,252,250)",
+                          ";:hover{background-color:",
+                          "#72c180",
+                          ";border-color:",
+                          "#63bc74",
+                          ";color:",
+                          "rgb(250,252,250)",
+                          ";}}}",
                         ],
                         Array [
-                          [Function],
+                          "&.btn-",
+                          "warning",
+                          "{background-color:",
+                          "#ffd200",
+                          ";border-color:",
+                          "#f9cd07",
+                          ";color:",
+                          "rgb(57,47,0)",
+                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                          "#ebc20c",
+                          ";border-color:",
+                          "#e6bd0e",
+                          ";color:",
+                          "#362d0c",
+                          ";}&.active{background-color:",
+                          "#f2c70a",
+                          ";border-color:",
+                          "#ebc20c",
+                          ";color:",
+                          "rgb(54,45,2)",
+                          ";:hover{background-color:",
+                          "#e0b80f",
+                          ";border-color:",
+                          "#d9b310",
+                          ";color:",
+                          "#332b0c",
+                          ";}}&[disabled],&.disabled{background-color:",
+                          "#e4bc0e",
+                          ";border-color:",
+                          "#ebc20c",
+                          ";color:",
+                          "rgb(88,73,5)",
+                          ";:hover{background-color:",
+                          "#e4bc0e",
+                          ";border-color:",
+                          "#ebc20c",
+                          ";color:",
+                          "rgb(88,73,5)",
+                          ";}}}",
                         ],
                       ],
                     },
@@ -373,69 +639,56 @@ exports[`SavedSearchForm render the SavedSearchForm should render create new 1`]
                               </FormGroup>
                             </FormGroup__StyledFormGroup>
                           </Component>
-                          <ForwardRef
+                          <Button
                             bsStyle="info"
                             className="button"
                             disabled={false}
                             onClick={[Function]}
                             type="submit"
                           >
-                            <Button__StyledButton
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
                               bsStyle="info"
-                              className="button"
+                              className="Button-c9cbmb-0 bNulii button"
                               disabled={false}
                               onClick={[Function]}
                               type="submit"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="info"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii button btn btn-info"
                                 disabled={false}
                                 onClick={[Function]}
                                 type="submit"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH button btn btn-info"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  type="submit"
-                                >
-                                  Create new
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
-                          <ForwardRef
+                                Create new
+                              </button>
+                            </Button>
+                          </Button>
+                          <Button
                             className="button"
                             onClick={[Function]}
                           >
-                            <Button__StyledButton
-                              className="button"
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
+                              bsStyle="default"
+                              className="Button-c9cbmb-0 bNulii button"
+                              disabled={false}
                               onClick={[Function]}
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="default"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii button btn btn-default"
                                 disabled={false}
                                 onClick={[Function]}
+                                type="button"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH button btn btn-default"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  Cancel
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
+                                Cancel
+                              </button>
+                            </Button>
+                          </Button>
                         </form>
                       </div>
                     </div>
@@ -674,25 +927,291 @@ exports[`SavedSearchForm render the SavedSearchForm should render disabled creat
                       ],
                       "button": Array [
                         Array [
-                          [Function],
+                          "&.btn-",
+                          "danger",
+                          "{background-color:",
+                          "#ad0707",
+                          ";border-color:",
+                          "#b23939",
+                          ";color:",
+                          "rgb(252,249,249)",
+                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                          "#a00e0e",
+                          ";border-color:",
+                          "#a53636",
+                          ";color:",
+                          "#e9e6e6",
+                          ";}&.active{background-color:",
+                          "#b75151",
+                          ";border-color:",
+                          "#bc6363",
+                          ";color:",
+                          "rgb(252,249,249)",
+                          ";:hover{background-color:",
+                          "#a94c4c",
+                          ";border-color:",
+                          "#ad5c5c",
+                          ";color:",
+                          "#e9e6e6",
+                          ";}}&[disabled],&.disabled{background-color:",
+                          "#c07272",
+                          ";border-color:",
+                          "#bc6363",
+                          ";color:",
+                          "rgb(252,250,250)",
+                          ";:hover{background-color:",
+                          "#c07272",
+                          ";border-color:",
+                          "#bc6363",
+                          ";color:",
+                          "rgb(252,250,250)",
+                          ";}}}",
                         ],
                         Array [
-                          [Function],
+                          "&.btn-",
+                          "default",
+                          "{background-color:",
+                          "#e6e6e6",
+                          ";border-color:",
+                          "#e0e0e0",
+                          ";color:",
+                          "rgb(73,73,73)",
+                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                          "#d4d4d4",
+                          ";border-color:",
+                          "#cfcfcf",
+                          ";color:",
+                          "#444444",
+                          ";}&.active{background-color:",
+                          "#dadada",
+                          ";border-color:",
+                          "#d4d4d4",
+                          ";color:",
+                          "rgb(49,49,49)",
+                          ";:hover{background-color:",
+                          "#cacaca",
+                          ";border-color:",
+                          "#c4c4c4",
+                          ";color:",
+                          "#2f2f2f",
+                          ";}}&[disabled],&.disabled{background-color:",
+                          "#cecece",
+                          ";border-color:",
+                          "#d4d4d4",
+                          ";color:",
+                          "rgb(80,80,80)",
+                          ";:hover{background-color:",
+                          "#cecece",
+                          ";border-color:",
+                          "#d4d4d4",
+                          ";color:",
+                          "rgb(80,80,80)",
+                          ";}}}",
                         ],
                         Array [
-                          [Function],
+                          "&.btn-",
+                          "info",
+                          "{background-color:",
+                          "#0063be",
+                          ";border-color:",
+                          "#3970c2",
+                          ";color:",
+                          "rgb(249,250,252)",
+                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                          "#0c5cb0",
+                          ";border-color:",
+                          "#3668b3",
+                          ";color:",
+                          "#e6e7e9",
+                          ";}&.active{background-color:",
+                          "#517cc5",
+                          ";border-color:",
+                          "#6386c9",
+                          ";color:",
+                          "rgb(249,250,252)",
+                          ";:hover{background-color:",
+                          "#4b73b6",
+                          ";border-color:",
+                          "#5c7dba",
+                          ";color:",
+                          "#e6e7e9",
+                          ";}}&[disabled],&.disabled{background-color:",
+                          "#7290cd",
+                          ";border-color:",
+                          "#6386c9",
+                          ";color:",
+                          "rgb(250,251,253)",
+                          ";:hover{background-color:",
+                          "#7290cd",
+                          ";border-color:",
+                          "#6386c9",
+                          ";color:",
+                          "rgb(250,251,253)",
+                          ";}}}",
                         ],
                         Array [
-                          [Function],
+                          "&.btn-",
+                          "link",
+                          "{background-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";border-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";color:",
+                          "#702785",
+                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                          "#ebebeb26",
+                          ";border-color:",
+                          "#ebebeb26",
+                          ";color:",
+                          "#68267b",
+                          ";}&.active{background-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";border-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";color:",
+                          "#410057",
+                          ";:hover{background-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";border-color:",
+                          "#ebebeb26",
+                          ";color:",
+                          "#3d0c51",
+                          ";}}&[disabled],&.disabled{background-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";border-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";color:",
+                          "#702785",
+                          ";:hover{background-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";border-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";color:",
+                          "#702785",
+                          ";}}}",
                         ],
                         Array [
-                          [Function],
+                          "&.btn-",
+                          "primary",
+                          "{background-color:",
+                          "#702785",
+                          ";border-color:",
+                          "#7b458e",
+                          ";color:",
+                          "rgb(234,229,236)",
+                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                          "#68267b",
+                          ";border-color:",
+                          "#724083",
+                          ";color:",
+                          "#d8d3da",
+                          ";}&.active{background-color:",
+                          "#855996",
+                          ";border-color:",
+                          "#8f699d",
+                          ";color:",
+                          "rgb(250,249,251)",
+                          ";:hover{background-color:",
+                          "#7c538b",
+                          ";border-color:",
+                          "#846292",
+                          ";color:",
+                          "#e7e6e8",
+                          ";}}&[disabled],&.disabled{background-color:",
+                          "#9877a5",
+                          ";border-color:",
+                          "#8f699d",
+                          ";color:",
+                          "rgb(251,250,251)",
+                          ";:hover{background-color:",
+                          "#9877a5",
+                          ";border-color:",
+                          "#8f699d",
+                          ";color:",
+                          "rgb(251,250,251)",
+                          ";}}}",
                         ],
                         Array [
-                          [Function],
+                          "&.btn-",
+                          "success",
+                          "{background-color:",
+                          "#00ae42",
+                          ";border-color:",
+                          "#39b356",
+                          ";color:",
+                          "rgb(249,252,249)",
+                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                          "#0ca13e",
+                          ";border-color:",
+                          "#36a550",
+                          ";color:",
+                          "#e6e9e6",
+                          ";}&.active{background-color:",
+                          "#51b866",
+                          ";border-color:",
+                          "#63bc74",
+                          ";color:",
+                          "rgb(249,252,250)",
+                          ";:hover{background-color:",
+                          "#4baa5f",
+                          ";border-color:",
+                          "#5cae6c",
+                          ";color:",
+                          "#e6e9e7",
+                          ";}}&[disabled],&.disabled{background-color:",
+                          "#72c180",
+                          ";border-color:",
+                          "#63bc74",
+                          ";color:",
+                          "rgb(250,252,250)",
+                          ";:hover{background-color:",
+                          "#72c180",
+                          ";border-color:",
+                          "#63bc74",
+                          ";color:",
+                          "rgb(250,252,250)",
+                          ";}}}",
                         ],
                         Array [
-                          [Function],
+                          "&.btn-",
+                          "warning",
+                          "{background-color:",
+                          "#ffd200",
+                          ";border-color:",
+                          "#f9cd07",
+                          ";color:",
+                          "rgb(57,47,0)",
+                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                          "#ebc20c",
+                          ";border-color:",
+                          "#e6bd0e",
+                          ";color:",
+                          "#362d0c",
+                          ";}&.active{background-color:",
+                          "#f2c70a",
+                          ";border-color:",
+                          "#ebc20c",
+                          ";color:",
+                          "rgb(54,45,2)",
+                          ";:hover{background-color:",
+                          "#e0b80f",
+                          ";border-color:",
+                          "#d9b310",
+                          ";color:",
+                          "#332b0c",
+                          ";}}&[disabled],&.disabled{background-color:",
+                          "#e4bc0e",
+                          ";border-color:",
+                          "#ebc20c",
+                          ";color:",
+                          "rgb(88,73,5)",
+                          ";:hover{background-color:",
+                          "#e4bc0e",
+                          ";border-color:",
+                          "#ebc20c",
+                          ";color:",
+                          "rgb(88,73,5)",
+                          ";}}}",
                         ],
                       ],
                     },
@@ -824,102 +1343,82 @@ exports[`SavedSearchForm render the SavedSearchForm should render disabled creat
                               </FormGroup>
                             </FormGroup__StyledFormGroup>
                           </Component>
-                          <ForwardRef
+                          <Button
                             bsStyle="primary"
                             className="button"
                             onClick={[Function]}
                             type="submit"
                           >
-                            <Button__StyledButton
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
                               bsStyle="primary"
-                              className="button"
+                              className="Button-c9cbmb-0 bNulii button"
+                              disabled={false}
                               onClick={[Function]}
                               type="submit"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="primary"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii button btn btn-primary"
                                 disabled={false}
                                 onClick={[Function]}
                                 type="submit"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH button btn btn-primary"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  type="submit"
-                                >
-                                  Save
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
-                          <ForwardRef
+                                Save
+                              </button>
+                            </Button>
+                          </Button>
+                          <Button
                             bsStyle="info"
                             className="button"
                             disabled={true}
                             onClick={[Function]}
                             type="submit"
                           >
-                            <Button__StyledButton
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
                               bsStyle="info"
-                              className="button"
+                              className="Button-c9cbmb-0 bNulii button"
                               disabled={true}
                               onClick={[Function]}
                               type="submit"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="info"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii button btn btn-info"
                                 disabled={true}
                                 onClick={[Function]}
                                 type="submit"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH button btn btn-info"
-                                  disabled={true}
-                                  onClick={[Function]}
-                                  type="submit"
-                                >
-                                  Save as
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
-                          <ForwardRef
+                                Save as
+                              </button>
+                            </Button>
+                          </Button>
+                          <Button
                             className="button"
                             onClick={[Function]}
                           >
-                            <Button__StyledButton
-                              className="button"
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
+                              bsStyle="default"
+                              className="Button-c9cbmb-0 bNulii button"
+                              disabled={false}
                               onClick={[Function]}
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="default"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii button btn btn-default"
                                 disabled={false}
                                 onClick={[Function]}
+                                type="button"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH button btn btn-default"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  Cancel
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
+                                Cancel
+                              </button>
+                            </Button>
+                          </Button>
                         </form>
                       </div>
                     </div>
@@ -1158,25 +1657,291 @@ exports[`SavedSearchForm render the SavedSearchForm should render save 1`] = `
                       ],
                       "button": Array [
                         Array [
-                          [Function],
+                          "&.btn-",
+                          "danger",
+                          "{background-color:",
+                          "#ad0707",
+                          ";border-color:",
+                          "#b23939",
+                          ";color:",
+                          "rgb(252,249,249)",
+                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                          "#a00e0e",
+                          ";border-color:",
+                          "#a53636",
+                          ";color:",
+                          "#e9e6e6",
+                          ";}&.active{background-color:",
+                          "#b75151",
+                          ";border-color:",
+                          "#bc6363",
+                          ";color:",
+                          "rgb(252,249,249)",
+                          ";:hover{background-color:",
+                          "#a94c4c",
+                          ";border-color:",
+                          "#ad5c5c",
+                          ";color:",
+                          "#e9e6e6",
+                          ";}}&[disabled],&.disabled{background-color:",
+                          "#c07272",
+                          ";border-color:",
+                          "#bc6363",
+                          ";color:",
+                          "rgb(252,250,250)",
+                          ";:hover{background-color:",
+                          "#c07272",
+                          ";border-color:",
+                          "#bc6363",
+                          ";color:",
+                          "rgb(252,250,250)",
+                          ";}}}",
                         ],
                         Array [
-                          [Function],
+                          "&.btn-",
+                          "default",
+                          "{background-color:",
+                          "#e6e6e6",
+                          ";border-color:",
+                          "#e0e0e0",
+                          ";color:",
+                          "rgb(73,73,73)",
+                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                          "#d4d4d4",
+                          ";border-color:",
+                          "#cfcfcf",
+                          ";color:",
+                          "#444444",
+                          ";}&.active{background-color:",
+                          "#dadada",
+                          ";border-color:",
+                          "#d4d4d4",
+                          ";color:",
+                          "rgb(49,49,49)",
+                          ";:hover{background-color:",
+                          "#cacaca",
+                          ";border-color:",
+                          "#c4c4c4",
+                          ";color:",
+                          "#2f2f2f",
+                          ";}}&[disabled],&.disabled{background-color:",
+                          "#cecece",
+                          ";border-color:",
+                          "#d4d4d4",
+                          ";color:",
+                          "rgb(80,80,80)",
+                          ";:hover{background-color:",
+                          "#cecece",
+                          ";border-color:",
+                          "#d4d4d4",
+                          ";color:",
+                          "rgb(80,80,80)",
+                          ";}}}",
                         ],
                         Array [
-                          [Function],
+                          "&.btn-",
+                          "info",
+                          "{background-color:",
+                          "#0063be",
+                          ";border-color:",
+                          "#3970c2",
+                          ";color:",
+                          "rgb(249,250,252)",
+                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                          "#0c5cb0",
+                          ";border-color:",
+                          "#3668b3",
+                          ";color:",
+                          "#e6e7e9",
+                          ";}&.active{background-color:",
+                          "#517cc5",
+                          ";border-color:",
+                          "#6386c9",
+                          ";color:",
+                          "rgb(249,250,252)",
+                          ";:hover{background-color:",
+                          "#4b73b6",
+                          ";border-color:",
+                          "#5c7dba",
+                          ";color:",
+                          "#e6e7e9",
+                          ";}}&[disabled],&.disabled{background-color:",
+                          "#7290cd",
+                          ";border-color:",
+                          "#6386c9",
+                          ";color:",
+                          "rgb(250,251,253)",
+                          ";:hover{background-color:",
+                          "#7290cd",
+                          ";border-color:",
+                          "#6386c9",
+                          ";color:",
+                          "rgb(250,251,253)",
+                          ";}}}",
                         ],
                         Array [
-                          [Function],
+                          "&.btn-",
+                          "link",
+                          "{background-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";border-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";color:",
+                          "#702785",
+                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                          "#ebebeb26",
+                          ";border-color:",
+                          "#ebebeb26",
+                          ";color:",
+                          "#68267b",
+                          ";}&.active{background-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";border-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";color:",
+                          "#410057",
+                          ";:hover{background-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";border-color:",
+                          "#ebebeb26",
+                          ";color:",
+                          "#3d0c51",
+                          ";}}&[disabled],&.disabled{background-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";border-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";color:",
+                          "#702785",
+                          ";:hover{background-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";border-color:",
+                          "rgba(255, 255, 255, 0)",
+                          ";color:",
+                          "#702785",
+                          ";}}}",
                         ],
                         Array [
-                          [Function],
+                          "&.btn-",
+                          "primary",
+                          "{background-color:",
+                          "#702785",
+                          ";border-color:",
+                          "#7b458e",
+                          ";color:",
+                          "rgb(234,229,236)",
+                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                          "#68267b",
+                          ";border-color:",
+                          "#724083",
+                          ";color:",
+                          "#d8d3da",
+                          ";}&.active{background-color:",
+                          "#855996",
+                          ";border-color:",
+                          "#8f699d",
+                          ";color:",
+                          "rgb(250,249,251)",
+                          ";:hover{background-color:",
+                          "#7c538b",
+                          ";border-color:",
+                          "#846292",
+                          ";color:",
+                          "#e7e6e8",
+                          ";}}&[disabled],&.disabled{background-color:",
+                          "#9877a5",
+                          ";border-color:",
+                          "#8f699d",
+                          ";color:",
+                          "rgb(251,250,251)",
+                          ";:hover{background-color:",
+                          "#9877a5",
+                          ";border-color:",
+                          "#8f699d",
+                          ";color:",
+                          "rgb(251,250,251)",
+                          ";}}}",
                         ],
                         Array [
-                          [Function],
+                          "&.btn-",
+                          "success",
+                          "{background-color:",
+                          "#00ae42",
+                          ";border-color:",
+                          "#39b356",
+                          ";color:",
+                          "rgb(249,252,249)",
+                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                          "#0ca13e",
+                          ";border-color:",
+                          "#36a550",
+                          ";color:",
+                          "#e6e9e6",
+                          ";}&.active{background-color:",
+                          "#51b866",
+                          ";border-color:",
+                          "#63bc74",
+                          ";color:",
+                          "rgb(249,252,250)",
+                          ";:hover{background-color:",
+                          "#4baa5f",
+                          ";border-color:",
+                          "#5cae6c",
+                          ";color:",
+                          "#e6e9e7",
+                          ";}}&[disabled],&.disabled{background-color:",
+                          "#72c180",
+                          ";border-color:",
+                          "#63bc74",
+                          ";color:",
+                          "rgb(250,252,250)",
+                          ";:hover{background-color:",
+                          "#72c180",
+                          ";border-color:",
+                          "#63bc74",
+                          ";color:",
+                          "rgb(250,252,250)",
+                          ";}}}",
                         ],
                         Array [
-                          [Function],
+                          "&.btn-",
+                          "warning",
+                          "{background-color:",
+                          "#ffd200",
+                          ";border-color:",
+                          "#f9cd07",
+                          ";color:",
+                          "rgb(57,47,0)",
+                          ";transition:background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;:hover{background-color:",
+                          "#ebc20c",
+                          ";border-color:",
+                          "#e6bd0e",
+                          ";color:",
+                          "#362d0c",
+                          ";}&.active{background-color:",
+                          "#f2c70a",
+                          ";border-color:",
+                          "#ebc20c",
+                          ";color:",
+                          "rgb(54,45,2)",
+                          ";:hover{background-color:",
+                          "#e0b80f",
+                          ";border-color:",
+                          "#d9b310",
+                          ";color:",
+                          "#332b0c",
+                          ";}}&[disabled],&.disabled{background-color:",
+                          "#e4bc0e",
+                          ";border-color:",
+                          "#ebc20c",
+                          ";color:",
+                          "rgb(88,73,5)",
+                          ";:hover{background-color:",
+                          "#e4bc0e",
+                          ";border-color:",
+                          "#ebc20c",
+                          ";color:",
+                          "rgb(88,73,5)",
+                          ";}}}",
                         ],
                       ],
                     },
@@ -1308,102 +2073,82 @@ exports[`SavedSearchForm render the SavedSearchForm should render save 1`] = `
                               </FormGroup>
                             </FormGroup__StyledFormGroup>
                           </Component>
-                          <ForwardRef
+                          <Button
                             bsStyle="primary"
                             className="button"
                             onClick={[Function]}
                             type="submit"
                           >
-                            <Button__StyledButton
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
                               bsStyle="primary"
-                              className="button"
+                              className="Button-c9cbmb-0 bNulii button"
+                              disabled={false}
                               onClick={[Function]}
                               type="submit"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="primary"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii button btn btn-primary"
                                 disabled={false}
                                 onClick={[Function]}
                                 type="submit"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH button btn btn-primary"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  type="submit"
-                                >
-                                  Save
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
-                          <ForwardRef
+                                Save
+                              </button>
+                            </Button>
+                          </Button>
+                          <Button
                             bsStyle="info"
                             className="button"
                             disabled={false}
                             onClick={[Function]}
                             type="submit"
                           >
-                            <Button__StyledButton
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
                               bsStyle="info"
-                              className="button"
+                              className="Button-c9cbmb-0 bNulii button"
                               disabled={false}
                               onClick={[Function]}
                               type="submit"
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="info"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii button btn btn-info"
                                 disabled={false}
                                 onClick={[Function]}
                                 type="submit"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH button btn btn-info"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  type="submit"
-                                >
-                                  Save as
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
-                          <ForwardRef
+                                Save as
+                              </button>
+                            </Button>
+                          </Button>
+                          <Button
                             className="button"
                             onClick={[Function]}
                           >
-                            <Button__StyledButton
-                              className="button"
+                            <Button
+                              active={false}
+                              block={false}
+                              bsClass="btn"
+                              bsStyle="default"
+                              className="Button-c9cbmb-0 bNulii button"
+                              disabled={false}
                               onClick={[Function]}
                             >
-                              <Button
-                                active={false}
-                                block={false}
-                                bsClass="btn"
-                                bsStyle="default"
-                                className="Button__StyledButton-c9cbmb-0 laZUlH button"
+                              <button
+                                className="Button-c9cbmb-0 bNulii button btn btn-default"
                                 disabled={false}
                                 onClick={[Function]}
+                                type="button"
                               >
-                                <button
-                                  className="Button__StyledButton-c9cbmb-0 laZUlH button btn btn-default"
-                                  disabled={false}
-                                  onClick={[Function]}
-                                  type="button"
-                                >
-                                  Cancel
-                                </button>
-                              </Button>
-                            </Button__StyledButton>
-                          </ForwardRef>
+                                Cancel
+                              </button>
+                            </Button>
+                          </Button>
                         </form>
                       </div>
                     </div>

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/__snapshots__/SavedSearchList.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/__snapshots__/SavedSearchList.test.jsx.snap
@@ -57,7 +57,7 @@ exports[`SavedSearchList render the SavedSearchList should render empty 1`] = `
                   style="margin-left: 5px;"
                 >
                   <button
-                    class="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
+                    class="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                     type="submit"
                   >
                     Search
@@ -68,7 +68,7 @@ exports[`SavedSearchList render the SavedSearchList should render empty 1`] = `
                   style="margin-left: 5px;"
                 >
                   <button
-                    class="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
+                    class="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                     type="reset"
                   >
                     Reset
@@ -92,7 +92,7 @@ exports[`SavedSearchList render the SavedSearchList should render empty 1`] = `
             class="modal-footer"
           >
             <button
-              class="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
+              class="Button-c9cbmb-0 bNulii btn btn-default"
               type="button"
             >
               Cancel
@@ -162,7 +162,7 @@ exports[`SavedSearchList render the SavedSearchList should render with views 1`]
                   style="margin-left: 5px;"
                 >
                   <button
-                    class="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
+                    class="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                     type="submit"
                   >
                     Search
@@ -173,7 +173,7 @@ exports[`SavedSearchList render the SavedSearchList should render with views 1`]
                   style="margin-left: 5px;"
                 >
                   <button
-                    class="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
+                    class="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                     type="reset"
                   >
                     Reset
@@ -251,7 +251,7 @@ exports[`SavedSearchList render the SavedSearchList should render with views 1`]
             class="modal-footer"
           >
             <button
-              class="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
+              class="Button-c9cbmb-0 bNulii btn btn-default"
               type="button"
             >
               Cancel

--- a/graylog2-web-interface/src/views/components/widgets/__snapshots__/CopyToDashboardForm.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/widgets/__snapshots__/CopyToDashboardForm.test.jsx.snap
@@ -57,7 +57,7 @@ exports[`CopyToDashboardForm should render the modal minimal 1`] = `
                   style="margin-left: 5px;"
                 >
                   <button
-                    class="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
+                    class="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                     type="submit"
                   >
                     Search
@@ -68,7 +68,7 @@ exports[`CopyToDashboardForm should render the modal minimal 1`] = `
                   style="margin-left: 5px;"
                 >
                   <button
-                    class="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
+                    class="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                     type="reset"
                   >
                     Reset
@@ -129,14 +129,14 @@ exports[`CopyToDashboardForm should render the modal minimal 1`] = `
             class="modal-footer"
           >
             <button
-              class="Button__StyledButton-c9cbmb-0 laZUlH btn btn-primary"
+              class="Button-c9cbmb-0 bNulii btn btn-primary"
               disabled=""
               type="button"
             >
               Select
             </button>
             <button
-              class="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
+              class="Button-c9cbmb-0 bNulii btn btn-default"
               type="button"
             >
               Cancel
@@ -206,7 +206,7 @@ exports[`CopyToDashboardForm should render the modal with entries 1`] = `
                   style="margin-left: 5px;"
                 >
                   <button
-                    class="Button__StyledButton-c9cbmb-0 laZUlH submit-button btn btn-default"
+                    class="Button-c9cbmb-0 bNulii submit-button btn btn-default"
                     type="submit"
                   >
                     Search
@@ -217,7 +217,7 @@ exports[`CopyToDashboardForm should render the modal with entries 1`] = `
                   style="margin-left: 5px;"
                 >
                   <button
-                    class="Button__StyledButton-c9cbmb-0 laZUlH reset-button btn btn-default"
+                    class="Button-c9cbmb-0 bNulii reset-button btn btn-default"
                     type="reset"
                   >
                     Reset
@@ -305,14 +305,14 @@ exports[`CopyToDashboardForm should render the modal with entries 1`] = `
             class="modal-footer"
           >
             <button
-              class="Button__StyledButton-c9cbmb-0 laZUlH btn btn-primary"
+              class="Button-c9cbmb-0 bNulii btn btn-primary"
               disabled=""
               type="button"
             >
               Select
             </button>
             <button
-              class="Button__StyledButton-c9cbmb-0 laZUlH btn btn-default"
+              class="Button-c9cbmb-0 bNulii btn btn-default"
               type="button"
             >
               Cancel

--- a/graylog2-web-interface/src/views/hooks/__snapshots__/RequirementsProvided.test.jsx.snap
+++ b/graylog2-web-interface/src/views/hooks/__snapshots__/RequirementsProvided.test.jsx.snap
@@ -106,41 +106,34 @@ exports[`RequirementsProvided throws Component if not all requirements are provi
                 onlyActiveOnIndex={false}
                 to="/path/to/views"
               >
-                <ForwardRef
+                <Button
                   action="push"
                   bsStyle="success"
                   onClick={[Function]}
                   type="submit"
                 >
-                  <Button__StyledButton
+                  <Button
                     action="push"
+                    active={false}
+                    block={false}
+                    bsClass="btn"
                     bsStyle="success"
+                    className="Button-c9cbmb-0 bNulii"
+                    disabled={false}
                     onClick={[Function]}
                     type="submit"
                   >
-                    <Button
+                    <button
                       action="push"
-                      active={false}
-                      block={false}
-                      bsClass="btn"
-                      bsStyle="success"
-                      className="Button__StyledButton-c9cbmb-0 laZUlH"
+                      className="Button-c9cbmb-0 bNulii btn btn-success"
                       disabled={false}
                       onClick={[Function]}
                       type="submit"
                     >
-                      <button
-                        action="push"
-                        className="Button__StyledButton-c9cbmb-0 laZUlH btn btn-success"
-                        disabled={false}
-                        onClick={[Function]}
-                        type="submit"
-                      >
-                        Back
-                      </button>
-                    </Button>
-                  </Button__StyledButton>
-                </ForwardRef>
+                      Back
+                    </button>
+                  </Button>
+                </Button>
               </LinkContainer>
             </div>
           </Col>


### PR DESCRIPTION
## Motivation
Prior to this change, the button styles were computed with
every rendering of every buttons for every variant.

## Description
This change will calculate the styles only once on page load and
use the calculated static css afterwards.

Also we removed the now unneeded forwardRef from all Buttons.

## How Has This Been Tested?
GrokPatterns load page took before this PR several seconds now milliseconds
with the default grok patterns.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [z] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

