### PR TITLE
Remove mock for entities which got shared with a team

### DIFF
--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -96,7 +96,7 @@ const ApiRoutes = {
     prepare: (entityGRN) => { return { url: `/shares/entities/${entityGRN}/prepare` }; },
     update: (entityGRN) => { return { url: `/shares/entities/${entityGRN}` }; },
     userSharesPaginated: (username) => { return { url: `/shares/user/${username}` }; },
-    teamSharesPaginated: (teamId) => { return { url: `/shares/team/${teamId}` }; },
+    teamSharesPaginated: (teamId) => { return { url: `/teams/shares/${teamId}` }; },
   },
   IndexerClusterApiController: {
     health: () => { return { url: '/system/indexer/cluster/health' }; },


### PR DESCRIPTION
This PR removes the mock for entities which got shared with a team, because the endpoint exists now.
The data is being used by the team details pages.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1569