### PR TITLE
Use activeShares as a fallback for the dependency permission check

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/entities/EntityDependencyPermissionChecker.java
+++ b/graylog2-server/src/main/java/org/graylog/security/entities/EntityDependencyPermissionChecker.java
@@ -27,6 +27,7 @@ import org.graylog.security.GranteeAuthorizer;
 import javax.inject.Inject;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 
 public class EntityDependencyPermissionChecker {
     private final GranteeAuthorizer.Factory granteeAuthorizerFactory;
@@ -50,7 +51,7 @@ public class EntityDependencyPermissionChecker {
      */
     public ImmutableMultimap<GRN, EntityDescriptor> check(GRN sharingUser,
                                                           ImmutableSet<EntityDescriptor> dependencies,
-                                                          ImmutableSet<GRN> selectedGrantees) {
+                                                          Set<GRN> selectedGrantees) {
         final ImmutableMultimap.Builder<GRN, EntityDescriptor> deniedDependencies = ImmutableMultimap.builder();
         final GranteeAuthorizer sharerAuthorizer = granteeAuthorizerFactory.create(sharingUser);
 


### PR DESCRIPTION
The initial prepareShare request does not contain any selectedGranteeCapabilities
The way this should be handled is to use the existing activeShares.

Fixes #9200

