### PR TITLE
Fix handling for health of empty indices in ES7.

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/indexer/cluster/ClusterIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/cluster/ClusterIT.java
@@ -104,6 +104,13 @@ public abstract class ClusterIT extends ElasticsearchBaseTest {
     }
 
     @Test
+    public void health_returns_green_with_no_indices() {
+        when(indexSetRegistry.getIndexWildcards()).thenReturn(new String[]{});
+        final Optional<HealthStatus> health = cluster.health();
+        assertThat(health).contains(HealthStatus.Green);
+    }
+
+    @Test
     public void deflectorHealth() {
         when(indexSetRegistry.getWriteIndexAliases()).thenReturn(new String[]{ALIAS_NAME});
         final Optional<HealthStatus> deflectorHealth = cluster.deflectorHealth();
@@ -117,6 +124,13 @@ public abstract class ClusterIT extends ElasticsearchBaseTest {
         when(indexSetRegistry.getWriteIndexAliases()).thenReturn(new String[]{"does_not_exist"});
         final Optional<HealthStatus> deflectorHealth = cluster.deflectorHealth();
         assertThat(deflectorHealth).isEmpty();
+    }
+
+    @Test
+    public void deflectorHealth_returns_green_with_empty_index() {
+        when(indexSetRegistry.getWriteIndexAliases()).thenReturn(new String[]{});
+        final Optional<HealthStatus> deflectorHealth = cluster.deflectorHealth();
+        assertThat(deflectorHealth).contains(HealthStatus.Green);
     }
 
     @Test
@@ -166,6 +180,13 @@ public abstract class ClusterIT extends ElasticsearchBaseTest {
         when(indexSetRegistry.getIndexWildcards()).thenReturn(new String[]{"does-not-exist"});
         when(indexSetRegistry.isUp()).thenReturn(true);
         assertThat(cluster.isHealthy()).isFalse();
+    }
+
+    @Test
+    public void isHealthy_returns_true_with_no_indices() {
+        when(indexSetRegistry.getIndexWildcards()).thenReturn(new String[]{});
+        when(indexSetRegistry.isUp()).thenReturn(true);
+        assertThat(cluster.isHealthy()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, the ES7 implementation of `ClusterAdapterES7#health` was inconsistent with the one for ES6. When an empty list was passed as an argument, an exception was thrown, instead of a valid response being returned. The method being called with an empty list can happen if it is called from `Cluster#health`, which retrieves all existing indices for an index set before using `Cluster#allIndexWildcards`, which returns an empty list if these have not been created yet. (E.g. as the consequence of a race condition when starting Graylog from scratch/with an empty ES). From what was seen during fixing this issue, the only relevant consequence is that `IndexRangesMigrationPeriodical` throws an exception and will be rerun during next startup. Usually, this is not an issue, as there are no index ranges to be migrated at this point anyway.

This change is now making the ES7 implementation of `ClusterAdapter#health` consistent with the one for ES6, by:
    
  - Returning `Optional.empty()` if the list of indices is not empty and not all of them exist.
  - Passing index options that do not return an error if none of the indices exist.
    
In addition, the read timeout is configured for the request just as in `ClusterAdapterES6#health`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.