### PR TITLE
Unify sidebar field list line-height with default line-height

### DIFF
--- a/graylog2-web-interface/src/views/components/sidebar/fields/List.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/fields/List.jsx
@@ -63,7 +63,7 @@ const List = ({ viewMetadata: { activeQuery }, filter, activeQueryFields, allFie
       {({ size: { height } }) => (
         <FixedSizeList height={height || DEFAULT_HEIGHT_PX}
                        itemCount={fieldList.size}
-                       itemSize={17}>
+                       itemSize={20}>
           {Row}
         </FixedSizeList>
       )}


### PR DESCRIPTION
This PR unifies the sidebar field list line-height with our default line-height. Once the line-height is part of our theme, we can use it probably for this case as well.