### PR TITLE
Prevent unintended search bar form submit in widget edit modal

### DIFF
--- a/graylog2-web-interface/src/views/components/aggregationbuilder/DescriptionBox.jsx
+++ b/graylog2-web-interface/src/views/components/aggregationbuilder/DescriptionBox.jsx
@@ -71,6 +71,7 @@ class DescriptionBox extends React.Component {
     if (configurableOptions) {
       return (
         <ConfigButton ref={(node) => { this.target = node; }}
+                      type="button"
                       onClick={this.onToggleConfig}>
           <Icon name="wrench" />
         </ConfigButton>

--- a/graylog2-web-interface/src/views/components/common/EditableTitle.jsx
+++ b/graylog2-web-interface/src/views/components/common/EditableTitle.jsx
@@ -65,6 +65,7 @@ export default class EditableTitle extends React.Component<Props, State> {
 
   _onSubmit = (e: SyntheticInputEvent<HTMLInputElement>) => {
     e.preventDefault();
+    e.stopPropagation();
     this._toggleEditing();
     this._submitValue();
   };

--- a/graylog2-web-interface/src/views/components/common/EditableTitle.test.jsx
+++ b/graylog2-web-interface/src/views/components/common/EditableTitle.test.jsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { render, screen } from 'wrappedTestingLibrary';
+import { fireEvent } from '@testing-library/dom';
+import EditableTitle from './EditableTitle';
+
+describe('EditableTitle', () => {
+  it('stops submit event propagation', () => {
+    const onSubmit = jest.fn((e) => e.persist());
+    render((
+      <div onSubmit={onSubmit}>
+        <EditableTitle value="Current title" onChange={jest.fn()} />
+      </div>
+    ));
+
+    const currentTitle = screen.getByText('Current title');
+    fireEvent.dblClick(currentTitle);
+
+    const titleInput = screen.getByRole('textbox');
+    fireEvent.change(titleInput, { target: { value: 'New title' } });
+    fireEvent.submit(titleInput);
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/graylog2-web-interface/src/views/components/widgets/FieldSortIcon.jsx
+++ b/graylog2-web-interface/src/views/components/widgets/FieldSortIcon.jsx
@@ -92,6 +92,7 @@ const FieldSortIcon = ({ fieldName, config, onSortChange, setLoadingState }: Pro
   return (
     <SortIcon sortActive={sortActive}
               title={tooltip(fieldName)}
+              type="button"
               aria-label={tooltip(fieldName)}
               onClick={() => handleSortChange(changeSort)}
               data-testid="messages-sort-icon">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Before these changes there were a few cases were we unintentionally submitted the widget search bar form in the widget edit modal:
- Clicking on the sort icons of a message table
- Clicking on the columns config icon
- Editing the widget title

The form should only be submitted when clicking on the modal "Save" button

Related to https://github.com/Graylog2/graylog2-server/pull/9085 which contains a more detailed description about the on submit behaviour.

This fix also needs to be applied for the master branch.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

