### PR TITLE
Caching singleton instance of `JestClient` in `JestClientProvider`.

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Module.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Module.java
@@ -1,6 +1,5 @@
 package org.graylog.storage.elasticsearch6;
 
-import com.google.inject.Scopes;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.binder.LinkedBindingBuilder;
 import io.searchbox.client.JestClient;
@@ -41,7 +40,7 @@ public class Elasticsearch6Module extends VersionAwareModule {
 
         install(new FactoryModuleBuilder().build(ScrollResultES6.Factory.class));
 
-        bind(JestClient.class).toProvider(JestClientProvider.class).in(Scopes.SINGLETON);
+        bind(JestClient.class).toProvider(JestClientProvider.class);
     }
 
     private <T> LinkedBindingBuilder<T> bindForSupportedVersion(Class<T> interfaceClass) {

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Module.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/Elasticsearch6Module.java
@@ -1,5 +1,6 @@
 package org.graylog.storage.elasticsearch6;
 
+import com.google.inject.Scopes;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.binder.LinkedBindingBuilder;
 import io.searchbox.client.JestClient;
@@ -40,7 +41,7 @@ public class Elasticsearch6Module extends VersionAwareModule {
 
         install(new FactoryModuleBuilder().build(ScrollResultES6.Factory.class));
 
-        bind(JestClient.class).toProvider(JestClientProvider.class).asEagerSingleton();
+        bind(JestClient.class).toProvider(JestClientProvider.class).in(Scopes.SINGLETON);
     }
 
     private <T> LinkedBindingBuilder<T> bindForSupportedVersion(Class<T> interfaceClass) {

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/JestClientProvider.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/JestClientProvider.java
@@ -42,12 +42,14 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 @Singleton
 public class JestClientProvider implements Provider<JestClient> {
     private final JestClientFactory factory;
     private final CredentialsProvider credentialsProvider;
+    private final AtomicReference<JestClient> instance = new AtomicReference<>();
 
     @Inject
     public JestClientProvider(@Named("elasticsearch_hosts") List<URI> elasticsearchHosts,
@@ -119,6 +121,6 @@ public class JestClientProvider implements Provider<JestClient> {
 
     @Override
     public JestClient get() {
-        return factory.getObject();
+        return this.instance.updateAndGet(instance -> instance == null ? factory.getObject() : instance);
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is made to avoid initializing a `JestClient` instance when it is not used at all (e.g. when the ES6 storage driver is not used).  Declaring the binding as eager singleton or even with the singleton scope results in an eager call to `JestClientProvider#get`, resulting in a creation of a `JestClient` instance and initializing the node discovery.
    
To avoid this, this change is removing any singleton declaration for the binding and caches the instance in the provider instead, always returning the same one.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.