### PR TITLE
Unify wizard navigation style

### DIFF
--- a/graylog2-web-interface/src/components/common/Wizard.jsx
+++ b/graylog2-web-interface/src/components/common/Wizard.jsx
@@ -73,6 +73,38 @@ const StyledNav: StyledComponent<{}, ThemeInterface, Nav> = styled(Nav)(({ theme
       }
     }
   }
+
+  @media (max-width: ${theme.breakpoints.max.md}) {
+    &.nav {
+      > li {
+        border-right: 0;
+        border-left: 0;
+
+        &:last-child, &:first-child {
+          border-radius: 0;
+        }
+
+        &:not(:last-child) {
+          border-bottom: 0;
+        }
+
+        &:not(:last-child) > a {
+          ::after {
+            bottom: 0;
+            left: 50%;
+            top: auto;
+            width: 10px;
+            height: 10px;
+            transform: translateY(50%) translateX(-50%) rotate(45deg);
+          }
+        }
+      }
+
+      &.nav-justified > li > a {
+        margin-bottom: 0;
+      }
+    }
+  }
 `);
 
 const HorizontalCol: StyledComponent<{}, ThemeInterface, Col> = styled(Col)`

--- a/graylog2-web-interface/src/components/common/Wizard.jsx
+++ b/graylog2-web-interface/src/components/common/Wizard.jsx
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 import lodash from 'lodash';
 import styled, { css, type StyledComponent } from 'styled-components';
 
-import { Button, ButtonToolbar, Col, Nav, NavItem, Row } from 'components/graylog';
 import { type ThemeInterface } from 'theme';
+import { Button, ButtonToolbar, Col, Nav, NavItem, Row } from 'components/graylog';
 
 import Icon from './Icon';
 

--- a/graylog2-web-interface/src/components/common/Wizard.jsx
+++ b/graylog2-web-interface/src/components/common/Wizard.jsx
@@ -13,6 +13,68 @@ const SubnavigationCol: StyledComponent<{}, ThemeInterface, Col> = styled(Col)((
   border-right: ${theme.colors.gray[80]} solid 1px;
 `);
 
+const StyledNav: StyledComponent<{}, ThemeInterface, Nav> = styled(Nav)(({ theme }) => css`
+  &.nav {
+    > li {
+      border: 1px solid ${theme.colors.variant.lighter.default};
+      border-left: 0;
+
+      &:first-child {
+        border-left: 1px solid ${theme.colors.variant.lighter.default};
+        border-radius: 4px 0 0 4px;
+
+        > a {
+          border-radius: 4px 0 0 4px;
+        }
+      }
+
+      &:last-child {
+        border-radius: 0 4px 4px 0;
+
+        > a {
+          border-radius: 0 4px 4px 0;
+        }
+      }
+
+      &:not(:last-child) > a {
+        ::after {
+          transition: background-color 150ms ease-in-out;
+          background-color: ${theme.colors.global.contentBackground};
+          border-color: ${theme.colors.variant.lighter.default};
+          border-style: solid;
+          border-width: 0 1px 1px 0;
+          content: '';
+          display: block;
+          height: 15px;
+          position: absolute;
+          right: -1px;
+          top: 50%;
+          transform: translateY(-50%) translateX(50%) rotate(-45deg);
+          width: 15px;
+          z-index: 2;
+        }
+
+        :hover::after {
+          background-color: ${theme.colors.variant.lightest.default};
+        }
+      }
+
+      &.active a {
+        &,
+        &:hover,
+        &::after,
+        &:hover::after {
+          background-color: ${theme.colors.global.link};
+        }
+      }
+
+      > a {
+        border-radius: 0;
+      }
+    }
+  }
+`);
+
 const HorizontalCol: StyledComponent<{}, ThemeInterface, Col> = styled(Col)`
   margin-bottom: 15px;
 `;
@@ -94,7 +156,7 @@ class Wizard extends React.Component<Props, State> {
     horizontal: false,
     justified: false,
     containerClassName: 'content',
-    NavigationComponent: Nav,
+    NavigationComponent: StyledNav,
     hidePreviousNextButtons: false,
   };
 

--- a/graylog2-web-interface/src/components/common/Wizard.jsx
+++ b/graylog2-web-interface/src/components/common/Wizard.jsx
@@ -84,7 +84,7 @@ const StyledNav: StyledComponent<{}, ThemeInterface, Nav> = styled(Nav)(({ theme
         border-right: 0;
         border-left: 0;
 
-        &:last-child, &:first-child {
+        &:last-child a, &:first-child a {
           border-radius: 0;
         }
 

--- a/graylog2-web-interface/src/components/common/Wizard.jsx
+++ b/graylog2-web-interface/src/components/common/Wizard.jsx
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 import lodash from 'lodash';
 import styled, { css, type StyledComponent } from 'styled-components';
 
-import { type ThemeInterface } from 'theme';
 import { Button, ButtonToolbar, Col, Nav, NavItem, Row } from 'components/graylog';
+import { type ThemeInterface } from 'theme';
 
 import Icon from './Icon';
 

--- a/graylog2-web-interface/src/components/common/Wizard.jsx
+++ b/graylog2-web-interface/src/components/common/Wizard.jsx
@@ -13,6 +13,10 @@ const SubnavigationCol: StyledComponent<{}, ThemeInterface, Col> = styled(Col)((
   border-right: ${theme.colors.gray[80]} solid 1px;
 `);
 
+const HorizontalCol: StyledComponent<{}, ThemeInterface, Col> = styled(Col)`
+  margin-bottom: 15px;
+`;
+
 const StyledNav: StyledComponent<{}, ThemeInterface, Nav> = styled(Nav)(({ theme }) => css`
   &.nav {
     > li {
@@ -107,10 +111,6 @@ const StyledNav: StyledComponent<{}, ThemeInterface, Nav> = styled(Nav)(({ theme
   }
 `);
 
-const HorizontalCol: StyledComponent<{}, ThemeInterface, Col> = styled(Col)`
-  margin-bottom: 15px;
-`;
-
 const HorizontalButtonToolbar = styled(ButtonToolbar)`
   padding: 7px;
 `;
@@ -134,7 +134,6 @@ type Props = {
   horizontal: boolean,
   justified: boolean,
   containerClassName: string,
-  NavigationComponent: Nav,
   hidePreviousNextButtons: boolean,
 };
 
@@ -175,8 +174,6 @@ class Wizard extends React.Component<Props, State> {
     justified: PropTypes.bool,
     /** Customize the container CSS class used by this component */
     containerClassName: PropTypes.string,
-    /** Customize the navigation componment used by Wizard */
-    NavigationComponent: PropTypes.elementType,
     /** Indicates if wizard should render next/previous buttons or not */
     hidePreviousNextButtons: PropTypes.bool,
   };
@@ -188,7 +185,6 @@ class Wizard extends React.Component<Props, State> {
     horizontal: false,
     justified: false,
     containerClassName: 'content',
-    NavigationComponent: StyledNav,
     hidePreviousNextButtons: false,
   };
 
@@ -320,7 +316,7 @@ class Wizard extends React.Component<Props, State> {
 
   _renderHorizontalStepNav = () => {
     const selectedStep = this._getSelectedStep();
-    const { justified, NavigationComponent, steps, hidePreviousNextButtons } = this.props;
+    const { justified, steps, hidePreviousNextButtons } = this.props;
 
     return (
       <HorizontalCol sm={12}>
@@ -342,15 +338,15 @@ class Wizard extends React.Component<Props, State> {
             </HorizontalButtonToolbar>
           </div>
         )}
-        <NavigationComponent bsStyle="pills"
-                             activeKey={selectedStep}
-                             onSelect={this._wizardChanged}
-                             justified={justified}>
+        <StyledNav bsStyle="pills"
+                   activeKey={selectedStep}
+                   onSelect={this._wizardChanged}
+                   justified={justified}>
           {steps.map((navItem) => {
             return (
               <NavItem key={navItem.key} eventKey={navItem.key} disabled={navItem.disabled}>{navItem.title}</NavItem>);
           })}
-        </NavigationComponent>
+        </StyledNav>
       </HorizontalCol>
     );
   };

--- a/graylog2-web-interface/src/components/common/Wizard.jsx
+++ b/graylog2-web-interface/src/components/common/Wizard.jsx
@@ -273,22 +273,22 @@ class Wizard extends React.Component<Props, State> {
   };
 
   _renderVerticalStepNav = () => {
-    const { justified, NavigationComponent, steps, hidePreviousNextButtons } = this.props;
+    const { justified, steps, hidePreviousNextButtons } = this.props;
     const selectedStep = this._getSelectedStep();
 
     return (
       <SubnavigationCol md={2}>
-        <NavigationComponent stacked
-                             bsStyle="pills"
-                             activeKey={selectedStep}
-                             onSelect={this._wizardChanged}
-                             justified={justified}>
+        <Nav stacked
+             bsStyle="pills"
+             activeKey={selectedStep}
+             onSelect={this._wizardChanged}
+             justified={justified}>
           {steps.map((navItem) => {
             return (
               <NavItem key={navItem.key} eventKey={navItem.key} disabled={navItem.disabled}>{navItem.title}</NavItem>
             );
           })}
-        </NavigationComponent>
+        </Nav>
         {!hidePreviousNextButtons && (
           <>
             <br />

--- a/graylog2-web-interface/src/components/common/Wizard.test.jsx
+++ b/graylog2-web-interface/src/components/common/Wizard.test.jsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import { mount } from 'wrappedEnzyme';
-import styled from 'styled-components';
-import { enzymeFind } from 'styled-components/test-utils';
 
-import { Nav } from 'components/graylog';
 import Wizard from 'components/common/Wizard';
 
 import 'helpers/mocking/react-dom_mock';

--- a/graylog2-web-interface/src/components/common/Wizard.test.jsx
+++ b/graylog2-web-interface/src/components/common/Wizard.test.jsx
@@ -216,15 +216,4 @@ describe('<Wizard />', () => {
     expect(wrapperH.find('button > svg.fa-caret-left').exists()).toBe(false);
     expect(wrapperH.find('button > svg.fa-caret-right').exists()).toBe(false);
   });
-
-  it('should render a new component if NavigationComponent is passed', () => {
-    const TestNavComponentFaux = styled(Nav)``;
-    const TestNavComponent = styled(Nav)`
-      background: #000;
-    `;
-    const wrapper = mount(<Wizard steps={steps} NavigationComponent={TestNavComponent} />);
-
-    expect(enzymeFind(wrapper, TestNavComponent).exists()).toBe(true);
-    expect(enzymeFind(wrapper, TestNavComponentFaux).exists()).toBe(false);
-  });
 });

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionForm.jsx
@@ -13,68 +13,6 @@ import FieldsForm from './FieldsForm';
 import NotificationsForm from './NotificationsForm';
 import EventDefinitionSummary from './EventDefinitionSummary';
 
-const StyledNav = styled(Nav)(({ theme }) => css`
-  &.nav {
-    > li {
-      border: 1px solid ${theme.colors.variant.lighter.default};
-      border-left: 0;
-
-      &:first-child {
-        border-left: 1px solid ${theme.colors.variant.lighter.default};
-        border-radius: 4px 0 0 4px;
-
-        > a {
-          border-radius: 4px 0 0 4px;
-        }
-      }
-
-      &:last-child {
-        border-radius: 0 4px 4px 0;
-
-        > a {
-          border-radius: 0 4px 4px 0;
-        }
-      }
-
-      &:not(:last-child) > a {
-        ::after {
-          transition: background-color 150ms ease-in-out;
-          background-color: ${theme.colors.global.contentBackground};
-          border-color: ${theme.colors.variant.lighter.default};
-          border-style: solid;
-          border-width: 0 1px 1px 0;
-          content: '';
-          display: block;
-          height: 15px;
-          position: absolute;
-          right: -1px;
-          top: 50%;
-          transform: translateY(-50%) translateX(50%) rotate(-45deg);
-          width: 15px;
-          z-index: 2;
-        }
-
-        :hover::after {
-          background-color: ${theme.colors.variant.lightest.default};
-        }
-      }
-
-      &.active a {
-        &,
-        &:hover,
-        &::after,
-        &:hover::after {
-          background-color: ${theme.colors.global.link};
-        }
-      }
-
-      > a {
-        border-radius: 0;
-      }
-    }
-  }
-`);
-
 const STEP_KEYS = ['event-details', 'condition', 'fields', 'notifications', 'summary'];
 
 class EventDefinitionForm extends React.Component {
@@ -232,7 +170,6 @@ class EventDefinitionForm extends React.Component {
                   onStepChange={this.handleStepChange}
                   horizontal
                   justified
-                  NavigationComponent={StyledNav}
                   containerClassName=""
                   hidePreviousNextButtons />
           {this.renderButtons(activeStep)}

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionForm.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import lodash from 'lodash';
-import styled, { css } from 'styled-components';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
-import { Button, ButtonToolbar, Col, Nav, Row } from 'components/graylog';
+import { Button, ButtonToolbar, Col, Row } from 'components/graylog';
 import { Wizard } from 'components/common';
 
 import EventDetailsForm from './EventDetailsForm';


### PR DESCRIPTION
This PR defines the `EventDefinitionFrom` wizard navigation style as the default for all horizontal wizards:

![image](https://user-images.githubusercontent.com/46300478/94426071-4edc2980-018d-11eb-905c-f0923b4639c3.png)

It looks better than the default style, which is being used in two plugins. The default style looks like this:
![image](https://user-images.githubusercontent.com/46300478/94426797-6b2c9600-018e-11eb-8164-12c449063b7f.png)

This PR also improves the responsiveness of the navigation.
Before:
![image](https://user-images.githubusercontent.com/46300478/94427010-b8106c80-018e-11eb-9726-332c0acab156.png)

After:
![image](https://user-images.githubusercontent.com/46300478/94433448-a03de600-0198-11eb-9075-f24e2e5fe559.png)

There are some ESLint warnings, but they are not related to this PR.
