### PR TITLE
Fix plugin routes with `null` parent components.

### DIFF
--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -121,13 +121,13 @@ const AppRouter = () => {
 
   return (
     <Router history={history}>
-      <Switch>
-        <RouterErrorBoundary>
+      <RouterErrorBoundary>
+        <Switch>
           {pluginRoutesWithNullParent}
 
-          <App>
-            <AppWithGlobalNotifications>
-              <Route path={Routes.STARTPAGE}>
+          <Route path={Routes.STARTPAGE}>
+            <App>
+              <AppWithGlobalNotifications>
                 <Switch>
                   <Route exact path={Routes.STARTPAGE} component={StartPage} />
                   {pluginRoutesWithParent}
@@ -281,12 +281,12 @@ const AppRouter = () => {
                   </Route>
                   <Route exact path={Routes.NOTFOUND} component={WrappedNotFoundPage} />
                 </Switch>
-              </Route>
-            </AppWithGlobalNotifications>
-            <Route exact path={Routes.NOTFOUND} component={WrappedNotFoundPage} />
-          </App>
-        </RouterErrorBoundary>
-      </Switch>
+              </AppWithGlobalNotifications>
+              <Route exact path={Routes.NOTFOUND} component={WrappedNotFoundPage} />
+            </App>
+          </Route>
+        </Switch>
+      </RouterErrorBoundary>
     </Router>
   );
 };

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Redirect, Router, Route, Switch } from 'react-router-dom';
-import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import App from 'routing/App';
 import AppWithoutSearchBar from 'routing/AppWithoutSearchBar';
@@ -90,6 +89,7 @@ import {
   UsersOverviewPage,
 } from 'pages';
 import RouterErrorBoundary from 'components/errors/RouterErrorBoundary';
+import usePluginEntities from 'views/logic/usePluginEntities';
 
 const renderPluginRoute = ({ path, component: Component, parentComponent }) => {
   const ParentComponent = parentComponent ?? React.Fragment;
@@ -114,7 +114,7 @@ const WrappedNotFoundPage = () => (
 );
 
 const AppRouter = () => {
-  const pluginRoutes = PluginStore.exports('routes');
+  const pluginRoutes = usePluginEntities('routes');
   const pluginRoutesWithNullParent = pluginRoutes.filter((route) => (route.parentComponent === null)).map(renderPluginRoute);
   const pluginRoutesWithParent = pluginRoutes.filter((route) => route.parentComponent).map(renderPluginRoute);
   const standardPluginRoutes = pluginRoutes.filter((route) => (route.parentComponent === undefined)).map(renderPluginRoute);

--- a/graylog2-web-interface/src/routing/AppRouter.test.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.test.jsx
@@ -3,24 +3,18 @@ import * as React from 'react';
 import { render } from 'wrappedTestingLibrary';
 import mockComponent from 'helpers/mocking/MockComponent';
 import { CombinedProviderMock as MockCombinedProvider, StoreMock as MockStore } from 'helpers/mocking';
+import asMock from 'helpers/mocking/AsMock';
+import { admin } from 'fixtures/users';
 
-import CurrentUserProvider from 'contexts/CurrentUserProvider';
+import CurrentUserContext from 'contexts/CurrentUserContext';
+import usePluginEntities from 'views/logic/usePluginEntities';
 
 import AppRouter from './AppRouter';
 
 jest.mock('components/throughput/GlobalThroughput', () => mockComponent('GlobalThroughput'));
 
 jest.mock('injection/CombinedProvider', () => {
-  const mockCurrentUserStore = MockStore('get', 'listen', ['getInitialState', () => ({
-    currentUser: {
-      full_name: 'Ares Vallis',
-      username: 'ares',
-      permissions: ['*'],
-    },
-  })]);
-
   return new MockCombinedProvider({
-    CurrentUser: { CurrentUserStore: mockCurrentUserStore },
     Notifications: { NotificationsActions: { list: jest.fn() }, NotificationsStore: MockStore() },
   });
 });
@@ -29,15 +23,32 @@ jest.mock('injection/CombinedProvider', () => {
 jest.mock('components/errors/RouterErrorBoundary', () => mockComponent('RouterErrorBoundary'));
 
 jest.mock('pages/StartPage', () => () => <>This is the start page</>);
+jest.mock('views/logic/usePluginEntities');
 
 describe('AppRouter', () => {
+  beforeEach(() => {
+    asMock(usePluginEntities).mockReturnValue([]);
+  });
+
+  const AppRouterWithContext = () => (
+    <CurrentUserContext.Provider value={admin}>
+      <AppRouter />
+    </CurrentUserContext.Provider>
+  );
+
   it('routes to Getting Started Page for `/` or empty location', async () => {
-    const { findByText } = render(
-      <CurrentUserProvider>
-        <AppRouter />
-      </CurrentUserProvider>,
-    );
+    const { findByText } = render(<AppRouterWithContext />);
 
     await findByText('This is the start page');
+  });
+
+  it('renders null-parent component plugin routes without application chrome', async () => {
+    asMock(usePluginEntities).mockReturnValue([{ parentComponent: null, component: () => <span>Hey there!</span> }]);
+
+    const { findByText, queryByTitle } = render(<AppRouterWithContext />);
+
+    await findByText('Hey there!');
+
+    expect(queryByTitle('Graylog Logo')).toBeNull();
   });
 });

--- a/graylog2-web-interface/src/routing/AppRouter.test.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.test.jsx
@@ -8,6 +8,7 @@ import { admin } from 'fixtures/users';
 
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import usePluginEntities from 'views/logic/usePluginEntities';
+import history from 'util/History';
 
 import AppRouter from './AppRouter';
 
@@ -24,6 +25,7 @@ jest.mock('components/errors/RouterErrorBoundary', () => mockComponent('RouterEr
 
 jest.mock('pages/StartPage', () => () => <>This is the start page</>);
 jest.mock('views/logic/usePluginEntities');
+jest.mock('components/layout/Footer', () => mockComponent('Footer'));
 
 describe('AppRouter', () => {
   beforeEach(() => {
@@ -50,5 +52,13 @@ describe('AppRouter', () => {
     await findByText('Hey there!');
 
     expect(queryByTitle('Graylog Logo')).toBeNull();
+  });
+
+  it('renders a not found page for unknown URLs', async () => {
+    const { findByText } = render(<AppRouterWithContext />);
+
+    history.push('/this-url-is-not-registered-and-should-never-be');
+
+    await findByText('Page not found');
   });
 });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Our application router allows plugins to register routes with a `null` parent component, which allows them to be rendered outside of our application chrome. This got broke in #9135, as react-router v5 is now rendering all matching routes (unless `Switch` is used) and the scoping of the `Switch` components and the plugin routes got messed up.

This change is now restoring the original behavior by

  a) placing the `RouterErrorBoundary` outside of the `Switch` clause.
  b) putting the application chrome components (`App`/`AppWith...`) inside the catch-all route for non-null-parent components.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.