### PR TITLE
Remove duplicate method call in MoreSearch

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
+++ b/graylog2-server/src/main/java/org/graylog/events/search/MoreSearch.java
@@ -147,7 +147,6 @@ public class MoreSearch {
         }
 
         moreSearchAdapter.scrollEvents(queryString, timeRange, affectedIndices, streams, scrollTime, batchSize, resultCallback::call);
-        moreSearchAdapter.scrollEvents(queryString, timeRange, affectedIndices, streams, scrollTime, batchSize, resultCallback::call);
     }
 
     public Set<Stream> loadStreams(Set<String> streamIds) {


### PR DESCRIPTION
`MoreSearchAdapter#scrollEvents` was accidentally called twice in `MoreSearch#scrollQuery`

This was an oversight in #8197
