### PR TITLE
added groupmembership attribute for resolving LDAP group mapping

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/ldap/LdapConnector.java
@@ -186,8 +186,8 @@ public class LdapConnector {
                     if (attribute.isHumanReadable()) {
                         ldapEntry.put(attribute.getId(), Joiner.on(", ").join(attribute.iterator()));
                     }
-                    // ActiveDirectory (memberOf) and Sun Directory Server (isMemberOf)
-                    if ("memberOf".equalsIgnoreCase(attribute.getId()) || "isMemberOf".equalsIgnoreCase(attribute.getId())) {
+                    // ActiveDirectory (memberOf), Sun Directory Server (isMemberOf) and LDAP (groupmembership)
+                    if ("memberOf".equalsIgnoreCase(attribute.getId()) || "isMemberOf".equalsIgnoreCase(attribute.getId()) || "groupmembership".equalsIgnoreCase(attribute.getId())) {
                         for (Value<?> group : attribute) {
                             groupDns.add(group.getString());
                         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Before this change, if users use Novell eDirectory for authentication, the group membership is referenced with the attribute groupMembership and this leads to a problem where group members are not being recognized by the authentication code. I`ve added groupMembership attribute for correctly resolving groups.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to the [8763 Issue](https://github.com/Graylog2/graylog2-server/issues/8763).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

