### PR TITLE
Quote search query values for regexp operators

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/search/SearchQueryOperator.java
+++ b/graylog2-server/src/main/java/org/graylog2/search/SearchQueryOperator.java
@@ -40,7 +40,7 @@ public abstract class SearchQueryOperator {
     public static class Regexp extends SearchQueryOperator {
         @Override
         public DBQuery.Query buildQuery(String key, Object value) {
-            return DBQuery.regex(key, Pattern.compile(value.toString(), CASE_INSENSITIVE));
+            return DBQuery.regex(key, Pattern.compile(Pattern.quote(value.toString()), CASE_INSENSITIVE));
         }
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/search/SearchQueryOperatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/search/SearchQueryOperatorTest.java
@@ -1,0 +1,39 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.search;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class SearchQueryOperatorTest {
+    @Nested
+    class RegexpTest {
+        private SearchQueryOperator.Regexp operator;
+
+        @BeforeEach
+        void setUp() {
+            this.operator = new SearchQueryOperator.Regexp();
+        }
+
+        @Test
+        void withRegexpMetaCharacters() {
+            // Using regexp meta characters should now throw an exception
+            operator.buildQuery("hello", "foo\\");
+        }
+    }
+}


### PR DESCRIPTION
Avoids errors when the search query contains regexp meta characters like
`\`.