### PR TITLE
Add unique compound index on "grants" table

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
@@ -58,6 +58,11 @@ public class DBGrantService extends PaginatedDbService<GrantDTO> {
 
         db.createIndex(new BasicDBObject(GrantDTO.FIELD_GRANTEE, 1));
         db.createIndex(new BasicDBObject(GrantDTO.FIELD_TARGET, 1));
+        db.createIndex(
+                new BasicDBObject(GrantDTO.FIELD_GRANTEE, 1)
+                        .append(GrantDTO.FIELD_CAPABILITY, 1)
+                        .append(GrantDTO.FIELD_TARGET, 1),
+                new BasicDBObject("unique", true));
         // TODO: Add more indices
 
         // TODO: Inline migration for development. Must be removed before shipping 4.0 GA!


### PR DESCRIPTION
The combination of "grantee", "capability" and "target" must me unique
to avoid the creation of duplicate grant entries.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1569