### PR TITLE
Update type definitions for AuthenticationActions, AuthzRolesActions, and UsersActions

### DIFF
--- a/graylog2-web-interface/src/actions/authentication/AuthenticationActions.js
+++ b/graylog2-web-interface/src/actions/authentication/AuthenticationActions.js
@@ -87,18 +87,18 @@ export type LoadActiveResponse = LoadActiveResponse & {
 };
 
 export type ActionsType = {
-  create: (AuthenticationBackendCreate) => Promise<void>,
+  create: (AuthenticationBackendCreate) => Promise<LoadResponse>,
   delete: (authBackendId: ?$PropertyType<AuthenticationBackend, 'id'>, authBackendTitle: $PropertyType<AuthenticationBackend, 'title'>) => Promise<void>,
   disableUser: (userId: string, username: string) => Promise<void>,
   enableUser: (userId: string, username: string) => Promise<void>,
-  load: (id: string) => Promise<?LoadResponse>,
-  loadActive: () => Promise<?LoadActiveResponse>,
-  loadBackendsPaginated: (page: number, perPage: number, query: string) => Promise<?PaginatedBackends>,
-  loadUsersPaginated: (page: number, perPage: number, query: string) => Promise<?PaginatedAuthUsers>,
+  load: (id: string) => Promise<LoadResponse>,
+  loadActive: () => Promise<LoadActiveResponse>,
+  loadBackendsPaginated: (page: number, perPage: number, query: string) => Promise<PaginatedBackends>,
+  loadUsersPaginated: (page: number, perPage: number, query: string) => Promise<PaginatedAuthUsers>,
   setActiveBackend: (authBackendId: ?$PropertyType<AuthenticationBackend, 'id'>, authBackendTitle: $PropertyType<AuthenticationBackend, 'title'>) => Promise<void>,
-  testConnection: (payload: ConnectionTestPayload) => Promise<?ConnectionTestResult>,
-  testLogin: (payload: LoginTestPayload) => Promise<?LoginTestResult>,
-  update: (id: string, AuthenticationBackendUpdate) => Promise<void>,
+  testConnection: (payload: ConnectionTestPayload) => Promise<ConnectionTestResult>,
+  testLogin: (payload: LoginTestPayload) => Promise<LoginTestResult>,
+  update: (id: string, AuthenticationBackendUpdate) => Promise<LoadResponse>,
 };
 
 const AuthenticationActions: RefluxActions<ActionsType> = singletonActions(

--- a/graylog2-web-interface/src/actions/roles/AuthzRolesActions.js
+++ b/graylog2-web-interface/src/actions/roles/AuthzRolesActions.js
@@ -8,20 +8,20 @@ import { singletonActions } from 'views/logic/singleton';
 import type { RefluxActions } from 'stores/StoreTypes';
 
 export type ActionsType = {
-  load: (roleId: string) => Promise<?Role>,
+  load: (roleId: string) => Promise<Role>,
   delete: (roleId: string, roleName: string) => Promise<void>,
-  addMembers: (roleId: string, usernames: Immutable.Set<string>) => Promise<?Role>,
-  removeMember: (roleId: string, username: string) => Promise<?Role>,
-  loadUsersForRole: (roleId: string, roleName: string, page: number, perPage: number, query: string) => Promise<?PaginatedUserListType>,
+  addMembers: (roleId: string, usernames: Immutable.Set<string>) => Promise<Role>,
+  removeMember: (roleId: string, username: string) => Promise<Role>,
+  loadUsersForRole: (roleId: string, roleName: string, page: number, perPage: number, query: string) => Promise<PaginatedUserListType>,
   loadRolesForUser: (
     username: string,
     page: number,
     perPage: number,
-    query: string) => Promise<?PaginatedListType>,
+    query: string) => Promise<PaginatedListType>,
   loadRolesPaginated: (
     page: number,
     perPage: number,
-    query: string) => Promise<?PaginatedListType>,
+    query: string) => Promise<PaginatedListType>,
 };
 
 const AuthzRolesActions: RefluxActions<ActionsType> = singletonActions(

--- a/graylog2-web-interface/src/actions/users/UsersActions.js
+++ b/graylog2-web-interface/src/actions/users/UsersActions.js
@@ -41,7 +41,7 @@ export type PaginatedUsers = {
 };
 
 export type ActionsType = {
-  create: (user: UserCreate) => Promise<string[]>,
+  create: (user: UserCreate) => Promise<void>,
   load: (username: string) => Promise<User>,
   update: (username: string, request: any) => Promise<void>,
   delete: (username: string) => Promise<void>,

--- a/graylog2-web-interface/src/actions/users/UsersActions.js
+++ b/graylog2-web-interface/src/actions/users/UsersActions.js
@@ -41,16 +41,16 @@ export type PaginatedUsers = {
 };
 
 export type ActionsType = {
-  create: (payload: any) => Promise<?string[]>,
-  load: (username: string) => Promise<?User>,
+  create: (user: UserCreate) => Promise<string[]>,
+  load: (username: string) => Promise<User>,
   update: (username: string, request: any) => Promise<void>,
   delete: (username: string) => Promise<void>,
   changePassword: (username: string, request: ChangePasswordRequest) => Promise<void>,
-  createToken: (username: string, tokenName: string) => Promise<?Token>,
-  loadTokens: (username: string) => Promise<?Token[]>,
+  createToken: (username: string, tokenName: string) => Promise<Token>,
+  loadTokens: (username: string) => Promise<Token[]>,
   deleteToken: (username: string, tokenId: string, tokenName: string) => Promise<void>,
-  loadUsers: () => Promise<?Immutable.List<User>>,
-  loadUsersPaginated: (page: number, perPage: number, query: string) => Promise<?PaginatedUsers>,
+  loadUsers: () => Promise<Immutable.List<User>>,
+  loadUsersPaginated: (page: number, perPage: number, query: string) => Promise<PaginatedUsers>,
 };
 
 const UsersActions: RefluxActions<ActionsType> = singletonActions(

--- a/graylog2-web-interface/src/components/authentication/BackendDetails/BackendDetails.jsx
+++ b/graylog2-web-interface/src/components/authentication/BackendDetails/BackendDetails.jsx
@@ -21,7 +21,7 @@ const BackendDetails = ({ authenticationBackend }: Props) => {
   useEffect(() => {
     const getUnlimited = [1, 0, ''];
 
-    AuthzRolesDomain.loadRolesPaginated(...getUnlimited).then((newPaginatedRoles) => newPaginatedRoles && setPaginatedRoles(newPaginatedRoles));
+    AuthzRolesDomain.loadRolesPaginated(...getUnlimited).then(setPaginatedRoles);
   }, []);
 
   if (!authService) {

--- a/graylog2-web-interface/src/components/authentication/BackendDetailsActive/BackendDetailsActive.jsx
+++ b/graylog2-web-interface/src/components/authentication/BackendDetailsActive/BackendDetailsActive.jsx
@@ -22,7 +22,7 @@ const BackendDetailsActive = ({ authenticationBackend }: Props) => {
   useEffect(() => {
     const getUnlimited = [1, 0, ''];
 
-    AuthzRolesDomain.loadRolesPaginated(...getUnlimited).then((newPaginatedRoles) => newPaginatedRoles && setPaginatedRoles(newPaginatedRoles));
+    AuthzRolesDomain.loadRolesPaginated(...getUnlimited).then(setPaginatedRoles);
   }, []);
 
   if (!authService) {

--- a/graylog2-web-interface/src/components/authentication/BackendDetailsActive/SyncedUsersSection/SyncedUsersSection.jsx
+++ b/graylog2-web-interface/src/components/authentication/BackendDetailsActive/SyncedUsersSection/SyncedUsersSection.jsx
@@ -49,8 +49,7 @@ const SyncedUsersSection = ({ roles }: Props) => {
   const _userOverviewItem = (user) => <SyncedUsersOverviewItem user={user} roles={roles} />;
 
   const _loadUsers = (newPage = page, newPerPage = perPage, newQuery = query) => {
-    return AuthenticationDomain.loadUsersPaginated(newPage, newPerPage, newQuery)
-      .then((newPaginatedUsers) => newPaginatedUsers && setPaginatedUsers(newPaginatedUsers));
+    return AuthenticationDomain.loadUsersPaginated(newPage, newPerPage, newQuery).then(setPaginatedUsers);
   };
 
   const _handleSearch = (newQuery) => _loadUsers(DEFAULT_PAGINATION.page, undefined, newQuery);

--- a/graylog2-web-interface/src/components/authentication/BackendsOverview/BackendsOverview.jsx
+++ b/graylog2-web-interface/src/components/authentication/BackendsOverview/BackendsOverview.jsx
@@ -65,7 +65,7 @@ const BackendsOverview = () => {
 
   useEffect(() => {
     const getUnlimited = [1, 0, ''];
-    AuthzRolesDomain.loadRolesPaginated(...getUnlimited).then((newPaginatedRoles) => newPaginatedRoles && setPaginatedRoles(newPaginatedRoles));
+    AuthzRolesDomain.loadRolesPaginated(...getUnlimited).then(setPaginatedRoles);
     _loadBackends(DEFAULT_PAGINATION.page, DEFAULT_PAGINATION.perPage, DEFAULT_PAGINATION.query);
 
     const unlistenDisableBackend = AuthenticationActions.disableUser.completed.listen(_refreshOverview);

--- a/graylog2-web-interface/src/components/authentication/BackendsOverview/BackendsOverview.jsx
+++ b/graylog2-web-interface/src/components/authentication/BackendsOverview/BackendsOverview.jsx
@@ -56,8 +56,7 @@ const BackendsOverview = () => {
   const _isActive = (authBackend) => authBackend.id === context?.activeBackend?.id;
 
   const _loadBackends = (newPage = page, newPerPage = perPage, newQuery = query) => {
-    return AuthenticationDomain.loadBackendsPaginated(newPage, newPerPage, newQuery)
-      .then((newPaginatedBackends) => newPaginatedBackends && setPaginatedBackends(newPaginatedBackends));
+    return AuthenticationDomain.loadBackendsPaginated(newPage, newPerPage, newQuery).then(setPaginatedBackends);
   };
 
   const _handleSearch = (newQuery) => _loadBackends(DEFAULT_PAGINATION.page, undefined, newQuery);

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizard.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizard.jsx
@@ -194,11 +194,7 @@ const BackendWizard = ({ initialValues, initialStepKey, onSubmit, authBackendMet
   useEffect(() => {
     const getUnlimited = [1, 0, ''];
 
-    AuthzRolesDomain.loadRolesPaginated(...getUnlimited).then((paginatedRoles) => {
-      if (paginatedRoles) {
-        setRoles(paginatedRoles.list);
-      }
-    });
+    AuthzRolesDomain.loadRolesPaginated(...getUnlimited).then((paginatedRoles) => setRoles(paginatedRoles.list));
   }, []);
 
   useEffect(() => {

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizard.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizard.jsx
@@ -16,6 +16,7 @@ import type { WizardSubmitPayload } from 'logic/authentication/directoryServices
 import { Row, Col, Alert } from 'components/graylog';
 import Wizard, { type Step } from 'components/common/Wizard';
 import { FetchError } from 'logic/rest/FetchProvider';
+import type { LoadResponse as LoadBackendResponse } from 'actions/authentication/AuthenticationActions';
 
 import BackendWizardContext, { type WizardStepsState, type WizardFormValues, type AuthBackendMeta } from './BackendWizardContext';
 import { FORM_VALIDATION as SERVER_CONFIG_VALIDATION, STEP_KEY as SERVER_CONFIG_KEY } from './ServerConfigStep';
@@ -170,7 +171,7 @@ type Props = {
   initialValues: WizardFormValues,
   excludedFields: {[ inputName: string ]: boolean },
   help: { [inputName: string]: ?React.Node },
-  onSubmit: (WizardSubmitPayload, WizardFormValues, serviceType: $PropertyType<AuthBackendMeta, 'serviceType'>, licenseIsValid?: boolean) => Promise<void>,
+  onSubmit: (WizardSubmitPayload, WizardFormValues, serviceType: $PropertyType<AuthBackendMeta, 'serviceType'>, licenseIsValid?: boolean) => Promise<LoadBackendResponse>,
 };
 
 const BackendWizard = ({ initialValues, initialStepKey, onSubmit, authBackendMeta, help, excludedFields }: Props) => {

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/UserLoginTest.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/UserLoginTest.jsx
@@ -29,16 +29,14 @@ const UserLoginTest = ({ prepareSubmitPayload }: Props) => {
       user_login: { username, password },
       backend_id: authBackendMeta.backendId,
     }).then((response) => {
-      if (response) {
-        setLoginStatus({
-          loading: false,
-          testFinished: true,
-          message: response.message,
-          result: response.result,
-          errors: response.errors,
-          success: response.success,
-        });
-      }
+      setLoginStatus({
+        loading: false,
+        testFinished: true,
+        message: response.message,
+        result: response.result,
+        errors: response.errors,
+        success: response.success,
+      });
     }).catch((error) => {
       const requestErrors = [error?.message, error?.additional?.res?.text];
       setLoginStatus({ loading: false, success: false, testFinished: true, result: {}, message: undefined, errors: requestErrors });

--- a/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendCreate.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendCreate.jsx
@@ -76,15 +76,8 @@ export const handleSubmit = (payload: WizardSubmitPayload, formValues: WizardFor
   };
 
   return AuthenticationDomain.create(backendCreateNotificationSettings)(payload).then((result) => {
-    if (result && shouldCreateGroupSync) {
-      return enterpriseGroupSyncPlugin.actions.onDirectoryServiceBackendUpdate(false, formValues, result.backend.id, serviceType).catch((error) => {
-        const backendDeleteNotificationSettings = {
-          notifyOnSuccess: false,
-        };
-        // clean up created auth backend if
-        AuthenticationDomain.delete(backendDeleteNotificationSettings)(result.backend.id, result.backend.titel);
-        throw error;
-      });
+    if (result.backend && formValues.synchronizeGroups && enterpriseGroupSyncPlugin && licenseIsValid) {
+      return enterpriseGroupSyncPlugin.actions.onDirectoryServiceBackendUpdate(false, formValues, result.backend.id, AUTH_BACKEND_META.serviceType);
     }
 
     return result;

--- a/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendEdit.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendEdit.jsx
@@ -67,7 +67,7 @@ export const handleSubmit = (payload: WizardSubmitPayload, formValues: WizardFor
     ...payload,
     id: backendId,
   }).then((result) => {
-    if (result && enterpriseGroupSyncPlugin && licenseIsValid) {
+    if (enterpriseGroupSyncPlugin && licenseIsValid) {
       return enterpriseGroupSyncPlugin.actions.onDirectoryServiceBackendUpdate(backendGroupSyncIsActive, formValues, backendId, serviceType);
     }
 

--- a/graylog2-web-interface/src/components/authentication/useActiveBackend.js
+++ b/graylog2-web-interface/src/components/authentication/useActiveBackend.js
@@ -11,10 +11,7 @@ const useActiveBackend = <T>(listenableActions: Array<ListenableAction<T>> = [])
   const [finishedLoading, setFinishedLoading] = useState(false);
   const _loadActive = () => AuthenticationDomain.loadActive().then((response) => {
     setFinishedLoading(true);
-
-    if (response) {
-      setLoadActiveResponse(response);
-    }
+    setLoadActiveResponse(response);
   });
 
   useEffect(() => {

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationFormContainer.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/EmailNotificationFormContainer.jsx
@@ -36,7 +36,7 @@ class EmailNotificationFormContainer extends React.Component {
     const { currentUser } = this.props;
 
     if (isPermitted(currentUser.permissions, 'users:list')) {
-      UsersDomain.loadUsers().then((users) => users && this.setState({ users }));
+      UsersDomain.loadUsers().then((users) => this.setState({ users }));
     } else {
       this.setState({ users: Immutable.List() });
     }

--- a/graylog2-web-interface/src/components/permissions/RolesSelector.jsx
+++ b/graylog2-web-interface/src/components/permissions/RolesSelector.jsx
@@ -7,7 +7,6 @@ import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import AuthzRolesDomain from 'domainActions/roles/AuthzRolesDomain';
-import { type PaginatedListType } from 'stores/roles/AuthzRolesStore';
 import Role from 'logic/roles/Role';
 import { Button } from 'components/graylog';
 import { Select } from 'components/common';

--- a/graylog2-web-interface/src/components/permissions/RolesSelector.jsx
+++ b/graylog2-web-interface/src/components/permissions/RolesSelector.jsx
@@ -78,7 +78,7 @@ const RolesSelector = ({ assignedRolesIds, onSubmit, identifier }: Props) => {
     const getUnlimited = [1, 0, ''];
 
     AuthzRolesDomain.loadRolesPaginated(...getUnlimited)
-      .then((paginatedRoles: ?PaginatedListType) => paginatedRoles && setRoles(Immutable.Set(paginatedRoles.list)));
+      .then((paginatedRoles) => setRoles(Immutable.Set(paginatedRoles.list)));
   }, [assignedRolesIds]);
 
   return (

--- a/graylog2-web-interface/src/components/roles/RoleEdit/UsersSelector.jsx
+++ b/graylog2-web-interface/src/components/roles/RoleEdit/UsersSelector.jsx
@@ -67,15 +67,13 @@ const UsersSelector = ({ role, onSubmit }: Props) => {
 
     UsersDomain.loadUsersPaginated(...getUnlimited)
       .then((newPaginatedUsers) => {
-        if (newPaginatedUsers) {
-          const resultUsers = newPaginatedUsers.list
-            .filter((u) => !u.roles.includes(role.name))
-            .map((u) => ({ label: u.name, value: u.name }))
-            .toArray();
+        const resultUsers = newPaginatedUsers.list
+          .filter((u) => !u.roles.includes(role.name))
+          .map((u) => ({ label: u.name, value: u.name }))
+          .toArray();
 
-          setOptions(resultUsers);
-          setUsers(newPaginatedUsers.list);
-        }
+        setOptions(resultUsers);
+        setUsers(newPaginatedUsers.list);
       });
   }, [role]);
 

--- a/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverview.jsx
+++ b/graylog2-web-interface/src/components/roles/RolesOverview/RolesOverview.jsx
@@ -64,8 +64,7 @@ const RolesOverview = () => {
   const { list: roles, pagination: { page, perPage, query, total } } = paginatedRoles;
 
   const _loadRoles = (newPage = page, newPerPage = perPage, newQuery = query) => {
-    return AuthzRolesDomain.loadRolesPaginated(newPage, newPerPage, newQuery)
-      .then((newPaginatedRoles) => newPaginatedRoles && setPaginatedRoles(newPaginatedRoles));
+    return AuthzRolesDomain.loadRolesPaginated(newPage, newPerPage, newQuery).then(setPaginatedRoles);
   };
 
   const _rolesOverviewItem = (role) => <RolesOverviewItem role={role} />;

--- a/graylog2-web-interface/src/components/users/UserCreate/UserCreate.jsx
+++ b/graylog2-web-interface/src/components/users/UserCreate/UserCreate.jsx
@@ -51,7 +51,7 @@ const UserCreate = () => {
   const [selectedRoles, setSelectedRoles] = useState<Immutable.Set<DescriptiveItem>>(Immutable.Set([initialRole]));
 
   useEffect(() => {
-    UsersDomain.loadUsers().then((newUsers) => newUsers && setUsers(newUsers));
+    UsersDomain.loadUsers().then(setUsers);
   }, []);
 
   const _onAssignRole = (roles: Immutable.Set<DescriptiveItem>) => {

--- a/graylog2-web-interface/src/components/users/UserEdit/RolesSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/RolesSection.jsx
@@ -39,14 +39,10 @@ const RolesSection = ({ user, onSubmit }: Props) => {
       .then((response) => {
         setLoading(false);
 
-        if (response) {
-          return {
-            pagination: response.pagination,
-            list: response.list.map((item) => (item: DescriptiveItem)),
-          };
-        }
-
-        return undefined;
+        return {
+          pagination: response.pagination,
+          list: response.list.map((item) => (item: DescriptiveItem)),
+        };
       });
   };
 

--- a/graylog2-web-interface/src/domainActions/notifyingAction.js
+++ b/graylog2-web-interface/src/domainActions/notifyingAction.js
@@ -4,12 +4,17 @@ import { createNotFoundError } from 'logic/errors/ReportedErrors';
 import ErrorsActions from 'actions/errors/ErrorsActions';
 import type { ListenableAction } from 'stores/StoreTypes';
 
-const _displaySuccessNotification = (successNotification, ...args) => {
+type Notification = {
+  title?: string,
+  message?: string,
+};
+
+const _displaySuccessNotification = <T, Args: Array<T>>(successNotification: (...Args) => Notification, ...args: Args) => {
   const { message, title } = successNotification(...args);
   UserNotification.success(message, title || 'Success');
 };
 
-const _displayErrorNotification = (errorNotification, error, ...args) => {
+const _displayErrorNotification = <T, Args: Array<T>>(errorNotification: (error: string, ...Args) => Notification, error, ...args: Args) => {
   let errorMessage = String(error);
 
   if ((error?.status === 400 || error?.status === 500) && error?.additional?.body?.message) {
@@ -18,11 +23,6 @@ const _displayErrorNotification = (errorNotification, error, ...args) => {
 
   const { message, title } = errorNotification(errorMessage, ...args);
   UserNotification.error(message, title || 'Error');
-};
-
-type Notification = {
-  title?: string,
-  message?: string,
 };
 
 type Props<Args, ActionResult> = {

--- a/graylog2-web-interface/src/domainActions/notifyingAction.js
+++ b/graylog2-web-interface/src/domainActions/notifyingAction.js
@@ -16,7 +16,7 @@ type Props<Args, ActionResult> = {
   notFoundRedirect?: boolean,
 };
 
-const notifyingAction = <T, Args: Array<T>, Result, ActionResult: Promise<Result | void>>({
+const notifyingAction = <T, Args: Array<T>, Result, ActionResult: Promise<Result>>({
   action,
   success: successNotification,
   error: errorNotification,
@@ -34,8 +34,7 @@ const notifyingAction = <T, Args: Array<T>, Result, ActionResult: Promise<Result
 
     if (notFoundRedirect && error?.status === 404) {
       ErrorsActions.report(createNotFoundError(error));
-
-      return;
+      throw error;
     }
 
     if ((error?.status === 400 || error?.status === 500) && error?.additional?.body?.message) {

--- a/graylog2-web-interface/src/pages/AuthenticationBackendDetailsPage.jsx
+++ b/graylog2-web-interface/src/pages/AuthenticationBackendDetailsPage.jsx
@@ -38,7 +38,7 @@ const AuthenticationBackendDetailsPage = ({ params: { backendId } }: Props) => {
   const { finishedLoading, activeBackend } = useActiveBackend();
 
   useEffect(() => {
-    AuthenticationDomain.load(backendId).then((response) => response && setAuthBackend(response.backend));
+    AuthenticationDomain.load(backendId).then((response) => setAuthBackend(response.backend));
   }, [backendId]);
 
   if (!authBackend) {

--- a/graylog2-web-interface/src/pages/AuthenticationBackendEditPage.jsx
+++ b/graylog2-web-interface/src/pages/AuthenticationBackendEditPage.jsx
@@ -20,7 +20,7 @@ const AuthenticationBackendEditPage = ({ params: { backendId }, location: { quer
   const [authBackend, setAuthBackend] = useState();
 
   useEffect(() => {
-    AuthenticationDomain.load(backendId).then((response) => response && setAuthBackend(response.backend));
+    AuthenticationDomain.load(backendId).then((response) => setAuthBackend(response.backend));
   }, []);
 
   if (!authBackend) {

--- a/graylog2-web-interface/src/pages/UserTokensEditPage.jsx
+++ b/graylog2-web-interface/src/pages/UserTokensEditPage.jsx
@@ -33,7 +33,7 @@ const PageTitle = ({ fullName }: {fullName: ?string}) => (
 
 const _loadTokens = (username, currentUser, setTokens) => {
   if (isPermitted(currentUser?.permissions, [`users:tokenlist:${username}`])) {
-    UsersDomain.loadTokens(username).then((tokens) => tokens && setTokens(tokens));
+    UsersDomain.loadTokens(username).then(setTokens);
   } else {
     setTokens([]);
   }

--- a/graylog2-web-interface/src/stores/authentication/AuthenticationStore.js
+++ b/graylog2-web-interface/src/stores/authentication/AuthenticationStore.js
@@ -48,7 +48,7 @@ const AuthenticationStore: Store<{ authenticators: any }> = singletonStore(
       };
     },
 
-    create(authBackend: AuthenticationBackendCreate): Promise<?LoadResponse> {
+    create(authBackend: AuthenticationBackendCreate): Promise<LoadResponse> {
       const url = qualifyUrl(ApiRoutes.AuthenticationController.create().url);
       const promise = fetch('POST', url, authBackend).then((result) => (result ? {
         backend: AuthenticationBackend.fromJSON(result.backend),
@@ -58,7 +58,7 @@ const AuthenticationStore: Store<{ authenticators: any }> = singletonStore(
       return promise;
     },
 
-    load(backendId: string): Promise<?LoadResponse> {
+    load(backendId: string): Promise<LoadResponse> {
       const url = qualifyUrl(ApiRoutes.AuthenticationController.load(encodeURIComponent(backendId)).url);
       const promise = fetch('GET', url).then((result) => (result ? {
         backend: AuthenticationBackend.fromJSON(result.backend),
@@ -69,7 +69,7 @@ const AuthenticationStore: Store<{ authenticators: any }> = singletonStore(
       return promise;
     },
 
-    loadActive(): Promise<?LoadActiveResponse> {
+    loadActive(): Promise<LoadActiveResponse> {
       const url = qualifyUrl(ApiRoutes.AuthenticationController.loadActive().url);
       const promise = fetch('GET', url).then((result) => (result ? {
         backend: result.backend ? AuthenticationBackend.fromJSON(result.backend) : null,
@@ -81,7 +81,7 @@ const AuthenticationStore: Store<{ authenticators: any }> = singletonStore(
       return promise;
     },
 
-    update(backendId: ?$PropertyType<AuthenticationBackend, 'id'>, payload: AuthenticationBackendUpdate): Promise<?LoadResponse> {
+    update(backendId: ?$PropertyType<AuthenticationBackend, 'id'>, payload: AuthenticationBackendUpdate): Promise<LoadResponse> {
       const url = qualifyUrl(ApiRoutes.AuthenticationController.update(backendId).url);
       const promise = fetch('PUT', url, payload).then((result) => (result ? {
         backend: AuthenticationBackend.fromJSON(result.backend),
@@ -100,7 +100,7 @@ const AuthenticationStore: Store<{ authenticators: any }> = singletonStore(
       return promise;
     },
 
-    testConnection(payload: ConnectionTestPayload): ConnectionTestResult {
+    testConnection(payload: ConnectionTestPayload): Promise<ConnectionTestResult> {
       const url = qualifyUrl(ApiRoutes.AuthenticationController.testConnection().url);
       const promise = fetch('POST', url, payload);
       AuthenticationActions.testConnection.promise(promise);
@@ -108,7 +108,7 @@ const AuthenticationStore: Store<{ authenticators: any }> = singletonStore(
       return promise;
     },
 
-    testLogin(payload: LoginTestPayload): LoginTestResult {
+    testLogin(payload: LoginTestPayload): Promise<LoginTestResult> {
       const url = qualifyUrl(ApiRoutes.AuthenticationController.testLogin().url);
       const promise = fetch('POST', url, payload);
       AuthenticationActions.testLogin.promise(promise);
@@ -140,7 +140,7 @@ const AuthenticationStore: Store<{ authenticators: any }> = singletonStore(
       return promise;
     },
 
-    loadBackendsPaginated(page: number, perPage: number, query: string): Promise<?PaginatedBackends> {
+    loadBackendsPaginated(page: number, perPage: number, query: string): Promise<PaginatedBackends> {
       const url = PaginationURL(ApiRoutes.AuthenticationController.servicesPaginated().url, page, perPage, query);
       const promise = fetch('GET', qualifyUrl(url))
         .then((response: PaginatedBackendsResponse) => ({
@@ -162,7 +162,7 @@ const AuthenticationStore: Store<{ authenticators: any }> = singletonStore(
       return promise;
     },
 
-    loadUsersPaginated(page: number, perPage: number, query: string): Promise<?PaginatedAuthUsers> {
+    loadUsersPaginated(page: number, perPage: number, query: string): Promise<PaginatedAuthUsers> {
       const url = PaginationURL(ApiRoutes.AuthenticationController.loadUsersPaginated().url, page, perPage, query);
 
       const promise = fetch('GET', qualifyUrl(url))

--- a/graylog2-web-interface/src/stores/roles/AuthzRolesStore.js
+++ b/graylog2-web-interface/src/stores/roles/AuthzRolesStore.js
@@ -85,7 +85,7 @@ const AuthzRolesStore: Store<{}> = singletonStore(
       return promise;
     },
 
-    addMembers(roleId: string, usernames: Immutable.Set<string>): Promise<?Role> {
+    addMembers(roleId: string, usernames: Immutable.Set<string>): Promise<Role> {
       const { url } = ApiRoutes.AuthzRolesController.addMembers(roleId);
       const promise = fetch('PUT', qualifyUrl(url), usernames.toArray());
 
@@ -125,7 +125,7 @@ const AuthzRolesStore: Store<{}> = singletonStore(
       return promise;
     },
 
-    loadRolesPaginated(page: number, perPage: number, query: string): Promise<?PaginatedListType> {
+    loadRolesPaginated(page: number, perPage: number, query: string): Promise<PaginatedListType> {
       const url = PaginationURL(ApiRoutes.AuthzRolesController.list().url, page, perPage, query);
 
       const promise = fetch('GET', qualifyUrl(url))

--- a/graylog2-web-interface/src/stores/users/UsersStore.js
+++ b/graylog2-web-interface/src/stores/users/UsersStore.js
@@ -27,7 +27,7 @@ const UsersStore: Store<{}> = singletonStore(
   () => Reflux.createStore({
     listenables: [UsersActions],
 
-    create(user: UserCreate): Promise<string[]> {
+    create(user: UserCreate): Promise<void> {
       const url = qualifyUrl(ApiRoutes.UsersApiController.create().url);
       const promise = fetch('POST', url, user);
       UsersActions.create.promise(promise);
@@ -35,7 +35,7 @@ const UsersStore: Store<{}> = singletonStore(
       return promise;
     },
 
-    load(username: string): Promise<?User> {
+    load(username: string): Promise<User> {
       const url = qualifyUrl(ApiRoutes.UsersApiController.load(encodeURIComponent(username)).url);
       const promise = fetch('GET', url).then(User.fromJSON);
 
@@ -44,7 +44,7 @@ const UsersStore: Store<{}> = singletonStore(
       return promise;
     },
 
-    update(username: string, user: UserUpdate): void {
+    update(username: string, user: UserUpdate): Promise<void> {
       const url = qualifyUrl(ApiRoutes.UsersApiController.update(encodeURIComponent(username)).url);
       const promise = fetch('PUT', url, user);
       UsersActions.update.promise(promise);
@@ -69,7 +69,7 @@ const UsersStore: Store<{}> = singletonStore(
       return promise;
     },
 
-    createToken(username: string, tokenName: string): Promise<?Token> {
+    createToken(username: string, tokenName: string): Promise<Token> {
       const url = qualifyUrl(ApiRoutes.UsersApiController.create_token(encodeURIComponent(username),
         encodeURIComponent(tokenName)).url);
       const promise = fetch('POST', url);
@@ -78,7 +78,7 @@ const UsersStore: Store<{}> = singletonStore(
       return promise;
     },
 
-    loadTokens(username: string): Promise<?Token[]> {
+    loadTokens(username: string): Promise<Token[]> {
       const url = qualifyUrl(ApiRoutes.UsersApiController.list_tokens(encodeURIComponent(username)).url);
       const promise = fetch('GET', url).then((response) => response.tokens);
       UsersActions.loadTokens.promise(promise);
@@ -86,7 +86,7 @@ const UsersStore: Store<{}> = singletonStore(
       return promise;
     },
 
-    deleteToken(username: string, tokenId: string): Promise<?string[]> {
+    deleteToken(username: string, tokenId: string): Promise<string[]> {
       const url = qualifyUrl(ApiRoutes.UsersApiController.delete_token(encodeURIComponent(username),
         encodeURIComponent(tokenId)).url, {});
       const promise = fetch('DELETE', url);
@@ -104,7 +104,7 @@ const UsersStore: Store<{}> = singletonStore(
       return promise;
     },
 
-    loadUsersPaginated(page: number, perPage: number, query: string): Promise<?PaginatedUsers> {
+    loadUsersPaginated(page: number, perPage: number, query: string): Promise<PaginatedUsers> {
       const url = PaginationURL(ApiRoutes.UsersApiController.paginated().url, page, perPage, query);
 
       const promise = fetch('GET', qualifyUrl(url))


### PR DESCRIPTION
## Description
## Motivation and Context
This PR refactors most type definitions for actions which are using the `notifyingAction`. We made sure, that the `notifyingAction` only returns on success and otherwise throws an error. This way all action response type definitions only need to consider the success case. It also simplifies processing the return value of these actions in components.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.


/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1840
