### PR TITLE
Fix performance problems with react-select and formik

### DIFF
--- a/graylog2-web-interface/src/components/users/UserCreate/TimezoneFormGroup.jsx
+++ b/graylog2-web-interface/src/components/users/UserCreate/TimezoneFormGroup.jsx
@@ -1,12 +1,12 @@
 // @flow strict
 import * as React from 'react';
-import { Field } from 'formik';
+import { FastField } from 'formik';
 
 import { Input } from 'components/bootstrap';
 import { TimezoneSelect } from 'components/common';
 
 const TimezoneFormGroup = () => (
-  <Field name="timezone">
+  <FastField name="timezone">
     {({ field: { name, value, onChange } }) => (
       <Input id="timezone-select"
              label="Time Zone"
@@ -19,7 +19,7 @@ const TimezoneFormGroup = () => (
                         onChange={(newValue) => onChange({ target: { name, value: newValue } })} />
       </Input>
     )}
-  </Field>
+  </FastField>
 );
 
 export default TimezoneFormGroup;


### PR DESCRIPTION
Formik is rerendering every key stroke. But react-select
is rendering rather slow. So we use `FastField` which is
implementing shouldComponentUpdate for that field.

Now react-select is only rendered when necessary.