### PR TITLE
Add ownership check to saved search/dashboard permission checks.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewPermissionChecks.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewPermissionChecks.java
@@ -1,0 +1,82 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.views.search.rest;
+
+import org.graylog.plugins.views.search.views.ViewDTO;
+import org.graylog.plugins.views.search.views.sharing.IsViewSharedForUser;
+import org.graylog.plugins.views.search.views.sharing.ViewSharing;
+import org.graylog.plugins.views.search.views.sharing.ViewSharingService;
+import org.graylog2.plugin.database.users.User;
+import org.graylog2.shared.security.RestPermissions;
+
+import javax.annotation.Nullable;
+import javax.inject.Inject;
+import java.util.Optional;
+import java.util.function.BiPredicate;
+
+public class ViewPermissionChecks {
+    private final ViewSharingService viewSharingService;
+    private final IsViewSharedForUser isViewSharedForUser;
+
+    @Inject
+    public ViewPermissionChecks(ViewSharingService viewSharingService, IsViewSharedForUser isViewSharedForUser) {
+        this.viewSharingService = viewSharingService;
+        this.isViewSharedForUser = isViewSharedForUser;
+    }
+
+    boolean allowedToSeeSavedSearch(User user, ViewDTO savedSearch, BiPredicate<String, String> isPermitted) {
+        return isPermitted.test(ViewsRestPermissions.VIEW_READ, savedSearch.id())
+                || ownsView(user, savedSearch)
+                || isSharedWithUser(user, savedSearch);
+    }
+
+    boolean allowedToSeeDashboard(User user, ViewDTO dashboard, BiPredicate<String, String> isPermitted) {
+        return isPermitted.test(ViewsRestPermissions.VIEW_READ, dashboard.id())
+                || isPermitted.test(RestPermissions.DASHBOARDS_READ, dashboard.id())
+                || isSharedWithUser(user, dashboard);
+    }
+
+    boolean allowedToSeeView(User user, ViewDTO view, BiPredicate<String, String> isPermitted) {
+        return isDashboard(view)
+                ? allowedToSeeDashboard(user, view, isPermitted)
+                : allowedToSeeSavedSearch(user, view, isPermitted);
+    }
+
+    boolean ownsView(@Nullable User currentUser, @Nullable ViewDTO view) {
+        if (currentUser == null || view == null) {
+            return false;
+        }
+
+        final String name = currentUser.getName();
+        if (name == null) {
+            return false;
+        }
+
+        return view.owner()
+                .map(name::equals)
+                .orElse(false);
+    }
+
+    private boolean isSharedWithUser(User user, ViewDTO view) {
+        final Optional<ViewSharing> viewSharing = viewSharingService.forView(view.id());
+        return viewSharing.map(sharing -> isViewSharedForUser.isAllowedToSee(user, sharing)).orElse(false);
+    }
+
+    boolean isDashboard(ViewDTO view) {
+        return view != null && view.type().equals(ViewDTO.Type.DASHBOARD);
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewPermissionChecks.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewPermissionChecks.java
@@ -47,6 +47,7 @@ public class ViewPermissionChecks {
     boolean allowedToSeeDashboard(User user, ViewDTO dashboard, BiPredicate<String, String> isPermitted) {
         return isPermitted.test(ViewsRestPermissions.VIEW_READ, dashboard.id())
                 || isPermitted.test(RestPermissions.DASHBOARDS_READ, dashboard.id())
+                || ownsView(user, dashboard)
                 || isSharedWithUser(user, dashboard);
     }
 

--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
@@ -26,9 +26,6 @@ import org.apache.shiro.authz.annotation.RequiresAuthentication;
 import org.graylog.plugins.views.audit.ViewsAuditEventTypes;
 import org.graylog.plugins.views.search.views.ViewDTO;
 import org.graylog.plugins.views.search.views.ViewService;
-import org.graylog.plugins.views.search.views.sharing.IsViewSharedForUser;
-import org.graylog.plugins.views.search.views.sharing.ViewSharing;
-import org.graylog.plugins.views.search.views.sharing.ViewSharingService;
 import org.graylog2.audit.jersey.AuditEvent;
 import org.graylog2.dashboards.events.DashboardDeletedEvent;
 import org.graylog2.database.PaginatedList;
@@ -62,7 +59,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -82,19 +78,16 @@ public class ViewsResource extends RestResource implements PluginRestResource {
 
     private final ViewService dbService;
     private final SearchQueryParser searchQueryParser;
-    private final ViewSharingService viewSharingService;
-    private final IsViewSharedForUser isViewSharedForUser;
     private final ClusterEventBus clusterEventBus;
+    private final ViewPermissionChecks permissionChecks;
 
     @Inject
     public ViewsResource(ViewService dbService,
-                         ViewSharingService viewSharingService,
-                         IsViewSharedForUser isViewSharedForUser,
-                         ClusterEventBus clusterEventBus) {
+                         ClusterEventBus clusterEventBus,
+                         ViewPermissionChecks permissionChecks) {
         this.dbService = dbService;
-        this.viewSharingService = viewSharingService;
-        this.isViewSharedForUser = isViewSharedForUser;
         this.clusterEventBus = clusterEventBus;
+        this.permissionChecks = permissionChecks;
         this.searchQueryParser = new SearchQueryParser(ViewDTO.FIELD_TITLE, SEARCH_FIELD_MAPPING);
     }
 
@@ -117,13 +110,7 @@ public class ViewsResource extends RestResource implements PluginRestResource {
             final SearchQuery searchQuery = searchQueryParser.parse(query);
             final PaginatedList<ViewDTO> result = dbService.searchPaginated(
                     searchQuery,
-                    view -> {
-                        final Optional<ViewSharing> viewSharing = viewSharingService.forView(view.id());
-
-                        return isPermitted(ViewsRestPermissions.VIEW_READ, view.id())
-                                || (view.type().equals(ViewDTO.Type.DASHBOARD) && isPermitted(RestPermissions.DASHBOARDS_READ, view.id()))
-                                || viewSharing.map(sharing -> isViewSharedForUser.isAllowedToSee(getCurrentUser(), sharing)).orElse(false);
-                    },
+                    view -> permissionChecks.allowedToSeeView(getCurrentUser(), view, this::isPermitted),
                     order,
                     sortField,
                     page,
@@ -146,11 +133,8 @@ public class ViewsResource extends RestResource implements PluginRestResource {
                     .orElseThrow(() -> new NotFoundException("Default view doesn't exist"));
         }
 
-        final Optional<ViewSharing> viewSharing = viewSharingService.forView(id);
         final ViewDTO view = loadView(id);
-        if (isPermitted(ViewsRestPermissions.VIEW_READ, id)
-                || (view.type().equals(ViewDTO.Type.DASHBOARD) && isPermitted(RestPermissions.DASHBOARDS_READ, view.id()))
-                || viewSharing.map(sharing -> isViewSharedForUser.isAllowedToSee(getCurrentUser(), sharing)).orElse(false)) {
+        if (permissionChecks.allowedToSeeView(getCurrentUser(), view, this::isPermitted)) {
             return view;
         }
 
@@ -161,7 +145,7 @@ public class ViewsResource extends RestResource implements PluginRestResource {
     @ApiOperation("Create a new view")
     @AuditEvent(type = ViewsAuditEventTypes.VIEW_CREATE)
     public ViewDTO create(@ApiParam @Valid ViewDTO dto) throws ValidationException {
-        if (dto.type().equals(ViewDTO.Type.DASHBOARD)) {
+        if (permissionChecks.isDashboard(dto)) {
             checkPermission(RestPermissions.DASHBOARDS_CREATE);
         }
         final String username = getCurrentUser() == null ? null : getCurrentUser().getName();
@@ -176,15 +160,17 @@ public class ViewsResource extends RestResource implements PluginRestResource {
     @AuditEvent(type = ViewsAuditEventTypes.VIEW_UPDATE)
     public ViewDTO update(@ApiParam(name="id") @PathParam("id") @NotEmpty String id,
                           @ApiParam @Valid ViewDTO dto) {
-        if (dto.type().equals(ViewDTO.Type.DASHBOARD)) {
-            checkAnyPermission(new String[]{
-                    ViewsRestPermissions.VIEW_EDIT,
-                    RestPermissions.DASHBOARDS_EDIT
-            }, id);
-        } else {
-            checkPermission(ViewsRestPermissions.VIEW_EDIT, id);
+        final ViewDTO savedView = loadView(id);
+        if (!permissionChecks.ownsView(getCurrentUser(), savedView)) {
+            if (permissionChecks.isDashboard(dto)) {
+                checkAnyPermission(new String[]{
+                        ViewsRestPermissions.VIEW_EDIT,
+                        RestPermissions.DASHBOARDS_EDIT
+                }, id);
+            } else {
+                checkPermission(ViewsRestPermissions.VIEW_EDIT, id);
+            }
         }
-        loadView(id);
         return dbService.update(dto.toBuilder().id(id).build());
     }
 
@@ -193,9 +179,12 @@ public class ViewsResource extends RestResource implements PluginRestResource {
     @ApiOperation("Configures the view as default view")
     @AuditEvent(type = ViewsAuditEventTypes.DEFAULT_VIEW_SET)
     public void setDefault(@ApiParam(name="id") @PathParam("id") @NotEmpty String id) {
-        checkPermission(ViewsRestPermissions.VIEW_READ, id);
+        final ViewDTO savedView = loadView(id);
+        if (!permissionChecks.ownsView(getCurrentUser(), savedView)) {
+            checkPermission(ViewsRestPermissions.VIEW_READ, id);
+        }
         checkPermission(ViewsRestPermissions.DEFAULT_VIEW_SET);
-        dbService.saveDefault(loadView(id));
+        dbService.saveDefault(savedView);
     }
 
     @DELETE
@@ -203,8 +192,10 @@ public class ViewsResource extends RestResource implements PluginRestResource {
     @ApiOperation("Delete view")
     @AuditEvent(type = ViewsAuditEventTypes.VIEW_DELETE)
     public ViewDTO delete(@ApiParam(name="id") @PathParam("id") @NotEmpty String id) {
-        checkPermission(ViewsRestPermissions.VIEW_DELETE, id);
         final ViewDTO dto = loadView(id);
+        if (!permissionChecks.ownsView(getCurrentUser(), dto)) {
+            checkPermission(ViewsRestPermissions.VIEW_DELETE, id);
+        }
         dbService.delete(id);
         removeUserPermissions(dto);
         triggerDeletedEvent(dto);

--- a/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewPermissionChecksTest.java
+++ b/graylog2-server/src/test/java/org/graylog/plugins/views/search/rest/ViewPermissionChecksTest.java
@@ -1,0 +1,161 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.plugins.views.search.rest;
+
+import org.graylog.plugins.views.search.views.ViewDTO;
+import org.graylog.plugins.views.search.views.sharing.IsViewSharedForUser;
+import org.graylog.plugins.views.search.views.sharing.ViewSharing;
+import org.graylog.plugins.views.search.views.sharing.ViewSharingService;
+import org.graylog2.plugin.database.users.User;
+import org.graylog2.shared.security.RestPermissions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.function.BiPredicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ViewPermissionChecksTest {
+    private ViewSharingService viewSharingService;
+    private IsViewSharedForUser isViewSharedForUser;
+    private ViewDTO view;
+    private User user;
+    private BiPredicate<String, String> notPermitted = (p, id) -> false;
+
+    private ViewPermissionChecks viewPermissionChecks;
+
+    @BeforeEach
+    void setUp() {
+        this.viewSharingService = mock(ViewSharingService.class);
+        this.isViewSharedForUser = mock(IsViewSharedForUser.class);
+        this.view = mock(ViewDTO.class);
+        this.user = mock(User.class);
+
+        this.viewPermissionChecks = new ViewPermissionChecks(viewSharingService, isViewSharedForUser);
+    }
+
+    @Test
+    void allowedToSeeSavedSearchReturnsTrueIfUserHasPermission() {
+        when(view.id()).thenReturn("view-id");
+        final BiPredicate<String, String> isPermitted = returnTrueFor(ViewsRestPermissions.VIEW_READ, "view-id");
+
+        final boolean result = this.viewPermissionChecks.allowedToSeeSavedSearch(user, view, isPermitted);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void allowedToSeeSavedSearchReturnsTrueIfUserIsOwner() {
+        when(view.id()).thenReturn("view-id");
+        when(view.owner()).thenReturn(Optional.of("hans-peter"));
+        when(user.getName()).thenReturn("hans-peter");
+
+        final boolean result = this.viewPermissionChecks.allowedToSeeSavedSearch(user, view, notPermitted);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void allowedToSeeSavedSearchReturnsTrueIfSharedWithUser() {
+        when(view.id()).thenReturn("view-id");
+        when(view.owner()).thenReturn(Optional.empty());
+        final ViewSharing viewSharing = mock(ViewSharing.class);
+        when(viewSharingService.forView("view-id")).thenReturn(Optional.of(viewSharing));
+        when(isViewSharedForUser.isAllowedToSee(user, viewSharing)).thenReturn(true);
+
+        final boolean result = this.viewPermissionChecks.allowedToSeeSavedSearch(user, view, notPermitted);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void allowedToSeeSavedSearchReturnsFalsePerDefault() {
+        assertThat(this.viewPermissionChecks.allowedToSeeSavedSearch(user, view, notPermitted)).isFalse();
+
+        when(view.id()).thenReturn("view-id");
+        when(user.getName()).thenReturn("frank");
+        when(view.owner()).thenReturn(Optional.of("hans-peter"));
+
+        assertThat(this.viewPermissionChecks.allowedToSeeSavedSearch(user, view, notPermitted)).isFalse();
+
+        final ViewSharing viewSharing = mock(ViewSharing.class);
+        when(viewSharingService.forView("view-id")).thenReturn(Optional.of(viewSharing));
+        when(isViewSharedForUser.isAllowedToSee(user, viewSharing)).thenReturn(false);
+
+        assertThat(this.viewPermissionChecks.allowedToSeeSavedSearch(user, view, notPermitted)).isFalse();
+    }
+
+    @Test
+    void allowedToSeeDashboardReturnsTrueIfUserHasPermission() {
+        when(view.id()).thenReturn("view-id");
+        final BiPredicate<String, String> isPermittedToSeeView = returnTrueFor(ViewsRestPermissions.VIEW_READ, "view-id");
+
+        assertThat(this.viewPermissionChecks.allowedToSeeDashboard(user, view, isPermittedToSeeView)).isTrue();
+
+        final BiPredicate<String, String> isPermittedToSeeDashboard = returnTrueFor(RestPermissions.DASHBOARDS_READ, "view-id");
+
+        assertThat(this.viewPermissionChecks.allowedToSeeDashboard(user, view, isPermittedToSeeDashboard)).isTrue();
+    }
+
+    @Test
+    void allowedToSeeDashboardReturnsTrueIfUserIsOwner() {
+        when(view.id()).thenReturn("view-id");
+        when(view.owner()).thenReturn(Optional.of("hans-peter"));
+        when(user.getName()).thenReturn("hans-peter");
+
+        final boolean result = this.viewPermissionChecks.allowedToSeeDashboard(user, view, notPermitted);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void allowedToSeeDashboardReturnsTrueIfSharedWithUser() {
+        when(view.id()).thenReturn("view-id");
+        when(view.owner()).thenReturn(Optional.empty());
+        final ViewSharing viewSharing = mock(ViewSharing.class);
+        when(viewSharingService.forView("view-id")).thenReturn(Optional.of(viewSharing));
+        when(isViewSharedForUser.isAllowedToSee(user, viewSharing)).thenReturn(true);
+
+        final boolean result = this.viewPermissionChecks.allowedToSeeDashboard(user, view, notPermitted);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void allowedToSeeDashboardReturnsFalsePerDefault() {
+        assertThat(this.viewPermissionChecks.allowedToSeeDashboard(user, view, notPermitted)).isFalse();
+
+        when(view.id()).thenReturn("view-id");
+        when(user.getName()).thenReturn("frank");
+        when(view.owner()).thenReturn(Optional.of("hans-peter"));
+
+        assertThat(this.viewPermissionChecks.allowedToSeeDashboard(user, view, notPermitted)).isFalse();
+
+        final ViewSharing viewSharing = mock(ViewSharing.class);
+        when(viewSharingService.forView("view-id")).thenReturn(Optional.of(viewSharing));
+        when(isViewSharedForUser.isAllowedToSee(user, viewSharing)).thenReturn(false);
+
+        assertThat(this.viewPermissionChecks.allowedToSeeDashboard(user, view, notPermitted)).isFalse();
+    }
+
+    private BiPredicate<String, String> returnTrueFor(String expectedPermission, String expectedId) {
+        return (permission, id) -> permission.equals(expectedPermission) && id.equals(expectedId);
+    }
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, the following checks were performed when a saved search/dashboard is listed/opened:

  - Does the user have permissions for the saved search/dashboard?
  - Is the saved search/dashboard shared with the user?

If one of them holds true, access is permitted. Although the object has an optional `owner` field, its presence and equality with the current user's name is not checked.

This did not cause any issues in general, because the permissions are added dynamically to the current user when a saved search/dashboard is created, so their was no reliance on the existence of an ownership check.

During the migration of legacy saved searches, their owner field was migrated too, but no permissions were added to this user. Therefore, migrated saved searches were visible only to the admin user, but not to the user creating them initially.

This change is now adding a check additionally to the previously existing ones, that checks for the presence of the `owner` field of a saved search/dashboard and compares it to the current user's name, permitting access if they are equal. This allows the users initially creating legacy saved searches seeing and accessing their migrated counterparts.

Fixes #9068.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.