### PR TITLE
Event definition share dialog

### DIFF
--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionSummary.jsx
@@ -1,16 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import { Col, Row } from 'components/graylog';
-
 import lodash from 'lodash';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 import moment from 'moment';
 import {} from 'moment-duration-format';
 import naturalSort from 'javascript-natural-sort';
 
+import { Col, Row } from 'components/graylog';
 import PermissionsMixin from 'util/PermissionsMixin';
 import EventDefinitionPriorityEnum from 'logic/alerts/EventDefinitionPriorityEnum';
+
+// Import built-in plugins
+import {} from 'components/event-definitions/event-definition-types';
+import {} from 'components/event-notifications/event-notification-types';
 
 import EventDefinitionValidationSummary from './EventDefinitionValidationSummary';
 import styles from './EventDefinitionSummary.css';
@@ -21,13 +23,21 @@ class EventDefinitionSummary extends React.Component {
   static propTypes = {
     eventDefinition: PropTypes.object.isRequired,
     notifications: PropTypes.array.isRequired,
-    validation: PropTypes.object.isRequired,
+    validation: PropTypes.object,
     currentUser: PropTypes.object.isRequired,
   };
 
-  state = {
-    showValidation: false,
+  static defaultProps = {
+    validation: undefined,
   };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      showValidation: false,
+    };
+  }
 
   componentDidUpdate() {
     this.showValidation();

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionSummary.jsx
@@ -6,8 +6,8 @@ import moment from 'moment';
 import {} from 'moment-duration-format';
 import naturalSort from 'javascript-natural-sort';
 
-import { Col, Row } from 'components/graylog';
-import PermissionsMixin from 'util/PermissionsMixin';
+import { Alert, Col, Row } from 'components/graylog';
+import { isPermitted } from 'util/PermissionsMixin';
 import EventDefinitionPriorityEnum from 'logic/alerts/EventDefinitionPriorityEnum';
 
 // Import built-in plugins
@@ -199,14 +199,26 @@ class EventDefinitionSummary extends React.Component {
   renderNotifications = (definitionNotifications, notificationSettings) => {
     const { currentUser } = this.props;
 
-    const effectiveDefinitionNotifications = PermissionsMixin.isPermitted(currentUser.permissions,
-      'eventnotifications:read')
-      ? definitionNotifications : [];
+    const effectiveDefinitionNotifications = definitionNotifications
+      .filter((n) => isPermitted(currentUser.permissions, `eventnotifications:read${n.notification_id}`));
+    const notificationsWithMissingPermissions = definitionNotifications
+      .filter((n) => !effectiveDefinitionNotifications.map((nObj) => nObj.notification_id).includes(n.notification_id));
+    const warning = notificationsWithMissingPermissions.length > 0
+      ? (
+        <Alert bsStyle="warning">
+          Missing Notifications Permissions for:<br />
+          {notificationsWithMissingPermissions.map((n) => n.notification_id).join(', ')}
+        </Alert>
+      )
+      : null;
 
     return (
       <>
         <h3 className={commonStyles.title}>Notifications</h3>
-        {effectiveDefinitionNotifications.length === 0
+        <p>
+          {warning}
+        </p>
+        {effectiveDefinitionNotifications.length === 0 && notificationsWithMissingPermissions.length <= 0
           ? <p>This Event is not configured to trigger any Notifications.</p>
           : (
             <>

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionValidationSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/EventDefinitionValidationSummary.jsx
@@ -11,7 +11,7 @@ class EventDefinitionValidationSummary extends React.Component {
   };
 
   render() {
-    const { validation } = this.props;
+    const { validation = {} } = this.props;
     const fieldsWithErrors = Object.keys(validation.errors);
 
     if (fieldsWithErrors.length === 0) {

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationsForm.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-form/NotificationsForm.jsx
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 import lodash from 'lodash';
 
 import { LinkContainer } from 'components/graylog/router';
-import { Col, Row, Button } from 'components/graylog';
+import { Alert, Col, Row, Button } from 'components/graylog';
 import { Icon } from 'components/common';
 import Routes from 'routing/Routes';
-import PermissionsMixin from 'util/PermissionsMixin';
+import { isPermitted } from 'util/PermissionsMixin';
 
 import AddNotificationForm from './AddNotificationForm';
 import NotificationSettingsForm from './NotificationSettingsForm';
@@ -58,7 +58,22 @@ class NotificationsForm extends React.Component {
     const { eventDefinition, notifications, defaults, currentUser, onChange } = this.props;
     const { showAddNotificationForm } = this.state;
 
-    if (!PermissionsMixin.isPermitted(currentUser.permissions, 'eventnotifications:read')) {
+    const notificationIds = eventDefinition.notifications.map((n) => n.notification_id);
+    const missingPermissions = notificationIds.filter((id) => !isPermitted(currentUser.permissions, `eventnotifications:read${id}`));
+
+    if (missingPermissions.length > 0) {
+      return (
+        <Row>
+          <Col md={6} lg={5}>
+            <Alert bsStyle="warning">
+              Missing Notifications Permissions for: <br /> {missingPermissions.join(', ')}
+            </Alert>
+          </Col>
+        </Row>
+      );
+    }
+
+    if (!isPermitted(currentUser.permissions, 'eventnotifications:read')) {
       return (
         <Row>
           <Col md={6} lg={5}>
@@ -74,7 +89,7 @@ class NotificationsForm extends React.Component {
                              onChange={this.handleAssignNotification}
                              onCancel={this.toggleAddNotificationForm}
                              hasCreationPermissions={
-                               PermissionsMixin.isPermitted(currentUser.permissions, 'eventnotifications:create')
+                               isPermitted(currentUser.permissions, 'eventnotifications:create')
                              } />
       );
     }

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.jsx
@@ -51,7 +51,7 @@ class FilterAggregationSummary extends React.Component {
       return 'No Streams selected, searches in all Streams';
     }
 
-    const warning = streamIdsWithMissingPermission
+    const warning = streamIdsWithMissingPermission.length > 0
       ? <Alert bsStyle="warning">Missing Stream Permissions for:<br />{streamIdsWithMissingPermission.join(', ')}</Alert>
       : null;
 

--- a/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definition-types/FilterAggregationSummary.jsx
@@ -6,7 +6,7 @@ import { Link } from 'components/graylog/router';
 import { Alert } from 'components/graylog';
 import { extractDurationAndUnit } from 'components/common/TimeUnitInput';
 import { Icon } from 'components/common';
-import PermissionsMixin from 'util/PermissionsMixin';
+import { isPermitted } from 'util/PermissionsMixin';
 import { naturalSortIgnoreCase } from 'util/SortUtils';
 import Routes from 'routing/Routes';
 import validateExpression from 'logic/alerts/AggregationExpressionValidation';
@@ -44,17 +44,28 @@ class FilterAggregationSummary extends React.Component {
     );
   };
 
-  renderStreams = (streamIds) => {
+  renderStreams = (streamIds, streamIdsWithMissingPermission) => {
     const { streams } = this.props;
 
-    if (!streamIds || streamIds.length === 0) {
+    if ((!streamIds || streamIds.length === 0) && streamIdsWithMissingPermission.length <= 0) {
       return 'No Streams selected, searches in all Streams';
     }
 
-    return streamIds
+    const warning = streamIdsWithMissingPermission
+      ? <Alert bsStyle="warning">Missing Stream Permissions for:<br />{streamIdsWithMissingPermission.join(', ')}</Alert>
+      : null;
+
+    const renderedStreams = streamIds
       .map((id) => streams.find((s) => s.id === id) || id)
       .sort((s1, s2) => naturalSortIgnoreCase(s1.title || s1, s2.title || s2))
       .map(this.formatStreamOrId);
+
+    return (
+      <>
+        {warning}
+        {renderedStreams}
+      </>
+    );
   };
 
   renderQueryParameters = (queryParameters) => {
@@ -92,8 +103,8 @@ class FilterAggregationSummary extends React.Component {
     const searchWithin = extractDurationAndUnit(searchWithinMs, TIME_UNITS);
     const executeEvery = extractDurationAndUnit(executeEveryMs, TIME_UNITS);
 
-    const effectiveStreamIds = PermissionsMixin.isPermitted(currentUser.permissions, 'streams:read')
-      ? streams : [];
+    const effectiveStreamIds = streams.filter((s) => isPermitted(currentUser.permissions, `streams:read:${s}`));
+    const streamIdsWithMissingPermission = streams.filter((s) => !effectiveStreamIds.includes(s));
 
     const validationResults = validateExpression(conditions.expression, series);
 
@@ -105,7 +116,7 @@ class FilterAggregationSummary extends React.Component {
         <dd>{query || '*'}</dd>
         {queryParameters.length > 0 && this.renderQueryParameters(queryParameters)}
         <dt>Streams</dt>
-        <dd className={styles.streamList}>{this.renderStreams(effectiveStreamIds)}</dd>
+        <dd className={styles.streamList}>{this.renderStreams(effectiveStreamIds, streamIdsWithMissingPermission)}</dd>
         <dt>Search within</dt>
         <dd>{searchWithin.duration} {searchWithin.unit.toLowerCase()}</dd>
         <dt>Execute search every</dt>

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.jsx
@@ -1,0 +1,124 @@
+// @flow strict
+import React, { useState } from 'react';
+import lodash from 'lodash';
+import { PluginStore } from 'graylog-web-plugin/plugin';
+
+import EntityShareModal from 'components/permissions/EntityShareModal';
+import SharingDisabledPopover from 'components/permissions/SharingDisabledPopover';
+import Routes from 'routing/Routes';
+import { LinkContainer } from 'components/graylog/router';
+import {
+  Button,
+  DropdownButton,
+  Label,
+  MenuItem,
+} from 'components/graylog';
+import {
+  EntityListItem,
+  IfPermitted,
+  HasOwnership,
+} from 'components/common';
+
+import EventDefinitionDescription from './EventDefinitionDescription';
+
+type EventDefinition = {
+  id: string,
+  config: {
+    type: string,
+  },
+  title: string,
+};
+
+type Props = {
+  context: {
+    scheduler: {
+      [id: string]: {
+        is_scheduled: boolean,
+      },
+    },
+  },
+  eventDefinition: EventDefinition,
+  onDisable: (EventDefinition) => void,
+  onEnable: (EventDefinition) => void,
+  onDelete: (EventDefinition) => void,
+};
+
+const getConditionPlugin = (type) => {
+  if (type === undefined) {
+    return {};
+  }
+
+  return PluginStore.exports('eventDefinitionTypes').find((edt) => edt.type === type) || {};
+};
+
+const renderDescription = (definition, context) => {
+  return <EventDefinitionDescription definition={definition} context={context} />;
+};
+
+const EventDefinitionEntry = ({
+  context,
+  eventDefinition,
+  onDisable,
+  onEnable,
+  onDelete,
+}: Props) => {
+  const [showEntityShareModal, setShowEntityShareModal] = useState(false);
+  const isScheduled = lodash.get(context, `scheduler.${eventDefinition.id}.is_scheduled`, true);
+
+  let toggle = <MenuItem onClick={onDisable(eventDefinition)}>Disable</MenuItem>;
+
+  if (!isScheduled) {
+    toggle = <MenuItem onClick={onEnable(eventDefinition)}>Enable</MenuItem>;
+  }
+
+  const actions = (
+    <React.Fragment key={`actions-${eventDefinition.id}`}>
+      <IfPermitted permissions={`eventdefinitions:edit:${eventDefinition.id}`}>
+        <LinkContainer to={Routes.ALERTS.DEFINITIONS.edit(eventDefinition.id)}>
+          <Button bsStyle="info">Edit</Button>
+        </LinkContainer>
+      </IfPermitted>
+      <IfPermitted permissions={`eventdefinitions:delete:${eventDefinition.id}`}>
+        <DropdownButton id="more-dropdown" title="More" pullRight>
+          {toggle}
+          <MenuItem divider />
+          <MenuItem onClick={onDelete(eventDefinition)}>Delete</MenuItem>
+          <HasOwnership id={eventDefinition.id} type="event_definition">
+            {({ disabled }) => (
+              <MenuItem key={`share-${eventDefinition.id}`} onSelect={() => setShowEntityShareModal(true)} disabled={disabled}>
+                Share {disabled && <SharingDisabledPopover type="stream" />}
+              </MenuItem>
+            )}
+          </HasOwnership>
+        </DropdownButton>
+      </IfPermitted>
+    </React.Fragment>
+  );
+
+  const plugin = getConditionPlugin(eventDefinition.config.type);
+  let titleSuffix = plugin.displayName || eventDefinition.config.type;
+
+  if (!isScheduled) {
+    titleSuffix = (<span>{titleSuffix} <Label bsStyle="warning">disabled</Label></span>);
+  }
+
+  return (
+    <>
+      <EntityListItem key={`event-definition-${eventDefinition.id}`}
+                      title={eventDefinition.title}
+                      titleSuffix={titleSuffix}
+                      description={renderDescription(eventDefinition, context)}
+                      noItemsText="Could not find any items with the given filter."
+                      actions={actions} />
+      { showEntityShareModal && (
+        <EntityShareModal entityId={eventDefinition.id}
+                        entityType="event_definition"
+                        entityTitle={eventDefinition.title}
+                        description="Search for a User or Team to add as collaborator on this event definition."
+                        onClose={() => setShowEntityShareModal(false)} />
+      )}
+    </>
+  );
+};
+
+export default EventDefinitionEntry;

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.jsx
@@ -6,7 +6,7 @@ import { PluginStore } from 'graylog-web-plugin/plugin';
 import EntityShareModal from 'components/permissions/EntityShareModal';
 import SharingDisabledPopover from 'components/permissions/SharingDisabledPopover';
 import Routes from 'routing/Routes';
-import { LinkContainer } from 'components/graylog/router';
+import { Link, LinkContainer } from 'components/graylog/router';
 import {
   Button,
   DropdownButton,
@@ -78,9 +78,6 @@ const EventDefinitionEntry = ({
           <Button bsStyle="info">Edit</Button>
         </LinkContainer>
       </IfPermitted>
-      <LinkContainer to={Routes.ALERTS.DEFINITIONS.view(eventDefinition.id)}>
-        <Button bsStyle="info">View</Button>
-      </LinkContainer>
       <IfPermitted permissions={`eventdefinitions:delete:${eventDefinition.id}`}>
         <DropdownButton id="more-dropdown" title="More" pullRight>
           {toggle}
@@ -105,20 +102,22 @@ const EventDefinitionEntry = ({
     titleSuffix = (<span>{titleSuffix} <Label bsStyle="warning">disabled</Label></span>);
   }
 
+  const linkTitle = <Link to={Routes.ALERTS.DEFINITIONS.view(eventDefinition.id)}>{eventDefinition.title}</Link>;
+
   return (
     <>
       <EntityListItem key={`event-definition-${eventDefinition.id}`}
-                      title={eventDefinition.title}
+                      title={linkTitle}
                       titleSuffix={titleSuffix}
                       description={renderDescription(eventDefinition, context)}
                       noItemsText="Could not find any items with the given filter."
                       actions={actions} />
       { showEntityShareModal && (
         <EntityShareModal entityId={eventDefinition.id}
-                        entityType="event_definition"
-                        entityTitle={eventDefinition.title}
-                        description="Search for a User or Team to add as collaborator on this event definition."
-                        onClose={() => setShowEntityShareModal(false)} />
+                          entityType="event_definition"
+                          entityTitle={eventDefinition.title}
+                          description="Search for a User or Team to add as collaborator on this event definition."
+                          onClose={() => setShowEntityShareModal(false)} />
       )}
     </>
   );

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.jsx
@@ -78,6 +78,9 @@ const EventDefinitionEntry = ({
           <Button bsStyle="info">Edit</Button>
         </LinkContainer>
       </IfPermitted>
+      <LinkContainer to={Routes.ALERTS.DEFINITIONS.view(eventDefinition.id)}>
+        <Button bsStyle="info">View</Button>
+      </LinkContainer>
       <IfPermitted permissions={`eventdefinitions:delete:${eventDefinition.id}`}>
         <DropdownButton id="more-dropdown" title="More" pullRight>
           {toggle}

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitions.jsx
@@ -1,22 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { PluginStore } from 'graylog-web-plugin/plugin';
-import lodash from 'lodash';
 
 import { LinkContainer } from 'components/graylog/router';
-import { Button, Col, DropdownButton, Label, MenuItem, Row } from 'components/graylog';
+import { Button, Col, Row } from 'components/graylog';
 import Routes from 'routing/Routes';
 import {
   EmptyEntity,
   EntityList,
-  EntityListItem,
   IfPermitted,
   PaginatedList,
   SearchForm,
 } from 'components/common';
 
-import EventDefinitionDescription from './EventDefinitionDescription';
 import styles from './EventDefinitions.css';
+import EventDefinitionEntry from './EventDefinitionEntry';
 
 class EventDefinitions extends React.Component {
   static propTypes = {
@@ -33,14 +30,6 @@ class EventDefinitions extends React.Component {
 
   static defaultProps = {
     context: {},
-  };
-
-  getConditionPlugin = (type) => {
-    if (type === undefined) {
-      return {};
-    }
-
-    return PluginStore.exports('eventDefinitionTypes').find((edt) => edt.type === type) || {};
   };
 
   renderEmptyContent = () => {
@@ -63,10 +52,6 @@ class EventDefinitions extends React.Component {
     );
   };
 
-  renderDescription = (definition, context) => {
-    return <EventDefinitionDescription definition={definition} context={context} />;
-  };
-
   render() {
     const { eventDefinitions, context, pagination, query, onPageChange, onQueryChange, onDelete, onEnable, onDisable } = this.props;
 
@@ -74,48 +59,13 @@ class EventDefinitions extends React.Component {
       return this.renderEmptyContent();
     }
 
-    const items = eventDefinitions.map((definition) => {
-      const isScheduled = lodash.get(context, `scheduler.${definition.id}.is_scheduled`, true);
-
-      let toggle = <MenuItem onClick={onDisable(definition)}>Disable</MenuItem>;
-
-      if (!isScheduled) {
-        toggle = <MenuItem onClick={onEnable(definition)}>Enable</MenuItem>;
-      }
-
-      const actions = (
-        <React.Fragment key={`actions-${definition.id}`}>
-          <IfPermitted permissions={`eventdefinitions:edit:${definition.id}`}>
-            <LinkContainer to={Routes.ALERTS.DEFINITIONS.edit(definition.id)}>
-              <Button bsStyle="info">Edit</Button>
-            </LinkContainer>
-          </IfPermitted>
-          <IfPermitted permissions={`eventdefinitions:delete:${definition.id}`}>
-            <DropdownButton id="more-dropdown" title="More" pullRight>
-              {toggle}
-              <MenuItem divider />
-              <MenuItem onClick={onDelete(definition)}>Delete</MenuItem>
-            </DropdownButton>
-          </IfPermitted>
-        </React.Fragment>
-      );
-
-      const plugin = this.getConditionPlugin(definition.config.type);
-      let titleSuffix = plugin.displayName || definition.config.type;
-
-      if (!isScheduled) {
-        titleSuffix = (<span>{titleSuffix} <Label bsStyle="warning">disabled</Label></span>);
-      }
-
-      return (
-        <EntityListItem key={`event-definition-${definition.id}`}
-                        title={definition.title}
-                        titleSuffix={titleSuffix}
-                        description={this.renderDescription(definition, context)}
-                        noItemsText="Could not find any items with the given filter."
-                        actions={actions} />
-      );
-    });
+    const items = eventDefinitions.map((definition) => (
+      <EventDefinitionEntry context={context}
+                            eventDefinition={definition}
+                            onDisable={onDisable}
+                            onEnable={onEnable}
+                            onDelete={onDelete} />
+    ));
 
     return (
       <Row>

--- a/graylog2-web-interface/src/pages/EditEventDefinitionPage.jsx
+++ b/graylog2-web-interface/src/pages/EditEventDefinitionPage.jsx
@@ -75,7 +75,7 @@ class EditEventDefinitionPage extends React.Component {
     const missingStreams = this._streamsWithMissingPermissions(eventDefinition, currentUser);
 
     if (missingStreams.length > 0) {
-      return <StreamPermissionErrorPage fetchError={{}} missingStreamIds={missingStreams} />;
+      return <StreamPermissionErrorPage error={{}} missingStreamIds={missingStreams} />;
     }
 
     if (!eventDefinition) {

--- a/graylog2-web-interface/src/pages/EditEventDefinitionPage.jsx
+++ b/graylog2-web-interface/src/pages/EditEventDefinitionPage.jsx
@@ -11,14 +11,14 @@ import connect from 'stores/connect';
 import CombinedProvider from 'injection/CombinedProvider';
 import Routes from 'routing/Routes';
 import DocsHelper from 'util/DocsHelper';
-import PermissionsMixin from 'util/PermissionsMixin';
+import { isPermitted } from 'util/PermissionsMixin';
 import history from 'util/History';
 import withParams from 'routing/withParams';
 
+import StreamPermissionErrorPage from './StreamPermissionErrorPage';
+
 const { EventDefinitionsActions } = CombinedProvider.get('EventDefinitions');
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
-
-const { isPermitted } = PermissionsMixin;
 
 class EditEventDefinitionPage extends React.Component {
   static propTypes = {
@@ -58,12 +58,24 @@ class EditEventDefinitionPage extends React.Component {
     }
   }
 
+  _streamsWithMissingPermissions(eventDefinition, currentUser) {
+    const streams = eventDefinition?.config?.streams || [];
+
+    return streams.filter((streamId) => !isPermitted(currentUser.permissions, `streams:read:${streamId}`));
+  }
+
   render() {
     const { params, currentUser } = this.props;
     const { eventDefinition } = this.state;
 
     if (!isPermitted(currentUser.permissions, `eventdefinitions:edit:${params.definitionId}`)) {
       history.push(Routes.NOTFOUND);
+    }
+
+    const missingStreams = this._streamsWithMissingPermissions(eventDefinition, currentUser);
+
+    if (missingStreams.length > 0) {
+      return <StreamPermissionErrorPage fetchError={{}} missingStreamIds={missingStreams} />;
     }
 
     if (!eventDefinition) {

--- a/graylog2-web-interface/src/pages/EventDefinitionsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventDefinitionsPage.jsx
@@ -27,11 +27,9 @@ const EventDefinitionsPage = () => {
             <LinkContainer to={Routes.ALERTS.LIST}>
               <Button bsStyle="info">Alerts & Events</Button>
             </LinkContainer>
-            <IfPermitted permissions={['eventdefinitions:read', 'eventdefinitions:create']} anyPermissions>
-              <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
-                <Button bsStyle="info" className="active">Event Definitions</Button>
-              </LinkContainer>
-            </IfPermitted>
+            <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
+              <Button bsStyle="info" className="active">Event Definitions</Button>
+            </LinkContainer>
             <IfPermitted permissions={['eventnotifications:read', 'eventnotifications:create']} anyPermissions>
               <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
                 <Button bsStyle="info">Notifications</Button>

--- a/graylog2-web-interface/src/pages/EventDefinitionsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventDefinitionsPage.jsx
@@ -30,11 +30,9 @@ const EventDefinitionsPage = () => {
             <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
               <Button bsStyle="info" className="active">Event Definitions</Button>
             </LinkContainer>
-            <IfPermitted permissions={['eventnotifications:read', 'eventnotifications:create']} anyPermissions>
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
-                <Button bsStyle="info">Notifications</Button>
-              </LinkContainer>
-            </IfPermitted>
+            <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
+              <Button bsStyle="info">Notifications</Button>
+            </LinkContainer>
           </ButtonToolbar>
         </PageHeader>
 

--- a/graylog2-web-interface/src/pages/EventNotificationsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventNotificationsPage.jsx
@@ -24,16 +24,12 @@ const EventNotificationsPage = () => {
             <LinkContainer to={Routes.ALERTS.LIST}>
               <Button bsStyle="info">Alerts & Events</Button>
             </LinkContainer>
-            <IfPermitted permissions={['eventdefinitions:read', 'eventdefinitions:create']} anyPermissions>
-              <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
-                <Button bsStyle="info">Event Definitions</Button>
-              </LinkContainer>
-            </IfPermitted>
-            <IfPermitted permissions={['eventnotifications:read', 'eventnotifications:create']} anyPermissions>
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
-                <Button bsStyle="info" className="active">Notifications</Button>
-              </LinkContainer>
-            </IfPermitted>
+            <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
+              <Button bsStyle="info">Event Definitions</Button>
+            </LinkContainer>
+            <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
+              <Button bsStyle="info" className="active">Notifications</Button>
+            </LinkContainer>
           </ButtonToolbar>
         </PageHeader>
 

--- a/graylog2-web-interface/src/pages/EventsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventsPage.jsx
@@ -31,16 +31,12 @@ const EventsPage = ({ location }) => {
             <LinkContainer to={Routes.ALERTS.LIST}>
               <Button bsStyle="info" className="active">Alerts &amp; Events</Button>
             </LinkContainer>
-            <IfPermitted permissions={['eventdefinitions:read', 'eventdefinitions:create']} anyPermissions>
-              <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
-                <Button bsStyle="info">Event Definitions</Button>
-              </LinkContainer>
-            </IfPermitted>
-            <IfPermitted permissions={['eventnotifications:read', 'eventnotifications:create']} anyPermissions>
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
-                <Button bsStyle="info">Notifications</Button>
-              </LinkContainer>
-            </IfPermitted>
+            <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
+              <Button bsStyle="info">Event Definitions</Button>
+            </LinkContainer>
+            <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
+              <Button bsStyle="info">Notifications</Button>
+            </LinkContainer>
           </ButtonToolbar>
         </PageHeader>
 

--- a/graylog2-web-interface/src/pages/StreamPermissionErrorPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamPermissionErrorPage.jsx
@@ -7,21 +7,22 @@ import { FetchError } from 'logic/rest/FetchProvider';
 import UnauthorizedErrorPage from './UnauthorizedErrorPage';
 
 type Props = {
-  error: FetchError,
+  fetchError: FetchError,
+  missingStreamIds: string[],
 };
 
-const StreamPermissionErrorPage = ({ error }: Props) => {
+const StreamPermissionErrorPage = ({ fetchError = {}, missingStreamIds }: Props) => {
   const description = (
     <>
       <p>This resource includes streams you do not have permissions for.</p>
       <p>Please contact your administrator and provide the error details which include a list of streams you need access to.</p>
     </>
   );
-  const streamIds = error?.additional?.body?.streams;
+  const streamIds = missingStreamIds || fetchError?.additional?.body?.streams;
   const errorDetails = streamIds?.length > 0 ? `You need permissions for streams with the id: ${streamIds.join(', ')}.` : undefined;
 
   return (
-    <UnauthorizedErrorPage error={error} description={description} title="Missing Stream Permissions" errorDetails={errorDetails} />
+    <UnauthorizedErrorPage error={fetchError} description={description} title="Missing Stream Permissions" errorDetails={errorDetails} />
   );
 };
 

--- a/graylog2-web-interface/src/pages/StreamPermissionErrorPage.jsx
+++ b/graylog2-web-interface/src/pages/StreamPermissionErrorPage.jsx
@@ -7,22 +7,24 @@ import { FetchError } from 'logic/rest/FetchProvider';
 import UnauthorizedErrorPage from './UnauthorizedErrorPage';
 
 type Props = {
-  fetchError: FetchError,
+  error: FetchError,
   missingStreamIds: string[],
 };
 
-const StreamPermissionErrorPage = ({ fetchError = {}, missingStreamIds }: Props) => {
+const StreamPermissionErrorPage = ({ error = {}, missingStreamIds = [] }: Props) => {
   const description = (
     <>
       <p>This resource includes streams you do not have permissions for.</p>
       <p>Please contact your administrator and provide the error details which include a list of streams you need access to.</p>
     </>
   );
-  const streamIds = missingStreamIds || fetchError?.additional?.body?.streams;
+  const streamIds = missingStreamIds.length > 0
+    ? missingStreamIds
+    : error?.additional?.body?.streams;
   const errorDetails = streamIds?.length > 0 ? `You need permissions for streams with the id: ${streamIds.join(', ')}.` : undefined;
 
   return (
-    <UnauthorizedErrorPage error={fetchError} description={description} title="Missing Stream Permissions" errorDetails={errorDetails} />
+    <UnauthorizedErrorPage error={error} description={description} title="Missing Stream Permissions" errorDetails={errorDetails} />
   );
 };
 
@@ -35,6 +37,11 @@ StreamPermissionErrorPage.propTypes = {
       }),
     }),
   }).isRequired,
+  missingStreamIds: PropTypes.arrayOf(PropTypes.string),
+};
+
+StreamPermissionErrorPage.defaultProps = {
+  missingStreamIds: [],
 };
 
 export default StreamPermissionErrorPage;

--- a/graylog2-web-interface/src/pages/ViewEventDefinitionPage.jsx
+++ b/graylog2-web-interface/src/pages/ViewEventDefinitionPage.jsx
@@ -1,0 +1,99 @@
+// @flow strict
+import * as React from 'react';
+import { useState, useEffect, useContext } from 'react';
+
+import withParams from 'routing/withParams';
+import { LinkContainer } from 'components/graylog/router';
+import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
+import CombinedProvider from 'injection/CombinedProvider';
+import Routes from 'routing/Routes';
+import DocsHelper from 'util/DocsHelper';
+import { DocumentTitle, PageHeader, Spinner } from 'components/common';
+import CurrentUserContext from 'contexts/CurrentUserContext';
+import DocumentationLink from 'components/support/DocumentationLink';
+import { isPermitted } from 'util/PermissionsMixin';
+import history from 'util/History';
+
+const { EventDefinitionsActions } = CombinedProvider.get('EventDefinitions');
+
+type Props = {
+  params: {
+    definitionId: string,
+  },
+};
+
+const ViewEventDefinitionPage = ({ params }: Props) => {
+  const currentUser = useContext(CurrentUserContext);
+  const [eventDefinition, setEventDefinition] = useState();
+
+  useEffect(() => {
+    if (currentUser && isPermitted(currentUser.permissions, `eventdefinitions:read:${params.definitionId}`)) {
+      EventDefinitionsActions.get(params.definitionId)
+        .then(
+          (response) => {
+            const eventDefinitionResp = response.event_definition;
+
+            // Inject an internal "_is_scheduled" field to indicate if the event definition should be scheduled in the
+            // backend. This field will be removed in the event definitions store before sending an event definition
+            // back to the server.
+            eventDefinitionResp.config._is_scheduled = response.context.scheduler.is_scheduled;
+            setEventDefinition(eventDefinitionResp);
+          },
+          (error) => {
+            if (error.status === 404) {
+              history.push(Routes.ALERTS.DEFINITIONS.LIST);
+            }
+          },
+        );
+    }
+  }, [currentUser, params]);
+
+  if (!eventDefinition) {
+    return (
+      <DocumentTitle title="Edit Event Definition">
+        <span>
+          <PageHeader title="Edit Event Definition">
+            <Spinner text="Loading Event Definition..." />
+          </PageHeader>
+        </span>
+      </DocumentTitle>
+    );
+  }
+
+  return (
+    <DocumentTitle title={`Edit "${eventDefinition.title}" Event Definition`}>
+      <span>
+        <PageHeader title={`Edit "${eventDefinition.title}" Event Definition`}>
+          <span>
+            Event Definitions allow you to create Events from different Conditions and alert on them.
+          </span>
+
+          <span>
+            Graylog&apos;s new Alerting system let you define more flexible and powerful rules. Learn more in the{' '}
+            <DocumentationLink page={DocsHelper.PAGES.ALERTS}
+                               text="documentation" />
+          </span>
+
+          <ButtonToolbar>
+            <LinkContainer to={Routes.ALERTS.LIST}>
+              <Button bsStyle="info">Alerts & Events</Button>
+            </LinkContainer>
+            <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
+              <Button bsStyle="info">Event Definitions</Button>
+            </LinkContainer>
+            <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
+              <Button bsStyle="info">Notifications</Button>
+            </LinkContainer>
+          </ButtonToolbar>
+        </PageHeader>
+
+        <Row className="content">
+          <Col md={12}>
+          </Col>
+        </Row>
+      </span>
+    </DocumentTitle>
+  );
+};
+
+export default withParams(ViewEventDefinitionPage);

--- a/graylog2-web-interface/src/pages/ViewEventDefinitionPage.jsx
+++ b/graylog2-web-interface/src/pages/ViewEventDefinitionPage.jsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { useState, useEffect, useContext } from 'react';
 
+import { useStore } from 'stores/connect';
 import withParams from 'routing/withParams';
 import { LinkContainer } from 'components/graylog/router';
 import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
@@ -13,8 +14,10 @@ import CurrentUserContext from 'contexts/CurrentUserContext';
 import DocumentationLink from 'components/support/DocumentationLink';
 import { isPermitted } from 'util/PermissionsMixin';
 import history from 'util/History';
+import EventDefinitionSummary from 'components/event-definitions/event-definition-form/EventDefinitionSummary';
 
 const { EventDefinitionsActions } = CombinedProvider.get('EventDefinitions');
+const { EventNotificationsStore, EventNotificationsActions } = CombinedProvider.get('EventNotifications');
 
 type Props = {
   params: {
@@ -25,6 +28,7 @@ type Props = {
 const ViewEventDefinitionPage = ({ params }: Props) => {
   const currentUser = useContext(CurrentUserContext);
   const [eventDefinition, setEventDefinition] = useState();
+  const { all: notifications } = useStore(EventNotificationsStore);
 
   useEffect(() => {
     if (currentUser && isPermitted(currentUser.permissions, `eventdefinitions:read:${params.definitionId}`)) {
@@ -45,10 +49,12 @@ const ViewEventDefinitionPage = ({ params }: Props) => {
             }
           },
         );
+
+      EventNotificationsActions.listAll();
     }
   }, [currentUser, params]);
 
-  if (!eventDefinition) {
+  if (!eventDefinition || !notifications) {
     return (
       <DocumentTitle title="Edit Event Definition">
         <span>
@@ -89,6 +95,9 @@ const ViewEventDefinitionPage = ({ params }: Props) => {
 
         <Row className="content">
           <Col md={12}>
+            <EventDefinitionSummary eventDefinition={eventDefinition}
+                                    currentUser={currentUser}
+                                    notifications={notifications} />
           </Col>
         </Row>
       </span>

--- a/graylog2-web-interface/src/pages/ViewEventDefinitionPage.jsx
+++ b/graylog2-web-interface/src/pages/ViewEventDefinitionPage.jsx
@@ -56,9 +56,9 @@ const ViewEventDefinitionPage = ({ params }: Props) => {
 
   if (!eventDefinition || !notifications) {
     return (
-      <DocumentTitle title="Edit Event Definition">
+      <DocumentTitle title="View Event Definition">
         <span>
-          <PageHeader title="Edit Event Definition">
+          <PageHeader title="View Event Definition">
             <Spinner text="Loading Event Definition..." />
           </PageHeader>
         </span>
@@ -67,9 +67,9 @@ const ViewEventDefinitionPage = ({ params }: Props) => {
   }
 
   return (
-    <DocumentTitle title={`Edit "${eventDefinition.title}" Event Definition`}>
+    <DocumentTitle title={`View "${eventDefinition.title}" Event Definition`}>
       <span>
-        <PageHeader title={`Edit "${eventDefinition.title}" Event Definition`}>
+        <PageHeader title={`View "${eventDefinition.title}" Event Definition`}>
           <span>
             Event Definitions allow you to create Events from different Conditions and alert on them.
           </span>

--- a/graylog2-web-interface/src/pages/index.jsx
+++ b/graylog2-web-interface/src/pages/index.jsx
@@ -82,6 +82,7 @@ const UserDetailsPage = loadAsync(() => import('./UserDetailsPage'));
 const UserEditPage = loadAsync(() => import('./UserEditPage'));
 const UserTokensEditPage = loadAsync(() => import('./UserTokensEditPage'));
 const UsersOverviewPage = loadAsync(() => import('./UsersOverviewPage'));
+const ViewEventDefinitionPage = loadAsync(() => import('./ViewEventDefinitionPage'));
 
 export {
   AlertConditionsPage,
@@ -166,4 +167,5 @@ export {
   UserDetailsPage,
   UserEditPage,
   UserTokensEditPage,
+  ViewEventDefinitionPage,
 };

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -87,6 +87,7 @@ import {
   UserEditPage,
   UserTokensEditPage,
   UsersOverviewPage,
+  ViewEventDefinitionPage,
 } from 'pages';
 import RouterErrorBoundary from 'components/errors/RouterErrorBoundary';
 import usePluginEntities from 'views/logic/usePluginEntities';
@@ -154,6 +155,9 @@ const AppRouter = () => {
                         <Route exact
                                path={Routes.ALERTS.DEFINITIONS.edit(':definitionId')}
                                component={EditEventDefinitionPage} />
+                        <Route exact
+                               path={Routes.ALERTS.DEFINITIONS.view(':definitionId')}
+                               component={ViewEventDefinitionPage} />
                         <Route exact path={Routes.ALERTS.NOTIFICATIONS.LIST} component={EventNotificationsPage} />
                         <Route exact path={Routes.ALERTS.NOTIFICATIONS.CREATE} component={CreateEventNotificationPage} />
                         <Route exact

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -22,6 +22,7 @@ const Routes = {
       LIST: '/alerts/definitions',
       CREATE: '/alerts/definitions/new',
       edit: (definitionId) => `/alerts/definitions/${definitionId}/edit`,
+      view: (definitionId) => `/alerts/definitions/${definitionId}`,
     },
     NOTIFICATIONS: {
       LIST: '/alerts/notifications',


### PR DESCRIPTION
## Description
Add share button to Event Definitions and create a read only page for a user with view permissions.

## Motivation and Context
If a user wants to verify the settings for a event definition (as a revisor) then he needs a read only page.

If a user is missing stream or notification permissions a warning will be displayed but the page otherwise rendered