### PR TITLE
Store username in localStorage which gets returned by the backend on login

### DIFF
--- a/graylog2-web-interface/src/stores/sessions/SessionStore.js
+++ b/graylog2-web-interface/src/stores/sessions/SessionStore.js
@@ -27,7 +27,7 @@ const SessionStore = Reflux.createStore({
       .json({ username: username, password: password, host: host });
     const promise = builder.build()
       .then((sessionInfo) => {
-        return { sessionId: sessionInfo.session_id, username: username };
+        return { sessionId: sessionInfo.session_id, username: sessionInfo.username };
       });
 
     SessionActions.login.promise(promise);


### PR DESCRIPTION
## Description
## Motivation and Context
Currently the username entered in the login form is getting stored in the localStorage. This login username can be different than the actual username, which gets returned by the backend on login.
We need to store the username provided by the backend, otherwise we can't load the user if these usernames vary.
This is not a problem with the default setup, but it can be problematic when an authentication service is configured.

## How Has This Been Tested?
Tested with the system admin, normal users and users which are being provided by an LDAP server.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

