### PR TITLE
Submit widget query form before saving edit widget modal.

### DIFF
--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.jsx
@@ -1,8 +1,7 @@
 // @flow strict
 import * as React from 'react';
-import { useCallback } from 'react';
 import styled from 'styled-components';
-import { Field } from 'formik';
+import { Field, useFormikContext } from 'formik';
 
 import connect from 'stores/connect';
 import { Col, Row } from 'components/graylog';
@@ -11,29 +10,22 @@ import DocumentationLink from 'components/support/DocumentationLink';
 import DocsHelper from 'util/DocsHelper';
 import Button from 'components/graylog/Button';
 import TopRow from 'views/components/searchbar/TopRow';
-import Widget from 'views/logic/widgets/Widget';
 import { StreamsStore } from 'views/stores/StreamsStore';
 import { SearchConfigStore } from 'views/stores/SearchConfigStore';
-import { WidgetActions } from 'views/stores/WidgetStore';
 import { GlobalOverrideActions, GlobalOverrideStore } from 'views/stores/GlobalOverrideStore';
 import GlobalOverride from 'views/logic/search/GlobalOverride';
 import SearchActions from 'views/actions/SearchActions';
-import { createElasticsearchQueryString } from 'views/logic/queries/Query';
 
 import TimeRangeTypeSelector from './searchbar/TimeRangeTypeSelector';
 import TimeRangeInput from './searchbar/TimeRangeInput';
 import StreamsFilter from './searchbar/StreamsFilter';
 import SearchButton from './searchbar/SearchButton';
 import QueryInput from './searchbar/AsyncQueryInput';
-import SearchBarForm from './searchbar/SearchBarForm';
-
-import { DEFAULT_TIMERANGE } from '../Constants';
 
 type Props = {
   availableStreams: Array<any>,
   config: any,
   globalOverride: ?GlobalOverride,
-  widget: Widget,
 };
 
 const BlurredWrapper = styled.div`
@@ -70,84 +62,63 @@ const ResetOverrideHint = () => (
   </CenteredBox>
 );
 
-const onSubmit = (values, widget: Widget) => {
-  const { timerange, streams, queryString } = values;
-  const newWidget = widget.toBuilder()
-    .timerange(timerange)
-    .query(createElasticsearchQueryString(queryString))
-    .streams(streams)
-    .build();
-
-  return WidgetActions.update(widget.id, newWidget);
-};
-
-const WidgetQueryControls = ({ availableStreams, config, globalOverride = {}, widget }: Props) => {
-  const { streams } = widget;
-  const timerange = widget.timerange || DEFAULT_TIMERANGE;
-  const { query_string: queryString } = widget.query || createElasticsearchQueryString('');
-
+const WidgetQueryControls = ({ availableStreams, config, globalOverride = {} }: Props) => {
   const isGloballyOverridden: boolean = globalOverride !== undefined
     && globalOverride !== null
     && (globalOverride.query !== undefined || globalOverride.timerange !== undefined);
   const Wrapper = isGloballyOverridden ? BlurredWrapper : React.Fragment;
-
-  const _onSubmit = useCallback((values) => onSubmit(values, widget), [widget]);
+  const { dirty, isValid, isSubmitting, handleSubmit } = useFormikContext();
 
   return (
     <>
       {isGloballyOverridden && <ResetOverrideHint />}
       <Wrapper>
-        <SearchBarForm initialValues={{ timerange, streams, queryString }}
-                       onSubmit={_onSubmit}>
-          {({ dirty, isSubmitting, isValid, handleSubmit }) => (
-            <>
-              <TopRow>
-                <Col md={4}>
-                  <TimeRangeTypeSelector disabled={isGloballyOverridden} />
-                  <TimeRangeInput disabled={isGloballyOverridden} config={config} />
-                </Col>
+        <>
+          <TopRow>
+            <Col md={4}>
+              <TimeRangeTypeSelector disabled={isGloballyOverridden} />
+              <TimeRangeInput disabled={isGloballyOverridden} config={config} />
+            </Col>
 
-                <Col md={8}>
-                  <Field name="streams">
-                    {({ field: { name, value, onChange } }) => (
-                      <StreamsFilter value={value}
-                                     disabled={isGloballyOverridden}
-                                     streams={availableStreams}
-                                     onChange={(newStreams) => onChange({ target: { value: newStreams, name } })} />
-                    )}
-                  </Field>
-                </Col>
-              </TopRow>
+            <Col md={8}>
+              <Field name="streams">
+                {({ field: { name, value, onChange } }) => (
+                  <StreamsFilter value={value}
+                                 disabled={isGloballyOverridden}
+                                 streams={availableStreams}
+                                 onChange={(newStreams) => onChange({ target: { value: newStreams, name } })} />
+                )}
+              </Field>
+            </Col>
+          </TopRow>
 
-              <Row className="no-bm">
-                <Col md={12}>
-                  <div className="pull-right search-help">
-                    <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
-                                       title="Search query syntax documentation"
-                                       text={<Icon name="lightbulb" type="regular" />} />
-                  </div>
-                  <SearchButton running={isSubmitting}
-                                disabled={isGloballyOverridden || isSubmitting || !isValid}
-                                dirty={dirty} />
+          <Row className="no-bm">
+            <Col md={12}>
+              <div className="pull-right search-help">
+                <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
+                                   title="Search query syntax documentation"
+                                   text={<Icon name="lightbulb" type="regular" />} />
+              </div>
+              <SearchButton running={isSubmitting}
+                            disabled={isGloballyOverridden || isSubmitting || !isValid}
+                            dirty={dirty} />
 
-                  <Field name="queryString">
-                    {({ field: { name, value, onChange } }) => (
-                      <QueryInput value={value}
-                                  disabled={isGloballyOverridden}
-                                  placeholder={'Type your search query here and press enter. E.g.: ("not found" AND http) OR http_response_code:[400 TO 404]'}
-                                  onChange={(newQuery) => {
-                                    onChange({ target: { value: newQuery, name } });
+              <Field name="queryString">
+                {({ field: { name, value, onChange } }) => (
+                  <QueryInput value={value}
+                              disabled={isGloballyOverridden}
+                              placeholder={'Type your search query here and press enter. E.g.: ("not found" AND http) OR http_response_code:[400 TO 404]'}
+                              onChange={(newQuery) => {
+                                onChange({ target: { value: newQuery, name } });
 
-                                    return Promise.resolve();
-                                  }}
-                                  onExecute={handleSubmit} />
-                    )}
-                  </Field>
-                </Col>
-              </Row>
-            </>
-          )}
-        </SearchBarForm>
+                                return Promise.resolve();
+                              }}
+                              onExecute={handleSubmit} />
+                )}
+              </Field>
+            </Col>
+          </Row>
+        </>
       </Wrapper>
     </>
   );

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.test.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.test.jsx
@@ -45,10 +45,6 @@ describe('WidgetQueryControls', () => {
   };
 
   const defaultProps = {
-    widget: Widget.builder()
-      .id('deadbeef')
-      .type('foo')
-      .build(),
     availableStreams: [],
     config,
   };

--- a/graylog2-web-interface/src/views/components/WidgetQueryControls.test.jsx
+++ b/graylog2-web-interface/src/views/components/WidgetQueryControls.test.jsx
@@ -5,7 +5,7 @@ import WrappingContainer from 'WrappingContainer';
 
 import { GlobalOverrideActions } from 'views/stores/GlobalOverrideStore';
 import SearchActions from 'views/actions/SearchActions';
-import Widget from 'views/logic/widgets/Widget';
+import { DEFAULT_TIMERANGE } from 'views/Constants';
 
 import WidgetQueryControls from './WidgetQueryControls';
 import SearchBarForm from './searchbar/SearchBarForm';
@@ -54,7 +54,7 @@ describe('WidgetQueryControls', () => {
 
   const Wrapper = ({ children }: { children: React.Node }) => (
     <WrappingContainer>
-      <SearchBarForm initialValues={{ timerange: { type: 'relative', range: 300 }, queryString: '', streams: [] }} onSubmit={() => {}}>
+      <SearchBarForm initialValues={{ timerange: DEFAULT_TIMERANGE, queryString: '', streams: [] }} onSubmit={() => {}}>
         {children}
       </SearchBarForm>
     </WrappingContainer>

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/EventListConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/EventListConfiguration.jsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 
-import { Checkbox, FormGroup } from 'components/graylog';
+import { Checkbox } from 'components/graylog';
 
 type Props = {
   enabled: boolean,
@@ -11,14 +11,10 @@ type Props = {
 
 const EventListConfiguration = ({ enabled, onChange }: Props) => {
   return (
-    <form>
-      <FormGroup>
-        {/* eslint-disable-next-line no-undef */}
-        <Checkbox onChange={(event: SyntheticInputEvent<HTMLInputElement>) => onChange(event.target.checked)} checked={enabled}>
-          Enable Event Annotation
-        </Checkbox>
-      </FormGroup>
-    </form>
+    <Checkbox onChange={(event: SyntheticInputEvent<HTMLInputElement>) => onChange(event.target.checked)}
+              checked={enabled}>
+      Enable Event Annotation
+    </Checkbox>
   );
 };
 

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/EventListConfiguration.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/__snapshots__/EventListConfiguration.test.jsx.snap
@@ -2,23 +2,17 @@
 
 exports[`EventListConfiguration should render minimal 1`] = `
 <div>
-  <form>
-    <div
-      class="form-group"
+  <div
+    class="checkbox"
+  >
+    <label
+      title=""
     >
-      <div
-        class="checkbox"
-      >
-        <label
-          title=""
-        >
-          <input
-            type="checkbox"
-          />
-          Enable Event Annotation
-        </label>
-      </div>
-    </div>
-  </form>
+      <input
+        type="checkbox"
+      />
+      Enable Event Annotation
+    </label>
+  </div>
 </div>
 `;

--- a/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/SearchBarForm.jsx
@@ -1,5 +1,6 @@
 // @flow strict
 import * as React from 'react';
+import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { useCallback } from 'react';
 import { Form, Formik } from 'formik';
@@ -34,6 +35,10 @@ const validate = (values) => {
   return errors;
 };
 
+const StyledForm = styled(Form)`
+  height: 100%;
+`;
+
 const SearchBarForm = ({ initialValues, onSubmit, children }: Props) => {
   const _onSubmit = useCallback(({ timerange, streams, queryString }) => {
     const newTimerange = onSubmittingTimerange(timerange);
@@ -57,9 +62,9 @@ const SearchBarForm = ({ initialValues, onSubmit, children }: Props) => {
             onSubmit={_onSubmit}
             validate={validate}>
       {(...args) => (
-        <Form>
+        <StyledForm>
           {isFunction(children) ? children(...args) : children}
-        </Form>
+        </StyledForm>
       )}
     </Formik>
   );

--- a/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.jsx
@@ -85,7 +85,7 @@ const EditWidgetFrame = ({ children }: Props) => {
             <Modal.Header className={styles.QueryControls}>
               <QueryEditModeContext.Provider value="widget">
                 <HeaderElements />
-                <WidgetQueryControls widget={widget} />
+                <WidgetQueryControls />
               </QueryEditModeContext.Provider>
             </Modal.Header>
           </IfDashboard>

--- a/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/EditWidgetFrame.test.jsx
@@ -1,0 +1,125 @@
+// @flow strict
+import * as React from 'react';
+import { asElement, render, fireEvent, waitFor } from 'wrappedTestingLibrary';
+import selectEvent from 'react-select-event';
+import MockStore from 'helpers/mocking/StoreMock';
+
+import { WidgetActions } from 'views/stores/WidgetStore';
+import Widget from 'views/logic/widgets/Widget';
+
+import EditWidgetFrame from './EditWidgetFrame';
+
+import ViewTypeContext from '../contexts/ViewTypeContext';
+import WidgetContext from '../contexts/WidgetContext';
+
+jest.mock('views/stores/WidgetStore', () => ({
+  WidgetActions: {
+    update: jest.fn(),
+  },
+}));
+
+jest.mock('views/stores/SearchConfigStore', () => ({
+  SearchConfigStore: MockStore(['getInitialState', () => ({
+    searchesClusterConfig: {
+      relative_timerange_options: { P1D: 'Search in last day', PT0S: 'Search in all messages' },
+      query_time_range_limit: 'PT0S',
+    },
+  })]),
+}));
+
+jest.mock('views/stores/StreamsStore', () => ({
+  StreamsStore: MockStore(['getInitialState', () => ({
+    streams: [
+      { title: 'PFLog', id: '5c2e27d6ba33a9681ad62775' },
+      { title: 'DNS Logs', id: '5d2d9649e117dc4df84cf83c' },
+    ],
+  })]),
+}));
+
+jest.mock('moment', () => {
+  const mockMoment = jest.requireActual('moment');
+
+  return Object.assign(() => mockMoment('2019-10-10T12:26:31.146Z'), mockMoment);
+});
+
+describe('EditWidgetFrame', () => {
+  describe('on a dashboard', () => {
+    const widget = Widget.builder()
+      .id('deadbeef')
+      .type('dummy')
+      .config({})
+      .build();
+    const renderSUT = () => render((
+      <ViewTypeContext.Provider value="DASHBOARD">
+        <WidgetContext.Provider value={widget}>
+          <EditWidgetFrame>
+            <>Hello World!</>
+            <>These are some buttons!</>
+          </EditWidgetFrame>
+        </WidgetContext.Provider>
+      </ViewTypeContext.Provider>
+    ));
+
+    it('changes the widget\'s timerange when time range input is used', async () => {
+      const { getByDisplayValue, getByText, getByTitle } = renderSUT();
+      const timeRangeSelect = getByDisplayValue('Search in last day');
+
+      expect(timeRangeSelect).not.toBeNull();
+
+      const optionForAllMessages = asElement(getByText('Search in all messages'), HTMLOptionElement);
+
+      fireEvent.change(timeRangeSelect, { target: { value: optionForAllMessages.value } });
+
+      const searchButton = getByTitle(/Perform search/);
+
+      fireEvent.click(searchButton);
+
+      await waitFor(() => expect(WidgetActions.update).toHaveBeenCalledWith('deadbeef', expect.objectContaining({
+        timerange: { type: 'relative', range: 0 },
+      })));
+    });
+
+    it('changes the widget\'s timerange type when switching to absolute time range', async () => {
+      const { getByText, getByTitle } = renderSUT();
+      const absoluteTimeRangeSelect = getByText('Absolute');
+
+      expect(absoluteTimeRangeSelect).not.toBeNull();
+
+      fireEvent.click(absoluteTimeRangeSelect);
+
+      const searchButton = getByTitle(/Perform search/);
+
+      fireEvent.click(searchButton);
+
+      await waitFor(() => expect(WidgetActions.update)
+        .toHaveBeenLastCalledWith('deadbeef', expect.objectContaining({
+          timerange: {
+            type: 'absolute',
+            from: '2019-10-10T12:21:31.146Z',
+            to: '2019-10-10T12:26:31.146Z',
+          },
+        })));
+    });
+
+    it('changes the widget\'s streams when using stream filter', async () => {
+      const { getByTitle, getByTestId } = renderSUT();
+      const streamFilter = getByTestId('streams-filter');
+      const reactSelect = streamFilter.querySelector('div');
+
+      expect(reactSelect).not.toBeNull();
+
+      // Flow is not parsing the jest assertion before
+      if (reactSelect) {
+        await selectEvent.select(reactSelect, 'PFLog');
+      }
+
+      const searchButton = getByTitle(/Perform search/);
+
+      fireEvent.click(searchButton);
+
+      await waitFor(() => expect(WidgetActions.update).toHaveBeenCalledWith('deadbeef', expect.objectContaining({
+        streams: ['5c2e27d6ba33a9681ad62775'],
+      })));
+    });
+  });
+});

--- a/graylog2-web-interface/src/views/components/widgets/SaveOrCancelButtons.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/SaveOrCancelButtons.jsx
@@ -1,5 +1,7 @@
 // @flow strict
 import * as React from 'react';
+import { useCallback } from 'react';
+import { useFormikContext } from 'formik';
 
 import { Button } from 'components/graylog';
 
@@ -8,11 +10,22 @@ type Props = {
   onFinish: () => void,
 };
 
-const SaveOrCancelButtons = ({ onFinish, onCancel }: Props) => (
-  <>
-    <Button onClick={onFinish} bsStyle="primary">Save</Button>
-    <Button onClick={onCancel}>Cancel</Button>
-  </>
-);
+const SaveOrCancelButtons = ({ onFinish, onCancel }: Props) => {
+  const { handleSubmit } = useFormikContext();
+  const _onFinish = useCallback((...args) => {
+    if (handleSubmit) {
+      handleSubmit();
+    }
+
+    return onFinish(...args);
+  }, [onFinish, handleSubmit]);
+
+  return (
+    <>
+      <Button onClick={_onFinish} bsStyle="primary">Save</Button>
+      <Button onClick={onCancel}>Cancel</Button>
+    </>
+  );
+};
 
 export default SaveOrCancelButtons;

--- a/graylog2-web-interface/src/views/components/widgets/SaveOrCancelButtons.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/SaveOrCancelButtons.jsx
@@ -11,9 +11,9 @@ type Props = {
 };
 
 const SaveOrCancelButtons = ({ onFinish, onCancel }: Props) => {
-  const { handleSubmit } = useFormikContext();
+  const { handleSubmit, dirty } = useFormikContext();
   const _onFinish = useCallback((...args) => {
-    if (handleSubmit) {
+    if (handleSubmit && dirty) {
       handleSubmit();
     }
 

--- a/graylog2-web-interface/src/views/components/widgets/SaveOrCancelButtons.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/SaveOrCancelButtons.jsx
@@ -18,7 +18,7 @@ const SaveOrCancelButtons = ({ onFinish, onCancel }: Props) => {
     }
 
     return onFinish(...args);
-  }, [onFinish, handleSubmit]);
+  }, [onFinish, handleSubmit, dirty]);
 
   return (
     <>

--- a/graylog2-web-interface/src/views/components/widgets/Widget.test.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/Widget.test.jsx
@@ -26,6 +26,8 @@ import MessagesWidget from 'views/logic/widgets/MessagesWidget';
 
 import Widget from './Widget';
 
+import WidgetContext from '../contexts/WidgetContext';
+
 jest.mock('views/actions/SearchActions', () => ({
   create: mockAction(jest.fn()),
   get: mockAction(jest.fn()),
@@ -81,7 +83,10 @@ describe('<Widget />', () => {
     jest.resetModules();
   });
 
-  const widget = { config: {}, id: 'widgetId', type: 'dummy' };
+  const widget = WidgetModel.builder().newId()
+    .type('dummy')
+    .config({})
+    .build();
 
   const viewState = ViewState.builder().build();
   const query = Query.builder().id('query-id').build();
@@ -118,15 +123,16 @@ describe('<Widget />', () => {
   };
 
   const DummyWidget = (props) => (
-    <Widget widget={widget}
-            id="widgetId"
-            fields={[]}
-            onPositionsChange={() => {}}
-            onSizeChange={() => {}}
-            title="Widget Title"
-            position={new WidgetPosition(1, 1, 1, 1)}
-            {...props} />
-
+    <WidgetContext.Provider value={widget}>
+      <Widget widget={widget}
+              id="widgetId"
+              fields={[]}
+              onPositionsChange={() => {}}
+              onSizeChange={() => {}}
+              title="Widget Title"
+              position={new WidgetPosition(1, 1, 1, 1)}
+              {...props} />
+    </WidgetContext.Provider>
   );
 
   it('should render with empty props', () => {
@@ -191,18 +197,23 @@ describe('<Widget />', () => {
   });
 
   it('renders placeholder in edit mode if widget type is unknown', async () => {
-    const unknownWidget = { config: {}, id: 'widgetId', type: 'i-dont-know-this-widget-type' };
+    const unknownWidget = WidgetModel.builder()
+      .newId()
+      .type('i-dont-know-this-widget-type')
+      .config({})
+      .build();
     const UnknownWidget = (props) => (
-      <Widget widget={unknownWidget}
-              editing
-              id="widgetId"
-              fields={[]}
-              onPositionsChange={() => {}}
-              onSizeChange={() => {}}
-              title="Widget Title"
-              position={new WidgetPosition(1, 1, 1, 1)}
-              {...props} />
-
+      <WidgetContext.Provider value={unknownWidget}>
+        <Widget widget={unknownWidget}
+                editing
+                id="widgetId"
+                fields={[]}
+                onPositionsChange={() => {}}
+                onSizeChange={() => {}}
+                title="Widget Title"
+                position={new WidgetPosition(1, 1, 1, 1)}
+                {...props} />
+      </WidgetContext.Provider>
     );
     const { findByText } = render(<UnknownWidget data={[]} />);
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, a successful change to the timerange/stream selection/query of a widget on a dashboard required submitting the widget's search after the change and before clicking "Save". This was unintuitive and unnecessarily complicated.

This change is now submitting the widget's query form when the user clicks "Save" and the form is dirty, not requiring the user to have submitted the form manually before.

Fixes #7922.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.