### PR TITLE
Merge new notification type to 3.3

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
@@ -61,6 +61,7 @@ public interface Notification extends Persisted {
         JOURNAL_UTILIZATION_TOO_HIGH,
         JOURNAL_UNCOMMITTED_MESSAGES_DELETED,
         OUTPUT_DISABLED,
+        OUTPUT_FAILING,
         INDEX_RANGES_RECALCULATION,
         GENERIC,
         ES_NODE_DISK_WATERMARK_LOW,

--- a/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
+++ b/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
@@ -208,6 +208,19 @@ class NotificationsFactory {
             </span>
           ),
         };
+      case 'output_failing':
+        return {
+          title: 'Output failing',
+          description: (
+            <span>
+              The output "{notification.details.outputTitle}" (id: {notification.details.outputId})
+              in stream "{notification.details.streamTitle}" (id: {notification.details.streamId})
+              is unable to send messages to the configured destination.
+              <br/>
+                The error message from the output is: <em>{notification.details.errorMessage}</em>
+            </span>
+          ),
+        };
       case 'stream_processing_disabled':
         return {
           title: 'Processing of a stream has been disabled due to excessive processing time.',


### PR DESCRIPTION
## Description
This PR is a backport of #9019 to the `3.3` branch

When outputs fail, we can't simply shut them down.  Thus, we need to give the users a clear message about what has happened.  This change adds a new notification type for outputs that are failing so we can do just that.

## How Has This Been Tested?
See #9019 

## Screenshots (if appropriate):
![Screen Shot 2020-09-22 at 1 31 58 PM](https://user-images.githubusercontent.com/6466251/93923101-e995bd80-fce0-11ea-89ad-547a8df421f3.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

