### PR TITLE
Expose `isCloud` to frontend

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/web/resources/AppConfigResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/web/resources/AppConfigResource.java
@@ -68,7 +68,8 @@ public class AppConfigResource {
         final Map<String, Object> model = ImmutableMap.of(
             "rootTimeZone", configuration.getRootTimeZone(),
             "serverUri", baseUri.resolve(HttpConfiguration.PATH_API),
-            "appPathPrefix", baseUri.getPath());
+            "appPathPrefix", baseUri.getPath(),
+            "isCloud", configuration.isCloud());
         return templateEngine.transform(template, model);
     }
 }

--- a/graylog2-server/src/main/resources/web-interface/config.js.template
+++ b/graylog2-server/src/main/resources/web-interface/config.js.template
@@ -2,4 +2,5 @@ window.appConfig = {
   gl2ServerUrl: '${serverUri}',
   gl2AppPathPrefix: '${appPathPrefix}',
   rootTimeZone: '${rootTimeZone}',
+  isCloud: ${isCloud},
 };

--- a/graylog2-web-interface/config.js
+++ b/graylog2-web-interface/config.js
@@ -2,5 +2,5 @@ window.appConfig = {
   gl2ServerUrl: 'http://localhost:9000/api',
   gl2AppPathPrefix: '',
   rootTimeZone: 'Europe/Berlin',
-  isCloud: <%= htmlWebpackPlugin.options.isCloud %>,
+  isCloud: false,
 };

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -90,7 +90,7 @@ const Navigation = ({ permissions, fullName, location, loginName }) => {
 
         {
         AppConfig.gl2DevMode()
-          && <Badge bsStyle="danger" className="small-scrn-badge dev-badge">DEV</Badge>
+          && <Badge bsStyle="danger" className="small-scrn-badge dev-badge">{AppConfig.isCloud() ? 'CLOUD ' : ''} DEV</Badge>
         }
       </Navbar.Header>
 

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -90,7 +90,7 @@ const Navigation = ({ permissions, fullName, location, loginName }) => {
 
         {
         AppConfig.gl2DevMode()
-          && <Badge bsStyle="danger" className="small-scrn-badge dev-badge">{AppConfig.isCloud() ? 'CLOUD ' : ''} DEV</Badge>
+          && <Badge bsStyle="danger" className="small-scrn-badge dev-badge">{AppConfig.isCloud() ? 'CLOUD' : ''} DEV</Badge>
         }
       </Navbar.Header>
 
@@ -124,7 +124,7 @@ const Navigation = ({ permissions, fullName, location, loginName }) => {
           AppConfig.gl2DevMode()
             && (
               <InactiveNavItem className="dev-badge-wrap">
-                <Badge bsStyle="danger" className="dev-badge">{AppConfig.isCloud() ? 'CLOUD ' : ''} DEV</Badge>
+                <Badge bsStyle="danger" className="dev-badge">{AppConfig.isCloud() ? 'CLOUD ' : ''}DEV</Badge>
               </InactiveNavItem>
             )
           }

--- a/graylog2-web-interface/src/components/navigation/Navigation.jsx
+++ b/graylog2-web-interface/src/components/navigation/Navigation.jsx
@@ -124,7 +124,7 @@ const Navigation = ({ permissions, fullName, location, loginName }) => {
           AppConfig.gl2DevMode()
             && (
               <InactiveNavItem className="dev-badge-wrap">
-                <Badge bsStyle="danger" className="dev-badge">DEV</Badge>
+                <Badge bsStyle="danger" className="dev-badge">{AppConfig.isCloud() ? 'CLOUD ' : ''} DEV</Badge>
               </InactiveNavItem>
             )
           }

--- a/graylog2-web-interface/src/util/AppConfig.js
+++ b/graylog2-web-interface/src/util/AppConfig.js
@@ -30,6 +30,15 @@ const AppConfig = {
     return this.appConfig().rootTimeZone;
   },
 
+  isCloud() {
+    if (typeof (IS_CLOUD) !== 'undefined') {
+      // The IS_CLOUD variable will be set by webpack via the DefinePlugin.
+      // eslint-disable-next-line no-undef
+      return IS_CLOUD;
+    }
+    return this.appConfig.isCloud;
+  },
+
   appConfig() {
     return window.appConfig || {};
   },

--- a/graylog2-web-interface/src/util/AppConfig.js
+++ b/graylog2-web-interface/src/util/AppConfig.js
@@ -31,7 +31,7 @@ const AppConfig = {
   },
 
   isCloud() {
-    if (typeof (IS_CLOUD) !== 'undefined') {
+    if (typeof IS_CLOUD !== 'undefined') {
       // The IS_CLOUD variable will be set by webpack via the DefinePlugin.
       // eslint-disable-next-line no-undef
       return IS_CLOUD;

--- a/graylog2-web-interface/src/util/AppConfig.js
+++ b/graylog2-web-interface/src/util/AppConfig.js
@@ -36,7 +36,7 @@ const AppConfig = {
       // eslint-disable-next-line no-undef
       return IS_CLOUD;
     }
-    return this.appConfig.isCloud;
+    return this.appConfig().isCloud;
   },
 
   appConfig() {

--- a/graylog2-web-interface/templates/config.js.template
+++ b/graylog2-web-interface/templates/config.js.template
@@ -2,4 +2,5 @@ window.appConfig = {
   gl2ServerUrl: 'http://localhost:9000/api',
   gl2AppPathPrefix: '',
   rootTimeZone: 'Europe/Berlin',
+  isCloud: <%= htmlWebpackPlugin.options.isCloud %>,
 };

--- a/graylog2-web-interface/webpack.combined.config.js
+++ b/graylog2-web-interface/webpack.combined.config.js
@@ -16,7 +16,7 @@ const globOptions = {
   nodir: true,
 };
 
-const pluginConfigs = process.env.disable_plugins === 'true' ? [] : glob.sync(pluginConfigPattern, globOptions).map(config => `${globCwd}/${config}`);
+const pluginConfigs = process.env.disable_plugins === 'true' ? [] : glob.sync(pluginConfigPattern, globOptions).map((config) => `${globCwd}/${config}`);
 
 if (pluginConfigs.filter((config) => config.includes('graylog-plugin-cloud/server-plugin')).length > 0) {
   process.env.IS_CLOUD = true;
@@ -33,10 +33,9 @@ function getPluginName(pluginConfig) {
     // If a package.json file exists (should normally be the case) use the package name for pluginName
     const pkg = JSON.parse(fs.readFileSync(packageConfig, 'utf8'));
     return pkg.name.replace(/\s+/g, '');
-  } else {
-    // Otherwise just use the directory name of the webpack config file
-    return path.basename(path.dirname(pluginConfig));
   }
+  // Otherwise just use the directory name of the webpack config file
+  return path.basename(path.dirname(pluginConfig));
 }
 
 function isNotDependency(pluginConfig) {

--- a/graylog2-web-interface/webpack.combined.config.js
+++ b/graylog2-web-interface/webpack.combined.config.js
@@ -18,7 +18,7 @@ const globOptions = {
 
 const pluginConfigs = process.env.disable_plugins === 'true' ? [] : glob.sync(pluginConfigPattern, globOptions).map((config) => `${globCwd}/${config}`);
 
-if (pluginConfigs.filter((config) => config.includes('graylog-plugin-cloud/server-plugin')).length > 0) {
+if (pluginConfigs.some((config) => config.includes('graylog-plugin-cloud/server-plugin'))) {
   process.env.IS_CLOUD = true;
 }
 

--- a/graylog2-web-interface/webpack.combined.config.js
+++ b/graylog2-web-interface/webpack.combined.config.js
@@ -71,12 +71,4 @@ if (TARGET === 'start') {
   webpackConfig.entry = hmrEntries;
 }
 
-// If the cloud plugin is present, inject "isCloud = true" into the generated `config.js` file
-if (pluginConfigs.filter((config) => config.includes('graylog-plugin-cloud/server-plugin')).length > 0) {
-  const configJs = webpackConfig.plugins.find((plugin) => 'options' in plugin
-    && 'filename' in plugin.options
-    && plugin.options.filename === 'config.js');
-  configJs.options.isCloud = true;
-}
-
 module.exports = webpackConfig;

--- a/graylog2-web-interface/webpack.combined.config.js
+++ b/graylog2-web-interface/webpack.combined.config.js
@@ -18,7 +18,7 @@ const globOptions = {
 
 const pluginConfigs = process.env.disable_plugins === 'true' ? [] : glob.sync(pluginConfigPattern, globOptions).map(config => `${globCwd}/${config}`);
 
-if (pluginConfigs.filter(config => config.includes('graylog-plugin-cloud/server-plugin')).length > 0) {
+if (pluginConfigs.filter((config) => config.includes('graylog-plugin-cloud/server-plugin')).length > 0) {
   process.env.IS_CLOUD = true;
 }
 
@@ -69,6 +69,14 @@ if (TARGET === 'start') {
   });
 
   webpackConfig.entry = hmrEntries;
+}
+
+// If the cloud plugin is present, inject "isCloud = true" into the generated `config.js` file
+if (pluginConfigs.filter((config) => config.includes('graylog-plugin-cloud/server-plugin')).length > 0) {
+  const configJs = webpackConfig.plugins.find((plugin) => 'options' in plugin
+    && 'filename' in plugin.options
+    && plugin.options.filename === 'config.js');
+  configJs.options.isCloud = true;
 }
 
 module.exports = webpackConfig;

--- a/graylog2-web-interface/webpack.combined.config.js
+++ b/graylog2-web-interface/webpack.combined.config.js
@@ -18,6 +18,10 @@ const globOptions = {
 
 const pluginConfigs = process.env.disable_plugins === 'true' ? [] : glob.sync(pluginConfigPattern, globOptions).map(config => `${globCwd}/${config}`);
 
+if (pluginConfigs.filter(config => config.includes('graylog-plugin-cloud/server-plugin')).length > 0) {
+  process.env.IS_CLOUD = true;
+}
+
 process.env.web_src_path = path.resolve(__dirname);
 
 // eslint-disable-next-line import/no-dynamic-require

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -147,7 +147,7 @@ const webpackConfig = {
       filename: 'config.js',
       inject: false,
       template: path.resolve(ROOT_PATH, 'templates/config.js.template'),
-      isCloud: process.env.IS_CLOUD,
+      isCloud: false,
     }),
     new webpack.DefinePlugin({
       FEATURES: JSON.stringify(process.env.FEATURES),

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -143,12 +143,6 @@ const webpackConfig = {
       template: path.resolve(ROOT_PATH, 'templates/module.json.template'),
       excludeChunks: ['config'],
     }),
-    new HtmlWebpackPlugin({
-      filename: 'config.js',
-      inject: false,
-      template: path.resolve(ROOT_PATH, 'templates/config.js.template'),
-      isCloud: false,
-    }),
     new webpack.DefinePlugin({
       FEATURES: JSON.stringify(process.env.FEATURES),
     }),
@@ -170,7 +164,9 @@ if (TARGET === 'start') {
       new webpack.DefinePlugin({
         DEVELOPMENT: true,
         GRAYLOG_HTTP_PUBLISH_URI: JSON.stringify(process.env.GRAYLOG_HTTP_PUBLISH_URI),
+        IS_CLOUD: process.env.IS_CLOUD,
       }),
+      new CopyWebpackPlugin([{ from: 'config.js' }]),
       new webpack.HotModuleReplacementPlugin(),
     ],
   });

--- a/graylog2-web-interface/webpack.config.js
+++ b/graylog2-web-interface/webpack.config.js
@@ -143,6 +143,12 @@ const webpackConfig = {
       template: path.resolve(ROOT_PATH, 'templates/module.json.template'),
       excludeChunks: ['config'],
     }),
+    new HtmlWebpackPlugin({
+      filename: 'config.js',
+      inject: false,
+      template: path.resolve(ROOT_PATH, 'templates/config.js.template'),
+      isCloud: process.env.IS_CLOUD,
+    }),
     new webpack.DefinePlugin({
       FEATURES: JSON.stringify(process.env.FEATURES),
     }),
@@ -165,7 +171,6 @@ if (TARGET === 'start') {
         DEVELOPMENT: true,
         GRAYLOG_HTTP_PUBLISH_URI: JSON.stringify(process.env.GRAYLOG_HTTP_PUBLISH_URI),
       }),
-      new CopyWebpackPlugin([{ from: 'config.js' }]),
       new webpack.HotModuleReplacementPlugin(),
     ],
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Exposes an `isCloud` flag via `config.js`.

When running in production mode, the flag is mirroring the `is_cloud` server configuration parameter which is by default `false` and has to be enabled explicitly.

When running in development mode (`env DEVELOPMENT=true`), the flag is `false` by default but will be automatically set to `true` when the cloud plugin is present.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When running in a cloud context, certain UI elements need to be different than for an on-premise deployment. With this flag exposed, the UI has an easy way to know about the context.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
To see if this works in development mode I altered the `DEV` badge we show in the header. If the cloud context is detected, it now looks like this:
![image](https://user-images.githubusercontent.com/886541/96130659-86223880-0ef8-11eb-9e4a-18b7436bb149.png)

Checked that this works also in the production build by temporarily adding `console.log` debugging statements and building with maven.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.