### PR TITLE
Revert "Bump webpack-merge (#9111)"

### DIFF
--- a/graylog2-web-interface/packages/graylog-web-plugin/package.json
+++ b/graylog2-web-interface/packages/graylog-web-plugin/package.json
@@ -55,7 +55,7 @@
     "webpack": "4.44.2",
     "webpack-cleanup-plugin": "0.5.1",
     "webpack-cli": "4.0.0",
-    "webpack-merge": "5.2.0"
+    "webpack-merge": "4.2.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.0",


### PR DESCRIPTION
This reverts commit d0c5de9387f8d2e18cf0d7105150b8861aff8464.

The upgrade requires a bit more work due to breaking changes in 5.x.