### PR TITLE
Add type definition for user create and update payload

### DIFF
--- a/graylog2-web-interface/src/actions/users/UsersActions.js
+++ b/graylog2-web-interface/src/actions/users/UsersActions.js
@@ -4,9 +4,24 @@ import * as Immutable from 'immutable';
 
 import { singletonActions } from 'views/logic/singleton';
 import type { RefluxActions } from 'stores/StoreTypes';
-import User from 'logic/users/User';
+import User, { type UserJSON } from 'logic/users/User';
 import UserOverview from 'logic/users/UserOverview';
 import type { PaginationType } from 'stores/PaginationTypes';
+
+export type UserCreate = {
+  email: $PropertyType<UserJSON, 'email'>,
+  full_name: $PropertyType<UserJSON, 'full_name'>,
+  password: string,
+  permissions: $PropertyType<UserJSON, 'permissions'>,
+  roles: $PropertyType<UserJSON, 'roles'>,
+  session_timeout_ms: $PropertyType<UserJSON, 'session_timeout_ms'>,
+  timezone: $PropertyType<UserJSON, 'timezone'>,
+  username: $PropertyType<UserJSON, 'username'>,
+};
+
+export type UserUpdate = $Shape<UserCreate & {
+  old_password: string,
+}>;
 
 export type Token = {
   token_name: string,
@@ -26,9 +41,9 @@ export type PaginatedUsers = {
 };
 
 type UsersActionsType = RefluxActions<{
-  create: (request: any) => Promise<string[]>,
+  create: (user: UserCreate) => Promise<string[]>,
   load: (username: string) => Promise<User>,
-  update: (username: string, request: any) => Promise<void>,
+  update: (username: string, user: UserUpdate) => Promise<void>,
   delete: (username: string) => Promise<string[]>,
   changePassword: (username: string, request: ChangePasswordRequest) => Promise<void>,
   createToken: (username: string, tokenName: string) => Promise<Token>,

--- a/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/SettingsSection.jsx
@@ -11,7 +11,7 @@ import TimeoutFormGroup from '../UserCreate/TimeoutFormGroup';
 
 type Props = {
   user: User,
-  onSubmit: ({timezone: $PropertyType<User, 'timezone'> }) => Promise<void>,
+  onSubmit: ({ timezone: $PropertyType<User, 'timezone'> }) => Promise<void>,
 };
 
 const SettingsSection = ({

--- a/graylog2-web-interface/src/components/users/UserEdit/UserEdit.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/UserEdit.jsx
@@ -2,7 +2,6 @@
 import * as React from 'react';
 import { useContext } from 'react';
 
-import type { UserUpdate } from 'actions/users/UsersActions';
 import { UsersActions } from 'stores/users/UsersStore';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import { Spinner, IfPermitted } from 'components/common';
@@ -26,7 +25,7 @@ type Props = {
   user: ?User,
 };
 
-const _updateUser = (data: UserUpdate, currentUser, user) => {
+const _updateUser = (data, currentUser, user) => {
   return UsersActions.update(user.username, data).then(() => {
     UserNotification.success('User updated successfully.', 'Success');
 

--- a/graylog2-web-interface/src/components/users/UserEdit/UserEdit.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/UserEdit.jsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { useContext } from 'react';
 
+import type { UserUpdate } from 'actions/users/UsersActions';
 import { UsersActions } from 'stores/users/UsersStore';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import { Spinner, IfPermitted } from 'components/common';
@@ -25,7 +26,7 @@ type Props = {
   user: ?User,
 };
 
-const _updateUser = (data, currentUser, user) => {
+const _updateUser = (data: UserUpdate, currentUser, user) => {
   return UsersActions.update(user.username, data).then(() => {
     UserNotification.success('User updated successfully.', 'Success');
 

--- a/graylog2-web-interface/src/stores/users/UsersStore.js
+++ b/graylog2-web-interface/src/stores/users/UsersStore.js
@@ -12,7 +12,8 @@ import UserNotification from 'util/UserNotification';
 import PaginationURL from 'util/PaginationURL';
 import UserOverview from 'logic/users/UserOverview';
 import User from 'logic/users/User';
-import UsersActions, { type ChangePasswordRequest, type Token, type PaginatedUsers } from 'actions/users/UsersActions';
+import UsersActions from 'actions/users/UsersActions';
+import type { ChangePasswordRequest, Token, PaginatedUsers, UserCreate, UserUpdate } from 'actions/users/UsersActions';
 import type { PaginatedResponseType } from 'stores/PaginationTypes';
 
 type PaginatedResponse = PaginatedResponseType & {
@@ -27,9 +28,9 @@ const UsersStore: Store<{}> = singletonStore(
   () => Reflux.createStore({
     listenables: [UsersActions],
 
-    create(request: any): Promise<string[]> {
+    create(user: UserCreate): Promise<string[]> {
       const url = qualifyUrl(ApiRoutes.UsersApiController.create().url);
-      const promise = fetch('POST', url, request);
+      const promise = fetch('POST', url, user);
       UsersActions.create.promise(promise);
 
       return promise;
@@ -49,9 +50,9 @@ const UsersStore: Store<{}> = singletonStore(
       return promise;
     },
 
-    update(username: string, request: any): void {
+    update(username: string, user: UserUpdate): void {
       const url = qualifyUrl(ApiRoutes.UsersApiController.update(encodeURIComponent(username)).url);
-      const promise = fetch('PUT', url, request);
+      const promise = fetch('PUT', url, user);
       UsersActions.update.promise(promise);
 
       return promise;


### PR DESCRIPTION
Right now the payload for the user create and update request is typed as `any`. This PR adds proper type definitions for the actions and store methods.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1569