### PR TITLE
Set font size defined in theme for query input

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
@@ -105,4 +105,6 @@ QueryInput.defaultProps = {
   placeholder: '',
 };
 
-export default withPluginEntities(withTheme<ThemeInterface, Props, typeof undefined>(QueryInput), { completers: 'views.completers' });
+const mapping = { completers: 'views.completers' };
+
+export default withPluginEntities<$Rest<Props, {| theme: ThemeInterface |}>, typeof mapping>(withTheme(QueryInput), mapping);

--- a/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
@@ -16,11 +16,11 @@ import type { Completer } from './SearchBarAutocompletions';
 type Props = {|
   completerFactory: (Array<Completer>) => AutoCompleter,
   completers: Array<Completer>,
-  disabled: boolean,
+  disabled?: boolean,
   onBlur?: (string) => void,
   onChange: (string) => Promise<string>,
   onExecute: (string) => void,
-  placeholder: string,
+  placeholder?: string,
   theme: ThemeInterface,
   value: string,
 |};
@@ -105,4 +105,4 @@ QueryInput.defaultProps = {
   placeholder: '',
 };
 
-export default withTheme(withPluginEntities(QueryInput, { completers: 'views.completers' }));
+export default withPluginEntities(withTheme<ThemeInterface, Props, typeof undefined>(QueryInput), { completers: 'views.completers' });

--- a/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react';
 import { withTheme } from 'styled-components';
 import PropTypes from 'prop-types';
 
-import type { ThemeInterface } from 'theme';
+import { type ThemeInterface, themePropTypes } from 'theme';
 import withPluginEntities from 'views/logic/withPluginEntities';
 import UserPreferencesContext from 'contexts/UserPreferencesContext';
 
@@ -85,13 +85,14 @@ const QueryInput = ({ disabled, onBlur, onChange, onExecute, placeholder, value,
 };
 
 QueryInput.propTypes = {
-  completers: PropTypes.array,
   completerFactory: PropTypes.func,
+  completers: PropTypes.array,
   disabled: PropTypes.bool,
   onBlur: PropTypes.func,
   onChange: PropTypes.func.isRequired,
   onExecute: PropTypes.func.isRequired,
   placeholder: PropTypes.string,
+  theme: themePropTypes.isRequired,
   value: PropTypes.string,
 };
 

--- a/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/QueryInput.jsx
@@ -1,8 +1,10 @@
 // @flow strict
 import * as React from 'react';
 import { useCallback, useMemo } from 'react';
+import { withTheme } from 'styled-components';
 import PropTypes from 'prop-types';
 
+import type { ThemeInterface } from 'theme';
 import withPluginEntities from 'views/logic/withPluginEntities';
 import UserPreferencesContext from 'contexts/UserPreferencesContext';
 
@@ -12,19 +14,20 @@ import SearchBarAutoCompletions from './SearchBarAutocompletions';
 import type { Completer } from './SearchBarAutocompletions';
 
 type Props = {|
-  disabled: boolean,
-  value: string,
-  completers: Array<Completer>,
   completerFactory: (Array<Completer>) => AutoCompleter,
+  completers: Array<Completer>,
+  disabled: boolean,
   onBlur?: (string) => void,
   onChange: (string) => Promise<string>,
   onExecute: (string) => void,
   placeholder: string,
+  theme: ThemeInterface,
+  value: string,
 |};
 
 const defaultCompleterFactory = (completers) => new SearchBarAutoCompletions(completers);
 
-const QueryInput = ({ disabled, onBlur, onChange, onExecute, placeholder, value, completers, completerFactory = defaultCompleterFactory }: Props) => {
+const QueryInput = ({ disabled, onBlur, onChange, onExecute, placeholder, value, completers, completerFactory = defaultCompleterFactory, theme }: Props) => {
   const completer = useMemo(() => completerFactory(completers), [completerFactory, completers]);
   const _onExecute = useCallback((editor: Editor) => {
     if (editor.completer && editor.completer.popup) {
@@ -45,9 +48,6 @@ const QueryInput = ({ disabled, onBlur, onChange, onExecute, placeholder, value,
       });
 
       editor.commands.removeCommands(['indent', 'outdent']);
-
-      editor.setFontSize(16);
-
       editor.completers = [completer];
     }
   }, [completer, _onExecute]);
@@ -76,7 +76,7 @@ const QueryInput = ({ disabled, onBlur, onChange, onExecute, placeholder, value,
                              $blockScrolling: Infinity,
                              selectionStyle: 'line',
                            }}
-                           fontSize={13}
+                           fontSize={theme.fonts.size.large}
                            placeholder={placeholder} />
         )}
       </UserPreferencesContext.Consumer>
@@ -104,4 +104,4 @@ QueryInput.defaultProps = {
   placeholder: '',
 };
 
-export default withPluginEntities(QueryInput, { completers: 'views.completers' });
+export default withTheme(withPluginEntities(QueryInput, { completers: 'views.completers' }));

--- a/graylog2-web-interface/src/views/components/searchbar/QueryInput.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/QueryInput.test.jsx
@@ -24,7 +24,7 @@ class Completer {
 describe('QueryInput', () => {
   const SimpleQueryInput = (props) => (
     <QueryInput value="*"
-                onChange={() => {}}
+                onChange={() => Promise.resolve('')}
                 onExecute={() => {}}
                 completerFactory={() => new Completer()}
                 {...props} />

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/StyledAceEditor.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/StyledAceEditor.jsx
@@ -139,8 +139,10 @@ const StyledAceEditor = styled(AceEditor).attrs(({ aceTheme, theme }) => ({
     .ace_content,
     .ace_placeholder {
       top: 6px;
-      font-size: ${scTheme.fonts.size.large};
       padding: 0 !important;
+    }
+
+    .ace_placeholder {
       font-family: inherit !important;
     }
   }


### PR DESCRIPTION
This PR fixes a problem with long queries where uncontrollable whitespace is being added before the cursor.
![image](https://user-images.githubusercontent.com/46300478/90907526-62001a80-e3d3-11ea-9030-b3049ebfe5a4.png)
In the above screenshot `query` is selected, but it looks like the selected text is `ery  `.

Fixes #8720.