### PR TITLE
Add GranteeService.getVisibleUsers()

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/shares/DefaultGranteeService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/DefaultGranteeService.java
@@ -18,20 +18,25 @@ package org.graylog.security.shares;
 
 import com.google.common.collect.ImmutableSet;
 import org.graylog.grn.GRNRegistry;
+import org.graylog.security.GranteeAuthorizer;
 import org.graylog.security.shares.EntityShareResponse.AvailableGrantee;
 import org.graylog2.plugin.database.users.User;
+import org.graylog2.shared.security.RestPermissions;
 import org.graylog2.shared.users.UserService;
 
 import javax.inject.Inject;
+import java.util.Set;
 
 public class DefaultGranteeService implements GranteeService {
-    private final UserService userService;
+    protected final UserService userService;
     protected final GRNRegistry grnRegistry;
+    protected final GranteeAuthorizer.Factory granteeAuthorizerFactory;
 
     @Inject
-    public DefaultGranteeService(UserService userService, GRNRegistry grnRegistry) {
+    public DefaultGranteeService(UserService userService, GRNRegistry grnRegistry, GranteeAuthorizer.Factory granteeAuthorizerFactory) {
         this.userService = userService;
         this.grnRegistry = grnRegistry;
+        this.granteeAuthorizerFactory = granteeAuthorizerFactory;
     }
 
     @Override
@@ -42,10 +47,21 @@ public class DefaultGranteeService implements GranteeService {
                 .build();
     }
 
+    @Override
+    public Set<User> getVisibleUsers(User requestingUser) {
+        final GranteeAuthorizer userAuthorizer = granteeAuthorizerFactory.create(requestingUser);
+
+        if (userAuthorizer.isPermitted(RestPermissions.USERS_LIST)) {
+            return userService.loadAll().stream().collect(ImmutableSet.toImmutableSet());
+        } else {
+            return userService.loadAll().stream()
+                    .filter(u -> userAuthorizer.isPermitted(RestPermissions.USERS_VIEW, u.getId()))
+                    .collect(ImmutableSet.toImmutableSet());
+        }
+    }
+
     private ImmutableSet<AvailableGrantee> getAvailableUserGrantees(User sharingUser) {
-        // TODO: We can only expose users that are in the same teams as the sharing user by default. There should
-        //       also be a global config setting to allow exposing all existing users in the system.
-        return userService.loadAll().stream()
+        return getVisibleUsers(sharingUser).stream()
                 // Don't return the sharing user in available grantees until we want to support that sharing users
                 // can remove themselves from an entity.
                 .filter(user -> !sharingUser.getId().equals(user.getId()))

--- a/graylog2-server/src/main/java/org/graylog/security/shares/DefaultGranteeService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/DefaultGranteeService.java
@@ -55,7 +55,7 @@ public class DefaultGranteeService implements GranteeService {
             return userService.loadAll().stream().collect(ImmutableSet.toImmutableSet());
         } else {
             return userService.loadAll().stream()
-                    .filter(u -> userAuthorizer.isPermitted(RestPermissions.USERS_READ, u.getId()))
+                    .filter(u -> userAuthorizer.isPermitted(RestPermissions.USERS_READ, u.getName()))
                     .collect(ImmutableSet.toImmutableSet());
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/security/shares/DefaultGranteeService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/DefaultGranteeService.java
@@ -55,7 +55,7 @@ public class DefaultGranteeService implements GranteeService {
             return userService.loadAll().stream().collect(ImmutableSet.toImmutableSet());
         } else {
             return userService.loadAll().stream()
-                    .filter(u -> userAuthorizer.isPermitted(RestPermissions.USERS_VIEW, u.getId()))
+                    .filter(u -> userAuthorizer.isPermitted(RestPermissions.USERS_READ, u.getId()))
                     .collect(ImmutableSet.toImmutableSet());
         }
     }

--- a/graylog2-server/src/main/java/org/graylog/security/shares/GranteeService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/shares/GranteeService.java
@@ -23,4 +23,6 @@ import java.util.Set;
 
 public interface GranteeService {
     Set<AvailableGrantee> getAvailableGrantees(User sharingUser);
+
+    Set<User> getVisibleUsers(User requestingUser);
 }

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
@@ -146,6 +146,7 @@ public class RestPermissions implements PluginPermissions {
     public static final String URL_WHITELIST_WRITE = "urlwhitelist:write";
     public static final String USERS_CREATE = "users:create";
     public static final String USERS_EDIT = "users:edit";
+    public static final String USERS_VIEW = "users:view";
     public static final String USERS_LIST = "users:list";
     public static final String USERS_PASSWORDCHANGE = "users:passwordchange";
     public static final String USERS_PERMISSIONSEDIT = "users:permissionsedit";
@@ -272,6 +273,7 @@ public class RestPermissions implements PluginPermissions {
             .add(create(URL_WHITELIST_WRITE, ""))
             .add(create(USERS_CREATE, ""))
             .add(create(USERS_EDIT, ""))
+            .add(create(USERS_VIEW, ""))
             .add(create(USERS_LIST, ""))
             .add(create(USERS_PASSWORDCHANGE, ""))
             .add(create(USERS_PERMISSIONSEDIT, ""))
@@ -312,6 +314,9 @@ public class RestPermissions implements PluginPermissions {
             )),
             BuiltinRole.create("Event Notification Creator", "Allows creation of Event Notifications (built-in)", ImmutableSet.of(
                     RestPermissions.EVENT_NOTIFICATIONS_CREATE
+            )),
+            BuiltinRole.create("User Inspector", "Allows listing all user accounts (built-in)", ImmutableSet.of(
+                    RestPermissions.USERS_LIST
             ))
     ).build();
 

--- a/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/RestPermissions.java
@@ -146,7 +146,7 @@ public class RestPermissions implements PluginPermissions {
     public static final String URL_WHITELIST_WRITE = "urlwhitelist:write";
     public static final String USERS_CREATE = "users:create";
     public static final String USERS_EDIT = "users:edit";
-    public static final String USERS_VIEW = "users:view";
+    public static final String USERS_READ = "users:read";
     public static final String USERS_LIST = "users:list";
     public static final String USERS_PASSWORDCHANGE = "users:passwordchange";
     public static final String USERS_PERMISSIONSEDIT = "users:permissionsedit";
@@ -273,7 +273,7 @@ public class RestPermissions implements PluginPermissions {
             .add(create(URL_WHITELIST_WRITE, ""))
             .add(create(USERS_CREATE, ""))
             .add(create(USERS_EDIT, ""))
-            .add(create(USERS_VIEW, ""))
+            .add(create(USERS_READ, ""))
             .add(create(USERS_LIST, ""))
             .add(create(USERS_PASSWORDCHANGE, ""))
             .add(create(USERS_PERMISSIONSEDIT, ""))
@@ -316,7 +316,7 @@ public class RestPermissions implements PluginPermissions {
                     RestPermissions.EVENT_NOTIFICATIONS_CREATE
             )),
             BuiltinRole.create("User Inspector", "Allows listing all user accounts (built-in)", ImmutableSet.of(
-                    RestPermissions.USERS_LIST
+                    RestPermissions.USERS_READ
             ))
     ).build();
 

--- a/graylog2-server/src/test/java/org/graylog/testing/TestUserService.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/TestUserService.java
@@ -46,7 +46,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-// An incomplete UserService implementation, that needs fewer dependencies
+/**
+ * Provides an incomplete UserService implementation for tests.
+ * It uses fewer dependencies than a full UserServiceImpl
+ */
 public class TestUserService extends PersistedServiceImpl implements UserService {
     final UserImpl.Factory userFactory;
 

--- a/graylog2-server/src/test/java/org/graylog/testing/TestUserService.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/TestUserService.java
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.graylog2.migrations.V20200803120800_GrantsMigrations;
+package org.graylog.testing;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -50,7 +50,7 @@ import java.util.Set;
 public class TestUserService extends PersistedServiceImpl implements UserService {
     final UserImpl.Factory userFactory;
 
-    protected TestUserService(MongoConnection mongoConnection) {
+    public TestUserService(MongoConnection mongoConnection) {
         super(mongoConnection);
         final Permissions permissions = new Permissions(ImmutableSet.of(new RestPermissions()));
         userFactory = new UserServiceImplTest.UserImplFactory(new Configuration(), permissions);
@@ -59,7 +59,12 @@ public class TestUserService extends PersistedServiceImpl implements UserService
     @Override
     @Nullable
     public User loadById(String id) {
-        return null;
+        final DBObject userObject = get(UserImpl.class, id);
+        if (userObject == null) {
+            return null;
+        }
+        final Object userId = userObject.get("_id");
+        return userFactory.create((ObjectId) userId, userObject.toMap());
     }
 
     @Nullable
@@ -91,12 +96,12 @@ public class TestUserService extends PersistedServiceImpl implements UserService
 
     @Override
     public int delete(String username) {
-        return 0;
+        throw new UnsupportedOperationException("Not implemented");
     }
 
     @Override
     public User create() {
-        return null;
+        throw new UnsupportedOperationException("Not implemented");
     }
 
     @Override
@@ -114,22 +119,22 @@ public class TestUserService extends PersistedServiceImpl implements UserService
 
     @Override
     public User getAdminUser() {
-        return null;
+        throw new UnsupportedOperationException("Not implemented");
     }
 
     @Override
     public Optional<User> getRootUser() {
-        return Optional.empty();
+        throw new UnsupportedOperationException("Not implemented");
     }
 
     @Override
     public long count() {
-        return 0;
+        throw new UnsupportedOperationException("Not implemented");
     }
 
     @Override
     public List<User> loadAllForAuthServiceBackend(String authServiceBackendId) {
-        return Collections.emptyList();
+        throw new UnsupportedOperationException("Not implemented");
     }
 
     @Override
@@ -151,27 +156,27 @@ public class TestUserService extends PersistedServiceImpl implements UserService
 
     @Override
     public Set<String> getRoleNames(User user) {
-        return null;
+        throw new UnsupportedOperationException("Not implemented");
     }
 
     @Override
     public List<Permission> getPermissionsForUser(User user) {
-        return null;
+        throw new UnsupportedOperationException("Not implemented");
     }
 
     @Override
     public List<WildcardPermission> getWildcardPermissionsForUser(User user) {
-        return null;
+        throw new UnsupportedOperationException("Not implemented");
     }
 
     @Override
     public List<GRNPermission> getGRNPermissionsForUser(User user) {
-        return null;
+        throw new UnsupportedOperationException("Not implemented");
     }
 
     @Override
     public Set<String> getUserPermissionsFromRoles(User user) {
-        return null;
+        throw new UnsupportedOperationException("Not implemented");
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog/testing/TestUserServiceExtension.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/TestUserServiceExtension.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
-public class UserServiceExtension implements ParameterResolver {
+public class TestUserServiceExtension implements ParameterResolver {
     @Override
     public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
         return Objects.equals(TestUserService.class, parameterContext.getParameter().getType());

--- a/graylog2-server/src/test/java/org/graylog/testing/UserServiceExtension.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/UserServiceExtension.java
@@ -1,0 +1,48 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog.testing;
+
+import org.graylog.testing.mongodb.MongoDBExtension;
+import org.graylog.testing.mongodb.MongoDBTestService;
+import org.graylog2.shared.users.UserService;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class UserServiceExtension implements ParameterResolver {
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        return Objects.equals(UserService.class, parameterContext.getParameter().getType());
+    }
+
+    @Override
+    public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        final Class<?> parameterType = parameterContext.getParameter().getType();
+
+        if (UserService.class.equals(parameterType)) {
+            final MongoDBTestService dbTestService = requireNonNull((MongoDBTestService) extensionContext.getStore(MongoDBExtension.NAMESPACE).get(MongoDBTestService.class));
+            return new TestUserService(dbTestService.mongoConnection());
+        }
+
+        throw new ParameterResolutionException("Unsupported parameter type: " + parameterContext.getParameter().getName());
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog/testing/UserServiceExtension.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/UserServiceExtension.java
@@ -18,7 +18,6 @@ package org.graylog.testing;
 
 import org.graylog.testing.mongodb.MongoDBExtension;
 import org.graylog.testing.mongodb.MongoDBTestService;
-import org.graylog2.shared.users.UserService;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
@@ -31,14 +30,14 @@ import static java.util.Objects.requireNonNull;
 public class UserServiceExtension implements ParameterResolver {
     @Override
     public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
-        return Objects.equals(UserService.class, parameterContext.getParameter().getType());
+        return Objects.equals(TestUserService.class, parameterContext.getParameter().getType());
     }
 
     @Override
     public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
         final Class<?> parameterType = parameterContext.getParameter().getType();
 
-        if (UserService.class.equals(parameterType)) {
+        if (TestUserService.class.equals(parameterType)) {
             final MongoDBTestService dbTestService = requireNonNull((MongoDBTestService) extensionContext.getStore(MongoDBExtension.NAMESPACE).get(MongoDBTestService.class));
             return new TestUserService(dbTestService.mongoConnection());
         }

--- a/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBExtension.java
+++ b/graylog2-server/src/test/java/org/graylog/testing/mongodb/MongoDBExtension.java
@@ -57,7 +57,7 @@ public class MongoDBExtension implements BeforeAllCallback, AfterAllCallback, Be
     }
 
     private static final Logger LOG = LoggerFactory.getLogger(MongoDBExtension.class);
-    private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(MongoDBExtension.class);
+    public static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(MongoDBExtension.class);
 
     /**
      * Create new extension instance using the {@link MongoDBTestService#DEFAULT_VERSION default version}.

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/RolesToGrantsMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/RolesToGrantsMigrationTest.java
@@ -24,7 +24,7 @@ import org.graylog.security.DBGrantService;
 import org.graylog.security.GrantDTO;
 import org.graylog.testing.GRNExtension;
 import org.graylog.testing.TestUserService;
-import org.graylog.testing.UserServiceExtension;
+import org.graylog.testing.TestUserServiceExtension;
 import org.graylog.testing.mongodb.MongoDBExtension;
 import org.graylog.testing.mongodb.MongoDBFixtures;
 import org.graylog.testing.mongodb.MongoDBTestService;
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MongoJackExtension.class)
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(GRNExtension.class)
-@ExtendWith(UserServiceExtension.class)
+@ExtendWith(TestUserServiceExtension.class)
 @MongoDBFixtures("V20200803120800_MigrateRolesToGrantsTest.json")
 class RolesToGrantsMigrationTest {
     private RolesToGrantsMigration migration;

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/RolesToGrantsMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/RolesToGrantsMigrationTest.java
@@ -23,6 +23,7 @@ import org.graylog.security.Capability;
 import org.graylog.security.DBGrantService;
 import org.graylog.security.GrantDTO;
 import org.graylog.testing.GRNExtension;
+import org.graylog.testing.TestUserService;
 import org.graylog.testing.UserServiceExtension;
 import org.graylog.testing.mongodb.MongoDBExtension;
 import org.graylog.testing.mongodb.MongoDBFixtures;
@@ -73,7 +74,7 @@ class RolesToGrantsMigrationTest {
     void setUp(MongoDBTestService mongodb,
                MongoJackObjectMapperProvider mongoJackObjectMapperProvider,
                GRNRegistry grnRegistry,
-               UserService userService) {
+               TestUserService userService) {
         when(permissions.readerBasePermissions()).thenReturn(ImmutableSet.of());
         when(validator.validate(any())).thenReturn(ImmutableSet.of());
 

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/RolesToGrantsMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/RolesToGrantsMigrationTest.java
@@ -23,6 +23,7 @@ import org.graylog.security.Capability;
 import org.graylog.security.DBGrantService;
 import org.graylog.security.GrantDTO;
 import org.graylog.testing.GRNExtension;
+import org.graylog.testing.UserServiceExtension;
 import org.graylog.testing.mongodb.MongoDBExtension;
 import org.graylog.testing.mongodb.MongoDBFixtures;
 import org.graylog.testing.mongodb.MongoDBTestService;
@@ -52,6 +53,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MongoJackExtension.class)
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(GRNExtension.class)
+@ExtendWith(UserServiceExtension.class)
 @MongoDBFixtures("V20200803120800_MigrateRolesToGrantsTest.json")
 class RolesToGrantsMigrationTest {
     private RolesToGrantsMigration migration;
@@ -70,7 +72,8 @@ class RolesToGrantsMigrationTest {
     @BeforeEach
     void setUp(MongoDBTestService mongodb,
                MongoJackObjectMapperProvider mongoJackObjectMapperProvider,
-               GRNRegistry grnRegistry) {
+               GRNRegistry grnRegistry,
+               UserService userService) {
         when(permissions.readerBasePermissions()).thenReturn(ImmutableSet.of());
         when(validator.validate(any())).thenReturn(ImmutableSet.of());
 
@@ -79,7 +82,7 @@ class RolesToGrantsMigrationTest {
         roleService = new RoleServiceImpl(mongodb.mongoConnection(), mongoJackObjectMapperProvider, permissions, validator);
 
         dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry);
-        userService = new TestUserService(mongodb.mongoConnection());
+        this.userService = userService;
         DBGrantService dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry);
         migration = new RolesToGrantsMigration(roleService, userService, dbGrantService, grnRegistry, "admin");
     }

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/UserPermissionsToGrantsMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/UserPermissionsToGrantsMigrationTest.java
@@ -22,6 +22,7 @@ import org.graylog.security.Capability;
 import org.graylog.security.DBGrantService;
 import org.graylog.security.GrantDTO;
 import org.graylog.testing.GRNExtension;
+import org.graylog.testing.TestUserService;
 import org.graylog.testing.UserServiceExtension;
 import org.graylog.testing.mongodb.MongoDBExtension;
 import org.graylog.testing.mongodb.MongoDBFixtures;
@@ -68,7 +69,7 @@ class UserPermissionsToGrantsMigrationTest {
     void setUp(MongoDBTestService mongodb,
                MongoJackObjectMapperProvider mongoJackObjectMapperProvider,
                GRNRegistry grnRegistry,
-               UserService userService) {
+               TestUserService userService) {
 
         this.grnRegistry = grnRegistry;
 

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/UserPermissionsToGrantsMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/UserPermissionsToGrantsMigrationTest.java
@@ -22,6 +22,7 @@ import org.graylog.security.Capability;
 import org.graylog.security.DBGrantService;
 import org.graylog.security.GrantDTO;
 import org.graylog.testing.GRNExtension;
+import org.graylog.testing.UserServiceExtension;
 import org.graylog.testing.mongodb.MongoDBExtension;
 import org.graylog.testing.mongodb.MongoDBFixtures;
 import org.graylog.testing.mongodb.MongoDBTestService;
@@ -46,6 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(MongoJackExtension.class)
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(GRNExtension.class)
+@ExtendWith(UserServiceExtension.class)
 @MongoDBFixtures("MigrateUserPermissionsToGrantsTest.json")
 class UserPermissionsToGrantsMigrationTest {
     private UserPermissionsToGrantsMigration migration;
@@ -65,14 +67,15 @@ class UserPermissionsToGrantsMigrationTest {
     @BeforeEach
     void setUp(MongoDBTestService mongodb,
                MongoJackObjectMapperProvider mongoJackObjectMapperProvider,
-               GRNRegistry grnRegistry) {
+               GRNRegistry grnRegistry,
+               UserService userService) {
 
         this.grnRegistry = grnRegistry;
 
         this.userSelfEditPermissionCount = new Permissions(ImmutableSet.of()).userSelfEditPermissions("dummy").size();
 
         dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry);
-        userService = new TestUserService(mongodb.mongoConnection());
+        this.userService = userService;
         DBGrantService dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry);
         migration = new UserPermissionsToGrantsMigration(userService, dbGrantService, grnRegistry, "admin");
     }

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/UserPermissionsToGrantsMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/UserPermissionsToGrantsMigrationTest.java
@@ -23,7 +23,7 @@ import org.graylog.security.DBGrantService;
 import org.graylog.security.GrantDTO;
 import org.graylog.testing.GRNExtension;
 import org.graylog.testing.TestUserService;
-import org.graylog.testing.UserServiceExtension;
+import org.graylog.testing.TestUserServiceExtension;
 import org.graylog.testing.mongodb.MongoDBExtension;
 import org.graylog.testing.mongodb.MongoDBFixtures;
 import org.graylog.testing.mongodb.MongoDBTestService;
@@ -48,7 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ExtendWith(MongoJackExtension.class)
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(GRNExtension.class)
-@ExtendWith(UserServiceExtension.class)
+@ExtendWith(TestUserServiceExtension.class)
 @MongoDBFixtures("MigrateUserPermissionsToGrantsTest.json")
 class UserPermissionsToGrantsMigrationTest {
     private UserPermissionsToGrantsMigration migration;

--- a/graylog2-web-interface/src/logic/permissions/GRN.js
+++ b/graylog2-web-interface/src/logic/permissions/GRN.js
@@ -25,7 +25,7 @@ export const getShowRouteFromGRN = (grn: string) => {
       return Routes.dashboard_show(id);
     case 'event_definition':
       return Routes.ALERTS.DEFINITIONS.edit(id);
-    case 'event_notification':
+    case 'notification':
       return Routes.ALERTS.NOTIFICATIONS.edit(id);
     case 'search':
       return Routes.getPluginRoute('SEARCH_VIEWID')(id);


### PR DESCRIPTION
Graylog users are visible to other users if the user that is running
the query has `users:read` permissions on certain (or all) users.

The `users:read` permission can be conveniently assigned by using the
new `User Inspector` role.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1833