### PR TITLE
Refactor repeated code block into method

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/events/notifications/EventNotificationModelData.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/EventNotificationModelData.java
@@ -20,15 +20,20 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import org.graylog.events.event.EventDto;
+import org.graylog.events.processor.EventDefinitionDto;
+import org.graylog.scheduler.JobTriggerDto;
 import org.graylog2.plugin.MessageSummary;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Data object that can be used in notifications to provide structured data to plugins.
  */
 @AutoValue
 public abstract class EventNotificationModelData {
+    private static final String UNKNOWN = "<unknown>";
+
     @JsonProperty("event_definition_id")
     public abstract String eventDefinitionId();
 
@@ -78,5 +83,21 @@ public abstract class EventNotificationModelData {
         public abstract Builder backlog(List<MessageSummary> backlog);
 
         public abstract EventNotificationModelData build();
+    }
+
+    public static EventNotificationModelData of(EventNotificationContext ctx, List<MessageSummary> backlog) {
+        final Optional<EventDefinitionDto> definitionDto = ctx.eventDefinition();
+        final Optional<JobTriggerDto> jobTriggerDto = ctx.jobTrigger();
+
+        return EventNotificationModelData.builder()
+                .eventDefinitionId(definitionDto.map(EventDefinitionDto::id).orElse(UNKNOWN))
+                .eventDefinitionType(definitionDto.map(d -> d.config().type()).orElse(UNKNOWN))
+                .eventDefinitionTitle(definitionDto.map(EventDefinitionDto::title).orElse(UNKNOWN))
+                .eventDefinitionDescription(definitionDto.map(EventDefinitionDto::description).orElse(UNKNOWN))
+                .jobDefinitionId(jobTriggerDto.map(JobTriggerDto::jobDefinitionId).orElse(UNKNOWN))
+                .jobTriggerId(jobTriggerDto.map(JobTriggerDto::id).orElse(UNKNOWN))
+                .event(ctx.event())
+                .backlog(backlog)
+                .build();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailSender.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/EmailSender.java
@@ -30,8 +30,6 @@ import org.graylog.events.notifications.EventBacklogService;
 import org.graylog.events.notifications.EventNotificationContext;
 import org.graylog.events.notifications.EventNotificationModelData;
 import org.graylog.events.processor.DBEventDefinitionService;
-import org.graylog.events.processor.EventDefinitionDto;
-import org.graylog.scheduler.JobTriggerDto;
 import org.graylog2.alerts.EmailRecipients;
 import org.graylog2.configuration.EmailConfiguration;
 import org.graylog2.jackson.TypeReferences;
@@ -46,7 +44,6 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -54,7 +51,6 @@ import static java.util.Objects.requireNonNull;
 
 public class EmailSender {
     private static final Logger LOG = LoggerFactory.getLogger(EmailSender.class);
-    private static final String UNKNOWN = "<unknown>";
 
     private final EmailConfiguration emailConfig;
     private final EmailRecipients.Factory emailRecipientsFactory;
@@ -109,21 +105,7 @@ public class EmailSender {
     }
 
     private Map<String, Object> getModel(EventNotificationContext ctx, ImmutableList<MessageSummary> backlog) {
-        final Optional<EventDefinitionDto> definitionDto = ctx.eventDefinition();
-        final Optional<JobTriggerDto> jobTriggerDto = ctx.jobTrigger();
-
-        // TODO: This needs at search URL, event definition URL, anything else?
-        final EventNotificationModelData modelData = EventNotificationModelData.builder()
-                .eventDefinitionId(definitionDto.map(EventDefinitionDto::id).orElse(UNKNOWN))
-                .eventDefinitionType(definitionDto.map(d -> d.config().type()).orElse(UNKNOWN))
-                .eventDefinitionTitle(definitionDto.map(EventDefinitionDto::title).orElse(UNKNOWN))
-                .eventDefinitionDescription(definitionDto.map(EventDefinitionDto::description).orElse(UNKNOWN))
-                .jobDefinitionId(jobTriggerDto.map(JobTriggerDto::jobDefinitionId).orElse(UNKNOWN))
-                .jobTriggerId(jobTriggerDto.map(JobTriggerDto::id).orElse(UNKNOWN))
-                .event(ctx.event())
-                .backlog(backlog)
-                .build();
-
+        final EventNotificationModelData modelData = EventNotificationModelData.of(ctx, backlog);
         return objectMapper.convertValue(modelData, TypeReferences.MAP_STRING_OBJECT);
     }
 

--- a/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotification.java
+++ b/graylog2-server/src/main/java/org/graylog/events/notifications/types/HTTPEventNotification.java
@@ -32,8 +32,6 @@ import org.graylog.events.notifications.EventNotificationService;
 import org.graylog.events.notifications.NotificationTestData;
 import org.graylog.events.notifications.PermanentEventNotificationException;
 import org.graylog.events.notifications.TemporaryEventNotificationException;
-import org.graylog.events.processor.EventDefinitionDto;
-import org.graylog.scheduler.JobTriggerDto;
 import org.graylog2.plugin.MessageSummary;
 import org.graylog2.system.urlwhitelist.UrlWhitelistNotificationService;
 import org.graylog2.system.urlwhitelist.UrlWhitelistService;
@@ -42,7 +40,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.io.IOException;
-import java.util.Optional;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
@@ -55,7 +52,6 @@ public class HTTPEventNotification implements EventNotification {
     private static final Logger LOG = LoggerFactory.getLogger(HTTPEventNotification.class);
 
     private static final MediaType CONTENT_TYPE = MediaType.parse(APPLICATION_JSON);
-    private static final String UNKNOWN = "<unknown>";
 
     private final EventNotificationService notificationCallbackService;
     private final ObjectMapper objectMapper;
@@ -85,7 +81,7 @@ public class HTTPEventNotification implements EventNotification {
         }
 
         ImmutableList<MessageSummary> backlog = notificationCallbackService.getBacklogForEvent(ctx);
-        final EventNotificationModelData model = getModel(ctx, backlog);
+        final EventNotificationModelData model = EventNotificationModelData.of(ctx, backlog);
 
         if (!whitelistService.isWhitelisted(config.url())) {
             if (!NotificationTestData.TEST_NOTIFICATION_ID.equals(ctx.notificationId())) {
@@ -117,22 +113,6 @@ public class HTTPEventNotification implements EventNotification {
         } catch (IOException e) {
             throw new PermanentEventNotificationException(e.getMessage());
         }
-    }
-
-    private EventNotificationModelData getModel(EventNotificationContext ctx, ImmutableList<MessageSummary> backlog) {
-        final Optional<EventDefinitionDto> definitionDto = ctx.eventDefinition();
-        final Optional<JobTriggerDto> jobTriggerDto = ctx.jobTrigger();
-
-        return EventNotificationModelData.builder()
-                .eventDefinitionId(definitionDto.map(EventDefinitionDto::id).orElse(UNKNOWN))
-                .eventDefinitionType(definitionDto.map(d -> d.config().type()).orElse(UNKNOWN))
-                .eventDefinitionTitle(definitionDto.map(EventDefinitionDto::title).orElse(UNKNOWN))
-                .eventDefinitionDescription(definitionDto.map(EventDefinitionDto::description).orElse(UNKNOWN))
-                .jobDefinitionId(jobTriggerDto.map(JobTriggerDto::jobDefinitionId).orElse(UNKNOWN))
-                .jobTriggerId(jobTriggerDto.map(JobTriggerDto::id).orElse(UNKNOWN))
-                .event(ctx.event())
-                .backlog(backlog)
-                .build();
     }
 
     private void publishSystemNotificationForWhitelistFailure(String url, String eventNotificationTitle) {


### PR DESCRIPTION
## Description
Every Event Notification seems to use the same block of code for creating an instance of `EventNotificationModelData`.  This change moves that block of code into a static method in `EventNotificationModelData` and updates existing Event Notifications to use the static method rather than using the same duplicated block of code.

## Motivation and Context
This is being done to ensure that all Event Notifications continue to construct `EventNotificationModelData` consistently as that object grows and evolves.  

## How Has This Been Tested?
This change has been tested locally as part of development of the Script Event Notification plugin.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

