### PR TITLE
Declare custom ES image as compatible w/ testcontainers.

### DIFF
--- a/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchInstance.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/elasticsearch/ElasticsearchInstance.java
@@ -22,6 +22,7 @@ import org.junit.rules.ExternalResource;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import java.net.URL;
 import java.nio.file.Paths;
@@ -72,7 +73,7 @@ public abstract class ElasticsearchInstance extends ExternalResource {
     }
 
     private ElasticsearchContainer buildContainer(String image, Network network) {
-        return new ElasticsearchContainer(image)
+        return new ElasticsearchContainer(DockerImageName.parse(image).asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch"))
                 .withReuse(true)
                 .withEnv("ES_JAVA_OPTS", "-Xms2g -Xmx2g")
                 .withEnv("discovery.type", "single-node")


### PR DESCRIPTION
Starting with testcontainers v1.15.0-rc2, it expects specific images compatible with their Elasticsearch container support to be used with it. Therefore we need to declare the OSS image we are using for integration tests to be compatible.