### PR TITLE
Don't validate initial share requests // provide validation context

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/shares/EntitySharesService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/EntitySharesService.java
@@ -41,6 +41,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
@@ -185,8 +186,13 @@ public class EntitySharesService {
 
         final List<GrantDTO> allEntityGrants = grantService.getForTarget(ownedEntity);
         final List<GrantDTO> existingGrants = grantService.getForTargetExcludingGrantee(ownedEntity, sharingUserGRN);
-        final ImmutableMap<GRN, Capability> selectedGranteeCapabilities = request.selectedGranteeCapabilities()
-                .orElse(ImmutableMap.of());
+
+        // The initial request doesn't submit a grantee selection. Just return.
+        if (!request.selectedGranteeCapabilities().isPresent()) {
+            return validationResult;
+        }
+
+        final ImmutableMap<GRN, Capability> selectedGranteeCapabilities = request.selectedGranteeCapabilities().get();
 
         // If there is still an owner in the selection, everything is fine
         if (selectedGranteeCapabilities.containsValue(Capability.OWN)) {
@@ -216,6 +222,9 @@ public class EntitySharesService {
         }
         validationResult.addError(EntityShareRequest.SELECTED_GRANTEE_CAPABILITIES,
                 String.format(Locale.US, "Removing the following owners <%s> will leave the entity ownerless.", removedOwners));
+        // Also return the grantees as list to be used by the frontend
+        validationResult.addContext(EntityShareRequest.SELECTED_GRANTEE_CAPABILITIES,
+                removedOwners.stream().map(Objects::toString).collect(Collectors.toSet()));
 
         return validationResult;
     }

--- a/graylog2-server/src/main/java/org/graylog2/plugin/rest/ValidationResult.java
+++ b/graylog2-server/src/main/java/org/graylog2/plugin/rest/ValidationResult.java
@@ -16,11 +16,10 @@
  */
 package org.graylog2.plugin.rest;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 
 import java.util.Collection;
 import java.util.Map;
@@ -29,10 +28,14 @@ import java.util.Map;
 public class ValidationResult {
 
     private final Multimap<String, String> errors = ArrayListMultimap.create();
+    private final Multimap<String, String> context = ArrayListMultimap.create();
 
 
     public void addError(String fieldName, String error) {
         errors.put(fieldName, error);
+    }
+    public void addContext(String fieldName, Iterable<String> values) {
+        context.putAll(fieldName, values);
     }
 
     public void addAll(Multimap<String, String> extraErrors) {
@@ -51,5 +54,10 @@ public class ValidationResult {
     @JsonProperty("errors")
     public Map<String, Collection<String>> getErrors() {
         return errors.asMap();
+    }
+
+    @JsonProperty("error_context")
+    public Map<String, Collection<String>> getContext() {
+        return context.asMap();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/security/shares/EntitySharesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/shares/EntitySharesServiceTest.java
@@ -158,4 +158,20 @@ public class EntitySharesServiceTest {
             assertThat(validationResult.getErrors()).isEmpty();
         });
     }
+
+    @DisplayName("Don't run validation on initial empty request")
+    @Test
+    void noValidationOnEmptyRequest() {
+        final GRN entity = grnRegistry.newGRN(GRNTypes.DASHBOARD, "54e3deadbeefdeadbeefaffe");
+        final EntityShareRequest shareRequest = EntityShareRequest.create(null);
+
+        final User user = mock(User.class);
+        final Subject subject = mock(Subject.class);
+        when(user.getName()).thenReturn("hans");
+        final EntityShareResponse entityShareResponse = entitySharesService.prepareShare(entity, shareRequest, user, subject);
+        assertThat(entityShareResponse.validationResult()).satisfies(validationResult -> {
+            assertThat(validationResult.failed()).isFalse();
+            assertThat(validationResult.getErrors()).isEmpty();
+        });
+    }
 }


### PR DESCRIPTION
Extend the validation result to contain an `error_context`.
This allows us to add entries that the frontend can parse more easily.

Example:

```
    "validation_result": {
        "context": {
            "selected_grantee_capabilities": [
                "grn::::team:5f1015e5619e2c125100c570",
                "grn::::user:hans"
            ]
        },
        "errors": {
            "selected_grantee_capabilities": [
                "Removing the following owners <[grn::::team:5f1015e5619e2c125100c570,grn::::user:hans]> will leave the entity ownerless."
            ]
        },
        "failed": true
    }

```

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1569
