### PR TITLE
Retry indexing message if primary shard is not active

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MessagesAdapterES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/MessagesAdapterES7.java
@@ -44,6 +44,8 @@ public class MessagesAdapterES7 implements MessagesAdapter {
     static final String INDEX_BLOCK_ERROR = "cluster_block_exception";
     static final String MAPPER_PARSING_EXCEPTION = "mapper_parsing_exception";
     static final String INDEX_BLOCK_REASON = "blocked by: [TOO_MANY_REQUESTS/12/index read-only / allow delete (api)";
+    static final String UNAVAILABLE_SHARDS_EXCEPTION = "unavailable_shards_exception";
+    static final String PRIMARY_SHARD_NOT_ACTIVE_REASON = "primary shard is not active";
 
     private final ElasticsearchClient client;
     private final Meter invalidTimestampMeter;
@@ -207,6 +209,7 @@ public class MessagesAdapterES7 implements MessagesAdapter {
         switch (exception.type()) {
             case MAPPER_PARSING_EXCEPTION: return Messages.IndexingError.ErrorType.MappingError;
             case INDEX_BLOCK_ERROR: if (exception.reason().contains(INDEX_BLOCK_REASON)) return Messages.IndexingError.ErrorType.IndexBlocked;
+            case UNAVAILABLE_SHARDS_EXCEPTION: if (exception.reason().contains(PRIMARY_SHARD_NOT_ACTIVE_REASON)) return Messages.IndexingError.ErrorType.IndexBlocked;
             default: return Messages.IndexingError.ErrorType.Unknown;
         }
     }

--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ParsedElasticsearchException.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/ParsedElasticsearchException.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 @AutoValue
 abstract class ParsedElasticsearchException {
     private static final Pattern exceptionPattern = Pattern
-            .compile("ElasticsearchException\\[Elasticsearch exception \\[type=(?<type>[\\w_]+), (?:reason=(?<reason>.+?)\\]+;)");
+            .compile("ElasticsearchException\\[Elasticsearch exception \\[type=(?<type>[\\w_]+), (?:reason=(?<reason>.+?)(\\]+;|\\]$))");
 
     abstract String type();
     abstract String reason();

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/ParsedElasticsearchExceptionTest.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/ParsedElasticsearchExceptionTest.java
@@ -34,4 +34,19 @@ class ParsedElasticsearchExceptionTest {
             assertThat(p.reason()).isEqualTo("index [messages_it_deflector] blocked by: [TOO_MANY_REQUESTS/12/index read-only / allow delete (api)");
         });
     }
+
+    @Test
+    void parsingPrimaryShardIsNotAvailable() {
+        final String exception = "Elasticsearch exception: ElasticsearchException[Elasticsearch exception [type=unavailable_shards_exception, " +
+                "reason=[graylog_0][2] primary shard is not active Timeout: [1m], request: [BulkShardRequest [[graylog_0][2]] containing [125] " +
+                "requests]]]";
+
+        final ParsedElasticsearchException parsed = ParsedElasticsearchException.from(exception);
+
+        assertThat(parsed).satisfies(p -> {
+            assertThat(p.type()).isEqualTo("unavailable_shards_exception");
+            assertThat(p.reason()).isEqualTo("[graylog_0][2] primary shard is not active Timeout: [1m], " +
+                    "request: [BulkShardRequest [[graylog_0][2]] containing [125] requests]]");
+        });
+    }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, when a message is tried to be ingested into Elasticsearch when the primary shard of an index is unavailable, indexing will fail and the message will be turned into an indexing failure. Most probably, this is not what a user wants. 
In most cases an unavailable primary shard is a) affecting most, if not all indices, b) is a temporary condition. These properties and the similarities to scenarios where a watermark threshold switches indices to read-only do justify a handling of this that attempts retries indefinitely until the condition is resolved. 

While this prevents message loss, it can also cause journal overflow (and causing message loss at the _other_ end of ingestion), while it buys operations time to fix the issue. Due to the watermark scenario, proper sizing of the journal is required anyway to prevent catastrophic scenarios where message indexing stops completely.

This change is extending parsing of ES errors returned during ingestion and categorizes the "primary shard not available" error in the same way as the "index r/o" error. Therefore, errors like this will be retried indefinitely, until the condition is resolved.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

