### PR TITLE
Offer GIM as a template option for index set configs.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping.java
@@ -305,7 +305,7 @@ public abstract class GIMMapping extends IndexMapping {
     private static final Set<String> DATE_FIELDS = ImmutableSet.<String>builder()
             .add("event_created")
             .add("event_start")
-            .add("event_recieved_time")
+            .add("event_received_time")
             .add("file_created_date")
             .build();
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping.java
@@ -401,7 +401,8 @@ public abstract class GIMMapping extends IndexMapping {
                                         "char_filter", Collections.emptyList(),
                                         "filter", Collections.singleton("lowercase")
                                 )
-                        )
+                        ),
+                        "analyzer", analyzerKeyword()
                 )
         );
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping.java
@@ -14,8 +14,25 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
+/**
+ * This file is part of Graylog.
+ * <p>
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * <p>
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * <p>
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog2.indexer;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
@@ -294,8 +311,9 @@ public abstract class GIMMapping extends IndexMapping {
 
     @Override
     protected List<Map<String, Map<String, Object>>> dynamicTemplate() {
-        return Collections.singletonList(
-                Collections.singletonMap(
+        return ImmutableList.<Map<String, Map<String, Object>>>builder()
+                .addAll(super.dynamicTemplate())
+                .add(Collections.singletonMap(
                         "winlogbeat_fields",
                         ImmutableMap.of(
                                 "match", "winlogbeat_*",
@@ -304,8 +322,8 @@ public abstract class GIMMapping extends IndexMapping {
                                         "type", "keyword"
                                 )
                         )
-                )
-        );
+                ))
+                .build();
     }
 
     private Map<String, Object> notAnalyzedString(Map<String, Object> settings) {
@@ -391,7 +409,7 @@ public abstract class GIMMapping extends IndexMapping {
     @Override
     protected Map<String, Map<String, Object>> fieldProperties(String analyzer) {
         return ImmutableMap.<String, Map<String, Object>>builder()
-                .put("message", analyzedString(analyzer, false))
+                .putAll(super.fieldProperties(analyzer))
                 .putAll(toMapping(KEYWORD_FIELDS, this::notAnalyzedString))
                 .putAll(toMapping(LOWERCASE_KEYWORD_FIELDS, this::notAnalyzedStringWithLowercaseNormalizer))
                 .putAll(toMapping(BYTE_FIELDS, this::byteField))
@@ -420,11 +438,5 @@ public abstract class GIMMapping extends IndexMapping {
     @Override
     public Map<String, Object> messageTemplate(String template, String analyzer, int order) {
         return createTemplate(template, order, settings(), mapping(analyzer));
-    }
-
-    @Override
-    Map<String, Object> dynamicStrings() {
-        // Not needed for GIM mapping
-        return Collections.emptyMap();
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping.java
@@ -1,0 +1,426 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public abstract class GIMMapping extends IndexMapping {
+    private static final Set<String> KEYWORD_FIELDS = ImmutableSet.<String>builder()
+            .add("gl2_gims_version")
+            .add("gl2_tags")
+            .add("gl2_event_category")
+            .add("gl2_event_subcategory")
+            .add("gl2_event_type")
+            .add("user_command")
+            .add("user_command_path")
+            .add("user_domain")
+            .add("user_email")
+            .add("user_id")
+            .add("user_category")
+            .add("user_type")
+            .add("user_priority")
+            .add("source_user_domain")
+            .add("source_user_email")
+            .add("source_user_id")
+            .add("source_user_category")
+            .add("source_user_type")
+            .add("source_user_priority")
+            .add("target_user_domain")
+            .add("target_user_email")
+            .add("target_user_id")
+            .add("target_user_category")
+            .add("target_user_type")
+            .add("target_user_priority")
+            .add("http_application")
+            .add("http_content_type")
+            .add("http_host")
+            .add("http_path")
+            .add("http_referrer")
+            .add("http_method")
+            .add("http_response")
+            .add("http_user_agent")
+            .add("http_user_agent_name")
+            .add("http_url")
+            .add("http_url_category")
+            .add("http_user_agent_os")
+            .add("http_version")
+            .add("http_xff")
+            .add("host_as_domain")
+            .add("host_as_isp")
+            .add("host_as_organization")
+            .add("host_as_number")
+            .add("host_geo_city")
+            .add("host_geo_country")
+            .add("host_geo_name")
+            .add("host_geo_country_iso")
+            .add("host_geo_coordinates")
+            .add("host_location_name")
+            .add("host_mac")
+            .add("host_category")
+            .add("host_priority")
+            .add("host_id")
+            .add("host_type")
+            .add("host_type_version")
+            .add("host_virtfw_id")
+            .add("host_virtfw_uid")
+            .add("source_as_organization")
+            .add("source_as_domain")
+            .add("source_as_number")
+            .add("source_geo_city")
+            .add("source_geo_country")
+            .add("source_geo_name")
+            .add("source_geo_country_iso")
+            .add("source_geo_coordinates")
+            .add("source_category")
+            .add("source_location_name")
+            .add("source_mac")
+            .add("source_priority")
+            .add("source_id")
+            .add("source_type")
+            .add("source_vsys_uuid")
+            .add("source_zone")
+            .add("destination_application_name")
+            .add("destination_as_domain")
+            .add("destination_as_isp")
+            .add("destination_as_organization")
+            .add("destination_as_number")
+            .add("destination_geo_city_name")
+            .add("destination_geo_country_name")
+            .add("destination_geo_name")
+            .add("destination_geo_state_name")
+            .add("destination_geo_country_iso")
+            .add("destination_geo_coordinates")
+            .add("destination_category")
+            .add("destination_location_name")
+            .add("destination_mac")
+            .add("destination_priority")
+            .add("destination_id")
+            .add("destination_type")
+            .add("destination_vsys_uuid")
+            .add("destination_zone")
+            .add("event_action")
+            .add("event_source")
+            .add("event_source_api_version")
+            .add("event_source_product")
+            .add("event_code")
+            .add("event_error_code")
+            .add("event_error_description")
+            .add("event_log_name")
+            .add("event_reporter")
+            .add("event_uid")
+            .add("event_observer_uid")
+            .add("event_outcome")
+            .add("event_severity")
+            .add("email_message_id")
+            .add("email_subject")
+            .add("file_company")
+            .add("file_name")
+            .add("file_path")
+            .add("file_size")
+            .add("file_type")
+            .add("hash_md5")
+            .add("hash_sha1")
+            .add("hash_sha256")
+            .add("hash_sha512")
+            .add("hash_imphash")
+            .add("alert_definitions_version")
+            .add("alert_category")
+            .add("alert_indicator")
+            .add("alert_signature")
+            .add("alert_signature_id")
+            .add("alert_severity")
+            .add("associated_host")
+            .add("associated_mac")
+            .add("associated_hash")
+            .add("associated_category")
+            .add("associated_session_id")
+            .add("associated_user_id")
+            .add("service_version")
+            .add("service_name")
+            .add("vendor_alert_severity")
+            .add("vendor_event_action")
+            .add("vendor_event_description")
+            .add("vendor_event_outcome")
+            .add("vendor_event_outcome_reason")
+            .add("vendor_event_severity")
+            .add("vendor_signin_protocol")
+            .add("vendor_threat_suspected")
+            .add("vendor_transaction_id")
+            .add("vendor_transaction_type")
+            .add("vendor_user_type")
+            .add("windows_logon_type_description")
+            .add("windows_kerberos_encryption")
+            .add("windows_kerberos_encryption_type")
+            .add("windows_kerberos_service_name")
+            .add("windows_authentication_package_name")
+            .add("windows_authentication_lmpackage_name")
+            .add("windows_authentication_process_name")
+            .add("source_user_sid_authority1")
+            .add("source_user_sid_authority2")
+            .add("source_user_sid_rid")
+            .add("user_sid_authority1")
+            .add("user_sid_authority2")
+            .add("user_sid_rid")
+            .add("target_sid_authority1")
+            .add("target_sid_authority2")
+            .add("target_sid_rid")
+            .add("network_name")
+            .add("network_community_id")
+            .add("network_direction")
+            .add("network_icmp_type")
+            .add("network_ip_version")
+            .add("network_transport")
+            .add("network_tunnel_type")
+            .add("application_sso_signonmode")
+            .add("application_sso_target_name")
+            .add("threat_category")
+            .add("threat_detected")
+            .build();
+
+    private static final Set<String> LOWERCASE_KEYWORD_FIELDS = ImmutableSet.<String>builder()
+            .add("user_previous_name")
+            .add("previous_user_name")
+            .add("user_name_mapped")
+            .add("source_user_name_mapped")
+            .add("target_user_name_mapped")
+            .add("host_reference")
+            .add("host_hostname")
+            .add("host_virtfw_hostname")
+            .add("source_reference")
+            .add("source_hostname")
+            .add("destination_domain")
+            .add("destination_reference")
+            .add("destination_hostname")
+            .add("event_observer_hostname")
+            .add("associated_user_name")
+            .add("network_application")
+            .add("network_interface_in")
+            .add("network_interface_out")
+            .add("network_protocol")
+            .add("application_name")
+            .build();
+
+    private static final Set<String> BYTE_FIELDS = ImmutableSet.<String>builder()
+            .add("user_priority_level")
+            .add("source_user_priority_level")
+            .add("target_user_priority_level")
+            .add("host_priority_level")
+            .add("source_priority_level")
+            .add("destination_priority_level")
+            .add("event_severity_level")
+            .add("alert_severity_level")
+            .add("windows_logon_type")
+            .build();
+
+    private static final Set<String> LONG_FIELDS = ImmutableSet.<String>builder()
+            .add("http_bytes")
+            .add("http_request_bytes")
+            .add("http_response_bytes")
+            .add("http_url_length")
+            .add("http_user_agent_length")
+            .add("source_bytes_sent")
+            .add("source_packets")
+            .add("destination_bytes_sent")
+            .add("destination_packets_sent")
+            .add("event_duration")
+            .add("event_repeat_count")
+            .add("network_bytes")
+            .add("network_bytes_rx")
+            .add("network_bytes_tx")
+            .add("network_data_bytes")
+            .add("network_header_bytes")
+            .add("network_packets")
+            .add("network_tunnel_duration")
+            .build();
+
+    private static final Set<String> INTEGER_FIELDS = ImmutableSet.<String>builder()
+            .add("gl2_event_type_code")
+            .add("http_response_code")
+            .add("source_nat_port")
+            .add("destination_nat_port")
+            .add("destination_port")
+            .add("vendor_alert_severity_level")
+            .add("vendor_event_severity_level")
+            .add("network_iana_number")
+            .build();
+
+    private static final Set<String> IP_FIELDS = ImmutableSet.<String>builder()
+            .add("associated_ip")
+            .add("vendor_private_ip")
+            .add("vendor_private_ipv6")
+            .add("vendor_public_ip")
+            .add("vendor_public_ipv6")
+            .build();
+
+    private static final Set<String> ASSOCIATED_IP_FIELDS = ImmutableSet.<String>builder()
+            .add("host_ip")
+            .add("source_ip")
+            .add("source_nat_ip")
+            .add("destination_ip")
+            .add("destination_nat_ip")
+            .add("network_forwarded_ip")
+            .add("event_observer_ip")
+            .build();
+
+    private static final Set<String> DATE_FIELDS = ImmutableSet.<String>builder()
+            .add("event_created")
+            .add("event_start")
+            .add("event_recieved_time")
+            .add("file_created_date")
+            .build();
+
+    @Override
+    protected List<Map<String, Map<String, Object>>> dynamicTemplate() {
+        return Collections.singletonList(
+                Collections.singletonMap(
+                        "winlogbeat_fields",
+                        ImmutableMap.of(
+                                "match", "winlogbeat_*",
+                                "match_mapping_type", "string",
+                                "mapping", Collections.singletonMap(
+                                        "type", "keyword"
+                                )
+                        )
+                )
+        );
+    }
+
+    private Map<String, Object> notAnalyzedString(Map<String, Object> settings) {
+        return ImmutableMap.<String, Object>builder()
+                .putAll(notAnalyzedString())
+                .putAll(settings)
+                .build();
+    }
+
+    private Map<String, Object> integerField() {
+        return typeField("integer");
+    }
+
+    private Map<String, Map<String, Object>> toMapping(Set<String> fields, Supplier<Map<String, Object>> typeFunction) {
+        return fields.stream()
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        field -> typeFunction.get()
+                ));
+    }
+
+    private Map<String, Object> notAnalyzedStringWithLowercaseNormalizer() {
+        return notAnalyzedString(Collections.singletonMap("normalizer", "loweronly"));
+    }
+
+    private Map<String, Object> byteField() {
+        return typeField("byte");
+    }
+
+    private Map<String, Object> longField() {
+        return typeField("long");
+    }
+
+    private Map<String, Object> ipField() {
+        return typeField("ip");
+    }
+
+    private Map<String, Object> dateField() {
+        return merge(typeField("date"), Collections.singletonMap(
+                "format",
+                "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
+        ));
+    }
+
+    private Map<String, Object> typeField(String type) {
+        return Collections.singletonMap("type", type);
+    }
+
+    private Map<String, Object> analyzedString(String analyzer) {
+        return super.analyzedString(analyzer, true);
+    }
+
+    private Map<String, Object> copyTo(Map<String, Object> source, String newField) {
+        return merge(source, Collections.singletonMap("copy_to", newField));
+    }
+
+    private Map<String, Object> merge(Map<String, Object> type1, Map<String, Object> type2) {
+        return ImmutableMap.<String, Object>builder()
+                .putAll(type1)
+                .putAll(type2)
+                .build();
+    }
+
+    private Map<String, Object> settings() {
+        return ImmutableMap.of(
+                "index.mapping.ignore_malformed", true,
+                "analysis", ImmutableMap.of(
+                        "normalizer", ImmutableMap.of(
+                                "loweronly", ImmutableMap.of(
+                                        "type", "custom",
+                                        "char_filter", Collections.emptyList(),
+                                        "filter", Collections.singleton("lowercase")
+                                )
+                        )
+                )
+        );
+    }
+
+    @Override
+    protected Map<String, Map<String, Object>> fieldProperties(String analyzer) {
+        return ImmutableMap.<String, Map<String, Object>>builder()
+                .put("message", analyzedString(analyzer, false))
+                .putAll(toMapping(KEYWORD_FIELDS, this::notAnalyzedString))
+                .putAll(toMapping(LOWERCASE_KEYWORD_FIELDS, this::notAnalyzedStringWithLowercaseNormalizer))
+                .putAll(toMapping(BYTE_FIELDS, this::byteField))
+                .putAll(toMapping(LONG_FIELDS, this::longField))
+                .putAll(toMapping(INTEGER_FIELDS, this::integerField))
+                .putAll(toMapping(IP_FIELDS, this::ipField))
+                .putAll(toMapping(ASSOCIATED_IP_FIELDS, () -> copyTo(ipField(), "associated_ip")))
+                .putAll(toMapping(DATE_FIELDS, this::dateField))
+                .put("user_name", copyTo(notAnalyzedStringWithLowercaseNormalizer(), "associated_user_name"))
+                .put("source_user_name", copyTo(notAnalyzedStringWithLowercaseNormalizer(), "associated_user_name"))
+                .put("target_user_name", copyTo(notAnalyzedStringWithLowercaseNormalizer(), "associated_user_name"))
+                .put("source_user_session_id", copyTo(notAnalyzedString(), "associated_session_id"))
+                .put("target_user_session_id", copyTo(notAnalyzedString(), "associated_session_id"))
+                .put("session_id", copyTo(notAnalyzedString(), "associated_session_id"))
+                .put("user_session_id", copyTo(notAnalyzedString(), "associated_session_id"))
+                .put("http_headers", ImmutableMap.<String, Object>builder()
+                        .putAll(analyzedString("standard"))
+                        .put("norms", false)
+                        .put("index_options", "freqs")
+                        .build())
+                .put("http_user_agent_analyzed", analyzedString("standard"))
+                .put("http_url_analyzed", analyzedString("standard"))
+                .build();
+    }
+
+    @Override
+    public Map<String, Object> messageTemplate(String template, String analyzer, int order) {
+        return createTemplate(template, order, settings(), mapping(analyzer));
+    }
+
+    @Override
+    Map<String, Object> dynamicStrings() {
+        // Not needed for GIM mapping
+        return Collections.emptyMap();
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping.java
@@ -350,16 +350,20 @@ public abstract class GIMMapping extends IndexMapping {
         ));
     }
 
+    private Map<String, Object> textField() {
+        return typeField("text");
+    }
+
     private Map<String, Object> typeField(String type) {
         return Collections.singletonMap("type", type);
     }
 
-    private Map<String, Object> analyzedString(String analyzer) {
-        return super.analyzedString(analyzer, true);
-    }
-
     private Map<String, Object> copyTo(Map<String, Object> source, String newField) {
         return merge(source, Collections.singletonMap("copy_to", newField));
+    }
+
+    private Map<String, Object> withAnalyzer(Map<String, Object> source, String analyzer) {
+        return merge(source, Collections.singletonMap("analyzer", analyzer));
     }
 
     private Map<String, Object> merge(Map<String, Object> type1, Map<String, Object> type2) {
@@ -404,12 +408,12 @@ public abstract class GIMMapping extends IndexMapping {
                 .put("session_id", copyTo(notAnalyzedString(), "associated_session_id"))
                 .put("user_session_id", copyTo(notAnalyzedString(), "associated_session_id"))
                 .put("http_headers", ImmutableMap.<String, Object>builder()
-                        .putAll(analyzedString("standard"))
+                        .putAll(withAnalyzer(textField(), "standard"))
                         .put("norms", false)
                         .put("index_options", "freqs")
                         .build())
-                .put("http_user_agent_analyzed", analyzedString("standard"))
-                .put("http_url_analyzed", analyzedString("standard"))
+                .put("http_user_agent_analyzed", withAnalyzer(textField(), "standard"))
+                .put("http_url_analyzed", withAnalyzer(textField(), "standard"))
                 .build();
     }
 

--- a/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping.java
@@ -14,22 +14,6 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-/**
- * This file is part of Graylog.
- * <p>
- * Graylog is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- * <p>
- * Graylog is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * <p>
- * You should have received a copy of the GNU General Public License
- * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
- */
 package org.graylog2.indexer;
 
 import com.google.common.collect.ImmutableList;

--- a/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping6.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping6.java
@@ -1,0 +1,20 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer;
+
+public class GIMMapping6 extends GIMMapping {
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping6.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping6.java
@@ -16,5 +16,16 @@
  */
 package org.graylog2.indexer;
 
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
 public class GIMMapping6 extends GIMMapping {
+    @Override
+    Map<String, Object> dynamicStrings() {
+        return ImmutableMap.of(
+                "match_mapping_type", "string",
+                "mapping", notAnalyzedString()
+        );
+    }
 }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping7.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping7.java
@@ -1,0 +1,38 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+public class GIMMapping7 extends GIMMapping {
+    @Override
+    protected Map<String, Object> mapping(String analyzer) {
+        return messageMapping(analyzer);
+    }
+
+    @Override
+    Map<String, Object> createTemplate(String template, int order, Map<String, Object> settings, Map<String, Object> mappings) {
+        return ImmutableMap.of(
+                "index_patterns", template,
+                "order", order,
+                "settings", settings,
+                "mappings", mappings
+        );
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping7.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/GIMMapping7.java
@@ -27,6 +27,14 @@ public class GIMMapping7 extends GIMMapping {
     }
 
     @Override
+    Map<String, Object> dynamicStrings() {
+        return ImmutableMap.of(
+                "match_mapping_type", "string",
+                "mapping", notAnalyzedString()
+        );
+    }
+
+    @Override
     Map<String, Object> createTemplate(String template, int order, Map<String, Object> settings, Map<String, Object> mappings) {
         return ImmutableMap.of(
                 "index_patterns", template,

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
@@ -22,6 +22,7 @@ import org.graylog2.indexer.indexset.IndexSetConfig;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.Tools;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -37,12 +38,16 @@ public abstract class IndexMapping implements IndexMappingTemplate {
         return messageTemplate(indexPattern, indexSetConfig.indexAnalyzer(), order);
     }
 
-    public Map<String, Object> messageTemplate(final String template, final String analyzer, final int order) {
-        final Map<String, Object> analyzerKeyword = ImmutableMap.of("analyzer_keyword", ImmutableMap.of(
+    protected Map<String, Object> analyzerKeyword() {
+        return ImmutableMap.of("analyzer_keyword", ImmutableMap.of(
                 "tokenizer", "keyword",
                 "filter", "lowercase"));
-        final Map<String, Object> analysis = ImmutableMap.of("analyzer", analyzerKeyword);
-        final Map<String, Object> settings = ImmutableMap.of("analysis", analysis);
+    }
+
+    public Map<String, Object> messageTemplate(final String template, final String analyzer, final int order) {
+        final Map<String, Object> settings = Collections.singletonMap(
+                "analysis", Collections.singletonMap("analyzer", analyzerKeyword())
+                );
         final Map<String, Object> mappings = mapping(analyzer);
 
         return createTemplate(template, order, settings, mappings);

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMapping.java
@@ -77,7 +77,7 @@ public abstract class IndexMapping implements IndexMappingTemplate {
         );
     }
 
-    private List<Map<String, Map<String, Object>>> dynamicTemplate() {
+    protected List<Map<String, Map<String, Object>>> dynamicTemplate() {
         final Map<String, Map<String, Object>> templateInternal = internalFieldsMapping();
 
         final Map<String, Map<String, Object>> templateAll = ImmutableMap.of("store_generic", dynamicStrings());
@@ -87,7 +87,7 @@ public abstract class IndexMapping implements IndexMappingTemplate {
 
     abstract Map<String, Object> dynamicStrings();
 
-    private Map<String, Map<String, Object>> fieldProperties(String analyzer) {
+    protected Map<String, Map<String, Object>> fieldProperties(String analyzer) {
         return ImmutableMap.<String, Map<String, Object>>builder()
                 .put("message", analyzedString(analyzer, false))
                 .put("full_message", analyzedString(analyzer, false))

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMappingFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMappingFactory.java
@@ -38,7 +38,7 @@ public class IndexMappingFactory {
         switch (templateType) {
             case MESSAGES: return indexMappingFor(elasticsearchVersion);
             case EVENTS: return eventsIndexMappingFor(elasticsearchVersion);
-            case GENERIC: return gimMappingFor(elasticsearchVersion);
+            case GIM_V1: return gimMappingFor(elasticsearchVersion);
             default: throw new IllegalStateException("Invalid index template type: " + templateType);
         }
     }

--- a/graylog2-server/src/main/java/org/graylog2/indexer/IndexMappingFactory.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/IndexMappingFactory.java
@@ -35,11 +35,22 @@ public class IndexMappingFactory {
     public IndexMappingTemplate createIndexMapping(IndexSetConfig.TemplateType templateType) {
         final Version elasticsearchVersion = node.getVersion().orElseThrow(() -> new ElasticsearchException("Unable to retrieve Elasticsearch version."));
 
-        if (IndexSetConfig.TemplateType.EVENTS.equals(templateType)) {
-            return eventsIndexMappingFor(elasticsearchVersion);
+        switch (templateType) {
+            case MESSAGES: return indexMappingFor(elasticsearchVersion);
+            case EVENTS: return eventsIndexMappingFor(elasticsearchVersion);
+            case GENERIC: return gimMappingFor(elasticsearchVersion);
+            default: throw new IllegalStateException("Invalid index template type: " + templateType);
         }
+    }
 
-        return indexMappingFor(elasticsearchVersion);
+    private IndexMapping gimMappingFor(Version elasticsearchVersion) {
+        if (elasticsearchVersion.satisfies("^6.0.0")) {
+            return new GIMMapping6();
+        } else if (elasticsearchVersion.satisfies("^7.0.0")) {
+            return new GIMMapping7();
+        } else {
+            throw new ElasticsearchException("Unsupported Elasticsearch version: " + elasticsearchVersion);
+        }
     }
 
     public static IndexMapping indexMappingFor(Version elasticsearchVersion) {

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
@@ -59,8 +59,8 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
         MESSAGES,
         @JsonProperty("events")
         EVENTS,
-        @JsonProperty("generic")
-        GENERIC
+        @JsonProperty("gim_v1")
+        GIM_V1
     }
 
     @JsonProperty("id")

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indexset/IndexSetConfig.java
@@ -58,7 +58,9 @@ public abstract class IndexSetConfig implements Comparable<IndexSetConfig> {
         @JsonProperty("messages")
         MESSAGES,
         @JsonProperty("events")
-        EVENTS
+        EVENTS,
+        @JsonProperty("generic")
+        GENERIC
     }
 
     @JsonProperty("id")

--- a/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
+++ b/graylog2-server/src/main/java/org/graylog2/indexer/indices/Indices.java
@@ -197,7 +197,7 @@ public class Indices {
             indicesAdapter.ensureIndexTemplate(templateName, template);
             indicesAdapter.create(indexName, indexSettings, templateName, template);
         } catch (Exception e) {
-            LOG.warn("Couldn't create index {}. Error: {}", indexName, e.getMessage());
+            LOG.warn("Couldn't create index {}. Error: {}", indexName, e.getMessage(), e);
             auditEventSender.failure(AuditActor.system(nodeId), ES_INDEX_CREATE, ImmutableMap.of("indexName", indexName));
             return false;
         }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/GIMMapping6Test.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/GIMMapping6Test.java
@@ -1,0 +1,36 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer;
+
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+class GIMMapping6Test extends GIMMappingTest {
+    @Test
+    void matchesJsonSource() throws Exception {
+        final IndexMappingTemplate template = new GIMMapping6();
+        final IndexSetConfig indexSetConfig = mockIndexSetConfig();
+
+        final Map<String, Object> result = template.toTemplate(indexSetConfig, "myindex*", -2147483648);
+
+        assertEquals(resource("expected_gim_template6.json"), json(result), true);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/GIMMapping7Test.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/GIMMapping7Test.java
@@ -1,0 +1,36 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer;
+
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+class GIMMapping7Test extends GIMMappingTest {
+    @Test
+    void matchesJsonSource() throws Exception {
+        final IndexMappingTemplate template = new GIMMapping7();
+        final IndexSetConfig indexSetConfig = mockIndexSetConfig();
+
+        final Map<String, Object> result = template.toTemplate(indexSetConfig, "myindex*", -2147483648);
+
+        assertEquals(resource("expected_gim_template7.json"), json(result), true);
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/GIMMappingTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/GIMMappingTest.java
@@ -1,0 +1,42 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.indexer;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GIMMappingTest {
+    static class GIMMappingImpl extends GIMMapping {
+        @Override
+        protected List<Map<String, Map<String, Object>>> dynamicTemplate() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        Map<String, Object> dynamicStrings() {
+            return Collections.
+        }
+    }
+    @Test
+    void matchesJsonSource() {
+    }
+}

--- a/graylog2-server/src/test/java/org/graylog2/indexer/GIMMappingTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/GIMMappingTest.java
@@ -16,27 +16,33 @@
  */
 package org.graylog2.indexer;
 
-import org.junit.jupiter.api.Test;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.Resources;
+import org.glassfish.grizzly.utils.Charsets;
+import org.graylog2.indexer.indexset.IndexSetConfig;
+import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.io.IOException;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-class GIMMappingTest {
-    static class GIMMappingImpl extends GIMMapping {
-        @Override
-        protected List<Map<String, Map<String, Object>>> dynamicTemplate() {
-            return Collections.emptyList();
-        }
+abstract class GIMMappingTest {
+    private static final ObjectMapper mapper = new ObjectMapperProvider().get();
 
-        @Override
-        Map<String, Object> dynamicStrings() {
-            return Collections.
-        }
+    String json(Object object) throws JsonProcessingException {
+        return mapper.writeValueAsString(object);
     }
-    @Test
-    void matchesJsonSource() {
+
+    IndexSetConfig mockIndexSetConfig() {
+        final IndexSetConfig indexSetConfig = mock(IndexSetConfig.class);
+        when(indexSetConfig.indexAnalyzer()).thenReturn("standard");
+
+        return indexSetConfig;
+    }
+
+    String resource(String filename) throws IOException {
+        return Resources.toString(Resources.getResource(this.getClass(), filename), Charsets.UTF8_CHARSET);
     }
 }

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/expected_gim_template.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/expected_gim_template.json
@@ -1,0 +1,837 @@
+{
+  "order": -2147483648,
+  "index_patterns": "myindex*",
+  "settings": {
+    "index.mapping.ignore_malformed": true,
+    "analysis": {
+      "normalizer": {
+        "loweronly": {
+          "type": "custom",
+          "char_filter": [],
+          "filter": [
+            "lowercase"
+          ]
+        }
+      }
+    }
+  },
+  "mappings": {
+    "message": {
+      "dynamic_templates": [
+        {
+          "winlogbeat_fields": {
+            "match": "winlogbeat_*",
+            "match_mapping_type": "string",
+            "mapping": {
+              "type": "keyword"
+            }
+          }
+        }
+      ],
+      "properties": {
+        "message": {
+          "type": "text",
+          "analyzer": "standard"
+        },
+        "gl2_gims_version": {
+          "type": "keyword"
+        },
+        "gl2_tags": {
+          "type": "keyword"
+        },
+        "gl2_event_category": {
+          "type": "keyword"
+        },
+        "gl2_event_subcategory": {
+          "type": "keyword"
+        },
+        "gl2_event_type": {
+          "type": "keyword"
+        },
+        "user_command": {
+          "type": "keyword"
+        },
+        "gl2_event_type_code": {
+          "type": "integer"
+        },
+        "user_command_path": {
+          "type": "keyword"
+        },
+        "user_name": {
+          "type": "keyword",
+          "normalizer": "loweronly",
+          "copy_to": "associated_user_name"
+        },
+        "user_previous_name": {
+          "type": "keyword",
+          "normalizer": "loweronly"
+        },
+        "previous_user_name": {
+          "type": "keyword",
+          "normalizer": "loweronly"
+        },
+        "user_name_mapped": {
+          "type": "keyword",
+          "normalizer": "loweronly"
+        },
+        "user_session_id": {
+          "type": "keyword",
+          "copy_to": "associated_session_id"
+        },
+        "user_domain": {
+          "type": "keyword"
+        },
+        "user_email": {
+          "type": "keyword"
+        },
+        "user_id": {
+          "type": "keyword"
+        },
+        "user_category": {
+          "type": "keyword"
+        },
+        "user_type": {
+          "type": "keyword"
+        },
+        "user_priority": {
+          "type": "keyword"
+        },
+        "user_priority_level": {
+          "type": "byte"
+        },
+        "source_user_name": {
+          "type": "keyword",
+          "normalizer": "loweronly",
+          "copy_to": "associated_user_name"
+        },
+        "source_user_name_mapped": {
+          "type": "keyword",
+          "normalizer": "loweronly"
+        },
+        "source_user_domain": {
+          "type": "keyword"
+        },
+        "source_user_email": {
+          "type": "keyword"
+        },
+        "source_user_session_id": {
+          "type": "keyword",
+          "copy_to": "associated_session_id"
+        },
+        "source_user_id": {
+          "type": "keyword"
+        },
+        "source_user_category": {
+          "type": "keyword"
+        },
+        "source_user_type": {
+          "type": "keyword"
+        },
+        "source_user_priority": {
+          "type": "keyword"
+        },
+        "source_user_priority_level": {
+          "type": "byte"
+        },
+        "target_user_name": {
+          "type": "keyword",
+          "normalizer": "loweronly",
+          "copy_to": "associated_user_name"
+        },
+        "target_user_name_mapped": {
+          "type": "keyword",
+          "normalizer": "loweronly"
+        },
+        "target_user_domain": {
+          "type": "keyword"
+        },
+        "target_user_email": {
+          "type": "keyword"
+        },
+        "target_user_session_id": {
+          "type": "keyword",
+          "copy_to": "associated_session_id"
+        },
+        "target_user_id": {
+          "type": "keyword"
+        },
+        "target_user_category": {
+          "type": "keyword"
+        },
+        "target_user_type": {
+          "type": "keyword"
+        },
+        "target_user_priority": {
+          "type": "keyword"
+        },
+        "target_user_priority_level": {
+          "type": "byte"
+        },
+        "http_application": {
+          "type": "keyword"
+        },
+        "http_bytes": {
+          "type": "long"
+        },
+        "http_content_type": {
+          "type": "keyword"
+        },
+        "http_headers": {
+          "type": "text",
+          "analyzer": "standard",
+          "norms": false,
+          "index_options": "freqs"
+        },
+        "http_host": {
+          "type": "keyword"
+        },
+        "http_path": {
+          "type": "keyword"
+        },
+        "http_referrer": {
+          "type": "keyword"
+        },
+        "http_request_bytes": {
+          "type": "long"
+        },
+        "http_method": {
+          "type": "keyword"
+        },
+        "http_response_bytes": {
+          "type": "long"
+        },
+        "http_response": {
+          "type": "keyword"
+        },
+        "http_response_code": {
+          "type": "integer"
+        },
+        "http_user_agent": {
+          "type": "keyword"
+        },
+        "http_user_agent_analyzed": {
+          "type": "text",
+          "analyzer": "standard"
+        },
+        "http_user_agent_name": {
+          "type": "keyword"
+        },
+        "http_url": {
+          "type": "keyword"
+        },
+        "http_url_analyzed": {
+          "type": "text",
+          "analyzer": "standard"
+        },
+        "http_url_category": {
+          "type": "keyword"
+        },
+        "http_url_length": {
+          "type": "long"
+        },
+        "http_user_agent_os": {
+          "type": "keyword"
+        },
+        "http_user_agent_length": {
+          "type": "long"
+        },
+        "http_version": {
+          "type": "keyword"
+        },
+        "http_xff": {
+          "type": "keyword"
+        },
+        "host_as_domain": {
+          "type": "keyword"
+        },
+        "host_as_isp": {
+          "type": "keyword"
+        },
+        "host_as_organization": {
+          "type": "keyword"
+        },
+        "host_as_number": {
+          "type": "keyword"
+        },
+        "host_geo_city": {
+          "type": "keyword"
+        },
+        "host_geo_country": {
+          "type": "keyword"
+        },
+        "host_geo_name": {
+          "type": "keyword"
+        },
+        "host_geo_country_iso": {
+          "type": "keyword"
+        },
+        "host_geo_coordinates": {
+          "type": "keyword"
+        },
+        "host_location_name": {
+          "type": "keyword"
+        },
+        "host_mac": {
+          "type": "keyword"
+        },
+        "host_reference": {
+          "type": "keyword",
+          "normalizer": "loweronly"
+        },
+        "host_ip": {
+          "type": "ip",
+          "copy_to": "associated_ip"
+        },
+        "host_hostname": {
+          "type": "keyword",
+          "normalizer": "loweronly"
+        },
+        "host_category": {
+          "type": "keyword"
+        },
+        "host_priority": {
+          "type": "keyword"
+        },
+        "host_priority_level": {
+          "type": "byte"
+        },
+        "host_id": {
+          "type": "keyword"
+        },
+        "host_type": {
+          "type": "keyword"
+        },
+        "host_type_version": {
+          "type": "keyword"
+        },
+        "host_virtfw_hostname": {
+          "type": "keyword",
+          "normalizer": "loweronly"
+        },
+        "host_virtfw_id": {
+          "type": "keyword"
+        },
+        "host_virtfw_uid": {
+          "type": "keyword"
+        },
+        "source_as_organization": {
+          "type": "keyword"
+        },
+        "source_as_domain": {
+          "type": "keyword"
+        },
+        "source_as_number": {
+          "type": "keyword"
+        },
+        "source_bytes_sent": {
+          "type": "long"
+        },
+        "source_geo_city": {
+          "type": "keyword"
+        },
+        "source_geo_country": {
+          "type": "keyword"
+        },
+        "source_geo_name": {
+          "type": "keyword"
+        },
+        "source_geo_country_iso": {
+          "type": "keyword"
+        },
+        "source_geo_coordinates": {
+          "type": "keyword"
+        },
+        "source_reference": {
+          "type": "keyword",
+          "normalizer": "loweronly"
+        },
+        "source_ip": {
+          "type": "ip",
+          "copy_to": "associated_ip"
+        },
+        "source_hostname": {
+          "type": "keyword",
+          "normalizer": "loweronly"
+        },
+        "source_category": {
+          "type": "keyword"
+        },
+        "source_location_name": {
+          "type": "keyword"
+        },
+        "source_mac": {
+          "type": "keyword"
+        },
+        "source_nat_ip": {
+          "type": "ip",
+          "copy_to": "associated_ip"
+        },
+        "source_nat_port": {
+          "type": "integer"
+        },
+        "source_priority": {
+          "type": "keyword"
+        },
+        "source_priority_level": {
+          "type": "byte"
+        },
+        "source_id": {
+          "type": "keyword"
+        },
+        "source_packets": {
+          "type": "long"
+        },
+        "source_type": {
+          "type": "keyword"
+        },
+        "source_vsys_uuid": {
+          "type": "keyword"
+        },
+        "source_zone": {
+          "type": "keyword"
+        },
+        "destination_application_name": {
+          "type": "keyword"
+        },
+        "destination_as_domain": {
+          "type": "keyword"
+        },
+        "destination_as_isp": {
+          "type": "keyword"
+        },
+        "destination_as_organization": {
+          "type": "keyword"
+        },
+        "destination_as_number": {
+          "type": "keyword"
+        },
+        "destination_bytes_sent": {
+          "type": "long"
+        },
+        "destination_domain": {
+          "type": "keyword",
+          "normalizer": "loweronly"
+        },
+        "destination_geo_city_name": {
+          "type": "keyword"
+        },
+        "destination_geo_country_name": {
+          "type": "keyword"
+        },
+        "destination_geo_name": {
+          "type": "keyword"
+        },
+        "destination_geo_state_name": {
+          "type": "keyword"
+        },
+        "destination_geo_country_iso": {
+          "type": "keyword"
+        },
+        "destination_geo_coordinates": {
+          "type": "keyword"
+        },
+        "destination_reference": {
+          "type": "keyword",
+          "normalizer": "loweronly"
+        },
+        "destination_ip": {
+          "type": "ip",
+          "copy_to": "associated_ip"
+        },
+        "destination_nat_ip": {
+          "type": "ip",
+          "copy_to": "associated_ip"
+        },
+        "destination_nat_port": {
+          "type": "integer"
+        },
+        "destination_packets_sent": {
+          "type": "long"
+        },
+        "destination_port": {
+          "type": "integer"
+        },
+        "destination_hostname": {
+          "type": "keyword",
+          "normalizer": "loweronly"
+        },
+        "destination_category": {
+          "type": "keyword"
+        },
+        "destination_location_name": {
+          "type": "keyword"
+        },
+        "destination_mac": {
+          "type": "keyword"
+        },
+        "destination_priority": {
+          "type": "keyword"
+        },
+        "destination_priority_level": {
+          "type": "byte"
+        },
+        "destination_id": {
+          "type": "keyword"
+        },
+        "destination_type": {
+          "type": "keyword"
+        },
+        "destination_vsys_uuid": {
+          "type": "keyword"
+        },
+        "destination_zone": {
+          "type": "keyword"
+        },
+        "event_action": {
+          "type": "keyword"
+        },
+        "event_created": {
+          "type": "date",
+          "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
+        },
+        "event_source": {
+          "type": "keyword"
+        },
+        "event_source_api_version": {
+          "type": "keyword"
+        },
+        "event_source_product": {
+          "type": "keyword"
+        },
+        "event_start": {
+          "type": "date",
+          "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
+        },
+        "event_code": {
+          "type": "keyword"
+        },
+        "event_duration": {
+          "type": "long"
+        },
+        "event_error_code": {
+          "type": "keyword"
+        },
+        "event_error_description": {
+          "type": "keyword"
+        },
+        "event_log_name": {
+          "type": "keyword"
+        },
+        "event_reporter": {
+          "type": "keyword"
+        },
+        "event_uid": {
+          "type": "keyword"
+        },
+        "event_observer_hostname": {
+          "type": "keyword",
+          "normalizer": "loweronly"
+        },
+        "event_observer_ip": {
+          "type": "ip",
+          "copy_to": "associated_ip"
+        },
+        "event_observer_uid": {
+          "type": "keyword"
+        },
+        "event_outcome": {
+          "type": "keyword"
+        },
+        "event_recieved_time": {
+          "type": "date",
+          "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
+        },
+        "event_repeat_count": {
+          "type": "long"
+        },
+        "event_severity": {
+          "type": "keyword"
+        },
+        "event_severity_level": {
+          "type": "byte"
+        },
+        "email_message_id": {
+          "type": "keyword"
+        },
+        "email_subject": {
+          "type": "keyword"
+        },
+        "file_company": {
+          "type": "keyword"
+        },
+        "file_created_date": {
+          "type": "date",
+          "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
+        },
+        "file_name": {
+          "type": "keyword"
+        },
+        "file_path": {
+          "type": "keyword"
+        },
+        "file_size": {
+          "type": "keyword"
+        },
+        "file_type": {
+          "type": "keyword"
+        },
+        "hash_md5": {
+          "type": "keyword"
+        },
+        "hash_sha1": {
+          "type": "keyword"
+        },
+        "hash_sha256": {
+          "type": "keyword"
+        },
+        "hash_sha512": {
+          "type": "keyword"
+        },
+        "hash_imphash": {
+          "type": "keyword"
+        },
+        "alert_definitions_version": {
+          "type": "keyword"
+        },
+        "alert_category": {
+          "type": "keyword"
+        },
+        "alert_indicator": {
+          "type": "keyword"
+        },
+        "alert_signature": {
+          "type": "keyword"
+        },
+        "alert_signature_id": {
+          "type": "keyword"
+        },
+        "alert_severity": {
+          "type": "keyword"
+        },
+        "alert_severity_level": {
+          "type": "byte"
+        },
+        "associated_ip": {
+          "type": "ip"
+        },
+        "associated_host": {
+          "type": "keyword"
+        },
+        "associated_mac": {
+          "type": "keyword"
+        },
+        "associated_hash": {
+          "type": "keyword"
+        },
+        "associated_category": {
+          "type": "keyword"
+        },
+        "associated_session_id": {
+          "type": "keyword"
+        },
+        "associated_user_name": {
+          "type": "keyword",
+          "normalizer": "loweronly"
+        },
+        "associated_user_id": {
+          "type": "keyword"
+        },
+        "session_id": {
+          "type": "keyword",
+          "copy_to": "associated_session_id"
+        },
+        "service_version": {
+          "type": "keyword"
+        },
+        "service_name": {
+          "type": "keyword"
+        },
+        "vendor_alert_severity": {
+          "type": "keyword"
+        },
+        "vendor_alert_severity_level": {
+          "type": "integer"
+        },
+        "vendor_event_action": {
+          "type": "keyword"
+        },
+        "vendor_event_description": {
+          "type": "keyword"
+        },
+        "vendor_event_outcome": {
+          "type": "keyword"
+        },
+        "vendor_event_outcome_reason": {
+          "type": "keyword"
+        },
+        "vendor_event_severity_level": {
+          "type": "integer"
+        },
+        "vendor_event_severity": {
+          "type": "keyword"
+        },
+        "vendor_private_ip": {
+          "type": "ip"
+        },
+        "vendor_private_ipv6": {
+          "type": "ip"
+        },
+        "vendor_public_ip": {
+          "type": "ip"
+        },
+        "vendor_public_ipv6": {
+          "type": "ip"
+        },
+        "vendor_signin_protocol": {
+          "type": "keyword"
+        },
+        "vendor_threat_suspected": {
+          "type": "keyword"
+        },
+        "vendor_transaction_id": {
+          "type": "keyword"
+        },
+        "vendor_transaction_type": {
+          "type": "keyword"
+        },
+        "vendor_user_type": {
+          "type": "keyword"
+        },
+        "windows_logon_type": {
+          "type": "byte"
+        },
+        "windows_logon_type_description": {
+          "type": "keyword"
+        },
+        "windows_kerberos_encryption": {
+          "type": "keyword"
+        },
+        "windows_kerberos_encryption_type": {
+          "type": "keyword"
+        },
+        "windows_kerberos_service_name": {
+          "type": "keyword"
+        },
+        "windows_authentication_package_name": {
+          "type": "keyword"
+        },
+        "windows_authentication_lmpackage_name": {
+          "type": "keyword"
+        },
+        "windows_authentication_process_name": {
+          "type": "keyword"
+        },
+        "source_user_sid_authority1": {
+          "type": "keyword"
+        },
+        "source_user_sid_authority2": {
+          "type": "keyword"
+        },
+        "source_user_sid_rid": {
+          "type": "keyword"
+        },
+        "user_sid_authority1": {
+          "type": "keyword"
+        },
+        "user_sid_authority2": {
+          "type": "keyword"
+        },
+        "user_sid_rid": {
+          "type": "keyword"
+        },
+        "target_sid_authority1": {
+          "type": "keyword"
+        },
+        "target_sid_authority2": {
+          "type": "keyword"
+        },
+        "target_sid_rid": {
+          "type": "keyword"
+        },
+        "network_application": {
+          "type": "keyword",
+          "normalizer": "loweronly"
+        },
+        "network_bytes": {
+          "type": "long"
+        },
+        "network_bytes_rx": {
+          "type": "long"
+        },
+        "network_bytes_tx": {
+          "type": "long"
+        },
+        "network_name": {
+          "type": "keyword"
+        },
+        "network_community_id": {
+          "type": "keyword"
+        },
+        "network_data_bytes": {
+          "type": "long"
+        },
+        "network_direction": {
+          "type": "keyword"
+        },
+        "network_forwarded_ip": {
+          "type": "ip",
+          "copy_to": "associated_ip"
+        },
+        "network_header_bytes": {
+          "type": "long"
+        },
+        "network_iana_number": {
+          "type": "integer"
+        },
+        "network_icmp_type": {
+          "type": "keyword"
+        },
+        "network_interface_in": {
+          "type": "keyword",
+          "normalizer": "loweronly"
+        },
+        "network_interface_out": {
+          "type": "keyword",
+          "normalizer": "loweronly"
+        },
+        "network_ip_version": {
+          "type": "keyword"
+        },
+        "network_packets": {
+          "type": "long"
+        },
+        "network_protocol": {
+          "type": "keyword",
+          "normalizer": "loweronly"
+        },
+        "network_transport": {
+          "type": "keyword"
+        },
+        "network_tunnel_type": {
+          "type": "keyword"
+        },
+        "network_tunnel_duration": {
+          "type": "long"
+        },
+        "application_name": {
+          "type": "keyword",
+          "normalizer": "loweronly"
+        },
+        "application_sso_signonmode": {
+          "type": "keyword"
+        },
+        "application_sso_target_name": {
+          "type": "keyword"
+        },
+        "threat_category": {
+          "type": "keyword"
+        },
+        "threat_detected": {
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "aliases": {
+  }
+}

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/expected_gim_template6.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/expected_gim_template6.json
@@ -19,6 +19,22 @@
     "message": {
       "dynamic_templates": [
         {
+          "internal_fields" : {
+            "match" : "gl2_*",
+            "match_mapping_type" : "string",
+            "mapping" : {
+              "type" : "keyword"
+            }
+          }
+        }, {
+          "store_generic" : {
+            "match_mapping_type" : "string",
+            "mapping" : {
+              "type" : "keyword"
+            }
+          }
+        },
+        {
           "winlogbeat_fields": {
             "match": "winlogbeat_*",
             "match_mapping_type": "string",
@@ -32,10 +48,38 @@
         "enabled": true
       },
       "properties": {
-        "message": {
-          "type": "text",
-          "analyzer": "standard",
-          "fielddata": false
+        "message" : {
+          "type" : "text",
+          "analyzer" : "standard",
+          "fielddata" : false
+        },
+        "full_message" : {
+          "type" : "text",
+          "analyzer" : "standard",
+          "fielddata" : false
+        },
+        "timestamp" : {
+          "type" : "date",
+          "format" : "yyyy-MM-dd HH:mm:ss.SSS"
+        },
+        "gl2_accounted_message_size" : {
+          "type" : "long"
+        },
+        "gl2_receive_timestamp" : {
+          "type" : "date",
+          "format" : "yyyy-MM-dd HH:mm:ss.SSS"
+        },
+        "gl2_processing_timestamp" : {
+          "type" : "date",
+          "format" : "yyyy-MM-dd HH:mm:ss.SSS"
+        },
+        "source" : {
+          "type" : "text",
+          "analyzer" : "analyzer_keyword",
+          "fielddata" : true
+        },
+        "streams" : {
+          "type" : "keyword"
         },
         "gl2_gims_version": {
           "type": "keyword"

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/expected_gim_template6.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/expected_gim_template6.json
@@ -1,6 +1,6 @@
 {
   "order": -2147483648,
-  "index_patterns": "myindex*",
+  "template": "myindex*",
   "settings": {
     "index.mapping.ignore_malformed": true,
     "analysis": {
@@ -28,10 +28,14 @@
           }
         }
       ],
+      "_source": {
+        "enabled": true
+      },
       "properties": {
         "message": {
           "type": "text",
-          "analyzer": "standard"
+          "analyzer": "standard",
+          "fielddata": false
         },
         "gl2_gims_version": {
           "type": "keyword"
@@ -831,7 +835,5 @@
         }
       }
     }
-  },
-  "aliases": {
   }
 }

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/expected_gim_template6.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/expected_gim_template6.json
@@ -585,7 +585,7 @@
         "event_outcome": {
           "type": "keyword"
         },
-        "event_recieved_time": {
+        "event_received_time": {
           "type": "date",
           "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
         },

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/expected_gim_template6.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/expected_gim_template6.json
@@ -12,6 +12,12 @@
             "lowercase"
           ]
         }
+      },
+      "analyzer": {
+        "analyzer_keyword": {
+          "filter": "lowercase",
+          "tokenizer": "keyword"
+        }
       }
     }
   },

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/expected_gim_template7.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/expected_gim_template7.json
@@ -18,6 +18,23 @@
   "mappings": {
     "dynamic_templates": [
       {
+        "internal_fields": {
+          "match": "gl2_*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      },
+      {
+        "store_generic": {
+          "mapping": {
+            "type": "keyword"
+          },
+          "match_mapping_type": "string"
+        }
+      },
+      {
         "winlogbeat_fields": {
           "match": "winlogbeat_*",
           "match_mapping_type": "string",
@@ -35,6 +52,34 @@
         "type": "text",
         "analyzer": "standard",
         "fielddata": false
+      },
+      "full_message": {
+        "type": "text",
+        "analyzer": "standard",
+        "fielddata": false
+      },
+      "timestamp": {
+        "type": "date",
+        "format": "yyyy-MM-dd HH:mm:ss.SSS"
+      },
+      "gl2_accounted_message_size": {
+        "type": "long"
+      },
+      "gl2_receive_timestamp": {
+        "type": "date",
+        "format": "yyyy-MM-dd HH:mm:ss.SSS"
+      },
+      "gl2_processing_timestamp": {
+        "type": "date",
+        "format": "yyyy-MM-dd HH:mm:ss.SSS"
+      },
+      "source": {
+        "type": "text",
+        "analyzer": "analyzer_keyword",
+        "fielddata": true
+      },
+      "streams": {
+        "type": "keyword"
       },
       "gl2_gims_version": {
         "type": "keyword"

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/expected_gim_template7.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/expected_gim_template7.json
@@ -1,0 +1,837 @@
+{
+  "order": -2147483648,
+  "index_patterns": "myindex*",
+  "settings": {
+    "index.mapping.ignore_malformed": true,
+    "analysis": {
+      "normalizer": {
+        "loweronly": {
+          "type": "custom",
+          "char_filter": [],
+          "filter": [
+            "lowercase"
+          ]
+        }
+      }
+    }
+  },
+  "mappings": {
+    "dynamic_templates": [
+      {
+        "winlogbeat_fields": {
+          "match": "winlogbeat_*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      }
+    ],
+    "_source": {
+      "enabled": true
+    },
+    "properties": {
+      "message": {
+        "type": "text",
+        "analyzer": "standard",
+        "fielddata": false
+      },
+      "gl2_gims_version": {
+        "type": "keyword"
+      },
+      "gl2_tags": {
+        "type": "keyword"
+      },
+      "gl2_event_category": {
+        "type": "keyword"
+      },
+      "gl2_event_subcategory": {
+        "type": "keyword"
+      },
+      "gl2_event_type": {
+        "type": "keyword"
+      },
+      "user_command": {
+        "type": "keyword"
+      },
+      "gl2_event_type_code": {
+        "type": "integer"
+      },
+      "user_command_path": {
+        "type": "keyword"
+      },
+      "user_name": {
+        "type": "keyword",
+        "normalizer": "loweronly",
+        "copy_to": "associated_user_name"
+      },
+      "user_previous_name": {
+        "type": "keyword",
+        "normalizer": "loweronly"
+      },
+      "previous_user_name": {
+        "type": "keyword",
+        "normalizer": "loweronly"
+      },
+      "user_name_mapped": {
+        "type": "keyword",
+        "normalizer": "loweronly"
+      },
+      "user_session_id": {
+        "type": "keyword",
+        "copy_to": "associated_session_id"
+      },
+      "user_domain": {
+        "type": "keyword"
+      },
+      "user_email": {
+        "type": "keyword"
+      },
+      "user_id": {
+        "type": "keyword"
+      },
+      "user_category": {
+        "type": "keyword"
+      },
+      "user_type": {
+        "type": "keyword"
+      },
+      "user_priority": {
+        "type": "keyword"
+      },
+      "user_priority_level": {
+        "type": "byte"
+      },
+      "source_user_name": {
+        "type": "keyword",
+        "normalizer": "loweronly",
+        "copy_to": "associated_user_name"
+      },
+      "source_user_name_mapped": {
+        "type": "keyword",
+        "normalizer": "loweronly"
+      },
+      "source_user_domain": {
+        "type": "keyword"
+      },
+      "source_user_email": {
+        "type": "keyword"
+      },
+      "source_user_session_id": {
+        "type": "keyword",
+        "copy_to": "associated_session_id"
+      },
+      "source_user_id": {
+        "type": "keyword"
+      },
+      "source_user_category": {
+        "type": "keyword"
+      },
+      "source_user_type": {
+        "type": "keyword"
+      },
+      "source_user_priority": {
+        "type": "keyword"
+      },
+      "source_user_priority_level": {
+        "type": "byte"
+      },
+      "target_user_name": {
+        "type": "keyword",
+        "normalizer": "loweronly",
+        "copy_to": "associated_user_name"
+      },
+      "target_user_name_mapped": {
+        "type": "keyword",
+        "normalizer": "loweronly"
+      },
+      "target_user_domain": {
+        "type": "keyword"
+      },
+      "target_user_email": {
+        "type": "keyword"
+      },
+      "target_user_session_id": {
+        "type": "keyword",
+        "copy_to": "associated_session_id"
+      },
+      "target_user_id": {
+        "type": "keyword"
+      },
+      "target_user_category": {
+        "type": "keyword"
+      },
+      "target_user_type": {
+        "type": "keyword"
+      },
+      "target_user_priority": {
+        "type": "keyword"
+      },
+      "target_user_priority_level": {
+        "type": "byte"
+      },
+      "http_application": {
+        "type": "keyword"
+      },
+      "http_bytes": {
+        "type": "long"
+      },
+      "http_content_type": {
+        "type": "keyword"
+      },
+      "http_headers": {
+        "type": "text",
+        "analyzer": "standard",
+        "norms": false,
+        "index_options": "freqs"
+      },
+      "http_host": {
+        "type": "keyword"
+      },
+      "http_path": {
+        "type": "keyword"
+      },
+      "http_referrer": {
+        "type": "keyword"
+      },
+      "http_request_bytes": {
+        "type": "long"
+      },
+      "http_method": {
+        "type": "keyword"
+      },
+      "http_response_bytes": {
+        "type": "long"
+      },
+      "http_response": {
+        "type": "keyword"
+      },
+      "http_response_code": {
+        "type": "integer"
+      },
+      "http_user_agent": {
+        "type": "keyword"
+      },
+      "http_user_agent_analyzed": {
+        "type": "text",
+        "analyzer": "standard"
+      },
+      "http_user_agent_name": {
+        "type": "keyword"
+      },
+      "http_url": {
+        "type": "keyword"
+      },
+      "http_url_analyzed": {
+        "type": "text",
+        "analyzer": "standard"
+      },
+      "http_url_category": {
+        "type": "keyword"
+      },
+      "http_url_length": {
+        "type": "long"
+      },
+      "http_user_agent_os": {
+        "type": "keyword"
+      },
+      "http_user_agent_length": {
+        "type": "long"
+      },
+      "http_version": {
+        "type": "keyword"
+      },
+      "http_xff": {
+        "type": "keyword"
+      },
+      "host_as_domain": {
+        "type": "keyword"
+      },
+      "host_as_isp": {
+        "type": "keyword"
+      },
+      "host_as_organization": {
+        "type": "keyword"
+      },
+      "host_as_number": {
+        "type": "keyword"
+      },
+      "host_geo_city": {
+        "type": "keyword"
+      },
+      "host_geo_country": {
+        "type": "keyword"
+      },
+      "host_geo_name": {
+        "type": "keyword"
+      },
+      "host_geo_country_iso": {
+        "type": "keyword"
+      },
+      "host_geo_coordinates": {
+        "type": "keyword"
+      },
+      "host_location_name": {
+        "type": "keyword"
+      },
+      "host_mac": {
+        "type": "keyword"
+      },
+      "host_reference": {
+        "type": "keyword",
+        "normalizer": "loweronly"
+      },
+      "host_ip": {
+        "type": "ip",
+        "copy_to": "associated_ip"
+      },
+      "host_hostname": {
+        "type": "keyword",
+        "normalizer": "loweronly"
+      },
+      "host_category": {
+        "type": "keyword"
+      },
+      "host_priority": {
+        "type": "keyword"
+      },
+      "host_priority_level": {
+        "type": "byte"
+      },
+      "host_id": {
+        "type": "keyword"
+      },
+      "host_type": {
+        "type": "keyword"
+      },
+      "host_type_version": {
+        "type": "keyword"
+      },
+      "host_virtfw_hostname": {
+        "type": "keyword",
+        "normalizer": "loweronly"
+      },
+      "host_virtfw_id": {
+        "type": "keyword"
+      },
+      "host_virtfw_uid": {
+        "type": "keyword"
+      },
+      "source_as_organization": {
+        "type": "keyword"
+      },
+      "source_as_domain": {
+        "type": "keyword"
+      },
+      "source_as_number": {
+        "type": "keyword"
+      },
+      "source_bytes_sent": {
+        "type": "long"
+      },
+      "source_geo_city": {
+        "type": "keyword"
+      },
+      "source_geo_country": {
+        "type": "keyword"
+      },
+      "source_geo_name": {
+        "type": "keyword"
+      },
+      "source_geo_country_iso": {
+        "type": "keyword"
+      },
+      "source_geo_coordinates": {
+        "type": "keyword"
+      },
+      "source_reference": {
+        "type": "keyword",
+        "normalizer": "loweronly"
+      },
+      "source_ip": {
+        "type": "ip",
+        "copy_to": "associated_ip"
+      },
+      "source_hostname": {
+        "type": "keyword",
+        "normalizer": "loweronly"
+      },
+      "source_category": {
+        "type": "keyword"
+      },
+      "source_location_name": {
+        "type": "keyword"
+      },
+      "source_mac": {
+        "type": "keyword"
+      },
+      "source_nat_ip": {
+        "type": "ip",
+        "copy_to": "associated_ip"
+      },
+      "source_nat_port": {
+        "type": "integer"
+      },
+      "source_priority": {
+        "type": "keyword"
+      },
+      "source_priority_level": {
+        "type": "byte"
+      },
+      "source_id": {
+        "type": "keyword"
+      },
+      "source_packets": {
+        "type": "long"
+      },
+      "source_type": {
+        "type": "keyword"
+      },
+      "source_vsys_uuid": {
+        "type": "keyword"
+      },
+      "source_zone": {
+        "type": "keyword"
+      },
+      "destination_application_name": {
+        "type": "keyword"
+      },
+      "destination_as_domain": {
+        "type": "keyword"
+      },
+      "destination_as_isp": {
+        "type": "keyword"
+      },
+      "destination_as_organization": {
+        "type": "keyword"
+      },
+      "destination_as_number": {
+        "type": "keyword"
+      },
+      "destination_bytes_sent": {
+        "type": "long"
+      },
+      "destination_domain": {
+        "type": "keyword",
+        "normalizer": "loweronly"
+      },
+      "destination_geo_city_name": {
+        "type": "keyword"
+      },
+      "destination_geo_country_name": {
+        "type": "keyword"
+      },
+      "destination_geo_name": {
+        "type": "keyword"
+      },
+      "destination_geo_state_name": {
+        "type": "keyword"
+      },
+      "destination_geo_country_iso": {
+        "type": "keyword"
+      },
+      "destination_geo_coordinates": {
+        "type": "keyword"
+      },
+      "destination_reference": {
+        "type": "keyword",
+        "normalizer": "loweronly"
+      },
+      "destination_ip": {
+        "type": "ip",
+        "copy_to": "associated_ip"
+      },
+      "destination_nat_ip": {
+        "type": "ip",
+        "copy_to": "associated_ip"
+      },
+      "destination_nat_port": {
+        "type": "integer"
+      },
+      "destination_packets_sent": {
+        "type": "long"
+      },
+      "destination_port": {
+        "type": "integer"
+      },
+      "destination_hostname": {
+        "type": "keyword",
+        "normalizer": "loweronly"
+      },
+      "destination_category": {
+        "type": "keyword"
+      },
+      "destination_location_name": {
+        "type": "keyword"
+      },
+      "destination_mac": {
+        "type": "keyword"
+      },
+      "destination_priority": {
+        "type": "keyword"
+      },
+      "destination_priority_level": {
+        "type": "byte"
+      },
+      "destination_id": {
+        "type": "keyword"
+      },
+      "destination_type": {
+        "type": "keyword"
+      },
+      "destination_vsys_uuid": {
+        "type": "keyword"
+      },
+      "destination_zone": {
+        "type": "keyword"
+      },
+      "event_action": {
+        "type": "keyword"
+      },
+      "event_created": {
+        "type": "date",
+        "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
+      },
+      "event_source": {
+        "type": "keyword"
+      },
+      "event_source_api_version": {
+        "type": "keyword"
+      },
+      "event_source_product": {
+        "type": "keyword"
+      },
+      "event_start": {
+        "type": "date",
+        "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
+      },
+      "event_code": {
+        "type": "keyword"
+      },
+      "event_duration": {
+        "type": "long"
+      },
+      "event_error_code": {
+        "type": "keyword"
+      },
+      "event_error_description": {
+        "type": "keyword"
+      },
+      "event_log_name": {
+        "type": "keyword"
+      },
+      "event_reporter": {
+        "type": "keyword"
+      },
+      "event_uid": {
+        "type": "keyword"
+      },
+      "event_observer_hostname": {
+        "type": "keyword",
+        "normalizer": "loweronly"
+      },
+      "event_observer_ip": {
+        "type": "ip",
+        "copy_to": "associated_ip"
+      },
+      "event_observer_uid": {
+        "type": "keyword"
+      },
+      "event_outcome": {
+        "type": "keyword"
+      },
+      "event_recieved_time": {
+        "type": "date",
+        "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
+      },
+      "event_repeat_count": {
+        "type": "long"
+      },
+      "event_severity": {
+        "type": "keyword"
+      },
+      "event_severity_level": {
+        "type": "byte"
+      },
+      "email_message_id": {
+        "type": "keyword"
+      },
+      "email_subject": {
+        "type": "keyword"
+      },
+      "file_company": {
+        "type": "keyword"
+      },
+      "file_created_date": {
+        "type": "date",
+        "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
+      },
+      "file_name": {
+        "type": "keyword"
+      },
+      "file_path": {
+        "type": "keyword"
+      },
+      "file_size": {
+        "type": "keyword"
+      },
+      "file_type": {
+        "type": "keyword"
+      },
+      "hash_md5": {
+        "type": "keyword"
+      },
+      "hash_sha1": {
+        "type": "keyword"
+      },
+      "hash_sha256": {
+        "type": "keyword"
+      },
+      "hash_sha512": {
+        "type": "keyword"
+      },
+      "hash_imphash": {
+        "type": "keyword"
+      },
+      "alert_definitions_version": {
+        "type": "keyword"
+      },
+      "alert_category": {
+        "type": "keyword"
+      },
+      "alert_indicator": {
+        "type": "keyword"
+      },
+      "alert_signature": {
+        "type": "keyword"
+      },
+      "alert_signature_id": {
+        "type": "keyword"
+      },
+      "alert_severity": {
+        "type": "keyword"
+      },
+      "alert_severity_level": {
+        "type": "byte"
+      },
+      "associated_ip": {
+        "type": "ip"
+      },
+      "associated_host": {
+        "type": "keyword"
+      },
+      "associated_mac": {
+        "type": "keyword"
+      },
+      "associated_hash": {
+        "type": "keyword"
+      },
+      "associated_category": {
+        "type": "keyword"
+      },
+      "associated_session_id": {
+        "type": "keyword"
+      },
+      "associated_user_name": {
+        "type": "keyword",
+        "normalizer": "loweronly"
+      },
+      "associated_user_id": {
+        "type": "keyword"
+      },
+      "session_id": {
+        "type": "keyword",
+        "copy_to": "associated_session_id"
+      },
+      "service_version": {
+        "type": "keyword"
+      },
+      "service_name": {
+        "type": "keyword"
+      },
+      "vendor_alert_severity": {
+        "type": "keyword"
+      },
+      "vendor_alert_severity_level": {
+        "type": "integer"
+      },
+      "vendor_event_action": {
+        "type": "keyword"
+      },
+      "vendor_event_description": {
+        "type": "keyword"
+      },
+      "vendor_event_outcome": {
+        "type": "keyword"
+      },
+      "vendor_event_outcome_reason": {
+        "type": "keyword"
+      },
+      "vendor_event_severity_level": {
+        "type": "integer"
+      },
+      "vendor_event_severity": {
+        "type": "keyword"
+      },
+      "vendor_private_ip": {
+        "type": "ip"
+      },
+      "vendor_private_ipv6": {
+        "type": "ip"
+      },
+      "vendor_public_ip": {
+        "type": "ip"
+      },
+      "vendor_public_ipv6": {
+        "type": "ip"
+      },
+      "vendor_signin_protocol": {
+        "type": "keyword"
+      },
+      "vendor_threat_suspected": {
+        "type": "keyword"
+      },
+      "vendor_transaction_id": {
+        "type": "keyword"
+      },
+      "vendor_transaction_type": {
+        "type": "keyword"
+      },
+      "vendor_user_type": {
+        "type": "keyword"
+      },
+      "windows_logon_type": {
+        "type": "byte"
+      },
+      "windows_logon_type_description": {
+        "type": "keyword"
+      },
+      "windows_kerberos_encryption": {
+        "type": "keyword"
+      },
+      "windows_kerberos_encryption_type": {
+        "type": "keyword"
+      },
+      "windows_kerberos_service_name": {
+        "type": "keyword"
+      },
+      "windows_authentication_package_name": {
+        "type": "keyword"
+      },
+      "windows_authentication_lmpackage_name": {
+        "type": "keyword"
+      },
+      "windows_authentication_process_name": {
+        "type": "keyword"
+      },
+      "source_user_sid_authority1": {
+        "type": "keyword"
+      },
+      "source_user_sid_authority2": {
+        "type": "keyword"
+      },
+      "source_user_sid_rid": {
+        "type": "keyword"
+      },
+      "user_sid_authority1": {
+        "type": "keyword"
+      },
+      "user_sid_authority2": {
+        "type": "keyword"
+      },
+      "user_sid_rid": {
+        "type": "keyword"
+      },
+      "target_sid_authority1": {
+        "type": "keyword"
+      },
+      "target_sid_authority2": {
+        "type": "keyword"
+      },
+      "target_sid_rid": {
+        "type": "keyword"
+      },
+      "network_application": {
+        "type": "keyword",
+        "normalizer": "loweronly"
+      },
+      "network_bytes": {
+        "type": "long"
+      },
+      "network_bytes_rx": {
+        "type": "long"
+      },
+      "network_bytes_tx": {
+        "type": "long"
+      },
+      "network_name": {
+        "type": "keyword"
+      },
+      "network_community_id": {
+        "type": "keyword"
+      },
+      "network_data_bytes": {
+        "type": "long"
+      },
+      "network_direction": {
+        "type": "keyword"
+      },
+      "network_forwarded_ip": {
+        "type": "ip",
+        "copy_to": "associated_ip"
+      },
+      "network_header_bytes": {
+        "type": "long"
+      },
+      "network_iana_number": {
+        "type": "integer"
+      },
+      "network_icmp_type": {
+        "type": "keyword"
+      },
+      "network_interface_in": {
+        "type": "keyword",
+        "normalizer": "loweronly"
+      },
+      "network_interface_out": {
+        "type": "keyword",
+        "normalizer": "loweronly"
+      },
+      "network_ip_version": {
+        "type": "keyword"
+      },
+      "network_packets": {
+        "type": "long"
+      },
+      "network_protocol": {
+        "type": "keyword",
+        "normalizer": "loweronly"
+      },
+      "network_transport": {
+        "type": "keyword"
+      },
+      "network_tunnel_type": {
+        "type": "keyword"
+      },
+      "network_tunnel_duration": {
+        "type": "long"
+      },
+      "application_name": {
+        "type": "keyword",
+        "normalizer": "loweronly"
+      },
+      "application_sso_signonmode": {
+        "type": "keyword"
+      },
+      "application_sso_target_name": {
+        "type": "keyword"
+      },
+      "threat_category": {
+        "type": "keyword"
+      },
+      "threat_detected": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/expected_gim_template7.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/expected_gim_template7.json
@@ -585,7 +585,7 @@
       "event_outcome": {
         "type": "keyword"
       },
-      "event_recieved_time": {
+      "event_received_time": {
         "type": "date",
         "format": "yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||basic_date_time||basic_date_time_no_millis||epoch_second||date_time_no_millis||date_hour_minute_second_fraction||epoch_millis"
       },

--- a/graylog2-server/src/test/resources/org/graylog2/indexer/expected_gim_template7.json
+++ b/graylog2-server/src/test/resources/org/graylog2/indexer/expected_gim_template7.json
@@ -12,6 +12,12 @@
             "lowercase"
           ]
         }
+      },
+      "analyzer": {
+        "analyzer_keyword": {
+          "filter": "lowercase",
+          "tokenizer": "keyword"
+        }
       }
     }
   },


### PR DESCRIPTION
## Goal

As a Graylog user, I would want to be able to configure an index set to use the Graylog Information Model mapping template, so every new index created in this index set automatically has the proper mappings.

## Description of Changes

This PR is adding a mapping template class similar to our standard mapping template, which includes the field types and namings as defined in the Graylog Information Model. A new possible value (`generic`) is added for the `index_template_type` field of the index set config, which can be used to enable the usage of this template type for a given index set.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.