### PR TITLE
Remove `add-module-exports` babel plugin.

### DIFF
--- a/graylog2-web-interface/babel.config.js
+++ b/graylog2-web-interface/babel.config.js
@@ -3,13 +3,16 @@ module.exports = {
   plugins: [
     '@babel/plugin-syntax-dynamic-import',
     '@babel/plugin-proposal-class-properties',
-    'add-module-exports',
     'babel-plugin-styled-components',
   ],
   env: {
     test: {
       presets: ['@babel/env'],
-      plugins: ['babel-plugin-dynamic-import-node', '@babel/plugin-transform-runtime'],
+      plugins: [
+        'babel-plugin-dynamic-import-node',
+        '@babel/plugin-transform-runtime',
+        'add-module-exports',
+      ],
     },
   },
 };

--- a/graylog2-web-interface/babel.config.js
+++ b/graylog2-web-interface/babel.config.js
@@ -11,7 +11,6 @@ module.exports = {
       plugins: [
         'babel-plugin-dynamic-import-node',
         '@babel/plugin-transform-runtime',
-        'add-module-exports',
       ],
     },
   },

--- a/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.test.jsx
@@ -46,7 +46,7 @@ describe('Navigation', () => {
 
   beforeEach(() => {
     // eslint-disable-next-line global-require
-    Navigation = require('./Navigation');
+    Navigation = require('./Navigation').default;
   });
 
   describe('has common elements', () => {

--- a/graylog2-web-interface/src/components/navigation/NotificationBadge.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/NotificationBadge.test.jsx
@@ -21,7 +21,7 @@ describe('NotificationBadge', () => {
     jest.doMock('injection/CombinedProvider', () => combinedProviderMock);
 
     // eslint-disable-next-line global-require
-    NotificationBadge = require('./NotificationBadge');
+    NotificationBadge = require('./NotificationBadge').default;
   });
 
   it('triggers update of notifications', () => {

--- a/graylog2-web-interface/src/components/navigation/SystemMenu.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/SystemMenu.test.jsx
@@ -45,7 +45,7 @@ describe('SystemMenu', () => {
 
     beforeEach(() => {
       // eslint-disable-next-line global-require
-      SystemMenu = require('./SystemMenu');
+      SystemMenu = require('./SystemMenu').default;
     });
 
     const verifyPermissions = ({ permissions, count, links }) => {
@@ -83,7 +83,7 @@ describe('SystemMenu', () => {
       ];
 
       // eslint-disable-next-line global-require
-      SystemMenu = require('./SystemMenu');
+      SystemMenu = require('./SystemMenu').default;
     });
 
     afterEach(() => {
@@ -129,7 +129,7 @@ describe('SystemMenu', () => {
       ];
 
       // eslint-disable-next-line global-require
-      SystemMenu = require('./SystemMenu');
+      SystemMenu = require('./SystemMenu').default;
     });
 
     afterEach(() => {

--- a/graylog2-web-interface/src/routing/Routes.test.jsx
+++ b/graylog2-web-interface/src/routing/Routes.test.jsx
@@ -8,7 +8,7 @@ describe('Routes', () => {
     beforeAll(() => {
       jest.resetModules();
       window.appConfig = {}; // Ensure no prefix is set
-      Routes = require.requireActual('./Routes');
+      Routes = require.requireActual('./Routes').default;
     });
 
     it('returns a route from constant', () => {
@@ -38,7 +38,7 @@ describe('Routes', () => {
         gl2AppPathPrefix: prefix,
       };
 
-      Routes = require.requireActual('./Routes');
+      Routes = require.requireActual('./Routes').default;
     });
 
     it('returns a route from constant', () => {

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesFunctionsSuggester.test.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/SeriesFunctionsSuggester.test.jsx
@@ -10,7 +10,7 @@ describe('SeriesFunctionsSuggester', () => {
     jest.doMock('views/stores/AggregationFunctionsStore', () => AggregationFunctionsStore);
 
     // eslint-disable-next-line global-require
-    SeriesFunctionsSuggester = require('./SeriesFunctionsSuggester');
+    SeriesFunctionsSuggester = require('./SeriesFunctionsSuggester').default;
   });
 
   afterEach(() => {

--- a/graylog2-web-interface/src/views/components/visualizations/__tests__/GenericPlot.test.jsx
+++ b/graylog2-web-interface/src/views/components/visualizations/__tests__/GenericPlot.test.jsx
@@ -11,7 +11,7 @@ import RenderCompletionCallback from '../../widgets/RenderCompletionCallback';
 jest.mock('components/graylog/Popover');
 
 // eslint-disable-next-line global-require
-jest.mock('views/components/visualizations/plotly/AsyncPlot', () => require('views/components/visualizations/plotly/Plot'));
+jest.mock('views/components/visualizations/plotly/AsyncPlot', () => require('views/components/visualizations/plotly/Plot').default);
 jest.mock('components/common/ColorPicker', () => 'color-picker');
 
 describe('GenericPlot', () => {

--- a/graylog2-web-interface/src/views/logic/views/OnSaveAsViewAction.test.js
+++ b/graylog2-web-interface/src/views/logic/views/OnSaveAsViewAction.test.js
@@ -1,7 +1,7 @@
 import View from './View';
 
 // eslint-disable-next-line global-require
-const loadSUT = () => require('./OnSaveAsViewAction');
+const loadSUT = () => require('./OnSaveAsViewAction').default;
 
 const mockActions = () => {
   const ViewActions = { load: jest.fn(() => Promise.resolve({ view: { id: 'deadbeef' } })).mockName('load') };

--- a/graylog2-web-interface/src/views/logic/views/OnSaveViewAction.test.js
+++ b/graylog2-web-interface/src/views/logic/views/OnSaveViewAction.test.js
@@ -3,7 +3,7 @@ import View from './View';
 jest.mock('routing/Routes', () => ({ VIEWS: { VIEWID: (viewId) => `/views/${viewId}` } }));
 
 // eslint-disable-next-line global-require
-const loadSUT = () => require('./OnSaveViewAction');
+const loadSUT = () => require('./OnSaveViewAction').default;
 
 const mockBaseView = { id: 'deadbeef', title: 'View title' };
 

--- a/graylog2-web-interface/src/views/pages/ViewManagementPage.test.jsx
+++ b/graylog2-web-interface/src/views/pages/ViewManagementPage.test.jsx
@@ -39,7 +39,7 @@ describe('ViewManagementPage', () => {
 
   it('passes retrieved views to list component', () => {
     // eslint-disable-next-line global-require
-    const ViewManagementPage = require('./ViewManagementPage');
+    const ViewManagementPage = require('./ViewManagementPage').default;
     const wrapper = shallow(<ViewManagementPage />);
 
     const viewList = wrapper.find('view-list');
@@ -51,7 +51,7 @@ describe('ViewManagementPage', () => {
 
   it('asks for confirmation when deleting view', () => {
     // eslint-disable-next-line global-require
-    const ViewManagementPage = require('./ViewManagementPage');
+    const ViewManagementPage = require('./ViewManagementPage').default;
     const wrapper = mount(<ViewManagementPage />);
 
     const viewList = wrapper.find('view-list');


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This plugin was used before mainly for interop between ancient Typescript parts and core. Recently, it was only needed for tests doing `require()` calls without a `default` suffix (we should get rid of `require` in tests anyway).

This change is removing the plugin and changes test calls.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.