### PR TITLE
Correct typo on SystemAdminOverview page

### DIFF
--- a/graylog2-web-interface/src/components/users/UsersOverview/SystemAdministratorOverview.jsx
+++ b/graylog2-web-interface/src/components/users/UsersOverview/SystemAdministratorOverview.jsx
@@ -17,7 +17,7 @@ const SystemAdministratorOverview = ({ adminUser, dataRowFormatter, headers, hea
     <Col xs={12}>
       <h2>System Administrator</h2>
       <p className="description">
-        The system administrator can only be edit in the graylog configuration file.
+        The system administrator can only be edited in the graylog configuration file.
       </p>
       <DataTable id="users-overview"
                  className="table-hover"


### PR DESCRIPTION
correct typo `can only be edit` -> `can only be edited`


