### PR TITLE
Remove GlobalStylesProvider and use createGlobalStyles

### DIFF
--- a/graylog2-web-interface/src/components/errors/ErrorPage.jsx
+++ b/graylog2-web-interface/src/components/errors/ErrorPage.jsx
@@ -1,14 +1,12 @@
 // @flow strict
 import * as React from 'react';
-import { useContext, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import styled, { css } from 'styled-components';
+import styled, { createGlobalStyle, css } from 'styled-components';
 
 import NotFoundBackgroundImage from 'assets/not-found-bg.jpg';
 import AppContentGrid from 'components/layout/AppContentGrid';
 import DocumentTitle from 'components/common/DocumentTitle';
 import ErrorJumbotron from 'components/errors/ErrorJumbotron';
-import { GlobalStylesContext } from 'contexts/GlobalStylesProvider';
 
 const errorPageStyles = (backgroundImage) => css`
   body {
@@ -41,18 +39,13 @@ type Props = {
 };
 
 const ErrorPage = ({ children, title, description, backgroundImage }: Props) => {
-  const { addGlobalStyles } = useContext(GlobalStylesContext);
-
-  useEffect(() => {
-    addGlobalStyles(errorPageStyles(backgroundImage));
-
-    return () => {
-      addGlobalStyles(null);
-    };
-  }, [backgroundImage]);
+  const LoadingPageStyles = createGlobalStyle`
+    ${errorPageStyles(backgroundImage)}
+  `;
 
   return (
     <AppContentGrid>
+      <LoadingPageStyles />
       <div className="container-fluid">
         <DocumentTitle title={title}>
           <ErrorJumbotron title={title}>

--- a/graylog2-web-interface/src/components/errors/ErrorPage.jsx
+++ b/graylog2-web-interface/src/components/errors/ErrorPage.jsx
@@ -8,7 +8,7 @@ import AppContentGrid from 'components/layout/AppContentGrid';
 import DocumentTitle from 'components/common/DocumentTitle';
 import ErrorJumbotron from 'components/errors/ErrorJumbotron';
 
-const errorPageStyles = (backgroundImage) => css`
+const generateStyles = (backgroundImage) => css`
   body {
     background: url(${backgroundImage}) no-repeat center center fixed;
     background-size: cover;
@@ -39,13 +39,13 @@ type Props = {
 };
 
 const ErrorPage = ({ children, title, description, backgroundImage }: Props) => {
-  const LoadingPageStyles = createGlobalStyle`
-    ${errorPageStyles(backgroundImage)}
+  const ErrorPageStyles = createGlobalStyle`
+    ${generateStyles(backgroundImage)}
   `;
 
   return (
     <AppContentGrid>
-      <LoadingPageStyles />
+      <ErrorPageStyles />
       <div className="container-fluid">
         <DocumentTitle title={title}>
           <ErrorJumbotron title={title}>

--- a/graylog2-web-interface/src/components/errors/ReportedErrorBoundary.test.jsx
+++ b/graylog2-web-interface/src/components/errors/ReportedErrorBoundary.test.jsx
@@ -7,7 +7,6 @@ import suppressConsole from 'helpers/suppressConsole';
 import ErrorsActions from 'actions/errors/ErrorsActions';
 import { createReactError, createUnauthorizedError, createNotFoundError } from 'logic/errors/ReportedErrors';
 import { FetchError } from 'logic/rest/FetchProvider';
-import { GlobalStylesContext } from 'contexts/GlobalStylesProvider';
 
 import ReportedErrorBoundary from './ReportedErrorBoundary';
 
@@ -19,16 +18,6 @@ const router = {
 };
 
 describe('ReportedErrorBoundary', () => {
-  const renderSUT = (children) => {
-    const addGlobalStyles = jest.fn();
-
-    return render(
-      <GlobalStylesContext.Provider value={{ addGlobalStyles }}>
-        {children}
-      </GlobalStylesContext.Provider>,
-    );
-  };
-
   it('registers to router upon mount', () => {
     const mockRouter = {
       listen: jest.fn(() => jest.fn()),
@@ -58,7 +47,7 @@ describe('ReportedErrorBoundary', () => {
   });
 
   it('displays runtime error page when react error got reported', async () => {
-    const { getByText, queryByText } = renderSUT(<ReportedErrorBoundary router={router}>Hello World!</ReportedErrorBoundary>);
+    const { getByText, queryByText } = render(<ReportedErrorBoundary router={router}>Hello World!</ReportedErrorBoundary>);
 
     suppressConsole(() => {
       ErrorsActions.report(createReactError(new Error('The error message'), { componentStack: 'The component stack' }));
@@ -71,7 +60,7 @@ describe('ReportedErrorBoundary', () => {
   });
 
   it('displays not found page when not found error got reported', async () => {
-    const { getByText, queryByText } = renderSUT(<ReportedErrorBoundary router={router}>Hello World!</ReportedErrorBoundary>);
+    const { getByText, queryByText } = render(<ReportedErrorBoundary router={router}>Hello World!</ReportedErrorBoundary>);
     const response = { status: 404, body: { message: 'The request error message' } };
 
     suppressConsole(() => {
@@ -85,7 +74,7 @@ describe('ReportedErrorBoundary', () => {
   });
 
   it('displays reported error with an unkown type', async () => {
-    const { getByText, queryByText } = renderSUT(<ReportedErrorBoundary router={router}>Hello World!</ReportedErrorBoundary>);
+    const { getByText, queryByText } = render(<ReportedErrorBoundary router={router}>Hello World!</ReportedErrorBoundary>);
     const response = { status: 404, body: { message: 'The error message' } };
 
     suppressConsole(() => {
@@ -99,7 +88,7 @@ describe('ReportedErrorBoundary', () => {
   });
 
   it('displays unauthorized error page when unauthorized error got reported', async () => {
-    const { getByText, queryByText } = renderSUT(<ReportedErrorBoundary router={router}>Hello World!</ReportedErrorBoundary>);
+    const { getByText, queryByText } = render(<ReportedErrorBoundary router={router}>Hello World!</ReportedErrorBoundary>);
     const response = { status: 403, body: { message: 'The request error message' } };
 
     suppressConsole(() => {
@@ -117,7 +106,7 @@ describe('ReportedErrorBoundary', () => {
       listen: jest.fn(() => jest.fn()),
     };
 
-    const { getByText } = renderSUT(<ReportedErrorBoundary router={mockRouter}>Hello World!</ReportedErrorBoundary>);
+    const { getByText } = render(<ReportedErrorBoundary router={mockRouter}>Hello World!</ReportedErrorBoundary>);
     const response = { status: 403, body: { message: 'The request error message' } };
 
     expect(getByText('Hello World!')).not.toBeNull();

--- a/graylog2-web-interface/src/components/errors/RouterErrorBoundary.test.jsx
+++ b/graylog2-web-interface/src/components/errors/RouterErrorBoundary.test.jsx
@@ -3,8 +3,6 @@ import React from 'react';
 import { render } from 'wrappedTestingLibrary';
 import suppressConsole from 'helpers/suppressConsole';
 
-import { GlobalStylesContext } from 'contexts/GlobalStylesProvider';
-
 import RouterErrorBoundary from './RouterErrorBoundary';
 
 jest.mock('react-router', () => ({ withRouter: (x) => x }));
@@ -20,16 +18,6 @@ const ErroneusComponent = () => {
 const WorkingComponent = () => <div>Hello World!</div>;
 
 describe('RouterErrorBoundary', () => {
-  const renderSUT = (children) => {
-    const addGlobalStyles = jest.fn();
-
-    return render(
-      <GlobalStylesContext.Provider value={{ addGlobalStyles }}>
-        {children}
-      </GlobalStylesContext.Provider>,
-    );
-  };
-
   it('displays child component if there is no error', () => {
     const { getByText } = render(
       <RouterErrorBoundary>
@@ -42,7 +30,7 @@ describe('RouterErrorBoundary', () => {
 
   it('displays error after catching', () => {
     suppressConsole(() => {
-      const { getByText } = renderSUT(
+      const { getByText } = render(
         <RouterErrorBoundary>
           <ErroneusComponent />
         </RouterErrorBoundary>,

--- a/graylog2-web-interface/src/index.jsx
+++ b/graylog2-web-interface/src/index.jsx
@@ -11,7 +11,7 @@ import AppFacade from 'routing/AppFacade';
 import GraylogThemeProvider from 'theme/GraylogThemeProvider';
 import CustomizationProvider from 'contexts/CustomizationProvider';
 import ViewsBindings from 'views/bindings';
-import GlobalStylesProvider from 'contexts/GlobalStylesProvider';
+import GlobalThemeStyles from 'theme/GlobalThemeStyles';
 
 PluginStore.register(new PluginManifest({}, ViewsBindings));
 
@@ -22,9 +22,8 @@ function renderAppContainer(appContainer) {
   ReactDOM.render(
     <CustomizationProvider>
       <GraylogThemeProvider>
-        <GlobalStylesProvider>
-          <AppFacade />
-        </GlobalStylesProvider>
+        <GlobalThemeStyles />
+        <AppFacade />
       </GraylogThemeProvider>
     </CustomizationProvider>,
     appContainer,

--- a/graylog2-web-interface/src/pages/LoadingPage.jsx
+++ b/graylog2-web-interface/src/pages/LoadingPage.jsx
@@ -1,16 +1,21 @@
+// @flow strict
+import * as React from 'react';
 import PropTypes from 'prop-types';
-import React from 'react';
 import { createGlobalStyle } from 'styled-components';
 
 import { DocumentTitle, Spinner, Icon } from 'components/common';
 import LoginBox from 'components/login/LoginBox';
 import authStyles from 'theme/styles/authStyles';
 
+type Props = {
+  text: string,
+};
+
 const LoadingPageStyles = createGlobalStyle`
   ${authStyles}
 `;
 
-const LoadingPage = ({ text }) => {
+const LoadingPage = ({ text }: Props) => {
   return (
     <DocumentTitle title="Loading...">
       <LoadingPageStyles />

--- a/graylog2-web-interface/src/pages/LoadingPage.jsx
+++ b/graylog2-web-interface/src/pages/LoadingPage.jsx
@@ -1,20 +1,19 @@
 import PropTypes from 'prop-types';
-import React, { useContext, useEffect } from 'react';
+import React from 'react';
+import { createGlobalStyle } from 'styled-components';
 
 import { DocumentTitle, Spinner, Icon } from 'components/common';
 import LoginBox from 'components/login/LoginBox';
 import authStyles from 'theme/styles/authStyles';
-import { GlobalStylesContext } from 'contexts/GlobalStylesProvider';
+
+const LoadingPageStyles = createGlobalStyle`
+  ${authStyles}
+`;
 
 const LoadingPage = ({ text }) => {
-  const { addGlobalStyles } = useContext(GlobalStylesContext);
-
-  useEffect(() => {
-    addGlobalStyles(authStyles);
-  }, []);
-
   return (
     <DocumentTitle title="Loading...">
+      <LoadingPageStyles />
       <LoginBox>
         <legend><Icon name="users" /> Welcome to Graylog</legend>
         <p>

--- a/graylog2-web-interface/src/pages/LoggedInPage.jsx
+++ b/graylog2-web-interface/src/pages/LoggedInPage.jsx
@@ -1,17 +1,10 @@
-import React, { useContext, useEffect } from 'react';
+import React from 'react';
 
 import CurrentUserPreferencesProvider from 'contexts/CurrentUserPreferencesProvider';
 import AppRouter from 'routing/AppRouter';
 import CurrentUserProvider from 'contexts/CurrentUserProvider';
-import { GlobalStylesContext } from 'contexts/GlobalStylesProvider';
 
 const LoggedInPage = () => {
-  const { addGlobalStyles } = useContext(GlobalStylesContext);
-
-  useEffect(() => {
-    addGlobalStyles(null);
-  }, []);
-
   return (
     <CurrentUserProvider>
       <CurrentUserPreferencesProvider>

--- a/graylog2-web-interface/src/pages/LoginPage.jsx
+++ b/graylog2-web-interface/src/pages/LoginPage.jsx
@@ -1,5 +1,6 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { PluginStore } from 'graylog-web-plugin/plugin';
+import { createGlobalStyle } from 'styled-components';
 
 import { DocumentTitle, Icon } from 'components/common';
 import { Alert } from 'components/graylog';
@@ -7,20 +8,21 @@ import LoginForm from 'components/login/LoginForm';
 import LoginBox from 'components/login/LoginBox';
 import authStyles from 'theme/styles/authStyles';
 import CombinedProvider from 'injection/CombinedProvider';
-import { GlobalStylesContext } from 'contexts/GlobalStylesProvider';
 
 import LoadingPage from './LoadingPage';
 
 const { SessionActions } = CombinedProvider.get('Session');
 
+const LoginPageStyles = createGlobalStyle`
+  ${authStyles}
+`;
+
 const LoginPage = () => {
   const [didValidateSession, setDidValidateSession] = useState(false);
   const [lastError, setLastError] = useState(undefined);
-  const { addGlobalStyles } = useContext(GlobalStylesContext);
 
   useEffect(() => {
     const sessionPromise = SessionActions.validate().then((response) => {
-      addGlobalStyles(authStyles);
       setDidValidateSession(true);
 
       return response;
@@ -28,7 +30,6 @@ const LoginPage = () => {
 
     return () => {
       sessionPromise.cancel();
-      addGlobalStyles(null);
     };
   }, []);
 
@@ -72,6 +73,7 @@ const LoginPage = () => {
     <DocumentTitle title="Sign in">
       <LoginBox>
         <legend><Icon name="users" /> Welcome to Graylog</legend>
+        <LoginPageStyles />
         {formatLastError()}
         {renderLoginForm()}
       </LoginBox>

--- a/graylog2-web-interface/src/pages/RuntimeErrorPage.test.jsx
+++ b/graylog2-web-interface/src/pages/RuntimeErrorPage.test.jsx
@@ -2,32 +2,20 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from 'wrappedTestingLibrary';
 
-import { GlobalStylesContext } from 'contexts/GlobalStylesProvider';
-
 import RuntimeErrorPage from './RuntimeErrorPage';
 
 describe('RuntimeErrorPage', () => {
-  const renderSUT = (children) => {
-    const addGlobalStyles = jest.fn();
-
-    return render(
-      <GlobalStylesContext.Provider value={{ addGlobalStyles }}>
-        {children}
-      </GlobalStylesContext.Provider>,
-    );
-  };
-
   const SimpleRuntimeErrorPage = () => <RuntimeErrorPage error={new Error('The error message')} componentStack="The component stack" />;
 
   it('displays runtime error', () => {
-    const { getByText } = renderSUT(<SimpleRuntimeErrorPage />);
+    const { getByText } = render(<SimpleRuntimeErrorPage />);
 
     expect(getByText('Something went wrong.')).not.toBeNull();
     expect(getByText('The error message')).not.toBeNull();
   });
 
   it('displays component stack', async () => {
-    const { getByText, queryByText } = renderSUT(<SimpleRuntimeErrorPage />);
+    const { getByText, queryByText } = render(<SimpleRuntimeErrorPage />);
 
     expect(getByText('Something went wrong.')).not.toBeNull();
     expect(queryByText('The component stack')).toBeNull();

--- a/graylog2-web-interface/src/pages/ServerUnavailablePage.jsx
+++ b/graylog2-web-interface/src/pages/ServerUnavailablePage.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useState, useContext, useEffect } from 'react';
+import React, { useState } from 'react';
 import styled, { createGlobalStyle } from 'styled-components';
 
 import { Button, Modal, Well } from 'components/graylog';

--- a/graylog2-web-interface/src/pages/ServerUnavailablePage.jsx
+++ b/graylog2-web-interface/src/pages/ServerUnavailablePage.jsx
@@ -1,29 +1,23 @@
 import PropTypes from 'prop-types';
 import React, { useState, useContext, useEffect } from 'react';
-import styled from 'styled-components';
+import styled, { createGlobalStyle } from 'styled-components';
 
 import { Button, Modal, Well } from 'components/graylog';
 import { Icon } from 'components/common';
 import DocumentTitle from 'components/common/DocumentTitle';
 import authStyles from 'theme/styles/authStyles';
 import { qualifyUrl } from 'util/URLUtils';
-import { GlobalStylesContext } from 'contexts/GlobalStylesProvider';
 
 const StyledIcon = styled(Icon)`
   margin-left: 6px;
 `;
 
+const ServerUnavailableStyles = createGlobalStyle`
+  ${authStyles}
+`;
+
 const ServerUnavailablePage = ({ server }) => {
   const [showDetails, setShowDetails] = useState(false);
-  const { addGlobalStyles } = useContext(GlobalStylesContext);
-
-  useEffect(() => {
-    addGlobalStyles(authStyles);
-
-    return () => {
-      addGlobalStyles(null);
-    };
-  }, []);
 
   const _toggleDetails = () => setShowDetails(!showDetails);
 
@@ -91,6 +85,7 @@ const ServerUnavailablePage = ({ server }) => {
 
   return (
     <DocumentTitle title="Server unavailable">
+      <ServerUnavailableStyles />
       <Modal show>
         <Modal.Header>
           <Modal.Title><Icon name="exclamation-triangle" /> Server currently unavailable</Modal.Title>

--- a/graylog2-web-interface/src/pages/StreamPermissionErrorPage.test.jsx
+++ b/graylog2-web-interface/src/pages/StreamPermissionErrorPage.test.jsx
@@ -4,28 +4,17 @@ import { render } from 'wrappedTestingLibrary';
 import suppressConsole from 'helpers/suppressConsole';
 
 import { FetchError } from 'logic/rest/FetchProvider';
-import { GlobalStylesContext } from 'contexts/GlobalStylesProvider';
 
 import StreamPermissionErrorPage from './StreamPermissionErrorPage';
 
 jest.unmock('logic/rest/FetchProvider');
 
 describe('StreamPermissionErrorPage', () => {
-  const renderSUT = (children) => {
-    const addGlobalStyles = jest.fn();
-
-    return render(
-      <GlobalStylesContext.Provider value={{ addGlobalStyles }}>
-        {children}
-      </GlobalStylesContext.Provider>,
-    );
-  };
-
   it('displays fetch error', () => {
     const response = { status: 403, body: { message: 'The request error message', streams: ['stream-1-id', 'stream-2-id'], type: 'MissingStreamPermission' } };
 
     suppressConsole(async () => {
-      const { getByText } = renderSUT(<StreamPermissionErrorPage error={new FetchError('The request error message', response)} />);
+      const { getByText } = render(<StreamPermissionErrorPage error={new FetchError('The request error message', response)} />);
 
       expect(getByText('Missing Stream Permissions')).not.toBeNull();
       expect(getByText('You need permissions for streams with the id: stream-1-id, stream-2-id.')).not.toBeNull();

--- a/graylog2-web-interface/src/pages/UnauthorizedErrorPage.test.jsx
+++ b/graylog2-web-interface/src/pages/UnauthorizedErrorPage.test.jsx
@@ -3,24 +3,17 @@ import React from 'react';
 import { render } from 'wrappedTestingLibrary';
 import suppressConsole from 'helpers/suppressConsole';
 
-import { GlobalStylesContext } from 'contexts/GlobalStylesProvider';
 import { FetchError } from 'logic/rest/FetchProvider';
 
 import UnauthorizedErrorPage from './UnauthorizedErrorPage';
 
 jest.unmock('logic/rest/FetchProvider');
 
-const addGlobalStyles = jest.fn();
-
 describe('UnauthorizedErrorPage', () => {
   it('displays fetch error', () => {
     suppressConsole(async () => {
       const response = { status: 403, body: { message: 'The request error message' } };
-      const { getByText } = render(
-        <GlobalStylesContext.Provider value={{ addGlobalStyles }}>
-          <UnauthorizedErrorPage error={new FetchError('The request error message', response)} />
-        </GlobalStylesContext.Provider>,
-      );
+      const { getByText } = render(<UnauthorizedErrorPage error={new FetchError('The request error message', response)} />);
 
       expect(getByText('Missing Permissions')).not.toBeNull();
       expect(getByText(/The request error message/)).not.toBeNull();

--- a/graylog2-web-interface/src/theme/GlobalThemeStyles.jsx
+++ b/graylog2-web-interface/src/theme/GlobalThemeStyles.jsx
@@ -1,31 +1,7 @@
 // @flow strict
-import * as React from 'react';
-import { createContext, useState } from 'react';
-import PropTypes from 'prop-types';
 import { createGlobalStyle, css, type CSSRules } from 'styled-components';
 
-type Props = {
-  children: React.Node,
-};
-
-type StyleTypes = {
-  addGlobalStyles: (?CSSRules) => void,
-};
-
-export const GlobalStylesContext = createContext<StyleTypes>({ addGlobalStyles: () => {} });
-
-const GlobalStylesProvider = ({ children }: Props) => {
-  const [additionalStyles, addGlobalStyles] = useState<?CSSRules>();
-
-  return (
-    <GlobalStylesContext.Provider value={{ addGlobalStyles }}>
-      <ThemeStyles additionalStyles={additionalStyles} />
-      {children}
-    </GlobalStylesContext.Provider>
-  );
-};
-
-const ThemeStyles = createGlobalStyle(({ additionalStyles, theme }) => css`
+const GlobalThemeStyles: CSSRules<> = createGlobalStyle(({ theme }) => css`
   #editor {
     height: 256px;
   }
@@ -735,12 +711,6 @@ const ThemeStyles = createGlobalStyle(({ additionalStyles, theme }) => css`
     box-shadow: none;
     height: auto;
   }
-
-  ${additionalStyles}
 `);
 
-GlobalStylesProvider.propTypes = {
-  children: PropTypes.node.isRequired,
-};
-
-export default GlobalStylesProvider;
+export default GlobalThemeStyles;

--- a/graylog2-web-interface/src/theme/GlobalThemeStyles.jsx
+++ b/graylog2-web-interface/src/theme/GlobalThemeStyles.jsx
@@ -1,7 +1,6 @@
-// @flow strict
-import { createGlobalStyle, css, type CSSRules } from 'styled-components';
+import { createGlobalStyle, css } from 'styled-components';
 
-const GlobalThemeStyles: CSSRules<> = createGlobalStyle(({ theme }) => css`
+const GlobalThemeStyles = createGlobalStyle(({ theme }) => css`
   #editor {
     height: 256px;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removes `GlobalStylesProvider`, replaced with directly using Styled-Components `createGlobalStyles`	where needed

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Login/Loading pages and sometimes after an error, the background was not resetting properly.
First we attempted the difficult way, then we realized it was being overthought and went for the simple solution.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

