### PR TITLE
Sync URL after updating current query from action.

### DIFF
--- a/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.js
+++ b/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.js
@@ -67,7 +67,7 @@ export const useSyncWithQueryParameters = (query: string) => {
   useEffect(() => syncWithQueryParameters(query, history.replace), []);
 
   useActionListeners(
-    [QueriesActions.update.completed],
+    [QueriesActions.update.completed, QueriesActions.query.completed],
     () => syncWithQueryParameters(query),
     [query],
   );

--- a/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.test.jsx
+++ b/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.test.jsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { render } from 'wrappedTestingLibrary';
 import * as Immutable from 'immutable';
 import asMock from 'helpers/mocking/AsMock';
+import mockAction from 'helpers/mocking/MockAction';
 
 import history from 'util/History';
 import { ViewStore } from 'views/stores/ViewStore';
@@ -16,11 +17,8 @@ import { syncWithQueryParameters, useSyncWithQueryParameters } from './SyncWithQ
 
 jest.mock('views/actions/QueriesActions', () => ({
   QueriesActions: {
-    update: {
-      completed: {
-        listen: jest.fn(() => () => {}),
-      },
-    },
+    update: mockAction(),
+    query: mockAction(),
   },
 }));
 
@@ -157,6 +155,7 @@ describe('SyncWithQueryParameters', () => {
       render(<TestComponent />);
 
       expect(QueriesActions.update.completed.listen).toHaveBeenCalled();
+      expect(QueriesActions.query.completed.listen).toHaveBeenCalled();
     });
   });
 });

--- a/graylog2-web-interface/test/helpers/mocking/MockAction.js
+++ b/graylog2-web-interface/test/helpers/mocking/MockAction.js
@@ -2,10 +2,13 @@
 
 import type { ListenableAction } from 'stores/StoreTypes';
 
-const mockAction = <R: function>(fn: R): ListenableAction<R> => {
-  return Object.assign(fn, {
-    listen: jest.fn(() => jest.fn()),
-    completed: { listen: jest.fn(() => jest.fn()) },
+const listenable = () => ({ listen: jest.fn(() => jest.fn()) });
+
+const noop: function = jest.fn();
+
+const mockAction = <R: function>(fn: R = noop): ListenableAction<R> => {
+  return Object.assign(fn, listenable(), {
+    completed: listenable(),
     promise: jest.fn(),
   });
 };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, the hook used to synchronize current search
parameters (query string, time range, streams) with the URL did listen
to `QueriesActions.update` only. This lead to query manipulations
through actions (e.g. when using the "Add to query"/"Exclude from
results") not triggering a URL sync.

This change makes the URL sync hook listen to `QueriesActions.query` as
well, so query manipulations trigger URL sync in any case.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.