### PR TITLE
Reorder Header Badge in Navigation

### DIFF
--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -120,14 +120,14 @@ const Navigation = ({ location }) => {
         <NotificationBadge />
 
         <Nav navbar pullRight className="header-meta-nav">
+          <LinkContainer to={Routes.SYSTEM.NODES.LIST}>
+            <GlobalThroughput />
+          </LinkContainer>
           <InactiveNavItem className="dev-badge-wrap">
             <DevelopmentHeaderBadge />
             {pluginItems.map(({ key, component: Item }) => <Item key={key} />)}
           </InactiveNavItem>
 
-          <LinkContainer to={Routes.SYSTEM.NODES.LIST}>
-            <GlobalThroughput />
-          </LinkContainer>
           <ScratchpadToggle />
           <HelpMenu active={_isActive(location.pathname, Routes.GETTING_STARTED)} />
           <UserMenu fullName={fullName} loginName={username} />


### PR DESCRIPTION
## Motivation
Prior to this change, the newly add enterprise header badge was moving around with
the Global Throughput indicator. When the indicator was big it was moved
to the left and vice versa.

## Description
This change will move the header badge after the Global Throughput.

## Screenshot
![Graylog - Customization](https://user-images.githubusercontent.com/448763/89769754-004fce80-dafe-11ea-9bb1-0dd70c10030c.png)


