### PR TITLE
Migrate dashboard and stream roles to grants

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
@@ -106,16 +106,20 @@ public class DBGrantService extends PaginatedDbService<GrantDTO> {
                 DBQuery.in(GrantDTO.FIELD_GRANTEE, grantees))).toArray();
     }
 
-    public GrantDTO create(GrantDTO grantDTO, @Nullable User currentUser) {
+    public GrantDTO create(GrantDTO grantDTO, String userName) {
         final ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
-        final String userName = requireNonNull(currentUser, "currentUser cannot be null").getName();
-
         return super.save(grantDTO.toBuilder()
                 .createdBy(userName)
                 .createdAt(now)
                 .updatedBy(userName)
                 .updatedAt(now)
                 .build());
+    }
+
+    public GrantDTO create(GrantDTO grantDTO, @Nullable User currentUser) {
+        final String userName = requireNonNull(currentUser, "currentUser cannot be null").getName();
+
+        return create(grantDTO, userName);
     }
 
     public GrantDTO update(GrantDTO updatedGrant, @Nullable User currentUser) {

--- a/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
@@ -42,7 +42,9 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class DBGrantService extends PaginatedDbService<GrantDTO> {
     public static final String COLLECTION_NAME = "grants";
@@ -108,6 +110,7 @@ public class DBGrantService extends PaginatedDbService<GrantDTO> {
 
     public GrantDTO create(GrantDTO grantDTO, String userName) {
         final ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        checkArgument(isNotBlank(userName), "userName cannot be null or empty");
         return super.save(grantDTO.toBuilder()
                 .createdBy(userName)
                 .createdAt(now)

--- a/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
@@ -47,5 +47,6 @@ public class MigrationsModule extends PluginModule {
         addMigration(V20200102140000_UnifyEventSeriesId.class);
         addMigration(V20200226181600_EncryptAccessTokensMigration.class);
         addMigration(V20200722110800_AddBuiltinRoles.class);
+        addMigration(V20200803120800_MigrateRolesToGrants.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20200803120800_MigrateRolesToGrants.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20200803120800_MigrateRolesToGrants.java
@@ -1,0 +1,218 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.migrations;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import org.apache.shiro.authz.permission.WildcardPermission;
+import org.graylog.grn.GRNRegistry;
+import org.graylog.grn.GRNType;
+import org.graylog.security.Capability;
+import org.graylog.security.DBGrantService;
+import org.graylog.security.GrantDTO;
+import org.graylog2.plugin.database.ValidationException;
+import org.graylog2.plugin.database.users.User;
+import org.graylog2.shared.users.Role;
+import org.graylog2.shared.users.UserService;
+import org.graylog2.users.RoleService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.time.ZonedDateTime;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.graylog.grn.GRNTypes.DASHBOARD;
+import static org.graylog.grn.GRNTypes.STREAM;
+import static org.graylog2.shared.security.RestPermissions.DASHBOARDS_EDIT;
+import static org.graylog2.shared.security.RestPermissions.DASHBOARDS_READ;
+import static org.graylog2.shared.security.RestPermissions.STREAMS_EDIT;
+import static org.graylog2.shared.security.RestPermissions.STREAMS_READ;
+
+public class V20200803120800_MigrateRolesToGrants extends Migration {
+    private static final Logger LOG = LoggerFactory.getLogger(V20200803120800_MigrateRolesToGrants.class);
+    private final RoleService roleService;
+    private final UserService userService;
+    private final DBGrantService dbGrantService;
+    private final GRNRegistry grnRegistry;
+    private final String rootUsername;
+
+    @Inject
+    public V20200803120800_MigrateRolesToGrants(RoleService roleService,
+                                                UserService userService,
+                                                DBGrantService dbGrantService,
+                                                GRNRegistry grnRegistry,
+                                                @Named("root_username") String rootUsername) {
+        this.roleService = roleService;
+        this.userService = userService;
+        this.dbGrantService = dbGrantService;
+        this.grnRegistry = grnRegistry;
+        this.rootUsername = rootUsername;
+    }
+
+    @Override
+    public ZonedDateTime createdAt() {
+        return ZonedDateTime.parse("2020-08-03T12:08:00Z");
+    }
+
+    private final Map<Set<String>, GRNTypeCapability> MIGRATION_MAP = ImmutableMap.of(
+            ImmutableSet.of(DASHBOARDS_READ, DASHBOARDS_EDIT), new GRNTypeCapability(DASHBOARD, Capability.MANAGE),
+            ImmutableSet.of(DASHBOARDS_READ), new GRNTypeCapability(DASHBOARD, Capability.VIEW),
+            ImmutableSet.of(STREAMS_READ, STREAMS_EDIT), new GRNTypeCapability(STREAM, Capability.MANAGE),
+            ImmutableSet.of(STREAMS_READ), new GRNTypeCapability(STREAM, Capability.VIEW)
+            );
+
+    @Override
+    public void upgrade() {
+        final Set<MigratableRole> migratableRoles = findMigratableRoles();
+
+        migratableRoles.forEach(migratableRole -> {
+            final Role role = migratableRole.role;
+
+            final Set<String> migratedPermissions = migrateRoleToGrant(migratableRole);
+
+            if (role.getPermissions().removeAll(migratedPermissions)) {
+                LOG.debug("Updating role <{}> new permissions: <{}>", role.getName(), role.getPermissions());
+
+                if (role.getPermissions().isEmpty()) {
+                    LOG.info("Removing the now empty role <{}>", role.getName());
+                    userService.dissociateAllUsersFromRole(role);
+                    roleService.delete(role.getName());
+                } else {
+                    try {
+                        roleService.save(role);
+                    } catch (ValidationException e) {
+                        LOG.error("Failed to update modified role <{}>", role.getName(), e);
+                    }
+                }
+            }
+        });
+    }
+
+    private Set<String> migrateRoleToGrant(MigratableRole migratableRole) {
+        final Set<String> migratedRolePermissions = new HashSet<>();
+        final Collection<User> allRoleUsers = userService.loadAllForRole(migratableRole.role);
+
+        migratableRole.migratableEntities.forEach((entityID, permissions) -> {
+            final GRNTypeCapability grnTypeCapability = MIGRATION_MAP.get(permissions);
+
+            // Permissions are mappable to a grant
+            if (grnTypeCapability != null) {
+                final Capability capability = grnTypeCapability.capability;
+                final GRNType grnType = grnTypeCapability.grnType;
+                allRoleUsers.forEach(user -> {
+                    final GrantDTO grant = GrantDTO.builder()
+                            .grantee(grnRegistry.ofUser(user))
+                            .target(grnType.toGRN(entityID))
+                            .capability(capability)
+                            .build();
+                    dbGrantService.create(grant, rootUsername);
+                    LOG.info("Migrating entity <{}> permissions <{}> to <{}> grant for user <{}>", entityID, permissions, capability, user.getName());
+                });
+                migratedRolePermissions.addAll(permissions.stream().map(p -> p + ":" + entityID).collect(Collectors.toSet()));
+            } else {
+                LOG.info("Skipping non-migratable entity <{}>. Permissions <{}> cannot be converted to a grant capability", entityID, permissions);
+            }
+        });
+        return migratedRolePermissions;
+    }
+
+    private Set<MigratableRole> findMigratableRoles() {
+        final Set<MigratableRole> migratableRoles= new HashSet<>();
+
+        final Set<Role> roles = roleService.loadAll();
+        roles.forEach(role -> {
+            final Map<String, Set<String>> migratableIds = new HashMap<>();
+
+            // Inspect all permissions that are made of 3 parts and don't contain multiple subparts
+            role.getPermissions().stream().map(MigrationWildcardPermission::new)
+                    .filter(p -> p.getParts().size() == 3 && p.getParts().stream().allMatch(part -> part.size() == 1))
+                    .forEach(p -> {
+                        String permissionType = p.subPart(0);
+                        String restPermission = p.subPart(0) + ":" + p.subPart(1);
+                        String id = p.subPart(2);
+
+                        if (MIGRATION_MAP.keySet().stream().flatMap(Collection::stream).anyMatch(perm -> perm.startsWith(permissionType + ":"))) {
+                            LOG.debug("Potentially migratable role <{}> permission <{}> id <{}>", role.getName(), restPermission, id);
+                            if (migratableIds.containsKey(id)) {
+                                migratableIds.get(id).add(restPermission);
+                            } else {
+                                migratableIds.put(id, Sets.newHashSet(restPermission));
+                            }
+                        }
+                    });
+            if (!migratableIds.isEmpty()) {
+                migratableRoles.add(new MigratableRole(role, migratableIds));
+            }
+        });
+        LOG.debug("migratableRoles <{}>", migratableRoles);
+        return migratableRoles;
+    }
+
+    private static class GRNTypeCapability {
+        final GRNType grnType;
+        final Capability capability;
+
+        public GRNTypeCapability(GRNType grnType, Capability capability) {
+            this.grnType = grnType;
+            this.capability = capability;
+        }
+    }
+
+    private static class MigratableRole {
+        Role role;
+        Map<String, Set<String>> migratableEntities;
+
+        public MigratableRole(Role role, Map<String, Set<String>> migratableEntities) {
+            this.role = role;
+            this.migratableEntities = migratableEntities;
+        }
+
+        @Override
+        public String toString() {
+            return "MigratableRole{" +
+                    "roleID='" + role.getId() + '\'' +
+                    ", migratableIds=" + migratableEntities +
+                    '}';
+        }
+    }
+
+    // only needed to access protected getParts() method from WildcardPermission
+    public static class MigrationWildcardPermission extends WildcardPermission {
+        public MigrationWildcardPermission(String wildcardString) {
+            super(wildcardString);
+        }
+
+        @Override
+        protected List<Set<String>> getParts() {
+            return super.getParts();
+        }
+
+        protected String subPart(int idx) {
+            return Iterables.getOnlyElement(getParts().get(idx));
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapSettingsImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapSettingsImpl.java
@@ -330,23 +330,18 @@ public class LdapSettingsImpl extends PersistedImpl implements LdapSettings {
             internal = Collections.emptyMap();
         } else {
             // we store ids internally but external users use the group names
-            try {
-                final Map<String, Role> nameToRole = Maps.uniqueIndex(roleService.loadAll(), Roles.roleToNameFunction());
+            final Map<String, Role> nameToRole = Maps.uniqueIndex(roleService.loadAll(), Roles.roleToNameFunction());
 
-                internal = Maps.newHashMap(Maps.transformValues(mapping, new Function<String, String>() {
-                    @Nullable
-                    @Override
-                    public String apply(@Nullable String groupName) {
-                        if (groupName == null || !nameToRole.containsKey(groupName)) {
-                            return null;
-                        }
-                        return nameToRole.get(groupName).getId();
+            internal = Maps.newHashMap(Maps.transformValues(mapping, new Function<String, String>() {
+                @Nullable
+                @Override
+                public String apply(@Nullable String groupName) {
+                    if (groupName == null || !nameToRole.containsKey(groupName)) {
+                        return null;
                     }
-                }));
-            } catch (NotFoundException e) {
-                LOG.error("Unable to convert group names to ids", e);
-                throw new IllegalStateException("Unable to convert group names to ids", e);
-            }
+                    return nameToRole.get(groupName).getId();
+                }
+            }));
         }
 
         // convert the group -> role_id map to a list of {"group" -> group, "role_id" -> roleid } maps
@@ -414,25 +409,20 @@ public class LdapSettingsImpl extends PersistedImpl implements LdapSettings {
 
     @Override
     public void setAdditionalDefaultGroups(Set<String> groupNames) {
-        try {
-            if (groupNames == null) return;
+        if (groupNames == null) return;
 
-            final Map<String, Role> nameToRole = Maps.uniqueIndex(roleService.loadAll(), Roles.roleToNameFunction());
-            final List<String> groupIds = Collections2.transform(groupNames, new Function<String, String>() {
-                @Nullable
-                @Override
-                public String apply(@Nullable String groupName) {
-                    if (groupName == null || !nameToRole.containsKey(groupName)) {
-                        return null;
-                    }
-                    return nameToRole.get(groupName).getId();
+        final Map<String, Role> nameToRole = Maps.uniqueIndex(roleService.loadAll(), Roles.roleToNameFunction());
+        final List<String> groupIds = Collections2.transform(groupNames, new Function<String, String>() {
+            @Nullable
+            @Override
+            public String apply(@Nullable String groupName) {
+                if (groupName == null || !nameToRole.containsKey(groupName)) {
+                    return null;
                 }
-            }).stream().filter(Objects::nonNull).collect(Collectors.toList());
-            fields.put(ADDITIONAL_DEFAULT_GROUPS, groupIds);
-        } catch (NotFoundException e) {
-            LOG.error("Unable to convert group names to ids", e);
-            throw new IllegalStateException("Unable to convert group names to ids", e);
-        }
+                return nameToRole.get(groupName).getId();
+            }
+        }).stream().filter(Objects::nonNull).collect(Collectors.toList());
+        fields.put(ADDITIONAL_DEFAULT_GROUPS, groupIds);
 
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/system/stats/ClusterStatsService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/ClusterStatsService.java
@@ -19,7 +19,6 @@ package org.graylog2.system.stats;
 import org.graylog.plugins.views.search.views.DashboardService;
 import org.graylog2.alarmcallbacks.AlarmCallbackConfigurationService;
 import org.graylog2.alerts.AlertService;
-import org.graylog2.database.NotFoundException;
 import org.graylog2.indexer.cluster.Cluster;
 import org.graylog2.inputs.InputService;
 import org.graylog2.security.ldap.LdapSettingsService;
@@ -115,10 +114,8 @@ public class ClusterStatsService {
     public LdapStats ldapStats() {
         int numberOfRoles = 0;
         LdapSettings ldapSettings = null;
-        try {
-            numberOfRoles = roleService.loadAll().size();
-            ldapSettings = ldapSettingsService.load();
-        } catch (NotFoundException ignored) {}
+        numberOfRoles = roleService.loadAll().size();
+        ldapSettings = ldapSettingsService.load();
         if (ldapSettings == null) {
             return LdapStats.create(false,
                                     false,

--- a/graylog2-server/src/main/java/org/graylog2/system/stats/ClusterStatsService.java
+++ b/graylog2-server/src/main/java/org/graylog2/system/stats/ClusterStatsService.java
@@ -112,10 +112,8 @@ public class ClusterStatsService {
     }
 
     public LdapStats ldapStats() {
-        int numberOfRoles = 0;
-        LdapSettings ldapSettings = null;
-        numberOfRoles = roleService.loadAll().size();
-        ldapSettings = ldapSettingsService.load();
+        int numberOfRoles = roleService.loadAll().size();
+        LdapSettings ldapSettings = ldapSettingsService.load();
         if (ldapSettings == null) {
             return LdapStats.create(false,
                                     false,

--- a/graylog2-server/src/main/java/org/graylog2/users/RoleService.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/RoleService.java
@@ -31,7 +31,7 @@ public interface RoleService {
 
     boolean exists(String roleName);
 
-    Set<Role> loadAll() throws NotFoundException;
+    Set<Role> loadAll();
 
     Map<String, Role> loadAllIdMap() throws NotFoundException;
 

--- a/graylog2-server/src/main/java/org/graylog2/users/RoleServiceImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/RoleServiceImpl.java
@@ -67,7 +67,7 @@ public class RoleServiceImpl implements RoleService {
     private final String readerRoleObjectId;
 
     @Inject
-    protected RoleServiceImpl(MongoConnection mongoConnection,
+    public RoleServiceImpl(MongoConnection mongoConnection,
                               MongoJackObjectMapperProvider mapper,
                               Permissions permissions,
                               Validator validator) {
@@ -154,7 +154,7 @@ public class RoleServiceImpl implements RoleService {
     }
 
     @Override
-    public Set<Role> loadAll() throws NotFoundException {
+    public Set<Role> loadAll() {
         try (DBCursor<RoleImpl> rolesCursor = dbCollection.find()) {
             return ImmutableSet.copyOf((Iterable<? extends Role>) rolesCursor);
         }

--- a/graylog2-server/src/test/java/org/graylog/security/DBGrantServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/DBGrantServiceTest.java
@@ -122,4 +122,22 @@ public class DBGrantServiceTest {
             assertThat(result).doesNotContainKey(stream1);
         });
     }
+
+    @Test
+    public void createWithUserName() {
+        final GRN john = grnRegistry.parse("grn::::user:john");
+        final GRN dashboard1 = grnRegistry.parse("grn::::dashboard:54e3deadbeefdeadbeef0000");
+        final GrantDTO grantDTO = GrantDTO.builder()
+                .capability(Capability.VIEW)
+                .grantee(john)
+                .target(dashboard1)
+                .build();
+
+        assertThat(dbService.create(grantDTO, "hans")).satisfies(result -> {
+            assertThat(result.grantee()).isEqualTo(john);
+            assertThat(result.createdBy()).isEqualTo("hans");
+            assertThat(result.updatedBy()).isEqualTo("hans");
+            assertThat(result.createdAt()).isNotNull();
+        });
+    }
 }

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_MigrateRolesToGrantsTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_MigrateRolesToGrantsTest.java
@@ -1,0 +1,309 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.migrations;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import com.mongodb.BasicDBObject;
+import com.mongodb.BasicDBObjectBuilder;
+import com.mongodb.DBObject;
+import org.apache.shiro.authz.Permission;
+import org.apache.shiro.authz.permission.WildcardPermission;
+import org.bson.types.ObjectId;
+import org.graylog.grn.GRNRegistry;
+import org.graylog.security.Capability;
+import org.graylog.security.DBGrantService;
+import org.graylog.security.GrantDTO;
+import org.graylog.security.permissions.GRNPermission;
+import org.graylog.testing.mongodb.MongoDBFixtures;
+import org.graylog.testing.mongodb.MongoDBInstance;
+import org.graylog2.Configuration;
+import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.database.NotFoundException;
+import org.graylog2.database.PersistedServiceImpl;
+import org.graylog2.plugin.database.ValidationException;
+import org.graylog2.plugin.database.users.User;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
+import org.graylog2.shared.security.Permissions;
+import org.graylog2.shared.security.RestPermissions;
+import org.graylog2.shared.users.Role;
+import org.graylog2.shared.users.UserService;
+import org.graylog2.users.RoleService;
+import org.graylog2.users.RoleServiceImpl;
+import org.graylog2.users.UserImpl;
+import org.graylog2.users.UserServiceImplTest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import javax.annotation.Nullable;
+import javax.validation.Validator;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+public class V20200803120800_MigrateRolesToGrantsTest {
+    private V20200803120800_MigrateRolesToGrants migration;
+    private RoleService roleService;
+    private DBGrantService dbGrantService;
+    private ObjectMapper objectMapper;
+
+    @Rule
+    public final MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Rule
+    public final MongoDBInstance mongodb = MongoDBInstance.createForClass();
+
+    @Mock
+    private Permissions permissions;
+
+    @Mock
+    private Validator validator;
+    private GRNRegistry grnRegistry;
+    private UserService userService;
+
+    @Before
+    public void setUp() {
+        objectMapper = new ObjectMapperProvider().get();
+        final MongoJackObjectMapperProvider mongoJackObjectMapperProvider = new MongoJackObjectMapperProvider(objectMapper);
+        when(permissions.readerBasePermissions()).thenReturn(ImmutableSet.of());
+        when(validator.validate(any())).thenReturn(ImmutableSet.of());
+
+        grnRegistry = GRNRegistry.createWithBuiltinTypes();
+
+        roleService = new RoleServiceImpl(mongodb.mongoConnection(), mongoJackObjectMapperProvider, permissions, validator);
+
+        dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry);
+        userService = new TestUserService(mongodb.mongoConnection());
+        DBGrantService dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry);
+        migration = new V20200803120800_MigrateRolesToGrants(roleService, userService, dbGrantService, grnRegistry, "admin");
+    }
+
+    @Test
+    @MongoDBFixtures("V20200803120800_MigrateRolesToGrantsTest.json")
+    public void migrateSimpleRole() throws NotFoundException {
+
+        final User testuser1 = userService.load("testuser1");
+        assertThat(testuser1).isNotNull();
+        final User testuser2 = userService.load("testuser2");
+        assertThat(testuser2).isNotNull();
+
+        assertThat(roleService.load("mig-test")).isNotNull();
+        assertThat(dbGrantService.getForGranteesOrGlobal(ImmutableSet.of(grnRegistry.ofUser(testuser1)))).isEmpty();
+
+        migration.upgrade();
+
+        // check created grants for testuser1
+        final ImmutableSet<GrantDTO> grants = dbGrantService.getForGranteesOrGlobal(ImmutableSet.of(grnRegistry.ofUser(testuser1)));
+        assertGrantInSet(grants, "grn::::dashboard:5e2afc66cd19517ec2dabadd", Capability.VIEW);
+        assertGrantInSet(grants, "grn::::dashboard:5e2afc66cd19517ec2dabadf", Capability.MANAGE);
+        assertGrantInSet(grants, "grn::::stream:5c40ad603c034441a56942bd", Capability.VIEW);
+        assertGrantInSet(grants, "grn::::stream:5e2f5cfb4868e67ad4da562d", Capability.VIEW);
+        assertGrantInSet(grants, "grn::::stream:000000000000000000000002", Capability.MANAGE);
+        assertThat(grants.size()).isEqualTo(5);
+
+        // testuser2 gets the same grants. a simple check should suffice
+        assertThat(dbGrantService.getForGranteesOrGlobal(ImmutableSet.of(grnRegistry.ofUser(testuser2)))).satisfies(grantDTOS -> {
+            assertThat(Iterables.size(grantDTOS)).isEqualTo(5);
+        });
+
+        // empty role should be dropped
+        assertThatThrownBy(() -> roleService.load("mig-test")).isInstanceOf(NotFoundException.class);
+
+    }
+
+    @Test
+    @MongoDBFixtures("V20200803120800_MigrateRolesToGrantsTest.json")
+    public void nonMigratableRole() throws NotFoundException {
+
+        final User testuser3 = userService.load("testuser3");
+        assertThat(testuser3).isNotNull();
+
+        assertThat(roleService.load("non-migratable-role")).satisfies(role -> {
+            assertThat(role.getPermissions().size()).isEqualTo(4);
+        });
+        assertThat(dbGrantService.getForGranteesOrGlobal(ImmutableSet.of(grnRegistry.ofUser(testuser3)))).isEmpty();
+        migration.upgrade();
+
+        assertThat(roleService.load("non-migratable-role")).satisfies(role -> {
+            assertThat(role.getPermissions().size()).isEqualTo(4);
+        });
+        assertThat(dbGrantService.getForGranteesOrGlobal(ImmutableSet.of(grnRegistry.ofUser(testuser3)))).isEmpty();
+
+    }
+
+    @Test
+    @MongoDBFixtures("V20200803120800_MigrateRolesToGrantsTest.json")
+    public void partlyMigratableRole() throws NotFoundException {
+
+        final User testuser4 = userService.load("testuser3");
+        assertThat(testuser4).isNotNull();
+
+        assertThat(roleService.load("partly-migratable-role")).satisfies(role -> {
+            assertThat(role.getPermissions().size()).isEqualTo(5);
+        });
+        assertThat(dbGrantService.getForGranteesOrGlobal(ImmutableSet.of(grnRegistry.ofUser(testuser4)))).isEmpty();
+        migration.upgrade();
+
+        assertThat(roleService.load("partly-migratable-role")).satisfies(role -> {
+            assertThat(role.getPermissions().size()).isEqualTo(3);
+        });
+        assertThat(dbGrantService.getForGranteesOrGlobal(ImmutableSet.of(grnRegistry.ofUser(testuser4)))).isEmpty();
+
+    }
+
+    private void assertGrantInSet(Set<GrantDTO> grants, String target, Capability capability) {
+        assertThat(grants.stream().anyMatch(g -> g.target().equals(grnRegistry.parse(target)) && g.capability().equals(capability))).isTrue();
+    }
+
+    // An incomplete UserService implementation, that needs fewer dependencies
+    public static class TestUserService extends PersistedServiceImpl implements UserService {
+        final UserImpl.Factory userFactory;
+        protected TestUserService(MongoConnection mongoConnection) {
+            super(mongoConnection);
+            final Permissions permissions = new Permissions(ImmutableSet.of(new RestPermissions()));
+            userFactory = new UserServiceImplTest.UserImplFactory(new Configuration(), permissions);
+        }
+
+        @Nullable
+        @Override
+        public User load(String username) {
+            final DBObject query = new BasicDBObject();
+            query.put(UserImpl.USERNAME, username);
+
+            final List<DBObject> result = query(UserImpl.class, query);
+            if (result == null || result.isEmpty()) {
+                return null;
+            }
+
+            if (result.size() > 1) {
+                final String msg = "There was more than one matching user for username " + username + ". This should never happen.";
+                throw new RuntimeException(msg);
+            }
+
+            final DBObject userObject = result.get(0);
+            final Object userId = userObject.get("_id");
+
+            return userFactory.create((ObjectId) userId, userObject.toMap());
+        }
+
+        @Override
+        public int delete(String username) {
+            return 0;
+        }
+
+        @Override
+        public User create() {
+            return null;
+        }
+
+        @Override
+        public List<User> loadAll() {
+            return null;
+        }
+
+        @Override
+        public User getAdminUser() {
+            return null;
+        }
+
+        @Override
+        public Optional<User> getRootUser() {
+            return Optional.empty();
+        }
+
+        @Override
+        public long count() {
+            return 0;
+        }
+
+        @Override
+        public Collection<User> loadAllForRole(Role role) {
+            final String roleId = role.getId();
+            final DBObject query = BasicDBObjectBuilder.start(UserImpl.ROLES, new ObjectId(roleId)).get();
+
+            final List<DBObject> result = query(UserImpl.class, query);
+            if (result == null || result.isEmpty()) {
+                return Collections.emptySet();
+            }
+            final Set<User> users = Sets.newHashSetWithExpectedSize(result.size());
+            for (DBObject dbObject : result) {
+                //noinspection unchecked
+                users.add(userFactory.create((ObjectId) dbObject.get("_id"), dbObject.toMap()));
+            }
+            return users;
+        }
+
+        @Override
+        public Set<String> getRoleNames(User user) {
+            return null;
+        }
+
+        @Override
+        public List<Permission> getPermissionsForUser(User user) {
+            return null;
+        }
+
+        @Override
+        public List<WildcardPermission> getWildcardPermissionsForUser(User user) {
+            return null;
+        }
+
+        @Override
+        public List<GRNPermission> getGRNPermissionsForUser(User user) {
+            return null;
+        }
+
+        @Override
+        public Set<String> getUserPermissionsFromRoles(User user) {
+            return null;
+        }
+
+        @Override
+        public void dissociateAllUsersFromRole(Role role) {
+            final Collection<User> usersInRole = loadAllForRole(role);
+            // remove role from any user still assigned
+            for (User user : usersInRole) {
+                if (user.isLocalAdmin()) {
+                    continue;
+                }
+                final HashSet<String> roles = Sets.newHashSet(user.getRoleIds());
+                roles.remove(role.getId());
+                user.setRoleIds(roles);
+                try {
+                    save(user);
+                } catch (ValidationException e) {
+                    throw new RuntimeException("Unable to remove role " + role.getName() + " from user " + user, e);
+                }
+            }
+        }
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/users/UserServiceImplTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/users/UserServiceImplTest.java
@@ -86,8 +86,8 @@ public class UserServiceImplTest {
     public void setUp() throws Exception {
         this.mongoConnection = mongodb.mongoConnection();
         this.configuration = new Configuration();
-        this.userFactory = new UserImplFactory(configuration);
         this.permissions = new Permissions(ImmutableSet.of(new RestPermissions()));
+        this.userFactory = new UserImplFactory(configuration, permissions);
         this.userService = new UserServiceImpl(mongoConnection, configuration, roleService, accessTokenService,
                 userFactory, permissionsResolver, serverEventBus, GRNRegistry.createWithBuiltinTypes(), grantPermissionResolver);
 
@@ -157,12 +157,14 @@ public class UserServiceImplTest {
         assertThat(userService.count()).isEqualTo(4L);
     }
 
-    class UserImplFactory implements UserImpl.Factory {
+    public static class UserImplFactory implements UserImpl.Factory {
         private final Configuration configuration;
+        private final Permissions permissions;
         private final PasswordAlgorithmFactory passwordAlgorithmFactory;
 
-        public UserImplFactory(Configuration configuration) {
+        public UserImplFactory(Configuration configuration, Permissions permissions) {
             this.configuration = configuration;
+            this.permissions = permissions;
             this.passwordAlgorithmFactory = new PasswordAlgorithmFactory(Collections.<String, PasswordAlgorithm>emptyMap(),
                     new SHA1HashPasswordAlgorithm("TESTSECRET"));
         }
@@ -194,7 +196,7 @@ public class UserServiceImplTest {
 
     @Test
     public void testGetRoleNames() throws Exception {
-        final UserImplFactory factory = new UserImplFactory(new Configuration());
+        final UserImplFactory factory = new UserImplFactory(new Configuration(), permissions);
         final UserImpl user = factory.create(new HashMap<>());
         final Role role = createRole("Foo");
 
@@ -220,7 +222,7 @@ public class UserServiceImplTest {
                 accessTokenService, userFactory, permissionResolver,
                 serverEventBus, grnRegistry, grantPermissionResolver);
 
-        final UserImplFactory factory = new UserImplFactory(new Configuration());
+        final UserImplFactory factory = new UserImplFactory(new Configuration(), permissions);
         final UserImpl user = factory.create(new HashMap<>());
         user.setName("user");
         final Role role = createRole("Foo");

--- a/graylog2-server/src/test/resources/org/graylog2/migrations/V20200803120800_MigrateRolesToGrantsTest.json
+++ b/graylog2-server/src/test/resources/org/graylog2/migrations/V20200803120800_MigrateRolesToGrantsTest.json
@@ -1,0 +1,112 @@
+{
+  "roles": [
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0001"
+      },
+      "name" : "mig-test",
+      "name_lower" : "mig-test",
+      "description" : "what can be done",
+      "read_only" : false,
+      "permissions": [
+        "dashboards:read:5e2afc66cd19517ec2dabadd",
+        "dashboards:read:5e2afc66cd19517ec2dabadf",
+        "dashboards:edit:5e2afc66cd19517ec2dabadf",
+        "streams:read:5c40ad603c034441a56942bd",
+        "streams:read:5e2f5cfb4868e67ad4da562d",
+        "streams:read:000000000000000000000002",
+        "streams:edit:000000000000000000000002"
+      ]
+    },
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0002"
+      },
+      "name" : "non-migratable-role",
+      "name_lower" : "non-migratable-role",
+      "description" : "contains non-migratable permissions",
+      "read_only" : false,
+      "permissions": [
+        "streams:read",
+        "streams:read:4e40ad603c034441a56942b0",
+        "streams:changestate:4e40ad603c034441a56942b0",
+        "dashboards:edit"
+      ]
+    },
+    {
+      "_id": {
+        "$oid": "54e3deadbeefdeadbeef0003"
+      },
+      "name" : "partly-migratable-role",
+      "name_lower" : "partly-migratable-role",
+      "description" : "contains partly migratable permissions",
+      "read_only" : false,
+      "permissions": [
+        "streams:read",
+        "streams:read:4e40ad603c034441a56942b0",
+        "streams:changestate:4e40ad603c034441a56942b0",
+        "dashboards:edit:4e40ad603c034441a56942c9",
+        "dashboards:read:4e40ad603c034441a56942c9"
+      ]
+    }
+  ],
+  "users": [
+    {
+      "_id" : {
+        "$oid": "5b8e4ef17ad37b64ee87eb57"
+      },
+      "full_name" : "Testuser1",
+      "username" : "testuser1",
+      "email" : "testuser1@graylog.org",
+      "password" : "{bcrypt}$2a$10$7kEUkcibcUkUKs2q9OHCpumI5XcBPHVmO37/D0YBYtWgR/Jisqkyi{salt}$2a$10$7kEUkcibcUkUKs2q9OHCpu",
+      "permissions" : [],
+      "timezone" : "UTC",
+      "roles" : [
+        { "$oid": "54e3deadbeefdeadbeef0001" }
+      ]
+    },
+    {
+      "_id" : {
+        "$oid": "5b8e4ef17ad37b64ee87eb58"
+      },
+      "full_name" : "Testuser2",
+      "email" : "testuser2@graylog.org",
+      "username" : "testuser2",
+      "password" : "{bcrypt}$2a$10$7kEUkcibcUkUKs2q9OHCpumI5XcBPHVmO37/D0YBYtWgR/Jisqkyi{salt}$2a$10$7kEUkcibcUkUKs2q9OHCpu",
+      "permissions" : [],
+      "timezone" : "UTC",
+      "roles" : [
+        { "$oid": "54e3deadbeefdeadbeef0001" },
+        { "$oid": "54e3deadbeefdeadbeef0008" }
+      ]
+    },
+    {
+      "_id" : {
+        "$oid": "5b8e4ef17ad37b64ee87ec59"
+      },
+      "full_name" : "Testuser3",
+      "email" : "testuser3@graylog.org",
+      "username" : "testuser3",
+      "password" : "{bcrypt}$2a$10$7kEUkcibcUkUKs2q9OHCpumI5XcBPHVmO37/D0YBYtWgR/Jisqkyi{salt}$2a$10$7kEUkcibcUkUKs2q9OHCpu",
+      "permissions" : [],
+      "timezone" : "UTC",
+      "roles" : [
+        { "$oid": "54e3deadbeefdeadbeef0002" }
+      ]
+    },
+    {
+      "_id" : {
+        "$oid": "5b8e4ef17ad37b64ee87ec7a"
+      },
+      "full_name" : "Testuser4",
+      "email" : "testuser4@graylog.org",
+      "username" : "testuser4",
+      "password" : "{bcrypt}$2a$10$7kEUkcibcUkUKs2q9OHCpumI5XcBPHVmO37/D0YBYtWgR/Jisqkyi{salt}$2a$10$7kEUkcibcUkUKs2q9OHCpu",
+      "permissions" : [],
+      "timezone" : "UTC",
+      "roles" : [
+        { "$oid": "54e3deadbeefdeadbeef0003" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This migrates the currently UI configurable roles
for dashboards and streams into grants.

If the permissions of a role are empty after the migration, it gets removed
completely.

If entities has permissions other than read and edit, we don't migrate
it, so we don't end up having permissions on two different places for a
single entity.

Fixes #8594 

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1569