### PR TITLE
Updating Pagination colors to prep for noire

### DIFF
--- a/graylog2-web-interface/src/components/common/Pagination.jsx
+++ b/graylog2-web-interface/src/components/common/Pagination.jsx
@@ -31,15 +31,15 @@ const StyledBootstrapPagination: StyledComponent<{}, ThemeInterface, *> = styled
     > li {
       > a,
       > span {
-        color: ${theme.utils.readableColor(theme.colors.global.contentBackground)};
+        color: ${theme.utils.contrastingColor(theme.colors.global.contentBackground)};
         background-color: ${theme.colors.global.contentBackground};
-        border-color: ${theme.colors.gray[80]};
+        border-color: ${theme.colors.variant.lighter.default};
 
         &:hover,
         &:focus {
-          color: ${theme.utils.readableColor(theme.colors.gray[90])};
-          background-color: ${theme.colors.gray[90]};
-          border-color: ${theme.colors.gray[80]};
+          color: ${theme.utils.contrastingColor(theme.colors.variant.light.default)};
+          background-color: ${theme.colors.variant.light.default};
+          border-color: ${theme.colors.variant.lighter.default};
         }
       }
 
@@ -48,7 +48,7 @@ const StyledBootstrapPagination: StyledComponent<{}, ThemeInterface, *> = styled
         &,
         &:hover,
         &:focus {
-          color: ${theme.utils.readableColor(theme.colors.variant.lightest.info)};
+          color: ${theme.utils.contrastingColor(theme.colors.variant.lightest.info)};
           background-color: ${theme.colors.variant.lightest.info};
           border-color: ${theme.colors.variant.lighter.info};
         }
@@ -61,9 +61,9 @@ const StyledBootstrapPagination: StyledComponent<{}, ThemeInterface, *> = styled
         > span,
         > span:hover,
         > span:focus {
-          color: ${theme.colors.gray[70]};
-          background-color: ${theme.colors.gray[100]};
-          border-color: ${theme.colors.gray[90]};
+          color: ${theme.colors.variant.light.default};
+          background-color: ${theme.colors.global.contentBackground};
+          border-color: ${theme.colors.variant.lighter.default};
         }
       }
     }

--- a/graylog2-web-interface/src/components/common/Pagination.jsx
+++ b/graylog2-web-interface/src/components/common/Pagination.jsx
@@ -33,13 +33,13 @@ const StyledBootstrapPagination: StyledComponent<{}, ThemeInterface, *> = styled
       > span {
         color: ${theme.utils.contrastingColor(theme.colors.global.contentBackground)};
         background-color: ${theme.colors.global.contentBackground};
-        border-color: ${theme.colors.variant.lighter.default};
+        border-color: ${theme.colors.variant.light.default};
 
         &:hover,
         &:focus {
-          color: ${theme.utils.contrastingColor(theme.colors.variant.light.default)};
-          background-color: ${theme.colors.variant.light.default};
-          border-color: ${theme.colors.variant.lighter.default};
+          color: ${theme.utils.contrastingColor(theme.colors.variant.lighter.default)};
+          background-color: ${theme.colors.variant.lighter.default};
+          border-color: ${theme.colors.variant.light.default};
         }
       }
 

--- a/graylog2-web-interface/src/components/common/__snapshots__/Pagination.test.jsx.snap
+++ b/graylog2-web-interface/src/components/common/__snapshots__/Pagination.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Pagination /> should display Pagination 1`] = `
 <ul
-  class="Pagination__StyledBootstrapPagination-aj0t2h-0 dPTPdm pagination"
+  class="Pagination__StyledBootstrapPagination-aj0t2h-0 ejkJpt pagination"
   data-testid="graylog-pagination"
 >
   <li

--- a/graylog2-web-interface/src/components/common/__snapshots__/Pagination.test.jsx.snap
+++ b/graylog2-web-interface/src/components/common/__snapshots__/Pagination.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Pagination /> should display Pagination 1`] = `
 <ul
-  class="Pagination__StyledBootstrapPagination-aj0t2h-0 ejkJpt pagination"
+  class="Pagination__StyledBootstrapPagination-aj0t2h-0 beYNSz pagination"
   data-testid="graylog-pagination"
 >
   <li

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPacksList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPacksList.test.jsx.snap
@@ -504,11 +504,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <Pagination
                       bsClass="pagination"
-                      className="Pagination__StyledBootstrapPagination-aj0t2h-0 ejkJpt"
+                      className="Pagination__StyledBootstrapPagination-aj0t2h-0 beYNSz"
                       data-testid="graylog-pagination"
                     >
                       <ul
-                        className="Pagination__StyledBootstrapPagination-aj0t2h-0 ejkJpt pagination"
+                        className="Pagination__StyledBootstrapPagination-aj0t2h-0 beYNSz pagination"
                         data-testid="graylog-pagination"
                       >
                         <Component
@@ -6624,11 +6624,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <Pagination
                       bsClass="pagination"
-                      className="Pagination__StyledBootstrapPagination-aj0t2h-0 ejkJpt"
+                      className="Pagination__StyledBootstrapPagination-aj0t2h-0 beYNSz"
                       data-testid="graylog-pagination"
                     >
                       <ul
-                        className="Pagination__StyledBootstrapPagination-aj0t2h-0 ejkJpt pagination"
+                        className="Pagination__StyledBootstrapPagination-aj0t2h-0 beYNSz pagination"
                         data-testid="graylog-pagination"
                       >
                         <Component

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPacksList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPacksList.test.jsx.snap
@@ -504,11 +504,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <Pagination
                       bsClass="pagination"
-                      className="Pagination__StyledBootstrapPagination-aj0t2h-0 dPTPdm"
+                      className="Pagination__StyledBootstrapPagination-aj0t2h-0 ejkJpt"
                       data-testid="graylog-pagination"
                     >
                       <ul
-                        className="Pagination__StyledBootstrapPagination-aj0t2h-0 dPTPdm pagination"
+                        className="Pagination__StyledBootstrapPagination-aj0t2h-0 ejkJpt pagination"
                         data-testid="graylog-pagination"
                       >
                         <Component
@@ -6624,11 +6624,11 @@ exports[`<ContentPacksList /> should render with content packs 1`] = `
                   >
                     <Pagination
                       bsClass="pagination"
-                      className="Pagination__StyledBootstrapPagination-aj0t2h-0 dPTPdm"
+                      className="Pagination__StyledBootstrapPagination-aj0t2h-0 ejkJpt"
                       data-testid="graylog-pagination"
                     >
                       <ul
-                        className="Pagination__StyledBootstrapPagination-aj0t2h-0 dPTPdm pagination"
+                        className="Pagination__StyledBootstrapPagination-aj0t2h-0 ejkJpt pagination"
                         data-testid="graylog-pagination"
                       >
                         <Component


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updating color usage to render better in dark mode

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Dark mode version of Pagination wasn't looking so great


## Screenshots (if appropriate):
- Page 1 is `active`
- Page 4 is `hovered`
- Previous buttons are `disabled`

![image](https://user-images.githubusercontent.com/122591/88674232-2c576280-d0af-11ea-9043-46c22c942834.png)


![image](https://user-images.githubusercontent.com/122591/88674179-1fd30a00-d0af-11ea-996e-89f58822783a.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

