### PR TITLE
Fix darkmode color of tableheader of data tables

### DIFF
--- a/graylog2-web-interface/src/views/components/datatable/MessagesTable.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/MessagesTable.jsx
@@ -41,7 +41,7 @@ const StyledTable = styled(Table)(({ theme }) => css`
   
   > tbody td {
     background-color: ${theme.colors.global.contentBackground};
-    color: ${theme.utils.readableColor(theme.colors.global.contentBackground)};
+    color: ${theme.utils.contrastingColor(theme.colors.global.contentBackground)};
   }
 
   tr {

--- a/graylog2-web-interface/src/views/components/datatable/MessagesTable.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/MessagesTable.jsx
@@ -34,7 +34,8 @@ const StyledTable = styled(Table)(({ theme }) => css`
     border: 0;
     font-size: ${theme.fonts.size.small};
     font-weight: normal;
-    background-color: ${theme.colors.gray[10]};
+    background-color: ${theme.colors.gray[90]};
+    color: ${theme.utils.readableColor(theme.colors.gray[90])};
     white-space: nowrap;
   }
 

--- a/graylog2-web-interface/src/views/components/datatable/MessagesTable.jsx
+++ b/graylog2-web-interface/src/views/components/datatable/MessagesTable.jsx
@@ -38,6 +38,11 @@ const StyledTable = styled(Table)(({ theme }) => css`
     color: ${theme.utils.readableColor(theme.colors.gray[90])};
     white-space: nowrap;
   }
+  
+  > tbody td {
+    background-color: ${theme.colors.global.contentBackground};
+    color: ${theme.utils.readableColor(theme.colors.global.contentBackground)};
+  }
 
   tr {
     border: 0 !important;


### PR DESCRIPTION
## Description
Fix darkmode color of tableheader of data tables

### Before
![Graylog (11)](https://user-images.githubusercontent.com/448763/91025714-0a8fc380-e5fa-11ea-98ca-5540e438a03a.png)

### After
![Graylog (10)](https://user-images.githubusercontent.com/448763/91025727-0d8ab400-e5fa-11ea-9fa1-d69b266e5b76.png)
