### PR TITLE
Hide CSV Adapter in cloud instances

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/Configuration.java
+++ b/graylog2-server/src/main/java/org/graylog2/Configuration.java
@@ -201,6 +201,10 @@ public class Configuration extends BaseConfiguration {
         return outputBufferProcessorKeepAliveTime;
     }
 
+    public boolean isCloud() {
+        return isCloud;
+    }
+
     @Override
     public String getNodeIdFile() {
         return nodeIdFile;

--- a/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
+++ b/graylog2-server/src/main/java/org/graylog2/bindings/ServerBindings.java
@@ -114,7 +114,7 @@ public class ServerBindings extends Graylog2Module {
         install(new AuthenticatingRealmModule(configuration));
         bindSearchResponseDecorators();
         install(new GrokModule());
-        install(new LookupModule());
+        install(new LookupModule(configuration));
         install(new FieldTypesModule());
 
         // Just to create the binders so they are present in the injector. Prevents a server startup error when no

--- a/graylog2-server/src/main/java/org/graylog2/lookup/LookupModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/lookup/LookupModule.java
@@ -17,6 +17,7 @@
 package org.graylog2.lookup;
 
 import com.google.inject.Scopes;
+import org.graylog2.Configuration;
 import org.graylog2.lookup.adapters.CSVFileDataAdapter;
 import org.graylog2.lookup.adapters.DSVHTTPDataAdapter;
 import org.graylog2.lookup.adapters.DnsLookupDataAdapter;
@@ -28,6 +29,11 @@ import org.graylog2.system.urlwhitelist.UrlWhitelistNotificationService;
 import org.graylog2.system.urlwhitelist.UrlWhitelistService;
 
 public class LookupModule extends Graylog2Module {
+    private final Configuration configuration;
+
+    public LookupModule(Configuration configuration) {
+        this.configuration = configuration;
+    }
 
     @Override
     protected void configure() {
@@ -46,15 +52,17 @@ public class LookupModule extends Graylog2Module {
                 CaffeineLookupCache.Factory.class,
                 CaffeineLookupCache.Config.class);
 
-        installLookupDataAdapter(CSVFileDataAdapter.NAME,
-                CSVFileDataAdapter.class,
-                CSVFileDataAdapter.Factory.class,
-                CSVFileDataAdapter.Config.class);
+        if (!configuration.isCloud()) {
+            installLookupDataAdapter(CSVFileDataAdapter.NAME,
+                    CSVFileDataAdapter.class,
+                    CSVFileDataAdapter.Factory.class,
+                    CSVFileDataAdapter.Config.class);
+        }
 
         installLookupDataAdapter2(DnsLookupDataAdapter.NAME,
-                                 DnsLookupDataAdapter.class,
-                                 DnsLookupDataAdapter.Factory.class,
-                                 DnsLookupDataAdapter.Config.class);
+                DnsLookupDataAdapter.class,
+                DnsLookupDataAdapter.Factory.class,
+                DnsLookupDataAdapter.Config.class);
 
         installLookupDataAdapter2(HTTPJSONPathDataAdapter.NAME,
                 HTTPJSONPathDataAdapter.class,


### PR DESCRIPTION
Using CSV adapters in cloud will have different requirements, so this
plugin should not be available.

Fixes https://github.com/Graylog2/graylog-plugin-cloud/issues/437
