### PR TITLE
Fix vertical scrolling for search sidebar content column

### DIFF
--- a/graylog2-web-interface/src/views/components/sidebar/ContentColumn.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/ContentColumn.jsx
@@ -22,20 +22,11 @@ type Props = {
 
 export const Container: StyledComponent<{ sidebarIsPinned: boolean }, ThemeInterface, HTMLDivElement> = styled.div(({ theme, sidebarIsPinned }) => css`
   position: ${sidebarIsPinned ? 'relative' : 'fixed'};
-  display: grid;
-  display: -ms-grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: auto 1fr;
-  -ms-grid-columns: 1fr;
-  -ms-grid-rows: auto 1fr;
+  width: 270px;
+  height:  ${sidebarIsPinned ? '100%' : 'calc(100% - 50px)'}; // subtract the nav height
   top: ${sidebarIsPinned ? 0 : '50px'};
   left: ${sidebarIsPinned ? 0 : '50px'};
 
-  width: 270px;
-  height: 100%;
-  padding: 5px 15px 15px 15px;
-
-  color: ${theme.colors.global.textDefault};
   background: ${theme.colors.global.contentBackground};
   border-right: ${sidebarIsPinned ? 'none' : `1px solid ${theme.colors.variant.light.default}`};
   box-shadow: ${sidebarIsPinned ? `3px 3px 3px ${theme.colors.global.navigationBoxShadow}` : 'none'};
@@ -56,23 +47,31 @@ export const Container: StyledComponent<{ sidebarIsPinned: boolean }, ThemeInter
       z-index: 4; /* to render over Sidebar ContentColumn */
     }
   `}
-
-  > *:nth-child(1) {
-    grid-column: 1;
-    -ms-grid-column: 1;
-    grid-row: 1;
-    -ms-grid-row: 1;
-  }
-
-  > *:nth-child(2) {
-    grid-column: 1;
-    -ms-grid-column: 1;
-    grid-row: 2;
-    -ms-grid-row: 2;
-  }
 `);
 
-const Header: StyledComponent<{}, void, HTMLDivElement> = styled.div`
+const ContentGrid = styled.div(({ theme }) => css`
+  display: grid;
+  display: -ms-grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: auto minmax(1px, 1fr);
+  -ms-grid-columns: 1fr;
+  -ms-grid-rows: auto 1fr;
+  height: 100%;
+  overflow-y: auto;
+
+  padding: 5px 15px 0 15px;
+
+  color: ${theme.colors.global.textDefault};
+`);
+
+const Header = styled.div`
+  grid-column: 1;
+  -ms-grid-column: 1;
+  grid-row: 1;
+  -ms-grid-row: 1;
+`;
+
+const SearchTitle: StyledComponent<{}, void, HTMLDivElement> = styled.div`
   height: 35px;
   display: grid;
   display: -ms-grid;
@@ -120,6 +119,18 @@ const CenterVertical = styled.div`
   align-content: center;
 `;
 
+const SectionContent = styled.div`
+  grid-column: 1;
+  -ms-grid-column: 1;
+  grid-row: 2;
+  -ms-grid-row: 2;
+
+  // Fixes padding problem with padding-bottom from container
+  > *:last-child {
+    padding-bottom: 15px;;
+  }
+`;
+
 const toggleSidebarPinning = (searchPageLayout) => {
   if (!searchPageLayout) {
     return;
@@ -152,25 +163,28 @@ const ContentColumn = ({ children, sectionTitle, closeSidebar, searchPageLayout,
 
         return (
           <Container sidebarIsPinned={sidebarIsPinned}>
-            <div>
-              <Header title={title}>
-                <CenterVertical>
-                  <Title onClick={closeSidebar}>{title}</Title>
-                </CenterVertical>
-                <CenterVertical>
-                  <OverlayToggle sidebarIsPinned={sidebarIsPinned}>
-                    <IconButton onClick={() => toggleSidebarPinning(searchPageLayout)}
-                                title={`Display sidebar ${sidebarIsPinned ? 'as overlay' : 'inline'}`}
-                                name="thumbtack" />
-                  </OverlayToggle>
-                </CenterVertical>
+
+            <ContentGrid>
+              <Header>
+                <SearchTitle title={title}>
+                  <CenterVertical>
+                    <Title onClick={closeSidebar}>{title}</Title>
+                  </CenterVertical>
+                  <CenterVertical>
+                    <OverlayToggle sidebarIsPinned={sidebarIsPinned}>
+                      <IconButton onClick={() => toggleSidebarPinning(searchPageLayout)}
+                                  title={`Display sidebar ${sidebarIsPinned ? 'as overlay' : 'inline'}`}
+                                  name="thumbtack" />
+                    </OverlayToggle>
+                  </CenterVertical>
+                </SearchTitle>
+                <HorizontalRule />
+                <SectionTitle>{sectionTitle}</SectionTitle>
               </Header>
-              <HorizontalRule />
-              <SectionTitle>{sectionTitle}</SectionTitle>
-            </div>
-            <div>
-              {children}
-            </div>
+              <SectionContent>
+                {children}
+              </SectionContent>
+            </ContentGrid>
           </Container>
         );
       }}

--- a/graylog2-web-interface/src/views/components/sidebar/fields/FieldsOverview.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/fields/FieldsOverview.jsx
@@ -30,9 +30,9 @@ const Container: StyledComponent<{}, ThemeInterface, HTMLDivElement> = styled.di
   display: grid;
   display: -ms-grid;
   grid-template-columns: 1fr;
-  grid-template-rows: auto 1fr;
+  grid-template-rows: max-content 1fr;
   -ms-grid-columns: 1fr;
-  -ms-grid-rows: auto 1fr;
+  -ms-grid-rows: max-content 1fr;
 
   > *:nth-child(1) {
     grid-column: 1;

--- a/graylog2-web-interface/src/views/components/sidebar/fields/List.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/fields/List.jsx
@@ -4,6 +4,7 @@ import { SizeMe } from 'react-sizeme';
 import { FixedSizeList } from 'react-window';
 import { List as ImmutableList } from 'immutable';
 import type { Styles } from 'styled-components';
+import styled from 'styled-components';
 
 import MessageFieldsFilter from 'logic/message/MessageFieldsFilter';
 import type { ViewMetaData as ViewMetadata } from 'views/stores/ViewMetadataStore';
@@ -12,6 +13,10 @@ import FieldTypeMapping from 'views/logic/fieldtypes/FieldTypeMapping';
 import ListItem from './ListItem';
 
 const DEFAULT_HEIGHT_PX = 50;
+
+const DynamicHeight = styled.div`
+  overflow: hidden;
+`;
 
 type Props = {
   activeQueryFields: ImmutableList<FieldTypeMapping>,
@@ -62,12 +67,14 @@ const List = ({ viewMetadata: { activeQuery }, filter, activeQueryFields, allFie
   return (
     <SizeMe monitorHeight refreshRate={100}>
       {({ size: { height, width } }) => (
-        <FixedSizeList height={height || DEFAULT_HEIGHT_PX}
-                       width={width}
-                       itemCount={fieldList.size}
-                       itemSize={20}>
-          {Row}
-        </FixedSizeList>
+        <DynamicHeight>
+          <FixedSizeList height={height || DEFAULT_HEIGHT_PX}
+                         width={width}
+                         itemCount={fieldList.size}
+                         itemSize={20}>
+            {Row}
+          </FixedSizeList>
+        </DynamicHeight>
       )}
     </SizeMe>
   );


### PR DESCRIPTION
## Description
## Motivation and Context
This PR is fixing a vertical scrolling bug for the search content column, which occurred when using the `FieldList`.
It also fixes a `FieldList` resizing problem and removes the horizontal scrollbar for pinned sidebars.

## How Has This Been Tested?
Tested with Chrome, Firefox, Safari and IE11

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

