### PR TITLE
Add is_cloud flag and disable "No input running" warning

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -162,6 +162,9 @@ public class Configuration extends BaseConfiguration {
     @Parameter(value = "enabled_tls_protocols", converter = StringSetConverter.class)
     private Set<String> enabledTlsProtocols = DefaultTLSProtocolProvider.getDefaultSupportedTlsProtocols();
 
+    @Parameter(value = "is_cloud")
+    private boolean isCloud = false;
+
     public boolean isMaster() {
         return isMaster;
     }

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ClusterHealthCheckThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ClusterHealthCheckThread.java
@@ -52,7 +52,6 @@ public class ClusterHealthCheckThread extends Periodical {
     @Override
     public void doRun() {
         if (isCloud) {
-            LOG.info("Skipping run of ClusterHealthCheckThread, since contained checks are not applicable for Cloud.");
             return;
         }
         try {
@@ -111,7 +110,7 @@ public class ClusterHealthCheckThread extends Periodical {
     public int getInitialDelaySeconds() {
         // Wait some time until all inputs have been started otherwise this will trigger a notification on every
         // startup of the server.
-        return 1;
+        return 120;
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ClusterHealthCheckThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ClusterHealthCheckThread.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 /**
  * @author Dennis Oelkers <dennis@torch.sh>
@@ -35,18 +36,25 @@ public class ClusterHealthCheckThread extends Periodical {
     private NotificationService notificationService;
     private final InputRegistry inputRegistry;
     private final NodeId nodeId;
+    private boolean isCloud;
 
     @Inject
     public ClusterHealthCheckThread(NotificationService notificationService,
                                     InputRegistry inputRegistry,
-                                    NodeId nodeId) {
+                                    NodeId nodeId,
+                                    @Named("is_cloud") boolean isCloud) {
         this.notificationService = notificationService;
         this.inputRegistry = inputRegistry;
         this.nodeId = nodeId;
+        this.isCloud = isCloud;
     }
 
     @Override
     public void doRun() {
+        if (!isCloud) {
+            LOG.trace("Skipping run of ClusterHealthCheckThread, since contained checks are not applicable for Cloud.");
+            return;
+        }
         try {
             if (inputRegistry.runningCount() == 0) {
                 LOG.debug("No input running in cluster!");

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ClusterHealthCheckThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ClusterHealthCheckThread.java
@@ -52,6 +52,7 @@ public class ClusterHealthCheckThread extends Periodical {
     @Override
     public void doRun() {
         if (isCloud) {
+            LOG.debug("Skipping run of ClusterHealthCheckThread, since contained checks are not applicable for Cloud.");
             return;
         }
         try {

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ClusterHealthCheckThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ClusterHealthCheckThread.java
@@ -51,7 +51,6 @@ public class ClusterHealthCheckThread extends Periodical {
 
     @Override
     public void doRun() {
-            LOG.info("Running CHCT!.");
         if (isCloud) {
             LOG.info("Skipping run of ClusterHealthCheckThread, since contained checks are not applicable for Cloud.");
             return;

--- a/graylog2-server/src/main/java/org/graylog2/periodical/ClusterHealthCheckThread.java
+++ b/graylog2-server/src/main/java/org/graylog2/periodical/ClusterHealthCheckThread.java
@@ -51,8 +51,9 @@ public class ClusterHealthCheckThread extends Periodical {
 
     @Override
     public void doRun() {
-        if (!isCloud) {
-            LOG.trace("Skipping run of ClusterHealthCheckThread, since contained checks are not applicable for Cloud.");
+            LOG.info("Running CHCT!.");
+        if (isCloud) {
+            LOG.info("Skipping run of ClusterHealthCheckThread, since contained checks are not applicable for Cloud.");
             return;
         }
         try {
@@ -111,7 +112,7 @@ public class ClusterHealthCheckThread extends Periodical {
     public int getInitialDelaySeconds() {
         // Wait some time until all inputs have been started otherwise this will trigger a notification on every
         // startup of the server.
-        return 120;
+        return 1;
     }
 
     @Override


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add an `is_cloud` configuration flag. When enabled, certain in functionality/behavior in Graylog can be disabled or altered as appropriate for running in the Cloud environment.

This PR also skips checks in the `ClusterHeathCheckThread`, which currently only raise a System Notification when no inputs are running on a node. This notification is not appropriate for Cloud, since Forwarders/Forwarder Inputs are used instead of Inputs. So, a node in Graylog Cloud can be healthy when no inputs are running on it.

## How Has This Been Tested?
Enabled the `is_cloud` flag and observed that the system notification is not raised.

Disabled the `is_cloud` flag, and observed that the notification is raised.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Closes https://github.com/Graylog2/graylog-plugin-cloud/issues/359