### PR TITLE
Add Java version to the issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -37,6 +37,7 @@ assignees: ''
 <!--- Include as many relevant details about the environment you experienced the bug in -->
 
 * Graylog Version:
+* Java Version:
 * Elasticsearch Version:
 * MongoDB Version:
 * Operating System:


### PR DESCRIPTION
This will be useful once people start using Java >8 more and more.
