### PR TITLE
Add share button to Dashboard LIst

### DIFF
--- a/graylog2-web-interface/src/views/components/views/ViewList.jsx
+++ b/graylog2-web-interface/src/views/components/views/ViewList.jsx
@@ -1,21 +1,28 @@
-import React, { useEffect, useReducer } from 'react';
+import React, { useEffect, useReducer, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { ButtonToolbar, DropdownButton, MenuItem } from 'components/graylog';
-import { PaginatedList, SearchForm, Spinner, EntityList } from 'components/common';
-import IfPermitted from 'components/common/IfPermitted';
+import { IfPermitted, HasOwnership, PaginatedList, SearchForm, Spinner, EntityList } from 'components/common';
+import EntityShareModal from 'components/permissions/EntityShareModal';
 
 import View from './View';
 
-const itemActionsFactory = (view, onViewDelete) => {
+import ViewTypeLabel from '../ViewTypeLabel';
+
+const itemActionsFactory = (view, onViewDelete, setViewToShare) => {
   return (
-    <IfPermitted permissions={[`view:edit:${view.id}`, 'view:edit']} anyPermissions>
-      <ButtonToolbar>
-        <DropdownButton title="Actions" id={`view-actions-dropdown-${view.id}`} bsSize="small" pullRight>
+    <ButtonToolbar>
+      <DropdownButton title="Actions" id={`view-actions-dropdown-${view.id}`} bsSize="small" pullRight>
+        <HasOwnership type="dashboard" id={view.id}>
+          {({ disabled }) => (
+            <MenuItem disabled={disabled} onSelect={() => setViewToShare(view)}>Share</MenuItem>
+          )}
+        </HasOwnership>
+        <IfPermitted permissions={[`view:edit:${view.id}`, 'view:edit']} anyPermissions>
           <MenuItem onSelect={onViewDelete(view)}>Delete</MenuItem>
-        </DropdownButton>
-      </ButtonToolbar>
-    </IfPermitted>
+        </IfPermitted>
+      </DropdownButton>
+    </ButtonToolbar>
   );
 };
 
@@ -39,6 +46,7 @@ const reducer = (state, action) => {
 
 const ViewList = ({ pagination, handleSearch, handleViewDelete, views }) => {
   const [{ query, page, perPage }, dispatch] = useReducer(reducer, { query: '', page: 1, perPage: 10 });
+  const [viewToShare, setViewToShare] = useState();
 
   const execSearch = () => handleSearch(query, page, perPage);
 
@@ -66,25 +74,34 @@ const ViewList = ({ pagination, handleSearch, handleViewDelete, views }) => {
           summary={view.summary}
           requires={view.requires}
           description={view.description}>
-      {itemActionsFactory(view, onViewDelete)}
+      {itemActionsFactory(view, onViewDelete, setViewToShare)}
     </View>
   ));
 
   return (
-    <PaginatedList onChange={(newPage, newPerPage) => dispatch({ type: 'pageChange', payload: { newPage, newPerPage } })}
-                   activePage={pagination.page}
-                   totalItems={pagination.total}
-                   pageSize={pagination.perPage}
-                   pageSizes={[10, 50, 100]}>
-      <div style={{ marginBottom: 15 }}>
-        <SearchForm onSearch={(newQuery) => dispatch({ type: 'search', payload: { newQuery } })}
-                    onReset={() => dispatch({ type: 'searchReset' })}
-                    topMargin={0} />
-      </div>
-      <EntityList items={items}
-                  bsNoItemsStyle="success"
-                  noItemsText="There are no views present/matching the filter!" />
-    </PaginatedList>
+    <>
+      { viewToShare && (
+        <EntityShareModal entityId={viewToShare.id}
+                          entityType="dashboard"
+                          description={`Search for a User or Team to add as collaborator on this ${ViewTypeLabel({ type: viewToShare.type })}.`}
+                          entityTitle={viewToShare.title}
+                          onClose={() => setViewToShare(undefined)} />
+      )}
+      <PaginatedList onChange={(newPage, newPerPage) => dispatch({ type: 'pageChange', payload: { newPage, newPerPage } })}
+                     activePage={pagination.page}
+                     totalItems={pagination.total}
+                     pageSize={pagination.perPage}
+                     pageSizes={[10, 50, 100]}>
+        <div style={{ marginBottom: 15 }}>
+          <SearchForm onSearch={(newQuery) => dispatch({ type: 'search', payload: { newQuery } })}
+                      onReset={() => dispatch({ type: 'searchReset' })}
+                      topMargin={0} />
+        </div>
+        <EntityList items={items}
+                    bsNoItemsStyle="success"
+                    noItemsText="There are no views present/matching the filter!" />
+      </PaginatedList>
+    </>
   );
 };
 


### PR DESCRIPTION
## Motivation
Prior to this change, the user needed to go to the Dashboard view/edit
page to add collaborators to a dashboard.

## Description
This change is now adding a MenuItem to the dashboard list so the user
can share the dashboard from the over view list. This might be helpful
if a user needs to share a lot of dashboards.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1569
Fixes #8793 