### PR TITLE
Fix message id field alias migration for non-existing indices.

### DIFF
--- a/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/migrations/V20200730000000_AddGl2MessageIdFieldAliasForEventsES7.java
+++ b/graylog-storage-elasticsearch7/src/main/java/org/graylog/storage/elasticsearch7/views/migrations/V20200730000000_AddGl2MessageIdFieldAliasForEventsES7.java
@@ -2,14 +2,13 @@ package org.graylog.storage.elasticsearch7.views.migrations;
 
 import com.google.common.collect.ImmutableMap;
 import org.graylog.plugins.views.migrations.V20200730000000_AddGl2MessageIdFieldAliasForEvents;
+import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.support.IndicesOptions;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RequestOptions;
-import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.RestHighLevelClient;
 import org.graylog.shaded.elasticsearch7.org.elasticsearch.client.indices.PutMappingRequest;
+import org.graylog.storage.elasticsearch7.ElasticsearchClient;
 import org.graylog2.indexer.ElasticsearchException;
 
 import javax.inject.Inject;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Set;
@@ -18,10 +17,10 @@ import static org.graylog2.plugin.Message.FIELD_GL2_MESSAGE_ID;
 
 public class V20200730000000_AddGl2MessageIdFieldAliasForEventsES7 implements V20200730000000_AddGl2MessageIdFieldAliasForEvents.ElasticsearchAdapter {
 
-    private final RestHighLevelClient client;
+    private final ElasticsearchClient client;
 
     @Inject
-    public V20200730000000_AddGl2MessageIdFieldAliasForEventsES7(RestHighLevelClient client) {
+    public V20200730000000_AddGl2MessageIdFieldAliasForEventsES7(ElasticsearchClient client) {
         this.client = client;
     }
 
@@ -31,14 +30,15 @@ public class V20200730000000_AddGl2MessageIdFieldAliasForEventsES7 implements V2
         final String[] prefixesWithWildcard = indexPrefixes.stream().map(p -> p + "*").toArray(String[]::new);
 
         final PutMappingRequest putMappingRequest = new PutMappingRequest(prefixesWithWildcard)
+                .indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED)
                 .source(ImmutableMap.of("properties", ImmutableMap.of(FIELD_GL2_MESSAGE_ID, aliasMapping())));
 
         try {
-            final AcknowledgedResponse acknowledgedResponse = client.indices().putMapping(putMappingRequest, RequestOptions.DEFAULT);
+            final AcknowledgedResponse acknowledgedResponse = client.execute((c, requestOptions) -> c.indices().putMapping(putMappingRequest, requestOptions));
             if (!acknowledgedResponse.isAcknowledged()) {
                 throw new ElasticsearchException(errorMsgFor(prefixesWithWildcard) + " Elasticsearch failed to acknowledge.");
             }
-        } catch (IOException e) {
+        } catch (ElasticsearchException e) {
             throw new ElasticsearchException(errorMsgFor(prefixesWithWildcard), e);
         }
     }

--- a/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/migrations/V20200730000000_AddGl2MessageIdFieldAliasForEventsES7IT.java
+++ b/graylog-storage-elasticsearch7/src/test/java/org/graylog/storage/elasticsearch7/views/migrations/V20200730000000_AddGl2MessageIdFieldAliasForEventsES7IT.java
@@ -35,7 +35,7 @@ public class V20200730000000_AddGl2MessageIdFieldAliasForEventsES7IT extends Ela
 
     @Before
     public void setUp() {
-        sut = new V20200730000000_AddGl2MessageIdFieldAliasForEventsES7(elasticsearch.restHighLevelClient());
+        sut = new V20200730000000_AddGl2MessageIdFieldAliasForEventsES7(elasticsearch.elasticsearchClient());
     }
 
     @Test


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to this change, the migration which adds a field alias for pre-existing indices failed if no indices at all existed before.

This change is changing the indices options of the request to ignore unavailable indices or having no indices at all.

Fixes #9148.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.