### PR TITLE
Fix SearchQueryParser for null queries

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/search/SearchQueryParser.java
+++ b/graylog2-server/src/main/java/org/graylog2/search/SearchQueryParser.java
@@ -135,14 +135,15 @@ public class SearchQueryParser {
 
     public SearchQuery parse(String encodedQueryString) {
         String queryString = encodedQueryString;
+
+        if (Strings.isNullOrEmpty(queryString) || "*".equals(queryString)) {
+            return new SearchQuery(queryString);
+        }
+
         try {
             queryString = URLDecoder.decode(encodedQueryString, StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException e) {
             LOG.warn("Could not find correct character set for decoding: {}", e.getMessage());
-        }
-
-        if (Strings.isNullOrEmpty(queryString) || "*".equals(queryString)) {
-            return new SearchQuery(queryString);
         }
 
         final Matcher matcher = querySplitterMatcher(requireNonNull(queryString).trim());

--- a/graylog2-server/src/test/java/org/graylog2/search/SearchQueryParserTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/search/SearchQueryParserTest.java
@@ -64,7 +64,7 @@ public class SearchQueryParserTest {
     }
 
     @Test
-    public void decodQuery() throws UnsupportedEncodingException {
+    public void decodeQuery() throws UnsupportedEncodingException {
         SearchQueryParser parser = new SearchQueryParser("defaultfield", ImmutableSet.of("name", "id"));
         final String urlEncodedQuery = URLEncoder.encode("name:foo", StandardCharsets.UTF_8.name());
         final SearchQuery query = parser.parse(urlEncodedQuery);
@@ -78,6 +78,18 @@ public class SearchQueryParserTest {
         final DBQuery.Query dbQuery = query.toDBQuery();
         final Collection<String> fieldNamesUsed = extractFieldNames(dbQuery.conditions());
         assertThat(fieldNamesUsed).containsExactly("name");
+    }
+
+    @Test
+    public void nullQuery() {
+        SearchQueryParser parser = new SearchQueryParser("defaultfield", ImmutableSet.of("name", "id"));
+        final SearchQuery query = parser.parse(null);
+
+        assertThat(query.getQueryString()).isNullOrEmpty();
+
+        final Multimap<String, SearchQueryParser.FieldValue> queryMap = query.getQueryMap();
+
+        assertThat(queryMap.size()).isEqualTo(0);
     }
 
     @Test


### PR DESCRIPTION
## Motivation
Prior this change the SearchQueryParser would fail
if null was passed to him since the newly add URLDecoder
was failing.

## Description
This change will first check if the query string is empty
or null before performing the url decoding.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1569