### PR TITLE
Show Spinner while Theme is loading

### DIFF
--- a/graylog2-web-interface/src/theme/types.js
+++ b/graylog2-web-interface/src/theme/types.js
@@ -11,5 +11,5 @@ export type ThemeInterface = {
   fonts: Fonts,
   utils: Utils,
   mode: string,
-  changeMode: (string) => void,
+  changeMode: (string) => Promise<{} | null>,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implemented Loading icon in `ThemeModeToggle` during Theme switching

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is a mild delay while Graylog renders the next theme making it appear as if your click did not register.
Double clicking, or clicking while it was loading, would lead to calling the theme you're currently on again.

## Screenshots (if appropriate):
Apologies about the quality, GIF does not handle the animation well.
![Aug-14-2020 10-18-00](https://user-images.githubusercontent.com/122591/90269069-a3b22380-de1d-11ea-8a82-e4f4d4be16ea.gif)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

