### PR TITLE
Stop pivot config form submit event propagation.

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationbuilder/PivotConfiguration.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/PivotConfiguration.jsx
@@ -33,6 +33,7 @@ export default class PivotConfiguration extends React.Component {
 
   _onSubmit = (e) => {
     e.preventDefault();
+    e.stopPropagation();
     const { onClose } = this.props;
     onClose(this.state);
   };

--- a/graylog2-web-interface/src/views/components/aggregationbuilder/PivotConfiguration.test.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/PivotConfiguration.test.jsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+import { fireEvent } from '@testing-library/dom';
+import FieldType from 'views/logic/fieldtypes/FieldType';
+import PivotConfiguration from './PivotConfiguration';
+
+describe('PivotConfiguration', () => {
+  it('stops submit event propagation', () => {
+    const onSubmit = jest.fn((e) => e.persist());
+    render((
+      <div onSubmit={onSubmit}>
+        <PivotConfiguration type={FieldType.create('terms')} config={{ limit: 3 }} onClose={jest.fn()} />
+      </div>
+    ));
+
+    const done = screen.getByRole('button', 'Done');
+    fireEvent.click(done);
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, when configuring the settings for a row/column pivot in the widget edit mode, submitting the form resulted in a double submit. First, the pivot config form is submitted and its config is changed. Then, the same submit event is propagated to the overlying widget edit form (as defined in `SearchBarForm`). The `onSubmit` handler in there is submitting the current widget again, but with stale pivot config settings, resulting in a mismatching view/search constellation. This results then in search results not being resolvable, as the widget mapping is based on a stale search.

This change is now preventing the pivot config form submit event to be propagated, therefore limiting its effect to the initial submit only.

Fixes #9087.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.