### PR TITLE
Implement PaginatedDataTable component

### DIFF
--- a/graylog2-web-interface/src/components/common/DataTable/DataTable.jsx
+++ b/graylog2-web-interface/src/components/common/DataTable/DataTable.jsx
@@ -197,17 +197,18 @@ class DataTable extends React.Component {
 
     return (
       <div>
-        <Filter customFilter={customFilter}
-                label={filterLabel}
-                id={id}
-                rows={rows}
-                displayKey={displayKey}
-                filterBy={filterBy}
-                filterSuggestions={filterSuggestions}
-                filterKeys={filterKeys}
-                onDataFiltered={this.filterDataRows}>
-          {children}
-        </Filter>
+        {customFilter || (
+          <Filter label={filterLabel}
+                  rows={rows}
+                  id={id}
+                  displayKey={displayKey}
+                  filterBy={filterBy}
+                  filterSuggestions={filterSuggestions}
+                  filterKeys={filterKeys}
+                  onDataFiltered={this.filterDataRows}>
+            {children}
+          </Filter>
+        )}
         <div className={`row ${rowClassName}`}>
           <div className="col-md-12">
             <div id={id} className={`data-table ${useResponsiveTable ? 'table-responsive' : ''}`}>

--- a/graylog2-web-interface/src/components/common/DataTable/Filter.jsx
+++ b/graylog2-web-interface/src/components/common/DataTable/Filter.jsx
@@ -12,7 +12,6 @@ const Wrapper = styled.div`
 
 const Filter = ({
   children,
-  customFilter,
   displayKey,
   filterBy,
   filterKeys,
@@ -22,10 +21,6 @@ const Filter = ({
   onDataFiltered,
   rows,
 }) => {
-  if (customFilter) {
-    return customFilter;
-  }
-
   if (filterKeys.length !== 0) {
     return (
       <Wrapper className="row">
@@ -53,7 +48,6 @@ const Filter = ({
 
 Filter.propTypes = {
   children: PropTypes.node,
-  customFilter: PropTypes.node,
   displayKey: PropTypes.string,
   filterBy: PropTypes.string,
   filterKeys: PropTypes.array,
@@ -66,7 +60,6 @@ Filter.propTypes = {
 
 Filter.defaultProps = {
   children: undefined,
-  customFilter: undefined,
   displayKey: undefined,
   filterBy: undefined,
   filterKeys: undefined,

--- a/graylog2-web-interface/src/components/common/PaginatedDataTable/Filter.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedDataTable/Filter.jsx
@@ -1,0 +1,30 @@
+// @flow strict
+import * as React from 'react';
+
+import DataTableFilter from 'components/common/DataTable/Filter';
+
+type Props = {
+  setFilteredRows: (Array<mixed>) => void,
+  resetPagination: () => void,
+  rows: Array<mixed>,
+};
+
+const Filter = ({ setFilteredRows, resetPagination, rows, ...filterProps }: Props) => {
+  const onDataFiltered = (newFilteredGroups, filterText) => {
+    if (filterText && filterText !== '') {
+      setFilteredRows(newFilteredGroups);
+    } else {
+      setFilteredRows(rows);
+    }
+
+    resetPagination();
+  };
+
+  return (
+    <DataTableFilter {...filterProps}
+                     rows={rows}
+                     onDataFiltered={onDataFiltered} />
+  );
+};
+
+export default Filter;

--- a/graylog2-web-interface/src/components/common/PaginatedDataTable/PaginatedDataTable.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedDataTable/PaginatedDataTable.jsx
@@ -22,6 +22,8 @@ const _paginatedRows = (rows: Array<mixed>, perPage: number, currentPage: number
 };
 
 type Props = {
+  /** Element id to use in the table container */
+  id: string,
   /** Array of objects to be rendered in the table. The render of those values is controlled by `dataRowFormatter`. */
   rows: Array<mixed>,
   /** Initial pagination. */
@@ -40,7 +42,7 @@ type Props = {
  * Component that renders a paginated data table. Should only be used for lists which are not already paginated.
  * If you want to display a lists which gets paginated by the backend, wrap use the DataTable in combination with the PaginatedList.
  */
-const PaginatedDataTable = ({ rows = [], pagination: initialPagination, filterKeys, filterLabel, displayKey, filterBy, ...rest }: Props) => {
+const PaginatedDataTable = ({ rows = [], pagination: initialPagination, filterKeys, filterLabel, displayKey, filterBy, id, ...rest }: Props) => {
   const [{ perPage, page }, setPagination] = useState(initialPagination);
   const [filteredRows, setFilteredRows] = useState(rows);
   const paginatedRows = _paginatedRows(filteredRows, perPage, page);
@@ -65,8 +67,10 @@ const PaginatedDataTable = ({ rows = [], pagination: initialPagination, filterKe
                    onChange={_onPageChange}
                    showPageSizeSelect>
       <DataTable {...rest}
+                 id={id}
                  customFilter={(
-                   <Filter filterKeys={filterKeys}
+                   <Filter id={id}
+                           filterKeys={filterKeys}
                            setFilteredRows={setFilteredRows}
                            rows={rows}
                            resetPagination={_resetPagination}

--- a/graylog2-web-interface/src/components/common/PaginatedDataTable/PaginatedDataTable.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedDataTable/PaginatedDataTable.jsx
@@ -1,10 +1,11 @@
 // @flow strict
 import * as React from 'react';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import type { Pagination } from 'stores/PaginationTypes';
-import { PaginatedList, DataTable } from 'components/common';
+import DataTable from 'components/common/DataTable';
+import PaginatedList from 'components/common/PaginatedList';
 
 import Filter from './Filter';
 

--- a/graylog2-web-interface/src/components/common/PaginatedDataTable/PaginatedDataTable.jsx
+++ b/graylog2-web-interface/src/components/common/PaginatedDataTable/PaginatedDataTable.jsx
@@ -1,0 +1,94 @@
+// @flow strict
+import * as React from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import PropTypes from 'prop-types';
+
+import type { Pagination } from 'stores/PaginationTypes';
+import { PaginatedList, DataTable } from 'components/common';
+
+import Filter from './Filter';
+
+const DEFAULT_PAGINATION = {
+  page: 1,
+  perPage: 10,
+  query: '',
+};
+
+const _paginatedRows = (rows: Array<mixed>, perPage: number, currentPage: number) => {
+  const begin = (perPage * (currentPage - 1));
+  const end = begin + perPage;
+
+  return rows.slice(begin, end);
+};
+
+type Props = {
+  /** Array of objects to be rendered in the table. The render of those values is controlled by `dataRowFormatter`. */
+  rows: Array<mixed>,
+  /** Initial pagination. */
+  pagination: Pagination,
+  /** Label to use next to the suggestions for the data filter input. */
+  filterBy?: string,
+  /** List of object keys to use as filter in the data filter input. Use an empty array to disable data filter. */
+  filterKeys?: Array<string>,
+  /** Label to use next to the data filter input. */
+  filterLabel?: string,
+  /** Object key that should be used to display data in the data filter input. */
+  displayKey?: string,
+};
+
+/**
+ * Component that renders a paginated data table. Should only be used for lists which are not already paginated.
+ * If you want to display a lists which gets paginated by the backend, wrap use the DataTable in combination with the PaginatedList.
+ */
+const PaginatedDataTable = ({ rows = [], pagination: initialPagination, filterKeys, filterLabel, displayKey, filterBy, ...rest }: Props) => {
+  const [{ perPage, page }, setPagination] = useState(initialPagination);
+  const [filteredRows, setFilteredRows] = useState(rows);
+  const paginatedRows = _paginatedRows(filteredRows, perPage, page);
+
+  useEffect(() => {
+    setFilteredRows(rows);
+    setPagination(initialPagination);
+  }, [rows, initialPagination]);
+
+  const _onPageChange = (newPage, newPerPage) => {
+    setPagination({ page: newPage, perPage: newPerPage });
+  };
+
+  const _resetPagination = () => {
+    setPagination({ perPage, page: initialPagination.page });
+  };
+
+  return (
+    <PaginatedList totalItems={filteredRows.length}
+                   pageSize={perPage}
+                   activePage={page}
+                   onChange={_onPageChange}
+                   showPageSizeSelect>
+      <DataTable {...rest}
+                 customFilter={(
+                   <Filter filterKeys={filterKeys}
+                           setFilteredRows={setFilteredRows}
+                           rows={rows}
+                           resetPagination={_resetPagination}
+                           displayKey={displayKey}
+                           filterBy={filterBy}
+                           filterLabel={filterLabel} />
+                 )}
+                 rows={paginatedRows} />
+    </PaginatedList>
+  );
+};
+
+PaginatedDataTable.defaultProps = {
+  displayKey: undefined,
+  filterKeys: undefined,
+  filterLabel: 'Filter',
+  filterBy: undefined,
+  pagination: DEFAULT_PAGINATION,
+};
+
+PaginatedDataTable.propTypes = {
+  pagination: PropTypes.object,
+};
+
+export default PaginatedDataTable;

--- a/graylog2-web-interface/src/components/common/PaginatedDataTable/index.js
+++ b/graylog2-web-interface/src/components/common/PaginatedDataTable/index.js
@@ -1,0 +1,4 @@
+// @flow strict
+import PaginatedDataTable from './PaginatedDataTable';
+
+export default PaginatedDataTable;

--- a/graylog2-web-interface/src/components/common/TypeAheadDataFilter.jsx
+++ b/graylog2-web-interface/src/components/common/TypeAheadDataFilter.jsx
@@ -55,7 +55,8 @@ class TypeAheadDataFilter extends React.Component {
     label: PropTypes.string,
     /**
      * Function that will be called when the user changes the filter.
-     * The function receives an array of data that matches the filter.
+     * The function receives an array of data that matches the filter
+     * and filter input value.
      */
     onDataFiltered: PropTypes.func,
     /**
@@ -175,6 +176,7 @@ class TypeAheadDataFilter extends React.Component {
 
   filterData = () => {
     const { filterData, data, onDataFiltered } = this.props;
+    const { filterText } = this.state;
 
     if (typeof filterData === 'function') {
       return filterData(data);
@@ -184,7 +186,7 @@ class TypeAheadDataFilter extends React.Component {
       return this._matchFilters(datum) && this._matchStringSearch(datum);
     }, this);
 
-    onDataFiltered(filteredData);
+    onDataFiltered(filteredData, filterText);
 
     return true;
   };

--- a/graylog2-web-interface/src/components/common/TypeAheadDataFilter.jsx
+++ b/graylog2-web-interface/src/components/common/TypeAheadDataFilter.jsx
@@ -199,7 +199,7 @@ class TypeAheadDataFilter extends React.Component {
         <li key={`li-${filter}`}>
           <span className="pill label label-default">
             {filterBy}: {filter}
-            <button type="button" className="tag-remove" data-target={filter} onClick={this._onFilterRemoved} />
+            <button type="button" className="tag-remove" data-target={filter} onClick={this._onFilterRemoved} aria-label={`Remove filter ${filter}`} />
           </span>
         </li>
       );

--- a/graylog2-web-interface/src/components/common/index.jsx
+++ b/graylog2-web-interface/src/components/common/index.jsx
@@ -44,6 +44,7 @@ export { default as PageErrorOverview } from './PageErrorOverview';
 export { default as PageHeader } from './PageHeader';
 export { default as Pagination } from './Pagination';
 export { default as PageSizeSelect } from './PageSizeSelect';
+export { default as PaginatedDataTable } from './PaginatedDataTable';
 export { default as PaginatedList } from './PaginatedList';
 export { default as PaginatedItemOverview } from './PaginatedItemOverview/PaginatedItemOverview';
 export { default as Pluralize } from './Pluralize';


### PR DESCRIPTION
## Description

This PR adds the `PaginatedDataTable` component to our `common` components directory. The `DataTable` component is only able to display the provided rows. When we have a list which is not getting paginated by the backend, we can't just combine the `DataTable` with the `PaginatedList`. This PR adds a component which handles this use case and ensures that the tables pagination works correctly in combination with the filter.
