### PR TITLE
Run analysers in production mode

### DIFF
--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -14,7 +14,7 @@ const APP_PATH = path.resolve(ROOT_PATH, 'src');
 const BUILD_PATH = path.resolve(ROOT_PATH, 'target/web/build');
 const MANIFESTS_PATH = path.resolve(ROOT_PATH, 'manifests');
 const VENDOR_MANIFEST_PATH = path.resolve(MANIFESTS_PATH, 'vendor-manifest.json');
-const TARGET = process.env.npm_lifecycle_event;
+const TARGET = process.env.npm_lifecycle_event || 'build';
 process.env.BABEL_ENV = TARGET;
 
 const BABELRC = path.resolve(ROOT_PATH, 'babel.config.js');
@@ -184,7 +184,7 @@ if (TARGET === 'start') {
   });
 }
 
-if (TARGET === 'build') {
+if (TARGET.startsWith('build')) {
   // eslint-disable-next-line no-console
   console.error('Running in production mode');
   process.env.NODE_ENV = 'production';

--- a/graylog2-web-interface/webpack.vendor.js
+++ b/graylog2-web-interface/webpack.vendor.js
@@ -41,19 +41,23 @@ const webpackConfig = {
         const jsfiles = [];
         const cssfiles = [];
         const chunks = {};
+
         Object.keys(assets).forEach((chunk) => {
           if (assets[chunk].js) {
             jsfiles.push(assets[chunk].js);
           }
+
           if (assets[chunk].css) {
             jsfiles.push(assets[chunk].css);
           }
+
           chunks[chunk] = {
             size: 0,
             entry: assets[chunk].js,
             css: assets[chunk].css || [],
           };
         });
+
         return JSON.stringify({
           files: {
             js: jsfiles,

--- a/graylog2-web-interface/webpack.vendor.js
+++ b/graylog2-web-interface/webpack.vendor.js
@@ -12,7 +12,7 @@ const MANIFESTS_PATH = path.resolve(ROOT_PATH, 'manifests');
 
 const vendorModules = require('./vendor.modules');
 
-const TARGET = process.env.npm_lifecycle_event;
+const TARGET = process.env.npm_lifecycle_event || 'build';
 process.env.BABEL_ENV = TARGET;
 
 // eslint-disable-next-line no-console
@@ -67,7 +67,7 @@ const webpackConfig = {
   recordsPath: path.resolve(ROOT_PATH, 'webpack/vendor-module-ids.json'),
 };
 
-if (TARGET === 'build') {
+if (TARGET.startsWith('build')) {
   module.exports = merge(webpackConfig, {
     mode: 'production',
     optimization: {


### PR DESCRIPTION
Make sure npm scripts which start with 'build' are built in production mode so analysers get production stats.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
It allows npm scripts starting with "build" to use production mode in webpack. This is so that analysers get the correct stats and data to work with when analysing bundles.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently analysing would result in looking at development builds. This is wrong.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By running `yarn build:analyze`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

