### PR TITLE
Add Share Button to streams

### DIFF
--- a/graylog2-web-interface/src/components/streams/Stream.jsx
+++ b/graylog2-web-interface/src/components/streams/Stream.jsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router';
 import { LinkContainer } from 'react-router-bootstrap';
 import styled, { css } from 'styled-components';
 
+import EntityShareModal from 'components/permissions/EntityShareModal';
 import { Button, Tooltip } from 'components/graylog';
 import { OverlayElement, Icon } from 'components/common';
 import StreamRuleForm from 'components/streamrules/StreamRuleForm';
@@ -79,6 +80,7 @@ class Stream extends React.Component {
     this.state = {
       loading: false,
       showStreamRuleForm: false,
+      showEntityShareModal: false,
     };
   }
 
@@ -88,6 +90,15 @@ class Stream extends React.Component {
 
   _openStreamRuleForm = () => {
     this.setState({ showStreamRuleForm: true });
+  };
+
+
+  _closeEntityShareModal = () => {
+    this.setState({ showEntityShareModal: false });
+  };
+
+  _openEntityShareModal = () => {
+    this.setState({ showEntityShareModal: true });
   };
 
   _onDelete= (stream) => {
@@ -146,7 +157,7 @@ class Stream extends React.Component {
 
   render() {
     const { indexSets, stream, permissions, streamRuleTypes, user } = this.props;
-    const { loading, showStreamRuleForm } = this.state;
+    const { loading, showStreamRuleForm, showEntityShareModal } = this.state;
 
     const isDefaultStream = stream.is_default;
     const defaultStreamTooltip = isDefaultStream
@@ -217,6 +228,7 @@ class Stream extends React.Component {
                         onDelete={this._onDelete}
                         onUpdate={this._onUpdate}
                         onClone={this._onClone}
+                        onShare={this._openEntityShareModal}
                         onQuickAdd={this._openStreamRuleForm}
                         indexSets={indexSets}
                         isDefaultStream={isDefaultStream} />
@@ -260,6 +272,13 @@ class Stream extends React.Component {
                           onSubmit={this._onSaveStreamRule}
                           streamRuleTypes={streamRuleTypes} />
         ) }
+        { showEntityShareModal && (
+          <EntityShareModal entityId={stream.id}
+                            entityType="stream"
+                            entityTitle={stream.title}
+                            description="Search for a User or Team to add as collaborator on this stream."
+                            onClose={this._closeEntityShareModal} />
+        )}
       </StreamListItem>
     );
   }

--- a/graylog2-web-interface/src/components/streams/StreamControls.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamControls.jsx
@@ -20,6 +20,7 @@ const StreamControls = createReactClass({
     indexSets: PropTypes.array.isRequired,
     onDelete: PropTypes.func.isRequired,
     onClone: PropTypes.func.isRequired,
+    onShare: PropTypes.func.isRequired,
     onQuickAdd: PropTypes.func.isRequired,
     onUpdate: PropTypes.func.isRequired,
     isDefaultStream: PropTypes.bool,
@@ -77,6 +78,9 @@ const StreamControls = createReactClass({
           </IfPermitted>
           <MenuItem key={`setAsStartpage-${stream.id}`} onSelect={this._setStartpage} disabled={this.props.user.read_only}>
             Set as startpage
+          </MenuItem>
+          <MenuItem key={`share-${stream.id}`} onSelect={this.props.onShare}>
+            Share
           </MenuItem>
           <IfPermitted permissions={`streams:edit:${stream.id}`}>
             <MenuItem key={`divider-${stream.id}`} divider />


### PR DESCRIPTION
Prior to this change, the EntityShareModal was missing for streams.

This change will add the EntityShareModal for streams.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1569