### PR TITLE
Update to Netty 4.1.52 and netty-tcnative-boringssl-static to 2.0.34

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,8 +134,8 @@
         <mongodb-driver.version>3.12.1</mongodb-driver.version>
         <mongojack.version>2.10.1</mongojack.version>
         <natty.version>0.13</natty.version>
-        <netty.version>4.1.50.Final</netty.version>
-        <netty-tcnative-boringssl-static.version>2.0.30.Final</netty-tcnative-boringssl-static.version>
+        <netty.version>4.1.52.Final</netty.version>
+        <netty-tcnative-boringssl-static.version>2.0.34.Final</netty-tcnative-boringssl-static.version>
         <okhttp.version>3.14.6</okhttp.version>
         <opencsv.version>2.3</opencsv.version>
         <os-platform-finder.version>1.2.3</os-platform-finder.version>


### PR DESCRIPTION
Changelogs:
- https://netty.io/news/2020/07/09/4-1-51-Final.html
- https://netty.io/news/2020/09/08/4-1-52-Final.html