### PR TITLE
Show better error message when user has no stream permissions. (3.3)

### DIFF
--- a/graylog2-web-interface/src/contexts/StreamsContext.jsx
+++ b/graylog2-web-interface/src/contexts/StreamsContext.jsx
@@ -1,0 +1,6 @@
+// @flow strict
+import * as React from 'react';
+
+const StreamsContext = React.createContext<?Array<*>>();
+
+export default StreamsContext;

--- a/graylog2-web-interface/src/contexts/StreamsProvider.jsx
+++ b/graylog2-web-interface/src/contexts/StreamsProvider.jsx
@@ -1,8 +1,9 @@
 // @flow strict
 import * as React from 'react';
+import { useEffect } from 'react';
 
 import connect from 'stores/connect';
-import { StreamsStore } from 'views/stores/StreamsStore';
+import { StreamsActions, StreamsStore } from 'views/stores/StreamsStore';
 
 import StreamsContext from './StreamsContext';
 
@@ -11,10 +12,16 @@ type Props = {
   streams: ?Array<*>,
 };
 
-const StreamsProvider = ({ children, streams }: Props) => (
-  <StreamsContext.Provider value={streams}>
-    {children}
-  </StreamsContext.Provider>
-);
+const StreamsProvider = ({ children, streams }: Props) => {
+  useEffect(() => {
+    StreamsActions.refresh();
+  }, []);
+
+  return (
+    <StreamsContext.Provider value={streams}>
+      {children}
+    </StreamsContext.Provider>
+  );
+};
 
 export default connect(StreamsProvider, { streams: StreamsStore }, ({ streams: { streams } = {} }) => ({ streams }));

--- a/graylog2-web-interface/src/contexts/StreamsProvider.jsx
+++ b/graylog2-web-interface/src/contexts/StreamsProvider.jsx
@@ -1,0 +1,22 @@
+// @flow strict
+import * as React from 'react';
+
+import connect from 'stores/connect';
+import { StreamsStore } from 'views/stores/StreamsStore';
+
+import StreamsContext from './StreamsContext';
+
+type Props = {
+  children: React.Node,
+  streams: ?Array<*>,
+};
+
+const StreamsProvider = ({ children, streams }: Props) => {
+  return (
+    <StreamsContext.Provider value={streams}>
+      {children}
+    </StreamsContext.Provider>
+  );
+};
+
+export default connect(StreamsProvider, { streams: StreamsStore }, ({ streams: { streams } = {} }) => ({ streams }));

--- a/graylog2-web-interface/src/contexts/StreamsProvider.jsx
+++ b/graylog2-web-interface/src/contexts/StreamsProvider.jsx
@@ -11,12 +11,10 @@ type Props = {
   streams: ?Array<*>,
 };
 
-const StreamsProvider = ({ children, streams }: Props) => {
-  return (
-    <StreamsContext.Provider value={streams}>
-      {children}
-    </StreamsContext.Provider>
-  );
-};
+const StreamsProvider = ({ children, streams }: Props) => (
+  <StreamsContext.Provider value={streams}>
+    {children}
+  </StreamsContext.Provider>
+);
 
 export default connect(StreamsProvider, { streams: StreamsStore }, ({ streams: { streams } = {} }) => ({ streams }));

--- a/graylog2-web-interface/src/pages/LoggedInPage.jsx
+++ b/graylog2-web-interface/src/pages/LoggedInPage.jsx
@@ -2,9 +2,13 @@ import React from 'react';
 import AppRouter from 'routing/AppRouter';
 import CurrentUserPreferencesProvider from '../contexts/CurrentUserPreferencesProvider';
 
+import StreamsProvider from '../contexts/StreamsProvider';
+
 const LoggedInPage = () => (
   <CurrentUserPreferencesProvider>
-    <AppRouter />
+    <StreamsProvider>
+      <AppRouter />
+    </StreamsProvider>
   </CurrentUserPreferencesProvider>
 );
 

--- a/graylog2-web-interface/src/pages/UserHasNoStreamAccess.jsx
+++ b/graylog2-web-interface/src/pages/UserHasNoStreamAccess.jsx
@@ -5,7 +5,7 @@ import ErrorPage from 'components/errors/ErrorPage';
 
 const UserHasNoStreamAccess = () => {
   return (
-    <ErrorPage title="No stream persmissions."
+    <ErrorPage title="No stream permissions."
                description={'We cannot start a search right now, because you are not allowed to access any stream. '
                  + 'If you feel this is an error, please contact your administrator.'} />
   );

--- a/graylog2-web-interface/src/pages/UserHasNoStreamAccess.jsx
+++ b/graylog2-web-interface/src/pages/UserHasNoStreamAccess.jsx
@@ -1,0 +1,14 @@
+// @flow strict
+import * as React from 'react';
+
+import ErrorPage from 'components/errors/ErrorPage';
+
+const UserHasNoStreamAccess = () => {
+  return (
+    <ErrorPage title="No stream persmissions."
+               description={'We cannot start a search right now, because you are not allowed to access any stream. '
+                 + 'If you feel this is an error, please contact your administrator.'} />
+  );
+};
+
+export default UserHasNoStreamAccess;

--- a/graylog2-web-interface/src/views/components/IfUserHasAccessToAnyStream.jsx
+++ b/graylog2-web-interface/src/views/components/IfUserHasAccessToAnyStream.jsx
@@ -1,0 +1,16 @@
+// @flow strict
+import * as React from 'react';
+import { useContext } from 'react';
+
+import StreamsContext from 'contexts/StreamsContext';
+import UserHasNoStreamAccess from 'pages/UserHasNoStreamAccess';
+
+type Props = {
+  children: React.Node,
+};
+
+export default ({ children }: Props) => {
+  const streams = useContext(StreamsContext);
+
+  return (streams && streams.length > 0 ? children : <UserHasNoStreamAccess />);
+};

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
@@ -16,6 +16,8 @@ import { SearchActions } from 'views/stores/SearchStore';
 import { ExtendedSearchPage } from 'views/pages';
 import { syncWithQueryParameters } from 'views/hooks/SyncWithQueryParameters';
 
+import IfUserHasAccessToAnyStream from '../components/IfUserHasAccessToAnyStream';
+
 type URLQuery = { [string]: any };
 
 type Props = {
@@ -125,7 +127,9 @@ class NewSearchPage extends React.Component<Props, State> {
       return (
         <ViewLoaderContext.Provider value={this.loadView}>
           <NewViewLoaderContext.Provider value={this.loadEmptyView}>
-            <ExtendedSearchPage route={route} location={location} />
+            <IfUserHasAccessToAnyStream>
+              <ExtendedSearchPage route={route} location={location} />
+            </IfUserHasAccessToAnyStream>
           </NewViewLoaderContext.Provider>
         </ViewLoaderContext.Provider>
       );

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.test.jsx
@@ -16,6 +16,8 @@ import ViewLoaderContext from 'views/logic/ViewLoaderContext';
 
 import NewSearchPage from './NewSearchPage';
 
+import StreamsContext from '../../contexts/StreamsContext';
+
 const mockExtendedSearchPage = jest.fn(() => <div>Extended search page</div>);
 const mockView = View.create()
   .toBuilder()
@@ -58,7 +60,11 @@ describe('NewSearchPage', () => {
       relative: '300',
     },
   };
-  const SimpleNewSearchPage = (props) => <NewSearchPage route={{}} router={mockRouter} location={{}} {...props} />;
+  const SimpleNewSearchPage = (props) => (
+    <StreamsContext.Provider value={[{}]}>
+      <NewSearchPage route={{}} router={mockRouter} location={{}} {...props} />
+    </StreamsContext.Provider>
+  );
 
   beforeAll(() => {
     jest.useFakeTimers();

--- a/graylog2-web-interface/src/views/stores/StreamsStore.js
+++ b/graylog2-web-interface/src/views/stores/StreamsStore.js
@@ -23,7 +23,11 @@ export const StreamsStore = singletonStore(
     streams: [],
     init() {
       this.refresh();
-      SessionActions.logout.completed.listen(() => this.clear());
+
+      SessionActions.logout.completed.listen(() => {
+        this.clear();
+        this.refresh();
+      });
     },
     getInitialState() {
       return this._state();

--- a/graylog2-web-interface/src/views/stores/StreamsStore.js
+++ b/graylog2-web-interface/src/views/stores/StreamsStore.js
@@ -24,10 +24,7 @@ export const StreamsStore = singletonStore(
     init() {
       this.refresh();
 
-      SessionActions.logout.completed.listen(() => {
-        this.clear();
-        this.refresh();
-      });
+      SessionActions.logout.completed.listen(() => this.clear());
     },
     getInitialState() {
       return this._state();


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, the user was seeing a "Missing stream permissions" page, that did not show a helpful error message if the user is not missing the permission for a specific stream, but for any stream at all.
    
This change is now checking if the user is having any stream permissions at all and shows a better message otherwise.
    
Fixes #8955.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.