### PR TITLE
Add missing routes to AuthzRolesResource

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRolesResource.java
+++ b/graylog2-server/src/main/java/org/graylog/security/authzroles/AuthzRolesResource.java
@@ -23,13 +23,20 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.apache.shiro.authz.annotation.RequiresPermissions;
+import org.graylog2.audit.AuditEventTypes;
+import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.database.PaginatedList;
+import org.graylog2.plugin.database.ValidationException;
+import org.graylog2.plugin.database.users.User;
 import org.graylog2.rest.models.PaginatedResponse;
 import org.graylog2.search.SearchQuery;
 import org.graylog2.search.SearchQueryField;
 import org.graylog2.search.SearchQueryParser;
 import org.graylog2.shared.rest.resources.RestResource;
 import org.graylog2.shared.security.RestPermissions;
+import org.graylog2.shared.users.UserService;
+import org.graylog2.users.PaginatedUserService;
+import org.graylog2.users.UserOverviewDTO;
 
 import javax.inject.Inject;
 import javax.validation.constraints.NotBlank;
@@ -38,46 +45,64 @@ import javax.ws.rs.BadRequestException;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.Set;
+
+import static org.graylog2.shared.security.RestPermissions.USERS_EDIT;
 
 @RequiresAuthentication
 @Api(value = "AuthzRoles", description = "Read Roles")
 @Path("/authzRoles")
+@Produces(MediaType.APPLICATION_JSON)
 public class AuthzRolesResource extends RestResource {
     protected static final ImmutableMap<String, SearchQueryField> SEARCH_FIELD_MAPPING = ImmutableMap.<String, SearchQueryField>builder()
             .put(AuthzRoleDTO.FIELD_NAME, SearchQueryField.create(AuthzRoleDTO.FIELD_NAME))
             .put(AuthzRoleDTO.FIELD_DESCRIPTION, SearchQueryField.create(AuthzRoleDTO.FIELD_DESCRIPTION))
             .build();
 
+    protected static final ImmutableMap<String, SearchQueryField> USER_SEARCH_FIELD_MAPPING = ImmutableMap.<String, SearchQueryField>builder()
+            .put(UserOverviewDTO.FIELD_USERNAME, SearchQueryField.create(UserOverviewDTO.FIELD_USERNAME))
+            .put(UserOverviewDTO.FIELD_FULL_NAME, SearchQueryField.create(UserOverviewDTO.FIELD_FULL_NAME))
+            .put(UserOverviewDTO.FIELD_EMAIL, SearchQueryField.create(UserOverviewDTO.FIELD_EMAIL))
+            .build();
+
     private final PaginatedAuthzRolesService authzRolesService;
+    private final PaginatedUserService paginatedUserService;
+    private final UserService userService;
     private final SearchQueryParser searchQueryParser;
+    private final SearchQueryParser userSearchQueryParser;
 
     @Inject
-    public AuthzRolesResource(PaginatedAuthzRolesService authzRolesService) {
+    public AuthzRolesResource(PaginatedAuthzRolesService authzRolesService, PaginatedUserService paginatedUserService, UserService userService) {
         this.authzRolesService = authzRolesService;
+        this.paginatedUserService = paginatedUserService;
+        this.userService = userService;
 
         this.searchQueryParser = new SearchQueryParser(AuthzRoleDTO.FIELD_NAME, SEARCH_FIELD_MAPPING);
+        this.userSearchQueryParser = new SearchQueryParser(UserOverviewDTO.FIELD_USERNAME, USER_SEARCH_FIELD_MAPPING);
     }
 
     @GET
     @Timed
     @ApiOperation(value = "Get a paginated list of all roles")
-    @Produces(MediaType.APPLICATION_JSON)
     @RequiresPermissions(RestPermissions.ROLES_READ)
-    public PaginatedResponse<AuthzRoleDTO> getList(@ApiParam(name = "page") @QueryParam("page") @DefaultValue("1") int page,
-        @ApiParam(name = "per_page") @QueryParam("per_page") @DefaultValue("50") int perPage,
-        @ApiParam(name = "query") @QueryParam("query") @DefaultValue("") String query,
-        @ApiParam(name = "sort",
-                value = "The field to sort the result on",
-                required = true,
-                allowableValues = "name,description")
-        @DefaultValue(AuthzRoleDTO.FIELD_NAME) @QueryParam("sort") String sort,
-        @ApiParam(name = "order", value = "The sort direction", allowableValues = "asc, desc")
-        @DefaultValue("asc") @QueryParam("order") String order) {
+    public PaginatedResponse<AuthzRoleDTO> getList(
+            @ApiParam(name = "page") @QueryParam("page") @DefaultValue("1") int page,
+            @ApiParam(name = "per_page") @QueryParam("per_page") @DefaultValue("50") int perPage,
+            @ApiParam(name = "query") @QueryParam("query") @DefaultValue("") String query,
+            @ApiParam(name = "sort",
+                    value = "The field to sort the result on",
+                    required = true,
+                    allowableValues = "name,description")
+            @DefaultValue(AuthzRoleDTO.FIELD_NAME) @QueryParam("sort") String sort,
+            @ApiParam(name = "order", value = "The sort direction", allowableValues = "asc, desc")
+            @DefaultValue("asc") @QueryParam("order") String order) {
 
         SearchQuery searchQuery;
         try {
@@ -86,14 +111,44 @@ public class AuthzRolesResource extends RestResource {
             throw new BadRequestException("Invalid argument in search query: " + e.getMessage());
         }
 
-        final PaginatedList<AuthzRoleDTO> result = authzRolesService.findPaginated(searchQuery, page, perPage,sort, order);
+        final PaginatedList<AuthzRoleDTO> result = authzRolesService.findPaginated(
+                searchQuery, page, perPage,sort, order);
         return PaginatedResponse.create("roles", result, query);
     }
 
+    @GET
+    @ApiOperation(value = "Get a paginated list of users for a role")
+    @Path("/{roleId}/assignees")
+    @Produces(MediaType.APPLICATION_JSON)
+    @RequiresPermissions(RestPermissions.USERS_LIST)
+    public PaginatedResponse<UserOverviewDTO> getUsersForRole(
+            @ApiParam(name = "roleId") @PathParam("roleId") @NotEmpty String roleId,
+            @ApiParam(name = "page") @QueryParam("page") @DefaultValue("1") int page,
+            @ApiParam(name = "per_page") @QueryParam("per_page") @DefaultValue("50") int perPage,
+            @ApiParam(name = "query") @QueryParam("query") @DefaultValue("") String query,
+            @ApiParam(name = "sort",
+                    value = "The field to sort the result on",
+                    required = true,
+                    allowableValues = "username,full_name,email")
+            @DefaultValue(AuthzRoleDTO.FIELD_NAME) @QueryParam("sort") String sort,
+            @ApiParam(name = "order", value = "The sort direction", allowableValues = "asc, desc")
+            @DefaultValue("asc") @QueryParam("order") String order) {
+
+        SearchQuery searchQuery;
+        try {
+            searchQuery = userSearchQueryParser.parse(query);
+        } catch (IllegalArgumentException e) {
+            throw new BadRequestException("Invalid argument in search query: " + e.getMessage());
+        }
+
+        final PaginatedList<UserOverviewDTO> result = paginatedUserService.findPaginatedByRole(
+                searchQuery, page, perPage,sort, order, roleId);
+        return PaginatedResponse.create("users", result, query);
+    }
 
     @GET
     @ApiOperation(value = "Get a single role")
-    @Path("/{roleId}")
+    @Path("{roleId}")
     @Produces(MediaType.APPLICATION_JSON)
     public AuthzRoleDTO get(@ApiParam(name = "roleId") @PathParam("roleId") @NotBlank String roleId) {
         checkPermission(RestPermissions.ROLES_READ, roleId);
@@ -104,7 +159,6 @@ public class AuthzRolesResource extends RestResource {
     @GET
     @ApiOperation(value = "Get a paginated list roles for a user")
     @Path("/rolesForUser/{username}")
-    @Produces(MediaType.APPLICATION_JSON)
     @RequiresPermissions(RestPermissions.ROLES_READ)
     public PaginatedResponse<AuthzRoleDTO> getListForUser(
         @ApiParam(name = "username") @PathParam("username") @NotEmpty String username,
@@ -126,7 +180,53 @@ public class AuthzRolesResource extends RestResource {
             throw new BadRequestException("Invalid argument in search query: " + e.getMessage());
         }
 
-        final PaginatedList<AuthzRoleDTO> result = authzRolesService.findPaginatedForUser(searchQuery, page, perPage,sort, order, username);
+        final PaginatedList<AuthzRoleDTO> result = authzRolesService.findPaginatedForUser(
+                searchQuery, page, perPage,sort, order, username);
         return PaginatedResponse.create("roles", result, query);
+    }
+
+    @PUT
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation("Add a user to a role")
+    @AuditEvent(type = AuditEventTypes.USER_UPDATE)
+    @Path("{roleId}/assignee/add/{username}")
+    public Response addUser(
+            @ApiParam(name = "roleId") @PathParam("roleId") @NotBlank String roleId,
+            @ApiParam(name = "username") @PathParam("username") @NotBlank String username) throws ValidationException {
+        checkPermission(USERS_EDIT, username);
+
+        final User user = userService.load(username);
+        if (user == null) {
+            throw new NotFoundException("Cannot find user with name: " + username);
+        }
+        authzRolesService.get(roleId).orElseThrow(() -> new NotFoundException("Cannot find role with id: " + roleId));
+        Set<String> roles = user.getRoleIds();
+        roles.add(roleId);
+        user.setRoleIds(roles);
+        userService.save(user);
+
+        return Response.ok().build();
+    }
+
+    @PUT
+    @ApiOperation("Remove a member to a team")
+    @Path("{roleId}/assignee/remove/{username}")
+    @AuditEvent(type = AuditEventTypes.USER_UPDATE)
+    public Response removeUser(
+            @ApiParam(name = "roleId") @PathParam("roleId") @NotBlank String roleId,
+            @ApiParam(name = "username") @PathParam("username") @NotBlank String username) throws ValidationException {
+        checkPermission(USERS_EDIT, username);
+
+        final User user = userService.load(username);
+        if (user == null) {
+            throw new NotFoundException("Cannot find user with name: " + username);
+        }
+        authzRolesService.get(roleId).orElseThrow(() -> new NotFoundException("Cannot find role with id: " + roleId));
+        Set<String> roles = user.getRoleIds();
+        roles.remove(roleId);
+        user.setRoleIds(roles);
+        userService.save(user);
+
+        return Response.ok().build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/users/PaginatedUserService.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/PaginatedUserService.java
@@ -55,4 +55,13 @@ public class PaginatedUserService extends PaginatedDbService<UserOverviewDTO> {
         final DBSort.SortBuilder sortBuilder = getSortBuilder(order, sortField);
         return findPaginatedWithQueryAndSort(dbQuery, sortBuilder, page, perPage);
     }
+
+    public PaginatedList<UserOverviewDTO> findPaginatedByRole(SearchQuery searchQuery, int page,
+                                                              int perPage, String sortField, String order,
+                                                              String roleId) {
+        final DBQuery.Query dbQuery = searchQuery.toDBQuery()
+                .all(UserImpl.ROLES, roleId);
+        final DBSort.SortBuilder sortBuilder = getSortBuilder(order, sortField);
+        return findPaginatedWithQueryAndSort(dbQuery, sortBuilder, page, perPage);
+    }
 }


### PR DESCRIPTION
## Motivation
Prior this change, there was no way to get all users which had a certain
role assigned. Also the user wanted to add and remove users from the
role.

## Description
With this change three new routes were introduced:
   - get all users for a role
   - add a role to a user
   - remove a role from a user

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1569