### PR TITLE
Remove permission check for Search Nav Item (3.3)

### DIFF
--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -1,20 +1,17 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { withRouter } from 'react-router';
-
-import { Badge, Navbar, Nav, NavItem, NavDropdown } from 'components/graylog';
 import { LinkContainer } from 'react-router-bootstrap';
 import naturalSort from 'javascript-natural-sort';
+import { PluginStore } from 'graylog-web-plugin/plugin';
 
+import { Badge, Navbar, Nav, NavItem, NavDropdown } from 'components/graylog';
 import connect from 'stores/connect';
 import StoreProvider from 'injection/StoreProvider';
 import { isPermitted } from 'util/PermissionsMixin';
-import { PluginStore } from 'graylog-web-plugin/plugin';
-
 import Routes from 'routing/Routes';
 import URLUtils from 'util/URLUtils';
 import AppConfig from 'util/AppConfig';
-
 import GlobalThroughput from 'components/throughput/GlobalThroughput';
 import { IfPermitted } from 'components/common';
 
@@ -49,6 +46,7 @@ const formatPluginRoute = (pluginRoute, permissions, location) => {
     const activeChild = pluginRoute.children.filter(({ path }) => (path && _isActive(location.pathname, path)));
     const title = activeChild.length > 0 ? `${pluginRoute.description} / ${activeChild[0].description}` : pluginRoute.description;
     const isEmpty = !pluginRoute.children.some((child) => isPermitted(permissions, child.permissions));
+
     if (isEmpty) {
       return null;
     }
@@ -65,6 +63,7 @@ const formatPluginRoute = (pluginRoute, permissions, location) => {
 
 const Navigation = ({ permissions, fullName, location, loginName }) => {
   const pluginExports = PluginStore.exports('navigation');
+
   if (!pluginExports.find((value) => value.description.toLowerCase() === 'enterprise')) {
     // no enterprise plugin menu, so we will add one
     pluginExports.push({
@@ -72,6 +71,7 @@ const Navigation = ({ permissions, fullName, location, loginName }) => {
       description: 'Enterprise',
     });
   }
+
   const pluginNavigations = pluginExports
     .sort((route1, route2) => naturalSort(route1.description.toLowerCase(), route2.description.toLowerCase()))
     .map((pluginRoute) => formatPluginRoute(pluginRoute, permissions, location));

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -28,10 +28,12 @@ import StyledNavbar from './Navigation.styles';
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
 
 const _isActive = (requestPath, prefix) => {
+  // eslint-disable-next-line import/no-named-as-default-member
   return requestPath.indexOf(URLUtils.appPrefixed(prefix)) === 0;
 };
 
 const formatSinglePluginRoute = ({ description, path, permissions }, topLevel = false) => {
+  // eslint-disable-next-line import/no-named-as-default-member
   const link = <NavigationLink key={description} description={description} path={URLUtils.appPrefixed(path)} topLevel={topLevel} />;
 
   if (permissions) {

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -94,11 +94,9 @@ const Navigation = ({ permissions, fullName, location, loginName }) => {
 
       <Navbar.Collapse>
         <Nav navbar>
-          <IfPermitted permissions={['searches:absolute', 'searches:relative', 'searches:keyword']}>
-            <LinkContainer to={Routes.SEARCH}>
-              <NavItem to="search">Search</NavItem>
-            </LinkContainer>
-          </IfPermitted>
+          <LinkContainer to={Routes.SEARCH}>
+            <NavItem to="search">Search</NavItem>
+          </LinkContainer>
 
           <LinkContainer to={Routes.STREAMS}>
             <NavItem>Streams</NavItem>

--- a/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
@@ -151,8 +151,7 @@ describe('Navigation', () => {
     };
     it.each`
     permissions                    | count | links
-    ${[]}                          | ${3}  | ${['Streams', 'Alerts', 'Dashboards']}
-    ${['searches:absolute', 'searches:relative', 'searches:keyword']} | ${4}  | ${['Search']}
+    ${[]}                          | ${5}  | ${['Search', 'Streams', 'Alerts', 'Dashboards']}
   `('shows $links for user with $permissions permissions', verifyPermissions);
   });
 });

--- a/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
@@ -151,7 +151,7 @@ describe('Navigation', () => {
     };
     it.each`
     permissions                    | count | links
-    ${[]}                          | ${5}  | ${['Search', 'Streams', 'Alerts', 'Dashboards']}
+    ${[]}                          | ${4}  | ${['Search', 'Streams', 'Alerts', 'Dashboards']}
   `('shows $links for user with $permissions permissions', verifyPermissions);
   });
 });

--- a/graylog2-web-interface/src/pages/StartPage.jsx
+++ b/graylog2-web-interface/src/pages/StartPage.jsx
@@ -1,15 +1,13 @@
 import React from 'react';
+// eslint-disable-next-line no-restricted-imports
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import { Spinner } from 'components/common';
 import Routes from 'routing/Routes';
-
 import history from 'util/History';
 import PermissionsMixin from 'util/PermissionsMixin';
-
 import StoreProvider from 'injection/StoreProvider';
-
 import ActionsProvider from 'injection/ActionsProvider';
 
 const CurrentUserStore = StoreProvider.getStore('CurrentUser');
@@ -47,10 +45,12 @@ const StartPage = createReactClass({
 
   _redirectToStartpage() {
     const { currentUser: { startpage, permissions }, gettingStarted } = this.state;
+
     // Show getting started page if user is an admin and getting started wasn't dismissed
     if (PermissionsMixin.isPermitted(permissions, ['inputs:create'])) {
       if (gettingStarted.show) {
         this._redirect(Routes.GETTING_STARTED);
+
         return;
       }
     }
@@ -62,6 +62,7 @@ const StartPage = createReactClass({
       } else {
         this._redirect(Routes.dashboard_show(startpage.id));
       }
+
       return;
     }
 
@@ -70,6 +71,7 @@ const StartPage = createReactClass({
 
   _isLoading() {
     const { currentUser, gettingStarted } = this.state;
+
     return !currentUser || !gettingStarted;
   },
 

--- a/graylog2-web-interface/src/pages/StartPage.jsx
+++ b/graylog2-web-interface/src/pages/StartPage.jsx
@@ -47,6 +47,7 @@ const StartPage = createReactClass({
     const { currentUser: { startpage, permissions }, gettingStarted } = this.state;
 
     // Show getting started page if user is an admin and getting started wasn't dismissed
+    // eslint-disable-next-line import/no-named-as-default-member
     if (PermissionsMixin.isPermitted(permissions, ['inputs:create'])) {
       if (gettingStarted.show) {
         this._redirect(Routes.GETTING_STARTED);

--- a/graylog2-web-interface/src/pages/StartPage.jsx
+++ b/graylog2-web-interface/src/pages/StartPage.jsx
@@ -65,12 +65,7 @@ const StartPage = createReactClass({
       return;
     }
 
-    // Show search page if permitted, or streams page in other case
-    if (PermissionsMixin.isAnyPermitted(permissions, ['searches:absolute', 'searches:keyword', 'searches:relative'])) {
-      this._redirect(Routes.SEARCH);
-    } else {
-      this._redirect(Routes.STREAMS);
-    }
+    this._redirect(Routes.SEARCH);
   },
 
   _isLoading() {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**This is a backport of #8917 for `3.3`.**

Prior to this change, the Search Menu Item was only displayed for admins or users which have searches:absolute', 'searches:relative', 'searches:keyword' permissions.

The mentioned permission could only be add via API requests. Which left the admin users as the only ones which could really see that Menu Item. 
 
But a user could go to that page either via a link (on the streams page) or by typing the url manually.

This change will now simply remove this check and always display the menu item. The search still will only work if the user has read permissions to a stream.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.