### PR TITLE
Make IndicesAdapterES7#indexCreationDate return UTC timestamps

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
@@ -159,7 +159,7 @@ public class IndicesAdapterES7 implements IndicesAdapter {
 
         return creationDate
                 .map(Long::valueOf)
-                .map(DateTime::new);
+                .map(instant -> new DateTime(instant, DateTimeZone.UTC));
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategy.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategy.java
@@ -120,7 +120,7 @@ public class TimeBasedRotationStrategy extends AbstractRotationStrategy {
             throw new IllegalArgumentException("Could not determine rotation stride length.");
         }
 
-        final DateTime anchorTime = MoreObjects.firstNonNull(lastAnchor, Tools.nowUTC());
+        final DateTime anchorTime = anchorTimeFrom(lastAnchor);
 
         final DateTimeField field = largestStrideType.getField(anchorTime.getChronology());
         // use normalized here to make sure we actually have the largestStride type available! see https://github.com/Graylog2/graylog2-server/issues/836
@@ -136,6 +136,13 @@ public class TimeBasedRotationStrategy extends AbstractRotationStrategy {
         final long difference = fieldValueInUnit % periodValue;
         final long newValue = field.add(fieldValue, -1 * difference);
         return new DateTime(newValue, DateTimeZone.UTC);
+    }
+
+    private static DateTime anchorTimeFrom(@Nullable DateTime lastAnchor) {
+        if (lastAnchor != null && !lastAnchor.getZone().equals(DateTimeZone.UTC)) {
+            return lastAnchor.withZone(DateTimeZone.UTC);
+        }
+        return MoreObjects.firstNonNull(lastAnchor, Tools.nowUTC());
     }
 
     @Nullable

--- a/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/indices/IndicesIT.java
@@ -364,12 +364,13 @@ public abstract class IndicesIT extends ElasticsearchBaseTest {
     }
 
     @Test
-    public void retrievesCreationTimeOfIndex() {
+    public void retrievesCreationTimeOfIndexInUTC() {
         final String index = client().createRandomIndex("foo");
 
         final Optional<DateTime> creationDate = indices.indexCreationDate(index);
 
-        assertThat(creationDate).isNotEmpty();
+        assertThat(creationDate).hasValueSatisfying(dt ->
+                assertThat(dt.getZone()).isEqualTo(DateTimeZone.UTC));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategyTest.java
@@ -38,6 +38,7 @@ import org.mockito.junit.MockitoRule;
 
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.joda.time.Period.minutes;
 import static org.joda.time.Period.seconds;
 import static org.junit.Assert.assertEquals;
@@ -83,6 +84,19 @@ public class TimeBasedRotationStrategyTest {
     @After
     public void resetTimeProvider() {
         DateTimeUtils.setCurrentMillisSystem();
+    }
+
+    @Test
+    public void anchorCalculationShouldWorkWhenLastAnchorIsNotUTC() {
+        final DateTime initialTime = new DateTime(2020, 7, 31, 14, 48, 35, 0, DateTimeZone.UTC);
+
+        final InstantMillisProvider clock = new InstantMillisProvider(initialTime);
+        DateTimeUtils.setCurrentMillisProvider(clock);
+
+        Period period = Period.months(1);
+        DateTime lastAnchor = initialTime.minusHours(1).withZone(DateTimeZone.forOffsetHours(2));
+        final DateTime monthAnchor = TimeBasedRotationStrategy.determineRotationPeriodAnchor(lastAnchor, period);
+        assertThat(monthAnchor).isEqualTo(DateTime.parse("2020-07-01T00:00:00.000Z"));
     }
 
     @Test
@@ -326,7 +340,7 @@ public class TimeBasedRotationStrategyTest {
 
         when(indexSetConfig1.id()).thenReturn("id1");
         when(indexSetConfig2.id()).thenReturn("id2");
-        
+
         when(indexSet1.getConfig()).thenReturn(indexSetConfig1);
         when(indexSet2.getConfig()).thenReturn(indexSetConfig2);
 


### PR DESCRIPTION
## Description
Non-UTC timestamps from `IndicesAdapterES7#indexCreationDate` led to a bug in `TimeBasedRotationStrategy#determineRotationPeriodAnchor` when calculating the new rotation period anchor.
`IndicesAdapterES7#indexCreationDate` was changed to always return UTC dates, just like `IndicesAdapterES6#indexCreationDate` does.

## Motivation and Context
New anchors were always created as UTC. But when the clalculation started from a non-UTC old anchor, this could lead to undesired shifts in date.
Example:
- old anchor (i.e., the index creation date) is `20200731T12:00:00.000+02:00` (CET)
- rotation period is 1 month (`P1M`)
- new anchor would first be calculated as `20200701T00:00:00.000+02:00` (CET)
- conversion to UTC would result in `20200630T22:00:00.000+00:00`

=> Index would be rotated wrongly.

See https://github.com/Graylog2/graylog2-server/blob/1f5a579c91c891d48fa0c6cd1ceb99e6093c1d1d/graylog2-server/src/main/java/org/graylog2/indexer/rotation/strategies/TimeBasedRotationStrategy.java#L96

## How Has This Been Tested?
- Added tests
- Manual tests on local machine

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

