### PR TITLE
Add PATCH HTTP verb support to our API documentation generator

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/rest/documentation/generator/Generator.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/rest/documentation/generator/Generator.java
@@ -48,6 +48,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.HEAD;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.OPTIONS;
+import javax.ws.rs.PATCH;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -390,6 +391,10 @@ public class Generator {
 
         if (m.isAnnotationPresent(PUT.class)) {
             return "PUT";
+        }
+
+        if (m.isAnnotationPresent(PATCH.class)) {
+            return "PATCH";
         }
 
         if (m.isAnnotationPresent(DELETE.class)) {


### PR DESCRIPTION
A simple addition to not return `null` for the `PATCH` HTTP verb.