### PR TITLE
Rename EventNotification GRNType in frontend

### DIFF
--- a/graylog2-web-interface/src/logic/permissions/GRN.js
+++ b/graylog2-web-interface/src/logic/permissions/GRN.js
@@ -25,7 +25,7 @@ export const getShowRouteFromGRN = (grn: string) => {
       return Routes.dashboard_show(id);
     case 'event_definition':
       return Routes.ALERTS.DEFINITIONS.edit(id);
-    case 'event_notification':
+    case 'notification':
       return Routes.ALERTS.NOTIFICATIONS.edit(id);
     case 'search':
       return Routes.getPluginRoute('SEARCH_VIEWID')(id);


### PR DESCRIPTION
Prior to this change, the dependency resolution which is using the
content pack mechanism tried to find the event notification type with
'event_notification' which is not a registered type in content pack.

This change will rename the type to `notification` so the dependency
resolution via content packs works again.
