### PR TITLE
Avoid URL synchronization if view is not currently dirty.

### DIFF
--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
@@ -41,16 +41,12 @@ const _getStreams = (query = {}): Array<string> => {
 
 const bindSearchParamsFromQuery: ViewHook = ({ query, view }) => {
   if (view.type !== View.Type.Search) {
-    console.log('no search');
-
     return Promise.resolve(true);
   }
 
   const { q: queryString } = query;
   const timerange = _getTimerange(query);
   const streams = filtersForQuery(_getStreams(query));
-
-  console.log('queryString: ', queryString);
 
   if (!queryString && !timerange && !streams) {
     return Promise.resolve(true);
@@ -66,7 +62,6 @@ const bindSearchParamsFromQuery: ViewHook = ({ query, view }) => {
   let queryBuilder = firstQuery.toBuilder();
 
   if (queryString !== undefined) {
-    console.log('setting new query: ', queryString);
     queryBuilder = queryBuilder.query(createElasticsearchQueryString(queryString));
   }
 

--- a/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
+++ b/graylog2-web-interface/src/views/hooks/BindSearchParamsFromQuery.js
@@ -41,12 +41,16 @@ const _getStreams = (query = {}): Array<string> => {
 
 const bindSearchParamsFromQuery: ViewHook = ({ query, view }) => {
   if (view.type !== View.Type.Search) {
+    console.log('no search');
+
     return Promise.resolve(true);
   }
 
   const { q: queryString } = query;
   const timerange = _getTimerange(query);
   const streams = filtersForQuery(_getStreams(query));
+
+  console.log('queryString: ', queryString);
 
   if (!queryString && !timerange && !streams) {
     return Promise.resolve(true);
@@ -62,6 +66,7 @@ const bindSearchParamsFromQuery: ViewHook = ({ query, view }) => {
   let queryBuilder = firstQuery.toBuilder();
 
   if (queryString !== undefined) {
+    console.log('setting new query: ', queryString);
     queryBuilder = queryBuilder.query(createElasticsearchQueryString(queryString));
   }
 

--- a/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.js
+++ b/graylog2-web-interface/src/views/hooks/SyncWithQueryParameters.js
@@ -31,9 +31,9 @@ const extractTimerangeParams = (timerange: TimeRange) => {
 };
 
 export const syncWithQueryParameters = (query: string, action: (string) => mixed = history.push) => {
-  const { view } = ViewStore.getInitialState() || {};
+  const { view, dirty } = ViewStore.getInitialState() || {};
 
-  if (view && view.type === View.Type.Search) {
+  if (view && view.type === View.Type.Search && dirty) {
     const { queries } = view.search;
 
     if (queries.size !== 1) {

--- a/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx
@@ -125,7 +125,7 @@ const ExtendedSearchPage = ({ route, location = { query: {} }, router, searchRef
     const { view } = ViewStore.getInitialState();
 
     bindSearchParamsFromQuery({ view, query: location.query, retry: () => Promise.resolve() });
-  }, [query]);
+  }, [location.query]);
 
   useEffect(() => {
     SearchConfigActions.refresh();


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, the URL synchronization hook unconditionally added query/timerange/streams information to the current URL if the current view is a search (and not a dashboard). This lead to an unnecessary URL change if a saved search is loaded (as the persisted query/timerange/streams are identical to the current state).

This change is checking if the current view is dirty. If not, no change is made.

<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

