### PR TITLE
Fix invalid options for force merge request during index optimization.

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/IndicesAdapterES7.java
@@ -373,8 +373,7 @@ public class IndicesAdapterES7 implements IndicesAdapter {
         final ForceMergeRequest request = new ForceMergeRequest()
                 .indices(index)
                 .maxNumSegments(maxNumSegments)
-                .flush(true)
-                .onlyExpungeDeletes(true);
+                .flush(true);
 
         client.execute((c, requestOptions) -> c.indices().forcemerge(request, requestOptions));
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change removes the "only expunge deletes" option from the force merge request, as it contradicts with the "max num segments" option. For every execution of the request, a warning is logged about this, also indicating that while the request is still performed, it might not in future ES versions.

```
2020-08-20 11:56:29,184 WARN : org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestClient - request [POST https://localhost:9200/graylog2_1/_forcemerge?only_expunge_deletes=true&flush=true&ignore_unavailable=false&expand_wildcards=open&allow_no_indices=true&ignore_throttled=false&max_num_segments=1] returned 1 warnings: [299 Elasticsearch-7.8.1-b5ca9c58fb664ca8bf9e4057fc229b3396bf3a89 "setting only_expunge_deletes and max_num_segments at the same time is deprecated and will be rejected in a future version"]
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.