### PR TITLE
Fix path traversal in swagger resource.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationBrowserResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/resources/documentation/DocumentationBrowserResource.java
@@ -98,14 +98,14 @@ public class DocumentationBrowserResource extends RestResource {
     @GET
     @Path("/{route: .*}")
     public Response asset(@PathParam("route") String route) throws IOException {
-        // Directory traversal should not be possible but just to make sure..
-        if (route.contains("..")) {
-            throw new BadRequestException("Not allowed to access parent directory");
-        }
-
         // Remove path globalModePath before we serve swagger resources
         if (route.startsWith("global/")) {
-            route = route.replace("global/", "");
+            route = route.replaceFirst("global/", "");
+        }
+
+        // Trying to prevent directory traversal
+        if (route.contains("..")) {
+            throw new BadRequestException("Not allowed to access parent directory");
         }
         final URL resource = classLoader.getResource("swagger/" + route);
         if (null != resource) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, the `/api-browser/.*` resource allowed to retrieve static assets used by swagger. Some of these were prefixed with a `global/` prefix, that needs to be stripped away before locating the file. The string replacement used for this was used unbounded (replacing every occurence of the prefix, not just the first one), so it could be used to create URLs containing `..`. The check if the route contains `..` was performed _before_ the string replacement, so it could effectively be used to evade it.

This change is:

1. Replacing _only the first_ occurrence of `global/`
2. Performing the check if the route contains `..` _after_ the replacement and _right before_ the file is tried to be opened.

Fixes #8986.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.