### PR TITLE
Fix AuthenticationBackendEditPage url query handling

### DIFF
--- a/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendConfigDetails/EditLinkButton.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendConfigDetails/EditLinkButton.jsx
@@ -1,6 +1,5 @@
 // @flow strict
 import * as React from 'react';
-import URI from 'urijs';
 
 import { LinkContainer } from 'components/graylog/router';
 import Routes from 'routing/Routes';
@@ -11,16 +10,10 @@ type Props = {
   stepKey: string,
 };
 
-const EditLinkButton = ({ authenticationBackendId, stepKey }: Props) => {
-  const editLink = new URI(Routes.SYSTEM.AUTHENTICATION.BACKENDS.edit(authenticationBackendId))
-    .search({ initialStepKey: stepKey })
-    .toString();
-
-  return (
-    <LinkContainer to={editLink}>
-      <Button bsStyle="success" bsSize="small">Edit</Button>
-    </LinkContainer>
-  );
-};
+const EditLinkButton = ({ authenticationBackendId, stepKey }: Props) => (
+  <LinkContainer to={Routes.SYSTEM.AUTHENTICATION.BACKENDS.edit(authenticationBackendId, stepKey)}>
+    <Button bsStyle="success" bsSize="small">Edit</Button>
+  </LinkContainer>
+);
 
 export default EditLinkButton;

--- a/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendConfigDetails/EditLinkButton.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendConfigDetails/EditLinkButton.jsx
@@ -1,5 +1,6 @@
 // @flow strict
 import * as React from 'react';
+import URI from 'urijs';
 
 import { LinkContainer } from 'components/graylog/router';
 import Routes from 'routing/Routes';
@@ -11,12 +12,9 @@ type Props = {
 };
 
 const EditLinkButton = ({ authenticationBackendId, stepKey }: Props) => {
-  const editLink = {
-    pathname: Routes.SYSTEM.AUTHENTICATION.BACKENDS.edit(authenticationBackendId),
-    query: {
-      initialStepKey: stepKey,
-    },
-  };
+  const editLink = new URI(Routes.SYSTEM.AUTHENTICATION.BACKENDS.edit(authenticationBackendId))
+    .search({ initialStepKey: stepKey })
+    .toString();
 
   return (
     <LinkContainer to={editLink}>

--- a/graylog2-web-interface/src/pages/AuthenticationBackendEditPage.jsx
+++ b/graylog2-web-interface/src/pages/AuthenticationBackendEditPage.jsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { useState, useEffect } from 'react';
 
 import withParams from 'routing/withParams';
+import withLocation, { type Location } from 'routing/withLocation';
 import {} from 'components/authentication/bindings'; // Bind all authentication plugins
 import { getAuthServicePlugin } from 'util/AuthenticationService';
 import { Spinner } from 'components/common';
@@ -12,11 +13,7 @@ type Props = {
   params: {
     backendId: string,
   },
-  location: {
-    query: {
-      initialStepKey?: string,
-    },
-  },
+  location: Location,
 };
 
 const AuthenticationBackendEditPage = ({ params: { backendId }, location: { query: { initialStepKey } } }: Props) => {
@@ -41,4 +38,4 @@ const AuthenticationBackendEditPage = ({ params: { backendId }, location: { quer
   return <BackendEdit authenticationBackend={authBackend} initialStepKey={initialStepKey} />;
 };
 
-export default withParams(AuthenticationBackendEditPage);
+export default withParams(withLocation(AuthenticationBackendEditPage));

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -75,7 +75,13 @@ const Routes = {
         CREATE: '/system/authentication/services/create',
         createBackend: (name) => `/system/authentication/services/create/${name}`,
         show: (id) => `/system/authentication/services/${id}`,
-        edit: (id) => `/system/authentication/services/edit/${id}`,
+        edit: (id, initialStepKey) => {
+          const editUrl = `/system/authentication/services/edit/${id}`;
+
+          if (initialStepKey) return `${editUrl}?initialStepKey=${initialStepKey}`;
+
+          return editUrl;
+        },
       },
     },
     USERS: {


### PR DESCRIPTION
## Description
## Motivation and Context
This PR fixes the url query handling for the `AuthenticationBackendEditPage`. Previously the query param `initialStepKey` was not being used correctly. The query params was also not set correctly on the authentication backend details page.

On the details page we've used:
```
<LinkContianer to={
  pathname,
  query: {
    initialStepKey: stepKey,
  }
}>...
```
Due to the the react router upgrade https://github.com/Graylog2/graylog2-server/pull/9135 and the `LinkContainer` changes, `query` is no longer supported when using an object for the `to` prop. We need to use e.g.`to={ ..., search: '?=initialStepKey=the-key', }` instead or attach the query string directly:
```

const url = new URI(pathname)
    .search({ initialStepKey: 'the-key })
    .toString();

<LinkContianer to={url} />...
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

