### PR TITLE
changed method to a public modifier

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationTestData.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/NotificationTestData.java
@@ -31,16 +31,16 @@ import org.graylog2.plugin.rest.ValidationResult;
 import org.graylog2.plugin.streams.Stream;
 
 public class NotificationTestData {
-    public static final String TEST_NOTIFICATION_ID = "this-is-a-test-notification";
+    public static final String TEST_NOTIFICATION_ID = "NotificationTestId";
 
-    static EventNotificationContext getDummyContext(NotificationDto notificationDto, String userName) {
+    public static EventNotificationContext getDummyContext(NotificationDto notificationDto, String userName) {
         final EventDto eventDto = EventDto.builder()
                 .alert(true)
                 .eventDefinitionId("EventDefinitionTestId")
                 .eventDefinitionType("notification-test-v1")
                 .eventTimestamp(Tools.nowUTC())
                 .processingTimestamp(Tools.nowUTC())
-                .id("NotificationTestId")
+                .id("TEST_NOTIFICATION_ID")
                 .streams(ImmutableSet.of(Stream.DEFAULT_EVENTS_STREAM_ID))
                 .message("Notification test message triggered from user <" + userName + ">")
                 .source(Stream.DEFAULT_STREAM_ID)


### PR DESCRIPTION
I need the method modifier of `getDummyContext` to be made public so that I can access the method in my test classes for SlackPlugin. (eg:-`SlackEventNotificationTest.java`  )

## Description
-same as above

## Motivation and Context
it avoids duplicating the creation of test objects in many test classes.

## How Has This Been Tested?
I have run the unit test in SlackClientTest.java and is green. This is in branch `slack_plugin_v001`

## Screenshots (if appropriate):
![slackclienttest](https://user-images.githubusercontent.com/6947168/96139815-d4b5df80-0ec4-11eb-90a1-311b9f25c42c.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

