### PR TITLE
Implement UsersActions and User class

### DIFF
--- a/graylog2-web-interface/src/actions/users/UsersActions.js
+++ b/graylog2-web-interface/src/actions/users/UsersActions.js
@@ -1,0 +1,35 @@
+// @flow strict
+import Reflux from 'reflux';
+
+import { singletonActions } from 'views/logic/singleton';
+import type { RefluxActions } from 'stores/StoreTypes';
+import type { UserJSON as User, ChangePasswordRequest, Token } from 'stores/users/UsersStore';
+
+type UsersActionsType = RefluxActions<{
+  create: (request: any) => Promise<string[]>,
+  loadUsers: () => Promise<User[]>,
+  load: (username: string) => Promise<User>,
+  deleteUser: (username: string) => Promise<string[]>,
+  changePassword: (username: string, request: ChangePasswordRequest) => Promise<void>,
+  update: (username: string, request: any) => Promise<void>,
+  createToken: (username: string, tokenName: string) => Promise<Token>,
+  deleteToken: (username: string, tokenId: string, tokenName: string) => Promise<string[]>,
+  loadTokens: (username: string) => Promise<Token[]>,
+}>;
+
+const UsersActions: UsersActionsType = singletonActions(
+  'Users',
+  () => Reflux.createActions({
+    create: { asyncResult: true },
+    loadUsers: { asyncResult: true },
+    load: { asyncResult: true },
+    deleteUser: { asyncResult: true },
+    changePassword: { asyncResult: true },
+    update: { asyncResult: true },
+    createToken: { asyncResult: true },
+    deleteToken: { asyncResult: true },
+    loadTokens: { asyncResult: true },
+  }),
+);
+
+export default UsersActions;

--- a/graylog2-web-interface/src/actions/users/UsersActions.js
+++ b/graylog2-web-interface/src/actions/users/UsersActions.js
@@ -1,9 +1,20 @@
 // @flow strict
 import Reflux from 'reflux';
 
+import User from 'logic/users/User';
 import { singletonActions } from 'views/logic/singleton';
 import type { RefluxActions } from 'stores/StoreTypes';
-import type { UserJSON as User, ChangePasswordRequest, Token } from 'stores/users/UsersStore';
+
+export type Token = {
+  token_name: string,
+  token: string,
+  last_access: string,
+};
+
+export type ChangePasswordRequest = {
+  old_password: string,
+  password: string,
+};
 
 type UsersActionsType = RefluxActions<{
   create: (request: any) => Promise<string[]>,

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationForm.jsx
@@ -74,7 +74,7 @@ class EmailNotificationForm extends React.Component {
   };
 
   formatUsers = (users) => {
-    return users.map((user) => ({ label: `${user.username} (${user.full_name})`, value: user.username }));
+    return users.map((user) => ({ label: `${user.username} (${user.fullName})`, value: user.username }));
   };
 
   render() {

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationFormContainer.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import * as React from 'react';
+import Immutable from 'immutable';
 import PropTypes from 'prop-types';
 
 import { Spinner } from 'components/common';
-import PermissionsMixin from 'util/PermissionsMixin';
+import { isPermitted } from 'util/PermissionsMixin';
 import CombinedProvider from 'injection/CombinedProvider';
 import connect from 'stores/connect';
 
@@ -19,9 +20,13 @@ class EmailNotificationFormContainer extends React.Component {
     onChange: PropTypes.func.isRequired,
   };
 
-  state = {
-    users: undefined,
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      users: undefined,
+    };
+  }
 
   componentDidMount() {
     this.loadUsers();
@@ -30,13 +35,11 @@ class EmailNotificationFormContainer extends React.Component {
   loadUsers = () => {
     const { currentUser } = this.props;
 
-    if (PermissionsMixin.isPermitted(currentUser.permissions, 'users:list')) {
+    if (isPermitted(currentUser.permissions, 'users:list')) {
       UsersStore.loadUsers()
-        .then((users) => {
-          this.setState({ users: users });
-        });
+        .then((users) => this.setState({ users }));
     } else {
-      this.setState({ users: [] });
+      this.setState({ users: Immutable.List() });
     }
   };
 

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationFormContainer.jsx
@@ -6,11 +6,11 @@ import { Spinner } from 'components/common';
 import { isPermitted } from 'util/PermissionsMixin';
 import CombinedProvider from 'injection/CombinedProvider';
 import connect from 'stores/connect';
+import { UsersActions } from 'stores/users/UsersStore';
 
 import EmailNotificationForm from './EmailNotificationForm';
 
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
-const { UsersStore } = CombinedProvider.get('Users');
 
 class EmailNotificationFormContainer extends React.Component {
   static propTypes = {
@@ -36,7 +36,7 @@ class EmailNotificationFormContainer extends React.Component {
     const { currentUser } = this.props;
 
     if (isPermitted(currentUser.permissions, 'users:list')) {
-      UsersStore.loadUsers()
+      UsersActions.loadUsers()
         .then((users) => this.setState({ users }));
     } else {
       this.setState({ users: Immutable.List() });

--- a/graylog2-web-interface/src/components/users/EditRolesForm.jsx
+++ b/graylog2-web-interface/src/components/users/EditRolesForm.jsx
@@ -10,12 +10,12 @@ import history from 'util/History';
 import StoreProvider from 'injection/StoreProvider';
 import RolesSelect from 'components/users/RolesSelect';
 import { Spinner } from 'components/common';
+import { UsersActions } from 'stores/users/UsersStore';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import EditRolesFormStyle from '!style!css!./EditRolesForm.css';
 
 const RolesStore = StoreProvider.getStore('Roles');
-const UsersStore = StoreProvider.getStore('Users');
 
 class EditRolesForm extends React.Component {
   static propTypes = {
@@ -44,7 +44,7 @@ class EditRolesForm extends React.Component {
 
       userClone.roles = roles;
 
-      UsersStore.update(user.username, userClone).then(() => {
+      UsersActions.update(user.username, userClone).then(() => {
         UserNotification.success('Roles updated successfully.', 'Success!');
         history.replace(Routes.SYSTEM.AUTHENTICATION.USERS.LIST);
       }, () => {

--- a/graylog2-web-interface/src/components/users/NewUserForm.jsx
+++ b/graylog2-web-interface/src/components/users/NewUserForm.jsx
@@ -6,10 +6,8 @@ import { Input } from 'components/bootstrap';
 import RolesSelect from 'components/users/RolesSelect';
 import TimeoutInput from 'components/users/TimeoutInput';
 import { TimezoneSelect } from 'components/common';
-import StoreProvider from 'injection/StoreProvider';
 import ValidationsUtils from 'util/ValidationsUtils';
-
-const UsersStore = StoreProvider.getStore('Users');
+import { UsersActions } from 'stores/users/UsersStore';
 
 class NewUserForm extends React.Component {
   static propTypes = {
@@ -24,7 +22,7 @@ class NewUserForm extends React.Component {
   };
 
   componentDidMount() {
-    UsersStore.loadUsers().then((users) => {
+    UsersActions.loadUsers().then((users) => {
       this.setState({ users });
     });
   }

--- a/graylog2-web-interface/src/components/users/UserForm.jsx
+++ b/graylog2-web-interface/src/components/users/UserForm.jsx
@@ -17,10 +17,10 @@ import TimeoutInput from 'components/users/TimeoutInput';
 import EditRolesForm from 'components/users/EditRolesForm';
 import { IfPermitted, MultiSelect, TimezoneSelect, Spinner } from 'components/common';
 import { DashboardsActions, DashboardsStore } from 'views/stores/DashboardsStore';
+import { UsersActions } from 'stores/users/UsersStore';
 
 const StreamsStore = StoreProvider.getStore('Streams');
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
-const UsersStore = StoreProvider.getStore('Users');
 
 const UserForm = createReactClass({
   displayName: 'UserForm',
@@ -103,7 +103,7 @@ const UserForm = createReactClass({
 
     request.password = this.inputs.password.getValue();
 
-    UsersStore.changePassword(this.props.user.username, request).then(() => {
+    UsersActions.changePassword(this.props.user.username, request).then(() => {
       UserNotification.success('Password updated successfully.', 'Success');
 
       if (this.isPermitted(this.state.currentUser.permissions, ['users:list'])) {
@@ -117,7 +117,7 @@ const UserForm = createReactClass({
   _updateUser(evt) {
     evt.preventDefault();
 
-    UsersStore.update(this.props.user.username, this.state.user).then(() => {
+    UsersActions.update(this.props.user.username, this.state.user).then(() => {
       UserNotification.success('User updated successfully.', 'Success');
 
       if (this.isPermitted(this.state.currentUser.permissions, ['users:list'])) {

--- a/graylog2-web-interface/src/components/users/UserList.jsx
+++ b/graylog2-web-interface/src/components/users/UserList.jsx
@@ -221,7 +221,6 @@ const UserList = createReactClass({
 
   render() {
     const { roles, users } = this.state;
-    console.log(users);
     const filterKeys = ['username', 'full_name', 'email', 'client_address'];
     const headers = ['', 'Name', 'Username', 'Email Address', 'Client Address', 'Role', 'Actions'];
 

--- a/graylog2-web-interface/src/components/users/UserList.jsx
+++ b/graylog2-web-interface/src/components/users/UserList.jsx
@@ -10,11 +10,11 @@ import Routes from 'routing/Routes';
 import StoreProvider from 'injection/StoreProvider';
 import { Button, OverlayTrigger, Popover, Tooltip, DropdownButton, MenuItem } from 'components/graylog';
 import { DataTable, Spinner, Timestamp, Icon } from 'components/common';
+import { UsersActions } from 'stores/users/UsersStore';
 
 // eslint-disable-next-line import/no-webpack-loader-syntax
 import UserListStyle from '!style!css!./UserList.css';
 
-const UsersStore = StoreProvider.getStore('Users');
 const RolesStore = StoreProvider.getStore('Roles');
 
 const ActiveIcon = styled(Icon)(({ theme }) => css`
@@ -47,7 +47,7 @@ const UserList = createReactClass({
   },
 
   loadUsers() {
-    const promise = UsersStore.loadUsers();
+    const promise = UsersActions.loadUsers();
 
     promise.done((users) => {
       this.setState({
@@ -61,7 +61,7 @@ const UserList = createReactClass({
   },
 
   deleteUser(username) {
-    const promise = UsersStore.deleteUser(username);
+    const promise = UsersActions.deleteUser(username);
 
     promise.done(() => {
       this.loadUsers();

--- a/graylog2-web-interface/src/components/users/UserList.jsx
+++ b/graylog2-web-interface/src/components/users/UserList.jsx
@@ -51,7 +51,7 @@ const UserList = createReactClass({
 
     promise.done((users) => {
       this.setState({
-        users: users,
+        users: users.toJS().map((user) => user.toJSON()),
       });
     });
   },
@@ -221,6 +221,7 @@ const UserList = createReactClass({
 
   render() {
     const { roles, users } = this.state;
+    console.log(users);
     const filterKeys = ['username', 'full_name', 'email', 'client_address'];
     const headers = ['', 'Name', 'Username', 'Email Address', 'Client Address', 'Role', 'Actions'];
 

--- a/graylog2-web-interface/src/contexts/CurrentUserContext.jsx
+++ b/graylog2-web-interface/src/contexts/CurrentUserContext.jsx
@@ -1,10 +1,10 @@
 // @flow strict
 import * as React from 'react';
 
-import type { User } from 'stores/users/UsersStore';
+import type { UserJSON } from 'logic/users/User';
 
 import { singleton } from '../views/logic/singleton';
 
-const CurrentUserContext = React.createContext<?User>();
+const CurrentUserContext = React.createContext<?UserJSON>();
 
 export default singleton('contexts.CurrentUserContext', () => CurrentUserContext);

--- a/graylog2-web-interface/src/logic/users/User.js
+++ b/graylog2-web-interface/src/logic/users/User.js
@@ -1,0 +1,471 @@
+// @flow strict
+import * as Immutable from 'immutable';
+
+type StartPage = {
+  id: string,
+  type: string,
+};
+
+export type UserJSON = {
+  client_address: string,
+  email: string,
+  external: boolean,
+  full_name: string,
+  id: string,
+  last_activity: string,
+  permissions: string[],
+  preferences?: any,
+  read_only: boolean,
+  roles: string[],
+  session_active: boolean,
+  session_timeout_ms: number,
+  startpage?: StartPage,
+  timezone: string,
+  username: string,
+};
+
+type InternalState = {
+  id: string,
+  username: string,
+  fullName: string,
+  email: string,
+  permissions: Immutable.List<string>,
+  timezone: string,
+  preferences?: any,
+  roles: Immutable.List<string>,
+  readOnly: boolean,
+  external: boolean,
+  sessionTimeoutMs: number,
+  startpage?: StartPage,
+  sessionActive: boolean,
+  clientAddress: string,
+  lastActivity: string,
+};
+
+export default class User {
+  _value: InternalState;
+
+  // eslint-disable-next-line no-undef
+  constructor(
+    id: $PropertyType<InternalState, 'id'>,
+    username: $PropertyType<InternalState, 'username'>,
+    fullName: $PropertyType<InternalState, 'fullName'>,
+    email: $PropertyType<InternalState, 'email'>,
+    permissions: $PropertyType<InternalState, 'permissions'>,
+    timezone: $PropertyType<InternalState, 'timezone'>,
+    preferences: $PropertyType<InternalState, 'preferences'>,
+    roles: $PropertyType<InternalState, 'roles'>,
+    readOnly: $PropertyType<InternalState, 'readOnly'>,
+    external: $PropertyType<InternalState, 'external'>,
+    sessionTimeoutMs: $PropertyType<InternalState, 'sessionTimeoutMs'>,
+    startpage: $PropertyType<InternalState, 'startpage'>,
+    sessionActive: $PropertyType<InternalState, 'sessionActive'>,
+    clientAddress: $PropertyType<InternalState, 'clientAddress'>,
+    lastActivity: $PropertyType<InternalState, 'lastActivity'>,
+  ) {
+    this._value = {
+      id,
+      username,
+      fullName,
+      email,
+      permissions,
+      timezone,
+      preferences,
+      roles,
+      readOnly,
+      external,
+      sessionTimeoutMs,
+      startpage,
+      sessionActive,
+      clientAddress,
+      lastActivity,
+    };
+  }
+
+  get id() {
+    return this._value.id;
+  }
+
+  get username() {
+    return this._value.username;
+  }
+
+  get fullName() {
+    return this._value.fullName;
+  }
+
+  get email() {
+    return this._value.email;
+  }
+
+  get permissions() {
+    return this._value.permissions;
+  }
+
+  get timezone() {
+    return this._value.timezone;
+  }
+
+  get preferences() {
+    return this._value.preferences;
+  }
+
+  get roles() {
+    return this._value.roles;
+  }
+
+  get readOnly() {
+    return this._value.readOnly;
+  }
+
+  get external() {
+    return this._value.external;
+  }
+
+  get sessionTimeoutMs() {
+    return this._value.sessionTimeoutMs;
+  }
+
+  get sessionTimeout() {
+    if (!this.sessionTimeoutMs) {
+      return undefined;
+    }
+
+    const MS_DAY = 24 * 60 * 60 * 1000;
+    const MS_HOUR = 60 * 60 * 1000;
+    const MS_MINUTE = 60 * 1000;
+    const MS_SECOND = 1000;
+
+    const _estimateUnit = (value) => {
+      if (value === 0) {
+        return [MS_SECOND, 'Seconds'];
+      }
+
+      if (value % MS_DAY === 0) {
+        return [MS_DAY, 'Days'];
+      }
+
+      if (value % MS_HOUR === 0) {
+        return [MS_HOUR, 'Hours'];
+      }
+
+      if (value % MS_MINUTE === 0) {
+        return [MS_MINUTE, 'Minutes'];
+      }
+
+      return [MS_SECOND, 'Seconds'];
+    };
+
+    const unit = _estimateUnit(this.sessionTimeoutMs);
+    const value = Math.floor(this.sessionTimeoutMs / unit[0]);
+
+    return {
+      value,
+      unitMS: unit[0],
+      unitString: unit[1],
+    };
+  }
+
+  get startpage() {
+    return this._value.startpage;
+  }
+
+  get sessionActive() {
+    return this._value.sessionActive;
+  }
+
+  get clientAddress() {
+    return this._value.clientAddress;
+  }
+
+  get lastActivity() {
+    return this._value.lastActivity;
+  }
+
+  toBuilder() {
+    const {
+      id,
+      username,
+      fullName,
+      email,
+      permissions,
+      timezone,
+      preferences,
+      roles,
+      readOnly,
+      external,
+      sessionTimeoutMs,
+      startpage,
+      sessionActive,
+      clientAddress,
+      lastActivity,
+    } = this._value;
+
+    // eslint-disable-next-line no-use-before-define
+    return new Builder(Immutable.Map({
+      id,
+      username,
+      fullName,
+      email,
+      permissions,
+      timezone,
+      preferences,
+      roles,
+      readOnly,
+      external,
+      sessionTimeoutMs,
+      startpage,
+      sessionActive,
+      clientAddress,
+      lastActivity,
+    }));
+  }
+
+  // eslint-disable-next-line no-undef
+  static create(
+    id: $PropertyType<InternalState, 'id'>,
+    username: $PropertyType<InternalState, 'username'>,
+    fullName: $PropertyType<InternalState, 'fullName'>,
+    email: $PropertyType<InternalState, 'email'>,
+    permissions: $PropertyType<InternalState, 'permissions'>,
+    timezone: $PropertyType<InternalState, 'timezone'>,
+    preferences: $PropertyType<InternalState, 'preferences'>,
+    roles: $PropertyType<InternalState, 'roles'>,
+    readOnly: $PropertyType<InternalState, 'readOnly'>,
+    external: $PropertyType<InternalState, 'external'>,
+    sessionTimeoutMs: $PropertyType<InternalState, 'sessionTimeoutMs'>,
+    startpage: $PropertyType<InternalState, 'startpage'>,
+    sessionActive: $PropertyType<InternalState, 'sessionActive'>,
+    clientAddress: $PropertyType<InternalState, 'clientAddress'>,
+    lastActivity: $PropertyType<InternalState, 'lastActivity'>,
+  ) {
+    return new User(
+      id,
+      username,
+      fullName,
+      email,
+      permissions,
+      timezone,
+      preferences,
+      roles,
+      readOnly,
+      external,
+      sessionTimeoutMs,
+      startpage,
+      sessionActive,
+      clientAddress,
+      lastActivity,
+    );
+  }
+
+  toJSON(): UserJSON {
+    const {
+      id,
+      username,
+      fullName,
+      email,
+      permissions,
+      timezone,
+      preferences,
+      roles,
+      readOnly,
+      external,
+      sessionTimeoutMs,
+      startpage,
+      sessionActive,
+      clientAddress,
+      lastActivity,
+    } = this._value;
+
+    return {
+      id,
+      username,
+      full_name: fullName,
+      email,
+      permissions: permissions ? permissions.toArray() : [],
+      timezone,
+      preferences,
+      roles: roles ? roles.toArray() : [],
+      read_only: readOnly,
+      external,
+      session_timeout_ms: sessionTimeoutMs,
+      startpage,
+      session_active: sessionActive,
+      client_address: clientAddress,
+      last_activity: lastActivity,
+    };
+  }
+
+  static fromJSON(value: UserJSON) {
+    const {
+      id,
+      username,
+      // eslint-disable-next-line camelcase
+      full_name,
+      email,
+      permissions,
+      timezone,
+      preferences,
+      roles,
+      // eslint-disable-next-line camelcase
+      read_only,
+      external,
+      // eslint-disable-next-line camelcase
+      session_timeout_ms,
+      startpage,
+      // eslint-disable-next-line camelcase
+      session_active,
+      // eslint-disable-next-line camelcase
+      client_address,
+      // eslint-disable-next-line camelcase
+      last_activity,
+    } = value;
+
+    return User.create(
+      id,
+      username,
+      full_name,
+      email,
+      Immutable.List(permissions),
+      timezone,
+      preferences,
+      Immutable.List(roles),
+      read_only,
+      external,
+      session_timeout_ms,
+      startpage,
+      session_active,
+      client_address,
+      last_activity,
+    );
+  }
+
+  // eslint-disable-next-line no-use-before-define
+  static builder(): Builder {
+    // eslint-disable-next-line no-use-before-define
+    return new Builder();
+  }
+}
+
+type BuilderState = Immutable.Map<string, any>;
+
+class Builder {
+  value: BuilderState;
+
+  constructor(value: BuilderState = Immutable.Map()) {
+    this.value = value;
+  }
+
+  // eslint-disable-next-line no-undef
+  id(value: $PropertyType<InternalState, 'id'>) {
+    return new Builder(this.value.set('id', value));
+  }
+
+  // eslint-disable-next-line no-undef
+  username(value: $PropertyType<InternalState, 'username'>) {
+    return new Builder(this.value.set('username', value));
+  }
+
+  // eslint-disable-next-line no-undef
+  fullName(value: $PropertyType<InternalState, 'fullName'>) {
+    return new Builder(this.value.set('fullName', value));
+  }
+
+  // eslint-disable-next-line no-undef
+  email(value: $PropertyType<InternalState, 'email'>) {
+    return new Builder(this.value.set('email', value));
+  }
+
+  // eslint-disable-next-line no-undef
+  permissions(value: $PropertyType<InternalState, 'permissions'>) {
+    return new Builder(this.value.set('permissions', value));
+  }
+
+  // eslint-disable-next-line no-undef
+  timezone(value: $PropertyType<InternalState, 'timezone'>) {
+    return new Builder(this.value.set('timezone', value));
+  }
+
+  // eslint-disable-next-line no-undef
+  preferences(value: $PropertyType<InternalState, 'preferences'>) {
+    return new Builder(this.value.set('preferences', value));
+  }
+
+  // eslint-disable-next-line no-undef
+  roles(value: $PropertyType<InternalState, 'roles'>) {
+    return new Builder(this.value.set('roles', value));
+  }
+
+  // eslint-disable-next-line no-undef
+  readOnly(value: $PropertyType<InternalState, 'readOnly'>) {
+    return new Builder(this.value.set('readOnly', value));
+  }
+
+  // eslint-disable-next-line no-undef
+  external(value: $PropertyType<InternalState, 'external'>) {
+    return new Builder(this.value.set('external', value));
+  }
+
+  // eslint-disable-next-line no-undef
+  sessionTimeoutMs(value: $PropertyType<InternalState, 'sessionTimeoutMs'>) {
+    return new Builder(this.value.set('sessionTimeoutMs', value));
+  }
+
+  // eslint-disable-next-line no-undef
+  startpage(value: $PropertyType<InternalState, 'startpage'>) {
+    return new Builder(this.value.set('startpage', value));
+  }
+
+  // eslint-disable-next-line no-undef
+  sessionActive(value: $PropertyType<InternalState, 'sessionActive'>) {
+    return new Builder(this.value.set('sessionActive', value));
+  }
+
+  // eslint-disable-next-line no-undef
+  clientAddress(value: $PropertyType<InternalState, 'clientAddress'>) {
+    return new Builder(this.value.set('clientAddress', value));
+  }
+
+  // eslint-disable-next-line no-undef
+  lastActivity(value: $PropertyType<InternalState, 'lastActivity'>) {
+    return new Builder(this.value.set('lastActivity', value));
+  }
+
+  build() {
+    const {
+      id,
+      username,
+      fullName,
+      email,
+      permissions,
+      timezone,
+      preferences,
+      roles,
+      readOnly,
+      external,
+      sessionTimeoutMs,
+      startpage,
+      sessionActive,
+      clientAddress,
+      lastActivity,
+    } = this.value.toObject();
+
+    return new User(
+      id,
+      username,
+      fullName,
+      email,
+      permissions,
+      timezone,
+      preferences,
+      roles,
+      readOnly,
+      external,
+      sessionTimeoutMs,
+      startpage,
+      sessionActive,
+      clientAddress,
+      lastActivity,
+    );
+  }
+}

--- a/graylog2-web-interface/src/pages/CreateUsersPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateUsersPage.jsx
@@ -7,9 +7,9 @@ import history from 'util/History';
 import StoreProvider from 'injection/StoreProvider';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import NewUserForm from 'components/users/NewUserForm';
+import { UsersActions } from 'stores/users/UsersStore';
 
 const RolesStore = StoreProvider.getStore('Roles');
-const UsersStore = StoreProvider.getStore('Users');
 
 class CreateUsersPage extends React.Component {
   state = {
@@ -28,7 +28,7 @@ class CreateUsersPage extends React.Component {
     request.permissions = [];
     delete request['session-timeout-never'];
 
-    UsersStore.create(request).then(() => {
+    UsersActions.create(request).then(() => {
       UserNotification.success(`User ${request.username} was created successfully.`, 'Success!');
       history.replace(Routes.SYSTEM.AUTHENTICATION.USERS.LIST);
     }, () => {

--- a/graylog2-web-interface/src/pages/EditTokensPage.jsx
+++ b/graylog2-web-interface/src/pages/EditTokensPage.jsx
@@ -7,8 +7,8 @@ import TokenList from 'components/users/TokenList';
 import StoreProvider from 'injection/StoreProvider';
 import { DocumentTitle, PageHeader } from 'components/common';
 import PermissionsMixin from 'util/PermissionsMixin';
+import { UsersActions } from 'stores/users/UsersStore';
 
-const UsersStore = StoreProvider.getStore('Users');
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
 const EditTokensPage = createReactClass({
@@ -40,7 +40,7 @@ const EditTokensPage = createReactClass({
 
   _loadTokens(username) {
     if (this._canListTokens(username)) {
-      UsersStore.loadTokens(username).then((tokens) => {
+      UsersActions.loadTokens(username).then((tokens) => {
         this.setState({ tokens: tokens });
       });
     } else {
@@ -54,7 +54,7 @@ const EditTokensPage = createReactClass({
   },
 
   _deleteToken(tokenId, tokenName) {
-    const promise = UsersStore.deleteToken(this.props.params.username, tokenId, tokenName);
+    const promise = UsersActions.deleteToken(this.props.params.username, tokenId, tokenName);
 
     this.setState({ deletingToken: tokenId });
 
@@ -65,7 +65,7 @@ const EditTokensPage = createReactClass({
   },
 
   _createToken(tokenName) {
-    const promise = UsersStore.createToken(this.props.params.username, tokenName);
+    const promise = UsersActions.createToken(this.props.params.username, tokenName);
 
     this.setState({ creatingToken: true });
 

--- a/graylog2-web-interface/src/pages/EditUsersPage.jsx
+++ b/graylog2-web-interface/src/pages/EditUsersPage.jsx
@@ -35,7 +35,7 @@ class EditUsersPage extends React.Component {
 
   _loadUser = (username) => {
     UsersStore.load(username).then((user) => {
-      this.setState({ user: user });
+      this.setState({ user: user.toJSON() });
     });
   };
 

--- a/graylog2-web-interface/src/pages/EditUsersPage.jsx
+++ b/graylog2-web-interface/src/pages/EditUsersPage.jsx
@@ -6,8 +6,8 @@ import { Button } from 'components/graylog';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import UserForm from 'components/users/UserForm';
 import UserPreferencesButton from 'components/users/UserPreferencesButton';
+import { UsersActions } from 'stores/users/UsersStore';
 
-const UsersStore = StoreProvider.getStore('Users');
 const StartpageStore = StoreProvider.getStore('Startpage');
 
 class EditUsersPage extends React.Component {
@@ -34,7 +34,7 @@ class EditUsersPage extends React.Component {
   }
 
   _loadUser = (username) => {
-    UsersStore.load(username).then((user) => {
+    UsersActions.load(username).then((user) => {
       this.setState({ user: user.toJSON() });
     });
   };

--- a/graylog2-web-interface/src/stores/users/RolesStore.js
+++ b/graylog2-web-interface/src/stores/users/RolesStore.js
@@ -5,8 +5,7 @@ import fetch from 'logic/rest/FetchProvider';
 import ApiRoutes from 'routing/ApiRoutes';
 import URLUtils from 'util/URLUtils';
 import UserNotification from 'util/UserNotification';
-
-import type { User } from './UsersStore';
+import type { UserJSON } from 'logic/users/User';
 
 type Role = {
   name: string,
@@ -16,7 +15,7 @@ type Role = {
 
 type RoleMembership = {
   role: string,
-  users: User[],
+  users: UserJSON[],
 };
 
 const RolesStore = Reflux.createStore({

--- a/graylog2-web-interface/src/stores/users/UsersStore.js
+++ b/graylog2-web-interface/src/stores/users/UsersStore.js
@@ -9,18 +9,7 @@ import fetch from 'logic/rest/FetchProvider';
 import type { Store } from 'stores/StoreTypes';
 import User from 'logic/users/User';
 import UserNotification from 'util/UserNotification';
-import UsersActions from 'actions/users/UsersActions';
-
-type Token = {
-  token_name: string,
-  token: string,
-  last_access: string,
-};
-
-type ChangePasswordRequest = {
-  old_password: string,
-  password: string,
-};
+import UsersActions, { type ChangePasswordRequest } from 'actions/users/UsersActions';
 
 const UsersStore: Store<{}> = singletonStore(
   'Users',

--- a/graylog2-web-interface/src/stores/users/UsersStore.js
+++ b/graylog2-web-interface/src/stores/users/UsersStore.js
@@ -9,7 +9,7 @@ import fetch from 'logic/rest/FetchProvider';
 import type { Store } from 'stores/StoreTypes';
 import User from 'logic/users/User';
 import UserNotification from 'util/UserNotification';
-import UsersActions, { type ChangePasswordRequest } from 'actions/users/UsersActions';
+import UsersActions, { type ChangePasswordRequest, type Token } from 'actions/users/UsersActions';
 
 const UsersStore: Store<{}> = singletonStore(
   'Users',

--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
@@ -18,7 +18,7 @@ import { SearchMetadataStore } from 'views/stores/SearchMetadataStore';
 import SearchMetadata from 'views/logic/search/SearchMetadata';
 import * as Permissions from 'views/Permissions';
 import View from 'views/logic/views/View';
-import type { User } from 'stores/users/UsersStore';
+import type { UserJSON } from 'logic/users/User';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 
 import ViewPropertiesModal from './views/ViewPropertiesModal';
@@ -26,7 +26,7 @@ import ShareViewModal from './views/ShareViewModal';
 import IfDashboard from './dashboard/IfDashboard';
 import BigDisplayModeConfiguration from './dashboard/BigDisplayModeConfiguration';
 
-const _isAllowedToEdit = (view: View, currentUser: ?User) => isPermitted(currentUser?.permissions, [Permissions.View.Edit(view.id)])
+const _isAllowedToEdit = (view: View, currentUser: ?UserJSON) => isPermitted(currentUser?.permissions, [Permissions.View.Edit(view.id)])
   || (view.type === View.Type.Dashboard && isPermitted(currentUser?.permissions, [`dashboards:edit:${view.id}`]));
 
 const _hasUndeclaredParameters = (searchMetadata: SearchMetadata) => searchMetadata.undeclared.size > 0;

--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.test.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.test.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { render, fireEvent } from 'wrappedTestingLibrary';
 import { viewsManager } from 'fixtures/users';
 
-import type { User } from 'stores/users/UsersStore';
+import type { UserJSON } from 'logic/users/User';
 import Search from 'views/logic/search/Search';
 import View from 'views/logic/views/View';
 import CurrentUserContext from 'contexts/CurrentUserContext';
@@ -63,7 +63,7 @@ jest.mock('views/stores/ViewSharingStore', () => ({
 }));
 
 describe('ViewActionsMenu', () => {
-  const SimpleViewActionMenu = ({ currentUser, ...props }: {currentUser?: User}) => (
+  const SimpleViewActionMenu = ({ currentUser, ...props }: {currentUser?: UserJSON}) => (
     <CurrentUserContext.Provider value={currentUser}>
       <ViewActionsMenu {...props} router={{}} />
     </CurrentUserContext.Provider>

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.jsx
@@ -23,7 +23,7 @@ import CSVExportModal from 'views/components/searchbar/csvexport/CSVExportModal'
 import ShareViewModal from 'views/components/views/ShareViewModal';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import * as Permissions from 'views/Permissions';
-import type { User } from 'stores/users/UsersStore';
+import type { UserJSON } from 'logic/users/User';
 import ViewPropertiesModal from 'views/components/views/ViewPropertiesModal';
 
 import SavedSearchForm from './SavedSearchForm';
@@ -43,7 +43,7 @@ type State = {
   newTitle: string,
 };
 
-const _isAllowedToEdit = (view: View, currentUser: ?User) => (
+const _isAllowedToEdit = (view: View, currentUser: ?UserJSON) => (
   view.owner === currentUser?.username
   || isPermitted(currentUser?.permissions, [Permissions.View.Edit(view.id)])
 );

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.test.jsx
@@ -11,7 +11,7 @@ import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import NewViewLoaderContext, { type NewViewLoaderContextType } from 'views/logic/NewViewLoaderContext';
 import * as Permissions from 'views/Permissions';
 import CurrentUserContext from 'contexts/CurrentUserContext';
-import type { User } from 'stores/users/UsersStore';
+import type { UserJSON } from 'logic/users/User';
 import type { ViewStoreState } from 'views/stores/ViewStore';
 
 import SavedSearchControls from './SavedSearchControls';
@@ -34,7 +34,7 @@ describe('SavedSearchControls', () => {
   type SimpleSavedSearchControlsProps = {
     loadNewView?: NewViewLoaderContextType,
     onLoadView?: ViewLoaderContextType,
-    currentUser?: User,
+    currentUser?: UserJSON,
     viewStoreState?: ViewStoreState,
   };
 

--- a/graylog2-web-interface/src/views/components/views/ShareViewModal.jsx
+++ b/graylog2-web-interface/src/views/components/views/ShareViewModal.jsx
@@ -17,12 +17,12 @@ import AllUsersOfInstance from 'views/logic/views/sharing/AllUsersOfInstance';
 import SpecificRoles from 'views/logic/views/sharing/SpecificRoles';
 import SpecificUsers from 'views/logic/views/sharing/SpecificUsers';
 import UserShortSummary from 'views/logic/views/sharing/UserShortSummary';
-import type { User } from 'stores/users/UsersStore';
+import type { UserJSON } from 'logic/users/User';
 
 const RolesStore = StoreProvider.getStore('Roles');
 
 type Props = {
-  currentUser: ?User,
+  currentUser: ?UserJSON,
   onClose: (?ViewSharing) => void,
   view: View,
   show: boolean,
@@ -141,7 +141,7 @@ class ShareViewModal extends React.Component<Props, State> {
     this.setState({ viewSharing: specificUsers.toBuilder().users(users).build() });
   };
 
-  _isAdmin = (user: ?User) => (user?.roles.includes('Admin') || user?.permissions.includes('*'));
+  _isAdmin = (user: ?UserJSON) => (user?.roles.includes('Admin') || user?.permissions.includes('*'));
 
   render() {
     const { show, view } = this.props;

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/XYPlot.test.jsx
@@ -5,7 +5,7 @@ import mockComponent from 'helpers/mocking/MockComponent';
 import { viewsManager } from 'fixtures/users';
 import asMock from 'helpers/mocking/AsMock';
 
-import type { User } from 'stores/users/UsersStore';
+import type { UserJSON } from 'logic/users/User';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import XYPlot, { type Props as XYPlotProps } from 'views/components/visualizations/XYPlot';
 import AggregationWidgetConfig from 'views/logic/aggregationbuilder/AggregationWidgetConfig';
@@ -39,7 +39,7 @@ describe('XYPlot', () => {
   const setChartColor = () => ({});
   const chartData = [{ y: [23, 42] }];
   type SimpleXYPlotProps = {
-    currentUser?: User,
+    currentUser?: UserJSON,
     config?: $PropertyType<XYPlotProps, 'chartData'>,
     chartData?: $PropertyType<XYPlotProps, 'chartData'>,
     currentQuery?: $PropertyType<XYPlotProps, 'currentQuery'>,

--- a/graylog2-web-interface/test/fixtures/users.js
+++ b/graylog2-web-interface/test/fixtures/users.js
@@ -1,9 +1,9 @@
 // @flow strict
-import type { User } from 'stores/users/UsersStore';
+import type { UserJSON } from 'logic/users/User';
 
 /* eslint-disable import/prefer-default-export */
 
-export const viewsManager: User = {
+export const viewsManager: UserJSON = {
   email: '',
   external: false,
   full_name: 'Betty Holberton',
@@ -14,9 +14,12 @@ export const viewsManager: User = {
   session_timeout_ms: 28800000,
   timezone: 'UTC',
   username: 'betty',
+  session_active: false,
+  client_address: '127.0.0.1',
+  last_activity: '2020-01-01T10:40:05.376+0000',
 };
 
-export const admin: User = {
+export const admin: UserJSON = {
   email: '',
   external: false,
   full_name: 'Alonzo Church',
@@ -27,4 +30,7 @@ export const admin: User = {
   session_timeout_ms: 28800000,
   timezone: 'UTC',
   username: 'alonzo',
+  session_active: false,
+  client_address: '127.0.0.1',
+  last_activity: '2020-01-01T10:40:05.376+0000',
 };


### PR DESCRIPTION
This PR implements the `UsersActions` and the `User` class. These changes were needed for the new permission UI, but they also improve the code in `master`.

We are currently not using the new `User` for the `CurrentUserStore` / `CurrentUserContext`. We will add these changes in a follow-up PR.


