### PR TITLE
Add error prop for `Input` to be able to display an error message together with the input help text

### DIFF
--- a/graylog2-web-interface/src/components/bootstrap/Input.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/Input.jsx
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { Checkbox, ControlLabel, FormControl, FormGroup, HelpBlock, InputGroup, Radio } from 'components/graylog';
+import { Checkbox, ControlLabel, FormControl, FormGroup, InputGroup, Radio } from 'components/graylog';
+import InputDescription from 'components/common/InputDescription';
 
 import InputWrapper from './InputWrapper';
 
@@ -29,6 +30,10 @@ class Input extends React.Component {
       PropTypes.number,
     ]),
     placeholder: PropTypes.string,
+    error: PropTypes.oneOfType([
+      PropTypes.element,
+      PropTypes.string,
+    ]),
     help: PropTypes.oneOfType([
       PropTypes.element,
       PropTypes.string,
@@ -57,7 +62,8 @@ class Input extends React.Component {
     bsStyle: null,
     value: undefined,
     placeholder: '',
-    help: '',
+    error: undefined,
+    help: undefined,
     wrapperClassName: undefined,
     addonAfter: null,
     buttonAfter: null,
@@ -103,6 +109,7 @@ class Input extends React.Component {
     wrapperClassName,
     label,
     labelClassName,
+    error,
     help,
     children,
     addon,
@@ -127,43 +134,43 @@ class Input extends React.Component {
         {label && <ControlLabel className={labelClassName}>{label}</ControlLabel>}
         <InputWrapper className={wrapperClassName}>
           {input}
-          {help && <HelpBlock>{help}</HelpBlock>}
+          <InputDescription error={error} help={help} />
         </InputWrapper>
       </FormGroup>
     );
   };
 
-  _renderCheckboxGroup = (id, validationState, formGroupClassName, wrapperClassName, label, help, props) => {
+  _renderCheckboxGroup = (id, validationState, formGroupClassName, wrapperClassName, label, error, help, props) => {
     return (
       <FormGroup controlId={id} validationState={validationState} bsClass={formGroupClassName}>
         <InputWrapper className={wrapperClassName}>
           <Checkbox inputRef={(ref) => { this.input = ref; }} {...props}>{label}</Checkbox>
-          {help && <HelpBlock>{help}</HelpBlock>}
+          <InputDescription error={error} help={help} />
         </InputWrapper>
       </FormGroup>
     );
   };
 
-  _renderRadioGroup = (id, validationState, formGroupClassName, wrapperClassName, label, help, props) => {
+  _renderRadioGroup = (id, validationState, formGroupClassName, wrapperClassName, label, error, help, props) => {
     return (
       <FormGroup controlId={id} validationState={validationState} bsClass={formGroupClassName}>
         <InputWrapper className={wrapperClassName}>
           <Radio inputRef={(ref) => { this.input = ref; }} {...props}>{label}</Radio>
-          {help && <HelpBlock>{help}</HelpBlock>}
+          <InputDescription error={error} help={help} />
         </InputWrapper>
       </FormGroup>
     );
   };
 
   render() {
-    const { id, type, bsStyle, formGroupClassName, wrapperClassName, label, labelClassName, name, help, children, addonAfter, buttonAfter, ...controlProps } = this.props;
+    const { id, type, bsStyle, formGroupClassName, wrapperClassName, label, labelClassName, name, error, help, children, addonAfter, buttonAfter, ...controlProps } = this.props;
 
     controlProps.type = type;
     controlProps.label = label;
     controlProps.name = name || id;
 
     if (!type) {
-      return this._renderFormGroup(id, bsStyle, formGroupClassName, wrapperClassName, label, labelClassName, help, children);
+      return this._renderFormGroup(id, bsStyle, formGroupClassName, wrapperClassName, label, labelClassName, error, help, children);
     }
 
     switch (type) {
@@ -172,15 +179,15 @@ class Input extends React.Component {
       case 'email':
       case 'number':
       case 'file':
-        return this._renderFormGroup(id, bsStyle, formGroupClassName, wrapperClassName, label, labelClassName, help, this._renderFormControl('input', controlProps), addonAfter, buttonAfter);
+        return this._renderFormGroup(id, bsStyle, formGroupClassName, wrapperClassName, label, labelClassName, error, help, this._renderFormControl('input', controlProps), addonAfter, buttonAfter);
       case 'textarea':
-        return this._renderFormGroup(id, bsStyle, formGroupClassName, wrapperClassName, label, labelClassName, help, this._renderFormControl('textarea', controlProps));
+        return this._renderFormGroup(id, bsStyle, formGroupClassName, wrapperClassName, label, labelClassName, error, help, this._renderFormControl('textarea', controlProps));
       case 'select':
-        return this._renderFormGroup(id, bsStyle, formGroupClassName, wrapperClassName, label, labelClassName, help, this._renderFormControl('select', controlProps, children));
+        return this._renderFormGroup(id, bsStyle, formGroupClassName, wrapperClassName, label, labelClassName, error, help, this._renderFormControl('select', controlProps, children));
       case 'checkbox':
-        return this._renderCheckboxGroup(id, bsStyle, formGroupClassName, wrapperClassName, label, help, controlProps);
+        return this._renderCheckboxGroup(id, bsStyle, formGroupClassName, wrapperClassName, label, error, help, controlProps);
       case 'radio':
-        return this._renderRadioGroup(id, bsStyle, formGroupClassName, wrapperClassName, label, help, controlProps);
+        return this._renderRadioGroup(id, bsStyle, formGroupClassName, wrapperClassName, label, error, help, controlProps);
       default:
         // eslint-disable-next-line no-console
         console.warn(`Unsupported input type ${type}`);

--- a/graylog2-web-interface/src/components/bootstrap/Input.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/Input.jsx
@@ -130,7 +130,7 @@ class Input extends React.Component {
     }
 
     return (
-      <FormGroup controlId={id} validationState={validationState} bsClass={formGroupClassName}>
+      <FormGroup controlId={id} validationState={error ? 'error' : validationState} bsClass={formGroupClassName}>
         {label && <ControlLabel className={labelClassName}>{label}</ControlLabel>}
         <InputWrapper className={wrapperClassName}>
           {input}
@@ -142,7 +142,7 @@ class Input extends React.Component {
 
   _renderCheckboxGroup = (id, validationState, formGroupClassName, wrapperClassName, label, error, help, props) => {
     return (
-      <FormGroup controlId={id} validationState={validationState} bsClass={formGroupClassName}>
+      <FormGroup controlId={id} validationState={error ? 'error' : validationState} bsClass={formGroupClassName}>
         <InputWrapper className={wrapperClassName}>
           <Checkbox inputRef={(ref) => { this.input = ref; }} {...props}>{label}</Checkbox>
           <InputDescription error={error} help={help} />
@@ -153,7 +153,7 @@ class Input extends React.Component {
 
   _renderRadioGroup = (id, validationState, formGroupClassName, wrapperClassName, label, error, help, props) => {
     return (
-      <FormGroup controlId={id} validationState={validationState} bsClass={formGroupClassName}>
+      <FormGroup controlId={id} validationState={error ? 'error' : validationState} bsClass={formGroupClassName}>
         <InputWrapper className={wrapperClassName}>
           <Radio inputRef={(ref) => { this.input = ref; }} {...props}>{label}</Radio>
           <InputDescription error={error} help={help} />

--- a/graylog2-web-interface/src/components/bootstrap/Input.test.jsx
+++ b/graylog2-web-interface/src/components/bootstrap/Input.test.jsx
@@ -39,4 +39,22 @@ describe('Input', () => {
 
     expect(wrapper.find('input[name="inputWithNameProp"]')).toExist();
   });
+
+  it('renders input w/ provided error', () => {
+    const wrapper = mount(<Input id="inputWithError" type="text" error="The error message" />);
+
+    expect(wrapper.find({ error: 'The error message' }).find('InputDescription').length).toEqual(1);
+  });
+
+  it('renders input w/ provided help', () => {
+    const wrapper = mount(<Input id="inputWithHelp" type="text" help="The help text" />);
+
+    expect(wrapper.find({ help: 'The help text' }).find('InputDescription').length).toEqual(1);
+  });
+
+  it('renders input w/ provided help and error', () => {
+    const wrapper = mount(<Input id="inputWithHelp" type="text" help="The help text" error="The error message" />);
+
+    expect(wrapper.find({ help: 'The help text', error: 'The error message' }).find('InputDescription').length).toEqual(1);
+  });
 });

--- a/graylog2-web-interface/src/components/common/FormikInput.jsx
+++ b/graylog2-web-interface/src/components/common/FormikInput.jsx
@@ -32,7 +32,8 @@ const FormikInput = ({ label, name, type, help, validate, ...rest }: Props) => (
         <Input {...rest}
                {...typeSepcificProps}
                bsStyle={error ? 'error' : undefined}
-               help={error ?? help}
+               error={error}
+               help={help}
                id={name}
                label={label}
                name={name}

--- a/graylog2-web-interface/src/components/common/InputDescription.jsx
+++ b/graylog2-web-interface/src/components/common/InputDescription.jsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import { HelpBlock } from 'components/graylog';
 
-const ErrorMessage = styled.span(({ theme, hasError }) => hasError && `
+const ErrorMessage = styled.span(({ theme }) => `
   color: ${theme.colors.variant.danger};
 `);
 
@@ -29,14 +29,17 @@ const InputDescription = ({ help, error }: Props) => {
 
   return (
     <HelpBlock>
-      <ErrorMessage hasError={!!error}>
-        {error}
-      </ErrorMessage>
+      {error && (
+        <ErrorMessage>
+          {error}
+        </ErrorMessage>
+      )}
       {(!!error && !!help) && <br />}
-      <HelpMessage>
-        {help}
-
-      </HelpMessage>
+      {help && (
+        <HelpMessage>
+          {help}
+        </HelpMessage>
+      )}
     </HelpBlock>
   );
 };

--- a/graylog2-web-interface/src/components/common/InputDescription.jsx
+++ b/graylog2-web-interface/src/components/common/InputDescription.jsx
@@ -29,7 +29,8 @@ const InputDescription = ({ help, error }: Props) => {
   return (
     <Wrapper hasError={!!error}>
       <HelpBlock>
-        {error && <>{error}<br /></>}
+        {error}
+        {(error && help) && <br />}
         {help}
       </HelpBlock>
     </Wrapper>

--- a/graylog2-web-interface/src/components/common/InputDescription.jsx
+++ b/graylog2-web-interface/src/components/common/InputDescription.jsx
@@ -6,10 +6,8 @@ import styled, { type StyledComponent } from 'styled-components';
 import type { ThemeInterface } from 'theme';
 import { HelpBlock } from 'components/graylog';
 
-const Wrapper: StyledComponent<{hasError: boolean}, ThemeInterface, HTMLSpanElement> = styled.span(({ theme, hasError }) => `
-  ${hasError ? `
-    color: ${theme.colors.variant.danger};
-  ` : ''};
+const Wrapper: StyledComponent<{hasError: boolean}, ThemeInterface, HTMLSpanElement> = styled.span(({ theme, hasError }) => hasError && `
+  color: ${theme.colors.variant.danger};
 `);
 
 type Props = {

--- a/graylog2-web-interface/src/components/common/InputDescription.jsx
+++ b/graylog2-web-interface/src/components/common/InputDescription.jsx
@@ -1,13 +1,16 @@
 // @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import styled, { type StyledComponent } from 'styled-components';
+import styled from 'styled-components';
 
-import type { ThemeInterface } from 'theme';
 import { HelpBlock } from 'components/graylog';
 
-const Wrapper: StyledComponent<{hasError: boolean}, ThemeInterface, HTMLSpanElement> = styled.span(({ theme, hasError }) => hasError && `
+const ErrorMessage = styled.span(({ theme, hasError }) => hasError && `
   color: ${theme.colors.variant.danger};
+`);
+
+const HelpMessage = styled.span(({ theme }) => `
+  color: ${theme.colors.gray[50]};
 `);
 
 type Props = {
@@ -25,13 +28,16 @@ const InputDescription = ({ help, error }: Props) => {
   }
 
   return (
-    <Wrapper hasError={!!error}>
-      <HelpBlock>
+    <HelpBlock>
+      <ErrorMessage hasError={!!error}>
         {error}
-        {(error && help) && <br />}
+      </ErrorMessage>
+      {(error && help) && <br />}
+      <HelpMessage>
         {help}
-      </HelpBlock>
-    </Wrapper>
+
+      </HelpMessage>
+    </HelpBlock>
   );
 };
 

--- a/graylog2-web-interface/src/components/common/InputDescription.jsx
+++ b/graylog2-web-interface/src/components/common/InputDescription.jsx
@@ -32,7 +32,7 @@ const InputDescription = ({ help, error }: Props) => {
       <ErrorMessage hasError={!!error}>
         {error}
       </ErrorMessage>
-      {(error && help) && <br />}
+      {(!!error && !!help) && <br />}
       <HelpMessage>
         {help}
 

--- a/graylog2-web-interface/src/components/common/InputDescription.jsx
+++ b/graylog2-web-interface/src/components/common/InputDescription.jsx
@@ -1,0 +1,55 @@
+// @flow strict
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import styled, { type StyledComponent } from 'styled-components';
+
+import type { ThemeInterface } from 'theme';
+import { HelpBlock } from 'components/graylog';
+
+const Wrapper: StyledComponent<{hasError: boolean}, ThemeInterface, HTMLSpanElement> = styled.span(({ theme, hasError }) => `
+  ${hasError ? `
+    color: ${theme.colors.variant.danger};
+  ` : ''};
+`);
+
+type Props = {
+  help?: React.Node,
+  error?: React.Node,
+};
+
+/**
+ * Component that renders a help and error message for an input.
+ * It always displays both messages.
+ */
+const InputDescription = ({ help, error }: Props) => {
+  if (!help && !error) {
+    return null;
+  }
+
+  return (
+    <Wrapper hasError={!!error}>
+      <HelpBlock>
+        {error && <>{error}<br /></>}
+        {help}
+      </HelpBlock>
+    </Wrapper>
+  );
+};
+
+InputDescription.propTypes = {
+  help: PropTypes.oneOfType([
+    PropTypes.element,
+    PropTypes.string,
+  ]),
+  error: PropTypes.oneOfType([
+    PropTypes.element,
+    PropTypes.string,
+  ]),
+};
+
+InputDescription.defaultProps = {
+  help: undefined,
+  error: undefined,
+};
+
+export default InputDescription;

--- a/graylog2-web-interface/src/components/common/InputDescription.test.jsx
+++ b/graylog2-web-interface/src/components/common/InputDescription.test.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render } from 'wrappedTestingLibrary';
+
+import InputDescription from './InputDescription';
+
+describe('<InputDescription />', () => {
+  it('should render error message', () => {
+    const { getByText } = render(<InputDescription error="The error message" />);
+
+    expect(getByText('The error message')).toBeInTheDocument();
+  });
+
+  it('should render help text', () => {
+    const { getByText } = render(<InputDescription help="The help text" />);
+
+    expect(getByText('The help text')).toBeInTheDocument();
+  });
+
+  it('should render help and error message', () => {
+    const { getByText } = render(<InputDescription help="The help text" error="The error message" />);
+
+    expect(getByText(/The help text/)).toBeInTheDocument();
+    expect(getByText(/The error message/)).toBeInTheDocument();
+  });
+});

--- a/graylog2-web-interface/src/components/common/index.jsx
+++ b/graylog2-web-interface/src/components/common/index.jsx
@@ -24,6 +24,7 @@ export { default as FormikFormGroup } from './FormikFormGroup';
 export { default as Icon } from './Icon';
 export { default as IconButton } from './IconButton';
 export { default as IfPermitted } from './IfPermitted';
+export { default as InputDescription } from './InputDescription';
 export { default as InteractableModal } from './InteractableModal';
 export { default as ISODurationInput } from './ISODurationInput';
 export { default as LinkToNode } from './LinkToNode';

--- a/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
@@ -265,7 +265,6 @@ class ContentPackSelection extends React.Component {
                 <Input name="name"
                        id="name"
                        type="text"
-                       bsStyle={errors.name ? 'error' : null}
                        maxLength={250}
                        value={contentPack.name}
                        onChange={this._bindValue}
@@ -276,7 +275,6 @@ class ContentPackSelection extends React.Component {
                 <Input name="summary"
                        id="summary"
                        type="text"
-                       bsStyle={errors.summary ? 'error' : null}
                        maxLength={250}
                        value={contentPack.summary}
                        onChange={this._bindValue}
@@ -295,7 +293,6 @@ class ContentPackSelection extends React.Component {
                 <Input name="vendor"
                        id="vendor"
                        type="text"
-                       bsStyle={errors.vendor ? 'error' : null}
                        maxLength={250}
                        value={contentPack.vendor}
                        onChange={this._bindValue}
@@ -307,7 +304,6 @@ class ContentPackSelection extends React.Component {
                        id="url"
                        type="text"
                        maxLength={250}
-                       bsStyle={errors.url ? 'error' : null}
                        value={contentPack.url}
                        onChange={this._bindValue}
                        label="URL"

--- a/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackSelection.jsx
@@ -270,7 +270,8 @@ class ContentPackSelection extends React.Component {
                        value={contentPack.name}
                        onChange={this._bindValue}
                        label="Name"
-                       help={errors.name ? errors.name : 'Required. Give a descriptive name for this content pack.'}
+                       help="Required. Give a descriptive name for this content pack."
+                       error={errors.name}
                        required />
                 <Input name="summary"
                        id="summary"
@@ -280,7 +281,8 @@ class ContentPackSelection extends React.Component {
                        value={contentPack.summary}
                        onChange={this._bindValue}
                        label="Summary"
-                       help={errors.summary ? errors.summary : 'Required. Give a short summary of the content pack.'}
+                       help="Required. Give a short summary of the content pack."
+                       error={errors.summary}
                        required />
                 <Input name="description"
                        id="description"
@@ -298,7 +300,8 @@ class ContentPackSelection extends React.Component {
                        value={contentPack.vendor}
                        onChange={this._bindValue}
                        label="Vendor"
-                       help={errors.vendor ? errors.vendor : 'Required. Who did this content pack and how can they be reached, e.g. Name and email.'}
+                       help="Required. Who did this content pack and how can they be reached, e.g. Name and email."
+                       error={errors.vendor}
                        required />
                 <Input name="url"
                        id="url"
@@ -308,7 +311,8 @@ class ContentPackSelection extends React.Component {
                        value={contentPack.url}
                        onChange={this._bindValue}
                        label="URL"
-                       help={errors.url ? errors.url : 'Where can I find the content pack. e.g. github url'} />
+                       help="Where can I find the content pack. e.g. github url"
+                       error={errors.url} />
               </fieldset>
             </form>
           </Col>

--- a/graylog2-web-interface/src/components/content-packs/ContentPackSelection.test.jsx
+++ b/graylog2-web-interface/src/components/content-packs/ContentPackSelection.test.jsx
@@ -175,14 +175,14 @@ describe('<ContentPackSelection />', () => {
       wrapper.instance()._validate();
       wrapper.update();
 
-      expect(wrapper.find('span[children="Must be filled out."]').length).toEqual(3);
+      expect(wrapper.find({ error: 'Must be filled out.' }).find('InputDescription').length).toEqual(3);
 
       const wrapper2 = mount(<ContentPackSelection contentPack={{ name: 'name' }} entities={entities} />);
 
       wrapper2.instance()._validate();
       wrapper2.update();
 
-      expect(wrapper2.find('span[children="Must be filled out."]').length).toEqual(2);
+      expect(wrapper2.find({ error: 'Must be filled out.' }).find('InputDescription').length).toEqual(2);
 
       const wrapper1 = mount(<ContentPackSelection contentPack={{ name: 'name', summary: 'summary' }}
                                                    entities={entities} />);
@@ -190,7 +190,7 @@ describe('<ContentPackSelection />', () => {
       wrapper1.instance()._validate();
       wrapper1.update();
 
-      expect(wrapper1.find('span[children="Must be filled out."]').length).toEqual(1);
+      expect(wrapper1.find({ error: 'Must be filled out.' }).find('InputDescription').length).toEqual(1);
 
       const wrapper0 = mount(<ContentPackSelection contentPack={{ name: 'name', summary: 'summary', vendor: 'vendor' }}
                                                    entities={entities} />);
@@ -198,7 +198,7 @@ describe('<ContentPackSelection />', () => {
       wrapper0.instance()._validate();
       wrapper0.update();
 
-      expect(wrapper0.find('span[children="Must be filled out."]').length).toEqual(0);
+      expect(wrapper0.find({ error: 'Must be filled out.' }).find('InputDescription').length).toEqual(0);
     });
 
     it('should validate that URLs only have http or https protocols', () => {
@@ -218,7 +218,7 @@ describe('<ContentPackSelection />', () => {
         invalidWrapper.instance()._validate();
         invalidWrapper.update();
 
-        expect(invalidWrapper.find('span[children="Must use a URL starting with http or https."]')).toHaveLength(errors);
+        expect(invalidWrapper.find({ error: 'Must use a URL starting with http or https.' }).find('InputDescription')).toHaveLength(errors);
       });
     });
   });


### PR DESCRIPTION
## Description
## Motivation and Context
The `Input` component currently allows defining a help text. We are also using this prop to display errors for an input. This way we always hide the help text when want to display an error. There are many cases where the help text is especially helpful when there is an error.

With this PR we are adding an extra error prop to be able to display both messages at the same time.

This change does not affect the current usage. I already adjusted the `ContentPackSelect` to demonstrate how to apply the change for existing components.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1790

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

