### PR TITLE
Allow specifying default user/password for discovered ES nodes.

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/JestClientProvider.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/JestClientProvider.java
@@ -64,8 +64,8 @@ public class JestClientProvider implements Provider<JestClient> {
                               @Named("elasticsearch_discovery_frequency") Duration discoveryFrequency,
                               @Named("elasticsearch_discovery_default_scheme") String defaultSchemeForDiscoveredNodes,
                               @Named("elasticsearch_compression_enabled") boolean compressionEnabled,
-                              @Named("elasticsearch_discovery_default_user") String defaultUserForDiscoveredNodes,
-                              @Named("elasticsearch_discovery_default_password") String defaultPasswordForDiscoveredNodes,
+                              @Named("elasticsearch_discovery_default_user") @Nullable String defaultUserForDiscoveredNodes,
+                              @Named("elasticsearch_discovery_default_password") @Nullable String defaultPasswordForDiscoveredNodes,
                               ObjectMapper objectMapper) {
         this.factory = new JestClientFactory() {
             @Override

--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/JestClientProvider.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/jest/JestClientProvider.java
@@ -64,6 +64,8 @@ public class JestClientProvider implements Provider<JestClient> {
                               @Named("elasticsearch_discovery_frequency") Duration discoveryFrequency,
                               @Named("elasticsearch_discovery_default_scheme") String defaultSchemeForDiscoveredNodes,
                               @Named("elasticsearch_compression_enabled") boolean compressionEnabled,
+                              @Named("elasticsearch_discovery_default_user") String defaultUserForDiscoveredNodes,
+                              @Named("elasticsearch_discovery_default_password") String defaultPasswordForDiscoveredNodes,
                               ObjectMapper objectMapper) {
         this.factory = new JestClientFactory() {
             @Override
@@ -97,6 +99,13 @@ public class JestClientProvider implements Provider<JestClient> {
                 return hostUri.toString();
             })
             .collect(Collectors.toList());
+
+        if (discoveryEnabled && !Strings.isNullOrEmpty(defaultUserForDiscoveredNodes) && !Strings.isNullOrEmpty(defaultPasswordForDiscoveredNodes)) {
+            credentialsProvider.setCredentials(
+                    new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT, AuthScope.ANY_REALM, defaultSchemeForDiscoveredNodes),
+                    new UsernamePasswordCredentials(defaultUserForDiscoveredNodes, defaultPasswordForDiscoveredNodes)
+            );
+        }
 
         final HttpClientConfig.Builder httpClientConfigBuilder = new HttpClientConfig
                 .Builder(hosts)

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/jest/JestClientProviderTest.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/jest/JestClientProviderTest.java
@@ -43,6 +43,8 @@ public class JestClientProviderTest {
                 Duration.seconds(5L),
                 "http",
                 false,
+                null,
+                null,
                 new ObjectMapper()
         );
 
@@ -65,6 +67,8 @@ public class JestClientProviderTest {
                 Duration.seconds(5L),
                 "http",
                 false,
+                null,
+                null,
                 new ObjectMapper()
         );
 
@@ -87,6 +91,8 @@ public class JestClientProviderTest {
                 Duration.seconds(5L),
                 "http",
                 false,
+                null,
+                null,
                 new ObjectMapper()
         );
 

--- a/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ElasticsearchInstanceES6.java
+++ b/graylog-storage-elasticsearch6/src/test/java/org/graylog/storage/elasticsearch6/testing/ElasticsearchInstanceES6.java
@@ -82,6 +82,8 @@ public class ElasticsearchInstanceES6 extends ElasticsearchInstance {
                 Duration.seconds(60),
                 "http",
                 false,
+                null,
+                null,
                 new ObjectMapperProvider().get()
         ).get();
     }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/client/ESCredentialsProvider.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/client/ESCredentialsProvider.java
@@ -16,10 +16,19 @@ import java.util.List;
 
 public class ESCredentialsProvider implements Provider<CredentialsProvider> {
     private final List<URI> elasticsearchHosts;
+    private final String defaultUserForDiscoveredNodes;
+    private final String defaultPasswordForDiscoveredNodes;
+    private final boolean discoveryEnabled;
 
     @Inject
-    public ESCredentialsProvider(@Named("elasticsearch_hosts") List<URI> elasticsearchHosts) {
+    public ESCredentialsProvider(@Named("elasticsearch_hosts") List<URI> elasticsearchHosts,
+                                 @Named("elasticsearch_discovery_default_user") String defaultUserForDiscoveredNodes,
+                                 @Named("elasticsearch_discovery_default_password") String defaultPasswordForDiscoveredNodes,
+                                 @Named("elasticsearch_discovery_enabled") boolean discoveryEnabled) {
         this.elasticsearchHosts = elasticsearchHosts;
+        this.defaultUserForDiscoveredNodes = defaultUserForDiscoveredNodes;
+        this.defaultPasswordForDiscoveredNodes = defaultPasswordForDiscoveredNodes;
+        this.discoveryEnabled = discoveryEnabled;
     }
 
     @Override
@@ -41,6 +50,13 @@ public class ESCredentialsProvider implements Provider<CredentialsProvider> {
                         }
                     }
                 });
+
+        if (discoveryEnabled && !Strings.isNullOrEmpty(defaultUserForDiscoveredNodes) && !Strings.isNullOrEmpty(defaultPasswordForDiscoveredNodes)) {
+            credentialsProvider.setCredentials(
+                    new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT, AuthScope.ANY_REALM, AuthScope.ANY_SCHEME),
+                    new UsernamePasswordCredentials(defaultUserForDiscoveredNodes, defaultPasswordForDiscoveredNodes)
+            );
+        }
 
         return credentialsProvider;
     }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/client/ESCredentialsProvider.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/client/ESCredentialsProvider.java
@@ -7,6 +7,7 @@ import org.graylog.shaded.elasticsearch7.org.apache.http.auth.UsernamePasswordCr
 import org.graylog.shaded.elasticsearch7.org.apache.http.client.CredentialsProvider;
 import org.graylog.shaded.elasticsearch7.org.apache.http.impl.client.BasicCredentialsProvider;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
@@ -22,8 +23,8 @@ public class ESCredentialsProvider implements Provider<CredentialsProvider> {
 
     @Inject
     public ESCredentialsProvider(@Named("elasticsearch_hosts") List<URI> elasticsearchHosts,
-                                 @Named("elasticsearch_discovery_default_user") String defaultUserForDiscoveredNodes,
-                                 @Named("elasticsearch_discovery_default_password") String defaultPasswordForDiscoveredNodes,
+                                 @Named("elasticsearch_discovery_default_user") @Nullable String defaultUserForDiscoveredNodes,
+                                 @Named("elasticsearch_discovery_default_password") @Nullable String defaultPasswordForDiscoveredNodes,
                                  @Named("elasticsearch_discovery_enabled") boolean discoveryEnabled) {
         this.elasticsearchHosts = elasticsearchHosts;
         this.defaultUserForDiscoveredNodes = defaultUserForDiscoveredNodes;

--- a/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
+++ b/graylog2-server/src/main/java/org/graylog2/configuration/ElasticsearchClientConfiguration.java
@@ -69,6 +69,12 @@ public class ElasticsearchClientConfiguration {
     @Parameter(value = "elasticsearch_discovery_default_scheme", validators = {HttpOrHttpsSchemeValidator.class})
     String defaultSchemeForDiscoveredNodes = "http";
 
+    @Parameter(value = "elasticsearch_discovery_default_user")
+    String defaultUserForDiscoveredNodes = null;
+
+    @Parameter(value = "elasticsearch_discovery_default_password")
+    String defaultPasswordForDiscoveredNodes = null;
+
     @Parameter(value = "elasticsearch_compression_enabled")
     boolean compressionEnabled = false;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this PR, it was not possible to combine Elasticsearch node discovery and authentication. Discovered Elasticsearch nodes must not have authentication enabled, because there was no way to configure credentials for them in Graylog.
This PR adds functionality for the user to supply a default user/password which is used for all discovered nodes. The same user & password must be used across all nodes in the Elasticsearch cluster, as the same user/password is used for every discovered node added to the node list.

The configuration settings are:

  `elasticsearch_discovery_default_user`: The default user name
  `elasticsearch_discovery_default_password`: The default password

The feature is supported for ES6 & ES7.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

