### PR TITLE
Stop pinned sidebar from overlapping header

### DIFF
--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -49,6 +49,8 @@ const GridContainer: StyledComponent<{ interactive: boolean }, void, HTMLDivElem
   ${({ interactive }) => (interactive ? css`
     height: calc(100vh - 50px);
     display: flex;
+    overflow: hidden;
+    
     > *:nth-child(2) {
       flex-grow: 1;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Stop pinned sidebar from overlapping header

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Small UI fragment was overlapping `Alert` in the navigation and was visible on hover.

## Screenshots (if appropriate):
### before
![image](https://user-images.githubusercontent.com/122591/89051164-72176380-d319-11ea-9202-426d22889b5c.png)


### after 
![image](https://user-images.githubusercontent.com/122591/89051148-6deb4600-d319-11ea-897f-537642118924.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

