### PR TITLE
Move Teams share url to enterprise

### DIFF
--- a/graylog2-web-interface/src/actions/permissions/EntityShareActions.js
+++ b/graylog2-web-interface/src/actions/permissions/EntityShareActions.js
@@ -16,7 +16,7 @@ type EntitySharesPaginationType = {
   additionalQueries?: AdditionalQueries,
 };
 
-export type PaginatedEnititySharesType = {
+export type PaginatedEntitySharesType = {
   list: SharedEntities,
   pagination: EntitySharesPaginationType,
   context: {
@@ -31,8 +31,7 @@ export type EntitySharePayload = {
 export type ActionsType = {
   prepare: (entityType: string, entityTitle: string, GRN: GRN, payload: ?EntitySharePayload) => Promise<?EntityShareState>,
   update: (entityType: string, entityTitle: string, GRN: GRN, payload: EntitySharePayload) => Promise<?EntityShareState>,
-  loadUserSharesPaginated: (username: string, page: number, perPage: number, query: string, additionalQueries?: AdditionalQueries) => Promise<?PaginatedEnititySharesType>,
-  loadTeamSharesPaginated: (teamId: string, page: number, perPage: number, query: string, additionalQueries?: AdditionalQueries) => Promise<?PaginatedEnititySharesType>,
+  loadUserSharesPaginated: (username: string, page: number, perPage: number, query: string, additionalQueries?: AdditionalQueries) => Promise<?PaginatedEntitySharesType>,
 };
 
 type EntityShareActionsType = RefluxActions<ActionsType>;
@@ -43,7 +42,6 @@ const EntityShareActions: EntityShareActionsType = singletonActions(
     prepare: { asyncResult: true },
     update: { asyncResult: true },
     loadUserSharesPaginated: { asyncResult: true },
-    loadTeamSharesPaginated: { asyncResult: true },
   }),
 );
 

--- a/graylog2-web-interface/src/components/permissions/SharedEntitiesOverview/SharedEntitiesFilter.jsx
+++ b/graylog2-web-interface/src/components/permissions/SharedEntitiesOverview/SharedEntitiesFilter.jsx
@@ -2,16 +2,16 @@
 import * as React from 'react';
 import styled from 'styled-components';
 
-import type { PaginatedEnititySharesType } from 'actions/permissions/EntityShareActions';
+import type { PaginatedEntitySharesType } from 'actions/permissions/EntityShareActions';
 import mockedPermissions from 'logic/permissions/mocked';
 import { SearchForm, Select } from 'components/common';
 
 import SharedEntitiesQueryHelper from './SharedEntitiesQueryHelper';
 
 type Props = {
-  onSearch: (query: string) => Promise<?PaginatedEnititySharesType>,
-  onReset: () => Promise<?PaginatedEnititySharesType>,
-  onFilter: (param: string, value: string) => Promise<?PaginatedEnititySharesType>,
+  onSearch: (query: string) => Promise<?PaginatedEntitySharesType>,
+  onReset: () => Promise<?PaginatedEntitySharesType>,
+  onFilter: (param: string, value: string) => Promise<?PaginatedEntitySharesType>,
 };
 
 const StyledSearchForm = styled(SearchForm)`

--- a/graylog2-web-interface/src/components/permissions/SharedEntitiesOverview/SharedEntitiesOverview.jsx
+++ b/graylog2-web-interface/src/components/permissions/SharedEntitiesOverview/SharedEntitiesOverview.jsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import type { AdditionalQueries } from 'util/PaginationURL';
 import mockedPermissions from 'logic/permissions/mocked';
-import type { PaginatedEnititySharesType } from 'actions/permissions/EntityShareActions';
+import type { PaginatedEntitySharesType } from 'actions/permissions/EntityShareActions';
 import { DataTable, PaginatedList } from 'components/common';
 
 import SharedEntitiesFilter from './SharedEntitiesFilter';
@@ -15,8 +15,8 @@ const TABLE_HEADERS = ['Entiy Name', 'Entity Type', 'Owner', 'Capability'];
 
 type Props = {
   entityType: string,
-  paginatedEntityShares: PaginatedEnititySharesType,
-  searchPaginated: (newPage: number, newPerPage: number, newQuery: string, additonalQueries?: AdditionalQueries) => Promise<?PaginatedEnititySharesType>,
+  paginatedEntityShares: PaginatedEntitySharesType,
+  searchPaginated: (newPage: number, newPerPage: number, newQuery: string, additonalQueries?: AdditionalQueries) => Promise<?PaginatedEntitySharesType>,
   setLoading: (loading: boolean) => void,
 };
 
@@ -40,7 +40,7 @@ const _sharedEntityOverviewItem = (sharedEntity, context) => {
 };
 
 const SharedEntitiesOverview = ({ paginatedEntityShares: initialPaginatedEntityShares, entityType, searchPaginated, setLoading }: Props) => {
-  const [paginatedEntityShares, setPaginatedEntityShares] = useState<PaginatedEnititySharesType>(initialPaginatedEntityShares);
+  const [paginatedEntityShares, setPaginatedEntityShares] = useState<PaginatedEntitySharesType>(initialPaginatedEntityShares);
   const { list, pagination: { page, perPage, total, query, additionalQueries }, context } = paginatedEntityShares;
 
   const _loadSharedEntities = (newPage = page, newPerPage = perPage, newQuery = query, newAdditonalQueries = additionalQueries) => {

--- a/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/SharedEntitiesSection.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { useState } from 'react';
 
 import SharedEntitiesOverview from 'components/permissions/SharedEntitiesOverview';
-import type { PaginatedEnititySharesType } from 'actions/permissions/EntityShareActions';
+import type { PaginatedEntitySharesType } from 'actions/permissions/EntityShareActions';
 import EntityShareDomain from 'domainActions/permissions/EntityShareDomain';
 import User from 'logic/users/User';
 import { Spinner } from 'components/common';
@@ -11,7 +11,7 @@ import SectionComponent from 'components/common/Section/SectionComponent';
 
 type Props = {
   username: $PropertyType<User, 'username'>,
-  paginatedUserShares: ?PaginatedEnititySharesType,
+  paginatedUserShares: ?PaginatedEntitySharesType,
 };
 
 const SharedEntitiesSection = ({ paginatedUserShares, username }: Props) => {

--- a/graylog2-web-interface/src/components/users/UserDetails/UserDetails.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/UserDetails.jsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { IfPermitted, Spinner } from 'components/common';
 import User from 'logic/users/User';
-import type { PaginatedEnititySharesType } from 'actions/permissions/EntityShareActions';
+import type { PaginatedEntitySharesType } from 'actions/permissions/EntityShareActions';
 import SectionGrid from 'components/common/Section/SectionGrid';
 
 import PreferencesSection from './PreferencesSection';
@@ -14,7 +14,7 @@ import SharedEntitiesSection from './SharedEntitiesSection';
 import TeamsSection from './TeamsSection';
 
 type Props = {
-  paginatedUserShares: ?PaginatedEnititySharesType,
+  paginatedUserShares: ?PaginatedEntitySharesType,
   user: ?User,
 };
 

--- a/graylog2-web-interface/src/domainActions/permissions/EntityShareDomain.js
+++ b/graylog2-web-interface/src/domainActions/permissions/EntityShareDomain.js
@@ -28,16 +28,8 @@ const loadUserSharesPaginated: $PropertyType<ActionsType, 'loadUserSharesPaginat
   }),
 });
 
-const loadTeamSharesPaginated: $PropertyType<ActionsType, 'loadTeamSharesPaginated'> = notifyingAction({
-  action: EntityShareActions.loadTeamSharesPaginated,
-  error: (error, teamId) => ({
-    message: `Loading entities which got shared with team with id "${teamId}" failed with status: ${error}`,
-  }),
-});
-
 export default {
   prepare,
   update,
   loadUserSharesPaginated,
-  loadTeamSharesPaginated,
 };

--- a/graylog2-web-interface/src/routing/ApiRoutes.js
+++ b/graylog2-web-interface/src/routing/ApiRoutes.js
@@ -96,7 +96,6 @@ const ApiRoutes = {
     prepare: (entityGRN) => { return { url: `/shares/entities/${entityGRN}/prepare` }; },
     update: (entityGRN) => { return { url: `/shares/entities/${entityGRN}` }; },
     userSharesPaginated: (username) => { return { url: `/shares/user/${username}` }; },
-    teamSharesPaginated: (teamId) => { return { url: `/teams/shares/${teamId}` }; },
   },
   IndexerClusterApiController: {
     health: () => { return { url: '/system/indexer/cluster/health' }; },

--- a/graylog2-web-interface/src/stores/permissions/EntityShareStore.js
+++ b/graylog2-web-interface/src/stores/permissions/EntityShareStore.js
@@ -6,7 +6,7 @@ import SharedEntity from 'logic/permissions/SharedEntity';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 import EntityShareState, { type EntityShareStateJson } from 'logic/permissions/EntityShareState';
-import EntityShareActions, { type EntitySharePayload, type PaginatedEnititySharesType } from 'actions/permissions/EntityShareActions';
+import EntityShareActions, { type EntitySharePayload, type PaginatedEntitySharesType } from 'actions/permissions/EntityShareActions';
 import { qualifyUrl } from 'util/URLUtils';
 import { singletonStore } from 'views/logic/singleton';
 import type { Store } from 'stores/StoreTypes';
@@ -74,20 +74,11 @@ const EntityShareStore: EntityShareStoreType = singletonStore(
       return promise;
     },
 
-    loadUserSharesPaginated(username: string, page: number, perPage: number, query: string, additionalQueries?: AdditionalQueries): Promise<PaginatedEnititySharesType> {
+    loadUserSharesPaginated(username: string, page: number, perPage: number, query: string, additionalQueries?: AdditionalQueries): Promise<PaginatedEntitySharesType> {
       const url = PaginationURL(ApiRoutes.EntityShareController.userSharesPaginated(username).url, page, perPage, query, additionalQueries);
       const promise = fetch('GET', qualifyUrl(url)).then(formatPaginatedSharesResponse);
 
       EntityShareActions.loadUserSharesPaginated.promise(promise);
-
-      return promise;
-    },
-
-    loadTeamSharesPaginated(teamId: string, page: number, perPage: number, query: string, additionalQueries?: AdditionalQueries): Promise<PaginatedEnititySharesType> {
-      const url = PaginationURL(ApiRoutes.EntityShareController.teamSharesPaginated(teamId).url, page, perPage, query, additionalQueries);
-      const promise = fetch('GET', qualifyUrl(url)).then(formatPaginatedSharesResponse);
-
-      EntityShareActions.loadTeamSharesPaginated.promise(promise);
 
       return promise;
     },


### PR DESCRIPTION
## Motivation
Prior to this change, the teams share url was accessed in the core
but we want to strictly avoid having enterprise code leaked into
core.

## Description
This change implements the teams share url and action in the
TeamsStore/Action/Domain

Also Fix type on type declaration

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1785

