### PR TITLE
Fix users overview when the user has no roles

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/users/UserOverviewDTO.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserOverviewDTO.java
@@ -27,6 +27,7 @@ import org.mongojack.Id;
 import org.mongojack.ObjectId;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Optional;
 import java.util.Set;
@@ -97,7 +98,8 @@ public abstract class UserOverviewDTO {
 
         @JsonCreator
         public static Builder create() {
-            return new AutoValue_UserOverviewDTO.Builder();
+            return new AutoValue_UserOverviewDTO.Builder()
+                    .roles(Collections.emptySet());
         }
 
         @Id


### PR DESCRIPTION
## Motivation
Prior to this change, the users overview would not render
and the resource couldn't return any users when one user
did not have roles.

## Description
This change will return an empty set of roles so the
Resource does not break on request.