### PR TITLE
Implement HasOwnership which checks for sharing

### DIFF
--- a/graylog2-web-interface/src/components/common/HasOwnership.jsx
+++ b/graylog2-web-interface/src/components/common/HasOwnership.jsx
@@ -46,7 +46,7 @@ HasOwnership.propTypes = {
     PropTypes.func,
   ]).isRequired,
   /** The id string which shows entity */
-  id: PropTypes.string.isRequired,
+  id: PropTypes.string,
   /** The type of the entity e.g dashboard, stream */
   type: PropTypes.string.isRequired,
   /** Will add disabled=true as a prop to the child in stead of not rendering it */
@@ -55,6 +55,7 @@ HasOwnership.propTypes = {
 
 HasOwnership.defaultProps = {
   hideChildren: false,
+  id: undefined,
 };
 
 export default HasOwnership;

--- a/graylog2-web-interface/src/components/common/HasOwnership.jsx
+++ b/graylog2-web-interface/src/components/common/HasOwnership.jsx
@@ -31,7 +31,7 @@ const HasOwnership = ({ children, id, type }: Props) => {
 };
 
 HasOwnership.propTypes = {
-  /**  Children to render if user has entity of entity */
+  /** Children to render if user has ownership of the entity */
   children: PropTypes.node,
   /** The id string which shows entity */
   id: PropTypes.string,

--- a/graylog2-web-interface/src/components/common/HasOwnership.jsx
+++ b/graylog2-web-interface/src/components/common/HasOwnership.jsx
@@ -1,0 +1,42 @@
+// @flow strict
+import * as React from 'react';
+import { useContext } from 'react';
+import PropTypes from 'prop-types';
+
+import CurrentUserContext from 'contexts/CurrentUserContext';
+import { createGRN } from 'logic/permissions/GRN';
+
+type Props = {
+  children: React.Node,
+  id: string,
+  type: string,
+};
+
+const HasOwnership = ({ children, id, type }: Props) => {
+  const currentUser = useContext(CurrentUserContext);
+  const entity = createGRN(id, type);
+  const ownership = `entity:own:${entity}`;
+  const adminPermission = '*';
+
+  if (currentUser) {
+    const { grn_permissions: grnPermissions = [], permissions } = currentUser;
+    const isAdmin = permissions.includes(adminPermission);
+
+    if (grnPermissions.includes(ownership) || isAdmin) {
+      return children;
+    }
+  }
+
+  return null;
+};
+
+HasOwnership.propTypes = {
+  /**  Children to render if user has entity of entity */
+  children: PropTypes.node,
+  /** The id string which shows entity */
+  id: PropTypes.string,
+  /** The type of the entity e.g dashboard, stream */
+  type: PropTypes.string,
+};
+
+export default HasOwnership;

--- a/graylog2-web-interface/src/components/common/HasOwnership.jsx
+++ b/graylog2-web-interface/src/components/common/HasOwnership.jsx
@@ -10,10 +10,10 @@ type Props = {
   children: React.Node | ({ disabled: boolean }) => React.Node,
   id: string,
   type: string,
-  disableChildren: boolean,
+  hideChildren: boolean,
 };
 
-const HasOwnership = ({ children, id, type, disableChildren }: Props) => {
+const HasOwnership = ({ children, id, type, hideChildren }: Props) => {
   const currentUser = useContext(CurrentUserContext);
   const entity = createGRN(id, type);
   const ownership = `entity:own:${entity}`;
@@ -24,7 +24,7 @@ const HasOwnership = ({ children, id, type, disableChildren }: Props) => {
     const isAdmin = permissions.includes(adminPermission);
 
     if (grnPermissions.includes(ownership) || isAdmin) {
-      if (disableChildren && typeof children === 'function') {
+      if (!hideChildren && typeof children === 'function') {
         return <>{ children({ disabled: false }) } </>;
       }
 
@@ -32,7 +32,7 @@ const HasOwnership = ({ children, id, type, disableChildren }: Props) => {
     }
   }
 
-  if (disableChildren && typeof children === 'function') {
+  if (!hideChildren && typeof children === 'function') {
     return <>{ children({ disabled: true }) } </>;
   }
 
@@ -50,11 +50,11 @@ HasOwnership.propTypes = {
   /** The type of the entity e.g dashboard, stream */
   type: PropTypes.string.isRequired,
   /** Will add disabled=true as a prop to the child in stead of not rendering it */
-  disableChildren: PropTypes.bool,
+  hideChildren: PropTypes.bool,
 };
 
 HasOwnership.defaultProps = {
-  disableChildren: false,
+  hideChildren: false,
 };
 
 export default HasOwnership;

--- a/graylog2-web-interface/src/components/common/HasOwnership.jsx
+++ b/graylog2-web-interface/src/components/common/HasOwnership.jsx
@@ -28,7 +28,7 @@ const HasOwnership = ({ children, id, type, hideChildren }: Props) => {
         return <>{ children({ disabled: false }) } </>;
       }
 
-      return children;
+      return <>children</>;
     }
   }
 

--- a/graylog2-web-interface/src/components/common/HasOwnership.test.jsx
+++ b/graylog2-web-interface/src/components/common/HasOwnership.test.jsx
@@ -1,0 +1,116 @@
+// @flow strict
+import * as React from 'react';
+import { render } from 'wrappedTestingLibrary';
+import { viewsManager } from 'fixtures/users';
+
+import CurrentUserContext from 'contexts/CurrentUserContext';
+import { createGRN } from 'logic/permissions/GRN';
+
+import HasOwnership from './HasOwnership';
+
+type Props = {
+  children: React.Node,
+  currentUser: {
+    grn_permissions: string[],
+    permissions: string[],
+  },
+  id: string,
+  type: string,
+};
+
+describe('HasOwnership', () => {
+  const SimpleHasOwnership = ({ children, currentUser, ...props }: Props) => (
+    <CurrentUserContext.Provider value={{ ...viewsManager, ...currentUser }}>
+      <HasOwnership {...props}>
+        {children}
+      </HasOwnership>
+    </CurrentUserContext.Provider>
+  );
+
+  const type = 'stream';
+  const id = '000000000001';
+  const grn = createGRN(id, type);
+  const grnPermission = `entity:own:${grn}`;
+
+  const otherType = 'dashboard';
+  const otherId = 'beef000011';
+  const otherGrn = createGRN(otherId, otherType);
+  const otherGrnPermission = `entity:own:${otherGrn}`;
+
+  it('should render children if user has ownership', () => {
+    const user = { grn_permissions: [grnPermission], permissions: [] };
+    const { getByText: queryByText } = render(
+      <SimpleHasOwnership currentUser={user} id={id} type={type}>
+        <span>Lovecraft</span>
+      </SimpleHasOwnership>,
+    );
+
+    expect(queryByText('Lovecraft')).toBeTruthy();
+  });
+
+  it('should not render children if user has empty ownership and is not admin', () => {
+    const user = { grn_permissions: [], permissions: [] };
+    const { queryByText } = render(
+      <SimpleHasOwnership currentUser={user} id={id} type={type}>
+        <span>Lovecraft</span>
+      </SimpleHasOwnership>,
+    );
+
+    expect(queryByText('Lovecraft')).toBeFalsy();
+  });
+
+  it('should not render children if user has wrong ownership and is not admin', () => {
+    const user = { grn_permissions: [otherGrnPermission], permissions: [] };
+    const { queryByText } = render(
+      <SimpleHasOwnership currentUser={user} id={id} type={type}>
+        <span>Lovecraft</span>
+      </SimpleHasOwnership>,
+    );
+
+    expect(queryByText('Lovecraft')).toBeFalsy();
+  });
+
+  it('should not render children if user has wrong ownership and is reader', () => {
+    const user = { grn_permissions: [otherGrnPermission], permissions: [`streams:read:${id}`] };
+    const { queryByText } = render(
+      <SimpleHasOwnership currentUser={user} id={id} type={type}>
+        <span>Lovecraft</span>
+      </SimpleHasOwnership>,
+    );
+
+    expect(queryByText('Lovecraft')).toBeFalsy();
+  });
+
+  it('should not render children if user has no ownership and is reader', () => {
+    const user = { grn_permissions: [], permissions: [`streams:read:${id}`] };
+    const { queryByText } = render(
+      <SimpleHasOwnership currentUser={user} id={id} type={type}>
+        <span>Lovecraft</span>
+      </SimpleHasOwnership>,
+    );
+
+    expect(queryByText('Lovecraft')).toBeFalsy();
+  });
+
+  it('should render children if user has empty ownership and is admin', () => {
+    const user = { grn_permissions: [], permissions: ['*'] };
+    const { queryByText } = render(
+      <SimpleHasOwnership currentUser={user} id={id} type={type}>
+        <span>Lovecraft</span>
+      </SimpleHasOwnership>,
+    );
+
+    expect(queryByText('Lovecraft')).toBeTruthy();
+  });
+
+  it('should render children if user has wrong ownership and is admin', () => {
+    const user = { grn_permissions: [otherGrnPermission], permissions: ['*'] };
+    const { queryByText } = render(
+      <SimpleHasOwnership currentUser={user} id={id} type={type}>
+        <span>Lovecraft</span>
+      </SimpleHasOwnership>,
+    );
+
+    expect(queryByText('Lovecraft')).toBeTruthy();
+  });
+});

--- a/graylog2-web-interface/src/components/common/HasOwnership.test.jsx
+++ b/graylog2-web-interface/src/components/common/HasOwnership.test.jsx
@@ -9,7 +9,6 @@ import { createGRN } from 'logic/permissions/GRN';
 import HasOwnership from './HasOwnership';
 
 type Props = {
-  children: React.Node | { disabled: boolean } => React.Node,
   currentUser: {|
     grn_permissions: string[],
     permissions: string[],
@@ -19,20 +18,22 @@ type Props = {
 };
 
 describe('HasOwnership', () => {
-  const SimpleHasOwnership = ({ children, currentUser, ...props }: Props) => (
-    <CurrentUserContext.Provider value={{ ...viewsManager, ...currentUser }}>
-      <HasOwnership {...props}>
-        {children}
-      </HasOwnership>
-    </CurrentUserContext.Provider>
-  );
-
   // eslint-disable-next-line react/prop-types
   const DisabledComponent = ({ disabled }: { disabled: boolean}) => {
     return disabled
       ? <span>disabled</span>
       : <span>enabled</span>;
   };
+
+  const SimpleHasOwnership = ({ currentUser, ...props }: Props) => (
+    <CurrentUserContext.Provider value={{ ...viewsManager, ...currentUser }}>
+      <HasOwnership {...props}>
+        {({ disabled }) => (
+          <DisabledComponent disabled={disabled} />
+        )}
+      </HasOwnership>
+    </CurrentUserContext.Provider>
+  );
 
   const type = 'stream';
   const id = '000000000001';
@@ -44,93 +45,76 @@ describe('HasOwnership', () => {
   const otherGrn = createGRN(otherId, otherType);
   const otherGrnPermission = `entity:own:${otherGrn}`;
 
-  it('should render children if user has ownership', () => {
+  it('should render children enabled if user has ownership', () => {
     const user = { grn_permissions: [grnPermission], permissions: [] };
     const { getByText: queryByText } = render(
-      <SimpleHasOwnership currentUser={user} id={id} type={type}>
-        <span>Lovecraft</span>
-      </SimpleHasOwnership>,
+      <SimpleHasOwnership currentUser={user} id={id} type={type} />,
     );
 
-    expect(queryByText('Lovecraft')).toBeTruthy();
+    expect(queryByText('enabled')).toBeTruthy();
   });
 
-  it('should not render children if user has empty ownership and is not admin', () => {
+  it('should render children disabled if user has empty ownership and is not admin', () => {
     const user = { grn_permissions: [], permissions: [] };
     const { queryByText } = render(
-      <SimpleHasOwnership currentUser={user} id={id} type={type}>
-        <span>Lovecraft</span>
-      </SimpleHasOwnership>,
-    );
-
-    expect(queryByText('Lovecraft')).toBeFalsy();
-  });
-
-  it('should not render children if user has wrong ownership and is not admin', () => {
-    const user = { grn_permissions: [otherGrnPermission], permissions: [] };
-    const { queryByText } = render(
-      <SimpleHasOwnership currentUser={user} id={id} type={type}>
-        <span>Lovecraft</span>
-      </SimpleHasOwnership>,
-    );
-
-    expect(queryByText('Lovecraft')).toBeFalsy();
-  });
-
-  it('should not render children if user has wrong ownership and is reader', () => {
-    const user = { grn_permissions: [otherGrnPermission], permissions: [`streams:read:${id}`] };
-    const { queryByText } = render(
-      <SimpleHasOwnership currentUser={user} id={id} type={type}>
-        <span>Lovecraft</span>
-      </SimpleHasOwnership>,
-    );
-
-    expect(queryByText('Lovecraft')).toBeFalsy();
-  });
-
-  it('should not render children if user has no ownership and is reader', () => {
-    const user = { grn_permissions: [], permissions: [`streams:read:${id}`] };
-    const { queryByText } = render(
-      <SimpleHasOwnership currentUser={user} id={id} type={type}>
-        <span>Lovecraft</span>
-      </SimpleHasOwnership>,
-    );
-
-    expect(queryByText('Lovecraft')).toBeFalsy();
-  });
-
-  it('should render children if user has empty ownership and is admin', () => {
-    const user = { grn_permissions: [], permissions: ['*'] };
-    const { queryByText } = render(
-      <SimpleHasOwnership currentUser={user} id={id} type={type}>
-        <span>Lovecraft</span>
-      </SimpleHasOwnership>,
-    );
-
-    expect(queryByText('Lovecraft')).toBeTruthy();
-  });
-
-  it('should render children if user has wrong ownership and is admin', () => {
-    const user = { grn_permissions: [otherGrnPermission], permissions: ['*'] };
-    const { queryByText } = render(
-      <SimpleHasOwnership currentUser={user} id={id} type={type}>
-        <span>Lovecraft</span>
-      </SimpleHasOwnership>,
-    );
-
-    expect(queryByText('Lovecraft')).toBeTruthy();
-  });
-
-  it('should disable children when configured', () => {
-    const user = { grn_permissions: [otherGrnPermission], permissions: [] };
-    const { queryByText } = render(
-      <SimpleHasOwnership currentUser={user} id={id} type={type} disableChildren>
-        {({ disabled }) => (
-          <DisabledComponent disabled={disabled} />
-        )}
-      </SimpleHasOwnership>,
+      <SimpleHasOwnership currentUser={user} id={id} type={type} />,
     );
 
     expect(queryByText('disabled')).toBeTruthy();
+  });
+
+  it('should render children disabled if user has wrong ownership and is not admin', () => {
+    const user = { grn_permissions: [otherGrnPermission], permissions: [] };
+    const { queryByText } = render(
+      <SimpleHasOwnership currentUser={user} id={id} type={type} />,
+    );
+
+    expect(queryByText('disabled')).toBeTruthy();
+  });
+
+  it('should render children disabled if user has wrong ownership and is reader', () => {
+    const user = { grn_permissions: [otherGrnPermission], permissions: [`streams:read:${id}`] };
+    const { queryByText } = render(
+      <SimpleHasOwnership currentUser={user} id={id} type={type} />,
+    );
+
+    expect(queryByText('disabled')).toBeTruthy();
+  });
+
+  it('should render children disabled if user has no ownership and is reader', () => {
+    const user = { grn_permissions: [], permissions: [`streams:read:${id}`] };
+    const { queryByText } = render(
+      <SimpleHasOwnership currentUser={user} id={id} type={type} />,
+    );
+
+    expect(queryByText('disabled')).toBeTruthy();
+  });
+
+  it('should render children enabled if user has empty ownership and is admin', () => {
+    const user = { grn_permissions: [], permissions: ['*'] };
+    const { queryByText } = render(
+      <SimpleHasOwnership currentUser={user} id={id} type={type} />,
+    );
+
+    expect(queryByText('enabled')).toBeTruthy();
+  });
+
+  it('should render children enabled if user has wrong ownership and is admin', () => {
+    const user = { grn_permissions: [otherGrnPermission], permissions: ['*'] };
+    const { queryByText } = render(
+      <SimpleHasOwnership currentUser={user} id={id} type={type} />,
+    );
+
+    expect(queryByText('enabled')).toBeTruthy();
+  });
+
+  it('should hide children when configured', () => {
+    const user = { grn_permissions: [otherGrnPermission], permissions: [] };
+    const { queryByText } = render(
+      <SimpleHasOwnership currentUser={user} id={id} type={type} hideChildren />,
+    );
+
+    expect(queryByText('disabled')).toBeFalsy();
+    expect(queryByText('enabled')).toBeFalsy();
   });
 });

--- a/graylog2-web-interface/src/components/common/HasOwnership.test.jsx
+++ b/graylog2-web-interface/src/components/common/HasOwnership.test.jsx
@@ -9,7 +9,7 @@ import { createGRN } from 'logic/permissions/GRN';
 import HasOwnership from './HasOwnership';
 
 type Props = {
-  children: React.Node,
+  children: React.Node | { disabled: boolean } => React.Node,
   currentUser: {|
     grn_permissions: string[],
     permissions: string[],
@@ -26,6 +26,13 @@ describe('HasOwnership', () => {
       </HasOwnership>
     </CurrentUserContext.Provider>
   );
+
+  // eslint-disable-next-line react/prop-types
+  const DisabledComponent = ({ disabled }: { disabled: boolean}) => {
+    return disabled
+      ? <span>disabled</span>
+      : <span>enabled</span>;
+  };
 
   const type = 'stream';
   const id = '000000000001';
@@ -112,5 +119,18 @@ describe('HasOwnership', () => {
     );
 
     expect(queryByText('Lovecraft')).toBeTruthy();
+  });
+
+  it('should disable children when configured', () => {
+    const user = { grn_permissions: [otherGrnPermission], permissions: [] };
+    const { queryByText } = render(
+      <SimpleHasOwnership currentUser={user} id={id} type={type} disableChildren>
+        {({ disabled }) => (
+          <DisabledComponent disabled={disabled} />
+        )}
+      </SimpleHasOwnership>,
+    );
+
+    expect(queryByText('disabled')).toBeTruthy();
   });
 });

--- a/graylog2-web-interface/src/components/common/HasOwnership.test.jsx
+++ b/graylog2-web-interface/src/components/common/HasOwnership.test.jsx
@@ -10,10 +10,10 @@ import HasOwnership from './HasOwnership';
 
 type Props = {
   children: React.Node,
-  currentUser: {
+  currentUser: {|
     grn_permissions: string[],
     permissions: string[],
-  },
+  |},
   id: string,
   type: string,
 };

--- a/graylog2-web-interface/src/components/common/index.jsx
+++ b/graylog2-web-interface/src/components/common/index.jsx
@@ -19,6 +19,7 @@ export { default as ExpandableList } from './ExpandableList';
 export { default as ExpandableListItem } from './ExpandableListItem';
 export { default as ExternalLink } from './ExternalLink';
 export { default as ExternalLinkButton } from './ExternalLinkButton';
+export { default as HasOwnership } from './HasOwnership';
 export { default as Icon } from './Icon';
 export { default as IconButton } from './IconButton';
 export { default as IfPermitted } from './IfPermitted';

--- a/graylog2-web-interface/src/components/streams/StreamControls.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamControls.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 
 import { DropdownButton, MenuItem } from 'components/graylog';
-import { IfPermitted } from 'components/common';
+import { IfPermitted, HasOwnership } from 'components/common';
 import PermissionsMixin from 'util/PermissionsMixin';
 import StoreProvider from 'injection/StoreProvider';
 
@@ -84,9 +84,12 @@ const StreamControls = createReactClass({
           <MenuItem key={`setAsStartpage-${stream.id}`} onSelect={this._setStartpage} disabled={user.read_only}>
             Set as startpage
           </MenuItem>
-          <MenuItem key={`share-${stream.id}`} onSelect={onShare}>
-            Share
-          </MenuItem>
+
+          <HasOwnership id={stream.id} type="stream">
+            <MenuItem key={`share-${stream.id}`} onSelect={onShare}>
+              Share
+            </MenuItem>
+          </HasOwnership>
           <IfPermitted permissions={`streams:edit:${stream.id}`}>
             <MenuItem key={`divider-${stream.id}`} divider />
           </IfPermitted>

--- a/graylog2-web-interface/src/components/streams/StreamControls.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamControls.jsx
@@ -86,9 +86,11 @@ const StreamControls = createReactClass({
           </MenuItem>
 
           <HasOwnership id={stream.id} type="stream">
-            <MenuItem key={`share-${stream.id}`} onSelect={onShare}>
-              Share
-            </MenuItem>
+            {({ disabled }) => (
+              <MenuItem key={`share-${stream.id}`} onSelect={onShare} disabled={disabled}>
+                Share
+              </MenuItem>
+            )}
           </HasOwnership>
           <IfPermitted permissions={`streams:edit:${stream.id}`}>
             <MenuItem key={`divider-${stream.id}`} divider />

--- a/graylog2-web-interface/src/logic/users/User.js
+++ b/graylog2-web-interface/src/logic/users/User.js
@@ -14,6 +14,7 @@ export type UserJSON = {
   id: string,
   last_activity: ?string,
   permissions: string[],
+  grn_permissions?: string[],
   preferences?: any,
   read_only: boolean,
   roles: string[],

--- a/graylog2-web-interface/src/views/components/SearchBar.test.jsx
+++ b/graylog2-web-interface/src/views/components/SearchBar.test.jsx
@@ -25,6 +25,7 @@ jest.mock('stores/streams/StreamsStore', () => MockStore(
 ));
 
 jest.mock('views/components/searchbar/QueryInput', () => 'query-input');
+jest.mock('views/components/searchbar/saved-search/SavedSearchControls', () => 'saved-search-controls');
 
 jest.mock('views/stores/CurrentQueryStore', () => ({
   CurrentQueryStore: MockStore(['getInitialState', () => MockQuery.builder()

--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
@@ -68,9 +68,11 @@ const ViewActionsMenu = ({ view, isNewView, metadata, router }) => {
           <Icon name="edit" /> Edit metadata
         </MenuItem>
         <HasOwnership id={view.id} type="dashboard">
-          <MenuItem onSelect={() => setShareViewOpen(true)} disabled={isNewView || !allowedToEdit}>
-            <Icon name="share-alt" /> Share
-          </MenuItem>
+          {({ disabled }) => (
+            <MenuItem onSelect={() => setShareViewOpen(true)} disabled={isNewView || !allowedToEdit || disabled}>
+              <Icon name="share-alt" /> Share
+            </MenuItem>
+          )}
         </HasOwnership>
         <MenuItem onSelect={() => setCsvExportOpen(true)}><Icon name="cloud-download-alt" /> Export to CSV</MenuItem>
         {debugOverlay}

--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
@@ -8,7 +8,7 @@ import connect from 'stores/connect';
 import { isPermitted } from 'util/PermissionsMixin';
 import AppConfig from 'util/AppConfig';
 import { DropdownButton, MenuItem, Button, ButtonGroup } from 'components/graylog';
-import { Icon } from 'components/common';
+import { Icon, HasOwnership } from 'components/common';
 import CSVExportModal from 'views/components/searchbar/csvexport/CSVExportModal';
 import DebugOverlay from 'views/components/DebugOverlay';
 import onSaveView from 'views/logic/views/OnSaveViewAction';
@@ -67,9 +67,11 @@ const ViewActionsMenu = ({ view, isNewView, metadata, router }) => {
         <MenuItem onSelect={() => setEditViewOpen(true)} disabled={isNewView || !allowedToEdit}>
           <Icon name="edit" /> Edit metadata
         </MenuItem>
-        <MenuItem onSelect={() => setShareViewOpen(true)} disabled={isNewView || !allowedToEdit}>
-          <Icon name="share-alt" /> Share
-        </MenuItem>
+        <HasOwnership id={view.id} type="dashboard">
+          <MenuItem onSelect={() => setShareViewOpen(true)} disabled={isNewView || !allowedToEdit}>
+            <Icon name="share-alt" /> Share
+          </MenuItem>
+        </HasOwnership>
         <MenuItem onSelect={() => setCsvExportOpen(true)}><Icon name="cloud-download-alt" /> Export to CSV</MenuItem>
         {debugOverlay}
         <IfDashboard>

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.jsx
@@ -265,9 +265,11 @@ class SavedSearchControls extends React.Component<Props, State> {
                       </MenuItem>
                       <MenuItem divider />
                       <HasOwnership id={view.id} type="search">
-                        <MenuItem onSelect={this.toggleShareSearch} title="Share search" disabled={!isAllowedToEdit}>
-                          <Icon name="share-alt" /> Share
-                        </MenuItem>
+                        {({ disabled }) => (
+                          <MenuItem onSelect={this.toggleShareSearch} title="Share search" disabled={!isAllowedToEdit || disabled}>
+                            <Icon name="share-alt" /> Share
+                          </MenuItem>
+                        )}
                       </HasOwnership>
                     </DropdownButton>
                     {showCSVExport && (

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.jsx
@@ -10,7 +10,7 @@ import Routes from 'routing/Routes';
 import { isPermitted } from 'util/PermissionsMixin';
 import { newDashboardsPath } from 'views/Constants';
 import { Button, ButtonGroup, DropdownButton, MenuItem } from 'components/graylog';
-import { Icon } from 'components/common';
+import { Icon, HasOwnership } from 'components/common';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import UserNotification from 'util/UserNotification';
 import { ViewStore, ViewActions } from 'views/stores/ViewStore';
@@ -264,9 +264,11 @@ class SavedSearchControls extends React.Component<Props, State> {
                         <Icon name="eraser" /> Reset search
                       </MenuItem>
                       <MenuItem divider />
-                      <MenuItem onSelect={this.toggleShareSearch} title="Share search" disabled={!isAllowedToEdit}>
-                        <Icon name="share-alt" /> Share
-                      </MenuItem>
+                      <HasOwnership id={view.id} type="search">
+                        <MenuItem onSelect={this.toggleShareSearch} title="Share search" disabled={!isAllowedToEdit}>
+                          <Icon name="share-alt" /> Share
+                        </MenuItem>
+                      </HasOwnership>
                     </DropdownButton>
                     {showCSVExport && (
                       <CSVExportModal view={view} closeModal={this.toggleCSVExport} />

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.test.jsx
@@ -135,12 +135,12 @@ describe('SavedSearchControls', () => {
         expect(shareSearch).not.toBeDisabled();
       });
 
-      it('which should be disabled if search is unsaved', () => {
+      it('which should be hidden if search is unsaved', () => {
         const wrapper = mount(<SimpleSavedSearchControls />);
 
         const shareSearch = wrapper.find('MenuItem[title="Share search"]');
 
-        expect(shareSearch).toBeDisabled();
+        expect(shareSearch).toMatchSnapshot();
       });
     });
   });

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.test.jsx
@@ -106,6 +106,7 @@ describe('SavedSearchControls', () => {
           ...viewsManager,
           username: 'owningUser',
           permissions: [],
+          grn_permissions: ['entity:own:grn::::search:user-id-1'],
         };
         const wrapper = mount(<SimpleSavedSearchControls currentUser={owningUser} viewStoreState={createViewStoreState(false, owningUser.id)} />);
         const shareSearch = wrapper.find('MenuItem[title="Share search"]');
@@ -118,6 +119,7 @@ describe('SavedSearchControls', () => {
           ...viewsManager,
           username: 'powerfulUser',
           permissions: [Permissions.View.Edit(viewsManager.id)],
+          grn_permissions: ['entity:own:grn::::search:user-id-1'],
         };
 
         const wrapper = mount(<SimpleSavedSearchControls currentUser={owningUser} viewStoreState={createViewStoreState(false, owningUser.id)} />);

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/__snapshots__/SavedSearchControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/__snapshots__/SavedSearchControls.test.jsx.snap
@@ -1,6 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SavedSearchControls Button handling has "Share search" option which should be hidden if search is unsaved 1`] = `null`;
+exports[`SavedSearchControls Button handling has "Share search" option which should be hidden if search is unsaved 1`] = `
+<MenuItem
+  bsClass="dropdown"
+  disabled={true}
+  divider={false}
+  header={false}
+  onSelect={[Function]}
+  title="Share search"
+>
+  <li
+    className="disabled"
+    role="presentation"
+  >
+    <SafeAnchor
+      componentClass="a"
+      onClick={[Function]}
+      role="menuitem"
+      tabIndex="-1"
+      title="Share search"
+    >
+      <a
+        href="#"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="menuitem"
+        tabIndex="-1"
+        title="Share search"
+      >
+        <Icon
+          name="share-alt"
+          type="solid"
+        >
+          <FontAwesomeIcon
+            icon={
+              Object {
+                "iconName": "share-alt",
+                "prefix": "fas",
+              }
+            }
+          >
+            <svg
+              className="svg-inline--fa fa-share-alt"
+            />
+          </FontAwesomeIcon>
+        </Icon>
+         Share
+      </a>
+    </SafeAnchor>
+  </li>
+</MenuItem>
+`;
 
 exports[`SavedSearchControls render the SavedSearchControls should render dirty 1`] = `
 <button

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/__snapshots__/SavedSearchControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/__snapshots__/SavedSearchControls.test.jsx.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SavedSearchControls Button handling has "Share search" option which should be hidden if search is unsaved 1`] = `null`;
+
 exports[`SavedSearchControls render the SavedSearchControls should render dirty 1`] = `
 <button
   className="Button-c9cbmb-0 kLwsUP btn btn-default"

--- a/graylog2-web-interface/test/fixtures/users.js
+++ b/graylog2-web-interface/test/fixtures/users.js
@@ -12,6 +12,7 @@ export const viewsManager: UserJSON = {
   id: 'user-id-1',
   last_activity: '2020-01-01T10:40:05.376+0000',
   permissions: ['dashboards:edit:view-id', 'view:edit:view-id'],
+  grn_permissions: ['entity:own:grn::::dashboard:view-id', 'entity:own:grn::::view:view-id', 'entity:own:grn::::search:some-id'],
   read_only: true,
   roles: ['Views Manager'],
   session_active: true,


### PR DESCRIPTION
## Motivation
Prior to this change, we always show the entity sharing modal button
even if you were not allowed to see it which would lead into a error
screen.

## Description
This change will implement a switching component which decides if a
child will be rendered depending on if the user has ownership over the
entity passed on.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1569