### PR TITLE
Auto-sense Elasticsearch version if no version is set.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20200730000000_AddGl2MessageIdFieldAliasForEvents.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/migrations/V20200730000000_AddGl2MessageIdFieldAliasForEvents.java
@@ -26,11 +26,11 @@ import org.graylog2.configuration.ElasticsearchConfiguration;
 import org.graylog2.migrations.Migration;
 import org.graylog2.plugin.Version;
 import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.storage.ElasticsearchVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import java.time.ZonedDateTime;
 import java.util.Set;
 
@@ -47,7 +47,7 @@ public class V20200730000000_AddGl2MessageIdFieldAliasForEvents extends Migratio
 
     @Inject
     public V20200730000000_AddGl2MessageIdFieldAliasForEvents(
-            @Named("elasticsearch_version") Version elasticsearchVersion,
+            @ElasticsearchVersion Version elasticsearchVersion,
             ClusterConfigService clusterConfigService,
             ElasticsearchAdapter elasticsearch,
             ElasticsearchConfiguration elasticsearchConfig) {

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/providers/ExportBackendProvider.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/providers/ExportBackendProvider.java
@@ -18,16 +18,16 @@ package org.graylog.plugins.views.providers;
 
 import org.graylog.plugins.views.search.export.ExportBackend;
 import org.graylog2.plugin.Version;
+import org.graylog2.storage.ElasticsearchVersion;
 import org.graylog2.storage.VersionAwareProvider;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Provider;
 import java.util.Map;
 
 public class ExportBackendProvider extends VersionAwareProvider<ExportBackend> {
     @Inject
-    public ExportBackendProvider(@Named("elasticsearch_version") Version version, Map<Version, Provider<ExportBackend>> pluginBindings) {
+    public ExportBackendProvider(@ElasticsearchVersion Version version, Map<Version, Provider<ExportBackend>> pluginBindings) {
         super(version, pluginBindings);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ElasticsearchModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ElasticsearchModule.java
@@ -18,10 +18,14 @@ package org.graylog2.bindings;
 
 import com.google.inject.AbstractModule;
 import org.graylog2.indexer.IndexMappingFactory;
+import org.graylog2.plugin.Version;
+import org.graylog2.storage.ElasticsearchVersion;
+import org.graylog2.storage.providers.ElasticsearchVersionProvider;
 
 public class ElasticsearchModule extends AbstractModule {
     @Override
     protected void configure() {
+        bind(Version.class).annotatedWith(ElasticsearchVersion.class).toProvider(ElasticsearchVersionProvider.class).asEagerSingleton();
         bind(IndexMappingFactory.class).asEagerSingleton();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
@@ -34,7 +34,7 @@ import java.util.List;
 
 public class ElasticsearchClientConfiguration {
     @Parameter(value = "elasticsearch_version", converter = MajorVersionConverter.class, validators = {ElasticsearchVersionValidator.class})
-    Version elasticsearchVersion = Version.from(6, 0, 0);
+    Version elasticsearchVersion;
 
     @Parameter(value = "elasticsearch_hosts", converter = URIListConverter.class, validators = {NonEmptyListValidator.class, ListOfURIsWithHostAndSchemeValidator.class})
     List<URI> elasticsearchHosts = Collections.singletonList(URI.create("http://127.0.0.1:9200"));

--- a/graylog2-server/src/main/java/org/graylog2/storage/ElasticsearchVersion.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/ElasticsearchVersion.java
@@ -14,20 +14,17 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.storage.providers;
+package org.graylog2.storage;
 
-import org.graylog2.indexer.messages.MessagesAdapter;
-import org.graylog2.plugin.Version;
-import org.graylog2.storage.ElasticsearchVersion;
-import org.graylog2.storage.VersionAwareProvider;
+import com.google.inject.BindingAnnotation;
 
-import javax.inject.Inject;
-import javax.inject.Provider;
-import java.util.Map;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-public class MessagesAdapterProvider extends VersionAwareProvider<MessagesAdapter> {
-    @Inject
-    public MessagesAdapterProvider(@ElasticsearchVersion Version version, Map<Version, Provider<MessagesAdapter>> pluginBindings) {
-        super(version, pluginBindings);
-    }
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@BindingAnnotation
+public @interface ElasticsearchVersion {
 }

--- a/graylog2-server/src/main/java/org/graylog2/storage/VersionAwareProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/VersionAwareProvider.java
@@ -19,7 +19,6 @@ package org.graylog2.storage;
 import org.graylog2.plugin.Version;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Provider;
 import java.util.Map;
 
@@ -28,7 +27,7 @@ public class VersionAwareProvider<T> implements Provider<T> {
     private final Map<Version, Provider<T>> pluginBindings;
 
     @Inject
-    public VersionAwareProvider(@Named("elasticsearch_version") Version elasticsearchMajorVersion, Map<Version, Provider<T>> pluginBindings) {
+    public VersionAwareProvider(@ElasticsearchVersion Version elasticsearchMajorVersion, Map<Version, Provider<T>> pluginBindings) {
         this.elasticsearchMajorVersion = elasticsearchMajorVersion;
         this.pluginBindings = pluginBindings;
     }

--- a/graylog2-server/src/main/java/org/graylog2/storage/providers/AtomicCache.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/providers/AtomicCache.java
@@ -1,0 +1,44 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.storage.providers;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+public class AtomicCache<T> {
+    private final AtomicReference<Future<T>> value;
+
+    public AtomicCache() {
+        this.value = new AtomicReference<>();
+    }
+
+    public T get(Supplier<T> valueSupplier) throws ExecutionException, InterruptedException {
+        final CompletableFuture<T> completableFuture = new CompletableFuture<>();
+        final Future<T> previous = this.value.getAndAccumulate(completableFuture, (prev, cur) -> prev == null ? cur : prev);
+        if (previous == null) {
+            final T newValue = valueSupplier.get();
+            completableFuture.complete(newValue);
+
+            return newValue;
+        } else {
+            return previous.get();
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/storage/providers/ClusterAdapterProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/providers/ClusterAdapterProvider.java
@@ -18,16 +18,16 @@ package org.graylog2.storage.providers;
 
 import org.graylog2.indexer.cluster.ClusterAdapter;
 import org.graylog2.plugin.Version;
+import org.graylog2.storage.ElasticsearchVersion;
 import org.graylog2.storage.VersionAwareProvider;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Provider;
 import java.util.Map;
 
 public class ClusterAdapterProvider extends VersionAwareProvider<ClusterAdapter> {
     @Inject
-    public ClusterAdapterProvider(@Named("elasticsearch_version") Version version, Map<Version, Provider<ClusterAdapter>> pluginBindings) {
+    public ClusterAdapterProvider(@ElasticsearchVersion Version version, Map<Version, Provider<ClusterAdapter>> pluginBindings) {
         super(version, pluginBindings);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/storage/providers/CountsAdapterProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/providers/CountsAdapterProvider.java
@@ -18,16 +18,16 @@ package org.graylog2.storage.providers;
 
 import org.graylog2.indexer.counts.CountsAdapter;
 import org.graylog2.plugin.Version;
+import org.graylog2.storage.ElasticsearchVersion;
 import org.graylog2.storage.VersionAwareProvider;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Provider;
 import java.util.Map;
 
 public class CountsAdapterProvider extends VersionAwareProvider<CountsAdapter> {
     @Inject
-    public CountsAdapterProvider(@Named("elasticsearch_version") Version version, Map<Version, Provider<CountsAdapter>> pluginBindings) {
+    public CountsAdapterProvider(@ElasticsearchVersion Version version, Map<Version, Provider<CountsAdapter>> pluginBindings) {
         super(version, pluginBindings);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/storage/providers/ElasticsearchBackendProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/providers/ElasticsearchBackendProvider.java
@@ -19,16 +19,16 @@ package org.graylog2.storage.providers;
 import org.graylog.plugins.views.search.engine.GeneratedQueryContext;
 import org.graylog.plugins.views.search.engine.QueryBackend;
 import org.graylog2.plugin.Version;
+import org.graylog2.storage.ElasticsearchVersion;
 import org.graylog2.storage.VersionAwareProvider;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Provider;
 import java.util.Map;
 
 public class ElasticsearchBackendProvider extends VersionAwareProvider<QueryBackend<? extends GeneratedQueryContext>> {
     @Inject
-    public ElasticsearchBackendProvider(@Named("elasticsearch_version") Version version,
+    public ElasticsearchBackendProvider(@ElasticsearchVersion Version version,
                                         Map<Version, Provider<QueryBackend<? extends GeneratedQueryContext>>> pluginBindings) {
         super(version, pluginBindings);
     }

--- a/graylog2-server/src/main/java/org/graylog2/storage/providers/ElasticsearchVersionProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/providers/ElasticsearchVersionProvider.java
@@ -1,0 +1,76 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.storage.providers;
+
+import org.graylog2.plugin.Version;
+import org.graylog2.storage.versionprobe.VersionProbe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+@Singleton
+public class ElasticsearchVersionProvider implements Provider<Version> {
+    private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchVersionProvider.class);
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private final Optional<Version> versionOverride;
+    private final List<URI> elasticsearchHosts;
+    private final VersionProbe versionProbe;
+    private final AtomicCache<Optional<Version>> cachedVersion;
+
+    @Inject
+    public ElasticsearchVersionProvider(@Named("elasticsearch_version") @Nullable Version versionOverride,
+                                        @Named("elasticsearch_hosts") List<URI> elasticsearchHosts,
+                                        VersionProbe versionProbe,
+                                        AtomicCache<Optional<Version>> cachedVersion) {
+
+        this.versionOverride = Optional.ofNullable(versionOverride);
+        this.elasticsearchHosts = elasticsearchHosts;
+        this.versionProbe = versionProbe;
+        this.cachedVersion = cachedVersion;
+    }
+
+    @Override
+    public Version get() {
+        if (this.versionOverride.isPresent()) {
+            final Version explicitVersion = versionOverride.get();
+            LOG.info("Elasticsearch version set to " + explicitVersion + " - disabling version probe.");
+            return explicitVersion;
+        }
+
+        try {
+            return this.cachedVersion.get(() -> this.versionProbe.probe(this.elasticsearchHosts))
+                    .map(this::majorVersionFrom)
+                    .orElseThrow(() -> new RuntimeException("Unable to probe for Elasticsearch version!"));
+        } catch (ExecutionException | InterruptedException e) {
+            throw new RuntimeException("Unable to probe for Elasticsearch version: ", e);
+        }
+    }
+
+    private Version majorVersionFrom(Version version) {
+        return Version.from(version.getVersion().getMajorVersion(), 0, 0);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/storage/providers/IndexFieldTypePollerAdapterProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/providers/IndexFieldTypePollerAdapterProvider.java
@@ -18,16 +18,16 @@ package org.graylog2.storage.providers;
 
 import org.graylog2.indexer.fieldtypes.IndexFieldTypePollerAdapter;
 import org.graylog2.plugin.Version;
+import org.graylog2.storage.ElasticsearchVersion;
 import org.graylog2.storage.VersionAwareProvider;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Provider;
 import java.util.Map;
 
 public class IndexFieldTypePollerAdapterProvider extends VersionAwareProvider<IndexFieldTypePollerAdapter> {
     @Inject
-    public IndexFieldTypePollerAdapterProvider(@Named("elasticsearch_version") Version version, Map<Version, Provider<IndexFieldTypePollerAdapter>> pluginBindings) {
+    public IndexFieldTypePollerAdapterProvider(@ElasticsearchVersion Version version, Map<Version, Provider<IndexFieldTypePollerAdapter>> pluginBindings) {
         super(version, pluginBindings);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/storage/providers/IndexToolsAdapterProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/providers/IndexToolsAdapterProvider.java
@@ -18,16 +18,16 @@ package org.graylog2.storage.providers;
 
 import org.graylog2.indexer.IndexToolsAdapter;
 import org.graylog2.plugin.Version;
+import org.graylog2.storage.ElasticsearchVersion;
 import org.graylog2.storage.VersionAwareProvider;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Provider;
 import java.util.Map;
 
 public class IndexToolsAdapterProvider extends VersionAwareProvider<IndexToolsAdapter> {
     @Inject
-    public IndexToolsAdapterProvider(@Named("elasticsearch_version") Version version, Map<Version, Provider<IndexToolsAdapter>> pluginBindings) {
+    public IndexToolsAdapterProvider(@ElasticsearchVersion Version version, Map<Version, Provider<IndexToolsAdapter>> pluginBindings) {
         super(version, pluginBindings);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/storage/providers/IndicesAdapterProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/providers/IndicesAdapterProvider.java
@@ -18,16 +18,16 @@ package org.graylog2.storage.providers;
 
 import org.graylog2.indexer.indices.IndicesAdapter;
 import org.graylog2.plugin.Version;
+import org.graylog2.storage.ElasticsearchVersion;
 import org.graylog2.storage.VersionAwareProvider;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Provider;
 import java.util.Map;
 
 public class IndicesAdapterProvider extends VersionAwareProvider<IndicesAdapter> {
     @Inject
-    public IndicesAdapterProvider(@Named("elasticsearch_version") Version version, Map<Version, Provider<IndicesAdapter>> pluginBindings) {
+    public IndicesAdapterProvider(@ElasticsearchVersion Version version, Map<Version, Provider<IndicesAdapter>> pluginBindings) {
         super(version, pluginBindings);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/storage/providers/MoreSearchAdapterProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/providers/MoreSearchAdapterProvider.java
@@ -18,16 +18,16 @@ package org.graylog2.storage.providers;
 
 import org.graylog.events.search.MoreSearchAdapter;
 import org.graylog2.plugin.Version;
+import org.graylog2.storage.ElasticsearchVersion;
 import org.graylog2.storage.VersionAwareProvider;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Provider;
 import java.util.Map;
 
 public class MoreSearchAdapterProvider extends VersionAwareProvider<MoreSearchAdapter> {
     @Inject
-    public MoreSearchAdapterProvider(@Named("elasticsearch_version") Version version, Map<Version, Provider<MoreSearchAdapter>> pluginBindings) {
+    public MoreSearchAdapterProvider(@ElasticsearchVersion Version version, Map<Version, Provider<MoreSearchAdapter>> pluginBindings) {
         super(version, pluginBindings);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/storage/providers/NodeAdapterProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/providers/NodeAdapterProvider.java
@@ -18,16 +18,16 @@ package org.graylog2.storage.providers;
 
 import org.graylog2.indexer.cluster.NodeAdapter;
 import org.graylog2.plugin.Version;
+import org.graylog2.storage.ElasticsearchVersion;
 import org.graylog2.storage.VersionAwareProvider;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Provider;
 import java.util.Map;
 
 public class NodeAdapterProvider extends VersionAwareProvider<NodeAdapter> {
     @Inject
-    public NodeAdapterProvider(@Named("elasticsearch_version") Version version, Map<Version, Provider<NodeAdapter>> pluginBindings) {
+    public NodeAdapterProvider(@ElasticsearchVersion Version version, Map<Version, Provider<NodeAdapter>> pluginBindings) {
         super(version, pluginBindings);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/storage/providers/SearchesAdapterProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/providers/SearchesAdapterProvider.java
@@ -18,16 +18,16 @@ package org.graylog2.storage.providers;
 
 import org.graylog2.indexer.searches.SearchesAdapter;
 import org.graylog2.plugin.Version;
+import org.graylog2.storage.ElasticsearchVersion;
 import org.graylog2.storage.VersionAwareProvider;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Provider;
 import java.util.Map;
 
 public class SearchesAdapterProvider extends VersionAwareProvider<SearchesAdapter> {
     @Inject
-    public SearchesAdapterProvider(@Named("elasticsearch_version") Version version, Map<Version, Provider<SearchesAdapter>> pluginBindings) {
+    public SearchesAdapterProvider(@ElasticsearchVersion Version version, Map<Version, Provider<SearchesAdapter>> pluginBindings) {
         super(version, pluginBindings);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/storage/providers/V20170607164210_MigrateReopenedIndicesToAliasesClusterStateAdapterProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/providers/V20170607164210_MigrateReopenedIndicesToAliasesClusterStateAdapterProvider.java
@@ -18,16 +18,16 @@ package org.graylog2.storage.providers;
 
 import org.graylog2.migrations.V20170607164210_MigrateReopenedIndicesToAliases;
 import org.graylog2.plugin.Version;
+import org.graylog2.storage.ElasticsearchVersion;
 import org.graylog2.storage.VersionAwareProvider;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Provider;
 import java.util.Map;
 
 public class V20170607164210_MigrateReopenedIndicesToAliasesClusterStateAdapterProvider extends VersionAwareProvider<V20170607164210_MigrateReopenedIndicesToAliases.ClusterState> {
     @Inject
-    public V20170607164210_MigrateReopenedIndicesToAliasesClusterStateAdapterProvider(@Named("elasticsearch_version") Version version, Map<Version, Provider<V20170607164210_MigrateReopenedIndicesToAliases.ClusterState>> pluginBindings) {
+    public V20170607164210_MigrateReopenedIndicesToAliasesClusterStateAdapterProvider(@ElasticsearchVersion Version version, Map<Version, Provider<V20170607164210_MigrateReopenedIndicesToAliases.ClusterState>> pluginBindings) {
         super(version, pluginBindings);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/storage/providers/V20200730000000_AddGl2MessageIdFieldAliasForEventsElasticsearchAdapterProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/providers/V20200730000000_AddGl2MessageIdFieldAliasForEventsElasticsearchAdapterProvider.java
@@ -18,10 +18,10 @@ package org.graylog2.storage.providers;
 
 import org.graylog.plugins.views.migrations.V20200730000000_AddGl2MessageIdFieldAliasForEvents;
 import org.graylog2.plugin.Version;
+import org.graylog2.storage.ElasticsearchVersion;
 import org.graylog2.storage.VersionAwareProvider;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Provider;
 import java.util.Map;
 
@@ -29,7 +29,7 @@ public class V20200730000000_AddGl2MessageIdFieldAliasForEventsElasticsearchAdap
         extends VersionAwareProvider<V20200730000000_AddGl2MessageIdFieldAliasForEvents.ElasticsearchAdapter> {
     @Inject
     public V20200730000000_AddGl2MessageIdFieldAliasForEventsElasticsearchAdapterProvider(
-            @Named("elasticsearch_version") Version version,
+            @ElasticsearchVersion Version version,
             Map<Version, Provider<V20200730000000_AddGl2MessageIdFieldAliasForEvents.ElasticsearchAdapter>> pluginBindings) {
         super(version, pluginBindings);
     }

--- a/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/RootResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/RootResponse.java
@@ -14,20 +14,22 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.storage.providers;
+package org.graylog2.storage.versionprobe;
 
-import org.graylog2.indexer.messages.MessagesAdapter;
-import org.graylog2.plugin.Version;
-import org.graylog2.storage.ElasticsearchVersion;
-import org.graylog2.storage.VersionAwareProvider;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
 
-import javax.inject.Inject;
-import javax.inject.Provider;
-import java.util.Map;
+@AutoValue
+@JsonAutoDetect
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class RootResponse {
+    public abstract VersionResponse version();
 
-public class MessagesAdapterProvider extends VersionAwareProvider<MessagesAdapter> {
-    @Inject
-    public MessagesAdapterProvider(@ElasticsearchVersion Version version, Map<Version, Provider<MessagesAdapter>> pluginBindings) {
-        super(version, pluginBindings);
+    @JsonCreator
+    public static RootResponse create(@JsonProperty("version") VersionResponse versionResponse) {
+        return new AutoValue_RootResponse(versionResponse);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/RootRoute.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/RootRoute.java
@@ -14,20 +14,12 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.storage.providers;
+package org.graylog2.storage.versionprobe;
 
-import org.graylog2.indexer.messages.MessagesAdapter;
-import org.graylog2.plugin.Version;
-import org.graylog2.storage.ElasticsearchVersion;
-import org.graylog2.storage.VersionAwareProvider;
+import retrofit2.Call;
+import retrofit2.http.GET;
 
-import javax.inject.Inject;
-import javax.inject.Provider;
-import java.util.Map;
-
-public class MessagesAdapterProvider extends VersionAwareProvider<MessagesAdapter> {
-    @Inject
-    public MessagesAdapterProvider(@ElasticsearchVersion Version version, Map<Version, Provider<MessagesAdapter>> pluginBindings) {
-        super(version, pluginBindings);
-    }
+public interface RootRoute {
+    @GET("/")
+    Call<RootResponse> root();
 }

--- a/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/VersionProbe.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/VersionProbe.java
@@ -1,0 +1,130 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.storage.versionprobe;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
+import okhttp3.Credentials;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import org.graylog2.plugin.Version;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import retrofit2.Response;
+import retrofit2.Retrofit;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.util.Collection;
+import java.util.Optional;
+
+public class VersionProbe {
+    private static final Logger LOG = LoggerFactory.getLogger(VersionProbe.class);
+    private final ObjectMapper objectMapper;
+    private final OkHttpClient okHttpClient;
+
+    @Inject
+    public VersionProbe(ObjectMapper objectMapper, OkHttpClient okHttpClient) {
+        this.objectMapper = objectMapper;
+        this.okHttpClient = okHttpClient;
+    }
+
+    public Optional<Version> probe(Collection<URI> hosts) {
+        return hosts
+                .stream()
+                .map(this::probe)
+                .filter(Optional::isPresent)
+                .findFirst()
+                .orElse(Optional.empty());
+    }
+
+    public Optional<Version> probe(URI host) {
+        final Retrofit retrofit;
+        try {
+            retrofit = new Retrofit.Builder()
+                    .baseUrl(host.toURL())
+                    .addConverterFactory(JacksonConverterFactory.create(objectMapper))
+                    .client(addAuthenticationIfPresent(host, okHttpClient))
+                    .build();
+        } catch (MalformedURLException e) {
+            LOG.error("Elasticsearch node URL is invalid: " + host.toString(), e);
+            return Optional.empty();
+        }
+
+        final RootRoute root = retrofit.create(RootRoute.class);
+
+        return rootResponse(root)
+                .map(RootResponse::version)
+                .map(VersionResponse::number)
+                .flatMap(this::parseVersion);
+    }
+
+    private OkHttpClient addAuthenticationIfPresent(URI host, OkHttpClient okHttpClient) {
+        if (Strings.emptyToNull(host.getUserInfo()) != null) {
+            final String[] credentials = host.getUserInfo().split(":");
+            final String username = credentials[0];
+            final String password = credentials[1];
+            final String authToken = Credentials.basic(username, password);
+
+            return okHttpClient.newBuilder()
+                    .addInterceptor(chain -> {
+                        final Request originalRequest = chain.request();
+                        final Request.Builder builder = originalRequest.newBuilder().header("Authorization", authToken);
+                        final Request newRequest = builder.build();
+                        return chain.proceed(newRequest);
+                    })
+                    .build();
+        }
+
+        return okHttpClient;
+    }
+
+    private Optional<Version> parseVersion(String versionString) {
+        final String[] versionParts = versionString.split("\\.");
+        if (versionParts.length != 3) {
+            LOG.error("Unable to parse version retrieved from Elasticsearch node: " + versionString);
+            return Optional.empty();
+        }
+        try {
+            final int major = Integer.parseUnsignedInt(versionParts[0]);
+            final int minor = Integer.parseUnsignedInt(versionParts[1]);
+            final int patch = Integer.parseUnsignedInt(versionParts[2]);
+
+            final Version version = Version.from(major, minor, patch);
+            LOG.info("Elasticsearch cluster is running v" + version);
+
+            return Optional.of(version);
+        } catch (NumberFormatException e) {
+            throw new RuntimeException("Unable to parse version retrieved from Elasticsearch node: " + versionString, e);
+        }
+    }
+
+    private Optional<RootResponse> rootResponse(RootRoute rootRoute) {
+        try {
+            final Response<RootResponse> response = rootRoute.root().execute();
+            if (response.isSuccessful()) {
+                return Optional.ofNullable(response.body());
+            }
+        } catch (IOException e) {
+            LOG.error("Unable to retrieve version from Elasticsearch node: ", e);
+        }
+        return Optional.empty();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/VersionResponse.java
+++ b/graylog2-server/src/main/java/org/graylog2/storage/versionprobe/VersionResponse.java
@@ -14,20 +14,22 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.storage.providers;
+package org.graylog2.storage.versionprobe;
 
-import org.graylog2.indexer.messages.MessagesAdapter;
-import org.graylog2.plugin.Version;
-import org.graylog2.storage.ElasticsearchVersion;
-import org.graylog2.storage.VersionAwareProvider;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
 
-import javax.inject.Inject;
-import javax.inject.Provider;
-import java.util.Map;
+@AutoValue
+@JsonAutoDetect
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class VersionResponse {
+    public abstract String number();
 
-public class MessagesAdapterProvider extends VersionAwareProvider<MessagesAdapter> {
-    @Inject
-    public MessagesAdapterProvider(@ElasticsearchVersion Version version, Map<Version, Provider<MessagesAdapter>> pluginBindings) {
-        super(version, pluginBindings);
+    @JsonCreator
+    public static VersionResponse create(@JsonProperty("number") String number) {
+        return new AutoValue_VersionResponse(number);
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is adding auto-sensing for the Elasticsearch version if the `elasticsearch_version` configuration field is not set. The config field is kept, but optional now. It can be used to explicitly override the chosen Elasticsearch storage driver implementation if auto-sensing fails.

If the config setting is not present, early at startup version probing will be attempted by iterating over the list of configured Elasticsearch nodes and requesting their root resource (`/`). All fields of the response will be ignored, besides the `$.version.number` field, which contains the server version as a string. The first successful attempt where the request succeeds and the retrieved version can be parsed properly will be used to determine the remote version and therefore which storage driver module is used. If no request succeeds, one or more errors will be logged and startup will fail.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.