### PR TITLE
Skip execution of field types poller if server is not running.

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodicalTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/fieldtypes/IndexFieldTypePollerPeriodicalTest.java
@@ -1,0 +1,69 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer.fieldtypes;
+
+import com.github.joschi.jadconfig.util.Duration;
+import com.google.common.eventbus.EventBus;
+import org.graylog2.indexer.MongoIndexSet;
+import org.graylog2.indexer.cluster.Cluster;
+import org.graylog2.indexer.indexset.IndexSetService;
+import org.graylog2.indexer.indices.Indices;
+import org.graylog2.plugin.ServerStatus;
+import org.graylog2.plugin.lifecycles.Lifecycle;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class IndexFieldTypePollerPeriodicalTest {
+    private IndexFieldTypePollerPeriodical periodical;
+    private final IndexFieldTypePoller indexFieldTypePoller = mock(IndexFieldTypePoller.class);
+    private final IndexFieldTypesService indexFieldTypesService = mock(IndexFieldTypesService.class);
+    private final IndexSetService indexSetService = mock(IndexSetService.class);
+    private final Indices indices = mock(Indices.class);
+    private final MongoIndexSet.Factory mongoIndexSetFactory = mock(MongoIndexSet.Factory.class);
+    private final Cluster cluster = mock(Cluster.class);
+    @SuppressWarnings("UnstableApiUsage")
+    private final EventBus eventBus = mock(EventBus.class);
+    private final ServerStatus serverStatus = mock(ServerStatus.class);
+    private final ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+
+    @BeforeEach
+    void setUp() {
+        this.periodical = new IndexFieldTypePollerPeriodical(indexFieldTypePoller,
+                indexFieldTypesService,
+                indexSetService,
+                indices,
+                mongoIndexSetFactory,
+                cluster,
+                eventBus,
+                serverStatus,
+                Duration.seconds(30),
+                scheduler);
+    }
+
+    @Test
+    void executionIsSkippedWhenServerIsNotRunning() {
+        when(serverStatus.getLifecycle()).thenReturn(Lifecycle.HALTING);
+        when(cluster.isConnected()).thenThrow(new RuntimeException("If this exception is thrown, then execution is not skipped!"));
+
+        this.periodical.doRun();
+    }
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change adds a check to the `IndexFieldTypePollerPeriodical` run, which returns early if the current server lifecycle is one that indicates that it's not running properly (either starting up or shutting down).

The check could be generalized into a `ServerStatus#isOperational` predicate if we want to, which could be reused in other places where a check like this is needed.
Having the load balancer override states intermingled with the general server state is irritating, as these are factually orthogonal from each other. Maybe we can separate them to a dedicated variable.

Fixes #8800.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.