### PR TITLE
Enabling flow declarations for `node_modules`.

### DIFF
--- a/graylog2-web-interface/.flowconfig
+++ b/graylog2-web-interface/.flowconfig
@@ -4,11 +4,14 @@ src
 [ignore]
 .*/build/.*
 .*/target/.*
-.*json$
-.*/node_modules/.*
+<PROJECT_ROOT>/node_modules/react-select/.*
+<PROJECT_ROOT>/node_modules/immutable/dist/immutable.js.flow
 
 [libs]
 flow-typed
+
+[declarations]
+<PROJECT_ROOT>/node_modules/.*
 
 [strict]
 untyped-type-import

--- a/graylog2-web-interface/src/views/components/sidebar/fields/List.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/fields/List.jsx
@@ -60,8 +60,9 @@ const List = ({ viewMetadata: { activeQuery }, filter, activeQueryFields, allFie
 
   return (
     <SizeMe monitorHeight refreshRate={100}>
-      {({ size: { height } }) => (
+      {({ size: { height, width } }) => (
         <FixedSizeList height={height || DEFAULT_HEIGHT_PX}
+                       width={width}
                        itemCount={fieldList.size}
                        itemSize={20}>
           {Row}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously, flow was not type-checking usage of third party modules in `node_modules`, if no `flow-typed` definition for a module was existant.
This PR is enabling flow type checks for our usage of third party dependencies in `node_modules` by removing the ignore for the directory and instead using it for declarations. This avoids type-checking of all modules in `node_modules`, but uses supplied flow definitions from modules. Flow type definitions from `flow-typed` are still used, but type definitions included in a package take precedence.

This change ignores type definitions for `react-select` & `immutable.js` from their packages right now. In the first case (`react-select`), we need to fix our usage of it in quite a number of cases. A follow-up PR for this will be created. For the second case (`immutable.js`), we are already using a `flow-typed` file that is more exact than the one included in the package (we also cannot expect the in-package typedefs to be fixed, as immutable.js 3.x has become unmaintained).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.