### PR TITLE
Abstracting link components by reexporting them.

### DIFF
--- a/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { DropdownButton, MenuItem, Button } from 'components/graylog';
 import { AlertConditionForm, AlertConditionSummary, AlertConditionTestModal, UnknownAlertCondition } from 'components/alertconditions';
 import PermissionsMixin from 'util/PermissionsMixin';

--- a/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertCondition.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { DropdownButton, MenuItem, Button } from 'components/graylog';
 import { AlertConditionForm, AlertConditionSummary, AlertConditionTestModal, UnknownAlertCondition } from 'components/alertconditions';

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionSummary.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionSummary.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionSummary.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionSummary.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from 'components/graylog/router';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
+import { Link } from 'components/graylog/router';
 import Routes from 'routing/Routes';
 import { Col } from 'components/graylog';
 import { EntityListItem } from 'components/common';

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionsComponent.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionsComponent.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import naturalSort from 'javascript-natural-sort';
 
 import { Button } from 'components/graylog';

--- a/graylog2-web-interface/src/components/alertconditions/AlertConditionsComponent.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/AlertConditionsComponent.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'components/graylog/router';
 import naturalSort from 'javascript-natural-sort';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Button } from 'components/graylog';
 import { Spinner } from 'components/common';
 import { AlertConditionsList } from 'components/alertconditions';

--- a/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import naturalSort from 'javascript-natural-sort';
 
 import { Button } from 'components/graylog';

--- a/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
+++ b/graylog2-web-interface/src/components/alertconditions/StreamAlertConditions.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
-import { LinkContainer } from 'components/graylog/router';
 import naturalSort from 'javascript-natural-sort';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Button } from 'components/graylog';
 import { AlertConditionsList } from 'components/alertconditions';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import PermissionsMixin from 'util/PermissionsMixin';
 import CombinedProvider from 'injection/CombinedProvider';
 import { Col, DropdownButton, MenuItem, Button } from 'components/graylog';

--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotification.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import PermissionsMixin from 'util/PermissionsMixin';
 import CombinedProvider from 'injection/CombinedProvider';

--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotificationsComponent.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotificationsComponent.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'components/graylog/router';
 import naturalSort from 'javascript-natural-sort';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Button } from 'components/graylog';
 import { Spinner } from 'components/common';
 import { AlertNotificationsList } from 'components/alertnotifications';

--- a/graylog2-web-interface/src/components/alertnotifications/AlertNotificationsComponent.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/AlertNotificationsComponent.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import naturalSort from 'javascript-natural-sort';
 
 import { Button } from 'components/graylog';

--- a/graylog2-web-interface/src/components/alertnotifications/StreamAlertNotifications.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/StreamAlertNotifications.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import naturalSort from 'javascript-natural-sort';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Button } from 'components/graylog';
 import { Spinner } from 'components/common';
 import { AlertNotificationsList } from 'components/alertnotifications';

--- a/graylog2-web-interface/src/components/alertnotifications/StreamAlertNotifications.jsx
+++ b/graylog2-web-interface/src/components/alertnotifications/StreamAlertNotifications.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import naturalSort from 'javascript-natural-sort';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { Button } from 'components/graylog';
 import { Spinner } from 'components/common';

--- a/graylog2-web-interface/src/components/alerts/Alert.jsx
+++ b/graylog2-web-interface/src/components/alerts/Alert.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from 'components/graylog/router';
 
+import { Link } from 'components/graylog/router';
 import { Col, Label } from 'components/graylog';
 import { EntityListItem, Timestamp } from 'components/common';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/alerts/Alert.jsx
+++ b/graylog2-web-interface/src/components/alerts/Alert.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 
 import { Col, Label } from 'components/graylog';
 import { EntityListItem, Timestamp } from 'components/common';

--- a/graylog2-web-interface/src/components/alerts/AlertMessages.jsx
+++ b/graylog2-web-interface/src/components/alerts/AlertMessages.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Alert, Button } from 'components/graylog';
 import { PaginatedList, Spinner, Timestamp } from 'components/common';
 import CombinedProvider from 'injection/CombinedProvider';

--- a/graylog2-web-interface/src/components/alerts/AlertMessages.jsx
+++ b/graylog2-web-interface/src/components/alerts/AlertMessages.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { Alert, Button } from 'components/graylog';
 import { PaginatedList, Spinner, Timestamp } from 'components/common';

--- a/graylog2-web-interface/src/components/alerts/AlertsHeaderToolbar.jsx
+++ b/graylog2-web-interface/src/components/alerts/AlertsHeaderToolbar.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { ButtonToolbar, Button } from 'components/graylog';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/alerts/AlertsHeaderToolbar.jsx
+++ b/graylog2-web-interface/src/components/alerts/AlertsHeaderToolbar.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { ButtonToolbar, Button } from 'components/graylog';
 import Routes from 'routing/Routes';
 

--- a/graylog2-web-interface/src/components/authentication/AuthenticationComponent.jsx
+++ b/graylog2-web-interface/src/components/authentication/AuthenticationComponent.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import styled, { css } from 'styled-components';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 

--- a/graylog2-web-interface/src/components/authentication/AuthenticationComponent.jsx
+++ b/graylog2-web-interface/src/components/authentication/AuthenticationComponent.jsx
@@ -3,10 +3,10 @@ import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'components/graylog/router';
 import styled, { css } from 'styled-components';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Alert, Nav, NavItem, Row, Col } from 'components/graylog';
 import { Spinner } from 'components/common';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/common/LinkToNode.jsx
+++ b/graylog2-web-interface/src/components/common/LinkToNode.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 
 import StoreProvider from 'injection/StoreProvider';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/common/LinkToNode.jsx
+++ b/graylog2-web-interface/src/components/common/LinkToNode.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { Link } from 'components/graylog/router';
 
+import { Link } from 'components/graylog/router';
 import StoreProvider from 'injection/StoreProvider';
 import Routes from 'routing/Routes';
 

--- a/graylog2-web-interface/src/components/content-packs/ContentPackStatus.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackStatus.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled, { css } from 'styled-components';
-import { Link } from 'components/graylog/router';
 
+import { Link } from 'components/graylog/router';
 import { StyledBadge } from 'components/graylog/Badge';
 import Routes from 'routing/Routes';
 

--- a/graylog2-web-interface/src/components/content-packs/ContentPackStatus.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackStatus.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled, { css } from 'styled-components';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 
 import { StyledBadge } from 'components/graylog/Badge';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/content-packs/ContentPackVersions.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackVersions.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import Routes from 'routing/Routes';
 import { DataTable } from 'components/common';
 import { Button, DropdownButton, ButtonToolbar, MenuItem, Modal } from 'components/graylog';

--- a/graylog2-web-interface/src/components/content-packs/ContentPackVersions.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackVersions.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import Routes from 'routing/Routes';
 import { DataTable } from 'components/common';

--- a/graylog2-web-interface/src/components/content-packs/ContentPacksList.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPacksList.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 import { LinkContainer } from 'components/graylog/router';
 import styled from 'styled-components';
 

--- a/graylog2-web-interface/src/components/content-packs/ContentPacksList.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPacksList.jsx
@@ -1,9 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from 'components/graylog/router';
-import { LinkContainer } from 'components/graylog/router';
 import styled from 'styled-components';
 
+import { Link, LinkContainer } from 'components/graylog/router';
 import Routes from 'routing/Routes';
 import {
   Button,

--- a/graylog2-web-interface/src/components/content-packs/ContentPacksList.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPacksList.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import styled from 'styled-components';
 
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationsForm.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'components/graylog/router';
 import lodash from 'lodash';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Col, Row, Button } from 'components/graylog';
 import { Icon } from 'components/common';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationsForm.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import lodash from 'lodash';
 
 import { Col, Row, Button } from 'components/graylog';

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
-import { Link } from 'components/graylog/router';
 
+import { Link } from 'components/graylog/router';
 import { Alert } from 'components/graylog';
 import { extractDurationAndUnit } from 'components/common/TimeUnitInput';
 import { Icon } from 'components/common';

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 
 import { Alert } from 'components/graylog';
 import { extractDurationAndUnit } from 'components/common/TimeUnitInput';

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'components/graylog/router';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import lodash from 'lodash';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Button, Col, DropdownButton, Label, MenuItem, Row } from 'components/graylog';
 import Routes from 'routing/Routes';
 import {

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import lodash from 'lodash';
 

--- a/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import { Col, DropdownButton, MenuItem, Row, Button } from 'components/graylog';

--- a/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'components/graylog/router';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Col, DropdownButton, MenuItem, Row, Button } from 'components/graylog';
 import {
   EmptyEntity,

--- a/graylog2-web-interface/src/components/events/events/EventDetails.jsx
+++ b/graylog2-web-interface/src/components/events/events/EventDetails.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import { Col, Row } from 'components/graylog';

--- a/graylog2-web-interface/src/components/events/events/EventDetails.jsx
+++ b/graylog2-web-interface/src/components/events/events/EventDetails.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
-import { Link } from 'components/graylog/router';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
+import { Link } from 'components/graylog/router';
 import { Col, Row } from 'components/graylog';
 import { Timestamp } from 'components/common';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/events/events/Events.jsx
+++ b/graylog2-web-interface/src/components/events/events/Events.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
 import { Link } from 'react-router';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import styled, { css } from 'styled-components';
 
 import { Alert, Col, Label, OverlayTrigger, Row, Table, Tooltip, Button } from 'components/graylog';

--- a/graylog2-web-interface/src/components/events/events/Events.jsx
+++ b/graylog2-web-interface/src/components/events/events/Events.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
-import { Link } from 'components/graylog/router';
-import { LinkContainer } from 'components/graylog/router';
 import styled, { css } from 'styled-components';
 
+import { Link, LinkContainer } from 'components/graylog/router';
 import { Alert, Col, Label, OverlayTrigger, Row, Table, Tooltip, Button } from 'components/graylog';
 import { EmptyEntity, IfPermitted, PaginatedList, Timestamp, Icon } from 'components/common';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/events/events/Events.jsx
+++ b/graylog2-web-interface/src/components/events/events/Events.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 import { LinkContainer } from 'components/graylog/router';
 import styled, { css } from 'styled-components';
 

--- a/graylog2-web-interface/src/components/extractors/ExtractorsListItem.jsx
+++ b/graylog2-web-interface/src/components/extractors/ExtractorsListItem.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 import numeral from 'numeral';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Button, Row, Col, Well } from 'components/graylog';
 import EntityListItem from 'components/common/EntityListItem';
 import ExtractorUtils from 'util/ExtractorUtils';

--- a/graylog2-web-interface/src/components/extractors/ExtractorsListItem.jsx
+++ b/graylog2-web-interface/src/components/extractors/ExtractorsListItem.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import numeral from 'numeral';
 
 import { Button, Row, Col, Well } from 'components/graylog';

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/LookupTableConverterConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/LookupTableConverterConfiguration.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 
 import { Row, Col } from 'components/graylog';
 import { Input } from 'components/bootstrap';

--- a/graylog2-web-interface/src/components/extractors/converters_configuration/LookupTableConverterConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/converters_configuration/LookupTableConverterConfiguration.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from 'components/graylog/router';
 
+import { Link } from 'components/graylog/router';
 import { Row, Col } from 'components/graylog';
 import { Input } from 'components/bootstrap';
 import { Select, Spinner } from 'components/common';

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/LookupTableExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/LookupTableExtractorConfiguration.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from 'components/graylog/router';
 
+import { Link } from 'components/graylog/router';
 import { Row, Col, Button } from 'components/graylog';
 import { Input } from 'components/bootstrap';
 import { Select, Spinner, Icon } from 'components/common';

--- a/graylog2-web-interface/src/components/extractors/extractors_configuration/LookupTableExtractorConfiguration.jsx
+++ b/graylog2-web-interface/src/components/extractors/extractors_configuration/LookupTableExtractorConfiguration.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 
 import { Row, Col, Button } from 'components/graylog';
 import { Input } from 'components/bootstrap';

--- a/graylog2-web-interface/src/components/graylog/router.jsx
+++ b/graylog2-web-interface/src/components/graylog/router.jsx
@@ -1,0 +1,8 @@
+// @flow strict
+import { LinkContainer as BootstrapLinkContainer } from 'react-router-bootstrap';
+
+type LinkContainerProps = {
+  to: string,
+  children: React.Node,
+};
+export const LinkContainer = ({ children, to }: LinkContainerProps) => <BootstrapLinkContainer to={to}>{children}</BootstrapLinkContainer>;

--- a/graylog2-web-interface/src/components/graylog/router.jsx
+++ b/graylog2-web-interface/src/components/graylog/router.jsx
@@ -1,4 +1,5 @@
 // @flow strict
+import * as React from 'react';
 import { LinkContainer as BootstrapLinkContainer } from 'react-router-bootstrap';
 
 type LinkContainerProps = {

--- a/graylog2-web-interface/src/components/graylog/router.jsx
+++ b/graylog2-web-interface/src/components/graylog/router.jsx
@@ -1,9 +1,8 @@
 // @flow strict
-import * as React from 'react';
-import { LinkContainer as BootstrapLinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
+import { Link } from 'react-router';
 
-type LinkContainerProps = {
-  to: string,
-  children: React.Node,
+export {
+  Link,
+  LinkContainer,
 };
-export const LinkContainer = ({ children, to }: LinkContainerProps) => <BootstrapLinkContainer to={to}>{children}</BootstrapLinkContainer>;

--- a/graylog2-web-interface/src/components/indexers/IndexerFailuresComponent.jsx
+++ b/graylog2-web-interface/src/components/indexers/IndexerFailuresComponent.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 import numeral from 'numeral';
 import moment from 'moment';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Alert, Col, Row, Button } from 'components/graylog';
 import { Icon, Spinner } from 'components/common';
 import StoreProvider from 'injection/StoreProvider';

--- a/graylog2-web-interface/src/components/indexers/IndexerFailuresComponent.jsx
+++ b/graylog2-web-interface/src/components/indexers/IndexerFailuresComponent.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import numeral from 'numeral';
 import moment from 'moment';
 

--- a/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import moment from 'moment';
 import lodash from 'lodash';
 import { PluginStore } from 'graylog-web-plugin/plugin';

--- a/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetConfigurationForm.jsx
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 import moment from 'moment';
 import lodash from 'lodash';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Col, Row, Button } from 'components/graylog';
 import { Input } from 'components/bootstrap';
 import { Spinner, TimeUnitInput } from 'components/common';

--- a/graylog2-web-interface/src/components/indices/IndexSetsComponent.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetsComponent.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import { LinkContainer } from 'components/graylog/router';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 
 import { Col, Label, DropdownButton, MenuItem, Button } from 'components/graylog';
 import { EntityList, EntityListItem, PaginatedList, Spinner } from 'components/common';

--- a/graylog2-web-interface/src/components/indices/IndexSetsComponent.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetsComponent.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import { Link } from 'react-router';
 
 import { Col, Label, DropdownButton, MenuItem, Button } from 'components/graylog';

--- a/graylog2-web-interface/src/components/indices/IndexSetsComponent.jsx
+++ b/graylog2-web-interface/src/components/indices/IndexSetsComponent.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'components/graylog/router';
-import { Link } from 'components/graylog/router';
 
+import { LinkContainer, Link } from 'components/graylog/router';
 import { Col, Label, DropdownButton, MenuItem, Button } from 'components/graylog';
 import { EntityList, EntityListItem, PaginatedList, Spinner } from 'components/common';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/inputs/InputListItem.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputListItem.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { DropdownButton, MenuItem, Col, Button } from 'components/graylog';
 import { EntityListItem, IfPermitted, LinkToNode, Spinner } from 'components/common';

--- a/graylog2-web-interface/src/components/inputs/InputListItem.jsx
+++ b/graylog2-web-interface/src/components/inputs/InputListItem.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { DropdownButton, MenuItem, Col, Button } from 'components/graylog';
 import { EntityListItem, IfPermitted, LinkToNode, Spinner } from 'components/common';
 import { ConfigurationWell } from 'components/configurationforms';

--- a/graylog2-web-interface/src/components/lookup-tables/Cache.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/Cache.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/lookup-tables/Cache.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/Cache.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
+import { LinkContainer } from 'components/graylog/router';
 import Routes from 'routing/Routes';
 import { Row, Col, Button } from 'components/graylog';
 import { ContentPackMarker } from 'components/common';

--- a/graylog2-web-interface/src/components/lookup-tables/CacheTableEntry.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CacheTableEntry.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import { Link } from 'react-router';
 
 import { Button } from 'components/graylog';

--- a/graylog2-web-interface/src/components/lookup-tables/CacheTableEntry.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CacheTableEntry.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { LinkContainer } from 'components/graylog/router';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 
 import { Button } from 'components/graylog';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/lookup-tables/CacheTableEntry.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CacheTableEntry.jsx
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
-import { Link } from 'components/graylog/router';
 
+import { LinkContainer, Link } from 'components/graylog/router';
 import { Button } from 'components/graylog';
 import Routes from 'routing/Routes';
 import CombinedProvider from 'injection/CombinedProvider';

--- a/graylog2-web-interface/src/components/lookup-tables/CachesOverview.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CachesOverview.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import Routes from 'routing/Routes';
 import CombinedProvider from 'injection/CombinedProvider';
 import { Row, Col, Table, Popover, OverlayTrigger, Button } from 'components/graylog';

--- a/graylog2-web-interface/src/components/lookup-tables/CachesOverview.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/CachesOverview.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import Routes from 'routing/Routes';
 import CombinedProvider from 'injection/CombinedProvider';

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapter.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapter.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import { Row, Col, Button } from 'components/graylog';

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapter.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapter.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'components/graylog/router';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Row, Col, Button } from 'components/graylog';
 import { Input } from 'components/bootstrap';
 import { ContentPackMarker } from 'components/common';

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterTableEntry.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterTableEntry.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { LinkContainer } from 'components/graylog/router';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 
 import Routes from 'routing/Routes';
 import CombinedProvider from 'injection/CombinedProvider';

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterTableEntry.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterTableEntry.jsx
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
-import { Link } from 'components/graylog/router';
 
+import { LinkContainer, Link } from 'components/graylog/router';
 import Routes from 'routing/Routes';
 import CombinedProvider from 'injection/CombinedProvider';
 import { Button } from 'components/graylog';

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdapterTableEntry.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdapterTableEntry.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import { Link } from 'react-router';
 
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdaptersOverview.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdaptersOverview.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { Row, Col, Table, Popover, OverlayTrigger, Button } from 'components/graylog';
 import { PaginatedList, SearchForm, Spinner, Icon } from 'components/common';

--- a/graylog2-web-interface/src/components/lookup-tables/DataAdaptersOverview.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/DataAdaptersOverview.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Row, Col, Table, Popover, OverlayTrigger, Button } from 'components/graylog';
 import { PaginatedList, SearchForm, Spinner, Icon } from 'components/common';
 import DataAdapterTableEntry from 'components/lookup-tables/DataAdapterTableEntry';

--- a/graylog2-web-interface/src/components/lookup-tables/LUTTableEntry.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LUTTableEntry.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import { Link } from 'react-router';
 
 import CombinedProvider from 'injection/CombinedProvider';

--- a/graylog2-web-interface/src/components/lookup-tables/LUTTableEntry.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LUTTableEntry.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { LinkContainer } from 'components/graylog/router';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 
 import CombinedProvider from 'injection/CombinedProvider';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/lookup-tables/LUTTableEntry.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LUTTableEntry.jsx
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
-import { Link } from 'components/graylog/router';
 
+import { LinkContainer, Link } from 'components/graylog/router';
 import CombinedProvider from 'injection/CombinedProvider';
 import Routes from 'routing/Routes';
 import { Button } from 'components/graylog';

--- a/graylog2-web-interface/src/components/lookup-tables/LookupTable.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LookupTable.jsx
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
-import { Link } from 'components/graylog/router';
 
+import { LinkContainer, Link } from 'components/graylog/router';
 import { ButtonToolbar, Row, Col, Button } from 'components/graylog';
 import { Input } from 'components/bootstrap';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/lookup-tables/LookupTable.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LookupTable.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { LinkContainer } from 'components/graylog/router';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 
 import { ButtonToolbar, Row, Col, Button } from 'components/graylog';
 import { Input } from 'components/bootstrap';

--- a/graylog2-web-interface/src/components/lookup-tables/LookupTable.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LookupTable.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import { Link } from 'react-router';
 
 import { ButtonToolbar, Row, Col, Button } from 'components/graylog';

--- a/graylog2-web-interface/src/components/lookup-tables/LookupTablesOverview.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LookupTablesOverview.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import Routes from 'routing/Routes';
 import CombinedProvider from 'injection/CombinedProvider';
 import { Row, Col, Table, Popover, OverlayTrigger, Button } from 'components/graylog';

--- a/graylog2-web-interface/src/components/lookup-tables/LookupTablesOverview.jsx
+++ b/graylog2-web-interface/src/components/lookup-tables/LookupTablesOverview.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import Routes from 'routing/Routes';
 import CombinedProvider from 'injection/CombinedProvider';

--- a/graylog2-web-interface/src/components/navigation/HelpMenu.jsx
+++ b/graylog2-web-interface/src/components/navigation/HelpMenu.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { MenuItem, NavDropdown } from 'components/graylog';
 import { ExternalLink, Icon } from 'components/common';

--- a/graylog2-web-interface/src/components/navigation/HelpMenu.jsx
+++ b/graylog2-web-interface/src/components/navigation/HelpMenu.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { MenuItem, NavDropdown } from 'components/graylog';
 import { ExternalLink, Icon } from 'components/common';
 import DocsHelper from 'util/DocsHelper';

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -3,10 +3,10 @@ import * as React from 'react';
 import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
-import { LinkContainer } from 'components/graylog/router';
 import naturalSort from 'javascript-natural-sort';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
+import { LinkContainer } from 'components/graylog/router';
 import { appPrefixed } from 'util/URLUtils';
 import { IfPermitted } from 'components/common';
 import { isPermitted } from 'util/PermissionsMixin';

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import naturalSort from 'javascript-natural-sort';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 

--- a/graylog2-web-interface/src/components/navigation/NavigationLink.jsx
+++ b/graylog2-web-interface/src/components/navigation/NavigationLink.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { MenuItem, NavItem } from 'components/graylog';
 
 // We render a NavItem if topLevel is set to avoid errors when the NavigationLink is place in the navigation

--- a/graylog2-web-interface/src/components/navigation/NavigationLink.jsx
+++ b/graylog2-web-interface/src/components/navigation/NavigationLink.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { MenuItem, NavItem } from 'components/graylog';
 

--- a/graylog2-web-interface/src/components/navigation/NotificationBadge.jsx
+++ b/graylog2-web-interface/src/components/navigation/NotificationBadge.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import styled from 'styled-components';
 
 import { Badge, Nav } from 'components/graylog';

--- a/graylog2-web-interface/src/components/navigation/NotificationBadge.jsx
+++ b/graylog2-web-interface/src/components/navigation/NotificationBadge.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'components/graylog/router';
 import styled from 'styled-components';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Badge, Nav } from 'components/graylog';
 import CombinedProvider from 'injection/CombinedProvider';
 import connect from 'stores/connect';

--- a/graylog2-web-interface/src/components/navigation/UserMenu.jsx
+++ b/graylog2-web-interface/src/components/navigation/UserMenu.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import StoreProvider from 'injection/StoreProvider';
 import ActionsProvider from 'injection/ActionsProvider';
 import { NavDropdown, MenuItem } from 'components/graylog';

--- a/graylog2-web-interface/src/components/navigation/UserMenu.jsx
+++ b/graylog2-web-interface/src/components/navigation/UserMenu.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import StoreProvider from 'injection/StoreProvider';
 import ActionsProvider from 'injection/ActionsProvider';

--- a/graylog2-web-interface/src/components/nodes/BufferUsage.jsx
+++ b/graylog2-web-interface/src/components/nodes/BufferUsage.jsx
@@ -3,9 +3,9 @@ import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'components/graylog/router';
 import styled from 'styled-components';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Button, ProgressBar } from 'components/graylog';
 import StoreProvider from 'injection/StoreProvider';
 import ActionsProvider from 'injection/ActionsProvider';

--- a/graylog2-web-interface/src/components/nodes/BufferUsage.jsx
+++ b/graylog2-web-interface/src/components/nodes/BufferUsage.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import styled from 'styled-components';
 
 import { Button, ProgressBar } from 'components/graylog';

--- a/graylog2-web-interface/src/components/nodes/JournalDetails.jsx
+++ b/graylog2-web-interface/src/components/nodes/JournalDetails.jsx
@@ -3,7 +3,9 @@ import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
+
 import { Link } from 'components/graylog/router';
+
 import numeral from 'numeral';
 import moment from 'moment';
 import {} from 'moment-duration-format';

--- a/graylog2-web-interface/src/components/nodes/JournalDetails.jsx
+++ b/graylog2-web-interface/src/components/nodes/JournalDetails.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 import numeral from 'numeral';
 import moment from 'moment';
 import {} from 'moment-duration-format';

--- a/graylog2-web-interface/src/components/nodes/NodeMaintenanceDropdown.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodeMaintenanceDropdown.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import URI from 'urijs';
 
 import { ButtonGroup, DropdownButton, MenuItem } from 'components/graylog';

--- a/graylog2-web-interface/src/components/nodes/NodeMaintenanceDropdown.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodeMaintenanceDropdown.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 import URI from 'urijs';
 
+import { LinkContainer } from 'components/graylog/router';
 import { ButtonGroup, DropdownButton, MenuItem } from 'components/graylog';
 import { ExternalLink, IfPermitted } from 'components/common';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/nodes/NodeOverview.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodeOverview.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { Row, Col, Button } from 'components/graylog';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/nodes/NodeOverview.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodeOverview.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Row, Col, Button } from 'components/graylog';
 import Routes from 'routing/Routes';
 

--- a/graylog2-web-interface/src/components/nodes/NodesActions.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodesActions.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 import URI from 'urijs';
 
+import { LinkContainer } from 'components/graylog/router';
 import { DropdownButton, DropdownSubmenu, MenuItem, Button } from 'components/graylog';
 import { ExternalLinkButton, IfPermitted } from 'components/common';
 import StoreProvider from 'injection/StoreProvider';

--- a/graylog2-web-interface/src/components/nodes/NodesActions.jsx
+++ b/graylog2-web-interface/src/components/nodes/NodesActions.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import URI from 'urijs';
 
 import { DropdownButton, DropdownSubmenu, MenuItem, Button } from 'components/graylog';

--- a/graylog2-web-interface/src/components/pipelines/PipelineConnectionsForm.jsx
+++ b/graylog2-web-interface/src/components/pipelines/PipelineConnectionsForm.jsx
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import { Link } from 'components/graylog/router';
 import naturalSort from 'javascript-natural-sort';
 
+import { Link } from 'components/graylog/router';
 import { ControlLabel, FormGroup, HelpBlock, Button } from 'components/graylog';
 import { SelectableList } from 'components/common';
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';

--- a/graylog2-web-interface/src/components/pipelines/PipelineConnectionsForm.jsx
+++ b/graylog2-web-interface/src/components/pipelines/PipelineConnectionsForm.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 import naturalSort from 'javascript-natural-sort';
 
 import { ControlLabel, FormGroup, HelpBlock, Button } from 'components/graylog';

--- a/graylog2-web-interface/src/components/pipelines/ProcessingTimelineComponent.jsx
+++ b/graylog2-web-interface/src/components/pipelines/ProcessingTimelineComponent.jsx
@@ -4,7 +4,7 @@ import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import styled, { css } from 'styled-components';
 import { LinkContainer } from 'components/graylog/router';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 import naturalSort from 'javascript-natural-sort';
 
 import { Alert, Button } from 'components/graylog';

--- a/graylog2-web-interface/src/components/pipelines/ProcessingTimelineComponent.jsx
+++ b/graylog2-web-interface/src/components/pipelines/ProcessingTimelineComponent.jsx
@@ -3,10 +3,9 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import styled, { css } from 'styled-components';
-import { LinkContainer } from 'components/graylog/router';
-import { Link } from 'components/graylog/router';
 import naturalSort from 'javascript-natural-sort';
 
+import { LinkContainer, Link } from 'components/graylog/router';
 import { Alert, Button } from 'components/graylog';
 import { DataTable, Spinner } from 'components/common';
 import { MetricContainer, CounterRate } from 'components/metrics';

--- a/graylog2-web-interface/src/components/pipelines/ProcessingTimelineComponent.jsx
+++ b/graylog2-web-interface/src/components/pipelines/ProcessingTimelineComponent.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 import styled, { css } from 'styled-components';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import { Link } from 'react-router';
 import naturalSort from 'javascript-natural-sort';
 

--- a/graylog2-web-interface/src/components/pipelines/Stage.jsx
+++ b/graylog2-web-interface/src/components/pipelines/Stage.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { Link } from 'components/graylog/router';
 
+import { Link } from 'components/graylog/router';
 import { Col, Button } from 'components/graylog';
 import { DataTable, EntityListItem, Spinner, Icon } from 'components/common';
 import { MetricContainer, CounterRate } from 'components/metrics';

--- a/graylog2-web-interface/src/components/pipelines/Stage.jsx
+++ b/graylog2-web-interface/src/components/pipelines/Stage.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 
 import { Col, Button } from 'components/graylog';
 import { DataTable, EntityListItem, Spinner, Icon } from 'components/common';

--- a/graylog2-web-interface/src/components/pipelines/StageForm.jsx
+++ b/graylog2-web-interface/src/components/pipelines/StageForm.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 import { cloneDeep } from 'lodash';
 
 import { Button, FormGroup, ControlLabel } from 'components/graylog';

--- a/graylog2-web-interface/src/components/pipelines/StageForm.jsx
+++ b/graylog2-web-interface/src/components/pipelines/StageForm.jsx
@@ -2,9 +2,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { Link } from 'components/graylog/router';
 import { cloneDeep } from 'lodash';
 
+import { Link } from 'components/graylog/router';
 import { Button, FormGroup, ControlLabel } from 'components/graylog';
 import { SelectableList } from 'components/common';
 import { BootstrapModalForm, Input } from 'components/bootstrap';

--- a/graylog2-web-interface/src/components/rules/PipelinesUsingRule.jsx
+++ b/graylog2-web-interface/src/components/rules/PipelinesUsingRule.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 
 import Routes from 'routing/Routes';
 import { PipelineRulesContext } from 'components/rules/RuleContext';

--- a/graylog2-web-interface/src/components/rules/PipelinesUsingRule.jsx
+++ b/graylog2-web-interface/src/components/rules/PipelinesUsingRule.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'components/graylog/router';
 
+import { Link } from 'components/graylog/router';
 import Routes from 'routing/Routes';
 import { PipelineRulesContext } from 'components/rules/RuleContext';
 import { Input } from 'components/bootstrap';

--- a/graylog2-web-interface/src/components/rules/Rule.jsx
+++ b/graylog2-web-interface/src/components/rules/Rule.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { Row, Col, Button } from 'components/graylog';
 import { PageHeader } from 'components/common';

--- a/graylog2-web-interface/src/components/rules/Rule.jsx
+++ b/graylog2-web-interface/src/components/rules/Rule.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Row, Col, Button } from 'components/graylog';
 import { PageHeader } from 'components/common';
 import DocumentationLink from 'components/support/DocumentationLink';

--- a/graylog2-web-interface/src/components/rules/RuleList.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleList.jsx
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
-import { Link } from 'components/graylog/router';
 
+import { LinkContainer, Link } from 'components/graylog/router';
 import connect from 'stores/connect';
 import { Button, ButtonToolbar } from 'components/graylog';
 import { DataTable, Timestamp } from 'components/common';

--- a/graylog2-web-interface/src/components/rules/RuleList.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleList.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { LinkContainer } from 'components/graylog/router';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 
 import connect from 'stores/connect';
 import { Button, ButtonToolbar } from 'components/graylog';

--- a/graylog2-web-interface/src/components/rules/RuleList.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleList.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import { Link } from 'react-router';
 
 import connect from 'stores/connect';

--- a/graylog2-web-interface/src/components/search/MessageDetail.jsx
+++ b/graylog2-web-interface/src/components/search/MessageDetail.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Immutable from 'immutable';
-import { Link } from 'components/graylog/router';
 
+import { Link } from 'components/graylog/router';
 import { Button, ButtonGroup, Col, Label, MessageDetailsDefinitionList, Row } from 'components/graylog';
 import { ClipboardButton, Icon, Timestamp } from 'components/common';
 import StreamLink from 'components/streams/StreamLink';

--- a/graylog2-web-interface/src/components/search/MessageDetail.jsx
+++ b/graylog2-web-interface/src/components/search/MessageDetail.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Immutable from 'immutable';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 
 import { Button, ButtonGroup, Col, Label, MessageDetailsDefinitionList, Row } from 'components/graylog';
 import { ClipboardButton, Icon, Timestamp } from 'components/common';

--- a/graylog2-web-interface/src/components/search/MessageFieldExtractorActions.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFieldExtractorActions.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { DropdownButton, MenuItem } from 'components/graylog';
 import ExtractorUtils from 'util/ExtractorUtils';
 

--- a/graylog2-web-interface/src/components/search/MessageFieldExtractorActions.jsx
+++ b/graylog2-web-interface/src/components/search/MessageFieldExtractorActions.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { DropdownButton, MenuItem } from 'components/graylog';
 import ExtractorUtils from 'util/ExtractorUtils';

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.jsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 import styled, { css } from 'styled-components';
 
 import { Col, Row } from 'components/graylog';

--- a/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.jsx
+++ b/graylog2-web-interface/src/components/sidecars/administration/CollectorsAdministration.jsx
@@ -3,9 +3,9 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
-import { Link } from 'components/graylog/router';
 import styled, { css } from 'styled-components';
 
+import { Link } from 'components/graylog/router';
 import { Col, Row } from 'components/graylog';
 import Routes from 'routing/Routes';
 import { ControlledTableList, PaginatedList } from 'components/common';

--- a/graylog2-web-interface/src/components/sidecars/configurations/CollectorList.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CollectorList.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { Col, Row, Button } from 'components/graylog';
 import { DataTable, PaginatedList, SearchForm } from 'components/common';

--- a/graylog2-web-interface/src/components/sidecars/configurations/CollectorList.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CollectorList.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Col, Row, Button } from 'components/graylog';
 import { DataTable, PaginatedList, SearchForm } from 'components/common';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/sidecars/configurations/CollectorRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CollectorRow.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { ButtonToolbar, DropdownButton, MenuItem, Button } from 'components/graylog';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/sidecars/configurations/CollectorRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/CollectorRow.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { ButtonToolbar, DropdownButton, MenuItem, Button } from 'components/graylog';
 import Routes from 'routing/Routes';
 import OperatingSystemIcon from 'components/sidecars/common/OperatingSystemIcon';

--- a/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationList.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationList.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { Col, Row, Button } from 'components/graylog';
 import { DataTable, PaginatedList, SearchForm } from 'components/common';

--- a/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationList.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationList.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Col, Row, Button } from 'components/graylog';
 import { DataTable, PaginatedList, SearchForm } from 'components/common';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationRow.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { Button, ButtonToolbar, DropdownButton, MenuItem } from 'components/graylog';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/configurations/ConfigurationRow.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Button, ButtonToolbar, DropdownButton, MenuItem } from 'components/graylog';
 import Routes from 'routing/Routes';
 import CollectorIndicator from 'components/sidecars/common/CollectorIndicator';

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 import { LinkContainer } from 'components/graylog/router';
 import styled, { css } from 'styled-components';
 

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
@@ -1,9 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from 'components/graylog/router';
-import { LinkContainer } from 'components/graylog/router';
 import styled, { css } from 'styled-components';
 
+import { Link, LinkContainer } from 'components/graylog/router';
 import { Button, ButtonToolbar } from 'components/graylog';
 import Routes from 'routing/Routes';
 import { Timestamp } from 'components/common';

--- a/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
+++ b/graylog2-web-interface/src/components/sidecars/sidecars/SidecarRow.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import styled, { css } from 'styled-components';
 
 import { Button, ButtonToolbar } from 'components/graylog';

--- a/graylog2-web-interface/src/components/simulator/ProcessorSimulator.jsx
+++ b/graylog2-web-interface/src/components/simulator/ProcessorSimulator.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import naturalSort from 'javascript-natural-sort';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 
 import { Col, ControlLabel, FormGroup, HelpBlock, Panel, Row } from 'components/graylog';
 import { Select } from 'components/common';

--- a/graylog2-web-interface/src/components/simulator/ProcessorSimulator.jsx
+++ b/graylog2-web-interface/src/components/simulator/ProcessorSimulator.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import naturalSort from 'javascript-natural-sort';
-import { Link } from 'components/graylog/router';
 
+import { Link } from 'components/graylog/router';
 import { Col, ControlLabel, FormGroup, HelpBlock, Panel, Row } from 'components/graylog';
 import { Select } from 'components/common';
 import RawMessageLoader from 'components/messageloaders/RawMessageLoader';

--- a/graylog2-web-interface/src/components/streamrules/StreamRulesEditor.jsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRulesEditor.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 import styled, { css } from 'styled-components';
 
+import { LinkContainer } from 'components/graylog/router';
 import Routes from 'routing/Routes';
 import { Button, Col, Panel, Row } from 'components/graylog';
 import { Icon } from 'components/common';

--- a/graylog2-web-interface/src/components/streamrules/StreamRulesEditor.jsx
+++ b/graylog2-web-interface/src/components/streamrules/StreamRulesEditor.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import styled, { css } from 'styled-components';
 
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/components/streams/Stream.jsx
+++ b/graylog2-web-interface/src/components/streams/Stream.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 import { LinkContainer } from 'components/graylog/router';
 import styled, { css } from 'styled-components';
 

--- a/graylog2-web-interface/src/components/streams/Stream.jsx
+++ b/graylog2-web-interface/src/components/streams/Stream.jsx
@@ -1,9 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from 'components/graylog/router';
-import { LinkContainer } from 'components/graylog/router';
 import styled, { css } from 'styled-components';
 
+import { Link, LinkContainer } from 'components/graylog/router';
 import { Button, Tooltip } from 'components/graylog';
 import { OverlayElement, Icon } from 'components/common';
 import StreamRuleForm from 'components/streamrules/StreamRuleForm';

--- a/graylog2-web-interface/src/components/streams/Stream.jsx
+++ b/graylog2-web-interface/src/components/streams/Stream.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import styled, { css } from 'styled-components';
 
 import { Button, Tooltip } from 'components/graylog';

--- a/graylog2-web-interface/src/components/streams/StreamLink.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamLink.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 
 import Routes from 'routing/Routes';
 

--- a/graylog2-web-interface/src/components/streams/StreamLink.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamLink.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Link } from 'components/graylog/router';
 
+import { Link } from 'components/graylog/router';
 import Routes from 'routing/Routes';
 
 class StreamLink extends React.Component {

--- a/graylog2-web-interface/src/components/users/UserList.jsx
+++ b/graylog2-web-interface/src/components/users/UserList.jsx
@@ -2,9 +2,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import createReactClass from 'create-react-class';
-import { LinkContainer } from 'components/graylog/router';
 import styled, { css } from 'styled-components';
 
+import { LinkContainer } from 'components/graylog/router';
 import PermissionsMixin from 'util/PermissionsMixin';
 import Routes from 'routing/Routes';
 import StoreProvider from 'injection/StoreProvider';

--- a/graylog2-web-interface/src/components/users/UserList.jsx
+++ b/graylog2-web-interface/src/components/users/UserList.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import createReactClass from 'create-react-class';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import styled, { css } from 'styled-components';
 
 import PermissionsMixin from 'util/PermissionsMixin';

--- a/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
+++ b/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 
 import Routes from 'routing/Routes';
 import DocsHelper from 'util/DocsHelper';

--- a/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
+++ b/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Link } from 'components/graylog/router';
 
+import { Link } from 'components/graylog/router';
 import Routes from 'routing/Routes';
 import DocsHelper from 'util/DocsHelper';
 import DocumentationLink from 'components/support/DocumentationLink';
@@ -216,8 +216,8 @@ class NotificationsFactory {
               The output "{notification.details.outputTitle}" (id: {notification.details.outputId})
               in stream "{notification.details.streamTitle}" (id: {notification.details.streamId})
               is unable to send messages to the configured destination.
-              <br/>
-                The error message from the output is: <em>{notification.details.errorMessage}</em>
+              <br />
+              The error message from the output is: <em>{notification.details.errorMessage}</em>
             </span>
           ),
         };

--- a/graylog2-web-interface/src/pages/ContentPacksPage.jsx
+++ b/graylog2-web-interface/src/pages/ContentPacksPage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Reflux from 'reflux';
 // eslint-disable-next-line no-restricted-imports
 import createReactClass from 'create-react-class';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import styled, { css } from 'styled-components';
 
 import { Row, Col, ButtonToolbar, Button } from 'components/graylog';

--- a/graylog2-web-interface/src/pages/ContentPacksPage.jsx
+++ b/graylog2-web-interface/src/pages/ContentPacksPage.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import Reflux from 'reflux';
 // eslint-disable-next-line no-restricted-imports
 import createReactClass from 'create-react-class';
-import { LinkContainer } from 'components/graylog/router';
 import styled, { css } from 'styled-components';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Row, Col, ButtonToolbar, Button } from 'components/graylog';
 import Routes from 'routing/Routes';
 import Spinner from 'components/common/Spinner';

--- a/graylog2-web-interface/src/pages/CreateContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateContentPackPage.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import Routes from 'routing/Routes';
 import { Button } from 'components/graylog';
 import history from 'util/History';

--- a/graylog2-web-interface/src/pages/CreateContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateContentPackPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import Routes from 'routing/Routes';
 import { Button } from 'components/graylog';

--- a/graylog2-web-interface/src/pages/CreateEventDefinitionPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateEventDefinitionPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import { DocumentTitle, IfPermitted, PageHeader } from 'components/common';
 import EventDefinitionFormContainer

--- a/graylog2-web-interface/src/pages/CreateEventDefinitionPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateEventDefinitionPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import { DocumentTitle, IfPermitted, PageHeader } from 'components/common';

--- a/graylog2-web-interface/src/pages/CreateEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateEventNotificationPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import { DocumentTitle, IfPermitted, PageHeader } from 'components/common';
 import DocumentationLink from 'components/support/DocumentationLink';

--- a/graylog2-web-interface/src/pages/CreateEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/CreateEventNotificationPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import { DocumentTitle, IfPermitted, PageHeader } from 'components/common';

--- a/graylog2-web-interface/src/pages/EditContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/EditContentPackPage.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 import { cloneDeep, groupBy } from 'lodash';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import Routes from 'routing/Routes';
 import { Button } from 'components/graylog';
 import history from 'util/History';

--- a/graylog2-web-interface/src/pages/EditContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/EditContentPackPage.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 import { cloneDeep, groupBy } from 'lodash';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import Routes from 'routing/Routes';
 import { Button } from 'components/graylog';

--- a/graylog2-web-interface/src/pages/EditEventDefinitionPage.jsx
+++ b/graylog2-web-interface/src/pages/EditEventDefinitionPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import { DocumentTitle, IfPermitted, PageHeader, Spinner } from 'components/common';
 import EventDefinitionFormContainer

--- a/graylog2-web-interface/src/pages/EditEventDefinitionPage.jsx
+++ b/graylog2-web-interface/src/pages/EditEventDefinitionPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import { DocumentTitle, IfPermitted, PageHeader, Spinner } from 'components/common';

--- a/graylog2-web-interface/src/pages/EditEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/EditEventNotificationPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import { DocumentTitle, IfPermitted, PageHeader, Spinner } from 'components/common';

--- a/graylog2-web-interface/src/pages/EditEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/EditEventNotificationPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import { DocumentTitle, IfPermitted, PageHeader, Spinner } from 'components/common';
 import DocumentationLink from 'components/support/DocumentationLink';

--- a/graylog2-web-interface/src/pages/EventDefinitionsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventDefinitionsPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Button, ButtonToolbar, Col, Row } from 'components/graylog';
 import { DocumentTitle, IfPermitted, PageHeader } from 'components/common';
 import DocumentationLink from 'components/support/DocumentationLink';

--- a/graylog2-web-interface/src/pages/EventDefinitionsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventDefinitionsPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { Button, ButtonToolbar, Col, Row } from 'components/graylog';
 import { DocumentTitle, IfPermitted, PageHeader } from 'components/common';

--- a/graylog2-web-interface/src/pages/EventNotificationsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventNotificationsPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Button, ButtonToolbar, Col, Row } from 'components/graylog';
 import { DocumentTitle, IfPermitted, PageHeader } from 'components/common';
 import EventNotificationsContainer from 'components/event-notifications/event-notifications/EventNotificationsContainer';

--- a/graylog2-web-interface/src/pages/EventNotificationsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventNotificationsPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { Button, ButtonToolbar, Col, Row } from 'components/graylog';
 import { DocumentTitle, IfPermitted, PageHeader } from 'components/common';

--- a/graylog2-web-interface/src/pages/EventsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventsPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import { DocumentTitle, IfPermitted, PageHeader } from 'components/common';
 import DocumentationLink from 'components/support/DocumentationLink';

--- a/graylog2-web-interface/src/pages/EventsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventsPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import { DocumentTitle, IfPermitted, PageHeader } from 'components/common';

--- a/graylog2-web-interface/src/pages/ExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/ExtractorsPage.jsx
@@ -1,9 +1,9 @@
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 import Reflux from 'reflux';
 
+import { LinkContainer } from 'components/graylog/router';
 import { DocumentTitle, Spinner } from 'components/common';
 import PageHeader from 'components/common/PageHeader';
 import ExtractorsList from 'components/extractors/ExtractorsList';

--- a/graylog2-web-interface/src/pages/ExtractorsPage.jsx
+++ b/graylog2-web-interface/src/pages/ExtractorsPage.jsx
@@ -1,7 +1,7 @@
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import Reflux from 'reflux';
 
 import { DocumentTitle, Spinner } from 'components/common';

--- a/graylog2-web-interface/src/pages/IndexSetConfigurationPage.jsx
+++ b/graylog2-web-interface/src/pages/IndexSetConfigurationPage.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Row, Col, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import { IndexSetConfigurationForm } from 'components/indices';

--- a/graylog2-web-interface/src/pages/IndexSetConfigurationPage.jsx
+++ b/graylog2-web-interface/src/pages/IndexSetConfigurationPage.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { Row, Col, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';

--- a/graylog2-web-interface/src/pages/IndexSetCreationPage.jsx
+++ b/graylog2-web-interface/src/pages/IndexSetCreationPage.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Row, Col, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import { IndexSetConfigurationForm } from 'components/indices';

--- a/graylog2-web-interface/src/pages/IndexSetCreationPage.jsx
+++ b/graylog2-web-interface/src/pages/IndexSetCreationPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { Row, Col, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';

--- a/graylog2-web-interface/src/pages/IndexSetPage.jsx
+++ b/graylog2-web-interface/src/pages/IndexSetPage.jsx
@@ -2,9 +2,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'components/graylog/router';
 import numeral from 'numeral';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Alert, Row, Col, Panel, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader, Spinner, Icon } from 'components/common';
 import { IndicesMaintenanceDropdown, IndicesOverview, IndexSetDetails } from 'components/indices';

--- a/graylog2-web-interface/src/pages/IndexSetPage.jsx
+++ b/graylog2-web-interface/src/pages/IndexSetPage.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import numeral from 'numeral';
 
 import { Alert, Row, Col, Panel, Button } from 'components/graylog';

--- a/graylog2-web-interface/src/pages/IndicesPage.jsx
+++ b/graylog2-web-interface/src/pages/IndicesPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import Routes from 'routing/Routes';
 import { Col, Row, Button } from 'components/graylog';
 import DocsHelper from 'util/DocsHelper';

--- a/graylog2-web-interface/src/pages/IndicesPage.jsx
+++ b/graylog2-web-interface/src/pages/IndicesPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import Routes from 'routing/Routes';
 import { Col, Row, Button } from 'components/graylog';

--- a/graylog2-web-interface/src/pages/LUTCachesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTCachesPage.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import connect from 'stores/connect';
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/pages/LUTCachesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTCachesPage.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import connect from 'stores/connect';
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';

--- a/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import connect from 'stores/connect';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import connect from 'stores/connect';
 import Routes from 'routing/Routes';
 import history from 'util/History';

--- a/graylog2-web-interface/src/pages/LUTTablesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTTablesPage.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import connect from 'stores/connect';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/pages/LUTTablesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTTablesPage.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import connect from 'stores/connect';
 import Routes from 'routing/Routes';
 import history from 'util/History';

--- a/graylog2-web-interface/src/pages/NodeInputsPage.jsx
+++ b/graylog2-web-interface/src/pages/NodeInputsPage.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { Link } from 'components/graylog/router';
 
+import { Link } from 'components/graylog/router';
 import StoreProvider from 'injection/StoreProvider';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import { InputsList } from 'components/inputs';

--- a/graylog2-web-interface/src/pages/NodeInputsPage.jsx
+++ b/graylog2-web-interface/src/pages/NodeInputsPage.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 
 import StoreProvider from 'injection/StoreProvider';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';

--- a/graylog2-web-interface/src/pages/PipelineDetailsPage.jsx
+++ b/graylog2-web-interface/src/pages/PipelineDetailsPage.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { Button, Col, Row } from 'components/graylog';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';

--- a/graylog2-web-interface/src/pages/PipelineDetailsPage.jsx
+++ b/graylog2-web-interface/src/pages/PipelineDetailsPage.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Button, Col, Row } from 'components/graylog';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import Pipeline from 'components/pipelines/Pipeline';

--- a/graylog2-web-interface/src/pages/PipelinesOverviewPage.jsx
+++ b/graylog2-web-interface/src/pages/PipelinesOverviewPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Row, Col, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader } from 'components/common';
 import DocumentationLink from 'components/support/DocumentationLink';

--- a/graylog2-web-interface/src/pages/PipelinesOverviewPage.jsx
+++ b/graylog2-web-interface/src/pages/PipelinesOverviewPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { Row, Col, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader } from 'components/common';

--- a/graylog2-web-interface/src/pages/RulesPage.jsx
+++ b/graylog2-web-interface/src/pages/RulesPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import Reflux from 'reflux';
 
 import { Row, Col, Button } from 'components/graylog';

--- a/graylog2-web-interface/src/pages/RulesPage.jsx
+++ b/graylog2-web-interface/src/pages/RulesPage.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
-import { LinkContainer } from 'components/graylog/router';
 import Reflux from 'reflux';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Row, Col, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader } from 'components/common';
 import DocumentationLink from 'components/support/DocumentationLink';

--- a/graylog2-web-interface/src/pages/ShowAlertPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowAlertPage.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { ButtonToolbar, Label, Tooltip, Button } from 'components/graylog';
 import { DocumentTitle, OverlayElement, PageHeader, Spinner, Timestamp } from 'components/common';

--- a/graylog2-web-interface/src/pages/ShowAlertPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowAlertPage.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { ButtonToolbar, Label, Tooltip, Button } from 'components/graylog';
 import { DocumentTitle, OverlayElement, PageHeader, Spinner, Timestamp } from 'components/common';
 import { AlertDetails } from 'components/alerts';

--- a/graylog2-web-interface/src/pages/ShowContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowContentPackPage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { Row, Col, Button, ButtonToolbar } from 'components/graylog';
 import Spinner from 'components/common/Spinner';

--- a/graylog2-web-interface/src/pages/ShowContentPackPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowContentPackPage.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Row, Col, Button, ButtonToolbar } from 'components/graylog';
 import Spinner from 'components/common/Spinner';
 import { BootstrapModalConfirm } from 'components/bootstrap';

--- a/graylog2-web-interface/src/pages/SidecarAdministrationPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarAdministrationPage.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import DocsHelper from 'util/DocsHelper';
 import { DocumentTitle, PageHeader } from 'components/common';

--- a/graylog2-web-interface/src/pages/SidecarAdministrationPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarAdministrationPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import DocsHelper from 'util/DocsHelper';

--- a/graylog2-web-interface/src/pages/SidecarConfigurationPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarConfigurationPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import DocsHelper from 'util/DocsHelper';
 import DocumentationLink from 'components/support/DocumentationLink';

--- a/graylog2-web-interface/src/pages/SidecarConfigurationPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarConfigurationPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import DocsHelper from 'util/DocsHelper';

--- a/graylog2-web-interface/src/pages/SidecarEditCollectorPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarEditCollectorPage.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/pages/SidecarEditCollectorPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarEditCollectorPage.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';

--- a/graylog2-web-interface/src/pages/SidecarEditConfigurationPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarEditConfigurationPage.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/pages/SidecarEditConfigurationPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarEditConfigurationPage.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';

--- a/graylog2-web-interface/src/pages/SidecarNewCollectorPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarNewCollectorPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader } from 'components/common';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/pages/SidecarNewCollectorPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarNewCollectorPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader } from 'components/common';

--- a/graylog2-web-interface/src/pages/SidecarNewConfigurationPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarNewConfigurationPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader } from 'components/common';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/pages/SidecarNewConfigurationPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarNewConfigurationPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader } from 'components/common';

--- a/graylog2-web-interface/src/pages/SidecarStatusPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarStatusPage.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { ButtonToolbar, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';

--- a/graylog2-web-interface/src/pages/SidecarStatusPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarStatusPage.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { ButtonToolbar, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import DocsHelper from 'util/DocsHelper';

--- a/graylog2-web-interface/src/pages/SidecarsPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarsPage.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
-import { Link } from 'components/graylog/router';
 
+import { LinkContainer, Link } from 'components/graylog/router';
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader } from 'components/common';
 import SidecarListContainer from 'components/sidecars/sidecars/SidecarListContainer';

--- a/graylog2-web-interface/src/pages/SidecarsPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarsPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 import { Link } from 'react-router';
 
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';

--- a/graylog2-web-interface/src/pages/SidecarsPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarsPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { LinkContainer } from 'components/graylog/router';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader } from 'components/common';

--- a/graylog2-web-interface/src/pages/SimulatorPage.jsx
+++ b/graylog2-web-interface/src/pages/SimulatorPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { Button, Col, Row } from 'components/graylog';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';

--- a/graylog2-web-interface/src/pages/SimulatorPage.jsx
+++ b/graylog2-web-interface/src/pages/SimulatorPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Button, Col, Row } from 'components/graylog';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import DocumentationLink from 'components/support/DocumentationLink';

--- a/graylog2-web-interface/src/pages/StreamAlertsOverviewPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamAlertsOverviewPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { ButtonToolbar, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';

--- a/graylog2-web-interface/src/pages/StreamAlertsOverviewPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamAlertsOverviewPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { ButtonToolbar, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/pages/StreamOutputsPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamOutputsPage.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'components/graylog/router';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 
+import { Link } from 'components/graylog/router';
 import { Col, Row } from 'components/graylog';
 import { ContentHeadRow, DocumentTitle, Spinner } from 'components/common';
 import OutputsComponent from 'components/outputs/OutputsComponent';

--- a/graylog2-web-interface/src/pages/StreamOutputsPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamOutputsPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 import Reflux from 'reflux';
 import createReactClass from 'create-react-class';
 

--- a/graylog2-web-interface/src/pages/UsersPage.jsx
+++ b/graylog2-web-interface/src/pages/UsersPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { Row, Col, Button } from 'components/graylog';
 import PermissionsMixin from 'util/PermissionsMixin';

--- a/graylog2-web-interface/src/pages/UsersPage.jsx
+++ b/graylog2-web-interface/src/pages/UsersPage.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import { Row, Col, Button } from 'components/graylog';
 import PermissionsMixin from 'util/PermissionsMixin';
 import Routes from 'routing/Routes';

--- a/graylog2-web-interface/src/views/components/messagelist/MessageActions.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageActions.jsx
@@ -1,7 +1,7 @@
 // @flow strict
 import * as React from 'react';
 import * as Immutable from 'immutable';
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import Routes from 'routing/Routes';
 import { ClipboardButton } from 'components/common';

--- a/graylog2-web-interface/src/views/components/messagelist/MessageActions.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageActions.jsx
@@ -1,8 +1,8 @@
 // @flow strict
 import * as React from 'react';
 import * as Immutable from 'immutable';
-import { LinkContainer } from 'components/graylog/router';
 
+import { LinkContainer } from 'components/graylog/router';
 import Routes from 'routing/Routes';
 import { ClipboardButton } from 'components/common';
 import { Button, ButtonGroup, DropdownButton, MenuItem } from 'components/graylog';

--- a/graylog2-web-interface/src/views/components/messagelist/MessageDetail.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageDetail.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Immutable from 'immutable';
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 
 import { Col, Label, Row } from 'components/graylog';
 import StreamLink from 'components/streams/StreamLink';

--- a/graylog2-web-interface/src/views/components/messagelist/MessageDetail.jsx
+++ b/graylog2-web-interface/src/views/components/messagelist/MessageDetail.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Immutable from 'immutable';
-import { Link } from 'components/graylog/router';
 
+import { Link } from 'components/graylog/router';
 import { Col, Label, Row } from 'components/graylog';
 import StreamLink from 'components/streams/StreamLink';
 import { MessageFields } from 'views/components/messagelist';

--- a/graylog2-web-interface/src/views/components/views/MissingRequirements.jsx
+++ b/graylog2-web-interface/src/views/components/views/MissingRequirements.jsx
@@ -1,9 +1,9 @@
 // @flow strict
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
+
 // $FlowFixMe: imports from core need to be fixed in flow
 import { LinkContainer } from 'components/graylog/router';
-
 import type { PluginMetadata, Requirements } from 'views/logic/views/View';
 import { Col, Row, Button } from 'components/graylog';
 import URLUtils from 'util/URLUtils';

--- a/graylog2-web-interface/src/views/components/views/MissingRequirements.jsx
+++ b/graylog2-web-interface/src/views/components/views/MissingRequirements.jsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 // $FlowFixMe: imports from core need to be fixed in flow
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import type { PluginMetadata, Requirements } from 'views/logic/views/View';
 import { Col, Row, Button } from 'components/graylog';

--- a/graylog2-web-interface/src/views/components/views/View.jsx
+++ b/graylog2-web-interface/src/views/components/views/View.jsx
@@ -1,9 +1,9 @@
 // @flow strict
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
+
 // $FlowFixMe: imports from core need to be fixed in flow
 import { Link } from 'components/graylog/router';
-
 import Routes from 'routing/Routes';
 import { EntityListItem } from 'components/common';
 import CurrentUserContext from 'contexts/CurrentUserContext';

--- a/graylog2-web-interface/src/views/components/views/View.jsx
+++ b/graylog2-web-interface/src/views/components/views/View.jsx
@@ -2,7 +2,7 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 // $FlowFixMe: imports from core need to be fixed in flow
-import { Link } from 'react-router';
+import { Link } from 'components/graylog/router';
 
 import Routes from 'routing/Routes';
 import { EntityListItem } from 'components/common';

--- a/graylog2-web-interface/src/views/pages/DashboardsPage.jsx
+++ b/graylog2-web-interface/src/views/pages/DashboardsPage.jsx
@@ -1,7 +1,7 @@
 // @flow strict
 import React, { useEffect } from 'react';
 // $FlowFixMe: imports from core need to be fixed in flow
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import { Col, Row, Button } from 'components/graylog';
 import connect from 'stores/connect';

--- a/graylog2-web-interface/src/views/pages/DashboardsPage.jsx
+++ b/graylog2-web-interface/src/views/pages/DashboardsPage.jsx
@@ -1,8 +1,8 @@
 // @flow strict
 import React, { useEffect } from 'react';
+
 // $FlowFixMe: imports from core need to be fixed in flow
 import { LinkContainer } from 'components/graylog/router';
-
 import { Col, Row, Button } from 'components/graylog';
 import connect from 'stores/connect';
 import { DocumentTitle, PageHeader, IfPermitted } from 'components/common/index';

--- a/graylog2-web-interface/src/views/pages/ViewManagementPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ViewManagementPage.jsx
@@ -2,9 +2,9 @@
 import * as React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
+
 // $FlowFixMe: imports from core need to be fixed in flow
 import { LinkContainer } from 'components/graylog/router';
-
 import Routes from 'routing/Routes';
 import { Col, Row, Button } from 'components/graylog';
 import { DocumentTitle, PageHeader } from 'components/common';

--- a/graylog2-web-interface/src/views/pages/ViewManagementPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ViewManagementPage.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 // $FlowFixMe: imports from core need to be fixed in flow
-import { LinkContainer } from 'react-router-bootstrap';
+import { LinkContainer } from 'components/graylog/router';
 
 import Routes from 'routing/Routes';
 import { Col, Row, Button } from 'components/graylog';


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR is creating an abstraction around our `react-router`-specific
link components (`Link` & `LinkContainer`) by reexporting them from an
own module. This allows us to replace them easily across core & plugins
when we are replacing `react-router` or `react-router-bootstrap` in a
future step.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.