### PR TITLE
Fix flickering of theme

### DIFF
--- a/graylog2-web-interface/src/theme/GraylogThemeProvider.jsx
+++ b/graylog2-web-interface/src/theme/GraylogThemeProvider.jsx
@@ -28,7 +28,7 @@ const GraylogThemeProvider = ({ children }: Props) => {
   const [theme, setTheme] = useState();
   const [userPreferences, setUserPreferences] = useState();
   const [themeColors, setThemeColors] = useState();
-  const [mode, setMode] = useState();
+  const [mode, setMode] = useState('');
 
   const currentUser = useStore(CurrentUserStore, (userStore) => {
     setUserPreferences(userStore?.currentUser?.preferences);
@@ -42,7 +42,7 @@ const GraylogThemeProvider = ({ children }: Props) => {
   };
 
   const handleModeChange = (nextMode) => Promise.resolve().then(() => {
-    if (nextMode && colors[nextMode]) {
+    if (colors[nextMode]) {
       const nextPreferences = { ...userPreferences, [PREFERENCES_THEME_MODE]: nextMode };
 
       setUserPreferences(nextPreferences);

--- a/graylog2-web-interface/src/theme/GraylogThemeProvider.jsx
+++ b/graylog2-web-interface/src/theme/GraylogThemeProvider.jsx
@@ -28,7 +28,7 @@ const GraylogThemeProvider = ({ children }: Props) => {
   const [theme, setTheme] = useState();
   const [userPreferences, setUserPreferences] = useState();
   const [themeColors, setThemeColors] = useState();
-  const [mode, setMode] = useState(colorScheme);
+  const [mode, setMode] = useState();
 
   const currentUser = useStore(CurrentUserStore, (userStore) => {
     setUserPreferences(userStore?.currentUser?.preferences);
@@ -65,7 +65,7 @@ const GraylogThemeProvider = ({ children }: Props) => {
 
     if (hasCurrentThemeMode) {
       setMode(hasCurrentThemeMode);
-    } else if (colorScheme !== mode) {
+    } else if (colorScheme) {
       setMode(colorScheme);
     } else {
       setMode(DEFAULT_THEME_MODE);

--- a/graylog2-web-interface/src/theme/GraylogThemeProvider.jsx
+++ b/graylog2-web-interface/src/theme/GraylogThemeProvider.jsx
@@ -42,7 +42,7 @@ const GraylogThemeProvider = ({ children }: Props) => {
   };
 
   const handleModeChange = (nextMode) => Promise.resolve().then(() => {
-    if (colors[nextMode]) {
+    if (nextMode && colors[nextMode]) {
       const nextPreferences = { ...userPreferences, [PREFERENCES_THEME_MODE]: nextMode };
 
       setUserPreferences(nextPreferences);

--- a/graylog2-web-interface/src/theme/types.js
+++ b/graylog2-web-interface/src/theme/types.js
@@ -10,6 +10,6 @@ export type ThemeInterface = {
   colors: Colors,
   fonts: Fonts,
   utils: Utils,
-  mode: ?string,
-  changeMode: (?string) => Promise<{} | null>,
+  mode: string,
+  changeMode: (string) => Promise<{} | null>,
 };

--- a/graylog2-web-interface/src/theme/types.js
+++ b/graylog2-web-interface/src/theme/types.js
@@ -10,6 +10,6 @@ export type ThemeInterface = {
   colors: Colors,
   fonts: Fonts,
   utils: Utils,
-  mode: string,
-  changeMode: (string) => Promise<{} | null>,
+  mode: ?string,
+  changeMode: (?string) => Promise<{} | null>,
 };


### PR DESCRIPTION
## Motivation
Prior to this change, when opening a popover, the opened popover would
flicker white then back to dark when in dark mode.

## Description
This change will do not set a default state for the mode. Which will
prevent the flickering.
