### PR TITLE
Avoid creating style component inline.

### DIFF
--- a/graylog2-web-interface/src/components/errors/ErrorPage.jsx
+++ b/graylog2-web-interface/src/components/errors/ErrorPage.jsx
@@ -8,9 +8,9 @@ import AppContentGrid from 'components/layout/AppContentGrid';
 import DocumentTitle from 'components/common/DocumentTitle';
 import ErrorJumbotron from 'components/errors/ErrorJumbotron';
 
-const generateStyles = (backgroundImage) => css`
+const generateStyles = () => css`
   body {
-    background: url(${backgroundImage}) no-repeat center center fixed;
+    background: url(${(props) => props.backgroundImage}) no-repeat center center fixed;
     background-size: cover;
   }
 `;
@@ -38,29 +38,27 @@ type Props = {
   title: string,
 };
 
-const ErrorPage = ({ children, title, description, backgroundImage }: Props) => {
-  const ErrorPageStyles = createGlobalStyle`
-    ${generateStyles(backgroundImage)}
+const ErrorPageStyles = createGlobalStyle`
+    ${generateStyles()}
   `;
 
-  return (
-    <AppContentGrid>
-      <ErrorPageStyles />
-      <div className="container-fluid">
-        <DocumentTitle title={title}>
-          <ErrorJumbotron title={title}>
-            {description}
-            {children && (
-              <ErrorMessage>
-                {children}
-              </ErrorMessage>
-            )}
-          </ErrorJumbotron>
-        </DocumentTitle>
-      </div>
-    </AppContentGrid>
-  );
-};
+const ErrorPage = ({ children, title, description, backgroundImage }: Props) => (
+  <AppContentGrid>
+    <ErrorPageStyles backgroundImage={backgroundImage} />
+    <div className="container-fluid">
+      <DocumentTitle title={title}>
+        <ErrorJumbotron title={title}>
+          {description}
+          {children && (
+          <ErrorMessage>
+            {children}
+          </ErrorMessage>
+          )}
+        </ErrorJumbotron>
+      </DocumentTitle>
+    </div>
+  </AppContentGrid>
+);
 
 ErrorPage.propTypes = {
   children: PropTypes.node,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

By creating the component once and parameterize it, instead of passing
in a parameter during creation, this avoids errors like:

```
The component sc-global-igkIyx has been created dynamically.
You may see this warning because you've called styled inside another component.
To resolve this only create new StyledComponents outside of any render method and function component.
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.