### PR TITLE
Remove state from UsersStore

### DIFF
--- a/graylog2-web-interface/src/actions/users/UsersActions.js
+++ b/graylog2-web-interface/src/actions/users/UsersActions.js
@@ -1,9 +1,12 @@
 // @flow strict
 import Reflux from 'reflux';
+import * as Immutable from 'immutable';
 
 import { singletonActions } from 'views/logic/singleton';
 import type { RefluxActions } from 'stores/StoreTypes';
 import User from 'logic/users/User';
+import UserOverview from 'logic/users/UserOverview';
+import type { PaginationType } from 'stores/PaginationTypes';
 
 export type Token = {
   token_name: string,
@@ -16,10 +19,16 @@ export type ChangePasswordRequest = {
   password: string,
 };
 
+export type PaginatedUsers = {
+  adminUser: ?UserOverview,
+  list: ?Immutable.List<UserOverview>,
+  pagination: PaginationType,
+};
+
 type UsersActionsType = RefluxActions<{
   create: (request: any) => Promise<string[]>,
   loadUsers: () => Promise<User[]>,
-  searchPaginated: (page: number, perPage: number, query: string) => Promise<User[]>,
+  searchPaginated: (page: number, perPage: number, query: string) => Promise<PaginatedUsers>,
   load: (username: string) => Promise<User>,
   deleteUser: (username: string) => Promise<string[]>,
   changePassword: (username: string, request: ChangePasswordRequest) => Promise<void>,

--- a/graylog2-web-interface/src/actions/users/UsersActions.js
+++ b/graylog2-web-interface/src/actions/users/UsersActions.js
@@ -27,7 +27,7 @@ export type PaginatedUsers = {
 
 type UsersActionsType = RefluxActions<{
   create: (request: any) => Promise<string[]>,
-  loadUsers: () => Promise<User[]>,
+  loadUsers: () => Promise<Immutable.List<User>>,
   searchPaginated: (page: number, perPage: number, query: string) => Promise<PaginatedUsers>,
   load: (username: string) => Promise<User>,
   deleteUser: (username: string) => Promise<string[]>,

--- a/graylog2-web-interface/src/components/users/UserCreate/UserCreate.jsx
+++ b/graylog2-web-interface/src/components/users/UserCreate/UserCreate.jsx
@@ -3,9 +3,8 @@ import * as React from 'react';
 import { useEffect, useState } from 'react';
 import { Formik, Form } from 'formik';
 
-import { useStore } from 'stores/connect';
 import { Alert, Col, Row, Button } from 'components/graylog';
-import { UsersStore, UsersActions } from 'stores/users/UsersStore';
+import { UsersActions } from 'stores/users/UsersStore';
 import UserNotification from 'util/UserNotification';
 import history from 'util/History';
 import Routes from 'routing/Routes';
@@ -40,11 +39,11 @@ const _validate = (values) => {
 };
 
 const UserCreate = () => {
-  const { list: users } = useStore(UsersStore);
+  const [users, setUsers] = useState();
   const [submitError, setSubmitError] = useState();
 
   useEffect(() => {
-    UsersActions.loadUsers();
+    UsersActions.loadUsers().then(setUsers);
   }, []);
 
   return (

--- a/graylog2-web-interface/src/components/users/UserCreate/UserCreate.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserCreate/UserCreate.test.jsx
@@ -11,22 +11,20 @@ import { UsersActions } from 'stores/users/UsersStore';
 import UserCreate from './UserCreate';
 
 const existingUser = alice;
-const mockExistingUsers = Immutable.List([alice]);
+const mockLoadusersPromise = Promise.resolve(Immutable.List([alice]));
 
 jest.mock('stores/users/UsersStore', () => ({
-  UsersStore: {
-    getInitialState: jest.fn(() => ({ list: mockExistingUsers })),
-    listen: jest.fn(),
-  },
   UsersActions: {
     create: jest.fn(() => Promise.resolve()),
-    loadUsers: jest.fn(() => Promise.resolve()),
+    loadUsers: jest.fn(() => mockLoadusersPromise),
   },
 }));
 
 describe('<UserCreate />', () => {
   it('should create user', async () => {
     const { getByLabelText, getByPlaceholderText, getByText, getByTestId } = render(<UserCreate />);
+
+    await act(() => mockLoadusersPromise);
 
     const usernameInput = getByLabelText('Username');
     const fullNameInput = getByLabelText('Full Name');
@@ -65,6 +63,8 @@ describe('<UserCreate />', () => {
   it('should display warning if username is alreafy taken', async () => {
     const { getByLabelText, getByText } = render(<UserCreate />);
 
+    await act(() => mockLoadusersPromise);
+
     const usernameInput = getByLabelText('Username');
 
     fireEvent.change(usernameInput, { target: { value: existingUser.username } });
@@ -74,6 +74,8 @@ describe('<UserCreate />', () => {
 
   it('should display warning, if password repeat does not match password', async () => {
     const { getByPlaceholderText, getByText } = render(<UserCreate />);
+
+    await act(() => mockLoadusersPromise);
 
     const passwordInput = getByPlaceholderText('Password');
     const passwordRepeatInput = getByPlaceholderText('Repeat password');

--- a/graylog2-web-interface/src/components/users/UserCreate/UserCreate.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserCreate/UserCreate.test.jsx
@@ -11,12 +11,12 @@ import { UsersActions } from 'stores/users/UsersStore';
 import UserCreate from './UserCreate';
 
 const existingUser = alice;
-const mockLoadusersPromise = Promise.resolve(Immutable.List([alice]));
+const mockLoadUsersPromise = Promise.resolve(Immutable.List([alice]));
 
 jest.mock('stores/users/UsersStore', () => ({
   UsersActions: {
     create: jest.fn(() => Promise.resolve()),
-    loadUsers: jest.fn(() => mockLoadusersPromise),
+    loadUsers: jest.fn(() => mockLoadUsersPromise),
   },
 }));
 
@@ -24,7 +24,7 @@ describe('<UserCreate />', () => {
   it('should create user', async () => {
     const { getByLabelText, getByPlaceholderText, getByText, getByTestId } = render(<UserCreate />);
 
-    await act(() => mockLoadusersPromise);
+    await act(() => mockLoadUsersPromise);
 
     const usernameInput = getByLabelText('Username');
     const fullNameInput = getByLabelText('Full Name');
@@ -63,7 +63,7 @@ describe('<UserCreate />', () => {
   it('should display warning if username is alreafy taken', async () => {
     const { getByLabelText, getByText } = render(<UserCreate />);
 
-    await act(() => mockLoadusersPromise);
+    await act(() => mockLoadUsersPromise);
 
     const usernameInput = getByLabelText('Username');
 
@@ -75,7 +75,7 @@ describe('<UserCreate />', () => {
   it('should display warning, if password repeat does not match password', async () => {
     const { getByPlaceholderText, getByText } = render(<UserCreate />);
 
-    await act(() => mockLoadusersPromise);
+    await act(() => mockLoadUsersPromise);
 
     const passwordInput = getByPlaceholderText('Password');
     const passwordRepeatInput = getByPlaceholderText('Repeat password');

--- a/graylog2-web-interface/src/components/users/UsersOverview/UsersFilter.jsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UsersFilter.jsx
@@ -2,10 +2,14 @@
 import * as React from 'react';
 import styled, { type StyledComponent } from 'styled-components';
 
-import { UsersActions } from 'stores/users/UsersStore';
 import type { ThemeInterface } from 'theme';
 import { SearchForm, Icon } from 'components/common';
 import { OverlayTrigger, Popover, Table, Button } from 'components/graylog';
+
+type Props = {
+  onSearch: (query: string) => Promise<void>,
+  onReset: () => Promise<void>,
+};
 
 const Container: StyledComponent<{}, ThemeInterface, HTMLDivElement> = styled.div`
   margin-bottom: 10px;
@@ -50,14 +54,13 @@ const userQueryHelper = (
   </OverlayTrigger>
 );
 
-const UsersFilter = ({ perPage }: { perPage: number }) => {
-  const handleSearch = (newQuery, resetLoading) => UsersActions.searchPaginated(1, perPage, newQuery).then(resetLoading);
-  const handleReset = () => UsersActions.searchPaginated(1, perPage, '');
+const UsersFilter = ({ onSearch, onReset }: Props) => {
+  const _handleSearch = (newQuery, resetLoading) => onSearch(newQuery).then(resetLoading);
 
   return (
     <Container>
-      <SearchForm onSearch={handleSearch}
-                  onReset={handleReset}
+      <SearchForm onSearch={_handleSearch}
+                  onReset={onReset}
                   useLoadingState
                   queryHelpComponent={userQueryHelper}
                   topMargin={0} />

--- a/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.jsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.jsx
@@ -1,15 +1,17 @@
 // @flow strict
 import * as React from 'react';
 import * as Immutable from 'immutable';
-import { render, act, waitFor } from 'wrappedTestingLibrary';
-import { alice, bob, adminUser } from 'fixtures/users';
+import { render, act, waitFor, fireEvent } from 'wrappedTestingLibrary';
+import { alice, bob, adminUser, admin } from 'fixtures/users';
+import asMock from 'helpers/mocking/AsMock';
 
+import CurrentUserContext from 'contexts/CurrentUserContext';
 import { UsersActions } from 'stores/users/UsersStore';
 
 import UsersOverview from './UsersOverview';
 
 const mockUsers = Immutable.List([alice, bob, adminUser]);
-const mockSearchPaginatedPromise = Promise.resolve({
+const searchPaginatedResponse = {
   list: mockUsers,
   pagination: {
     page: 1,
@@ -17,7 +19,8 @@ const mockSearchPaginatedPromise = Promise.resolve({
     total: mockUsers.size,
   },
   adminUser: undefined,
-});
+};
+const mockSearchPaginatedPromise = Promise.resolve(searchPaginatedResponse);
 
 jest.mock('stores/users/UsersStore', () => ({
   UsersStore: {
@@ -74,67 +77,71 @@ describe('UsersOverview', () => {
     `('$username', displaysUserAttributes);
   });
 
-  // describe('admin should', () => {
-  //   const modifiableUser = alice.toBuilder().readOnly(false).build();
-  //   const modifiableUsersList = Immutable.List([modifiableUser]);
-  //   const readOnlyUser = alice.toBuilder().readOnly(true).build();
-  //   const readOnlyUsersList = Immutable.List([readOnlyUser]);
-  //   let oldConfirm;
+  describe('admin should', () => {
+    const modifiableUser = alice.toBuilder().readOnly(false).build();
+    const modifiableUsersList = Immutable.List([modifiableUser]);
+    const readOnlyUser = alice.toBuilder().readOnly(true).build();
+    const readOnlyUsersList = Immutable.List([readOnlyUser]);
+    let oldConfirm;
 
-  //   const UsersOverviewAsAdmin = () => (
-  //     <CurrentUserContext.Provider value={admin}>
-  //       <UsersOverview />
-  //     </CurrentUserContext.Provider>
-  //   );
+    const UsersOverviewAsAdmin = () => (
+      <CurrentUserContext.Provider value={admin}>
+        <UsersOverview />
+      </CurrentUserContext.Provider>
+    );
 
-  //   beforeEach(() => {
-  //     oldConfirm = window.confirm;
-  //     window.confirm = jest.fn(() => true);
-  //   });
+    beforeEach(() => {
+      oldConfirm = window.confirm;
+      window.confirm = jest.fn(() => true);
+    });
 
-  //   afterEach(() => {
-  //     window.confirm = oldConfirm;
-  //   });
+    afterEach(() => {
+      window.confirm = oldConfirm;
+    });
 
-  //   it('be able to delete a modifiable user', () => {
-  //     asMock(UsersStore.getInitialState).mockReturnValueOnce({ list: modifiableUsersList });
-  //     const { getByTitle } = render(<UsersOverviewAsAdmin />);
+    it('be able to delete a modifiable user', async () => {
+      const searchPaginatedPromise = Promise.resolve({ ...searchPaginatedResponse, list: modifiableUsersList });
+      asMock(UsersActions.searchPaginated).mockReturnValueOnce(searchPaginatedPromise);
+      const { getByTitle } = render(<UsersOverviewAsAdmin />);
+      await act(() => searchPaginatedPromise);
 
-  //     fireEvent.click(getByTitle(`Delete user ${modifiableUser.username}`));
+      fireEvent.click(getByTitle(`Delete user ${modifiableUser.username}`));
 
-  //     expect(window.confirm).toHaveBeenCalledTimes(1);
-  //     expect(window.confirm).toHaveBeenCalledWith(`Do you really want to delete user ${modifiableUser.username}?`);
-  //     expect(UsersActions.deleteUser).toHaveBeenCalledTimes(1);
-  //     expect(UsersActions.deleteUser).toHaveBeenCalledWith(alice.username);
-  //   });
+      expect(window.confirm).toHaveBeenCalledTimes(1);
+      expect(window.confirm).toHaveBeenCalledWith(`Do you really want to delete user ${modifiableUser.username}?`);
+      expect(UsersActions.deleteUser).toHaveBeenCalledTimes(1);
+      expect(UsersActions.deleteUser).toHaveBeenCalledWith(alice.username);
+    });
 
-  //   it('not be able to delete a "read only" user', () => {
-  //     asMock(UsersStore.getInitialState).mockReturnValueOnce({ list: readOnlyUsersList });
-  //     const { queryByTitle } = render(<UsersOverviewAsAdmin />);
+    it('not be able to delete a "read only" user', async () => {
+      asMock(UsersActions.searchPaginated).mockReturnValueOnce(Promise.resolve({ ...searchPaginatedResponse, list: readOnlyUsersList }));
+      const { queryByTitle } = render(<UsersOverviewAsAdmin />);
 
-  //     expect(queryByTitle(`Delete user ${readOnlyUser.username}`)).toBeNull();
-  //   });
+      await waitFor(() => expect(queryByTitle(`Delete user ${readOnlyUser.username}`)).toBeNull());
+    });
 
-  //   it('see edit and edit tokens link for a modifiable user ', () => {
-  //     asMock(UsersStore.getInitialState).mockReturnValueOnce({ list: modifiableUsersList });
-  //     const { queryByTitle } = render(<UsersOverviewAsAdmin />);
+    it('see edit and edit tokens link for a modifiable user ', async () => {
+      asMock(UsersActions.searchPaginated).mockReturnValueOnce(Promise.resolve({ ...searchPaginatedResponse, list: modifiableUsersList }));
+      const { queryByTitle } = render(<UsersOverviewAsAdmin />);
 
-  //     expect(queryByTitle(`Edit user ${modifiableUser.username}`)).not.toBeNull();
-  //     expect(queryByTitle(`Edit tokens of user ${modifiableUser.username}`)).not.toBeNull();
-  //   });
+      await waitFor(() => {
+        expect(queryByTitle(`Edit user ${modifiableUser.username}`)).not.toBeNull();
+        expect(queryByTitle(`Edit tokens of user ${modifiableUser.username}`)).not.toBeNull();
+      });
+    });
 
-  //   it('not see edit link for a "read only" user', () => {
-  //     asMock(UsersStore.getInitialState).mockReturnValueOnce({ list: readOnlyUsersList });
-  //     const { queryByTitle } = render(<UsersOverviewAsAdmin />);
+    it('not see edit link for a "read only" user', async () => {
+      asMock(UsersActions.searchPaginated).mockReturnValueOnce(Promise.resolve({ ...searchPaginatedResponse, list: readOnlyUsersList }));
+      const { queryByTitle } = render(<UsersOverviewAsAdmin />);
 
-  //     expect(queryByTitle(`Edit user ${readOnlyUser.username}`)).toBeNull();
-  //   });
+      await waitFor(() => expect(queryByTitle(`Edit user ${readOnlyUser.username}`)).toBeNull());
+    });
 
-  //   it('see edit tokens link for a "read only" user', () => {
-  //     asMock(UsersStore.getInitialState).mockReturnValueOnce({ list: readOnlyUsersList });
-  //     const { queryByTitle } = render(<UsersOverviewAsAdmin />);
+    it('see edit tokens link for a "read only" user', async () => {
+      asMock(UsersActions.searchPaginated).mockReturnValueOnce(Promise.resolve({ ...searchPaginatedResponse, list: readOnlyUsersList }));
+      const { queryByTitle } = render(<UsersOverviewAsAdmin />);
 
-  //     expect(queryByTitle(`Edit tokens for user ${readOnlyUser.username}`)).toBeNull();
-  //   });
-  // });
+      await waitFor(() => expect(queryByTitle(`Edit tokens for user ${readOnlyUser.username}`)).toBeNull());
+    });
+  });
 });

--- a/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.jsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.jsx
@@ -9,7 +9,7 @@ import { UsersActions } from 'stores/users/UsersStore';
 import UsersOverview from './UsersOverview';
 
 const mockUsers = Immutable.List([alice, bob, adminUser]);
-const mockPaginatedUsersPromise = Promise.resolve({
+const mockSearchPaginatedPromise = Promise.resolve({
   list: mockUsers,
   pagination: {
     page: 1,
@@ -24,7 +24,7 @@ jest.mock('stores/users/UsersStore', () => ({
     listen: jest.fn(),
   },
   UsersActions: {
-    searchPaginated: jest.fn(() => mockPaginatedUsersPromise),
+    searchPaginated: jest.fn(() => mockSearchPaginatedPromise),
     deleteUser: jest.fn(),
   },
 }));
@@ -57,7 +57,7 @@ describe('UsersOverview', () => {
       const { queryByText } = render(<UsersOverview />);
       const attributes = ['username', 'fullName', 'email', 'clientAddress'];
 
-      await act(() => mockPaginatedUsersPromise);
+      await act(() => mockSearchPaginatedPromise);
 
       attributes.forEach(async (attribute) => {
         if (user[attribute]) {

--- a/graylog2-web-interface/src/pages/UserDetailsPage.jsx
+++ b/graylog2-web-interface/src/pages/UserDetailsPage.jsx
@@ -38,7 +38,7 @@ const UserDetailsPage = ({ params }: Props) => {
     EntityShareActions.searchPaginatedUserShares(username, 1, 10, '').then((response) => {
       setPaginatedUserShares(response);
     });
-  }, []);
+  }, [username]);
 
   return (
     <DocumentTitle title={`User Details ${username ?? ''}`}>

--- a/graylog2-web-interface/src/pages/UserDetailsPage.jsx
+++ b/graylog2-web-interface/src/pages/UserDetailsPage.jsx
@@ -5,8 +5,7 @@ import { withRouter } from 'react-router';
 
 import { EntityShareActions } from 'stores/permissions/EntityShareStore';
 import DocsHelper from 'util/DocsHelper';
-import { useStore } from 'stores/connect';
-import { UsersActions, UsersStore } from 'stores/users/UsersStore';
+import { UsersActions } from 'stores/users/UsersStore';
 import { PageHeader, DocumentTitle } from 'components/common';
 import UserDetails from 'components/users/UserDetails';
 import UserManagementLinks from 'components/users/UserManagementLinks';
@@ -29,12 +28,12 @@ const PageTitle = ({ fullName }: {fullName: ?string}) => (
 );
 
 const UserDetailsPage = ({ params }: Props) => {
-  const { loadedUser } = useStore(UsersStore);
   const [paginatedUserShares, setPaginatedUserShares] = useState();
+  const [loadedUser, setLoadedUser] = useState();
   const username = params?.username;
 
   useEffect(() => {
-    UsersActions.load(username);
+    UsersActions.load(username).then(setLoadedUser);
 
     EntityShareActions.searchPaginatedUserShares(username, 1, 10, '').then((response) => {
       setPaginatedUserShares(response);
@@ -55,7 +54,7 @@ const UserDetailsPage = ({ params }: Props) => {
         </span>
 
         <UserManagementLinks username={username}
-                             userIsReadOnly={loadedUser?.readOnly} />
+                             userIsReadOnly={loadedUser?.readOnly ?? false} />
       </PageHeader>
 
       <UserDetails paginatedUserShares={paginatedUserShares}

--- a/graylog2-web-interface/src/pages/UserEditPage.jsx
+++ b/graylog2-web-interface/src/pages/UserEditPage.jsx
@@ -32,7 +32,7 @@ const UserEditPage = ({ params }: Props) => {
 
   useEffect(() => {
     UsersActions.load(username).then(setLoadedUser);
-  });
+  }, [username]);
 
   return (
     <DocumentTitle title={`Edit User ${loadedUser?.fullName ?? ''}`}>

--- a/graylog2-web-interface/src/pages/UserEditPage.jsx
+++ b/graylog2-web-interface/src/pages/UserEditPage.jsx
@@ -1,11 +1,10 @@
 // @flow strict
 import * as React from 'react';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { withRouter } from 'react-router';
 
 import DocsHelper from 'util/DocsHelper';
-import { useStore } from 'stores/connect';
-import { UsersActions, UsersStore } from 'stores/users/UsersStore';
+import { UsersActions } from 'stores/users/UsersStore';
 import { PageHeader, DocumentTitle } from 'components/common';
 import UserEdit from 'components/users/UserEdit';
 import DocumentationLink from 'components/support/DocumentationLink';
@@ -28,11 +27,11 @@ const PageTitle = ({ fullName }: {fullName: ?string}) => (
 );
 
 const UserEditPage = ({ params }: Props) => {
-  const { loadedUser } = useStore(UsersStore);
+  const [loadedUser, setLoadedUser] = useState();
   const username = params?.username;
 
   useEffect(() => {
-    UsersActions.load(username);
+    UsersActions.load(username).then(setLoadedUser);
   });
 
   return (
@@ -49,7 +48,7 @@ const UserEditPage = ({ params }: Props) => {
         </span>
 
         <UserManagementLinks username={username}
-                             userIsReadOnly={loadedUser?.readOnly} />
+                             userIsReadOnly={loadedUser?.readOnly ?? false} />
       </PageHeader>
       <UserEdit user={username === loadedUser?.username ? loadedUser : undefined} />
     </DocumentTitle>

--- a/graylog2-web-interface/src/pages/UserTokensEditPage.jsx
+++ b/graylog2-web-interface/src/pages/UserTokensEditPage.jsx
@@ -7,8 +7,7 @@ import { Row, Col } from 'components/graylog';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import { isPermitted } from 'util/PermissionsMixin';
 import DocsHelper from 'util/DocsHelper';
-import { useStore } from 'stores/connect';
-import { UsersActions, UsersStore } from 'stores/users/UsersStore';
+import { UsersActions } from 'stores/users/UsersStore';
 import { PageHeader, DocumentTitle } from 'components/common';
 import { Headline } from 'components/common/Section/SectionComponent';
 import TokenList from 'components/users/TokenList';
@@ -64,8 +63,8 @@ const _createToken = (tokenName, username, loadTokens, setCreatingToken) => {
 };
 
 const UserEditPage = ({ params }: Props) => {
-  const { loadedUser } = useStore(UsersStore);
   const currentUser = useContext(CurrentUserContext);
+  const [loadedUser, setLoadedUser] = useState();
   const [tokens, setTokens] = useState([]);
   const [deletingTokenId, setDeletingTokenId] = useState();
   const [creatingToken, setCreatingToken] = useState(false);
@@ -78,6 +77,7 @@ const UserEditPage = ({ params }: Props) => {
 
   useEffect(() => {
     loadTokens();
+    UsersActions.load(username).then(setLoadedUser);
   }, [currentUser, username]);
 
   return (
@@ -94,7 +94,7 @@ const UserEditPage = ({ params }: Props) => {
         </span>
 
         <UserManagementLinks username={username}
-                             userIsReadOnly={loadedUser?.readOnly} />
+                             userIsReadOnly={loadedUser?.readOnly ?? false} />
       </PageHeader>
 
       <Row className="content">

--- a/graylog2-web-interface/src/stores/users/UsersStore.test.js
+++ b/graylog2-web-interface/src/stores/users/UsersStore.test.js
@@ -6,12 +6,14 @@ import { UsersActions } from 'stores/users/UsersStore';
 import fetch from 'logic/rest/FetchProvider';
 
 describe('UsersStore', () => {
-  it('should load json users and store them as value classes', async () => {
+  it('should load json users and store them as value classes', async (done) => {
     const jsonList = userList.map((u) => u.toJSON()).toArray();
     asMock(fetch).mockReturnValueOnce(Promise.resolve({ users: jsonList }));
 
-    UsersActions.loadUsers().then((users) => {
-      expect(users).toBe(jsonList);
+    UsersActions.loadUsers().then((result) => {
+      expect(result).toStrictEqual(userList);
+
+      done();
     });
   });
 });


### PR DESCRIPTION
This PR removes the state from `UsersStore` which we implemented for the new UserManagement. We've decided to set the result of the `UsersActions` inside the related components as a state instead.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1697
