### PR TITLE
Do not show `Enterprise` navigation if user is lacking permission

### DIFF
--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -66,7 +66,10 @@ const Navigation = ({ location }) => {
 
   const pluginExports = PluginStore.exports('navigation');
 
-  if (!pluginExports.find((value) => value.description.toLowerCase() === 'enterprise')) {
+  const enterpriseMenuIsMissing = !pluginExports.find((value) => value.description.toLowerCase() === 'enterprise');
+  const isPermittedToEnterprise = isPermitted(permissions, ['licenseinfos:read']);
+
+  if (enterpriseMenuIsMissing && isPermittedToEnterprise) {
     // no enterprise plugin menu, so we will add one
     pluginExports.push({
       path: Routes.SYSTEM.ENTERPRISE,

--- a/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
@@ -174,5 +174,19 @@ describe('Navigation', () => {
     permissions                    | count | links
     ${[]}                          | ${5}  | ${['Search', 'Streams', 'Alerts', 'Dashboards']}
   `('shows $links for user with $permissions permissions', verifyPermissions);
+
+    it('should not show `Enterprise` item if user is lacking permissions', () => {
+      const wrapper = mount(<SimpleNavigation component={Navigation}
+                                              permissions={[]} />);
+
+      expect(wrapper.find('NavigationLink[description="Enterprise"]')).not.toExist();
+    });
+
+    it('should show `Enterprise` item if user has permission to read license', () => {
+      const wrapper = mount(<SimpleNavigation component={Navigation}
+                                              permissions={['licenseinfos:read']} />);
+
+      expect(wrapper.find('NavigationLink[description="Enterprise"]')).toExist();
+    });
   });
 });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This change is adding a check to show the `Enterprise` top navigation item only if the user has the require `licenseinfos:read` permission. If the user does not have this permission, clicking the navigation item would result in a 403 error page.

Fixes #8936.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.