### PR TITLE
Fix race conditions on system/configuration

### DIFF
--- a/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
+++ b/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
@@ -29,11 +29,13 @@ const EVENTS_CONFIG = 'org.graylog.events.configuration.EventsConfiguration';
 const URL_WHITELIST_CONFIG = 'org.graylog2.system.urlwhitelist.UrlWhitelist';
 
 class ConfigurationsPage extends React.Component {
-  state = {
-    loaded: false,
-  }
-
   checkLoadedTimer = undefined
+
+  constructor() {
+    super();
+
+    this.state = { loaded: false };
+  }
 
   componentDidMount() {
     style.use();

--- a/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
+++ b/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
@@ -31,8 +31,8 @@ const URL_WHITELIST_CONFIG = 'org.graylog2.system.urlwhitelist.UrlWhitelist';
 class ConfigurationsPage extends React.Component {
   checkLoadedTimer = undefined
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = { loaded: false };
   }

--- a/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
+++ b/graylog2-web-interface/src/pages/ConfigurationsPage.jsx
@@ -156,23 +156,31 @@ class ConfigurationsPage extends React.Component {
 
       Output = (
         <>
+          {searchesConfig && (
           <Col md={6}>
             <SearchesConfig config={searchesConfig}
                             updateConfig={this._onUpdate(SEARCHES_CLUSTER_CONFIG)} />
           </Col>
+          )}
+          {messageProcessorsConfig && (
           <Col md={6}>
             <MessageProcessorsConfig config={messageProcessorsConfig}
                                      updateConfig={this._onUpdate(MESSAGE_PROCESSORS_CONFIG)} />
           </Col>
+          )}
+          {sidecarConfig && (
           <Col md={6}>
             <SidecarConfig config={sidecarConfig}
                            updateConfig={this._onUpdate(SIDECAR_CONFIG)} />
           </Col>
+          )}
+          {eventsConfig && (
           <Col md={6}>
             <EventsConfig config={eventsConfig}
                           updateConfig={this._onUpdate(EVENTS_CONFIG)} />
           </Col>
-          {isPermitted(permissions, ['urlwhitelist:read']) && (
+          )}
+          {isPermitted(permissions, ['urlwhitelist:read']) && urlWhiteListConfig && (
           <Col md={6}>
             <UrlWhiteListConfig config={urlWhiteListConfig}
                                 updateConfig={this._onUpdate(URL_WHITELIST_CONFIG)} />


### PR DESCRIPTION
Will prevent problem occurring in #8392

The `state.loaded` only checks _if_ there is some config available, not which.

This patch will allow each configuration block to load individually as data comes in.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

