### PR TITLE
Merge webpack overrides from plugin into core config

### DIFF
--- a/graylog2-web-interface/webpack.combined.config.js
+++ b/graylog2-web-interface/webpack.combined.config.js
@@ -1,11 +1,9 @@
-const webpack = require('webpack');
-const glob = require('glob');
-const path = require('path');
 const fs = require('fs');
 
-const ROOT_PATH = path.resolve(__dirname);
-const MANIFESTS_PATH = path.resolve(ROOT_PATH, 'manifests');
-const VENDOR_MANIFEST_PATH = path.resolve(MANIFESTS_PATH, 'vendor-manifest.json');
+const glob = require('glob');
+const path = require('path');
+const merge = require('webpack-merge');
+
 const TARGET = process.env.npm_lifecycle_event;
 
 const pluginConfigPattern = 'graylog-plugin-*/**/webpack.config.js';
@@ -16,7 +14,14 @@ const globOptions = {
   nodir: true,
 };
 
-const pluginConfigs = process.env.disable_plugins === 'true' ? [] : glob.sync(pluginConfigPattern, globOptions).map(config => `${globCwd}/${config}`);
+function isNotDependency(pluginConfig) {
+  // Avoid including webpack configs of dependencies and built files.
+  return !pluginConfig.includes('/target/') && !pluginConfig.includes('/node_modules/');
+}
+
+const pluginConfigs = process.env.disable_plugins === 'true' ? [] : glob.sync(pluginConfigPattern, globOptions)
+  .map((config) => `${globCwd}/${config}`)
+  .filter(isNotDependency);
 
 process.env.web_src_path = path.resolve(__dirname);
 
@@ -25,46 +30,43 @@ const webpackConfig = require(path.resolve(__dirname, './webpack.config.js'));
 
 function getPluginName(pluginConfig) {
   const packageConfig = path.join(path.dirname(pluginConfig), 'package.json');
+
   if (fs.existsSync(packageConfig)) {
     // If a package.json file exists (should normally be the case) use the package name for pluginName
     const pkg = JSON.parse(fs.readFileSync(packageConfig, 'utf8'));
+
     return pkg.name.replace(/\s+/g, '');
-  } else {
-    // Otherwise just use the directory name of the webpack config file
-    return path.basename(path.dirname(pluginConfig));
   }
+
+  // Otherwise just use the directory name of the webpack config file
+  return path.basename(path.dirname(pluginConfig));
 }
 
-function isNotDependency(pluginConfig) {
-  // Avoid including webpack configs of dependencies and built files.
-  return !pluginConfig.includes('/target/') && !pluginConfig.includes('/node_modules/');
-}
+const mergedPluginConfigs = pluginConfigs
+  .map((configFile) => require(configFile))
+  .reduce((config, pluginConfig) => merge.smart(config, pluginConfig), {});
 
-pluginConfigs.filter(isNotDependency).forEach((pluginConfig) => {
-  const pluginName = getPluginName(pluginConfig);
-  const pluginDir = path.resolve(pluginConfig, '../src/web');
-  webpackConfig.entry[pluginName] = pluginDir;
-  webpackConfig.resolve.modules.unshift(pluginDir);
-  webpackConfig.plugins.unshift(new webpack.DllReferencePlugin({ manifest: VENDOR_MANIFEST_PATH, context: path.resolve(pluginDir, '../..') }));
-});
+const finalConfig = merge.smart(mergedPluginConfigs, webpackConfig);
 
 // We need to inject webpack-hot-middleware to all entries, ensuring the app is able to reload on changes.
 if (TARGET === 'start') {
   const hmrEntries = {};
   const webpackHotMiddlewareEntry = 'webpack-hot-middleware/client?reload=true';
 
-  Object.keys(webpackConfig.entry).forEach((entryKey) => {
-    const entryValue = webpackConfig.entry[entryKey];
+  Object.keys(finalConfig.entry).forEach((entryKey) => {
+    const entryValue = finalConfig.entry[entryKey];
     const hmrValue = [webpackHotMiddlewareEntry];
+
     if (Array.isArray(entryValue)) {
       hmrValue.push(...entryValue);
     } else {
       hmrValue.push(entryValue);
     }
+
     hmrEntries[entryKey] = hmrValue;
   });
 
-  webpackConfig.entry = hmrEntries;
+  finalConfig.entry = hmrEntries;
 }
 
-module.exports = webpackConfig;
+module.exports = finalConfig;

--- a/graylog2-web-interface/webpack.combined.config.js
+++ b/graylog2-web-interface/webpack.combined.config.js
@@ -1,5 +1,3 @@
-const fs = require('fs');
-
 const glob = require('glob');
 const path = require('path');
 const merge = require('webpack-merge');
@@ -28,21 +26,8 @@ process.env.web_src_path = path.resolve(__dirname);
 // eslint-disable-next-line import/no-dynamic-require
 const webpackConfig = require(path.resolve(__dirname, './webpack.config.js'));
 
-function getPluginName(pluginConfig) {
-  const packageConfig = path.join(path.dirname(pluginConfig), 'package.json');
-
-  if (fs.existsSync(packageConfig)) {
-    // If a package.json file exists (should normally be the case) use the package name for pluginName
-    const pkg = JSON.parse(fs.readFileSync(packageConfig, 'utf8'));
-
-    return pkg.name.replace(/\s+/g, '');
-  }
-
-  // Otherwise just use the directory name of the webpack config file
-  return path.basename(path.dirname(pluginConfig));
-}
-
 const mergedPluginConfigs = pluginConfigs
+  // eslint-disable-next-line global-require,import/no-dynamic-require
   .map((configFile) => require(configFile))
   .reduce((config, pluginConfig) => merge.smart(config, pluginConfig), {});
 

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -1,10 +1,12 @@
 const fs = require('fs');
+
 const webpack = require('webpack');
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const merge = require('webpack-merge');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
+
 const UniqueChunkIdPlugin = require('./webpack/UniqueChunkIdPlugin');
 
 const ROOT_PATH = path.resolve(__dirname);
@@ -33,6 +35,7 @@ const getCssLoaderOptions = () => {
       localIdentName: '[name]__[local]--[hash:base64:5]',
     };
   }
+
   return {};
 };
 
@@ -41,21 +44,27 @@ const chunksSortMode = (c1, c2) => {
   if (c1 === 'polyfill') {
     return -1;
   }
+
   if (c2 === 'polyfill') {
     return 1;
   }
+
   if (c1 === 'builtins') {
     return -1;
   }
+
   if (c2 === 'builtins') {
     return 1;
   }
+
   if (c1 === 'app') {
     return 1;
   }
+
   if (c2 === 'app') {
     return -1;
   }
+
   return 0;
 };
 
@@ -155,6 +164,7 @@ const webpackConfig = {
 if (TARGET === 'start') {
   // eslint-disable-next-line no-console
   console.error('Running in development (no HMR) mode');
+
   module.exports = merge(webpackConfig, {
     mode: 'development',
     devtool: 'cheap-module-source-map',
@@ -178,6 +188,7 @@ if (TARGET === 'build') {
   // eslint-disable-next-line no-console
   console.error('Running in production mode');
   process.env.NODE_ENV = 'production';
+
   module.exports = merge(webpackConfig, {
     mode: 'production',
     optimization: {
@@ -197,11 +208,6 @@ if (TARGET === 'build') {
       new webpack.DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify('production'),
       }),
-      // Looking at https://webpack.js.org/plugins/loader-options-plugin, this plugin seems to not
-      // be needed any longer. We should try deleting it next time we clean up this configuration.
-      new webpack.LoaderOptionsPlugin({
-        minimize: true,
-      }),
     ],
   });
 }
@@ -209,6 +215,7 @@ if (TARGET === 'build') {
 if (TARGET === 'test') {
   // eslint-disable-next-line no-console
   console.error('Running test/ci mode');
+
   module.exports = merge(webpackConfig, {
     module: {
       rules: [


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, adding a webpack config override in a plugin's
`webpack.config.js` lead to it being included in the webpack config used
to build the plugin's assets in its own build (producing the plugin's
production artifacts), but overrides were not integrated into the
webpack config used for development (when doing a `yarn start` in the
core repo).

This change is now adding logic to merge the generated plugin webpack
configs together and merges the core config into to generate a final
config including the core config and all plugin's overrides.

**Note:** In a first attempt a multi-compiler (separate compilers for
plugins, using their generated config) config was created. It works, but
unfortunately there is no easy way to sync compiler runs with the core
compiler run and to assemble the generated assets from plugin compilers
in order to include them in the boilerplate HTML. As this was a
timeboxed attempt, future attempts may be more successful.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.