### PR TITLE
Fix empty search result in stream

### DIFF
--- a/graylog2-web-interface/src/components/streams/StreamComponent.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamComponent.jsx
@@ -109,24 +109,22 @@ class StreamComponent extends React.Component {
       );
     }
 
-    if (streams.length === 0) {
-      const createStreamButton = (
-        <IfPermitted permissions="streams:create">
-          <CreateStreamButton bsSize="small"
-                              bsStyle="link"
-                              className="btn-text"
-                              buttonText="Create one now"
-                              indexSets={indexSets}
-                              onSave={onStreamSave} />
-        </IfPermitted>
-      );
+    const createStreamButton = (
+      <IfPermitted permissions="streams:create">
+        <CreateStreamButton bsSize="small"
+                            bsStyle="link"
+                            className="btn-text"
+                            buttonText="Create one now"
+                            indexSets={indexSets}
+                            onSave={onStreamSave} />
+      </IfPermitted>
+    );
 
-      return (
-        <Alert bsStyle="warning">
-          <Icon name="info-circle" />&nbsp;No streams configured. {createStreamButton}
-        </Alert>
-      );
-    }
+    const noStreams = (
+      <Alert bsStyle="warning">
+        <Icon name="info-circle" />&nbsp;No streams found. {createStreamButton}
+      </Alert>
+    );
 
     const streamsList = (
       <StreamList streams={streams}
@@ -137,6 +135,10 @@ class StreamComponent extends React.Component {
                   indexSets={indexSets} />
     );
 
+    const streamListComp = streams.length === 0
+      ? noStreams
+      : streamsList;
+
     return (
       <div>
         <PaginatedList onChange={this._onPageChange}
@@ -144,7 +146,7 @@ class StreamComponent extends React.Component {
           <div style={{ marginBottom: 15 }}>
             <SearchForm onSearch={this._onSearch} onReset={this._onReset} useLoadingState />
           </div>
-          <div>{streamsList}</div>
+          <div>{streamListComp}</div>
         </PaginatedList>
       </div>
     );


### PR DESCRIPTION
## Motivation
Prior to this change, when the user was executing a search on streams
which resulted in no streams. The search bar was removed and the user
could not reset the search.

## Description
This change will display the Alert which will show that there are no
streams found below the search bar in stead of replacing it.

