### PR TITLE
 Find a better default for `enabled_tls_protocols` (3.3)

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -27,9 +27,9 @@ import com.github.joschi.jadconfig.validators.PositiveDurationValidator;
 import com.github.joschi.jadconfig.validators.PositiveIntegerValidator;
 import com.github.joschi.jadconfig.validators.PositiveLongValidator;
 import com.github.joschi.jadconfig.validators.StringNotBlankValidator;
-import com.google.common.collect.ImmutableSet;
 import org.graylog2.plugin.BaseConfiguration;
 import org.graylog2.security.realm.RootAccountRealm;
+import org.graylog2.shared.security.tls.DefaultTLSProtocolProvider;
 import org.graylog2.utilities.IPSubnetConverter;
 import org.graylog2.utilities.IpSubnet;
 import org.joda.time.DateTimeZone;
@@ -159,10 +159,8 @@ public class Configuration extends BaseConfiguration {
     @Parameter(value = "deactivated_builtin_authentication_providers", converter = StringSetConverter.class)
     private Set<String> deactivatedBuiltinAuthenticationProviders = Collections.emptySet();
 
-    // Defaults to TLS protocols that are currently considered secure
     @Parameter(value = "enabled_tls_protocols", converter = StringSetConverter.class)
-    private Set<String> enabledTlsProtocols = ImmutableSet.of("TLSv1.2", "TLSv1.3");
-
+    private Set<String> enabledTlsProtocols = DefaultTLSProtocolProvider.getDefaultSupportedTlsProtocols();
 
     public boolean isMaster() {
         return isMaster;

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/tls/DefaultTLSProtocolProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/tls/DefaultTLSProtocolProvider.java
@@ -1,0 +1,53 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.shared.security.tls;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLContext;
+import java.security.NoSuchAlgorithmException;
+import java.util.Set;
+
+public abstract class DefaultTLSProtocolProvider {
+    // Defaults to TLS protocols that are currently considered secure
+    public static final Set<String> DEFAULT_TLS_PROTOCOLS = ImmutableSet.of("TLSv1.2", "TLSv1.3");
+
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultTLSProtocolProvider.class);
+    private static Set<String> defaultSupportedTlsProtocols = null;
+
+    public synchronized static Set<String> getDefaultSupportedTlsProtocols() {
+        if (defaultSupportedTlsProtocols != null) {
+            return defaultSupportedTlsProtocols;
+        }
+
+        final Set<String> tlsProtocols = Sets.newHashSet(DEFAULT_TLS_PROTOCOLS);
+        try {
+            final Set<String> supportedProtocols = ImmutableSet.copyOf(SSLContext.getDefault().createSSLEngine().getEnabledProtocols());
+            if (tlsProtocols.retainAll(supportedProtocols)) {
+                LOG.warn("JRE doesn't support all default TLS protocols. Changing <{}> to <{}>", DEFAULT_TLS_PROTOCOLS, tlsProtocols);
+            }
+            defaultSupportedTlsProtocols = tlsProtocols;
+        } catch (NoSuchAlgorithmException e) {
+            LOG.error("Failed to detect supported TLS protocols. Keeping default <{}>", DEFAULT_TLS_PROTOCOLS, e);
+            defaultSupportedTlsProtocols = DEFAULT_TLS_PROTOCOLS;
+        }
+        return defaultSupportedTlsProtocols;
+    }
+}

--- a/misc/graylog.conf
+++ b/misc/graylog.conf
@@ -686,5 +686,5 @@ proxied_requests_thread_pool_size = 32
 
 # The allowed TLS protocols for system wide TLS enabled servers. (e.g. message inputs, http interface)
 # Setting this to an empty value, leaves it up to system libraries and the used JDK to chose a default.
-# Default: TLSv1.2,TLSv1.3
+# Default: TLSv1.2,TLSv1.3  (might be automatically adjusted to protocols supported by the JDK) 
 #enabled_tls_protocols= TLSv1.2,TLSv1.3


### PR DESCRIPTION
The default TLS protocol setting introduced with PR #7130
contained TLSv1.3.
TLS1.3 only worked for netty based inputs when openssl was used as a tls
provider.

This change builds the default based on what is supported by the
currently running JRE.

Fixes #7726

(cherry picked from commit 90e6b0b)

