### PR TITLE
Add unique index for grantee and entity

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
@@ -65,6 +65,10 @@ public class DBGrantService extends PaginatedDbService<GrantDTO> {
                         .append(GrantDTO.FIELD_CAPABILITY, 1)
                         .append(GrantDTO.FIELD_TARGET, 1),
                 new BasicDBObject("unique", true));
+        db.createIndex(
+                new BasicDBObject(GrantDTO.FIELD_GRANTEE, 1)
+                        .append(GrantDTO.FIELD_TARGET, 1),
+                new BasicDBObject("unique", true));
         // TODO: Add more indices
 
         // TODO: Inline migration for development. Must be removed before shipping 4.0 GA!

--- a/graylog2-server/src/test/resources/org/graylog/security/shares/EntitySharesServiceTest.json
+++ b/graylog2-server/src/test/resources/org/graylog/security/shares/EntitySharesServiceTest.json
@@ -2,15 +2,6 @@
   "grants": [
     {
       "_id": {
-        "$oid": "55e0261a0cc6210000000002"
-      },
-      "grantee": "grn::::user:john",
-      "capability": "view",
-      "target": "grn::::stream:54e3deadbeefdeadbeefaffe",
-      "created_by": "grn::::user:admin"
-    },
-    {
-      "_id": {
         "$oid": "55e0261a0cc6210000000003"
       },
       "grantee": "grn::::user:john",


### PR DESCRIPTION
There should be only one grant per grantee and entity.
Having multiple will even break some of our code.
Better fail early.

Fixes #8927

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1765