### PR TITLE
Rename EventNotification GRNType

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/grn/GRNTypes.java
+++ b/graylog2-server/src/main/java/org/graylog/grn/GRNTypes.java
@@ -23,7 +23,7 @@ public class GRNTypes {
     public static final GRNType COLLECTION = GRNType.create("collection", "collections:");
     public static final GRNType DASHBOARD = GRNType.create("dashboard", "dashboards:");
     public static final GRNType EVENT_DEFINITION = GRNType.create("event_definition", "eventdefinitions:");
-    public static final GRNType EVENT_NOTIFICATION = GRNType.create("event_notification", "eventnotifications:");
+    public static final GRNType EVENT_NOTIFICATION = GRNType.create("notification", "eventnotifications:");
     public static final GRNType GRANT = GRNType.create("grant", "grants:");
     public static final GRNType ROLE = GRNType.create("role", "roles:");
     public static final GRNType SEARCH = GRNType.create("search", "view:");


### PR DESCRIPTION
## Motivation
Prior to this change, the dependency resolution which is using the
content pack mechanism tried to find the event notification type with
'event_notification' which is not a registered type in content pack.

## Description
This change will rename the type to `notification` so the dependency
resolution via content packs works again.