### PR TITLE
Define theme input background color for Scratchpad textarea

### DIFF
--- a/graylog2-web-interface/src/components/common/Scratchpad.jsx
+++ b/graylog2-web-interface/src/components/common/Scratchpad.jsx
@@ -27,6 +27,7 @@ const Textarea = styled.textarea(({ copied, theme }) => css`
   flex: 1;
   margin: 15px 0 7px;
   border: 1px solid ${copied ? theme.colors.variant.success : theme.colors.variant.lighter.default};
+  background-color: ${theme.colors.input.background};
   box-shadow: inset 1px 1px 1px rgba(0, 0, 0, 0.075)${copied && `, 0 0 8px ${chroma(theme.colors.variant.success).alpha(0.4).css()}`};
   transition: border 150ms ease-in-out, box-shadow 150ms ease-in-out;
   font-family: ${theme.fonts.family.monospace};


### PR DESCRIPTION
As described in the title this PR defines the theme input background color for the Scratchpad textarea. Right now the text is not visible, using the darkmode:
![image](https://user-images.githubusercontent.com/46300478/91548289-78532c80-e925-11ea-9c27-7027ff846f77.png)

