### PR TITLE
Display loading spinner for search sidebar execution info, during execution

### DIFF
--- a/graylog2-web-interface/src/views/components/sidebar/description/SearchResultOverview.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/description/SearchResultOverview.jsx
@@ -1,20 +1,31 @@
+// @flow strict
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import numeral from 'numeral';
 
 import AppConfig from 'util/AppConfig';
-import { Timestamp } from 'components/common';
+import { Timestamp, Spinner } from 'components/common';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import DateTime from 'logic/datetimes/DateTime';
 
-const SearchResultOverview = ({ results }) => {
-  const { timestamp } = results;
+type Props = {
+  results: {
+    timestamp?: string,
+    duration?: number,
+  },
+};
+
+const SearchResultOverview = ({ results: { timestamp, duration } }: Props) => {
   const currentUser = useContext(CurrentUserContext);
   const timezone = currentUser?.timezone ?? AppConfig.rootTimeZone();
 
+  if (!timestamp || !duration) {
+    return <Spinner />;
+  }
+
   return (
     <span>
-      Query executed in {numeral(results.duration).format('0,0')}ms at <Timestamp dateTime={timestamp} format={DateTime.Formats.DATETIME} tz={timezone} />.
+      Query executed in {numeral(duration).format('0,0')}ms at <Timestamp dateTime={timestamp} format={DateTime.Formats.DATETIME} tz={timezone} />.
     </span>
   );
 };


### PR DESCRIPTION
With this PR we are displaying a loading spinner for search sidebar execution info, during the search execution.
These changes also fix a prop type warning for the `Timestamp` component.