### PR TITLE
Remove permission check for Search Nav Item

### DIFF
--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -94,11 +94,9 @@ const Navigation = ({ location }) => {
 
       <Navbar.Collapse>
         <Nav navbar>
-          <IfPermitted permissions={['searches:absolute', 'searches:relative', 'searches:keyword']}>
-            <LinkContainer to={Routes.SEARCH}>
-              <NavItem to="search">Search</NavItem>
-            </LinkContainer>
-          </IfPermitted>
+          <LinkContainer to={Routes.SEARCH}>
+            <NavItem to="search">Search</NavItem>
+          </LinkContainer>
 
           <LinkContainer to={Routes.STREAMS}>
             <NavItem>Streams</NavItem>

--- a/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
@@ -172,8 +172,7 @@ describe('Navigation', () => {
 
     it.each`
     permissions                    | count | links
-    ${[]}                          | ${4}  | ${['Streams', 'Alerts', 'Dashboards']}
-    ${['searches:absolute', 'searches:relative', 'searches:keyword']} | ${5}  | ${['Search']}
+    ${[]}                          | ${5}  | ${['Search', 'Streams', 'Alerts', 'Dashboards']}
   `('shows $links for user with $permissions permissions', verifyPermissions);
   });
 });

--- a/graylog2-web-interface/src/pages/StartPage.jsx
+++ b/graylog2-web-interface/src/pages/StartPage.jsx
@@ -65,12 +65,7 @@ const StartPage = createReactClass({
       return;
     }
 
-    // Show search page if permitted, or streams page in other case
-    if (PermissionsMixin.isAnyPermitted(permissions, ['searches:absolute', 'searches:keyword', 'searches:relative'])) {
-      this._redirect(Routes.SEARCH);
-    } else {
-      this._redirect(Routes.STREAMS);
-    }
+    this._redirect(Routes.SEARCH);
   },
 
   _isLoading() {


### PR DESCRIPTION
## Motivation
Prior to this change, the Search Menu Item was only displayd for admins
or users which have searches:absolute', 'searches:relative',
'searches:keyword' permissions.

The mentioned permission could only be add via API requests. Which left
the admin users as the only ones which could really see that Menu Item.

But a user could go to that page either via a link (on the streams page)
or by typing the url manually.

## Description
This change will now simply remove this check and always display the
menu item. The search still will only work if the user has read
permissions to a stream.

Fixes #8745
Fixes #8779
Fixes #8921

## Notes
**Needs backport to 3.3**

## How Has This Been Tested?
1. created a user with only reader permissions
1. loggedin and see the `Search` Menu item, when user clicks on item he sees a Permissions error, since he misses stream reading permissions
1. adding stream reading permissions
1. user can normally use the search

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

