### PR TITLE
Avoid unnecessary search execution when starting/loading search.

### DIFF
--- a/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
@@ -116,8 +116,6 @@ class NewSearchPage extends React.Component<Props, State> {
       this.setState({ loaded: true });
 
       return view;
-    }).then(() => {
-      SearchActions.executeWithCurrentState();
     }).catch((e) => e);
   };
 

--- a/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/NewSearchPage.jsx
@@ -12,7 +12,6 @@ import NewViewLoaderContext from 'views/logic/NewViewLoaderContext';
 import ViewLoaderContext from 'views/logic/ViewLoaderContext';
 import View from 'views/logic/views/View';
 import ViewLoader, { processHooks } from 'views/logic/views/ViewLoader';
-import { SearchActions } from 'views/stores/SearchStore';
 import { ExtendedSearchPage } from 'views/pages';
 import { syncWithQueryParameters } from 'views/hooks/SyncWithQueryParameters';
 

--- a/graylog2-web-interface/src/views/pages/ShowViewPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ShowViewPage.jsx
@@ -105,10 +105,6 @@ class ShowViewPage extends React.Component<Props, State> {
       this.setState({ loaded: true });
 
       return results;
-    }).then((results) => {
-      SearchActions.executeWithCurrentState();
-
-      return results;
     }).catch((e) => e);
   };
 

--- a/graylog2-web-interface/src/views/pages/ShowViewPage.jsx
+++ b/graylog2-web-interface/src/views/pages/ShowViewPage.jsx
@@ -12,7 +12,6 @@ import withPluginEntities from 'views/logic/withPluginEntities';
 import type { ViewHook } from 'views/logic/hooks/ViewHook';
 import type { ViewLoaderFn } from 'views/logic/views/ViewLoader';
 import ViewLoader from 'views/logic/views/ViewLoader';
-import { SearchActions } from 'views/stores/SearchStore';
 import NewViewLoaderContext from 'views/logic/NewViewLoaderContext';
 import { ExtendedSearchPage } from 'views/pages';
 
@@ -58,10 +57,14 @@ class ShowViewPage extends React.Component<Props, State> {
     viewLoader: ViewLoader,
   };
 
-  state = {
-    hookComponent: undefined,
-    loaded: false,
-  };
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      hookComponent: undefined,
+      loaded: false,
+    };
+  }
 
   componentDidMount = () => {
     const { params } = this.props;

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.jsx
@@ -84,6 +84,7 @@ const StreamSearchPage = ({ params: { streamId }, route, router, loadingViewHook
     });
   };
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => { loadViewFromParams(); }, [streamId]);
 
   if (hookComponent) {

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.jsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from 'react';
 
 import UserNotification from 'util/UserNotification';
 import { ViewActions } from 'views/stores/ViewStore';
-import { SearchActions } from 'views/stores/SearchStore';
 import { syncWithQueryParameters } from 'views/hooks/SyncWithQueryParameters';
 import NewViewLoaderContext from 'views/logic/NewViewLoaderContext';
 import View from 'views/logic/views/View';

--- a/graylog2-web-interface/src/views/pages/StreamSearchPage.jsx
+++ b/graylog2-web-interface/src/views/pages/StreamSearchPage.jsx
@@ -56,8 +56,6 @@ const StreamSearchPage = ({ params: { streamId }, route, router, loadingViewHook
       setLoaded(true);
 
       return view;
-    }).then(() => {
-      SearchActions.executeWithCurrentState();
     }).catch((e) => e);
   };
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, starting a new or loading an existing search triggered a search job execution at least twice. This leads to unnecessary load and might even be the cause for bugs which are hard to reproduce (#8820).

This change is removing two unneeded search executions during mount. Both are factually unneeded, as the initial search execution after loading the saved search is performed in [`_refreshIfNotUndeclared`](https://github.com/Graylog2/graylog2-server/blob/53838fc/graylog2-web-interface/src/views/pages/ExtendedSearchPage.jsx#L103).

<!--- Provide a general summary of your changes in the Title above -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

