### PR TITLE
Make the admin owner of every entity

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/permissions/GRNPermission.java
+++ b/graylog2-server/src/main/java/org/graylog/security/permissions/GRNPermission.java
@@ -19,7 +19,6 @@ package org.graylog.security.permissions;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.auto.value.AutoValue;
 import org.apache.shiro.authz.Permission;
-import org.apache.shiro.authz.permission.WildcardPermission;
 import org.graylog.grn.GRN;
 
 @AutoValue
@@ -34,13 +33,6 @@ public abstract class GRNPermission implements Permission {
 
     @Override
     public boolean implies(Permission p) {
-        // The admin permission also implies access to every GRNPermission
-        if ((p instanceof WildcardPermission)) {
-            if (((WildcardPermission)p).equals(new WildcardPermission("*"))) {
-                return true;
-            }
-        }
-
         // GRNPermissions only supports comparisons with other GRNPermissions
         if (!(p instanceof GRNPermission)) {
             return false;

--- a/graylog2-server/src/main/java/org/graylog/security/permissions/GRNPermission.java
+++ b/graylog2-server/src/main/java/org/graylog/security/permissions/GRNPermission.java
@@ -19,6 +19,7 @@ package org.graylog.security.permissions;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.auto.value.AutoValue;
 import org.apache.shiro.authz.Permission;
+import org.apache.shiro.authz.permission.WildcardPermission;
 import org.graylog.grn.GRN;
 
 @AutoValue
@@ -33,7 +34,14 @@ public abstract class GRNPermission implements Permission {
 
     @Override
     public boolean implies(Permission p) {
-        // By default only supports comparisons with other GRNPermission
+        // The admin permission also implies access to every GRNPermission
+        if ((p instanceof WildcardPermission)) {
+            if (((WildcardPermission)p).equals(new WildcardPermission("*"))) {
+                return true;
+            }
+        }
+
+        // GRNPermissions only supports comparisons with other GRNPermissions
         if (!(p instanceof GRNPermission)) {
             return false;
         }

--- a/graylog2-server/src/main/java/org/graylog/security/rest/RestResourceWithOwnerCheck.java
+++ b/graylog2-server/src/main/java/org/graylog/security/rest/RestResourceWithOwnerCheck.java
@@ -32,9 +32,9 @@ public abstract class RestResourceWithOwnerCheck extends RestResource implements
 
     protected void checkOwnership(GRN entity) {
         if (!isOwner(entity)) {
-            LOG.info("Not authorized to access resource <{}>. User <{}> is missing permission <{}:{}>",
+            LOG.info("Not authorized to access entity <{}>. User <{}> is missing permission <{}:{}>",
                     entity, getSubject().getPrincipal(), RestPermissions.ENTITY_OWN, entity);
-            throw new ForbiddenException("Not authorized to access resource <" + entity + ">");
+            throw new ForbiddenException("Not authorized to access entity <" + entity + ">");
         }
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/plugin/database/users/User.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/database/users/User.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.plugin.database.users;
 
+import org.apache.shiro.authz.Permission;
 import org.graylog2.plugin.database.Persisted;
 import org.graylog2.rest.models.users.requests.Startpage;
 import org.joda.time.DateTimeZone;
@@ -45,6 +46,8 @@ public interface User extends Persisted {
     String getEmail();
 
     List<String> getPermissions();
+
+    Set<Permission> getObjectPermissions();
 
     Map<String, Object> getPreferences();
 

--- a/graylog2-server/src/main/java/org/graylog2/security/realm/MongoDbAuthorizationRealm.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/realm/MongoDbAuthorizationRealm.java
@@ -17,13 +17,13 @@
 package org.graylog2.security.realm;
 
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Sets;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.authz.AuthorizationInfo;
+import org.apache.shiro.authz.Permission;
 import org.apache.shiro.authz.SimpleAuthorizationInfo;
 import org.apache.shiro.realm.AuthorizingRealm;
 import org.apache.shiro.subject.PrincipalCollection;
@@ -35,7 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.util.List;
+import java.util.Set;
 
 public class MongoDbAuthorizationRealm extends AuthorizingRealm {
 
@@ -68,11 +68,9 @@ public class MongoDbAuthorizationRealm extends AuthorizingRealm {
             return new SimpleAuthorizationInfo();
         } else {
             final SimpleAuthorizationInfo info = new UserAuthorizationInfo(user);
-            final List<String> permissions = user.getPermissions();
 
-            if (permissions != null) {
-                info.setStringPermissions(Sets.newHashSet(permissions));
-            }
+            final Set<Permission> permissions = user.getObjectPermissions();
+            info.setObjectPermissions(permissions);
             info.setRoles(user.getRoleIds());
 
             LOG.debug("User {} has permissions: {}", principals, permissions);

--- a/graylog2-server/src/main/java/org/graylog2/users/UserImpl.java
+++ b/graylog2-server/src/main/java/org/graylog2/users/UserImpl.java
@@ -22,6 +22,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.AssistedInject;
+import org.apache.shiro.authz.Permission;
+import org.apache.shiro.authz.permission.AllPermission;
+import org.apache.shiro.authz.permission.WildcardPermission;
 import org.bson.types.ObjectId;
 import org.graylog2.Configuration;
 import org.graylog2.database.CollectionName;
@@ -51,6 +54,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Strings.nullToEmpty;
@@ -172,6 +176,18 @@ public class UserImpl extends PersistedImpl implements User {
             permissionSet.addAll(permissions);
         }
         return new ArrayList<>(permissionSet);
+    }
+
+    @Override
+    public Set<Permission> getObjectPermissions() {
+        return getPermissions().stream().map(p -> {
+            if (p.equals("*")) {
+                return new AllPermission();
+            } else {
+                return new WildcardPermission(p);
+            }
+
+        }).collect(Collectors.toSet());
     }
 
     @Override
@@ -376,6 +392,11 @@ public class UserImpl extends PersistedImpl implements User {
         @Override
         public List<String> getPermissions() {
             return Collections.singletonList("*");
+        }
+
+        @Override
+        public Set<Permission> getObjectPermissions() {
+            return Collections.singleton(new AllPermission());
         }
 
         @Override


### PR DESCRIPTION
Convert WildcardPermission("*") to AllPermission 

WildcardPermissions are not comparable with other types of permissions.
In case of the admin permission "*" we want it to imply also
a GRNPermission, which is used for handling entity ownership.

Having the AllPermission allows a User to "own" every entity
inside Graylog.

Improve error message

Fixes #8727 

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1569