### PR TITLE
Implement share dialog and details pages for event notifications

### DIFF
--- a/graylog2-web-interface/src/components/event-notifications/event-notification-details/EmailNotificationDetails.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-details/EmailNotificationDetails.jsx
@@ -17,7 +17,7 @@ const EmailNotificationDetails = ({ notification }) => (
                          <Well bsSize="small" className={styles.bodyPreview}>
                            {notification.config.body_template || <em>Empty body</em>}
                          </Well>
-                         )} />
+                       )} />
   </>
 );
 

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-details/EmailNotificationDetails.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-details/EmailNotificationDetails.jsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+import { ReadOnlyFormGroup } from 'components/common';
+import { Well } from 'components/graylog';
+
+import styles from '../event-notification-types/EmailNotificationSummary.css';
+
+const EmailNotificationDetails = ({ notification }) => (
+  <>
+    <ReadOnlyFormGroup label="Sender" value={notification.config.sender} />
+    <ReadOnlyFormGroup label="Subject" value={notification.config.subject} />
+    <ReadOnlyFormGroup label="User recipients" value={notification.config.user_recipients.join(', ') || 'No users will receive this notification.'} />
+    <ReadOnlyFormGroup label="Email recipients" value={notification.config.email_recipients.join(', ') || 'No email addresses are configured to receive this notification.'} />
+    <ReadOnlyFormGroup label="Email Body"
+                       value={(
+                         <Well bsSize="small" className={styles.bodyPreview}>
+                           {notification.config.body_template || <em>Empty body</em>}
+                         </Well>
+                         )} />
+  </>
+);
+
+EmailNotificationDetails.propTypes = {
+  notification: PropTypes.object.isRequired,
+};
+
+export default EmailNotificationDetails;

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-details/EventNotificationActionLinks.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-details/EventNotificationActionLinks.jsx
@@ -8,7 +8,7 @@ import Routes from 'routing/Routes';
 
 const EventNotificationActionLinks = ({ notificationId }) => (
   <ButtonToolbar>
-    <IfPermitted permissions={`eventnotifications:view:${notificationId}`}>
+    <IfPermitted permissions={`eventnotifications:read:${notificationId}`}>
       <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.show(notificationId)}>
         <Button bsStyle="success">View Details</Button>
       </LinkContainer>

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-details/EventNotificationActionLinks.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-details/EventNotificationActionLinks.jsx
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+import { LinkContainer } from 'components/graylog/router';
+import { IfPermitted } from 'components/common';
+import { Button, ButtonToolbar } from 'components/graylog';
+import Routes from 'routing/Routes';
+
+const EventNotificationActionLinks = ({ notificationId }) => (
+  <ButtonToolbar>
+    <IfPermitted permissions={`eventnotifications:view:${notificationId}`}>
+      <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.show(notificationId)}>
+        <Button bsStyle="success">View Details</Button>
+      </LinkContainer>
+    </IfPermitted>
+    <IfPermitted permissions={`eventnotifications:edit:${notificationId}`}>
+      <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.edit(notificationId)}>
+        <Button bsStyle="success">Edit Notification</Button>
+      </LinkContainer>
+    </IfPermitted>
+  </ButtonToolbar>
+);
+
+EventNotificationActionLinks.propTypes = {
+  notificationId: PropTypes.string.isRequired,
+};
+
+export default EventNotificationActionLinks;

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-details/EventNotificationDetails.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-details/EventNotificationDetails.jsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { PluginStore } from 'graylog-web-plugin/plugin';
+import PropTypes from 'prop-types';
+
+import { ReadOnlyFormGroup } from 'components/common';
+import SectionComponent from 'components/common/Section/SectionComponent';
+import { Alert } from 'components/graylog';
+
+const _getNotificationPlugin = (type) => {
+  if (type === undefined) {
+    return {};
+  }
+
+  return PluginStore.exports('eventNotificationTypes').find((n) => n.type === type) || {};
+};
+
+const EventNotificationDetails = ({ notification }) => {
+  const notificationPlugin = _getNotificationPlugin(notification.config.type);
+  const DetailsComponent = notificationPlugin?.detailsComponent;
+
+  return (
+    <SectionComponent title="Details">
+      <ReadOnlyFormGroup label="Title" value={notification.title} />
+      <ReadOnlyFormGroup label="Description" value={notification.description} />
+      <ReadOnlyFormGroup label="Notification Type" value={notification.config.type} />
+      {DetailsComponent ? <DetailsComponent notification={notification} /> : <Alert bsStyle="danger">Notification type not supported</Alert>}
+    </SectionComponent>
+  );
+};
+
+EventNotificationDetails.propTypes = {
+  notification: PropTypes.object.isRequired,
+};
+
+export default EventNotificationDetails;

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-details/HttpNotificationDetails.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-details/HttpNotificationDetails.jsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+import { ReadOnlyFormGroup } from 'components/common';
+
+const HttpNotificationDetails = ({ notification }) => {
+  return (
+    <>
+      <ReadOnlyFormGroup label="URL" value={notification.config.url} />
+    </>
+  );
+};
+
+HttpNotificationDetails.propTypes = {
+  notification: PropTypes.object.isRequired,
+};
+
+export default HttpNotificationDetails;

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-details/LegacyNotificationDetails.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-details/LegacyNotificationDetails.jsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+
+import CombinedProvider from 'injection/CombinedProvider';
+import { ReadOnlyFormGroup, Spinner } from 'components/common';
+import { Alert, Well } from 'components/graylog';
+
+import emailStyles from '../event-notification-types/EmailNotificationSummary.css';
+import notificationStyles from '../event-notification-types/LegacyNotificationCommonStyles.css';
+
+const { EventNotificationsActions } = CombinedProvider.get('EventNotifications');
+
+const LegacyNotificationDetails = ({ notification }) => {
+  const [legacyTypes, setLegacyTypes] = useState();
+  const configurationValues = notification.config.configuration;
+  const callbackType = notification.config.callback_type;
+  const typeData = legacyTypes?.[callbackType];
+
+  useEffect(() => {
+    EventNotificationsActions.listAllLegacyTypes().then((result) => setLegacyTypes(result.types));
+  }, []);
+
+  if (!legacyTypes) {
+    return <p><Spinner text="Loading legacy notification information..." /></p>;
+  }
+
+  return (
+    <>
+      {!typeData && (
+        <Alert bsStyle="danger" className={notificationStyles.legacyNotificationAlert}>
+          Error in {notification.title || 'Legacy Alarm Callback'}: Unknown type <code>{callbackType}</code>,
+          please ensure the plugin is installed.
+        </Alert>
+      )}
+      {typeData && Object.entries(typeData.configuration).map(([key, value]) => {
+        if (key === 'body' || key === 'script_args') {
+          return (
+            <ReadOnlyFormGroup label={value.human_name}
+                               value={(
+                                 <Well bsSize="small" className={emailStyles.bodyPreview}>
+                                   {configurationValues[key] || <em>Empty body</em>}
+                                 </Well>
+                               )} />
+          );
+        }
+
+        return <ReadOnlyFormGroup label={value.human_name} value={configurationValues[key]} />;
+      })}
+    </>
+  );
+};
+
+LegacyNotificationDetails.propTypes = {
+  notification: PropTypes.object.isRequired,
+};
+
+export default LegacyNotificationDetails;

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
@@ -10,7 +10,7 @@ import FormsUtils from 'util/FormsUtils';
 
 class EventNotificationForm extends React.Component {
   static propTypes = {
-    action: PropTypes.oneOf(['create', 'edit', 'view']),
+    action: PropTypes.oneOf(['create', 'edit']),
     notification: PropTypes.object.isRequired,
     validation: PropTypes.object.isRequired,
     testResult: PropTypes.shape({

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-form/EventNotificationForm.jsx
@@ -10,7 +10,7 @@ import FormsUtils from 'util/FormsUtils';
 
 class EventNotificationForm extends React.Component {
   static propTypes = {
-    action: PropTypes.oneOf(['create', 'edit']),
+    action: PropTypes.oneOf(['create', 'edit', 'view']),
     notification: PropTypes.object.isRequired,
     validation: PropTypes.object.isRequired,
     testResult: PropTypes.shape({

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/index.js
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/index.js
@@ -9,6 +9,10 @@ import LegacyNotificationForm from './LegacyNotificationForm';
 import LegacyNotificationFormContainer from './LegacyNotificationFormContainer';
 import LegacyNotificationSummaryContainer from './LegacyNotificationSummaryContainer';
 
+import EmailNotificationDetails from '../event-notification-details/EmailNotificationDetails';
+import HttpNotificationDetails from '../event-notification-details/HttpNotificationDetails';
+import LegacyNotificationDetails from '../event-notification-details/LegacyNotificationDetails';
+
 PluginStore.register(new PluginManifest({}, {
   eventNotificationTypes: [
     {
@@ -16,6 +20,7 @@ PluginStore.register(new PluginManifest({}, {
       displayName: 'Email Notification',
       formComponent: EmailNotificationFormContainer,
       summaryComponent: EmailNotificationSummary,
+      detailsComponent: EmailNotificationDetails,
       defaultConfig: EmailNotificationForm.defaultConfig,
     },
     {
@@ -23,6 +28,7 @@ PluginStore.register(new PluginManifest({}, {
       displayName: 'HTTP Notification',
       formComponent: HttpNotificationForm,
       summaryComponent: HttpNotificationSummary,
+      detailsComponent: HttpNotificationDetails,
       defaultConfig: HttpNotificationForm.defaultConfig,
     },
     {
@@ -30,6 +36,7 @@ PluginStore.register(new PluginManifest({}, {
       displayName: 'Legacy Alarm Callbacks',
       formComponent: LegacyNotificationFormContainer,
       summaryComponent: LegacyNotificationSummaryContainer,
+      detailsComponent: LegacyNotificationDetails,
       defaultConfig: LegacyNotificationForm.defaultConfig,
     },
   ],

--- a/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.jsx
@@ -3,16 +3,19 @@ import PropTypes from 'prop-types';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import { LinkContainer, Link } from 'components/graylog/router';
+import EntityShareModal from 'components/permissions/EntityShareModal';
 import { Col, DropdownButton, MenuItem, Row, Button } from 'components/graylog';
 import {
   EmptyEntity,
   EntityList,
   EntityListItem,
+  HasOwnership,
   IfPermitted,
   PaginatedList,
   SearchForm,
   Spinner,
 } from 'components/common';
+import SharingDisabledPopover from 'components/permissions/SharingDisabledPopover';
 import Routes from 'routing/Routes';
 
 import styles from './EventNotifications.css';
@@ -33,6 +36,14 @@ class EventNotifications extends React.Component {
     onDelete: PropTypes.func.isRequired,
     onTest: PropTypes.func.isRequired,
   };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      notificationToShare: undefined,
+    };
+  }
 
   renderEmptyContent = () => {
     return (
@@ -62,12 +73,12 @@ class EventNotifications extends React.Component {
     return PluginStore.exports('eventNotificationTypes').find((n) => n.type === type) || {};
   };
 
-  formatNotification = (notifications) => {
+  formatNotification = (notifications, setNotificationToShare) => {
     const { testResult } = this.props;
 
     return notifications.map((notification) => {
       const isTestLoading = testResult.id === notification.id && testResult.isLoading;
-      const actions = this.formatActions(notification, isTestLoading);
+      const actions = this.formatActions(notification, isTestLoading, setNotificationToShare);
 
       const plugin = this.getNotificationPlugin(notification.config.type);
       const content = testResult.id === notification.id ? (
@@ -95,7 +106,7 @@ class EventNotifications extends React.Component {
     });
   };
 
-  formatActions(notification, isTestLoading) {
+  formatActions(notification, isTestLoading, setNotificationToShare) {
     const { onDelete, onTest } = this.props;
 
     return (
@@ -112,6 +123,13 @@ class EventNotifications extends React.Component {
                 {isTestLoading ? 'Testing...' : 'Test Notification'}
               </MenuItem>
             </IfPermitted>
+            <HasOwnership type="dashboard" id={notification.id}>
+              {({ disabled }) => (
+                <MenuItem disabled={disabled} onSelect={() => setNotificationToShare(notification)}>
+                  Share {disabled && <SharingDisabledPopover type="dashboard" />}
+                </MenuItem>
+              )}
+            </HasOwnership>
             <MenuItem divider />
             <IfPermitted permissions={`eventnotifications:delete:${notification.id}`}>
               <MenuItem onClick={onDelete(notification)}>Delete</MenuItem>
@@ -124,41 +142,53 @@ class EventNotifications extends React.Component {
 
   render() {
     const { notifications, pagination, query, onPageChange, onQueryChange } = this.props;
+    const { notificationToShare } = this.state;
+
+    const setNotificationToShare = (notification) => this.setState({ notificationToShare: notification });
 
     if (pagination.grandTotal === 0) {
       return this.renderEmptyContent();
     }
 
     return (
-      <Row>
-        <Col md={12}>
-          <SearchForm query={query}
-                      onSearch={onQueryChange}
-                      onReset={onQueryChange}
-                      searchButtonLabel="Find"
-                      placeholder="Find Notifications"
-                      wrapperClass={styles.inline}
-                      queryWidth={200}
-                      topMargin={0}
-                      useLoadingState>
-            <IfPermitted permissions="eventnotifications:create">
-              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.CREATE}>
-                <Button bsStyle="success" className={styles.createButton}>Create Notification</Button>
-              </LinkContainer>
-            </IfPermitted>
-          </SearchForm>
+      <>
+        <Row>
+          <Col md={12}>
+            <SearchForm query={query}
+                        onSearch={onQueryChange}
+                        onReset={onQueryChange}
+                        searchButtonLabel="Find"
+                        placeholder="Find Notifications"
+                        wrapperClass={styles.inline}
+                        queryWidth={200}
+                        topMargin={0}
+                        useLoadingState>
+              <IfPermitted permissions="eventnotifications:create">
+                <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.CREATE}>
+                  <Button bsStyle="success" className={styles.createButton}>Create Notification</Button>
+                </LinkContainer>
+              </IfPermitted>
+            </SearchForm>
 
-          <PaginatedList activePage={pagination.page}
-                         pageSize={pagination.pageSize}
-                         pageSizes={[10, 25, 50]}
-                         totalItems={pagination.total}
-                         onChange={onPageChange}>
-            <div className={styles.notificationList}>
-              <EntityList items={this.formatNotification(notifications)} />
-            </div>
-          </PaginatedList>
-        </Col>
-      </Row>
+            <PaginatedList activePage={pagination.page}
+                           pageSize={pagination.pageSize}
+                           pageSizes={[10, 25, 50]}
+                           totalItems={pagination.total}
+                           onChange={onPageChange}>
+              <div className={styles.notificationList}>
+                <EntityList items={this.formatNotification(notifications, setNotificationToShare)} />
+              </div>
+            </PaginatedList>
+          </Col>
+        </Row>
+        {notificationToShare && (
+          <EntityShareModal entityId={notificationToShare.id}
+                            entityType="notification"
+                            description="Search for a User or Team to add as collaborator on this notification."
+                            entityTitle={notificationToShare.title}
+                            onClose={() => setNotificationToShare(undefined)} />
+        )}
+      </>
     );
   }
 }

--- a/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
-import { LinkContainer } from 'components/graylog/router';
+import { LinkContainer, Link } from 'components/graylog/router';
 import { Col, DropdownButton, MenuItem, Row, Button } from 'components/graylog';
 import {
   EmptyEntity,
@@ -82,9 +82,11 @@ class EventNotifications extends React.Component {
         </Col>
       ) : null;
 
+      const title = <Link to={Routes.ALERTS.NOTIFICATIONS.show(notification.id)}>{notification.title}</Link>;
+
       return (
         <EntityListItem key={`event-definition-${notification.id}`}
-                        title={notification.title}
+                        title={title}
                         titleSuffix={plugin.displayName || notification.config.type}
                         description={notification.description || <em>No description given</em>}
                         actions={actions}

--- a/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.jsx
@@ -123,10 +123,10 @@ class EventNotifications extends React.Component {
                 {isTestLoading ? 'Testing...' : 'Test Notification'}
               </MenuItem>
             </IfPermitted>
-            <HasOwnership type="dashboard" id={notification.id}>
+            <HasOwnership type="notification" id={notification.id}>
               {({ disabled }) => (
                 <MenuItem disabled={disabled} onSelect={() => setNotificationToShare(notification)}>
-                  Share {disabled && <SharingDisabledPopover type="dashboard" />}
+                  Share {disabled && <SharingDisabledPopover type="notification" />}
                 </MenuItem>
               )}
             </HasOwnership>

--- a/graylog2-web-interface/src/pages/EditEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/EditEventNotificationPage.jsx
@@ -12,6 +12,7 @@ import connect from 'stores/connect';
 import PermissionsMixin from 'util/PermissionsMixin';
 import history from 'util/History';
 import EventNotificationFormContainer from 'components/event-notifications/event-notification-form/EventNotificationFormContainer';
+import EventNotificationActionLinks from 'components/event-notifications/event-notification-details/EventNotificationActionLinks';
 import withParams from 'routing/withParams';
 
 const { EventNotificationsActions } = CombinedProvider.get('EventNotifications');
@@ -72,7 +73,7 @@ class EditEventDefinitionPage extends React.Component {
     return (
       <DocumentTitle title={`Edit "${notification.title}" Notification`}>
         <span>
-          <PageHeader title={`Edit "${notification.title}" Notification`}>
+          <PageHeader title={`Edit "${notification.title}" Notification`} subactions={<EventNotificationActionLinks notificationId={notification.id} />}>
             <span>
               Notifications alert you of any configured Event when they occur. Graylog can send Notifications directly
               to you or to other systems you use for that purpose.

--- a/graylog2-web-interface/src/pages/ShowEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowEventNotificationPage.jsx
@@ -1,4 +1,3 @@
-// @flow strict
 import * as React from 'react';
 import { useContext, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
@@ -6,24 +5,25 @@ import PropTypes from 'prop-types';
 import ErrorsActions from 'actions/errors/ErrorsActions';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import { LinkContainer } from 'components/graylog/router';
-import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
+import { ButtonToolbar, Button } from 'components/graylog';
 import { createFromFetchError } from 'logic/errors/ReportedErrors';
 import { DocumentTitle, IfPermitted, PageHeader, Spinner } from 'components/common';
 import DocumentationLink from 'components/support/DocumentationLink';
 import Routes from 'routing/Routes';
 import DocsHelper from 'util/DocsHelper';
 import CombinedProvider from 'injection/CombinedProvider';
-import PermissionsMixin from 'util/PermissionsMixin';
+import { isPermitted } from 'util/PermissionsMixin';
 import history from 'util/History';
-import EventNotificationFormContainer from 'components/event-notifications/event-notification-form/EventNotificationFormContainer';
 import withParams from 'routing/withParams';
+import EventNotificationDetails from 'components/event-notifications/event-notification-details/EventNotificationDetails';
+import EventNotificationActionLinks from 'components/event-notifications/event-notification-details/EventNotificationActionLinks';
+
+import {} from 'components/event-notifications/event-notification-types';
 
 const { EventNotificationsActions } = CombinedProvider.get('EventNotifications');
 
-const { isPermitted } = PermissionsMixin;
-
-const ShowEventDefinitionPage = ({ params: { notificationId } }: Props) => {
-  const currentUser = useContext(CurrentUserContext);
+const ShowEventDefinitionPage = ({ params: { notificationId } }) => {
+  const currentUser = useContext(CurrentUserContext) || {};
   const [notification, setNotification] = useState();
 
   useEffect(() => {
@@ -37,15 +37,15 @@ const ShowEventDefinitionPage = ({ params: { notificationId } }: Props) => {
     );
   }, [notificationId]);
 
-  if (!isPermitted(currentUser.permissions, `eventnotifications:view:${params.notificationId}`)) {
+  if (!isPermitted(currentUser.permissions, `eventnotifications:view:${notificationId}`)) {
     history.push(Routes.NOTFOUND);
   }
 
   if (!notification) {
     return (
-      <DocumentTitle title="Edit Notification">
+      <DocumentTitle title="Notification Details">
         <span>
-          <PageHeader title="Edit Notification">
+          <PageHeader title="Notification Details">
             <Spinner text="Loading Notification information..." />
           </PageHeader>
         </span>
@@ -54,9 +54,9 @@ const ShowEventDefinitionPage = ({ params: { notificationId } }: Props) => {
   }
 
   return (
-    <DocumentTitle title={`Edit "${notification.title}" Notification`}>
+    <DocumentTitle title={`View "${notification.title}" Notification`}>
       <span>
-        <PageHeader title={`Edit "${notification.title}" Notification`}>
+        <PageHeader title={`View "${notification.title}" Notification`} subactions={notification && <EventNotificationActionLinks notificationId={notification.id} />}>
           <span>
             Notifications alert you of any configured Event when they occur. Graylog can send Notifications directly
             to you or to other systems you use for that purpose.
@@ -85,14 +85,15 @@ const ShowEventDefinitionPage = ({ params: { notificationId } }: Props) => {
           </ButtonToolbar>
         </PageHeader>
 
-        <Row className="content">
-          <Col md={12}>
-            <EventNotificationFormContainer action="edit" notification={notification} />
-          </Col>
-        </Row>
+        <EventNotificationDetails notification={notification} />
+
       </span>
     </DocumentTitle>
   );
+};
+
+ShowEventDefinitionPage.propTypes = {
+  params: PropTypes.object.isRequired,
 };
 
 export default withParams(ShowEventDefinitionPage);

--- a/graylog2-web-interface/src/pages/ShowEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowEventNotificationPage.jsx
@@ -37,7 +37,7 @@ const ShowEventDefinitionPage = ({ params: { notificationId } }) => {
     );
   }, [notificationId]);
 
-  if (!isPermitted(currentUser.permissions, `eventnotifications:view:${notificationId}`)) {
+  if (!isPermitted(currentUser.permissions, `eventnotifications:read:${notificationId}`)) {
     history.push(Routes.NOTFOUND);
   }
 

--- a/graylog2-web-interface/src/pages/ShowEventNotificationPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowEventNotificationPage.jsx
@@ -1,0 +1,98 @@
+// @flow strict
+import * as React from 'react';
+import { useContext, useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+import ErrorsActions from 'actions/errors/ErrorsActions';
+import CurrentUserContext from 'contexts/CurrentUserContext';
+import { LinkContainer } from 'components/graylog/router';
+import { ButtonToolbar, Col, Row, Button } from 'components/graylog';
+import { createFromFetchError } from 'logic/errors/ReportedErrors';
+import { DocumentTitle, IfPermitted, PageHeader, Spinner } from 'components/common';
+import DocumentationLink from 'components/support/DocumentationLink';
+import Routes from 'routing/Routes';
+import DocsHelper from 'util/DocsHelper';
+import CombinedProvider from 'injection/CombinedProvider';
+import PermissionsMixin from 'util/PermissionsMixin';
+import history from 'util/History';
+import EventNotificationFormContainer from 'components/event-notifications/event-notification-form/EventNotificationFormContainer';
+import withParams from 'routing/withParams';
+
+const { EventNotificationsActions } = CombinedProvider.get('EventNotifications');
+
+const { isPermitted } = PermissionsMixin;
+
+const ShowEventDefinitionPage = ({ params: { notificationId } }: Props) => {
+  const currentUser = useContext(CurrentUserContext);
+  const [notification, setNotification] = useState();
+
+  useEffect(() => {
+    EventNotificationsActions.get(notificationId).then(
+      setNotification,
+      (error) => {
+        if (error.status === 404) {
+          ErrorsActions.report(createFromFetchError(error));
+        }
+      },
+    );
+  }, [notificationId]);
+
+  if (!isPermitted(currentUser.permissions, `eventnotifications:view:${params.notificationId}`)) {
+    history.push(Routes.NOTFOUND);
+  }
+
+  if (!notification) {
+    return (
+      <DocumentTitle title="Edit Notification">
+        <span>
+          <PageHeader title="Edit Notification">
+            <Spinner text="Loading Notification information..." />
+          </PageHeader>
+        </span>
+      </DocumentTitle>
+    );
+  }
+
+  return (
+    <DocumentTitle title={`Edit "${notification.title}" Notification`}>
+      <span>
+        <PageHeader title={`Edit "${notification.title}" Notification`}>
+          <span>
+            Notifications alert you of any configured Event when they occur. Graylog can send Notifications directly
+            to you or to other systems you use for that purpose.
+          </span>
+
+          <span>
+            Graylog&apos;s new Alerting system let you define more flexible and powerful rules. Learn more in the{' '}
+            <DocumentationLink page={DocsHelper.PAGES.ALERTS}
+                               text="documentation" />
+          </span>
+
+          <ButtonToolbar>
+            <LinkContainer to={Routes.ALERTS.LIST}>
+              <Button bsStyle="info">Alerts & Events</Button>
+            </LinkContainer>
+            <IfPermitted permissions="eventdefinitions:read">
+              <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
+                <Button bsStyle="info">Event Definitions</Button>
+              </LinkContainer>
+            </IfPermitted>
+            <IfPermitted permissions="eventnotifications:read">
+              <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
+                <Button bsStyle="info">Notifications</Button>
+              </LinkContainer>
+            </IfPermitted>
+          </ButtonToolbar>
+        </PageHeader>
+
+        <Row className="content">
+          <Col md={12}>
+            <EventNotificationFormContainer action="edit" notification={notification} />
+          </Col>
+        </Row>
+      </span>
+    </DocumentTitle>
+  );
+};
+
+export default withParams(ShowEventDefinitionPage);

--- a/graylog2-web-interface/src/pages/index.jsx
+++ b/graylog2-web-interface/src/pages/index.jsx
@@ -56,6 +56,7 @@ const RuleDetailsPage = loadAsync(() => import('./RuleDetailsPage'));
 const RulesPage = loadAsync(() => import('./RulesPage'));
 const ShowAlertPage = loadAsync(() => import('./ShowAlertPage'));
 const ShowContentPackPage = loadAsync(() => import('pages/ShowContentPackPage'));
+const ShowEventNotificationPage = loadAsync(() => import('./ShowEventNotificationPage'));
 const ShowMessagePage = loadAsync(() => import('./ShowMessagePage'));
 const ShowMetricsPage = loadAsync(() => import('./ShowMetricsPage'));
 const ShowNodePage = loadAsync(() => import('./ShowNodePage'));
@@ -141,6 +142,7 @@ export {
   RulesPage,
   ShowAlertPage,
   ShowContentPackPage,
+  ShowEventNotificationPage,
   ShowMessagePage,
   ShowMetricsPage,
   ShowNodePage,

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -63,6 +63,7 @@ import {
   RulesPage,
   ShowAlertPage,
   ShowContentPackPage,
+  ShowEventNotificationPage,
   ShowMessagePage,
   ShowMetricsPage,
   ShowNodePage,
@@ -159,6 +160,9 @@ const AppRouter = () => {
                         <Route exact
                                path={Routes.ALERTS.NOTIFICATIONS.edit(':notificationId')}
                                component={EditEventNotificationPage} />
+                        <Route exact
+                               path={Routes.ALERTS.NOTIFICATIONS.show(':notificationId')}
+                               component={ShowEventNotificationPage} />
                         <Route exact
                                path={Routes.show_alert_condition(':streamId', ':conditionId')}
                                component={EditAlertConditionPage} />

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -27,6 +27,7 @@ const Routes = {
       LIST: '/alerts/notifications',
       CREATE: '/alerts/notifications/new',
       edit: (notificationId) => `/alerts/notifications/${notificationId}/edit`,
+      show: (notificationId) => `/alerts/notifications/${notificationId}`,
     },
   },
   SOURCES: '/sources',


### PR DESCRIPTION
This PR implements details pages and the share dialog for event notifications. The share action can be found in the notifications list.

## Description
## Motivation and Context
The backend already supports sharing event notifications, these changes are required to support it in the UI as well.