### PR TITLE
Add flow type definitions, create test and use styled-components for EmptyEntity

### DIFF
--- a/graylog2-web-interface/src/components/common/EmptyEntity.css
+++ b/graylog2-web-interface/src/components/common/EmptyEntity.css
@@ -1,9 +1,0 @@
-:local(.component) {
-    text-align: center;
-    font-size: 1rem; /* theme.fonts.size.body */
-}
-
-:local(.component) h3 {
-    margin-top: 5px;
-    margin-bottom: 10px;
-}

--- a/graylog2-web-interface/src/components/common/EmptyEntity.jsx
+++ b/graylog2-web-interface/src/components/common/EmptyEntity.jsx
@@ -1,40 +1,57 @@
-import React from 'react';
+// @flow strict
+import * as React from 'react';
 import PropTypes from 'prop-types';
+import styled, { type StyledComponent } from 'styled-components';
 
-import style from './EmptyEntity.css';
+import type { ThemeInterface } from 'theme';
+
+const Container: StyledComponent<{}, ThemeInterface, HTMLDivElement> = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  p {
+    text-align: center;
+  }
+`;
+
+const Headline = styled.h2`
+  margin-top: 5px;
+  margin-bottom: 10px;
+  text-align: center;
+`;
+
+type Props = {
+  children: React.Node,
+  title: string,
+};
 
 /**
  * Component used to represent an empty entity in Graylog. This component allows us to display some larger
  * text to the user explaining what that entity is and a link to create a new one.
  */
-class EmptyEntity extends React.Component {
-  static propTypes = {
-    /** Text or node to be rendered as title. */
-    title: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.node,
-    ]),
-    /**
-     * Any other content the component should display below the title. This may include a description and button
-     * or link to easily create a new entity.
-     */
-    children: PropTypes.node.isRequired,
-  };
+const EmptyEntity = ({ children, title }: Props) => (
+  <Container>
+    <Headline>{title}</Headline>
+    {children}
+  </Container>
+);
 
-  static defaultProps = {
-    title: 'Looks like there is nothing here, yet!',
-  };
+EmptyEntity.propTypes = {
+  /** Text or node to be rendered as title. */
+  title: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+  ]),
+  /**
+   * Any other content the component should display below the title. This may include a description and button
+   * or link to easily create a new entity.
+   */
+  children: PropTypes.node.isRequired,
+};
 
-  render() {
-    const { children, title } = this.props;
-
-    return (
-      <div className={style.component}>
-        <h3>{title}</h3>
-        {children}
-      </div>
-    );
-  }
-}
+EmptyEntity.defaultProps = {
+  title: 'Looks like there is nothing here, yet!',
+};
 
 export default EmptyEntity;

--- a/graylog2-web-interface/src/components/common/EmptyEntity.test.jsx
+++ b/graylog2-web-interface/src/components/common/EmptyEntity.test.jsx
@@ -1,0 +1,20 @@
+// @flow strict
+import * as React from 'react';
+import { render } from 'wrappedTestingLibrary';
+
+import EmptyEntity from './EmptyEntity';
+
+describe('<EmptyEntity />', () => {
+  it('should render children and default title', () => {
+    const { getByText } = render(<EmptyEntity>The children</EmptyEntity>);
+
+    expect(getByText('Looks like there is nothing here, yet!')).not.toBeNull();
+    expect(getByText('The children')).not.toBeNull();
+  });
+
+  it('should render custom title', () => {
+    const { getByText } = render(<EmptyEntity title="The custom title">The children</EmptyEntity>);
+
+    expect(getByText('The custom title')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
With this PR we are adding flow type definitions, creating a test and using styled-components for the `EmptyEntity` component.