### PR TITLE
Fixing dialog shown when abandoning changes on current page.

### DIFF
--- a/graylog2-web-interface/src/components/common/ConfirmLeaveDialog.jsx
+++ b/graylog2-web-interface/src/components/common/ConfirmLeaveDialog.jsx
@@ -7,7 +7,7 @@ import AppConfig from 'util/AppConfig';
 /**
  * This component should be conditionally rendered if you have a form that is in a "dirty" state. It will confirm with the user that they want to navigate away, refresh, or in any way unload the component.
  */
-const ConfirmLeaveDialog = ({ question, router, route }) => {
+const ConfirmLeaveDialog = ({ question, router }) => {
   const handleLeavePage = (e) => {
     if (AppConfig.gl2DevMode()) {
       return null;
@@ -24,6 +24,8 @@ const ConfirmLeaveDialog = ({ question, router, route }) => {
 
   useEffect(() => {
     window.addEventListener('beforeunload', handleLeavePage);
+    const { routes } = router;
+    const route = routes[routes.length - 1];
     const unsubscribe = router.setRouteLeaveHook(route, routerWillLeave);
 
     return () => {
@@ -38,8 +40,6 @@ const ConfirmLeaveDialog = ({ question, router, route }) => {
 ConfirmLeaveDialog.propTypes = {
   /** Phrase used in the confirmation dialog. */
   question: PropTypes.string,
-  /** `route` object from withRouter() HOC */
-  route: PropTypes.object.isRequired,
   router: PropTypes.shape({
     setRouteLeaveHook: PropTypes.func.isRequired,
   }).isRequired,

--- a/graylog2-web-interface/src/components/common/ConfirmLeaveDialog.test.jsx
+++ b/graylog2-web-interface/src/components/common/ConfirmLeaveDialog.test.jsx
@@ -9,6 +9,7 @@ jest.mock('util/AppConfig');
 
 const mockRouter = () => ({
   setRouteLeaveHook: jest.fn(),
+  routes: [{ __id__: 42 }],
 });
 
 describe('ConfirmLeaveDialog', () => {
@@ -29,7 +30,7 @@ describe('ConfirmLeaveDialog', () => {
   it('registers window beforeunload handler', () => {
     const router = mockRouter();
 
-    mount(<ConfirmLeaveDialog route={{}} router={router} />);
+    mount(<ConfirmLeaveDialog router={router} />);
 
     expect(window.addEventListener).toHaveBeenCalledWith('beforeunload', expect.any(Function));
   });
@@ -40,7 +41,7 @@ describe('ConfirmLeaveDialog', () => {
 
     router.setRouteLeaveHook.mockReturnValue(unsubscribe);
 
-    const wrapper = mount(<ConfirmLeaveDialog route={{}} router={router} />);
+    const wrapper = mount(<ConfirmLeaveDialog router={router} />);
 
     wrapper.unmount();
 
@@ -50,7 +51,7 @@ describe('ConfirmLeaveDialog', () => {
   it('registers route leave handler', () => {
     const router = mockRouter();
 
-    mount(<ConfirmLeaveDialog route={{ __id__: 42 }} router={router} />);
+    mount(<ConfirmLeaveDialog router={router} />);
 
     expect(router.setRouteLeaveHook).toHaveBeenCalledTimes(1);
     expect(router.setRouteLeaveHook).toHaveBeenCalledWith({ __id__: 42 }, expect.any(Function));
@@ -62,7 +63,7 @@ describe('ConfirmLeaveDialog', () => {
 
     router.setRouteLeaveHook.mockReturnValue(unsubscribe);
 
-    const wrapper = mount(<ConfirmLeaveDialog route={{ __id__: 42 }} router={router} />);
+    const wrapper = mount(<ConfirmLeaveDialog router={router} />);
 
     wrapper.unmount();
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In #9118, a refactoring was performed that removes passing the current route as a prop to `ConfirmLeaveDialog`. It was erroneously assumed that `withRouter` also supplies the `route` object. This was effectively breaking the dialog that is shown in production when the current route is left (by using the navigation), the current browser tab is closed or reloaded.
    
This change is now retrieving the current route from the `router.routes` object (the current child route is the last object) and uses it to register the hook called when the current route is left.
    
In the future (with react-router v5), another refactoring is performed replacing the imperative logic from `ConfirmLeaveDialog` with the usage of the `Prompt` component.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.