### PR TITLE
Display entities which got shared with the user on user details page

### DIFF
--- a/graylog2-web-interface/src/components/common/SearchForm.jsx
+++ b/graylog2-web-interface/src/components/common/SearchForm.jsx
@@ -30,6 +30,8 @@ class SearchForm extends React.Component {
     onReset: PropTypes.func,
     /** Search field label. */
     label: PropTypes.string,
+    /** The className is needed to override the component style with styled-components  */
+    className: PropTypes.string,
     /** Search field placeholder. */
     placeholder: PropTypes.string,
     /** Class name for the search form container. */
@@ -79,6 +81,7 @@ class SearchForm extends React.Component {
 
   static defaultProps = {
     query: '',
+    className: '',
     onQueryChange: () => {},
     onReset: null,
     label: null,
@@ -182,6 +185,7 @@ class SearchForm extends React.Component {
       queryWidth,
       focusAfterMount,
       children,
+      className,
       placeholder,
       resetButtonLabel,
       buttonLeftMargin,
@@ -196,7 +200,7 @@ class SearchForm extends React.Component {
     const { query, isLoading } = this.state;
 
     return (
-      <div className={wrapperClass} style={{ marginTop: topMargin }}>
+      <div className={`${wrapperClass} ${className}`} style={{ marginTop: topMargin }}>
         <form className="form-inline" onSubmit={this._onSearch}>
           <div className="form-group has-feedback">
             {label && <label htmlFor="common-search-form-query-input" className="control-label">{label}</label>}

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEdit.test.jsx.snap
@@ -1005,6 +1005,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                             >
                               <SearchForm
                                 buttonLeftMargin={5}
+                                className=""
                                 focusAfterMount={false}
                                 id="filter-input"
                                 label={null}
@@ -1024,7 +1025,7 @@ exports[`<ContentPackEdit /> should render empty content pack for create 1`] = `
                                 wrapperClass="search"
                               >
                                 <div
-                                  className="search"
+                                  className="search "
                                   style={
                                     Object {
                                       "marginTop": 15,
@@ -2528,6 +2529,7 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
                             >
                               <SearchForm
                                 buttonLeftMargin={5}
+                                className=""
                                 focusAfterMount={false}
                                 id="filter-input"
                                 label={null}
@@ -2547,7 +2549,7 @@ exports[`<ContentPackEdit /> should render with content pack for edit 1`] = `
                                 wrapperClass="search"
                               >
                                 <div
-                                  className="search"
+                                  className="search "
                                   style={
                                     Object {
                                       "marginTop": 15,

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntitiesList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackEntitiesList.test.jsx.snap
@@ -19,6 +19,7 @@ exports[`<ContentPackEntitiesList /> should render with empty entities 1`] = `
     <br />
     <SearchForm
       buttonLeftMargin={5}
+      className=""
       focusAfterMount={false}
       label={null}
       loadingLabel="Loading..."
@@ -37,7 +38,7 @@ exports[`<ContentPackEntitiesList /> should render with empty entities 1`] = `
       wrapperClass="search"
     >
       <div
-        className="search"
+        className="search "
         style={
           Object {
             "marginTop": 15,
@@ -295,6 +296,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
     <br />
     <SearchForm
       buttonLeftMargin={5}
+      className=""
       focusAfterMount={false}
       label={null}
       loadingLabel="Loading..."
@@ -313,7 +315,7 @@ exports[`<ContentPackEntitiesList /> should render with entities and parameters 
       wrapperClass="search"
     >
       <div
-        className="search"
+        className="search "
         style={
           Object {
             "marginTop": 15,

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstall.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackInstall.test.jsx.snap
@@ -377,6 +377,7 @@ exports[`<ContentPackInstall /> should render a install 1`] = `
                   <br />
                   <SearchForm
                     buttonLeftMargin={5}
+                    className=""
                     focusAfterMount={false}
                     label={null}
                     loadingLabel="Loading..."
@@ -395,7 +396,7 @@ exports[`<ContentPackInstall /> should render a install 1`] = `
                     wrapperClass="search"
                   >
                     <div
-                      className="search"
+                      className="search "
                       style={
                         Object {
                           "marginTop": 15,

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameterList.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameterList.test.jsx.snap
@@ -28,6 +28,7 @@ exports[`<ContentPackParameterList /> should render with empty parameters with r
     <br />
     <SearchForm
       buttonLeftMargin={5}
+      className=""
       focusAfterMount={false}
       label={null}
       loadingLabel="Loading..."
@@ -46,7 +47,7 @@ exports[`<ContentPackParameterList /> should render with empty parameters with r
       wrapperClass="search"
     >
       <div
-        className="search"
+        className="search "
         style={
           Object {
             "marginTop": 15,
@@ -339,6 +340,7 @@ exports[`<ContentPackParameterList /> should render with empty parameters withou
     </span>
     <SearchForm
       buttonLeftMargin={5}
+      className=""
       focusAfterMount={false}
       label={null}
       loadingLabel="Loading..."
@@ -357,7 +359,7 @@ exports[`<ContentPackParameterList /> should render with empty parameters withou
       wrapperClass="search"
     >
       <div
-        className="search"
+        className="search "
         style={
           Object {
             "marginTop": 15,
@@ -554,6 +556,7 @@ exports[`<ContentPackParameterList /> should render with parameters with readOnl
     <br />
     <SearchForm
       buttonLeftMargin={5}
+      className=""
       focusAfterMount={false}
       label={null}
       loadingLabel="Loading..."
@@ -572,7 +575,7 @@ exports[`<ContentPackParameterList /> should render with parameters with readOnl
       wrapperClass="search"
     >
       <div
-        className="search"
+        className="search "
         style={
           Object {
             "marginTop": 15,
@@ -1039,6 +1042,7 @@ exports[`<ContentPackParameterList /> should render with parameters without read
     </span>
     <SearchForm
       buttonLeftMargin={5}
+      className=""
       focusAfterMount={false}
       label={null}
       loadingLabel="Loading..."
@@ -1057,7 +1061,7 @@ exports[`<ContentPackParameterList /> should render with parameters without read
       wrapperClass="search"
     >
       <div
-        className="search"
+        className="search "
         style={
           Object {
             "marginTop": 15,

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameters.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackParameters.test.jsx.snap
@@ -246,6 +246,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                   </span>
                   <SearchForm
                     buttonLeftMargin={5}
+                    className=""
                     focusAfterMount={false}
                     label={null}
                     loadingLabel="Loading..."
@@ -264,7 +265,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                     wrapperClass="search"
                   >
                     <div
-                      className="search"
+                      className="search "
                       style={
                         Object {
                           "marginTop": 15,
@@ -911,6 +912,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                   <br />
                   <SearchForm
                     buttonLeftMargin={5}
+                    className=""
                     focusAfterMount={false}
                     label={null}
                     loadingLabel="Loading..."
@@ -929,7 +931,7 @@ exports[`<ContentPackParameters /> should render a parameter 1`] = `
                     wrapperClass="search"
                   >
                     <div
-                      className="search"
+                      className="search "
                       style={
                         Object {
                           "marginTop": 15,
@@ -1673,6 +1675,7 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
                   </span>
                   <SearchForm
                     buttonLeftMargin={5}
+                    className=""
                     focusAfterMount={false}
                     label={null}
                     loadingLabel="Loading..."
@@ -1691,7 +1694,7 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
                     wrapperClass="search"
                   >
                     <div
-                      className="search"
+                      className="search "
                       style={
                         Object {
                           "marginTop": 15,
@@ -1975,6 +1978,7 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
                   <br />
                   <SearchForm
                     buttonLeftMargin={5}
+                    className=""
                     focusAfterMount={false}
                     label={null}
                     loadingLabel="Loading..."
@@ -1993,7 +1997,7 @@ exports[`<ContentPackParameters /> should render with empty parameters 1`] = `
                     wrapperClass="search"
                   >
                     <div
-                      className="search"
+                      className="search "
                       style={
                         Object {
                           "marginTop": 15,

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackPreview.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackPreview.test.jsx.snap
@@ -263,6 +263,7 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
                   <br />
                   <SearchForm
                     buttonLeftMargin={5}
+                    className=""
                     focusAfterMount={false}
                     label={null}
                     loadingLabel="Loading..."
@@ -281,7 +282,7 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
                     wrapperClass="search"
                   >
                     <div
-                      className="search"
+                      className="search "
                       style={
                         Object {
                           "marginTop": 15,
@@ -464,6 +465,7 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
                   <br />
                   <SearchForm
                     buttonLeftMargin={5}
+                    className=""
                     focusAfterMount={false}
                     label={null}
                     loadingLabel="Loading..."
@@ -482,7 +484,7 @@ exports[`<ContentPackPreview /> should render with empty content pack 1`] = `
                     wrapperClass="search"
                   >
                     <div
-                      className="search"
+                      className="search "
                       style={
                         Object {
                           "marginTop": 15,
@@ -1025,6 +1027,7 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
                   <br />
                   <SearchForm
                     buttonLeftMargin={5}
+                    className=""
                     focusAfterMount={false}
                     label={null}
                     loadingLabel="Loading..."
@@ -1043,7 +1046,7 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
                     wrapperClass="search"
                   >
                     <div
-                      className="search"
+                      className="search "
                       style={
                         Object {
                           "marginTop": 15,
@@ -1226,6 +1229,7 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
                   <br />
                   <SearchForm
                     buttonLeftMargin={5}
+                    className=""
                     focusAfterMount={false}
                     label={null}
                     loadingLabel="Loading..."
@@ -1244,7 +1248,7 @@ exports[`<ContentPackPreview /> should render with filled content pack 1`] = `
                     wrapperClass="search"
                   >
                     <div
-                      className="search"
+                      className="search "
                       style={
                         Object {
                           "marginTop": 15,

--- a/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
+++ b/graylog2-web-interface/src/components/content-packs/__snapshots__/ContentPackSelection.test.jsx.snap
@@ -630,6 +630,7 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
             >
               <SearchForm
                 buttonLeftMargin={5}
+                className=""
                 focusAfterMount={false}
                 id="filter-input"
                 label={null}
@@ -649,7 +650,7 @@ exports[`<ContentPackSelection /> should render with empty content pack 1`] = `
                 wrapperClass="search"
               >
                 <div
-                  className="search"
+                  className="search "
                   style={
                     Object {
                       "marginTop": 15,
@@ -1488,6 +1489,7 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
             >
               <SearchForm
                 buttonLeftMargin={5}
+                className=""
                 focusAfterMount={false}
                 id="filter-input"
                 label={null}
@@ -1507,7 +1509,7 @@ exports[`<ContentPackSelection /> should render with filled content pack 1`] = `
                 wrapperClass="search"
               >
                 <div
-                  className="search"
+                  className="search "
                   style={
                     Object {
                       "marginTop": 15,

--- a/graylog2-web-interface/src/components/permissions/CapabilitySelect.jsx
+++ b/graylog2-web-interface/src/components/permissions/CapabilitySelect.jsx
@@ -4,10 +4,10 @@ import { useCallback } from 'react';
 import { Field } from 'formik';
 
 import { Select } from 'components/common';
-import type { AvailableCapabilities } from 'logic/permissions/EntityShareState';
+import type { CapabilitiesList } from 'logic/permissions/EntityShareState';
 import type { CapabilityType } from 'logic/permissions/types';
 
-const _capabilitiesOptions = (capabilities: AvailableCapabilities) => (
+const _capabilitiesOptions = (capabilities: CapabilitiesList) => (
   capabilities.map((capability) => (
     { label: capability.title, value: capability.id }
   )).toJS()
@@ -15,7 +15,7 @@ const _capabilitiesOptions = (capabilities: AvailableCapabilities) => (
 
 type Props = {
   onChange?: $PropertyType<CapabilityType, 'id'> => void,
-  capabilities: AvailableCapabilities,
+  capabilities: CapabilitiesList,
   title?: string,
 };
 

--- a/graylog2-web-interface/src/components/permissions/CapabilitySelect.jsx
+++ b/graylog2-web-interface/src/components/permissions/CapabilitySelect.jsx
@@ -5,7 +5,7 @@ import { Field } from 'formik';
 
 import { Select } from 'components/common';
 import type { AvailableCapabilities } from 'logic/permissions/EntityShareState';
-import type { Capability } from 'logic/permissions/types';
+import type { CapabilityType } from 'logic/permissions/types';
 
 const _capabilitiesOptions = (capabilities: AvailableCapabilities) => (
   capabilities.map((capability) => (
@@ -14,7 +14,7 @@ const _capabilitiesOptions = (capabilities: AvailableCapabilities) => (
 );
 
 type Props = {
-  onChange?: $PropertyType<Capability, 'id'> => void,
+  onChange?: $PropertyType<CapabilityType, 'id'> => void,
   capabilities: AvailableCapabilities,
   title?: string,
 };

--- a/graylog2-web-interface/src/components/permissions/GranteesList.jsx
+++ b/graylog2-web-interface/src/components/permissions/GranteesList.jsx
@@ -5,7 +5,7 @@ import styled, { type StyledComponent } from 'styled-components';
 
 import type { GRN } from 'logic/permissions/types';
 import { Pagination, PageSizeSelect } from 'components/common';
-import EntityShareState, { type ActiveShares, type AvailableCapabilities, type SelectedGrantees } from 'logic/permissions/EntityShareState';
+import EntityShareState, { type ActiveShares, type CapabilitiesList, type SelectedGrantees } from 'logic/permissions/EntityShareState';
 import Grantee from 'logic/permissions/Grantee';
 import Capability from 'logic/permissions/Capability';
 import { type ThemeInterface } from 'theme';
@@ -46,7 +46,7 @@ const StyledPageSizeSelect = styled(PageSizeSelect)(({ theme }) => `
 
 type Props = {
   activeShares: ActiveShares,
-  availableCapabilities: AvailableCapabilities,
+  availableCapabilities: CapabilitiesList,
   className?: string,
   entityGRN: GRN,
   onDelete: (GRN) => Promise<EntityShareState>,

--- a/graylog2-web-interface/src/components/permissions/GranteesListItem.jsx
+++ b/graylog2-web-interface/src/components/permissions/GranteesListItem.jsx
@@ -5,7 +5,7 @@ import styled, { type StyledComponent } from 'styled-components';
 import { Formik, Form } from 'formik';
 
 import { type ThemeInterface } from 'theme';
-import EntityShareState, { type AvailableCapabilities } from 'logic/permissions/EntityShareState';
+import EntityShareState, { type CapabilitiesList } from 'logic/permissions/EntityShareState';
 import Grantee from 'logic/permissions/Grantee';
 import { Spinner, IconButton } from 'components/common';
 import Capability from 'logic/permissions/Capability';
@@ -65,7 +65,7 @@ const Actions = styled.div`
 `;
 
 type Props = {
-  availableCapabilities: AvailableCapabilities,
+  availableCapabilities: CapabilitiesList,
   currentGranteeState: CurrentGranteeState,
   grantee: SelectedGrantee,
   onDelete: ($PropertyType<Grantee, 'id'>) => Promise<EntityShareState>,

--- a/graylog2-web-interface/src/components/permissions/GranteesSelector.jsx
+++ b/graylog2-web-interface/src/components/permissions/GranteesSelector.jsx
@@ -4,7 +4,7 @@ import { Formik, Form, Field } from 'formik';
 import styled, { type StyledComponent } from 'styled-components';
 
 import { type ThemeInterface } from 'theme';
-import EntityShareState, { type AvailableGrantees, type AvailableCapabilities } from 'logic/permissions/EntityShareState';
+import EntityShareState, { type GranteesList, type CapabilitiesList } from 'logic/permissions/EntityShareState';
 import Capability from 'logic/permissions/Capability';
 import Grantee from 'logic/permissions/Grantee';
 import { Button } from 'components/graylog';
@@ -20,8 +20,8 @@ export type SelectionRequest = {
 };
 
 type Props = {
-  availableGrantees: AvailableGrantees,
-  availableCapabilities: AvailableCapabilities,
+  availableGrantees: GranteesList,
+  availableCapabilities: CapabilitiesList,
   className?: string,
   onSubmit: SelectionRequest => Promise<EntityShareState>,
 };
@@ -69,13 +69,13 @@ const SubmitButton = styled(Button)`
   margin-left: 15px;
 `;
 
-const _granteesOptions = (grantees: AvailableGrantees) => {
+const _granteesOptions = (grantees: GranteesList) => {
   return grantees.map((grantee) => (
     { label: grantee.title, value: grantee.id, granteeType: grantee.type }
   )).toJS();
 };
 
-const _initialCapabilityId = (capabilities: AvailableCapabilities) => {
+const _initialCapabilityId = (capabilities: CapabilitiesList) => {
   const initialCapabilityTitle = 'Viewer';
 
   return capabilities.find((capability) => capability.title === initialCapabilityTitle)?.id;

--- a/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesFilter.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesFilter.jsx
@@ -2,14 +2,13 @@
 import * as React from 'react';
 import styled, { type StyledComponent } from 'styled-components';
 
-import type { PaginatedUserSharesType } from 'stores/permissions/EntityShareStore';
 import type { ThemeInterface } from 'theme';
 import { SearchForm, Select } from 'components/common';
 
 type Props = {
-  onSearch: (query: string) => Promise<PaginatedUserSharesType>,
-  onReset: () => Promise<PaginatedUserSharesType>,
-  onFilter: (param: string, value: string) => Promise<PaginatedUserSharesType>,
+  onSearch: (query: string, resetLoading: () => void) => Promise<void>,
+  onReset: () => Promise<void>,
+  onFilter: (param: string, value: string) => Promise<void>,
 };
 
 const Container: StyledComponent<{}, ThemeInterface, HTMLDivElement> = styled.div`

--- a/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesFilter.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesFilter.jsx
@@ -2,21 +2,86 @@
 import * as React from 'react';
 import styled, { type StyledComponent } from 'styled-components';
 
+import type { PaginatedUserSharesType } from 'stores/permissions/EntityShareStore';
 import type { ThemeInterface } from 'theme';
-import { SearchForm } from 'components/common';
+import { SearchForm, Select } from 'components/common';
+
+type Props = {
+  onSearch: (query: string) => Promise<PaginatedUserSharesType>,
+  onReset: () => Promise<PaginatedUserSharesType>,
+  onFilter: (param: string, value: string) => Promise<PaginatedUserSharesType>,
+};
 
 const Container: StyledComponent<{}, ThemeInterface, HTMLDivElement> = styled.div`
+  
+`;
+
+const StyledSearchForm = styled(SearchForm)`
+  display: inline-block;
+  margin-bottom: 10px;
+  margin-right: 15px;
+`;
+
+const Filters = styled.div`
+  display: inline-block;
+  vertical-align: top;
+  margin-right: 15px;
   margin-bottom: 10px;
 `;
 
-const SharedEntitiesFilter = ({ onSearch, onReset }: { onSearch: any, onReset: any }) => (
-  <Container>
-    <SearchForm onSearch={onSearch}
-                onReset={onReset}
-                placeholder="Enter query to filter"
-                useLoadingState
-                topMargin={0} />
-  </Container>
-);
+const SelectWrapper = styled.div`
+  display: inline-flex;
+  top: 0;
+  margin-left: 10px;
+  vertical-align: top;
+  align-items: center;
+  white-space: nowrap;
+  width: 260px;
+  margin-right: 10px;
+`;
+
+const StyledSelect = styled(Select)`
+  width: 300px;
+  margin-left: 10px;
+`;
+
+const entityTypeOptions = [
+  { label: 'Stream', value: 'stream' },
+  { label: 'Dashboard', value: 'dashboard' },
+  { label: 'Saved Search', value: 'saved_search' },
+];
+
+const capabilityOptions = [
+  { label: 'Owner', value: 'own' },
+  { label: 'Viewer', value: 'view' },
+  { label: 'Manager', value: 'manage' },
+];
+
+const SharedEntitiesFilter = ({ onSearch, onFilter, onReset }: Props) => {
+  return (
+    <Container>
+      <StyledSearchForm onSearch={onSearch}
+                        onReset={onReset}
+                        placeholder="Filter by name"
+                        useLoadingState
+                        topMargin={0} />
+      <Filters>
+
+        <SelectWrapper>
+          Entity types
+          <StyledSelect placeholder="Filter entity types"
+                        onChange={(entityType) => onFilter('entity_type', entityType)}
+                        options={entityTypeOptions} />
+        </SelectWrapper>
+        <SelectWrapper>
+          Capability
+          <StyledSelect placeholder="Filter capabilies"
+                        onChange={(capability) => onFilter('capability', capability)}
+                        options={capabilityOptions} />
+        </SelectWrapper>
+      </Filters>
+    </Container>
+  );
+};
 
 export default SharedEntitiesFilter;

--- a/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesFilter.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesFilter.jsx
@@ -1,0 +1,22 @@
+// @flow strict
+import * as React from 'react';
+import styled, { type StyledComponent } from 'styled-components';
+
+import type { ThemeInterface } from 'theme';
+import { SearchForm } from 'components/common';
+
+const Container: StyledComponent<{}, ThemeInterface, HTMLDivElement> = styled.div`
+  margin-bottom: 10px;
+`;
+
+const SharedEntitiesFilter = ({ onSearch, onReset }: { onSearch: any, onReset: any }) => (
+  <Container>
+    <SearchForm onSearch={onSearch}
+                onReset={onReset}
+                placeholder="Enter query to filter"
+                useLoadingState
+                topMargin={0} />
+  </Container>
+);
+
+export default SharedEntitiesFilter;

--- a/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesFilter.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesFilter.jsx
@@ -4,6 +4,7 @@ import styled, { type StyledComponent } from 'styled-components';
 
 import type { ThemeInterface } from 'theme';
 import { SearchForm, Select } from 'components/common';
+import mockedPermissions from 'logic/permissions/mocked';
 
 type Props = {
   onSearch: (query: string, resetLoading: () => void) => Promise<void>,
@@ -44,43 +45,31 @@ const StyledSelect = styled(Select)`
   margin-left: 10px;
 `;
 
-const entityTypeOptions = [
-  { label: 'Stream', value: 'stream' },
-  { label: 'Dashboard', value: 'dashboard' },
-  { label: 'Saved Search', value: 'saved_search' },
-];
+const entityTypeOptions = Object.entries(mockedPermissions.availabeEntityTypes).map(([key, value]) => ({ label: value, value: key }));
+const capabilityOptions = Object.entries(mockedPermissions.availableCapabilities).map(([key, value]) => ({ label: value, value: key }));
 
-const capabilityOptions = [
-  { label: 'Owner', value: 'own' },
-  { label: 'Viewer', value: 'view' },
-  { label: 'Manager', value: 'manage' },
-];
-
-const SharedEntitiesFilter = ({ onSearch, onFilter, onReset }: Props) => {
-  return (
-    <Container>
-      <StyledSearchForm onSearch={onSearch}
-                        onReset={onReset}
-                        placeholder="Filter by name"
-                        useLoadingState
-                        topMargin={0} />
-      <Filters>
-
-        <SelectWrapper>
-          Entity types
-          <StyledSelect placeholder="Filter entity types"
-                        onChange={(entityType) => onFilter('entity_type', entityType)}
-                        options={entityTypeOptions} />
-        </SelectWrapper>
-        <SelectWrapper>
-          Capability
-          <StyledSelect placeholder="Filter capabilies"
-                        onChange={(capability) => onFilter('capability', capability)}
-                        options={capabilityOptions} />
-        </SelectWrapper>
-      </Filters>
-    </Container>
-  );
-};
+const SharedEntitiesFilter = ({ onSearch, onFilter, onReset }: Props) => (
+  <Container>
+    <StyledSearchForm onSearch={onSearch}
+                      onReset={onReset}
+                      placeholder="Filter by name"
+                      useLoadingState
+                      topMargin={0} />
+    <Filters>
+      <SelectWrapper>
+        Entity types
+        <StyledSelect placeholder="Filter entity types"
+                      onChange={(entityType) => onFilter('entity_type', entityType)}
+                      options={entityTypeOptions} />
+      </SelectWrapper>
+      <SelectWrapper>
+        Capability
+        <StyledSelect placeholder="Filter capabilies"
+                      onChange={(capability) => onFilter('capability', capability)}
+                      options={capabilityOptions} />
+      </SelectWrapper>
+    </Filters>
+  </Container>
+);
 
 export default SharedEntitiesFilter;

--- a/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesFilter.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesFilter.jsx
@@ -56,14 +56,16 @@ const SharedEntitiesFilter = ({ onSearch, onFilter, onReset }: Props) => (
 
     <Filters>
       <SelectWrapper>
-        Entity types
-        <StyledSelect onChange={(entityType) => onFilter('entity_type', entityType)}
+        <label htmlFor="entity-type-select">Entity Type</label>
+        <StyledSelect inputId="entity-type-select"
+                      onChange={(entityType) => onFilter('entity_type', entityType)}
                       options={entityTypeOptions}
                       placeholder="Filter entity types" />
       </SelectWrapper>
       <SelectWrapper>
-        Capability
-        <StyledSelect onChange={(capability) => onFilter('capability', capability)}
+        <label htmlFor="capability-select">Capability</label>
+        <StyledSelect inputId="capability-select"
+                      onChange={(capability) => onFilter('capability', capability)}
                       options={capabilityOptions}
                       placeholder="Filter capabilies" />
       </SelectWrapper>

--- a/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesFilter.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesFilter.jsx
@@ -1,10 +1,9 @@
 // @flow strict
 import * as React from 'react';
-import styled, { type StyledComponent } from 'styled-components';
+import styled from 'styled-components';
 
-import type { ThemeInterface } from 'theme';
-import { SearchForm, Select } from 'components/common';
 import mockedPermissions from 'logic/permissions/mocked';
+import { SearchForm, Select } from 'components/common';
 
 type Props = {
   onSearch: (query: string, resetLoading: () => void) => Promise<void>,
@@ -12,12 +11,9 @@ type Props = {
   onFilter: (param: string, value: string) => Promise<void>,
 };
 
-const Container: StyledComponent<{}, ThemeInterface, HTMLDivElement> = styled.div`
-  
-`;
-
 const StyledSearchForm = styled(SearchForm)`
   display: inline-block;
+
   margin-bottom: 10px;
   margin-right: 15px;
 `;
@@ -25,19 +21,21 @@ const StyledSearchForm = styled(SearchForm)`
 const Filters = styled.div`
   display: inline-block;
   vertical-align: top;
+
   margin-right: 15px;
   margin-bottom: 10px;
 `;
 
 const SelectWrapper = styled.div`
   display: inline-flex;
-  top: 0;
-  margin-left: 10px;
-  vertical-align: top;
   align-items: center;
-  white-space: nowrap;
+  vertical-align: top;
+
   width: 260px;
+  margin-left: 10px;
   margin-right: 10px;
+
+  white-space: nowrap;
 `;
 
 const StyledSelect = styled(Select)`
@@ -49,27 +47,28 @@ const entityTypeOptions = Object.entries(mockedPermissions.availabeEntityTypes).
 const capabilityOptions = Object.entries(mockedPermissions.availableCapabilities).map(([key, value]) => ({ label: value, value: key }));
 
 const SharedEntitiesFilter = ({ onSearch, onFilter, onReset }: Props) => (
-  <Container>
-    <StyledSearchForm onSearch={onSearch}
-                      onReset={onReset}
+  <>
+    <StyledSearchForm onReset={onReset}
+                      onSearch={onSearch}
                       placeholder="Filter by name"
-                      useLoadingState
-                      topMargin={0} />
+                      topMargin={0}
+                      useLoadingState />
+
     <Filters>
       <SelectWrapper>
         Entity types
-        <StyledSelect placeholder="Filter entity types"
-                      onChange={(entityType) => onFilter('entity_type', entityType)}
-                      options={entityTypeOptions} />
+        <StyledSelect onChange={(entityType) => onFilter('entity_type', entityType)}
+                      options={entityTypeOptions}
+                      placeholder="Filter entity types" />
       </SelectWrapper>
       <SelectWrapper>
         Capability
-        <StyledSelect placeholder="Filter capabilies"
-                      onChange={(capability) => onFilter('capability', capability)}
-                      options={capabilityOptions} />
+        <StyledSelect onChange={(capability) => onFilter('capability', capability)}
+                      options={capabilityOptions}
+                      placeholder="Filter capabilies" />
       </SelectWrapper>
     </Filters>
-  </Container>
+  </>
 );
 
 export default SharedEntitiesFilter;

--- a/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesOverview.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesOverview.jsx
@@ -65,7 +65,7 @@ const SharedEntitiesOverview = ({ paginatedUserShares: initialPaginatedUserShare
                      <SharedEntitiesFilter onSearch={_handleSearch}
                                            onReset={_handleSearchReset}
                                            onFilter={_handleFilter} />
-                       )}
+                   )}
                    dataRowFormatter={(sharedEntity) => _sharedEntityOverviewItem(sharedEntity, context)}
                    filterKeys={[]}
                    headers={TABLE_HEADERS}

--- a/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesOverview.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesOverview.jsx
@@ -48,9 +48,9 @@ const SharedEntitiesOverview = ({ paginatedUserShares: initialPaginatedUserShare
     });
   };
 
-  const _handleSearch = (newQuery: string, resetLoading: () => void) => _fetchSharedEntities(1, pagination.perPage, newQuery).then(resetLoading);
-  const _handleSearchReset = () => _fetchSharedEntities(1, pagination.perPage, '');
-  const _handleFilter = (param: string, value: string) => _fetchSharedEntities(1, pagination.perPage, pagination.query, { [param]: value });
+  const _handleSearch = (newQuery: string, resetLoading: () => void) => _fetchSharedEntities(1, pagination.perPage, newQuery, pagination.additionalQueries).then(resetLoading);
+  const _handleSearchReset = () => _fetchSharedEntities(1, pagination.perPage, '', pagination.additionalQueries);
+  const _handleFilter = (param: string, value: string) => _fetchSharedEntities(1, pagination.perPage, pagination.query, { ...pagination.additionalQueries, [param]: value });
 
   return (
     <>

--- a/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesOverview.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesOverview.jsx
@@ -1,0 +1,81 @@
+// @flow strict
+import * as React from 'react';
+import { useState } from 'react';
+import styled from 'styled-components';
+
+import User from 'logic/users/User';
+import mockedPermissions from 'logic/permissions/mocked';
+import { EntityShareActions, type PaginatedUserSharesType } from 'stores/permissions/EntityShareStore';
+import { DataTable, PaginatedList } from 'components/common';
+
+import SharedEntitiesFilter from './SharedEntitiesFilter';
+import SharedEntitiesOverviewItem from './SharedEntitiesOverviewItem';
+
+const TABLE_HEADERS = ['Entiy Name', 'Entity Type', 'Owner', 'Capability'];
+
+type Props = {
+  username: $PropertyType<User, 'username'>,
+  paginatedUserShares: PaginatedUserSharesType,
+  setLoading: (loading: boolean) => void,
+};
+
+const StyledPaginatedList = styled(PaginatedList)`
+  .pagination {
+    margin: 0;
+  }
+`;
+
+const _onPageChange = (pagination, fetchSharedEntities, setLoading) => (page, perPage) => {
+  setLoading(true);
+
+  return fetchSharedEntities(page, perPage, pagination.query, pagination.additionalQueries).then(() => setLoading(false));
+};
+
+const _sharedEntityOverviewItem = (sharedEntity, context) => {
+  const capability = context?.userCapabilities?.[sharedEntity.id];
+  const capabilityTitle = mockedPermissions.availableCapabilities[capability];
+
+  return <SharedEntitiesOverviewItem sharedEntity={sharedEntity} capabilityTitle={capabilityTitle} />;
+};
+
+const SharedEntitiesOverview = ({ paginatedUserShares: initialPaginatedUserShares, username, setLoading }: Props) => {
+  const [paginatedUserShares, setPaginatedUserShares] = useState<PaginatedUserSharesType>(initialPaginatedUserShares);
+  const { list, pagination, context } = paginatedUserShares;
+
+  const _fetchSharedEntities = (newPage, newPerPage, newQuery, additonalQueries) => {
+    return EntityShareActions.searchPaginatedUserShares(username, newPage, newPerPage, newQuery, additonalQueries).then((newPaginatedUserShares) => {
+      setPaginatedUserShares(newPaginatedUserShares);
+    });
+  };
+
+  const _handleSearch = (newQuery: string, resetLoading: () => void) => _fetchSharedEntities(1, pagination.perPage, newQuery).then(resetLoading);
+  const _handleSearchReset = () => _fetchSharedEntities(1, pagination.perPage, '');
+  const _handleFilter = (param: string, value: string) => _fetchSharedEntities(1, pagination.perPage, pagination.query, { [param]: value });
+
+  return (
+    <>
+      <p className="description">
+        Found {pagination.total} entities which are shared with the user.
+      </p>
+      <StyledPaginatedList activePage={pagination.page}
+                           onChange={_onPageChange(pagination, _fetchSharedEntities, setLoading)}
+                           totalItems={pagination.total}>
+        <DataTable className="table-hover"
+                   customFilter={(
+                     <SharedEntitiesFilter onSearch={_handleSearch}
+                                           onReset={_handleSearchReset}
+                                           onFilter={_handleFilter} />
+                       )}
+                   dataRowFormatter={(sharedEntity) => _sharedEntityOverviewItem(sharedEntity, context)}
+                   filterKeys={[]}
+                   headers={TABLE_HEADERS}
+                   id="user-shared-entities"
+                   rowClassName="no-bm"
+                   rows={list.toJS()}
+                   sortByKey="type" />
+      </StyledPaginatedList>
+    </>
+  );
+};
+
+export default SharedEntitiesOverview;

--- a/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesOverviewItem.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesOverviewItem.jsx
@@ -7,6 +7,7 @@ import Routes from 'routing/Routes';
 import SharedEntity from 'logic/permissions/SharedEntity';
 
 type Props = {
+  capabilityTitle: string,
   sharedEntity: SharedEntity,
 };
 
@@ -38,20 +39,19 @@ const OwnersCell = ({ owners }: {owners: GranteesList}) => (
 );
 
 const SharedEntitiesOverviewItem = ({
+  capabilityTitle,
   sharedEntity: {
     owners,
     title,
     type,
   },
-}: Props) => {
-  return (
-    <tr key={title + type}>
-      <td className="limited">{title}</td>
-      <td className="limited">{type}</td>
-      <OwnersCell owners={owners} />
-      <td className="limited">Viewer</td>
-    </tr>
-  );
-};
+}: Props) => (
+  <tr key={title + type}>
+    <td className="limited">{title}</td>
+    <td className="limited">{type}</td>
+    <OwnersCell owners={owners} />
+    <td className="limited">{capabilityTitle}</td>
+  </tr>
+);
 
 export default SharedEntitiesOverviewItem;

--- a/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesOverviewItem.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesOverviewItem.jsx
@@ -2,8 +2,8 @@
 import * as React from 'react';
 import { Link } from 'react-router';
 
-import type { GranteesList } from 'logic/permissions/EntityShareState';
 import Routes from 'routing/Routes';
+import type { GranteesList } from 'logic/permissions/EntityShareState';
 import SharedEntity from 'logic/permissions/SharedEntity';
 
 type Props = {

--- a/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesOverviewItem.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesOverviewItem.jsx
@@ -1,0 +1,27 @@
+// @flow strict
+import * as React from 'react';
+
+import SharedEntity from 'logic/permissions/SharedEntity';
+
+type Props = {
+  sharedEntity: SharedEntity,
+};
+
+const SharedEntitiesOverviewItem = ({
+  sharedEntity: {
+    owners,
+    title,
+    type,
+  },
+}: Props) => {
+  return (
+    <tr key={title + type}>
+      <td className="limited">{title}</td>
+      <td className="limited">{type}</td>
+      <td className="limited">{owners.toJS().join(', ')}</td>
+      <td className="limited">Viewer</td>
+    </tr>
+  );
+};
+
+export default SharedEntitiesOverviewItem;

--- a/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesOverviewItem.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesOverviewItem.jsx
@@ -1,11 +1,41 @@
 // @flow strict
 import * as React from 'react';
+import { Link } from 'react-router';
 
+import type { GranteesList } from 'logic/permissions/EntityShareState';
+import Routes from 'routing/Routes';
 import SharedEntity from 'logic/permissions/SharedEntity';
 
 type Props = {
   sharedEntity: SharedEntity,
 };
+
+const _getOwnerLink = ({ type, title }) => {
+  switch (type) {
+    case 'user':
+      return Routes.SYSTEM.USERS.show(title);
+    case 'team':
+      return Routes.SYSTEM.USERS.show(title); // need to be updated when page exists
+    default:
+      throw new Error(`Owner of entity has not supported type: ${type}`);
+  }
+};
+
+const OwnersCell = ({ owners }: {owners: GranteesList}) => (
+  <td className="limited">
+    {owners.map((owner, index) => {
+      const link = _getOwnerLink(owner);
+      const isLast = index >= owners.size - 1;
+
+      return (
+        <React.Fragment key={owner.id}>
+          <Link to={link}>{owner.title}</Link>
+          {!isLast && ', '}
+        </React.Fragment>
+      );
+    })}
+  </td>
+);
 
 const SharedEntitiesOverviewItem = ({
   sharedEntity: {
@@ -18,7 +48,7 @@ const SharedEntitiesOverviewItem = ({
     <tr key={title + type}>
       <td className="limited">{title}</td>
       <td className="limited">{type}</td>
-      <td className="limited">{owners.toJS().join(', ')}</td>
+      <OwnersCell owners={owners} />
       <td className="limited">Viewer</td>
     </tr>
   );

--- a/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesSection.jsx
@@ -1,88 +1,29 @@
 // @flow strict
 import * as React from 'react';
 import { useState } from 'react';
-import * as Immutable from 'immutable';
-import styled from 'styled-components';
 
 import User from 'logic/users/User';
-import mockedPermissions from 'logic/permissions/mocked';
-import { EntityShareActions, type PaginatedUserSharesType } from 'stores/permissions/EntityShareStore';
-import { DataTable, PaginatedList, Spinner } from 'components/common';
+import { type PaginatedUserSharesType } from 'stores/permissions/EntityShareStore';
+import { Spinner } from 'components/common';
 
-import SharedEntitiesFilter from './SharedEntitiesFilter';
-import SharedEntitiesOverviewItem from './SharedEntitiesOverviewItem';
+import SharedEntitiesOverview from './SharedEntitiesOverview';
 
 import SectionComponent from '../SectionComponent';
 
-const TABLE_HEADERS = ['Entiy Name', 'Entity Type', 'Owner', 'Capability'];
-
 type Props = {
   username: $PropertyType<User, 'username'>,
-  paginatedUserShares: PaginatedUserSharesType,
+  paginatedUserShares: ?PaginatedUserSharesType,
 };
 
-const StyledPaginatedList = styled(PaginatedList)`
-  .pagination {
-    margin: 0;
-  }
-`;
-
-const _onPageChange = (pagination, fetchSharedEntities, setLoading) => (page, perPage) => {
-  setLoading(true);
-
-  return fetchSharedEntities(page, perPage, pagination.query, pagination.additionalQueries).then(() => setLoading(false));
-};
-
-const _sharedEntityOverviewItem = (sharedEntity, context) => {
-  const capability = context?.userCapabilities?.[sharedEntity.id];
-  const capabilityTitle = mockedPermissions.availableCapabilities[capability];
-
-  return <SharedEntitiesOverviewItem sharedEntity={sharedEntity} capabilityTitle={capabilityTitle} />;
-};
-
-const SharedEntitiesSection = ({ paginatedUserShares: initialPaginatedUserShares, username }: Props) => {
+const SharedEntitiesSection = ({ paginatedUserShares, username }: Props) => {
   const [loading, setLoading] = useState(false);
-  const [paginatedUserShares, setPaginatedUserShares] = useState<PaginatedUserSharesType>(initialPaginatedUserShares);
-  const { list, pagination, context } = paginatedUserShares || { list: Immutable.List(), pagination: { total: 0 } };
-
-  const _fetchSharedEntities = (newPage, newPerPage, newQuery, additonalQueries) => {
-    return EntityShareActions.searchPaginatedUserShares(username, newPage, newPerPage, newQuery, additonalQueries).then((newPaginatedUserShares) => {
-      setPaginatedUserShares(newPaginatedUserShares);
-    });
-  };
-
-  const _handleSearch = (newQuery: string, resetLoading: () => void) => _fetchSharedEntities(1, pagination.perPage, newQuery).then(resetLoading);
-  const _handleSearchReset = () => _fetchSharedEntities(1, pagination.perPage, '');
-  const _handleFilter = (param: string, value: string) => _fetchSharedEntities(1, pagination.perPage, pagination.query, { [param]: value });
 
   return (
     <SectionComponent title="Shared Entities" showLoading={loading}>
-      {!paginatedUserShares && (
+      {paginatedUserShares ? (
+        <SharedEntitiesOverview paginatedUserShares={paginatedUserShares} username={username} setLoading={setLoading} />
+      ) : (
         <Spinner />
-      )}
-      {paginatedUserShares && (
-        <>
-          <p className="description">
-            Found {pagination.total} entities which are shared with the user.
-          </p>
-          <StyledPaginatedList activePage={pagination.page}
-                               onChange={_onPageChange(pagination, _fetchSharedEntities, setLoading)}
-                               totalItems={pagination.total}>
-            <DataTable className="table-hover"
-                       customFilter={(
-                         <SharedEntitiesFilter onSearch={_handleSearch}
-                                               onReset={_handleSearchReset}
-                                               onFilter={_handleFilter} />
-                       )}
-                       dataRowFormatter={(sharedEntity) => _sharedEntityOverviewItem(sharedEntity, context)}
-                       filterKeys={[]}
-                       headers={TABLE_HEADERS}
-                       id="user-shared-entities"
-                       rowClassName="no-bm"
-                       rows={list.toJS()}
-                       sortByKey="type" />
-          </StyledPaginatedList>
-        </>
       )}
     </SectionComponent>
   );

--- a/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesSection.jsx
@@ -28,10 +28,10 @@ const StyledPaginatedList = styled(PaginatedList)`
   }
 `;
 
-const _onPageChange = (query, setLoading) => (page, perPage) => {
+const _onPageChange = (pagination, fetchSharedEntities, setLoading) => (page, perPage) => {
   setLoading(true);
 
-  return EntityShareActions.searchPaginatedUserShares(page, perPage, query).then(() => setLoading(false));
+  return fetchSharedEntities(page, perPage, pagination.query, pagination.additionalQueries).then(() => setLoading(false));
 };
 
 const SharedEntitiesSection = ({ paginatedUserShares: initialPaginatedUserShares, username }: Props) => {
@@ -71,7 +71,7 @@ const SharedEntitiesSection = ({ paginatedUserShares: initialPaginatedUserShares
           <p className="description">
             Found {pagination.total} entities which got shared with the user.
           </p>
-          <StyledPaginatedList onChange={_onPageChange(pagination.query, setLoading)} totalItems={pagination.total} activePage={pagination.page}>
+          <StyledPaginatedList onChange={_onPageChange(pagination, _fetchSharedEntities, setLoading)} totalItems={pagination.total} activePage={pagination.page}>
             <DataTable id="user-shared-entities"
                        rowClassName="no-bm"
                        className="table-hover"

--- a/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesSection.jsx
@@ -4,11 +4,11 @@ import { useState } from 'react';
 import * as Immutable from 'immutable';
 import styled from 'styled-components';
 
-import { EntityShareActions, type UserSharesPaginationType } from 'stores/permissions/EntityShareStore';
+import mockedPermissions from 'logic/permissions/mocked';
+import { EntityShareActions } from 'stores/permissions/EntityShareStore';
 import type { PaginatedUserSharesType } from 'stores/permissions/EntityShareStore';
 import { DataTable, PaginatedList, Spinner } from 'components/common';
 import User from 'logic/users/User';
-import type { UserSharedEntities } from 'logic/permissions/types';
 
 import SharedEntitiesFilter from './SharedEntitiesFilter';
 import SharedEntitiesOverviewItem from './SharedEntitiesOverviewItem';
@@ -37,7 +37,7 @@ const _onPageChange = (pagination, fetchSharedEntities, setLoading) => (page, pe
 const SharedEntitiesSection = ({ paginatedUserShares: initialPaginatedUserShares, username }: Props) => {
   const [currentSearchQuery, setCurrentSearchQuery] = useState<string>(initialPaginatedUserShares?.pagination?.query || '');
   const [paginatedUserShares, setPaginatedUserShares] = useState<PaginatedUserSharesType>(initialPaginatedUserShares || { list: Immutable.List(), pagination: { total: 0 } });
-  const { list, pagination } = paginatedUserShares;
+  const { list, pagination, context } = paginatedUserShares;
   const [loading, setLoading] = useState(false);
 
   const _fetchSharedEntities = (newPage, newPerPage, newQuery, additonalQueries) => {
@@ -46,7 +46,12 @@ const SharedEntitiesSection = ({ paginatedUserShares: initialPaginatedUserShares
     });
   };
 
-  const _sharedEntityOverviewItem = (sharedEntity) => <SharedEntitiesOverviewItem sharedEntity={sharedEntity} />;
+  const _sharedEntityOverviewItem = (sharedEntity) => {
+    const capability = context?.userCapabilities?.[sharedEntity.id];
+    const capabilityTitle = mockedPermissions.availableCapabilities[capability];
+
+    return <SharedEntitiesOverviewItem sharedEntity={sharedEntity} capabilityTitle={capabilityTitle} />;
+  };
 
   const _handleSearch = (newQuery: string, resetLoading: () => void) => {
     setCurrentSearchQuery(newQuery || '');
@@ -61,7 +66,6 @@ const SharedEntitiesSection = ({ paginatedUserShares: initialPaginatedUserShares
   };
 
   const _handleFilter = (param: string, value: string) => _fetchSharedEntities(1, pagination.perPage, currentSearchQuery, { [param]: value });
-  console.log(paginatedUserShares);
 
   return (
     <SectionComponent title="Shared Entities" showLoading={loading}>

--- a/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesSection.jsx
@@ -4,10 +4,11 @@ import { useState } from 'react';
 import * as Immutable from 'immutable';
 import styled from 'styled-components';
 
-import { EntityShareActions } from 'stores/permissions/EntityShareStore';
+import { EntityShareActions, type UserSharesPaginationType } from 'stores/permissions/EntityShareStore';
 import type { PaginatedUserSharesType } from 'stores/permissions/EntityShareStore';
 import { DataTable, PaginatedList, Spinner } from 'components/common';
 import User from 'logic/users/User';
+import type { UserSharedEntities } from 'logic/permissions/types';
 
 import SharedEntitiesFilter from './SharedEntitiesFilter';
 import SharedEntitiesOverviewItem from './SharedEntitiesOverviewItem';
@@ -33,11 +34,18 @@ const _onPageChange = (query, setLoading) => (page, perPage) => {
   return EntityShareActions.searchPaginatedUserShares(page, perPage, query).then(() => setLoading(false));
 };
 
-const SharedEntitiesSection = ({ paginatedUserShares, username }: Props) => {
-  const { list, pagination } = paginatedUserShares || { list: Immutable.List(), pagination: { total: 0 } };
-  const [currentSearchQuery, setCurrentSearchQuery] = useState<string>(paginatedUserShares?.pagination?.query || '');
+const SharedEntitiesSection = ({ paginatedUserShares: initialPaginatedUserShares, username }: Props) => {
+  const [currentSearchQuery, setCurrentSearchQuery] = useState<string>(initialPaginatedUserShares?.pagination?.query || '');
+  const [paginatedUserShares, setPaginatedUserShares] = useState<PaginatedUserSharesType>(initialPaginatedUserShares || { list: Immutable.List(), pagination: { total: 0 } });
+  const { list, pagination } = paginatedUserShares;
   const [loading, setLoading] = useState(false);
-  const _fetchSharedEntities = (page, perPage, query, additonalQueries) => EntityShareActions.searchPaginatedUserShares(username, page, perPage, query, additonalQueries);
+
+  const _fetchSharedEntities = (newPage, newPerPage, newQuery, additonalQueries) => {
+    return EntityShareActions.searchPaginatedUserShares(username, newPage, newPerPage, newQuery, additonalQueries).then((newPaginatedUserShares) => {
+      setPaginatedUserShares(newPaginatedUserShares);
+    });
+  };
+
   const _sharedEntityOverviewItem = (sharedEntity) => <SharedEntitiesOverviewItem sharedEntity={sharedEntity} />;
 
   const _handleSearch = (newQuery: string, resetLoading: () => void) => {
@@ -53,6 +61,7 @@ const SharedEntitiesSection = ({ paginatedUserShares, username }: Props) => {
   };
 
   const _handleFilter = (param: string, value: string) => _fetchSharedEntities(1, pagination.perPage, currentSearchQuery, { [param]: value });
+  console.log(paginatedUserShares);
 
   return (
     <SectionComponent title="Shared Entities" showLoading={loading}>

--- a/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesSection.jsx
@@ -1,0 +1,60 @@
+// @flow strict
+import * as React from 'react';
+import { useState } from 'react';
+import * as Immutable from 'immutable';
+
+import { EntityShareActions } from 'stores/permissions/EntityShareStore';
+import type { PaginatedUserSharesType } from 'stores/permissions/EntityShareStore';
+import { DataTable, PaginatedList, Spinner } from 'components/common';
+import User from 'logic/users/User';
+
+import SharedEntitiesFilter from './SharedEntitiesFilter';
+import SharedEntitiesOverviewItem from './SharedEntitiesOverviewItem';
+
+import SectionComponent from '../SectionComponent';
+
+type Props = {
+  username: $PropertyType<User, 'username'>,
+  paginatedUserShares: PaginatedUserSharesType,
+};
+
+const _onPageChange = (query, setLoading) => (page, perPage) => {
+  setLoading(true);
+
+  return EntityShareActions.searchPaginatedUserShares(page, perPage, query).then(() => setLoading(false));
+};
+
+const SharedEntitiesSection = ({ paginatedUserShares, username }: Props) => {
+  const { list, pagination } = paginatedUserShares || { list: Immutable.List(), pagination: { total: 0 } };
+  const [loading, setLoading] = useState(false);
+  const headers = ['Entiy Name', 'Entity Type', 'Owner', 'Capability'];
+  const _handleSearch = (newQuery, resetLoading) => EntityShareActions.searchPaginatedUserShares(username, 1, pagination.perPage, newQuery).then(resetLoading);
+  const _handleSearchReset = () => EntityShareActions.searchPaginatedUserShares(username, 1, pagination.perPage, '');
+  const _sharedEntityOverviewItem = (sharedEntity) => <SharedEntitiesOverviewItem sharedEntity={sharedEntity} />;
+
+  return (
+    <SectionComponent title="Shared Entities" showLoading={loading}>
+
+      {!paginatedUserShares && <Spinner />}
+      {paginatedUserShares && (
+        <>
+          <p className="description">
+            Found {pagination.total} entities which got shared with the user.
+          </p>
+          <PaginatedList onChange={_onPageChange(pagination.query, setLoading)} totalItems={pagination.total} activePage={pagination.page}>
+            <DataTable id="user-shared-entities"
+                       className="table-hover"
+                       headers={headers}
+                       sortByKey="type"
+                       rows={list.toJS()}
+                       customFilter={<SharedEntitiesFilter onSearch={_handleSearch} onReset={_handleSearchReset} />}
+                       dataRowFormatter={_sharedEntityOverviewItem}
+                       filterKeys={[]} />
+          </PaginatedList>
+        </>
+      )}
+    </SectionComponent>
+  );
+};
+
+export default SharedEntitiesSection;

--- a/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesSection.jsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { useState } from 'react';
 import * as Immutable from 'immutable';
+import styled from 'styled-components';
 
 import { EntityShareActions } from 'stores/permissions/EntityShareStore';
 import type { PaginatedUserSharesType } from 'stores/permissions/EntityShareStore';
@@ -13,10 +14,18 @@ import SharedEntitiesOverviewItem from './SharedEntitiesOverviewItem';
 
 import SectionComponent from '../SectionComponent';
 
+const TABLE_HEADERS = ['Entiy Name', 'Entity Type', 'Owner', 'Capability'];
+
 type Props = {
   username: $PropertyType<User, 'username'>,
   paginatedUserShares: PaginatedUserSharesType,
 };
+
+const StyledPaginatedList = styled(PaginatedList)`
+  .pagination {
+    margin: 0;
+  }
+`;
 
 const _onPageChange = (query, setLoading) => (page, perPage) => {
   setLoading(true);
@@ -26,31 +35,44 @@ const _onPageChange = (query, setLoading) => (page, perPage) => {
 
 const SharedEntitiesSection = ({ paginatedUserShares, username }: Props) => {
   const { list, pagination } = paginatedUserShares || { list: Immutable.List(), pagination: { total: 0 } };
+  const [currentSearchQuery, setCurrentSearchQuery] = useState<string>(paginatedUserShares?.pagination?.query || '');
   const [loading, setLoading] = useState(false);
-  const headers = ['Entiy Name', 'Entity Type', 'Owner', 'Capability'];
-  const _handleSearch = (newQuery, resetLoading) => EntityShareActions.searchPaginatedUserShares(username, 1, pagination.perPage, newQuery).then(resetLoading);
-  const _handleSearchReset = () => EntityShareActions.searchPaginatedUserShares(username, 1, pagination.perPage, '');
+  const _fetchSharedEntities = (page, perPage, query, additonalQueries) => EntityShareActions.searchPaginatedUserShares(username, page, perPage, query, additonalQueries);
   const _sharedEntityOverviewItem = (sharedEntity) => <SharedEntitiesOverviewItem sharedEntity={sharedEntity} />;
+
+  const _handleSearch = (newQuery: string, resetLoading: () => void) => {
+    setCurrentSearchQuery(newQuery || '');
+
+    return _fetchSharedEntities(1, pagination.perPage, newQuery).then(resetLoading);
+  };
+
+  const _handleSearchReset = () => {
+    setCurrentSearchQuery('');
+
+    return _fetchSharedEntities(1, pagination.perPage, '');
+  };
+
+  const _handleFilter = (param: string, value: string) => _fetchSharedEntities(1, pagination.perPage, currentSearchQuery, { [param]: value });
 
   return (
     <SectionComponent title="Shared Entities" showLoading={loading}>
-
       {!paginatedUserShares && <Spinner />}
       {paginatedUserShares && (
         <>
           <p className="description">
             Found {pagination.total} entities which got shared with the user.
           </p>
-          <PaginatedList onChange={_onPageChange(pagination.query, setLoading)} totalItems={pagination.total} activePage={pagination.page}>
+          <StyledPaginatedList onChange={_onPageChange(pagination.query, setLoading)} totalItems={pagination.total} activePage={pagination.page}>
             <DataTable id="user-shared-entities"
+                       rowClassName="no-bm"
                        className="table-hover"
-                       headers={headers}
+                       headers={TABLE_HEADERS}
                        sortByKey="type"
                        rows={list.toJS()}
-                       customFilter={<SharedEntitiesFilter onSearch={_handleSearch} onReset={_handleSearchReset} />}
+                       customFilter={<SharedEntitiesFilter onSearch={_handleSearch} onReset={_handleSearchReset} onFilter={_handleFilter} />}
                        dataRowFormatter={_sharedEntityOverviewItem}
                        filterKeys={[]} />
-          </PaginatedList>
+          </StyledPaginatedList>
         </>
       )}
     </SectionComponent>

--- a/graylog2-web-interface/src/components/users/UserDetails/UserDetails.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/UserDetails.jsx
@@ -14,10 +14,10 @@ import SharedEntitiesSection from './SharedEntitiesSection';
 
 type Props = {
   user: ?User,
-  paginatedUserShares: PaginatedUserSharesType,
+  initialPaginatedUserShares: PaginatedUserSharesType,
 };
 
-const UserDetails = ({ user, paginatedUserShares }: Props) => {
+const UserDetails = ({ user, initialPaginatedUserShares }: Props) => {
   if (!user) {
     return <Spinner />;
   }
@@ -34,7 +34,7 @@ const UserDetails = ({ user, paginatedUserShares }: Props) => {
           <TeamsSection user={user} />
         </div>
       </MainDetailsGrid>
-      <SharedEntitiesSection paginatedUserShares={paginatedUserShares} username={user.username} />
+      <SharedEntitiesSection paginatedUserShares={initialPaginatedUserShares} username={user.username} />
     </>
   );
 };

--- a/graylog2-web-interface/src/components/users/UserDetails/UserDetails.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/UserDetails.jsx
@@ -13,7 +13,7 @@ import TeamsSection from './TeamSection';
 import SharedEntitiesSection from './SharedEntitiesSection';
 
 type Props = {
-  paginatedUserShares: PaginatedUserSharesType,
+  paginatedUserShares: ?PaginatedUserSharesType,
   user: ?User,
 };
 

--- a/graylog2-web-interface/src/components/users/UserDetails/UserDetails.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/UserDetails.jsx
@@ -13,11 +13,11 @@ import TeamsSection from './TeamSection';
 import SharedEntitiesSection from './SharedEntitiesSection';
 
 type Props = {
+  paginatedUserShares: PaginatedUserSharesType,
   user: ?User,
-  initialPaginatedUserShares: PaginatedUserSharesType,
 };
 
-const UserDetails = ({ user, initialPaginatedUserShares }: Props) => {
+const UserDetails = ({ user, paginatedUserShares }: Props) => {
   if (!user) {
     return <Spinner />;
   }
@@ -34,7 +34,8 @@ const UserDetails = ({ user, initialPaginatedUserShares }: Props) => {
           <TeamsSection user={user} />
         </div>
       </MainDetailsGrid>
-      <SharedEntitiesSection paginatedUserShares={initialPaginatedUserShares} username={user.username} />
+      <SharedEntitiesSection paginatedUserShares={paginatedUserShares}
+                             username={user.username} />
     </>
   );
 };

--- a/graylog2-web-interface/src/components/users/UserDetails/UserDetails.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/UserDetails.jsx
@@ -3,20 +3,21 @@ import * as React from 'react';
 
 import { Spinner } from 'components/common';
 import User from 'logic/users/User';
+import type { PaginatedUserSharesType } from 'stores/permissions/EntityShareStore';
 
 import SettingsSection from './SettingsSection';
 import ProfileSection from './ProfileSection';
 import MainDetailsGrid from './MainDetailsGrid';
 import RolesSection from './RolesSection';
-
-import SectionComponent from '../SectionComponent';
-import TeamsSection from "./TeamSection";
+import TeamsSection from './TeamSection';
+import SharedEntitiesSection from './SharedEntitiesSection';
 
 type Props = {
   user: ?User,
+  paginatedUserShares: PaginatedUserSharesType,
 };
 
-const UserDetails = ({ user }: Props) => {
+const UserDetails = ({ user, paginatedUserShares }: Props) => {
   if (!user) {
     return <Spinner />;
   }
@@ -33,7 +34,7 @@ const UserDetails = ({ user }: Props) => {
           <TeamsSection user={user} />
         </div>
       </MainDetailsGrid>
-      <SectionComponent title="Entity Shares">Children</SectionComponent>
+      <SharedEntitiesSection paginatedUserShares={paginatedUserShares} username={user.username} />
     </>
   );
 };

--- a/graylog2-web-interface/src/components/users/UserDetails/UserDetails.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/UserDetails.test.jsx
@@ -1,10 +1,20 @@
 // @flow strict
-import React from 'react';
-import { render } from 'wrappedTestingLibrary';
+import * as React from 'react';
+import * as Immutable from 'immutable';
+import { render, act } from 'wrappedTestingLibrary';
 
 import User from 'logic/users/User';
 
 import UserDetails from './UserDetails';
+
+const mockAuthzRolesPromise = Promise.resolve({ list: Immutable.List(), pagination: { total: 0 } });
+
+jest.mock('stores/roles/AuthzRolesStore', () => ({
+  AuthzRolesActions: {
+    loadForUser: jest.fn(() => mockAuthzRolesPromise),
+    loadPaginated: jest.fn(() => mockAuthzRolesPromise),
+  },
+}));
 
 const user = User
   .builder()
@@ -18,7 +28,7 @@ const user = User
   .build();
 
 describe('<UserDetails />', () => {
-  it('should display user profile', () => {
+  it('user profile should display profile information', async () => {
     const { getByText } = render(<UserDetails user={user} paginatedUserShares={undefined} />);
 
     expect(getByText(user.username)).not.toBeNull();
@@ -26,39 +36,51 @@ describe('<UserDetails />', () => {
     expect(getByText(user.email)).not.toBeNull();
     expect(getByText(user.clientAddress)).not.toBeNull();
     expect(getByText(user.lastActivity)).not.toBeNull();
+
+    await act(() => mockAuthzRolesPromise);
   });
 
   describe('user settings', () => {
-    it('should display timezone', () => {
+    it('should display timezone', async () => {
       const { getByText } = render(<UserDetails user={user} paginatedUserShares={undefined} />);
 
       expect(getByText(user.timezone)).not.toBeNull();
+
+      await act(() => mockAuthzRolesPromise);
     });
 
     describe('should display session timeout in a readable format', () => {
-      it('for seconds', () => {
+      it('for seconds', async () => {
         const test = user.toBuilder().sessionTimeoutMs(10000).build();
         const { getByText } = render(<UserDetails user={test} paginatedUserShares={undefined} />);
 
         expect(getByText('10 Seconds')).not.toBeNull();
+
+        await act(() => mockAuthzRolesPromise);
       });
 
-      it('for minutes', () => {
+      it('for minutes', async () => {
         const { getByText } = render(<UserDetails user={user.toBuilder().sessionTimeoutMs(600000).build()} paginatedUserShares={undefined} />);
 
         expect(getByText('10 Minutes')).not.toBeNull();
+
+        await act(() => mockAuthzRolesPromise);
       });
 
-      it('for hours', () => {
+      it('for hours', async () => {
         const { getByText } = render(<UserDetails user={user.toBuilder().sessionTimeoutMs(36000000).build()} paginatedUserShares={undefined} />);
 
         expect(getByText('10 Hours')).not.toBeNull();
+
+        await act(() => mockAuthzRolesPromise);
       });
 
-      it('for days', () => {
+      it('for days', async () => {
         const { getByText } = render(<UserDetails user={user.toBuilder().sessionTimeoutMs(864000000).build()} paginatedUserShares={undefined} />);
 
         expect(getByText('10 Days')).not.toBeNull();
+
+        await act(() => mockAuthzRolesPromise);
       });
     });
   });

--- a/graylog2-web-interface/src/components/users/UserDetails/UserDetails.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/UserDetails.test.jsx
@@ -19,7 +19,7 @@ const user = User
 
 describe('<UserDetails />', () => {
   it('should display user profile', () => {
-    const { getByText } = render(<UserDetails user={user} />);
+    const { getByText } = render(<UserDetails user={user} paginatedUserShares={undefined} />);
 
     expect(getByText(user.username)).not.toBeNull();
     expect(getByText(user.fullName)).not.toBeNull();
@@ -30,7 +30,7 @@ describe('<UserDetails />', () => {
 
   describe('user settings', () => {
     it('should display timezone', () => {
-      const { getByText } = render(<UserDetails user={user} />);
+      const { getByText } = render(<UserDetails user={user} paginatedUserShares={undefined} />);
 
       expect(getByText(user.timezone)).not.toBeNull();
     });
@@ -38,25 +38,25 @@ describe('<UserDetails />', () => {
     describe('should display session timeout in a readable format', () => {
       it('for seconds', () => {
         const test = user.toBuilder().sessionTimeoutMs(10000).build();
-        const { getByText } = render(<UserDetails user={test} />);
+        const { getByText } = render(<UserDetails user={test} paginatedUserShares={undefined} />);
 
         expect(getByText('10 Seconds')).not.toBeNull();
       });
 
       it('for minutes', () => {
-        const { getByText } = render(<UserDetails user={user.toBuilder().sessionTimeoutMs(600000).build()} />);
+        const { getByText } = render(<UserDetails user={user.toBuilder().sessionTimeoutMs(600000).build()} paginatedUserShares={undefined} />);
 
         expect(getByText('10 Minutes')).not.toBeNull();
       });
 
       it('for hours', () => {
-        const { getByText } = render(<UserDetails user={user.toBuilder().sessionTimeoutMs(36000000).build()} />);
+        const { getByText } = render(<UserDetails user={user.toBuilder().sessionTimeoutMs(36000000).build()} paginatedUserShares={undefined} />);
 
         expect(getByText('10 Hours')).not.toBeNull();
       });
 
       it('for days', () => {
-        const { getByText } = render(<UserDetails user={user.toBuilder().sessionTimeoutMs(864000000).build()} />);
+        const { getByText } = render(<UserDetails user={user.toBuilder().sessionTimeoutMs(864000000).build()} paginatedUserShares={undefined} />);
 
         expect(getByText('10 Days')).not.toBeNull();
       });

--- a/graylog2-web-interface/src/components/users/UserDetails/UserDetails.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/UserDetails.test.jsx
@@ -1,18 +1,28 @@
 // @flow strict
 import * as React from 'react';
 import * as Immutable from 'immutable';
-import { render, act } from 'wrappedTestingLibrary';
+import { render, act, fireEvent, waitFor } from 'wrappedTestingLibrary';
+import { simplePaginatedUserShares } from 'fixtures/userEntityShares';
+import selectEvent from 'react-select-event';
 
+import { EntityShareActions } from 'stores/permissions/EntityShareStore';
 import User from 'logic/users/User';
 
 import UserDetails from './UserDetails';
 
 const mockAuthzRolesPromise = Promise.resolve({ list: Immutable.List(), pagination: { total: 0 } });
+const mockPaginatedUserShares = simplePaginatedUserShares(1, 10, '');
 
 jest.mock('stores/roles/AuthzRolesStore', () => ({
   AuthzRolesActions: {
     loadForUser: jest.fn(() => mockAuthzRolesPromise),
     loadPaginated: jest.fn(() => mockAuthzRolesPromise),
+  },
+}));
+
+jest.mock('stores/permissions/EntityShareStore', () => ({
+  EntityShareActions: {
+    searchPaginatedUserShares: jest.fn(() => Promise.resolve(mockPaginatedUserShares)),
   },
 }));
 
@@ -28,6 +38,10 @@ const user = User
   .build();
 
 describe('<UserDetails />', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('user profile should display profile information', async () => {
     const { getByText } = render(<UserDetails user={user} paginatedUserShares={undefined} />);
 
@@ -79,6 +93,56 @@ describe('<UserDetails />', () => {
         const { getByText } = render(<UserDetails user={user.toBuilder().sessionTimeoutMs(864000000).build()} paginatedUserShares={undefined} />);
 
         expect(getByText('10 Days')).not.toBeNull();
+
+        await act(() => mockAuthzRolesPromise);
+      });
+    });
+
+    describe('shared entities section', () => {
+      it('should list provided paginated user shares', async () => {
+        const { getAllByText } = render(<UserDetails user={user} paginatedUserShares={mockPaginatedUserShares} />);
+
+        expect(getAllByText(mockPaginatedUserShares.list.first().title)).not.toBeNull();
+
+        await act(() => mockAuthzRolesPromise);
+      });
+
+      it('should fetch paginated user shares when using search', async () => {
+        const { getByPlaceholderText, getByText } = render(<UserDetails user={user} paginatedUserShares={mockPaginatedUserShares} />);
+
+        const searchInput = getByPlaceholderText('Filter by name');
+        const searchSubmitButton = getByText('Search');
+
+        fireEvent.change(searchInput, { target: { value: 'the username' } });
+        fireEvent.click(searchSubmitButton);
+
+        await waitFor(() => expect(EntityShareActions.searchPaginatedUserShares).toHaveBeenCalledWith(user.username, 1, 10, 'the username', undefined));
+
+        await act(() => mockAuthzRolesPromise);
+      });
+
+      it('should fetch user shares when filtering by entity type', async () => {
+        const existingPaginatedUserShares = { ...mockPaginatedUserShares, pagination: { ...mockPaginatedUserShares.pagination, page: 3, perPage: 50, query: 'existing query' } };
+        const { getByLabelText } = render(<UserDetails user={user} paginatedUserShares={existingPaginatedUserShares} />);
+
+        const entityTypeSelect = getByLabelText('Entity Type');
+        await selectEvent.openMenu(entityTypeSelect);
+        await act(async () => { await selectEvent.select(entityTypeSelect, 'Dashboard'); });
+
+        expect(EntityShareActions.searchPaginatedUserShares).toHaveBeenCalledWith(user.username, 1, 50, 'existing query', { entity_type: 'dashboard' });
+
+        await act(() => mockAuthzRolesPromise);
+      });
+
+      it('should fetch user shares when filtering by capability', async () => {
+        const existingPaginatedUserShares = { ...mockPaginatedUserShares, pagination: { ...mockPaginatedUserShares.pagination, page: 3, perPage: 50, query: 'existing query' } };
+        const { getByLabelText } = render(<UserDetails user={user} paginatedUserShares={existingPaginatedUserShares} />);
+
+        const capabilitySelect = getByLabelText('Capability');
+        await selectEvent.openMenu(capabilitySelect);
+        await act(async () => { await selectEvent.select(capabilitySelect, 'Manager'); });
+
+        expect(EntityShareActions.searchPaginatedUserShares).toHaveBeenCalledWith(user.username, 1, 50, 'existing query', { capability: 'manage' });
 
         await act(() => mockAuthzRolesPromise);
       });

--- a/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.jsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.jsx
@@ -15,6 +15,8 @@ import UsersFilter from './UsersFilter';
 import ClientAddressHead from './ClientAddressHead';
 import SystemAdministrator from './SystemAdministratorOverview';
 
+const TABLE_HEADERS = ['', 'Full name', 'Username', 'E-Mail Address', 'Client Address', 'Role', 'Actions'];
+
 const Container: StyledComponent<{}, ThemeInterface, HTMLDivElement> = styled.div`
   .data-table {
     overflow-x: visible;
@@ -64,7 +66,6 @@ const UsersOverview = () => {
   } = useStore(UsersStore);
   const [loading, setLoading] = useState(false);
   const currentUser = useContext(CurrentUserContext);
-  const headers = ['', 'Full name', 'Username', 'E-Mail Address', 'Client Address', 'Role', 'Actions'];
   const _isActiveItem = (user) => currentUser?.username === user.username;
   const _userOverviewItem = (user) => <UserOverviewItem user={user} isActive={_isActiveItem(user)} />;
 
@@ -105,7 +106,7 @@ const UsersOverview = () => {
             <DataTable id="users-overview"
                        className="table-hover"
                        rowClassName="no-bm"
-                       headers={headers}
+                       headers={TABLE_HEADERS}
                        headerCellFormatter={_headerCellFormatter}
                        sortByKey="fullName"
                        rows={users.toJS()}

--- a/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.jsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.jsx
@@ -91,7 +91,7 @@ const UsersOverview = () => {
         <SystemAdministrator adminUser={adminUser}
                              dataRowFormatter={_userOverviewItem}
                              headerCellFormatter={_headerCellFormatter}
-                             headers={headers} />
+                             headers={TABLE_HEADERS} />
       )}
       <Row className="content">
         <Col xs={12}>

--- a/graylog2-web-interface/src/logic/permissions/ActiveShare.js
+++ b/graylog2-web-interface/src/logic/permissions/ActiveShare.js
@@ -1,7 +1,7 @@
 // @flow strict
 import * as Immutable from 'immutable';
 
-import type { ActiveShare as ActiveShareType } from 'logic/permissions/types';
+import type { ActiveShareType } from 'logic/permissions/types';
 
 type InternalState = ActiveShareType;
 

--- a/graylog2-web-interface/src/logic/permissions/Capability.js
+++ b/graylog2-web-interface/src/logic/permissions/Capability.js
@@ -1,7 +1,7 @@
 // @flow strict
 import * as Immutable from 'immutable';
 
-import type { Capability as CapabilityType } from 'logic/permissions/types';
+import type { CapabilityType } from 'logic/permissions/types';
 
 type InternalState = CapabilityType;
 

--- a/graylog2-web-interface/src/logic/permissions/EntityShareState.js
+++ b/graylog2-web-interface/src/logic/permissions/EntityShareState.js
@@ -17,8 +17,8 @@ import SharedEntity from './SharedEntity';
 import SelectedGrantee from './SelectedGrantee';
 import type { GranteeInterface } from './GranteeInterface';
 
-export type AvailableGrantees = Immutable.List<Grantee>;
-export type AvailableCapabilities = Immutable.List<Capability>;
+export type GranteesList = Immutable.List<Grantee>;
+export type CapabilitiesList = Immutable.List<Capability>;
 export type ActiveShares = Immutable.List<ActiveShare>;
 export type MissingDependencies = Immutable.Map<GRN, Immutable.List<SharedEntity>>;
 export type SelectedGranteeCapabilities = Immutable.Map<$PropertyType<GranteeType, 'id'>, $PropertyType<CapabilityType, 'id'>>;
@@ -64,8 +64,8 @@ const _sortAndOrderGrantees = <T: GranteeInterface>(grantees: Immutable.List<T>)
 
 type InternalState = {|
   entity: GRN,
-  availableGrantees: AvailableGrantees,
-  availableCapabilities: AvailableCapabilities,
+  availableGrantees: GranteesList,
+  availableCapabilities: CapabilitiesList,
   activeShares: ActiveShares,
   selectedGranteeCapabilities: SelectedGranteeCapabilities,
   missingDependencies: MissingDependencies,

--- a/graylog2-web-interface/src/logic/permissions/EntityShareState.js
+++ b/graylog2-web-interface/src/logic/permissions/EntityShareState.js
@@ -4,7 +4,7 @@ import * as Immutable from 'immutable';
 import type {
   Grantee as GranteeType,
   Capability as CapabilityType,
-  MissingDependency as MissingDependencyType,
+  ShareEntity as ShareEntityType,
   ActiveShare as ActiveShareType,
   GRN,
 } from 'logic/permissions/types';
@@ -13,14 +13,14 @@ import { defaultCompare } from 'views/logic/DefaultCompare';
 import Capability from './Capability';
 import Grantee from './Grantee';
 import ActiveShare from './ActiveShare';
-import MissingDependency from './MissingDependency';
+import ShareEntity from './ShareEntity';
 import SelectedGrantee from './SelectedGrantee';
 import type { GranteeInterface } from './GranteeInterface';
 
 export type AvailableGrantees = Immutable.List<Grantee>;
 export type AvailableCapabilities = Immutable.List<Capability>;
 export type ActiveShares = Immutable.List<ActiveShare>;
-export type MissingDependencies = Immutable.Map<GRN, Immutable.List<MissingDependency>>;
+export type MissingDependencies = Immutable.Map<GRN, Immutable.List<ShareEntity>>;
 export type SelectedGranteeCapabilities = Immutable.Map<$PropertyType<GranteeType, 'id'>, $PropertyType<CapabilityType, 'id'>>;
 export type SelectedGrantees = Immutable.List<SelectedGrantee>;
 
@@ -39,7 +39,7 @@ const mockMissingDependencies = () => {
     .type('team')
     .build();
 
-  const missingDependecy = MissingDependency
+  const missingDependecy = ShareEntity
     .builder()
     .id('grn::::stream:57bc9188e62a2373778d9e03')
     .type('stream')
@@ -79,7 +79,7 @@ export type EntityShareStateJson = {|
   selected_grantee_capabilities: {|
     [grantee: $PropertyType<Grantee, 'id'>]: $PropertyType<Capability, 'id'>,
   |} | {||},
-  missing_permissions_on_dependencies: {[GRN]: Array<MissingDependencyType>},
+  missing_permissions_on_dependencies: {[GRN]: Array<ShareEntityType>},
 |};
 
 export default class EntityShareState {
@@ -204,7 +204,7 @@ export default class EntityShareState {
       Object.entries(missing_permissions_on_dependencies).map(
         ([granteeGRN, dependencyList]) => ({
           // $FlowFixMe: Object entries returns mixed value
-          [granteeGRN]: dependencyList.map((dependency) => MissingDependency.fromJSON(dependency)),
+          [granteeGRN]: dependencyList.map((dependency) => ShareEntity.fromJSON(dependency)),
         }),
       ),
     );

--- a/graylog2-web-interface/src/logic/permissions/EntityShareState.js
+++ b/graylog2-web-interface/src/logic/permissions/EntityShareState.js
@@ -2,10 +2,10 @@
 import * as Immutable from 'immutable';
 
 import type {
-  Grantee as GranteeType,
-  Capability as CapabilityType,
-  ShareEntity as ShareEntityType,
-  ActiveShare as ActiveShareType,
+  GranteeType,
+  CapabilityType,
+  SharedEntityType,
+  ActiveShareType,
   GRN,
 } from 'logic/permissions/types';
 import { defaultCompare } from 'views/logic/DefaultCompare';
@@ -13,14 +13,14 @@ import { defaultCompare } from 'views/logic/DefaultCompare';
 import Capability from './Capability';
 import Grantee from './Grantee';
 import ActiveShare from './ActiveShare';
-import ShareEntity from './ShareEntity';
+import SharedEntity from './SharedEntity';
 import SelectedGrantee from './SelectedGrantee';
 import type { GranteeInterface } from './GranteeInterface';
 
 export type AvailableGrantees = Immutable.List<Grantee>;
 export type AvailableCapabilities = Immutable.List<Capability>;
 export type ActiveShares = Immutable.List<ActiveShare>;
-export type MissingDependencies = Immutable.Map<GRN, Immutable.List<ShareEntity>>;
+export type MissingDependencies = Immutable.Map<GRN, Immutable.List<SharedEntity>>;
 export type SelectedGranteeCapabilities = Immutable.Map<$PropertyType<GranteeType, 'id'>, $PropertyType<CapabilityType, 'id'>>;
 export type SelectedGrantees = Immutable.List<SelectedGrantee>;
 
@@ -39,7 +39,7 @@ const mockMissingDependencies = () => {
     .type('team')
     .build();
 
-  const missingDependecy = ShareEntity
+  const missingDependecy = SharedEntity
     .builder()
     .id('grn::::stream:57bc9188e62a2373778d9e03')
     .type('stream')
@@ -79,7 +79,7 @@ export type EntityShareStateJson = {|
   selected_grantee_capabilities: {|
     [grantee: $PropertyType<Grantee, 'id'>]: $PropertyType<Capability, 'id'>,
   |} | {||},
-  missing_permissions_on_dependencies: {[GRN]: Array<ShareEntityType>},
+  missing_permissions_on_dependencies: {[GRN]: Array<SharedEntityType>},
 |};
 
 export default class EntityShareState {
@@ -204,7 +204,7 @@ export default class EntityShareState {
       Object.entries(missing_permissions_on_dependencies).map(
         ([granteeGRN, dependencyList]) => ({
           // $FlowFixMe: Object entries returns mixed value
-          [granteeGRN]: dependencyList.map((dependency) => ShareEntity.fromJSON(dependency)),
+          [granteeGRN]: dependencyList.map((dependency) => SharedEntity.fromJSON(dependency)),
         }),
       ),
     );

--- a/graylog2-web-interface/src/logic/permissions/Grantee.js
+++ b/graylog2-web-interface/src/logic/permissions/Grantee.js
@@ -1,7 +1,7 @@
 // @flow strict
 import * as Immutable from 'immutable';
 
-import type { Grantee as GranteeType } from 'logic/permissions/types';
+import type { GranteeType } from 'logic/permissions/types';
 
 import type { GranteeInterface } from './GranteeInterface';
 

--- a/graylog2-web-interface/src/logic/permissions/ShareEntity.js
+++ b/graylog2-web-interface/src/logic/permissions/ShareEntity.js
@@ -1,18 +1,18 @@
 // @flow strict
 import * as Immutable from 'immutable';
 
-import type { MissingDependency as MissingDependencyType } from 'logic/permissions/types';
+import type { ShareEntity as ShareEntityType } from 'logic/permissions/types';
 
 import Grantee from './Grantee';
 
 type InternalState = {
-  id: $PropertyType<MissingDependencyType, 'id'>,
+  id: $PropertyType<ShareEntityType, 'id'>,
   owners: Immutable.List<Grantee>,
-  title: $PropertyType<MissingDependencyType, 'title'>,
-  type: $PropertyType<MissingDependencyType, 'type'>,
+  title: $PropertyType<ShareEntityType, 'title'>,
+  type: $PropertyType<ShareEntityType, 'type'>,
 };
 
-export default class MissingDependency {
+export default class ShareEntity {
   _value: InternalState;
 
   constructor(
@@ -54,11 +54,11 @@ export default class MissingDependency {
     return { id, owners, title, type };
   }
 
-  static fromJSON(value: MissingDependencyType): MissingDependency {
+  static fromJSON(value: ShareEntityType): ShareEntity {
     const { id, owners, title, type } = value;
     const formattedOwners = Immutable.fromJS(owners.map((o) => Grantee.fromJSON(o)));
 
-    return MissingDependency
+    return ShareEntity
       .builder()
       .id(id)
       .owners(formattedOwners)
@@ -99,9 +99,9 @@ class Builder {
     return new Builder(this.value.set('type', value));
   }
 
-  build(): MissingDependency {
+  build(): ShareEntity {
     const { id, owners, title, type } = this.value.toObject();
 
-    return new MissingDependency(id, owners, title, type);
+    return new ShareEntity(id, owners, title, type);
   }
 }

--- a/graylog2-web-interface/src/logic/permissions/SharedEntity.js
+++ b/graylog2-web-interface/src/logic/permissions/SharedEntity.js
@@ -1,18 +1,18 @@
 // @flow strict
 import * as Immutable from 'immutable';
 
-import type { ShareEntity as ShareEntityType } from 'logic/permissions/types';
+import type { SharedEntityType } from 'logic/permissions/types';
 
 import Grantee from './Grantee';
 
 type InternalState = {
-  id: $PropertyType<ShareEntityType, 'id'>,
+  id: $PropertyType<SharedEntityType, 'id'>,
   owners: Immutable.List<Grantee>,
-  title: $PropertyType<ShareEntityType, 'title'>,
-  type: $PropertyType<ShareEntityType, 'type'>,
+  title: $PropertyType<SharedEntityType, 'title'>,
+  type: $PropertyType<SharedEntityType, 'type'>,
 };
 
-export default class ShareEntity {
+export default class SharedEntity {
   _value: InternalState;
 
   constructor(
@@ -54,11 +54,11 @@ export default class ShareEntity {
     return { id, owners, title, type };
   }
 
-  static fromJSON(value: ShareEntityType): ShareEntity {
+  static fromJSON(value: SharedEntityType): SharedEntity {
     const { id, owners, title, type } = value;
     const formattedOwners = Immutable.fromJS(owners.map((o) => Grantee.fromJSON(o)));
 
-    return ShareEntity
+    return SharedEntity
       .builder()
       .id(id)
       .owners(formattedOwners)
@@ -99,9 +99,9 @@ class Builder {
     return new Builder(this.value.set('type', value));
   }
 
-  build(): ShareEntity {
+  build(): SharedEntity {
     const { id, owners, title, type } = this.value.toObject();
 
-    return new ShareEntity(id, owners, title, type);
+    return new SharedEntity(id, owners, title, type);
   }
 }

--- a/graylog2-web-interface/src/logic/permissions/mocked.js
+++ b/graylog2-web-interface/src/logic/permissions/mocked.js
@@ -1,0 +1,64 @@
+// @flow strict
+import * as Immutable from 'immutable';
+
+import SharedEntity from 'logic/permissions/SharedEntity';
+import { type AdditionalQueries } from 'util/PaginationURL';
+
+// Temporary file to mock api responses
+
+const searchPaginatedUserSharesResponse = (page: number, perPage: number, query: string, additionalQueries?: AdditionalQueries) => {
+  const mockedEntities = new Array(perPage).fill({
+    id: 'grn::::stream:57bc9188e62a2373778d9e03',
+    type: 'stream',
+    title: 'Security Data',
+    owners: [
+      {
+        id: 'grn::::user:jane',
+        type: 'user',
+        title: 'Jane Doe',
+      },
+    ],
+  });
+
+  const mockedResponse = {
+    additionalQueries: additionalQueries,
+    total: 230,
+    count: Math.round(230 / perPage),
+    page: page || 1,
+    per_page: perPage || 10,
+    query: query || '',
+    entities: mockedEntities,
+    context: {
+      user_capabilities: {
+        'grn::::stream:57bc9188e62a2373778d9e03': 'view',
+      },
+    },
+  };
+
+  return Promise.resolve({
+    list: Immutable.List<any>(mockedResponse.entities.map((se) => SharedEntity.fromJSON(se))),
+    context: { userCapabilities: mockedResponse.context.user_capabilities },
+    pagination: {
+      additionalQueries: mockedResponse.additionalQueries,
+      count: mockedResponse.count,
+      total: mockedResponse.total,
+      page: mockedResponse.page,
+      perPage: mockedResponse.per_page,
+      query: mockedResponse.query,
+    },
+  });
+};
+
+const availabeEntityTypes = {
+  stream: 'Stream',
+  dashboard: 'Dashboard',
+  saved_search: 'Saved Search',
+};
+
+const availableCapabilities = {
+  own: 'Owner',
+  view: 'Viewer',
+  manage: 'Manager',
+};
+
+export default { searchPaginatedUserSharesResponse, availabeEntityTypes, availableCapabilities };

--- a/graylog2-web-interface/src/logic/permissions/types.js
+++ b/graylog2-web-interface/src/logic/permissions/types.js
@@ -19,7 +19,7 @@ export type ActiveShare = {|
   capability: GRN,
 |};
 
-export type MissingDependency = {|
+export type ShareEntity = {|
   id: GRN,
   owners: Array<Grantee>,
   title: string,

--- a/graylog2-web-interface/src/logic/permissions/types.js
+++ b/graylog2-web-interface/src/logic/permissions/types.js
@@ -1,27 +1,32 @@
 // @flow strict
+import * as Immutable from 'immutable';
+
+import SharedEntity from 'logic/permissions/SharedEntity';
 
 export type GRN = string;
 
-export type Capability = {|
+export type CapabilityType = {|
   id: GRN,
   title: 'Viewer' | 'Manager' | 'Owner',
 |};
 
-export type Grantee = {|
+export type GranteeType = {|
   id: GRN,
   title: string,
   type: 'global' | 'team' | 'user',
 |};
 
-export type ActiveShare = {|
+export type ActiveShareType = {|
   grant: GRN,
   grantee: GRN,
   capability: GRN,
 |};
 
-export type ShareEntity = {|
+export type SharedEntityType = {|
   id: GRN,
-  owners: Array<Grantee>,
+  owners: Array<GranteeType>,
   title: string,
   type: string,
 |};
+
+export type UserSharedEntities = Immutable.List<SharedEntity>;

--- a/graylog2-web-interface/src/pages/UserDetailsPage.jsx
+++ b/graylog2-web-interface/src/pages/UserDetailsPage.jsx
@@ -1,8 +1,9 @@
 // @flow strict
 import * as React from 'react';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { withRouter } from 'react-router';
 
+import { EntityShareActions } from 'stores/permissions/EntityShareStore';
 import DocsHelper from 'util/DocsHelper';
 import { useStore } from 'stores/connect';
 import { UsersActions, UsersStore } from 'stores/users/UsersStore';
@@ -29,10 +30,15 @@ const PageTitle = ({ fullName }: {fullName: ?string}) => (
 
 const UserDetailsPage = ({ params }: Props) => {
   const { loadedUser } = useStore(UsersStore);
+  const [paginatedUserShares, setPaginatedUserShares] = useState();
   const username = params?.username;
 
   useEffect(() => {
     UsersActions.load(username);
+
+    EntityShareActions.searchPaginatedUserShares(username, 1, 10, '').then((response) => {
+      setPaginatedUserShares(response);
+    });
   }, []);
 
   return (
@@ -52,7 +58,7 @@ const UserDetailsPage = ({ params }: Props) => {
                              userIsReadOnly={loadedUser?.readOnly} />
       </PageHeader>
 
-      <UserDetails user={username === params?.username ? loadedUser : undefined} />
+      <UserDetails user={username === params?.username ? loadedUser : undefined} paginatedUserShares={paginatedUserShares} />
     </DocumentTitle>
   );
 };

--- a/graylog2-web-interface/src/pages/UserDetailsPage.jsx
+++ b/graylog2-web-interface/src/pages/UserDetailsPage.jsx
@@ -58,7 +58,7 @@ const UserDetailsPage = ({ params }: Props) => {
                              userIsReadOnly={loadedUser?.readOnly} />
       </PageHeader>
 
-      <UserDetails user={username === loadedUser?.username ? loadedUser : undefined} paginatedUserShares={paginatedUserShares} />
+      <UserDetails user={username === loadedUser?.username ? loadedUser : undefined} initialPaginatedUserShares={paginatedUserShares} />
     </DocumentTitle>
   );
 };

--- a/graylog2-web-interface/src/pages/UserDetailsPage.jsx
+++ b/graylog2-web-interface/src/pages/UserDetailsPage.jsx
@@ -58,7 +58,8 @@ const UserDetailsPage = ({ params }: Props) => {
                              userIsReadOnly={loadedUser?.readOnly} />
       </PageHeader>
 
-      <UserDetails user={username === loadedUser?.username ? loadedUser : undefined} initialPaginatedUserShares={paginatedUserShares} />
+      <UserDetails paginatedUserShares={paginatedUserShares}
+                   user={username === loadedUser?.username ? loadedUser : undefined} />
     </DocumentTitle>
   );
 };

--- a/graylog2-web-interface/src/pages/UserDetailsPage.jsx
+++ b/graylog2-web-interface/src/pages/UserDetailsPage.jsx
@@ -58,7 +58,7 @@ const UserDetailsPage = ({ params }: Props) => {
                              userIsReadOnly={loadedUser?.readOnly} />
       </PageHeader>
 
-      <UserDetails user={username === params?.username ? loadedUser : undefined} paginatedUserShares={paginatedUserShares} />
+      <UserDetails user={username === loadedUser?.username ? loadedUser : undefined} paginatedUserShares={paginatedUserShares} />
     </DocumentTitle>
   );
 };

--- a/graylog2-web-interface/src/pages/UserEditPage.jsx
+++ b/graylog2-web-interface/src/pages/UserEditPage.jsx
@@ -51,7 +51,7 @@ const UserEditPage = ({ params }: Props) => {
         <UserManagementLinks username={username}
                              userIsReadOnly={loadedUser?.readOnly} />
       </PageHeader>
-      <UserEdit user={username === loadedUser?.username ? loadedUser : undefined} paginatedUserShares={paginatedUserShares} />
+      <UserEdit user={username === loadedUser?.username ? loadedUser : undefined} />
     </DocumentTitle>
   );
 };

--- a/graylog2-web-interface/src/pages/UserEditPage.jsx
+++ b/graylog2-web-interface/src/pages/UserEditPage.jsx
@@ -51,8 +51,7 @@ const UserEditPage = ({ params }: Props) => {
         <UserManagementLinks username={username}
                              userIsReadOnly={loadedUser?.readOnly} />
       </PageHeader>
-
-      <UserEdit user={username === loadedUser?.username ? loadedUser : undefined} />
+      <UserEdit user={username === loadedUser?.username ? loadedUser : undefined} paginatedUserShares={paginatedUserShares} />
     </DocumentTitle>
   );
 };

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -90,6 +90,7 @@ const ApiRoutes = {
   EntityShareController: {
     prepare: (entityGRN) => { return { url: `/shares/entities/${entityGRN}/prepare` }; },
     update: (entityGRN) => { return { url: `/shares/entities/${entityGRN}` }; },
+    userSharesPaginated: (username) => { return { url: `/shares/user/${username}` }; },
   },
   IndexerClusterApiController: {
     health: () => { return { url: '/system/indexer/cluster/health' }; },

--- a/graylog2-web-interface/src/stores/permissions/EntityShareStore.js
+++ b/graylog2-web-interface/src/stores/permissions/EntityShareStore.js
@@ -1,7 +1,7 @@
 // @flow strict
 import Reflux from 'reflux';
-import * as Immutable from 'immutable';
 
+// import * as Immutable from 'immutable';
 import ApiRoutes from 'routing/ApiRoutes';
 import { qualifyUrl } from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
@@ -10,9 +10,9 @@ import { singletonActions, singletonStore } from 'views/logic/singleton';
 // import type { GRN, SharedEntityType, UserSharedEntities } from 'logic/permissions/types';
 import type { GRN, UserSharedEntities } from 'logic/permissions/types';
 // import PaginationURL, { type AdditionalQueries } from 'util/PaginationURL';
+import permissionsMock from 'logic/permissions/mocked';
 import { type AdditionalQueries } from 'util/PaginationURL';
 import EntityShareState, { type EntityShareStateJson, type SelectedGranteeCapabilities } from 'logic/permissions/EntityShareState';
-import SharedEntity from 'logic/permissions/SharedEntity';
 
 type EntityShareStoreState = {
   state: EntityShareState,
@@ -105,46 +105,7 @@ export const EntityShareStore: EntityShareStoreType = singletonStore(
       //   };
       // });
 
-      const mockedEntities = new Array(perPage).fill({
-        id: 'grn::::stream:57bc9188e62a2373778d9e03',
-        type: 'stream',
-        title: 'Security Data',
-        owners: [
-          {
-            id: 'grn::::user:jane',
-            type: 'user',
-            title: 'Jane Doe',
-          },
-        ],
-      });
-
-      const mockedResponse = {
-        additionalQueries: additionalQueries,
-        total: 230,
-        count: Math.round(230 / perPage),
-        page: page || 1,
-        per_page: perPage || 10,
-        query: query || '',
-        entities: mockedEntities,
-        context: {
-          user_capabilities: {
-            'grn::::stream:57bc9188e62a2373778d9e03': 'view',
-          },
-        },
-      };
-
-      const promise = Promise.resolve({
-        list: Immutable.List(mockedResponse.entities.map((se) => SharedEntity.fromJSON(se))),
-        context: { userCapabilities: mockedResponse.context.user_capabilities },
-        pagination: {
-          additionalQueries: mockedResponse.additionalQueries,
-          count: mockedResponse.count,
-          total: mockedResponse.total,
-          page: mockedResponse.page,
-          perPage: mockedResponse.per_page,
-          query: mockedResponse.query,
-        },
-      });
+      const promise = permissionsMock.searchPaginatedUserSharesResponse(page, perPage, query, additionalQueries);
       EntityShareActions.searchPaginatedUserShares.promise(promise);
 
       return promise;

--- a/graylog2-web-interface/src/stores/permissions/EntityShareStore.js
+++ b/graylog2-web-interface/src/stores/permissions/EntityShareStore.js
@@ -28,15 +28,17 @@ type EntityShareStoreState = {
 //   },
 // };
 
+export type UserSharesPaginationType = {
+  count: number,
+  total: number,
+  page: number,
+  perPage: number,
+  query: string,
+};
+
 export type PaginatedUserSharesType = {
   list: UserSharedEntities,
-  pagination: {
-    count: number,
-    total: number,
-    page: number,
-    perPage: number,
-    query: string,
-  },
+  pagination: UserSharesPaginationType,
   context: {
     userCapabilities: { [grn: GRN]: string },
   },

--- a/graylog2-web-interface/src/stores/permissions/EntityShareStore.js
+++ b/graylog2-web-interface/src/stores/permissions/EntityShareStore.js
@@ -1,16 +1,38 @@
 // @flow strict
 import Reflux from 'reflux';
+import * as Immutable from 'immutable';
 
 import ApiRoutes from 'routing/ApiRoutes';
 import { qualifyUrl } from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 import type { RefluxActions, Store } from 'stores/StoreTypes';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
-import type { GRN } from 'logic/permissions/types';
+import type { GRN, ShareEntity as ShareEntityType } from 'logic/permissions/types';
+// import PaginationURL from 'util/PaginationURL';
 import EntityShareState, { type EntityShareStateJson, type SelectedGranteeCapabilities } from 'logic/permissions/EntityShareState';
+import ShareEntity from 'logic/permissions/ShareEntity';
 
 type EntityShareStoreState = {
   state: EntityShareState,
+};
+
+// type PaginatedUserSharesResponse = {
+//   total: number,
+//   count: number,
+//   page: number,
+//   per_page: number,
+//   query: string,
+//   entities: Array<ShareEntityType>,
+//   context: {
+//     user_capabilities: { [grn: GRN]: string },
+//   },
+// };
+
+type PaginatedUserSharesType = {
+  list: Immutable.List<ShareEntity>,
+  context: {
+    userCapabilities: { [grn: GRN]: string },
+  },
 };
 
 export type EntitySharePayload = {
@@ -20,6 +42,7 @@ export type EntitySharePayload = {
 type EntityShareActionsType = RefluxActions<{
   prepare: (GRN, ?EntitySharePayload) => Promise<EntityShareState>,
   update: (GRN, EntitySharePayload) => Promise<EntityShareState>,
+  searchPaginatedUserShares: (username: string, page: number, perPage: number, query: string) => Promise<PaginatedUserSharesType>,
 }>;
 
 type EntityShareStoreType = Store<EntityShareStoreState>;
@@ -59,6 +82,67 @@ export const EntityShareStore: EntityShareStoreType = singletonStore(
       const promise = fetch('POST', url, JSON.stringify(payload)).then(this._handleResponse);
 
       EntityShareActions.update.promise(promise);
+
+      return promise;
+    },
+
+    searchPaginatedUserShares(username: string, page: number, perPage: number, query: string): Promise<PaginatedUserSharesType> {
+      // const url = PaginationURL(ApiRoutes.EntityShareController.userSharesPaginated(username).url, page, perPage, query);
+      // const promise = fetch('GET', qualifyUrl(url)).then((response: PaginatedUserSharesResponse) => {
+      //   return {
+      //     list: Immutable.List(response.entities.map((se) => ShareEntity.fromJSON(se))),
+      //     context: {
+      //       userCapabilities: response.context.user_capabilities,
+      //     },
+      //     pagination: {
+      //       count: response.count,
+      //       total: response.total,
+      //       page: response.page,
+      //       perPage: response.per_page,
+      //       query: response.query,
+      //     },
+      //   };
+      // });
+
+      const mockedResponse = {
+        total: 1,
+        count: 1,
+        page: page || 1,
+        per_page: perPage || 10,
+        query: query || '',
+        entities: [
+          {
+            id: 'grn::::stream:57bc9188e62a2373778d9e03',
+            type: 'stream',
+            title: 'Security Data',
+            owners: [
+              {
+                id: 'grn::::user:jane',
+                type: 'user',
+                title: 'Jane Doe',
+              },
+            ],
+          },
+        ],
+        context: {
+          user_capabilities: {
+            'grn::::stream:57bc9188e62a2373778d9e03': 'view',
+          },
+        },
+      };
+
+      const promise = Promise.resolve({
+        list: Immutable.List(mockedResponse.entities.map((se) => ShareEntity.fromJSON(se))),
+        context: { userCapabilities: mockedResponse.context.user_capabilities },
+        pagination: {
+          count: mockedResponse.count,
+          total: mockedResponse.total,
+          page: mockedResponse.page,
+          perPage: mockedResponse.per_page,
+          query: mockedResponse.query,
+        },
+      });
+      EntityShareActions.searchPaginatedUserShares.promise(promise);
 
       return promise;
     },

--- a/graylog2-web-interface/src/stores/permissions/EntityShareStore.js
+++ b/graylog2-web-interface/src/stores/permissions/EntityShareStore.js
@@ -7,8 +7,10 @@ import { qualifyUrl } from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 import type { RefluxActions, Store } from 'stores/StoreTypes';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
-import type { GRN, SharedEntityType, UserSharedEntities } from 'logic/permissions/types';
-import PaginationURL, { type AdditionalQueries } from 'util/PaginationURL';
+// import type { GRN, SharedEntityType, UserSharedEntities } from 'logic/permissions/types';
+import type { GRN, UserSharedEntities } from 'logic/permissions/types';
+// import PaginationURL, { type AdditionalQueries } from 'util/PaginationURL';
+import { type AdditionalQueries } from 'util/PaginationURL';
 import EntityShareState, { type EntityShareStateJson, type SelectedGranteeCapabilities } from 'logic/permissions/EntityShareState';
 import SharedEntity from 'logic/permissions/SharedEntity';
 
@@ -16,24 +18,13 @@ type EntityShareStoreState = {
   state: EntityShareState,
 };
 
-// type PaginatedUserSharesResponse = {
-//   total: number,
-//   count: number,
-//   page: number,
-//   per_page: number,
-//   query: string,
-//   entities: Array<SharedEntityType>,
-//   context: {
-//     user_capabilities: { [grn: GRN]: string },
-//   },
-// };
-
 export type UserSharesPaginationType = {
   count: number,
   total: number,
   page: number,
   perPage: number,
   query: string,
+  additionalQueries?: AdditionalQueries,
 };
 
 export type PaginatedUserSharesType = {
@@ -128,9 +119,9 @@ export const EntityShareStore: EntityShareStoreType = singletonStore(
       });
 
       const mockedResponse = {
-        ...additionalQueries,
-        total: 230 / perPage,
-        count: 230,
+        additionalQueries: additionalQueries,
+        total: 230,
+        count: Math.round(230 / perPage),
         page: page || 1,
         per_page: perPage || 10,
         query: query || '',
@@ -146,6 +137,7 @@ export const EntityShareStore: EntityShareStoreType = singletonStore(
         list: Immutable.List(mockedResponse.entities.map((se) => SharedEntity.fromJSON(se))),
         context: { userCapabilities: mockedResponse.context.user_capabilities },
         pagination: {
+          additionalQueries: mockedResponse.additionalQueries,
           count: mockedResponse.count,
           total: mockedResponse.total,
           page: mockedResponse.page,

--- a/graylog2-web-interface/src/stores/permissions/EntityShareStore.js
+++ b/graylog2-web-interface/src/stores/permissions/EntityShareStore.js
@@ -8,7 +8,7 @@ import fetch from 'logic/rest/FetchProvider';
 import type { RefluxActions, Store } from 'stores/StoreTypes';
 import { singletonActions, singletonStore } from 'views/logic/singleton';
 import type { GRN, SharedEntityType, UserSharedEntities } from 'logic/permissions/types';
-// import PaginationURL from 'util/PaginationURL';
+import PaginationURL, { type AdditionalQueries } from 'util/PaginationURL';
 import EntityShareState, { type EntityShareStateJson, type SelectedGranteeCapabilities } from 'logic/permissions/EntityShareState';
 import SharedEntity from 'logic/permissions/SharedEntity';
 
@@ -49,7 +49,7 @@ export type EntitySharePayload = {
 type EntityShareActionsType = RefluxActions<{
   prepare: (GRN, ?EntitySharePayload) => Promise<EntityShareState>,
   update: (GRN, EntitySharePayload) => Promise<EntityShareState>,
-  searchPaginatedUserShares: (username: string, page: number, perPage: number, query: string) => Promise<PaginatedUserSharesType>,
+  searchPaginatedUserShares: (username: string, page: number, perPage: number, query: string, additionalQueries?: AdditionalQueries) => Promise<PaginatedUserSharesType>,
 }>;
 
 type EntityShareStoreType = Store<EntityShareStoreState>;
@@ -94,8 +94,8 @@ export const EntityShareStore: EntityShareStoreType = singletonStore(
       return promise;
     },
 
-    searchPaginatedUserShares(username: string, page: number, perPage: number, query: string): Promise<PaginatedUserSharesType> {
-      // const url = PaginationURL(ApiRoutes.EntityShareController.userSharesPaginated(username).url, page, perPage, query);
+    searchPaginatedUserShares(username: string, page: number, perPage: number, query: string, additionalQueries?: AdditionalQueries): Promise<PaginatedUserSharesType> {
+      // const url = PaginationURL(ApiRoutes.EntityShareController.userSharesPaginated(username).url, page, perPage, query, additionalQueries);
       // const promise = fetch('GET', qualifyUrl(url)).then((response: PaginatedUserSharesResponse) => {
       //   return {
       //     list: Immutable.List(response.entities.map((se) => SharedEntity.fromJSON(se))),
@@ -126,6 +126,7 @@ export const EntityShareStore: EntityShareStoreType = singletonStore(
       });
 
       const mockedResponse = {
+        ...additionalQueries,
         total: 230 / perPage,
         count: 230,
         page: page || 1,

--- a/graylog2-web-interface/src/util/PaginationURL.js
+++ b/graylog2-web-interface/src/util/PaginationURL.js
@@ -1,7 +1,7 @@
 // @flow strict
 import URI from 'urijs';
 
-type AdditionalQueries = { [string]: any };
+export type AdditionalQueries = { [string]: any };
 
 export default (destUrl: string, page: number, perPage: number, query: string, additional: AdditionalQueries = {}): string => {
   let uri = new URI(destUrl).addSearch('page', page)

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/__snapshots__/SavedSearchList.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/__snapshots__/SavedSearchList.test.jsx.snap
@@ -32,7 +32,7 @@ exports[`SavedSearchList render the SavedSearchList should render empty 1`] = `
             class="modal-body"
           >
             <div
-              class="search"
+              class="search "
               style="margin-top: 15px;"
             >
               <form
@@ -137,7 +137,7 @@ exports[`SavedSearchList render the SavedSearchList should render with views 1`]
             class="modal-body"
           >
             <div
-              class="search"
+              class="search "
               style="margin-top: 15px;"
             >
               <form

--- a/graylog2-web-interface/src/views/components/widgets/__snapshots__/CopyToDashboardForm.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/widgets/__snapshots__/CopyToDashboardForm.test.jsx.snap
@@ -32,7 +32,7 @@ exports[`CopyToDashboardForm should render the modal minimal 1`] = `
             class="modal-body"
           >
             <div
-              class="search"
+              class="search "
               style="margin-top: 15px;"
             >
               <form
@@ -181,7 +181,7 @@ exports[`CopyToDashboardForm should render the modal with entries 1`] = `
             class="modal-body"
           >
             <div
-              class="search"
+              class="search "
               style="margin-top: 15px;"
             >
               <form

--- a/graylog2-web-interface/src/views/pages/ShowViewPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ShowViewPage.jsx
@@ -102,6 +102,7 @@ class ShowViewPage extends React.Component<Props, State> {
         this.setState({ hookComponent: e });
       },
     ).then((results) => {
+      console.log('results', results);
       this.setState({ loaded: true });
 
       return results;

--- a/graylog2-web-interface/src/views/pages/ShowViewPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ShowViewPage.jsx
@@ -102,7 +102,6 @@ class ShowViewPage extends React.Component<Props, State> {
         this.setState({ hookComponent: e });
       },
     ).then((results) => {
-      console.log('results', results);
       this.setState({ loaded: true });
 
       return results;

--- a/graylog2-web-interface/test/fixtures/entityShareState.js
+++ b/graylog2-web-interface/test/fixtures/entityShareState.js
@@ -4,7 +4,7 @@ import * as Immutable from 'immutable';
 import EntityShareState, { type MissingDependencies } from 'logic/permissions/EntityShareState';
 import Grantee from 'logic/permissions/Grantee';
 import Capability from 'logic/permissions/Capability';
-import MissingDependency from 'logic/permissions/MissingDependency';
+import SharedEntity from 'logic/permissions/SharedEntity';
 import ActiveShare from 'logic/permissions/ActiveShare';
 
 // grantees
@@ -72,7 +72,7 @@ const activeShares = Immutable.List([janeIsOwner]);
 const janeIsSelected = Immutable.Map({ [janeIsOwner.grantee]: janeIsOwner.capability });
 
 // missing dependencies
-const missingDependecy = MissingDependency
+const missingDependecy = SharedEntity
   .builder()
   .id('grn::::stream:57bc9188e62a2373778d9e03')
   .type('stream')

--- a/graylog2-web-interface/test/fixtures/userEntityShares.js
+++ b/graylog2-web-interface/test/fixtures/userEntityShares.js
@@ -1,0 +1,39 @@
+// @flow strict
+/* eslint-disable import/prefer-default-export */
+import * as Immutable from 'immutable';
+
+import Grantee from 'logic/permissions/Grantee';
+import SharedEntity from 'logic/permissions/SharedEntity';
+import { type AdditionalQueries } from 'util/PaginationURL';
+
+export const simplePaginatedUserShares = (page: number, perPage: number, query: string, additionalQueries?: AdditionalQueries) => {
+  const entityOwner = Grantee
+    .builder()
+    .id('grn::::user:jane')
+    .type('user')
+    .title('Jane Doe')
+    .build();
+  const sharedEntity = SharedEntity
+    .builder()
+    .id('grn::::stream:57bc9188e62a2373778d9e03')
+    .type('stream')
+    .title('Security Data')
+    .owners(Immutable.List([entityOwner]))
+    .build();
+  const sharedEnitites = new Array(perPage).fill(sharedEntity);
+
+  return {
+    list: Immutable.List<SharedEntity>(sharedEnitites),
+    context: {
+      userCapabilities: { 'grn::::stream:57bc9188e62a2373778d9e03': 'view' },
+    },
+    pagination: {
+      additionalQueries,
+      count: Math.round(230 / perPage),
+      total: 230,
+      page: page || 1,
+      perPage: perPage || 10,
+      query: query || '',
+    },
+  };
+};


### PR DESCRIPTION
Display entities which got shared with the user on user details page.

- The request for the shared entities is currently mocked, I've created a file `logic/permissions/mocked` which contains the mock and can be removed in the future
- I renamed the class `MissingDependency` to `SharedEntity` because we need it also for the user entity shares. In both cases we need the same structure (id, title, type, owners). But I am not completely happy with the naming.
- I adjusted the existing entity share type definition names, they are more generic now and can be used in more cases. E.g. `AvailableGrantees` is now `GranteesList`
- The link for the user details page of an owner is currently not working, because we don't know the username at this point, I will adjust this when we implement the link for a teams details page.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

