### PR TITLE
Fix Typeahead input background color

### DIFF
--- a/graylog2-web-interface/src/components/common/TypeAheadInput.jsx
+++ b/graylog2-web-interface/src/components/common/TypeAheadInput.jsx
@@ -1,13 +1,19 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import lodash from 'lodash';
+import escape from 'lodash/escape';
 import $ from 'jquery';
 import 'typeahead.js';
+import styled from 'styled-components';
 
 import UniversalSearch from 'logic/search/UniversalSearch';
-// eslint-disable-next-line no-unused-vars
 import { Input } from 'components/bootstrap';
+
+const StyledInput = styled(Input)`
+  input&.tt-hint {
+    background-color: transparent !important;
+  }
+`;
 
 /**
  * Component that renders a field input with auto-completion capabilities.
@@ -113,10 +119,10 @@ class TypeAheadInput extends React.Component {
         suggestion: (value) => {
           // Escape all text here that may be user-generated, since this is not automatically escaped by React.
           if (suggestionText) {
-            return `<div><strong>${lodash.escape(suggestionText)}</strong> ${lodash.escape(value[displayKey])}</div>`;
+            return `<div><strong>${escape(suggestionText)}</strong> ${escape(value[displayKey])}</div>`;
           }
 
-          return `<div>${lodash.escape(value[displayKey])}</div>`;
+          return `<div>${escape(value[displayKey])}</div>`;
         },
       },
     });
@@ -137,12 +143,12 @@ class TypeAheadInput extends React.Component {
     const { id, label, onKeyPress } = this.props;
 
     return (
-      <Input id={id}
-             type="text"
-             ref={(fieldInput) => { this.fieldInputElem = fieldInput; }}
-             wrapperClassName="typeahead-wrapper"
-             label={label}
-             onKeyPress={onKeyPress} />
+      <StyledInput id={id}
+                   type="text"
+                   ref={(fieldInput) => { this.fieldInputElem = fieldInput; }}
+                   wrapperClassName="typeahead-wrapper"
+                   label={label}
+                   onKeyPress={onKeyPress} />
     );
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated Typeahead overlay to be transparent instead of rendering color

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Typeahead inputs not swapping automatically with Theme switch

## Screenshots (if appropriate):
![typeahead-input](https://user-images.githubusercontent.com/122591/94030384-5d88a200-fd83-11ea-85bf-548999013e7d.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

