### PR TITLE
Add function to PaginatedUserService to load users by username

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/users/PaginatedUserService.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/PaginatedUserService.java
@@ -25,6 +25,7 @@ import org.mongojack.DBQuery;
 import org.mongojack.DBSort;
 
 import javax.inject.Inject;
+import java.util.Set;
 
 public class PaginatedUserService extends PaginatedDbService<UserOverviewDTO> {
     private static final String COLLECTION_NAME = "users";
@@ -42,6 +43,15 @@ public class PaginatedUserService extends PaginatedDbService<UserOverviewDTO> {
     public PaginatedList<UserOverviewDTO> findPaginated(SearchQuery searchQuery, int page,
                                                         int perPage, String sortField, String order) {
         final DBQuery.Query dbQuery = searchQuery.toDBQuery();
+        final DBSort.SortBuilder sortBuilder = getSortBuilder(order, sortField);
+        return findPaginatedWithQueryAndSort(dbQuery, sortBuilder, page, perPage);
+    }
+
+    public PaginatedList<UserOverviewDTO> findPaginatedByUserName(SearchQuery searchQuery, int page,
+                                                                  int perPage, String sortField, String order,
+                                                                  Set<String> usernames) {
+        final DBQuery.Query dbQuery = searchQuery.toDBQuery()
+                .in(UserOverviewDTO.FIELD_USERNAME, usernames);
         final DBSort.SortBuilder sortBuilder = getSortBuilder(order, sortField);
         return findPaginatedWithQueryAndSort(dbQuery, sortBuilder, page, perPage);
     }

--- a/graylog2-web-interface/src/logic/users/UserOverview.js
+++ b/graylog2-web-interface/src/logic/users/UserOverview.js
@@ -53,7 +53,15 @@ export default class UserOverview {
     return this._value.username;
   }
 
+  get name() {
+    return this._value.username;
+  }
+
   get fullName() {
+    return this._value.fullName;
+  }
+
+  get description() {
     return this._value.fullName;
   }
 

--- a/graylog2-web-interface/src/pages/UserDetailsPage.jsx
+++ b/graylog2-web-interface/src/pages/UserDetailsPage.jsx
@@ -33,10 +33,10 @@ const UserDetailsPage = ({ params }: Props) => {
 
   useEffect(() => {
     UsersActions.load(username);
-  });
+  }, []);
 
   return (
-    <DocumentTitle title={`User Detials ${username ?? ''}`}>
+    <DocumentTitle title={`User Details ${username ?? ''}`}>
       <PageHeader title={<PageTitle fullName={loadedUser?.fullName} />}>
         <span>
           Overview of details like profile information, settings, teams and roles.


### PR DESCRIPTION
## Motviation
Prior to this change, there was no way to retrive a paginated list of
users by there username. This is needed for the Team Details Page
where we want to display the Users of Team.

## Description
Also we add `name` and `description` to UserOverview, which is simply
giving `username` and `fullname`.

This change will also fix everloading UserDetailsPage and a small typo.

