### PR TITLE
Unifications for management frontend

### DIFF
--- a/graylog2-web-interface/src/actions/permissions/EntityShareActions.js
+++ b/graylog2-web-interface/src/actions/permissions/EntityShareActions.js
@@ -31,8 +31,8 @@ export type EntitySharePayload = {
 type EntityShareActionsType = RefluxActions<{
   prepare: (GRN, ?EntitySharePayload) => Promise<EntityShareState>,
   update: (GRN, EntitySharePayload) => Promise<EntityShareState>,
-  searchPaginatedUserShares: (username: string, page: number, perPage: number, query: string, additionalQueries?: AdditionalQueries) => Promise<PaginatedEnititySharesType>,
-  searchPaginatedTeamShares: (username: string, page: number, perPage: number, query: string, additionalQueries?: AdditionalQueries) => Promise<PaginatedEnititySharesType>,
+  loadUserSharesPaginated: (username: string, page: number, perPage: number, query: string, additionalQueries?: AdditionalQueries) => Promise<PaginatedEnititySharesType>,
+  loadTeamSharesPaginated: (username: string, page: number, perPage: number, query: string, additionalQueries?: AdditionalQueries) => Promise<PaginatedEnititySharesType>,
 }>;
 
 const EntityShareActions: EntityShareActionsType = singletonActions(
@@ -40,8 +40,8 @@ const EntityShareActions: EntityShareActionsType = singletonActions(
   () => Reflux.createActions({
     prepare: { asyncResult: true },
     update: { asyncResult: true },
-    searchPaginatedUserShares: { asyncResult: true },
-    searchPaginatedTeamShares: { asyncResult: true },
+    loadUserSharesPaginated: { asyncResult: true },
+    loadTeamSharesPaginated: { asyncResult: true },
   }),
 );
 

--- a/graylog2-web-interface/src/actions/roles/AuthzRolesActions.js
+++ b/graylog2-web-interface/src/actions/roles/AuthzRolesActions.js
@@ -7,30 +7,32 @@ import { singletonActions } from 'views/logic/singleton';
 import type { RefluxActions } from 'stores/StoreTypes';
 
 type AuthzRolesActionsType = RefluxActions<{
+  load: (roleId: string) => Promise<Role>,
+  delete: (roleId: string) => Promise<void>,
   addMember: (roleId: string, username: string) => Promise<Role>,
-  deleteRole: (roleId: string) => Promise<void>,
   removeMember: (roleId: string, username: string) => Promise<Role>,
   loadUsersForRole: (roleId: string, page: number, perPage: number, query: string) => Promise<PaginatedUserListType>,
-  load: (roleId: string) => Promise<Role>,
-  loadForUser: (username: string,
-                page: number,
-                perPage: number,
-                query: string) => Promise<PaginatedListType>,
-  loadPaginated: (page: number,
-                  perPage: number,
-                  query: string) => Promise<PaginatedListType>,
+  loadRolesForUser: (
+    username: string,
+    page: number,
+    perPage: number,
+    query: string) => Promise<PaginatedListType>,
+  loadRolesPaginated: (
+    page: number,
+    perPage: number,
+    query: string) => Promise<PaginatedListType>,
 }>;
 
 const AuthzRolesActions: AuthzRolesActionsType = singletonActions(
   'AuthzRoles',
   () => Reflux.createActions({
+    load: { asyncResult: true },
+    delete: { asyncResult: true },
     addMember: { asyncResult: true },
     removeMember: { asyncResult: true },
     loadUsersForRole: { asyncResult: true },
-    deleteRole: { asyncResult: true },
-    load: { asyncResult: true },
-    loadForUser: { asyncResult: true },
-    loadPaginated: { asyncResult: true },
+    loadRolesForUser: { asyncResult: true },
+    loadRolesPaginated: { asyncResult: true },
   }),
 );
 

--- a/graylog2-web-interface/src/actions/users/UsersActions.js
+++ b/graylog2-web-interface/src/actions/users/UsersActions.js
@@ -27,30 +27,30 @@ export type PaginatedUsers = {
 
 type UsersActionsType = RefluxActions<{
   create: (request: any) => Promise<string[]>,
-  loadUsers: () => Promise<Immutable.List<User>>,
-  searchPaginated: (page: number, perPage: number, query: string) => Promise<PaginatedUsers>,
   load: (username: string) => Promise<User>,
-  deleteUser: (username: string) => Promise<string[]>,
-  changePassword: (username: string, request: ChangePasswordRequest) => Promise<void>,
   update: (username: string, request: any) => Promise<void>,
+  delete: (username: string) => Promise<string[]>,
+  changePassword: (username: string, request: ChangePasswordRequest) => Promise<void>,
   createToken: (username: string, tokenName: string) => Promise<Token>,
-  deleteToken: (username: string, tokenId: string, tokenName: string) => Promise<string[]>,
   loadTokens: (username: string) => Promise<Token[]>,
+  deleteToken: (username: string, tokenId: string, tokenName: string) => Promise<string[]>,
+  loadUsers: () => Promise<Immutable.List<User>>,
+  loadUsersPaginated: (page: number, perPage: number, query: string) => Promise<PaginatedUsers>,
 }>;
 
 const UsersActions: UsersActionsType = singletonActions(
   'Users',
   () => Reflux.createActions({
     create: { asyncResult: true },
-    loadUsers: { asyncResult: true },
-    searchPaginated: { asyncResult: true },
     load: { asyncResult: true },
-    deleteUser: { asyncResult: true },
-    changePassword: { asyncResult: true },
     update: { asyncResult: true },
+    delete: { asyncResult: true },
+    changePassword: { asyncResult: true },
     createToken: { asyncResult: true },
-    deleteToken: { asyncResult: true },
     loadTokens: { asyncResult: true },
+    deleteToken: { asyncResult: true },
+    loadUsersPaginated: { asyncResult: true },
+    loadUsers: { asyncResult: true },
   }),
 );
 

--- a/graylog2-web-interface/src/components/permissions/RolesSelector.jsx
+++ b/graylog2-web-interface/src/components/permissions/RolesSelector.jsx
@@ -66,7 +66,7 @@ const RolesSelector = ({ user, onSubmit }: Props) => {
   useEffect(() => {
     const getUnlimited = [1, 0, ''];
 
-    AuthzRolesActions.loadPaginated(...getUnlimited)
+    AuthzRolesActions.loadRolesPaginated(...getUnlimited)
       .then(({ list }: PaginatedListType) => setRoles(list));
   }, [user]);
 

--- a/graylog2-web-interface/src/components/roles/RoleEdit/UsersSelector.jsx
+++ b/graylog2-web-interface/src/components/roles/RoleEdit/UsersSelector.jsx
@@ -61,7 +61,7 @@ const UsersSelector = ({ role, onSubmit }: Props) => {
   const [options, setOptions] = useState([]);
   const getUnlimited = [1, 0, ''];
 
-  const _loadUsers = () => UsersActions.searchPaginated(...getUnlimited)
+  const _loadUsers = () => UsersActions.loadUsersPaginated(...getUnlimited)
     .then(({ list }) => {
       if (list) {
         const resultUsers = list

--- a/graylog2-web-interface/src/components/roles/RolesOverview/ActionsCell.jsx
+++ b/graylog2-web-interface/src/components/roles/RolesOverview/ActionsCell.jsx
@@ -25,7 +25,7 @@ const ActionsCell = ({ roleId, roleName, readOnly }: Props) => {
   const _deleteRole = () => {
     // eslint-disable-next-line no-alert
     if (window.confirm(`Do you really want to delete role ${roleName}?`)) {
-      AuthzRolesActions.deleteRole(roleId).then(() => {
+      AuthzRolesActions.delete(roleId).then(() => {
         UserNotification.success(`Role "${roleName}" was deleted successfully`);
       }, () => {
         UserNotification.error(`There was an error deleting the role "${roleName}"`);
@@ -35,7 +35,7 @@ const ActionsCell = ({ roleId, roleName, readOnly }: Props) => {
       //   if (membership.users.length !== 0) {
       //     UserNotification.error(`Cannot delete role ${roleName}. It is still assigned to ${membership.users.length} users.`);
       //   } else {
-      //     AuthzRolesActions.deleteRole(roleId).then(() => {
+      //     AuthzRolesActions.delete(roleId).then(() => {
       //       UserNotification.success(`Role "${roleName}" was deleted successfully`);
       //     }, () => {
       //       UserNotification.error(`There was an error deleting the role "${roleName}"`);

--- a/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverview.jsx
+++ b/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverview.jsx
@@ -63,7 +63,7 @@ const RolesOverview = () => {
   const { list: roles, pagination: { page, perPage, query, total } } = paginatedRoles;
 
   const _loadRoles = (newPage = page, newPerPage = perPage, newQuery = query) => {
-    return AuthzRolesActions.loadPaginated(newPage, newPerPage, newQuery).then(setPaginatedRoles);
+    return AuthzRolesActions.loadRolesPaginated(newPage, newPerPage, newQuery).then(setPaginatedRoles);
   };
 
   const _rolesOverviewItem = (role) => <RolesOverviewItem role={role} />;
@@ -72,7 +72,7 @@ const RolesOverview = () => {
   useEffect(() => {
     _loadRoles(DEFAULT_PAGINATION.page, DEFAULT_PAGINATION.perPage, DEFAULT_PAGINATION.query);
 
-    const unlistenDeleteRole = AuthzRolesActions.deleteRole.completed.listen(() => {
+    const unlistenDeleteRole = AuthzRolesActions.delete.completed.listen(() => {
       _loadRoles(DEFAULT_PAGINATION.page, undefined, DEFAULT_PAGINATION.query);
     });
 

--- a/graylog2-web-interface/src/components/users/UserCreate/UserCreate.jsx
+++ b/graylog2-web-interface/src/components/users/UserCreate/UserCreate.jsx
@@ -8,7 +8,7 @@ import type { DescriptiveItem } from 'components/common/PaginatedItemOverview';
 import User from 'logic/users/User';
 import PaginatedItem from 'components/common/PaginatedItemOverview/PaginatedItem';
 import RolesSelector from 'components/permissions/RolesSelector';
-import { Alert, Col, Row, Button } from 'components/graylog';
+import { Alert, Col, Row, Button, ButtonToolbar } from 'components/graylog';
 import { UsersActions } from 'stores/users/UsersStore';
 import { Input } from 'components/bootstrap';
 import UserNotification from 'util/UserNotification';
@@ -67,6 +67,7 @@ const UserCreate = () => {
     setUser(user.toBuilder().roles(user.roles.toSet().remove(role?.name).toList()).build());
   };
 
+  const handleCancel = () => history.goBack();
   const hasValidRole = selectedRoles.size > 0 && selectedRoles.filter((role) => role.name === 'Reader' || role.name === 'Admin');
 
   return (
@@ -127,12 +128,15 @@ const UserCreate = () => {
               )}
               <Row>
                 <Col xs={9} xsOffset={3}>
-                  <Button bsStyle="success"
-                          disabled={isSubmitting || !isValid || !hasValidRole}
-                          title="Create User"
-                          type="submit">
-                    Create User
-                  </Button>
+                  <ButtonToolbar>
+                    <Button bsStyle="success"
+                            disabled={isSubmitting || !isValid || !hasValidRole}
+                            title="Create User"
+                            type="submit">
+                      Create User
+                    </Button>
+                    <Button type="button" onClick={handleCancel}>Cancel</Button>
+                  </ButtonToolbar>
                 </Col>
               </Row>
             </Form>

--- a/graylog2-web-interface/src/components/users/UserCreate/UserCreate.jsx
+++ b/graylog2-web-interface/src/components/users/UserCreate/UserCreate.jsx
@@ -67,7 +67,7 @@ const UserCreate = () => {
     setUser(user.toBuilder().roles(user.roles.toSet().remove(role?.name).toList()).build());
   };
 
-  const handleCancel = () => history.goBack();
+  const _handleCancel = () => history.push(Routes.SYSTEM.USERS.OVERVIEW);
   const hasValidRole = selectedRoles.size > 0 && selectedRoles.filter((role) => role.name === 'Reader' || role.name === 'Admin');
 
   return (
@@ -135,7 +135,7 @@ const UserCreate = () => {
                             type="submit">
                       Create User
                     </Button>
-                    <Button type="button" onClick={handleCancel}>Cancel</Button>
+                    <Button type="button" onClick={_handleCancel}>Cancel</Button>
                   </ButtonToolbar>
                 </Col>
               </Row>

--- a/graylog2-web-interface/src/components/users/UserCreate/UserCreate.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserCreate/UserCreate.test.jsx
@@ -33,7 +33,7 @@ jest.mock('stores/users/UsersStore', () => ({
 
 jest.mock('stores/roles/AuthzRolesStore', () => ({
   AuthzRolesActions: {
-    loadPaginated: jest.fn(() => Promise.resolve(mockLoadRolesPromise)),
+    loadRolesPaginated: jest.fn(() => Promise.resolve(mockLoadRolesPromise)),
   },
 }));
 

--- a/graylog2-web-interface/src/components/users/UserDetails/RolesSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/RolesSection.jsx
@@ -23,7 +23,7 @@ const RolesSection = ({ user: { username } }: Props) => {
   const _onLoad = ({ page, perPage, query }: PaginationInfo, isSubscribed: boolean): Promise<?PaginatedListType> => {
     setLoading(true);
 
-    return AuthzRolesActions.loadForUser(username, page, perPage, query)
+    return AuthzRolesActions.loadRolesForUser(username, page, perPage, query)
       .then((response) => {
         if (isSubscribed) {
           setLoading(false);

--- a/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesSection.jsx
@@ -16,7 +16,7 @@ type Props = {
 
 const SharedEntitiesSection = ({ paginatedUserShares, username }: Props) => {
   const [loading, setLoading] = useState(false);
-  const _searchPaginated = (newPage, newPerPage, newQuery, additonalQueries) => EntityShareActions.searchPaginatedUserShares(username, newPage, newPerPage, newQuery, additonalQueries);
+  const _searchPaginated = (newPage, newPerPage, newQuery, additonalQueries) => EntityShareActions.loadUserSharesPaginated(username, newPage, newPerPage, newQuery, additonalQueries);
 
   return (
     <SectionComponent title="Shared Entities" showLoading={loading}>

--- a/graylog2-web-interface/src/components/users/UserDetails/UserDetails.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/UserDetails.test.jsx
@@ -16,14 +16,14 @@ const mockPaginatedUserShares = simplePaginatedUserShares(1, 10, '');
 
 jest.mock('stores/roles/AuthzRolesStore', () => ({
   AuthzRolesActions: {
-    loadForUser: jest.fn(() => mockAuthzRolesPromise),
-    loadPaginated: jest.fn(() => mockAuthzRolesPromise),
+    loadRolesForUser: jest.fn(() => mockAuthzRolesPromise),
+    loadRolesPaginated: jest.fn(() => mockAuthzRolesPromise),
   },
 }));
 
 jest.mock('stores/permissions/EntityShareStore', () => ({
   EntityShareActions: {
-    searchPaginatedUserShares: jest.fn(() => Promise.resolve(mockPaginatedUserShares)),
+    loadUserSharesPaginated: jest.fn(() => Promise.resolve(mockPaginatedUserShares)),
   },
 }));
 
@@ -128,7 +128,7 @@ describe('<UserDetails />', () => {
         fireEvent.change(searchInput, { target: { value: 'the username' } });
         fireEvent.click(searchSubmitButton);
 
-        await waitFor(() => expect(EntityShareActions.searchPaginatedUserShares).toHaveBeenCalledWith(user.username, 1, 10, 'the username', undefined));
+        await waitFor(() => expect(EntityShareActions.loadUserSharesPaginated).toHaveBeenCalledWith(user.username, 1, 10, 'the username', undefined));
 
         await act(() => mockAuthzRolesPromise);
       });
@@ -141,7 +141,7 @@ describe('<UserDetails />', () => {
         await selectEvent.openMenu(entityTypeSelect);
         await act(async () => { await selectEvent.select(entityTypeSelect, 'Dashboard'); });
 
-        expect(EntityShareActions.searchPaginatedUserShares).toHaveBeenCalledWith(user.username, 1, 50, 'existing query', { entity_type: 'dashboard' });
+        expect(EntityShareActions.loadUserSharesPaginated).toHaveBeenCalledWith(user.username, 1, 50, 'existing query', { entity_type: 'dashboard' });
 
         await act(() => mockAuthzRolesPromise);
       });
@@ -154,7 +154,7 @@ describe('<UserDetails />', () => {
         await selectEvent.openMenu(capabilitySelect);
         await act(async () => { await selectEvent.select(capabilitySelect, 'Manager'); });
 
-        expect(EntityShareActions.searchPaginatedUserShares).toHaveBeenCalledWith(user.username, 1, 50, 'existing query', { capability: 'manage' });
+        expect(EntityShareActions.loadUserSharesPaginated).toHaveBeenCalledWith(user.username, 1, 50, 'existing query', { capability: 'manage' });
 
         await act(() => mockAuthzRolesPromise);
       });

--- a/graylog2-web-interface/src/components/users/UserEdit/PasswordSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/PasswordSection.jsx
@@ -3,8 +3,6 @@ import * as React from 'react';
 import { useContext } from 'react';
 import { Formik, Form } from 'formik';
 
-import history from 'util/History';
-import Routes from 'routing/Routes';
 import { UsersActions } from 'stores/users/UsersStore';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import { Button, Row, Col } from 'components/graylog';
@@ -28,16 +26,12 @@ const _validate = (values) => {
   return errors;
 };
 
-const _onSubmit = (formData, username, currentUser) => {
+const _onSubmit = (formData, username) => {
   const data = { ...formData };
   delete data.password_repeat;
 
   return UsersActions.changePassword(username, data).then(() => {
     UserNotification.success('Password updated successfully.', 'Success');
-
-    if (isPermitted(currentUser?.permissions, ['users:list'])) {
-      history.replace(Routes.SYSTEM.USERS.OVERVIEW);
-    }
   }, () => {
     UserNotification.error('Could not update password. Please verify that your current password is correct.', 'Updating password failed');
   });
@@ -54,7 +48,7 @@ const PasswordSection = ({ user: { username } }: Props) => {
 
   return (
     <SectionComponent title="Password">
-      <Formik onSubmit={(formData) => _onSubmit(formData, username, currentUser)}
+      <Formik onSubmit={(formData) => _onSubmit(formData, username)}
               validate={_validate}
               initialValues={{}}>
         {({ isSubmitting, isValid }) => (

--- a/graylog2-web-interface/src/components/users/UserEdit/RolesSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/RolesSection.jsx
@@ -37,7 +37,7 @@ const RolesSection = ({ user, onSubmit }: Props) => {
   const _onLoad = ({ page, perPage, query }: PaginationInfo = defaultPageInfo): Promise<PaginatedListType> => {
     setLoading(true);
 
-    return AuthzRolesActions.loadForUser(username, page, perPage, query)
+    return AuthzRolesActions.loadRolesForUser(username, page, perPage, query)
       .then((response) => {
         setLoading(false);
 

--- a/graylog2-web-interface/src/components/users/UserEdit/UserEdit.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/UserEdit.test.jsx
@@ -32,8 +32,8 @@ const mockAuthzRolesPromise = Promise.resolve({ list: Immutable.List(), paginati
 
 jest.mock('stores/roles/AuthzRolesStore', () => ({
   AuthzRolesActions: {
-    loadForUser: jest.fn(() => mockAuthzRolesPromise),
-    loadPaginated: jest.fn(() => mockAuthzRolesPromise),
+    loadRolesForUser: jest.fn(() => mockAuthzRolesPromise),
+    loadRolesPaginated: jest.fn(() => mockAuthzRolesPromise),
   },
 }));
 

--- a/graylog2-web-interface/src/components/users/UserList.jsx
+++ b/graylog2-web-interface/src/components/users/UserList.jsx
@@ -61,7 +61,7 @@ const UserList = createReactClass({
   },
 
   deleteUser(username) {
-    const promise = UsersActions.deleteUser(username);
+    const promise = UsersActions.delete(username);
 
     promise.done(() => {
       this.loadUsers();

--- a/graylog2-web-interface/src/components/users/UserList.jsx
+++ b/graylog2-web-interface/src/components/users/UserList.jsx
@@ -70,6 +70,7 @@ const UserList = createReactClass({
 
   _deleteUserFunction(username) {
     return () => {
+      // eslint-disable-next-line no-alert
       if (window.confirm(`Do you really want to delete user ${username}?`)) {
         this.deleteUser(username);
       }

--- a/graylog2-web-interface/src/components/users/UsersOverview/UserOverviewItem/ActionsCell.jsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UserOverviewItem/ActionsCell.jsx
@@ -54,7 +54,7 @@ const EditActions = ({ username }: { username: $PropertyType<Props, 'username'> 
   const _deleteUser = () => {
     // eslint-disable-next-line no-alert
     if (window.confirm(`Do you really want to delete user ${username}?`)) {
-      UsersActions.deleteUser(username);
+      UsersActions.delete(username);
     }
   };
 

--- a/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.jsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.jsx
@@ -72,7 +72,7 @@ const UsersOverview = () => {
   const _userOverviewItem = (user) => <UserOverviewItem user={user} isActive={_isActiveItem(user)} />;
 
   const _loadUsers = (newPage = page, newPerPage = perPage, newQuery = query) => {
-    return UsersActions.searchPaginated(newPage, newPerPage, newQuery).then(setPaginatedUsers);
+    return UsersActions.loadUsersPaginated(newPage, newPerPage, newQuery).then(setPaginatedUsers);
   };
 
   const _handleSearch = (newQuery) => _loadUsers(DEFAULT_PAGINATION.page, undefined, newQuery);
@@ -80,7 +80,7 @@ const UsersOverview = () => {
   useEffect(() => {
     _loadUsers(DEFAULT_PAGINATION.page, DEFAULT_PAGINATION.perPage, DEFAULT_PAGINATION.query);
 
-    const unlistenDeleteUser = UsersActions.deleteUser.completed.listen(() => {
+    const unlistenDeleteUser = UsersActions.delete.completed.listen(() => {
       _loadUsers(DEFAULT_PAGINATION.page, undefined, DEFAULT_PAGINATION.query);
     });
 

--- a/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.jsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/UsersOverview.test.jsx
@@ -12,7 +12,7 @@ import { UsersActions } from 'stores/users/UsersStore';
 import UsersOverview from './UsersOverview';
 
 const mockUsers = Immutable.List([alice, bob, adminOverview]);
-const searchPaginatedResponse = {
+const loadUsersPaginatedResponse = {
   list: mockUsers,
   pagination: {
     page: 1,
@@ -21,21 +21,21 @@ const searchPaginatedResponse = {
   },
   adminUser: undefined,
 };
-const mockSearchPaginatedPromise = Promise.resolve(searchPaginatedResponse);
+const mockloadUsersPaginatedPromise = Promise.resolve(loadUsersPaginatedResponse);
 
 jest.mock('stores/users/UsersStore', () => ({
   UsersStore: {
     listen: jest.fn(),
   },
   UsersActions: {
-    searchPaginated: jest.fn(() => mockSearchPaginatedPromise),
-    deleteUser: jest.fn(),
+    loadUsersPaginated: jest.fn(() => mockloadUsersPaginatedPromise),
+    delete: jest.fn(),
   },
 }));
 
 describe('UsersOverview', () => {
   beforeEach(() => {
-    UsersActions.deleteUser.completed = { listen: jest.fn(() => jest.fn()) };
+    UsersActions.delete.completed = { listen: jest.fn(() => jest.fn()) };
   });
 
   describe('should display table header', () => {
@@ -61,7 +61,7 @@ describe('UsersOverview', () => {
       const { queryByText } = render(<UsersOverview />);
       const attributes = ['username', 'fullName', 'email', 'clientAddress'];
 
-      await act(() => mockSearchPaginatedPromise);
+      await act(() => mockloadUsersPaginatedPromise);
 
       attributes.forEach(async (attribute) => {
         if (user[attribute]) {
@@ -101,28 +101,28 @@ describe('UsersOverview', () => {
     });
 
     it('be able to delete a modifiable user', async () => {
-      const searchPaginatedPromise = Promise.resolve({ ...searchPaginatedResponse, list: modifiableUsersList });
-      asMock(UsersActions.searchPaginated).mockReturnValueOnce(searchPaginatedPromise);
+      const loadUsersPaginatedPromise = Promise.resolve({ ...loadUsersPaginatedResponse, list: modifiableUsersList });
+      asMock(UsersActions.loadUsersPaginated).mockReturnValueOnce(loadUsersPaginatedPromise);
       const { getByTitle } = render(<UsersOverviewAsAdmin />);
-      await act(() => searchPaginatedPromise);
+      await act(() => loadUsersPaginatedPromise);
 
       fireEvent.click(getByTitle(`Delete user ${modifiableUser.username}`));
 
       expect(window.confirm).toHaveBeenCalledTimes(1);
       expect(window.confirm).toHaveBeenCalledWith(`Do you really want to delete user ${modifiableUser.username}?`);
-      expect(UsersActions.deleteUser).toHaveBeenCalledTimes(1);
-      expect(UsersActions.deleteUser).toHaveBeenCalledWith(alice.username);
+      expect(UsersActions.delete).toHaveBeenCalledTimes(1);
+      expect(UsersActions.delete).toHaveBeenCalledWith(alice.username);
     });
 
     it('not be able to delete a "read only" user', async () => {
-      asMock(UsersActions.searchPaginated).mockReturnValueOnce(Promise.resolve({ ...searchPaginatedResponse, list: readOnlyUsersList }));
+      asMock(UsersActions.loadUsersPaginated).mockReturnValueOnce(Promise.resolve({ ...loadUsersPaginatedResponse, list: readOnlyUsersList }));
       const { queryByTitle } = render(<UsersOverviewAsAdmin />);
 
       await waitFor(() => expect(queryByTitle(`Delete user ${readOnlyUser.username}`)).toBeNull());
     });
 
     it('see edit and edit tokens link for a modifiable user ', async () => {
-      asMock(UsersActions.searchPaginated).mockReturnValueOnce(Promise.resolve({ ...searchPaginatedResponse, list: modifiableUsersList }));
+      asMock(UsersActions.loadUsersPaginated).mockReturnValueOnce(Promise.resolve({ ...loadUsersPaginatedResponse, list: modifiableUsersList }));
       const { queryByTitle } = render(<UsersOverviewAsAdmin />);
 
       await waitFor(() => {
@@ -132,14 +132,14 @@ describe('UsersOverview', () => {
     });
 
     it('not see edit link for a "read only" user', async () => {
-      asMock(UsersActions.searchPaginated).mockReturnValueOnce(Promise.resolve({ ...searchPaginatedResponse, list: readOnlyUsersList }));
+      asMock(UsersActions.loadUsersPaginated).mockReturnValueOnce(Promise.resolve({ ...loadUsersPaginatedResponse, list: readOnlyUsersList }));
       const { queryByTitle } = render(<UsersOverviewAsAdmin />);
 
       await waitFor(() => expect(queryByTitle(`Edit user ${readOnlyUser.username}`)).toBeNull());
     });
 
     it('see edit tokens link for a "read only" user', async () => {
-      asMock(UsersActions.searchPaginated).mockReturnValueOnce(Promise.resolve({ ...searchPaginatedResponse, list: readOnlyUsersList }));
+      asMock(UsersActions.loadUsersPaginated).mockReturnValueOnce(Promise.resolve({ ...loadUsersPaginatedResponse, list: readOnlyUsersList }));
       const { queryByTitle } = render(<UsersOverviewAsAdmin />);
 
       await waitFor(() => expect(queryByTitle(`Edit tokens for user ${readOnlyUser.username}`)).toBeNull());

--- a/graylog2-web-interface/src/pages/UserDetailsPage.jsx
+++ b/graylog2-web-interface/src/pages/UserDetailsPage.jsx
@@ -36,7 +36,7 @@ const UserDetailsPage = ({ params }: Props) => {
   useEffect(() => {
     UsersActions.load(username).then(setLoadedUser);
 
-    EntityShareActions.searchPaginatedUserShares(username, 1, 10, '').then((response) => {
+    EntityShareActions.loadUserSharesPaginated(username, 1, 10, '').then((response) => {
       setPaginatedUserShares(response);
     });
   }, [username]);

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -25,13 +25,13 @@ const ApiRoutes = {
     list: () => { return { url: '/alerts/conditions' }; },
   },
   AuthzRolesController: {
-    delete: (roleId) => { return { url: `/authzRoles/${roleId}` }; },
     load: (roleId) => { return { url: `/authzRoles/${roleId}` }; },
+    delete: (roleId) => { return { url: `/authzRoles/${roleId}` }; },
     list: () => { return { url: '/authzRoles' }; },
-    loadForUser: (username) => { return { url: `/authzRoles/rolesForUser/${username}` }; },
-    loadUsersForRole: (roleId) => { return { url: `/authzRoles/${roleId}/assignees` }; },
     removeMember: (roleId, username) => { return { url: `/authzRoles/${roleId}/assignee/${username}` }; },
     addMember: (roleId, username) => { return { url: `/authzRoles/${roleId}/assignee/${username}` }; },
+    loadRolesForUser: (username) => { return { url: `/authzRoles/rolesForUser/${username}` }; },
+    loadUsersForRole: (roleId) => { return { url: `/authzRoles/${roleId}/assignees` }; },
   },
   CatalogsController: {
     showEntityIndex: () => { return { url: '/system/catalog' }; },

--- a/graylog2-web-interface/src/stores/permissions/EntityShareStore.js
+++ b/graylog2-web-interface/src/stores/permissions/EntityShareStore.js
@@ -52,7 +52,7 @@ const EntityShareStore: EntityShareStoreType = singletonStore(
       return promise;
     },
 
-    searchPaginatedUserShares(username: string, page: number, perPage: number, query: string, additionalQueries?: AdditionalQueries): Promise<PaginatedEnititySharesType> {
+    loadUserSharesPaginated(username: string, page: number, perPage: number, query: string, additionalQueries?: AdditionalQueries): Promise<PaginatedEnititySharesType> {
       // const url = PaginationURL(ApiRoutes.EntityShareController.userSharesPaginated(username).url, page, perPage, query, additionalQueries);
       // const promise = fetch('GET', qualifyUrl(url)).then((response: PaginatedUserSharesResponse) => {
       //   return {
@@ -71,16 +71,16 @@ const EntityShareStore: EntityShareStoreType = singletonStore(
       // });
 
       const promise = permissionsMock.searchPaginatedEntitySharesResponse(page, perPage, query, additionalQueries);
-      EntityShareActions.searchPaginatedUserShares.promise(promise);
+      EntityShareActions.loadUserSharesPaginated.promise(promise);
 
       return promise;
     },
 
-    searchPaginatedTeamShares(teamId: string, page: number, perPage: number, query: string, additionalQueries?: AdditionalQueries): Promise<PaginatedEnititySharesType> {
-      // Todo implmenet same code like for searchPaginatedUserShares, but with EntityShareController.teamSharesPaginated
+    loadTeamSharesPaginated(teamId: string, page: number, perPage: number, query: string, additionalQueries?: AdditionalQueries): Promise<PaginatedEnititySharesType> {
+      // Todo implement same code like for loadUserSharesPaginated, but with EntityShareController.teamSharesPaginated
 
       const promise = permissionsMock.searchPaginatedEntitySharesResponse(page, perPage, query, additionalQueries);
-      EntityShareActions.searchPaginatedTeamShares.promise(promise);
+      EntityShareActions.loadTeamSharesPaginated.promise(promise);
 
       return promise;
     },

--- a/graylog2-web-interface/src/stores/roles/AuthzRolesStore.js
+++ b/graylog2-web-interface/src/stores/roles/AuthzRolesStore.js
@@ -67,15 +67,6 @@ const AuthzRolesStore: Store<{}> = singletonStore(
   () => Reflux.createStore({
     listenables: [AuthzRolesActions],
 
-    deleteRole(roleId: string): Promise<string[]> {
-      const url = qualifyUrl(ApiRoutes.AuthzRolesController.delete(encodeURIComponent(roleId)).url);
-      const promise = fetch('DELETE', url);
-
-      AuthzRolesActions.deleteRole.promise(promise);
-
-      return promise;
-    },
-
     load(roleId: $PropertyType<Role, 'id'>): Promise<Role> {
       const url = qualifyUrl(ApiRoutes.AuthzRolesController.load(encodeURIComponent(roleId)).url);
       const promise = fetch('GET', url).then(Role.fromJSON);
@@ -85,35 +76,11 @@ const AuthzRolesStore: Store<{}> = singletonStore(
       return promise;
     },
 
-    loadForUser(username: string, page: number, perPage: number, query: string): Promise<PaginatedListType> {
-      const url = PaginationURL(ApiRoutes.AuthzRolesController.loadForUser(username).url, page, perPage, query);
+    delete(roleId: string): Promise<string[]> {
+      const url = qualifyUrl(ApiRoutes.AuthzRolesController.delete(encodeURIComponent(roleId)).url);
+      const promise = fetch('DELETE', url);
 
-      const promise = fetch('GET', qualifyUrl(url))
-        .then(_responseToPaginatedList);
-
-      AuthzRolesActions.loadForUser.promise(promise);
-
-      return promise;
-    },
-
-    loadPaginated(page: number, perPage: number, query: string): Promise<PaginatedListType> {
-      const url = PaginationURL(ApiRoutes.AuthzRolesController.list().url, page, perPage, query);
-
-      const promise = fetch('GET', qualifyUrl(url))
-        .then(_responseToPaginatedList);
-
-      AuthzRolesActions.loadPaginated.promise(promise);
-
-      return promise;
-    },
-
-    loadUsersForRole(roleId: string, page: number, perPage: number, query: string): Promise<PaginatedUserListType> {
-      const url = PaginationURL(ApiRoutes.AuthzRolesController.loadUsersForRole(roleId).url, page, perPage, query);
-
-      const promise = fetch('GET', qualifyUrl(url))
-        .then(_responseToPaginatedUserList);
-
-      AuthzRolesActions.loadUsersForRole.promise(promise);
+      AuthzRolesActions.delete.promise(promise);
 
       return promise;
     },
@@ -136,6 +103,38 @@ const AuthzRolesStore: Store<{}> = singletonStore(
       return promise;
     },
 
+    loadUsersForRole(roleId: string, page: number, perPage: number, query: string): Promise<PaginatedUserListType> {
+      const url = PaginationURL(ApiRoutes.AuthzRolesController.loadUsersForRole(roleId).url, page, perPage, query);
+
+      const promise = fetch('GET', qualifyUrl(url))
+        .then(_responseToPaginatedUserList);
+
+      AuthzRolesActions.loadUsersForRole.promise(promise);
+
+      return promise;
+    },
+
+    loadRolesForUser(username: string, page: number, perPage: number, query: string): Promise<PaginatedListType> {
+      const url = PaginationURL(ApiRoutes.AuthzRolesController.loadRolesForUser(username).url, page, perPage, query);
+
+      const promise = fetch('GET', qualifyUrl(url))
+        .then(_responseToPaginatedList);
+
+      AuthzRolesActions.loadRolesForUser.promise(promise);
+
+      return promise;
+    },
+
+    loadRolesPaginated(page: number, perPage: number, query: string): Promise<PaginatedListType> {
+      const url = PaginationURL(ApiRoutes.AuthzRolesController.list().url, page, perPage, query);
+
+      const promise = fetch('GET', qualifyUrl(url))
+        .then(_responseToPaginatedList);
+
+      AuthzRolesActions.loadRolesPaginated.promise(promise);
+
+      return promise;
+    },
   }),
 );
 

--- a/graylog2-web-interface/src/stores/users/UsersStore.js
+++ b/graylog2-web-interface/src/stores/users/UsersStore.js
@@ -34,47 +34,6 @@ const UsersStore: Store<{}> = singletonStore(
       return promise;
     },
 
-    loadUsers(): Promise<Immutable.List<User>> {
-      const url = qualifyUrl(ApiRoutes.UsersApiController.list().url);
-      const promise = fetch('GET', url)
-        .then(({ users }) => Immutable.List(users.map((user) => UserOverview.fromJSON(user))),
-          (error) => {
-            if (error.additional.status !== 404) {
-              UserNotification.error(`Loading user list failed with status: ${error}`,
-                'Could not load user list');
-            }
-          });
-
-      UsersActions.loadUsers.promise(promise);
-
-      return promise;
-    },
-
-    searchPaginated(page: number, perPage: number, query: string): Promise<PaginatedUsers> {
-      const url = PaginationURL(ApiRoutes.UsersApiController.paginated().url, page, perPage, query);
-
-      const promise = fetch('GET', qualifyUrl(url))
-        .then((response: PaginatedResponse) => ({
-          adminUser: response.context.admin_user ? UserOverview.fromJSON(response.context.admin_user) : undefined,
-          list: Immutable.List(response.users.map((user) => UserOverview.fromJSON(user))),
-          pagination: {
-            count: response.count,
-            total: response.total,
-            page: response.page,
-            perPage: response.per_page,
-            query: response.query,
-          },
-        }))
-        .catch((errorThrown) => {
-          UserNotification.error(`Loading user list failed with status: ${errorThrown}`,
-            'Could not load user list');
-        });
-
-      UsersActions.searchPaginated.promise(promise);
-
-      return promise;
-    },
-
     load(username: string): Promise<User> {
       const url = qualifyUrl(ApiRoutes.UsersApiController.load(encodeURIComponent(username)).url);
       const promise = fetch('GET', url)
@@ -89,7 +48,15 @@ const UsersStore: Store<{}> = singletonStore(
       return promise;
     },
 
-    deleteUser(username: string): Promise<string[]> {
+    update(username: string, request: any): void {
+      const url = qualifyUrl(ApiRoutes.UsersApiController.update(encodeURIComponent(username)).url);
+      const promise = fetch('PUT', url, request);
+      UsersActions.update.promise(promise);
+
+      return promise;
+    },
+
+    delete(username: string): Promise<string[]> {
       const url = qualifyUrl(ApiRoutes.UsersApiController.delete(encodeURIComponent(username)).url);
       const promise = fetch('DELETE', url).then(() => {
         UserNotification.success(`User "${username}" was deleted successfully`);
@@ -100,7 +67,7 @@ const UsersStore: Store<{}> = singletonStore(
         }
       });
 
-      UsersActions.deleteUser.promise(promise);
+      UsersActions.delete.promise(promise);
 
       return promise;
     },
@@ -113,19 +80,25 @@ const UsersStore: Store<{}> = singletonStore(
       return promise;
     },
 
-    update(username: string, request: any): void {
-      const url = qualifyUrl(ApiRoutes.UsersApiController.update(encodeURIComponent(username)).url);
-      const promise = fetch('PUT', url, request);
-      UsersActions.update.promise(promise);
-
-      return promise;
-    },
-
     createToken(username: string, tokenName: string): Promise<Token> {
       const url = qualifyUrl(ApiRoutes.UsersApiController.create_token(encodeURIComponent(username),
         encodeURIComponent(tokenName)).url);
       const promise = fetch('POST', url);
       UsersActions.createToken.promise(promise);
+
+      return promise;
+    },
+
+    loadTokens(username: string): Promise<Token[]> {
+      const url = qualifyUrl(ApiRoutes.UsersApiController.list_tokens(encodeURIComponent(username)).url);
+      const promise = fetch('GET', url).then(
+        (response) => response.tokens,
+        (error) => {
+          UserNotification.error(`Loading tokens of user failed with status: ${error}`,
+            `Could not load tokens of user ${username}`);
+        },
+      );
+      UsersActions.loadTokens.promise(promise);
 
       return promise;
     },
@@ -149,16 +122,43 @@ const UsersStore: Store<{}> = singletonStore(
       return promise;
     },
 
-    loadTokens(username: string): Promise<Token[]> {
-      const url = qualifyUrl(ApiRoutes.UsersApiController.list_tokens(encodeURIComponent(username)).url);
-      const promise = fetch('GET', url).then(
-        (response) => response.tokens,
-        (error) => {
-          UserNotification.error(`Loading tokens of user failed with status: ${error}`,
-            `Could not load tokens of user ${username}`);
-        },
-      );
-      UsersActions.loadTokens.promise(promise);
+    loadUsers(): Promise<Immutable.List<User>> {
+      const url = qualifyUrl(ApiRoutes.UsersApiController.list().url);
+      const promise = fetch('GET', url)
+        .then(({ users }) => Immutable.List(users.map((user) => UserOverview.fromJSON(user))),
+          (error) => {
+            if (error.additional.status !== 404) {
+              UserNotification.error(`Loading user list failed with status: ${error}`,
+                'Could not load user list');
+            }
+          });
+
+      UsersActions.loadUsers.promise(promise);
+
+      return promise;
+    },
+
+    loadUsersPaginated(page: number, perPage: number, query: string): Promise<PaginatedUsers> {
+      const url = PaginationURL(ApiRoutes.UsersApiController.paginated().url, page, perPage, query);
+
+      const promise = fetch('GET', qualifyUrl(url))
+        .then((response: PaginatedResponse) => ({
+          adminUser: response.context.admin_user ? UserOverview.fromJSON(response.context.admin_user) : undefined,
+          list: Immutable.List(response.users.map((user) => UserOverview.fromJSON(user))),
+          pagination: {
+            count: response.count,
+            total: response.total,
+            page: response.page,
+            perPage: response.per_page,
+            query: response.query,
+          },
+        }))
+        .catch((errorThrown) => {
+          UserNotification.error(`Loading user list failed with status: ${errorThrown}`,
+            'Could not load user list');
+        });
+
+      UsersActions.loadUsersPaginated.promise(promise);
 
       return promise;
     },

--- a/graylog2-web-interface/src/stores/users/UsersStore.test.js
+++ b/graylog2-web-interface/src/stores/users/UsersStore.test.js
@@ -39,7 +39,7 @@ describe('UsersStore', () => {
     });
   });
 
-  describe('searchPaginated', () => {
+  describe('loadUsersPaginated', () => {
     it('should load paginated json users and return result with value classes', async (done) => {
       const jsonList = userOverviewList.map((u) => u.toJSON()).toArray();
 
@@ -51,7 +51,7 @@ describe('UsersStore', () => {
         ...paginationJSON,
       }));
 
-      UsersActions.searchPaginated(pagination.page, pagination.perPage, pagination.query).then((result) => {
+      UsersActions.loadUsersPaginated(pagination.page, pagination.perPage, pagination.query).then((result) => {
         expect(result).toStrictEqual({ list: userOverviewList, adminUser: admin, pagination });
 
         done();
@@ -69,7 +69,7 @@ describe('UsersStore', () => {
         ...paginationJSON,
       }));
 
-      UsersActions.searchPaginated(pagination.page, pagination.perPage, pagination.query).then((result) => {
+      UsersActions.loadUsersPaginated(pagination.page, pagination.perPage, pagination.query).then((result) => {
         expect(result).toStrictEqual({ list: userOverviewList, adminUser: undefined, pagination });
 
         done();


### PR DESCRIPTION
This PR:
* implements a cancel button on user and team create page
* removes redirect to users overview after changing password on user edit page.
* displays info in entity share modal when there is no collaborator.
* unifies store method / actions names

Fixes: https://github.com/Graylog2/graylog2-server/issues/8795

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1733