### PR TITLE
Theming Typeahead autocomplete options

### DIFF
--- a/graylog2-web-interface/src/components/common/TypeAheadFieldInput.jsx
+++ b/graylog2-web-interface/src/components/common/TypeAheadFieldInput.jsx
@@ -24,6 +24,8 @@ class TypeAheadFieldInput extends React.Component {
      * instead.
      */
     valueLink: PropTypes.object,
+    /** Label of the field input */
+    label: PropTypes.string,
     /** Specifies if the input should have the input focus or not. */
     autoFocus: PropTypes.bool,
     /**
@@ -35,8 +37,16 @@ class TypeAheadFieldInput extends React.Component {
     onChange: PropTypes.func,
   };
 
+  static defaultProps = {
+    valueLink: undefined,
+    autoFocus: false,
+    label: undefined,
+    onChange: () => {},
+  }
+
   componentDidMount() {
     if (this.fieldInput) {
+      const { autoFocus, valueLink, onChange } = this.props;
       const fieldInput = $(this.fieldInput.getInputDOMNode());
 
       fetch('GET', qualifyUrl(ApiRoutes.SystemApiController.fields().url))
@@ -55,22 +65,23 @@ class TypeAheadFieldInput extends React.Component {
               },
             );
 
-            if (this.props.autoFocus) {
+            if (autoFocus) {
               fieldInput.focus();
               fieldInput.typeahead('close');
             }
           },
         );
 
+      // eslint-disable-next-line react/no-find-dom-node
       const fieldFormGroup = ReactDOM.findDOMNode(this.fieldInput);
 
       $(fieldFormGroup).on('typeahead:change typeahead:selected', (event) => {
-        if (this.props.onChange) {
-          this.props.onChange(event);
+        if (onChange) {
+          onChange(event);
         }
 
-        if (this.props.valueLink) {
-          this.props.valueLink.requestChange(event.target.value);
+        if (valueLink) {
+          valueLink.requestChange(event.target.value);
         }
       });
     }
@@ -81,6 +92,8 @@ class TypeAheadFieldInput extends React.Component {
       const fieldInput = $(this.fieldInput.getInputDOMNode());
 
       fieldInput.typeahead('destroy');
+
+      // eslint-disable-next-line react/no-find-dom-node
       const fieldFormGroup = ReactDOM.findDOMNode(this.fieldInput);
 
       $(fieldFormGroup).off('typeahead:change typeahead:selected');
@@ -100,12 +113,14 @@ class TypeAheadFieldInput extends React.Component {
   };
 
   render() {
+    const { id, label, valueLink } = this.props;
+
     return (
-      <Input id={this.props.id}
+      <Input id={id}
              ref={(fieldInput) => { this.fieldInput = fieldInput; }}
-             label={this.props.label}
+             label={label}
              wrapperClassName="typeahead-wrapper"
-             defaultValue={this.props.valueLink ? this.props.valueLink.value : null}
+             defaultValue={valueLink ? valueLink.value : null}
              {...this._getFilteredProps()} />
     );
   }

--- a/graylog2-web-interface/src/components/common/TypeAheadFieldInput.jsx
+++ b/graylog2-web-interface/src/components/common/TypeAheadFieldInput.jsx
@@ -3,14 +3,12 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import Immutable from 'immutable';
 import $ from 'jquery';
-import Typeahead from 'typeahead.js'; // Need to import this to load typeahead, even if the variable is never used
+import 'typeahead.js';
 
 import { Input } from 'components/bootstrap';
-// eslint-disable-next-line no-unused-vars
-
 import UniversalSearch from 'logic/search/UniversalSearch';
 import ApiRoutes from 'routing/ApiRoutes';
-import URLUtils from 'util/URLUtils';
+import { qualifyUrl } from 'util/URLUtils';
 import fetch from 'logic/rest/FetchProvider';
 
 /**
@@ -41,7 +39,7 @@ class TypeAheadFieldInput extends React.Component {
     if (this.fieldInput) {
       const fieldInput = $(this.fieldInput.getInputDOMNode());
 
-      fetch('GET', URLUtils.qualifyUrl(ApiRoutes.SystemApiController.fields().url))
+      fetch('GET', qualifyUrl(ApiRoutes.SystemApiController.fields().url))
         .then(
           (data) => {
             fieldInput.typeahead(

--- a/graylog2-web-interface/src/components/common/TypeAheadInput.jsx
+++ b/graylog2-web-interface/src/components/common/TypeAheadInput.jsx
@@ -57,10 +57,17 @@ class TypeAheadInput extends React.Component {
 
   static defaultProps = {
     displayKey: 'suggestion',
-  };
+    onKeyPress: () => {},
+    onTypeaheadLoaded: () => {},
+    onSuggestionSelected: () => {},
+    suggestions: [],
+    suggestionText: undefined,
+  }
 
   componentDidMount() {
-    this._updateTypeahead(this.props);
+    const { suggestions, displayKey, suggestionText, onTypeaheadLoaded, onSuggestionSelected } = this.props;
+
+    this._updateTypeahead({ suggestions, displayKey, suggestionText, onTypeaheadLoaded, onSuggestionSelected });
   }
 
   // eslint-disable-next-line camelcase
@@ -86,8 +93,9 @@ class TypeAheadInput extends React.Component {
     $(this.fieldFormGroup).off('typeahead:select typeahead:autocomplete');
   };
 
-  _updateTypeahead = (props) => {
+  _updateTypeahead = ({ suggestions, displayKey, suggestionText, onTypeaheadLoaded, onSuggestionSelected }) => {
     this.fieldInput = this.fieldInputElem.getInputDOMNode();
+    // eslint-disable-next-line react/no-find-dom-node
     this.fieldFormGroup = ReactDOM.findDOMNode(this.fieldInputElem);
 
     const $fieldInput = $(this.fieldInput);
@@ -99,40 +107,42 @@ class TypeAheadInput extends React.Component {
     },
     {
       name: 'dataset-name',
-      displayKey: props.displayKey,
-      source: UniversalSearch.substringMatcher(props.suggestions, props.displayKey, 6),
+      displayKey: displayKey,
+      source: UniversalSearch.substringMatcher(suggestions, displayKey, 6),
       templates: {
         suggestion: (value) => {
           // Escape all text here that may be user-generated, since this is not automatically escaped by React.
-          if (props.suggestionText) {
-            return `<div><strong>${lodash.escape(props.suggestionText)}</strong> ${lodash.escape(value[props.displayKey])}</div>`;
+          if (suggestionText) {
+            return `<div><strong>${lodash.escape(suggestionText)}</strong> ${lodash.escape(value[displayKey])}</div>`;
           }
 
-          return `<div>${lodash.escape(value[props.displayKey])}</div>`;
+          return `<div>${lodash.escape(value[displayKey])}</div>`;
         },
       },
     });
 
-    if (typeof props.onTypeaheadLoaded === 'function') {
-      props.onTypeaheadLoaded();
+    if (typeof onTypeaheadLoaded === 'function') {
+      onTypeaheadLoaded();
       $fieldInput.typeahead('close');
     }
 
     $(this.fieldFormGroup).on('typeahead:select typeahead:autocomplete', (event, suggestion) => {
-      if (props.onSuggestionSelected) {
-        props.onSuggestionSelected(event, suggestion);
+      if (onSuggestionSelected) {
+        onSuggestionSelected(event, suggestion);
       }
     });
   };
 
   render() {
+    const { id, label, onKeyPress } = this.props;
+
     return (
-      <Input id={this.props.id}
+      <Input id={id}
              type="text"
              ref={(fieldInput) => { this.fieldInputElem = fieldInput; }}
              wrapperClassName="typeahead-wrapper"
-             label={this.props.label}
-             onKeyPress={this.props.onKeyPress} />
+             label={label}
+             onKeyPress={onKeyPress} />
     );
   }
 }

--- a/graylog2-web-interface/src/components/common/TypeAheadInput.jsx
+++ b/graylog2-web-interface/src/components/common/TypeAheadInput.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import lodash from 'lodash';
 import $ from 'jquery';
-import Typeahead from 'typeahead.js';
+import 'typeahead.js';
 
 import UniversalSearch from 'logic/search/UniversalSearch';
 // eslint-disable-next-line no-unused-vars

--- a/graylog2-web-interface/src/contexts/GlobalStylesProvider.jsx
+++ b/graylog2-web-interface/src/contexts/GlobalStylesProvider.jsx
@@ -638,6 +638,19 @@ const ThemeStyles = createGlobalStyle(({ additionalStyles, theme }) => css`
     vertical-align: middle;
     width: auto;
   }
+  
+  .tt-menu {
+    background-color: ${theme.colors.global.contentBackground};
+    box-shadow: 0 3px 3px ${theme.colors.global.navigationBoxShadow};
+    color: ${theme.colors.global.textDefault};
+    
+    .tt-suggestion:hover, 
+    .tt-suggestion.tt-cursor {
+      color: ${theme.colors.variant.darkest.info};
+      background-color: ${theme.colors.variant.lighter.info};
+      background-image: none;
+    }
+  }
 
   .form-group-inline {
     display: inline-block;

--- a/graylog2-web-interface/src/contexts/GlobalStylesProvider.jsx
+++ b/graylog2-web-interface/src/contexts/GlobalStylesProvider.jsx
@@ -639,7 +639,7 @@ const ThemeStyles = createGlobalStyle(({ additionalStyles, theme }) => css`
     width: auto;
   }
   
-  .tt-menu {
+  .typeahead-wrapper .tt-menu {
     background-color: ${theme.colors.global.contentBackground};
     box-shadow: 0 3px 3px ${theme.colors.global.navigationBoxShadow};
     color: ${theme.colors.global.textDefault};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding theme to autocomplete options generated by Typeahead components

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes Graylog2/graylog-plugin-enterprise-integrations#353

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/122591/91767880-7649d180-eba2-11ea-8711-9ab59c87b9b1.png)
![image](https://user-images.githubusercontent.com/122591/91767913-7fd33980-eba2-11ea-8bdb-08991c5499df.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

