### PR TITLE
Use correct interval type for time bucketing.

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/buckets/ESTimeHandler.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivot/buckets/ESTimeHandler.java
@@ -46,13 +46,22 @@ public class ESTimeHandler extends ESPivotBucketSpecHandler<Time, ParsedDateHist
         final DateHistogramInterval dateHistogramInterval = new DateHistogramInterval(timeSpec.interval().toDateInterval(query.effectiveTimeRange(pivot)).toString());
         final Optional<BucketOrder> ordering = orderForPivot(pivot, timeSpec, esGeneratedQueryContext);
         final DateHistogramAggregationBuilder builder = AggregationBuilders.dateHistogram(name)
-                .fixedInterval(dateHistogramInterval)
                 .field(timeSpec.field())
                 .order(ordering.orElse(BucketOrder.key(true)))
                 .format("date_time");
+
+        setInterval(builder, dateHistogramInterval);
         record(esGeneratedQueryContext, pivot, timeSpec, name, ParsedDateHistogram.class);
 
         return Optional.of(builder);
+    }
+
+    private void setInterval(DateHistogramAggregationBuilder builder, DateHistogramInterval interval) {
+        if (DateHistogramAggregationBuilder.DATE_FIELD_UNITS.get(interval.toString()) != null) {
+            builder.calendarInterval(interval);
+        } else {
+            builder.fixedInterval(interval);
+        }
     }
 
 

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivots/buckets/ESTimeHandlerTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/searchtypes/pivots/buckets/ESTimeHandlerTest.java
@@ -28,47 +28,36 @@ import org.graylog.storage.elasticsearch7.views.searchtypes.pivot.buckets.ESTime
 import org.graylog2.plugin.indexer.searches.timeranges.InvalidRangeParametersException;
 import org.graylog2.plugin.indexer.searches.timeranges.RelativeRange;
 import org.graylog2.plugin.indexer.searches.timeranges.TimeRange;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.mockito.Answers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class ESTimeHandlerTest {
-    @Rule
-    public final MockitoRule mockitoRule = MockitoJUnit.rule();
-
+class ESTimeHandlerTest {
     private ESTimeHandler esTimeHandler;
 
-    @Mock
-    private Pivot pivot;
+    private final Pivot pivot = mock(Pivot.class);
 
-    @Mock
-    private Time time;
+    private final Time time = mock(Time.class);
 
-    @Mock
-    private ESPivot esPivot;
+    private final ESPivot esPivot = mock(ESPivot.class);
 
-    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-    private ESGeneratedQueryContext queryContext;
+    private final ESGeneratedQueryContext queryContext = mock(ESGeneratedQueryContext.class, RETURNS_DEEP_STUBS);
 
-    @Mock
-    private Query query;
+    private final Query query = mock(Query.class);
 
-    @Mock
-    private Interval interval;
+    private final Interval interval = mock(Interval.class, RETURNS_DEEP_STUBS);
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         this.esTimeHandler = new ESTimeHandler();
         when(time.interval()).thenReturn(interval);
@@ -101,5 +90,16 @@ public class ESTimeHandlerTest {
 
         final TimeRange argumentTimeRange = timeRangeCaptor.getValue();
         assertThat(argumentTimeRange).isEqualTo(RelativeRange.create(2323));
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(strings = { "1s", "1M", "4s", "14d" })
+    public void correctIntervalTypeIsUsedForAggregation(String intervalString) throws InvalidRangeParametersException {
+        when(pivot.timerange()).thenReturn(Optional.empty());
+        when(query.timerange()).thenReturn(RelativeRange.create(2323));
+        when(interval.toDateInterval(any(TimeRange.class)).toString()).thenReturn(intervalString);
+
+        this.esTimeHandler.doCreateAggregation("foobar", pivot, time, esPivot, queryContext, query);
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The Elasticsearch high-level REST client offers two ways to define the
interval for time-based bucketing, fixed and calendar intervals. Those
can be used for different interval specifications. Before this change,
the fixed interval was used for everything, leading to exceptions being
thrown e.g. when the interval was specified as `1M` (one month). (The
easiest way to reproduce this is to switch the time range to "all
messages" on ES7).

Therefore, this change checks if the given interval matches the ones
suitable for calendar intervals or uses fixed intervals otherwise.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.