### PR TITLE
Modify POM for full-backend-tests module to not create an empty jar.

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -12,6 +12,7 @@
     <artifactId>distribution</artifactId>
     <name>Graylog Binary Distribution Tarball</name>
     <description>Module solely performing final assembly step after all other modules artifacts have been built</description>
+    <packaging>pom</packaging>
 
     <properties>
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -12,7 +12,6 @@
     <artifactId>distribution</artifactId>
     <name>Graylog Binary Distribution Tarball</name>
     <description>Module solely performing final assembly step after all other modules artifacts have been built</description>
-    <packaging>pom</packaging>
 
     <properties>
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>

--- a/full-backend-tests/pom.xml
+++ b/full-backend-tests/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>full-backend-tests</artifactId>
-    <packaging>jar</packaging>
+    <packaging>pom</packaging>
 
     <name>full-backend-tests</name>
     <description>Graylog REST API integration tests</description>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updating the 'packaging' element from "jar" to "pom" so the submodule doesn't generate an empty jar. Just a bit of minor cleanup. 

## Motivation and Context
The pom for the 'full-backend-tests' modules doesn't need to generate a jar for the work it do. The generated jar just has a few small meta text files in it. 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

