### PR TITLE
Avoid deletion of old index in ES7 index alias cycling

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
@@ -345,8 +345,9 @@ public class IndicesAdapterES7 implements IndicesAdapter {
         final IndicesAliasesRequest.AliasActions addAlias = new IndicesAliasesRequest.AliasActions(IndicesAliasesRequest.AliasActions.Type.ADD)
                 .index(targetIndex)
                 .alias(aliasName);
-        final IndicesAliasesRequest.AliasActions removeAlias = new IndicesAliasesRequest.AliasActions(IndicesAliasesRequest.AliasActions.Type.REMOVE_INDEX)
-                .index(oldIndex);
+        final IndicesAliasesRequest.AliasActions removeAlias = new IndicesAliasesRequest.AliasActions(IndicesAliasesRequest.AliasActions.Type.REMOVE)
+                .index(oldIndex)
+                .alias(aliasName);
         final IndicesAliasesRequest indicesAliasesRequest = new IndicesAliasesRequest()
                 .addAliasAction(removeAlias)
                 .addAliasAction(addAlias);


### PR DESCRIPTION
## Description
We accidentally used the Alias Action `REMOVE_INDEX`, which actually deletes the old index instead of only removing the alias from it:
https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-aliases.html

## Motivation and Context
A little data loss never hurt no one, but this would have been a bit much. :)

## How Has This Been Tested?
Manual testing and new integration test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


