### PR TITLE
Fix moving widget if no titles have been set before.

### DIFF
--- a/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.js
+++ b/graylog2-web-interface/src/views/logic/views/MoveWidgetToTab.js
@@ -82,7 +82,7 @@ const _getWidgetPosition = (widgetId: WidgetId, queryId: QueryId, view: View): W
 };
 
 const _getWidgetTitle = (widgetId: WidgetId, queryId: QueryId, view: View): ?string => {
-  return view.state.get(queryId).titles.get('widget').get(widgetId);
+  return view.state.get(queryId).titles.getIn(['widget', widgetId]);
 };
 
 const MoveWidgetToTab = (widgetId: WidgetId, targetQueryId: QueryId, dashboard: View, copy: boolean = false): ?View => {

--- a/graylog2-web-interface/src/views/logic/views/__snapshots__/MoveWidgetToTab.test.js.snap
+++ b/graylog2-web-interface/src/views/logic/views/__snapshots__/MoveWidgetToTab.test.js.snap
@@ -193,3 +193,75 @@ Object {
   "type": "DASHBOARD",
 }
 `;
+
+exports[`MoveWidgetToTab should work when titles are empty 1`] = `
+Object {
+  "created_at": "2020-05-27T12:32:49.786Z",
+  "description": "move widget to tab",
+  "id": "5ece5e1b74ff709b0b0dc69b",
+  "owner": "admin",
+  "properties": Immutable.List [],
+  "search_id": "new-search-id",
+  "state": Immutable.Map {
+    "fa247d8f-7afa-45b7-b57e-3cdef4ee53be": Object {
+      "formatting": Object {
+        "highlighting": Array [],
+      },
+      "positions": Immutable.Map {},
+      "selected_fields": undefined,
+      "titles": Immutable.Map {},
+      "widget_mapping": Immutable.Map {},
+      "widgets": Immutable.List [],
+    },
+    "5faea09b-4187-4eda-9d59-7a86d4774c73": Object {
+      "formatting": Object {
+        "highlighting": Array [],
+      },
+      "positions": Immutable.Map {
+        "dead-beef": Object {
+          "col": 1,
+          "height": 4,
+          "row": 1,
+          "width": 4,
+        },
+      },
+      "selected_fields": undefined,
+      "titles": Immutable.Map {},
+      "widget_mapping": Immutable.Map {
+        "dead-beef": Immutable.Set [
+          "dead-beef",
+        ],
+      },
+      "widgets": Immutable.List [
+        Object {
+          "config": Object {
+            "column_pivots": Array [],
+            "event_annotation": false,
+            "rollup": true,
+            "row_pivots": Array [],
+            "series": Array [
+              Object {
+                "config": Object {
+                  "name": "Message Count",
+                },
+                "function": "count()",
+              },
+            ],
+            "sort": Array [],
+            "visualization": "numeric",
+          },
+          "filter": undefined,
+          "id": "dead-beef",
+          "query": null,
+          "streams": Array [],
+          "timerange": null,
+          "type": "aggregation",
+        },
+      ],
+    },
+  },
+  "summary": "move widget to tab",
+  "title": "MoveWidgetToTab",
+  "type": "DASHBOARD",
+}
+`;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Before this change, moving a widget from one dashboard page to another failed if no title had been changed on the dashboard before. This was related to the titles map not being initialized with the `widgets` key.

This PR is now using `getIn` to protect against the absence of the `widgets` key.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.