### PR TITLE
Prevent devision by 0 if PaginatedList pageSize prop is 0

### DIFF
--- a/graylog2-web-interface/src/components/common/PaginatedList.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.jsx
@@ -41,7 +41,7 @@ const PaginatedList = ({
   const initialPage = activePage > 0 ? activePage : INITIAL_PAGE;
   const [pageSize, setPageSize] = useState(propsPageSize);
   const [currentPage, setCurrentPage] = useState(initialPage);
-  const numberPages = Math.ceil(totalItems / pageSize);
+  const numberPages = pageSize > 0 ? Math.ceil(totalItems / pageSize) : 0;
 
   useEffect(() => {
     if (activePage > 0) {

--- a/graylog2-web-interface/src/components/common/PaginatedList.test.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedList.test.jsx
@@ -14,6 +14,12 @@ describe('PaginatedList', () => {
     expect(getByText('1')).not.toBeNull();
   });
 
+  it('should not dived by 0 if pageSize is 0 Pagination', () => {
+    const { getByText } = render(<PaginatedList totalItems={100} pageSize={0} onChange={() => {}}>The list</PaginatedList>);
+
+    expect(getByText('The list')).not.toBeNull();
+  });
+
   it('should not display Pagination, when context is not interactive', () => {
     const { queryByText } = render(
       <InteractiveContext.Provider value={false}>


### PR DESCRIPTION
## Motivation
Prior to this change, the PaginatedList would use pageSize to caluclate
the amount of pages to show by deviding totalItems by pageSize.
But the code did not check if pageSize is 0 which leads to an NaN.

## Description
This change will check if pageSize is 0.

Fixes #9163 
