### PR TITLE
Revert "Construct jest client provider lazily instead of eager. (#8703)"

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Module.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Module.java
@@ -40,7 +40,7 @@ public class Elasticsearch6Module extends VersionAwareModule {
 
         install(new FactoryModuleBuilder().build(ScrollResultES6.Factory.class));
 
-        bind(JestClient.class).toProvider(JestClientProvider.class);
+        bind(JestClient.class).toProvider(JestClientProvider.class).asEagerSingleton();
     }
 
     private <T> LinkedBindingBuilder<T> bindForSupportedVersion(Class<T> interfaceClass) {


### PR DESCRIPTION
## Description
This reverts commit 557010d3448059261b9caee321a119268ff2f3ad from PR #8703.

Lazy instantiation means that an instance is created every time the class is injected, which is not what we want.

Thanks to @mpfz0r for finding this!

## Motivation and Context
While the reverted PR successfully avoided initializing a `JestClient` and the associated node discovery when it's not needed, because ES 7 is used, it led to the new problem described above. 
To avoid it we should instead manage an instance in `JestClientProvider` the same way we do in `RestHighLevelClientProvider`.
https://github.com/Graylog2/graylog2-server/blob/0c48877a9abff31246605c429320770a684bff7c/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/RestHighLevelClientProvider.java#L27

## How Has This Been Tested?
Debugged in local dev environment using ES 6.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

