### PR TITLE
Make RolesSelector reusable by removing the connection to users

### DIFF
--- a/graylog2-web-interface/src/components/permissions/RolesSelector.jsx
+++ b/graylog2-web-interface/src/components/permissions/RolesSelector.jsx
@@ -9,11 +9,10 @@ import { type PaginatedListType } from 'stores/roles/AuthzRolesStore';
 import Role from 'logic/roles/Role';
 import { Button } from 'components/graylog';
 import { Select } from 'components/common';
-import User from 'logic/users/User';
 
 type Props = {
   onSubmit: (role: Role) => Promise<void>,
-  user: User,
+  assignedRolesNames: Immutable.List<string>,
 };
 
 const SubmitButton = styled(Button)`
@@ -37,16 +36,16 @@ const _renderRoleOption = ({ label }: { label: string }) => (
   <RoleSelectOption>{label}</RoleSelectOption>
 );
 
-const _options = (roles: Immutable.List<Role>, user: User) => roles
-  .filter((r) => !user.roles.includes(r.name))
+const _options = (roles: Immutable.List<Role>, assignedRolesNames) => roles
+  .filter((r) => !assignedRolesNames.includes(r.name))
   .toArray()
   .map((r) => ({ label: r.name, value: r.name, role: r }));
 
-const _assignRole = (username, selectedRoleName, roles, onSubmit, setSelectedRoleName, setIsSubmitting) => {
+const _assignRole = (selectedRoleName, roles, onSubmit, setSelectedRoleName, setIsSubmitting) => {
   const selectedRole = roles.find((r) => r.name === selectedRoleName);
 
   if (!selectedRole) {
-    throw Error(`Role assigment for user ${username} failed, because role with name ${selectedRoleName ?? '(undefined)'} does not exist`);
+    throw Error(`Role assigment failed, because role with name ${selectedRoleName ?? '(undefined)'} does not exist`);
   }
 
   setIsSubmitting(true);
@@ -57,19 +56,19 @@ const _assignRole = (username, selectedRoleName, roles, onSubmit, setSelectedRol
   });
 };
 
-const RolesSelector = ({ user, onSubmit }: Props) => {
+const RolesSelector = ({ assignedRolesNames, onSubmit }: Props) => {
   const [roles, setRoles] = useState(Immutable.List());
   const [selectedRoleName, setSelectedRoleName] = useState();
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const _onSubmit = () => _assignRole(user.username, selectedRoleName, roles, onSubmit, setSelectedRoleName, setIsSubmitting);
-  const options = _options(roles, user);
+  const _onSubmit = () => _assignRole(selectedRoleName, roles, onSubmit, setSelectedRoleName, setIsSubmitting);
+  const options = _options(roles, assignedRolesNames);
 
   useEffect(() => {
     const getUnlimited = [1, 0, ''];
 
     AuthzRolesDomain.loadRolesPaginated(...getUnlimited)
       .then((paginatedRoles: ?PaginatedListType) => paginatedRoles && setRoles(paginatedRoles.list));
-  }, [user]);
+  }, [assignedRolesNames]);
 
   return (
     <div>

--- a/graylog2-web-interface/src/components/users/UserCreate/UserCreate.jsx
+++ b/graylog2-web-interface/src/components/users/UserCreate/UserCreate.jsx
@@ -99,7 +99,7 @@ const UserCreate = () => {
                        labelClassName="col-sm-3"
                        wrapperClassName="col-sm-9"
                        label="Assign Roles">
-                  <RolesSelector onSubmit={_onAssignRole} assignedRolesNames={user.roles} />
+                  <RolesSelector onSubmit={_onAssignRole} assignedRolesIds={user.roles} identifier={(role) => role.name} />
                 </Input>
 
                 <Input id="selected-roles-overview"

--- a/graylog2-web-interface/src/components/users/UserCreate/UserCreate.jsx
+++ b/graylog2-web-interface/src/components/users/UserCreate/UserCreate.jsx
@@ -99,7 +99,7 @@ const UserCreate = () => {
                        labelClassName="col-sm-3"
                        wrapperClassName="col-sm-9"
                        label="Assign Roles">
-                  <RolesSelector onSubmit={_onAssignRole} user={user} />
+                  <RolesSelector onSubmit={_onAssignRole} assignedRolesNames={user.roles} />
                 </Input>
 
                 <Input id="selected-roles-overview"

--- a/graylog2-web-interface/src/components/users/UserDetails/RolesSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/RolesSection.jsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { useState } from 'react';
 
 import AuthzRolesDomain from 'domainActions/roles/AuthzRolesDomain';
-import UserNotification from 'util/UserNotification';
 import User from 'logic/users/User';
 import PaginatedItemOverview, {
   type PaginationInfo,
@@ -31,11 +30,6 @@ const RolesSection = ({ user: { username } }: Props) => {
 
         // $FlowFixMe Role has DescriptiveItem implemented!!!
         return response;
-      }).catch((error) => {
-        if (error?.additional?.status === 404) {
-          UserNotification.error(`Loading roles for user ${username} failed with status: ${error}`,
-            'Could not load roles for user');
-        }
       });
   };
 

--- a/graylog2-web-interface/src/components/users/UserEdit/RolesSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/RolesSection.jsx
@@ -72,7 +72,7 @@ const RolesSection = ({ user, onSubmit }: Props) => {
     <SectionComponent title="Roles" showLoading={loading}>
       <h3>Assign Roles</h3>
       <Container>
-        <RolesSelector onSubmit={_onAssignRole} user={user} />
+        <RolesSelector onSubmit={_onAssignRole} assignedRolesNames={user.roles} />
       </Container>
       <h3>Selected Roles</h3>
       <Container>

--- a/graylog2-web-interface/src/components/users/UserEdit/RolesSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/RolesSection.jsx
@@ -72,7 +72,7 @@ const RolesSection = ({ user, onSubmit }: Props) => {
     <SectionComponent title="Roles" showLoading={loading}>
       <h3>Assign Roles</h3>
       <Container>
-        <RolesSelector onSubmit={_onAssignRole} assignedRolesNames={user.roles} />
+        <RolesSelector onSubmit={_onAssignRole} assignedRolesIds={user.roles} identifier={(role) => role.name} />
       </Container>
       <h3>Selected Roles</h3>
       <Container>


### PR DESCRIPTION
This PR makes the `RolesSelector` reusable by removing the connection to users. This way it can not only be used to assign roles for users but also for teams.

Have a look at the enterprise PR for more information.
/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1772