### PR TITLE
Remove view userpermission

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
+++ b/graylog2-server/src/main/java/org/graylog/plugins/views/search/rest/ViewsResource.java
@@ -16,9 +16,7 @@
  */
 package org.graylog.plugins.views.search.rest;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -59,11 +57,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Locale.ENGLISH;
 
 @Api(value = "Views")
@@ -151,7 +145,6 @@ public class ViewsResource extends RestResource implements PluginRestResource {
         }
         final User user = userContext.getUser();
         final ViewDTO savedDto = dbService.saveWithOwner(dto.toBuilder().owner(user.getName()).build(), user);
-        ensureUserPermissions(savedDto);
         return savedDto;
     }
 
@@ -190,7 +183,6 @@ public class ViewsResource extends RestResource implements PluginRestResource {
         checkPermission(ViewsRestPermissions.VIEW_DELETE, id);
         final ViewDTO dto = loadView(id);
         dbService.delete(id);
-        removeUserPermissions(dto);
         triggerDeletedEvent(dto);
         return dto;
     }
@@ -213,45 +205,5 @@ public class ViewsResource extends RestResource implements PluginRestResource {
 
     private NotFoundException viewNotFoundException(String id) {
         return new NotFoundException("View " + id + " doesn't exist");
-    }
-
-    private void ensureUserPermissions(ViewDTO dto) throws ValidationException {
-        final User user = getCurrentUser();
-        if (user != null && !user.isLocalAdmin()) {
-            final List<String> permissions = ImmutableList.<String>builder()
-                    .addAll(user.getPermissions())
-                    .addAll(getViewPermissions(dto))
-                    .build();
-            user.setPermissions(permissions);
-            userService.save(user);
-        }
-    }
-
-    // TODO: Should be moved to org.graylog2.users.UserPermissionsCleanupListener once view are merged into the server
-    private void removeUserPermissions(ViewDTO dto) {
-        userService.loadAll().forEach(user -> {
-            final List<String> newPermissions = new ArrayList<>(user.getPermissions());
-            boolean modifiedPermissions = newPermissions.removeAll(getViewPermissions(dto));
-
-            if (modifiedPermissions) {
-                user.setPermissions(newPermissions);
-                try {
-                    userService.save(user);
-                    LOG.debug("Successfully updated permissions of user <{}>: {}", user.getName(), newPermissions);
-                } catch (ValidationException e) {
-                    LOG.warn("Unable to save user <{}> while removing permissions of deleted dashboard: ", user.getName(), e);
-                }
-            }
-        });
-    }
-
-    private Set<String> getViewPermissions(ViewDTO dto) {
-        if (isNullOrEmpty(dto.id())) {
-            throw new IllegalArgumentException("ViewDTO needs an ID to create permissions");
-        }
-        return ImmutableSet.of(
-                ViewsRestPermissions.VIEW_READ + ":" + dto.id(),
-                ViewsRestPermissions.VIEW_EDIT + ":" + dto.id()
-        );
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
+++ b/graylog2-server/src/main/java/org/graylog/security/DBGrantService.java
@@ -18,11 +18,16 @@ package org.graylog.security;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.eventbus.EventBus;
 import com.mongodb.BasicDBObject;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.Projections;
 import com.mongodb.client.model.Updates;
+import com.mongodb.client.result.DeleteResult;
 import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.bson.types.ObjectId;
 import org.graylog.grn.GRN;
 import org.graylog.grn.GRNRegistry;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
@@ -38,9 +43,11 @@ import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -50,13 +57,18 @@ public class DBGrantService extends PaginatedDbService<GrantDTO> {
     public static final String COLLECTION_NAME = "grants";
 
     private final GRNRegistry grnRegistry;
+    private final EventBus serverEventBus;
+    private final MongoCollection<Document> dbCollection;
 
     @Inject
     public DBGrantService(MongoConnection mongoConnection,
                           MongoJackObjectMapperProvider mapper,
-                          GRNRegistry grnRegistry) {
+                          GRNRegistry grnRegistry,
+                          EventBus serverEventBus) {
         super(mongoConnection, mapper, GrantDTO.class, COLLECTION_NAME);
         this.grnRegistry = grnRegistry;
+        this.serverEventBus = serverEventBus;
+        this.dbCollection = mongoConnection.getMongoDatabase().getCollection(COLLECTION_NAME);
 
         db.createIndex(new BasicDBObject(GrantDTO.FIELD_GRANTEE, 1));
         db.createIndex(new BasicDBObject(GrantDTO.FIELD_TARGET, 1));
@@ -85,6 +97,20 @@ public class DBGrantService extends PaginatedDbService<GrantDTO> {
                 Filters.eq(GrantDTO.FIELD_CAPABILITY, "grn::::capability:54e3deadbeefdeadbeef0002"),
                 Updates.set(GrantDTO.FIELD_CAPABILITY, Capability.OWN.toId())
         );
+    }
+
+    @Override
+    public GrantDTO save(GrantDTO grantDTO) {
+        final GrantDTO savedGrantDTO = super.save(grantDTO);
+        serverEventBus.post(GrantChangedEvent.create(savedGrantDTO.id()));
+        return savedGrantDTO;
+    }
+
+    @Override
+    public int delete(String id) {
+        final int delete = super.delete(id);
+        serverEventBus.post(GrantChangedEvent.create(id));
+        return delete;
     }
 
     public ImmutableSet<GrantDTO> getForGranteesOrGlobal(Set<GRN> grantees) {
@@ -124,7 +150,7 @@ public class DBGrantService extends PaginatedDbService<GrantDTO> {
         checkArgument(isNotBlank(creatorUsername), "creatorUsername cannot be null or empty");
         final ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
 
-        return super.save(grantDTO.toBuilder()
+        return save(grantDTO.toBuilder()
                 .createdBy(creatorUsername)
                 .createdAt(now)
                 .updatedBy(creatorUsername)
@@ -166,7 +192,7 @@ public class DBGrantService extends PaginatedDbService<GrantDTO> {
         final GrantDTO existingGrant = get(updatedGrant.id())
                 .orElseThrow(() -> new IllegalArgumentException("Couldn't find grant with ID " + updatedGrant.id()));
 
-        return super.save(existingGrant.toBuilder()
+        return save(existingGrant.toBuilder()
                 .grantee(updatedGrant.grantee())
                 .capability(updatedGrant.capability())
                 .target(updatedGrant.target())
@@ -185,8 +211,23 @@ public class DBGrantService extends PaginatedDbService<GrantDTO> {
         return db.find(DBQuery.is(GrantDTO.FIELD_TARGET, target.toString())).toArray();
     }
 
-    public int deleteForTarget(GRN target) {
-        return db.remove(DBQuery.is(GrantDTO.FIELD_TARGET, target.toString())).getN();
+    public long deleteForTarget(GRN target) {
+        final Bson filter = Filters.eq(GrantDTO.FIELD_TARGET, target.toString());
+        final Set<String> deletedIds = StreamSupport.stream(dbCollection.find(filter).projection(Projections.include()).spliterator(), false)
+                .map(doc -> {
+                    final Object o = doc.get("_id");
+                    if (o instanceof ObjectId) {
+                        return ((ObjectId) o).toHexString();
+                    }
+                    return null;
+                }).filter(Objects::nonNull).collect(Collectors.toSet());
+        final DeleteResult deleteResult = dbCollection.deleteMany(filter);
+
+        final long deletedCount = deleteResult.getDeletedCount();
+        if (deletedCount > 0) {
+            serverEventBus.post(GrantChangedEvent.create(deletedIds));
+        }
+        return deletedCount;
     }
 
     public List<GrantDTO> getForTargetExcludingGrantee(GRN target, GRN grantee) {

--- a/graylog2-server/src/main/java/org/graylog/security/GrantChangedEvent.java
+++ b/graylog2-server/src/main/java/org/graylog/security/GrantChangedEvent.java
@@ -1,0 +1,27 @@
+package org.graylog.security;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+import org.graylog.autovalue.WithBeanGetter;
+
+import java.util.Set;
+
+@JsonAutoDetect
+@AutoValue
+@WithBeanGetter
+public abstract class GrantChangedEvent {
+    private final static String FIELD_GRANT_IDS = "grant_ids";
+
+    @JsonProperty(FIELD_GRANT_IDS)
+    public abstract Set<String> grantIds();
+
+    public static GrantChangedEvent create(Set<String> grantIds) {
+        return new AutoValue_GrantChangedEvent(grantIds);
+    }
+
+    public static GrantChangedEvent create(String grantId) {
+        return new AutoValue_GrantChangedEvent(ImmutableSet.of(grantId));
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog/security/GrantChangedEvent.java
+++ b/graylog2-server/src/main/java/org/graylog/security/GrantChangedEvent.java
@@ -1,6 +1,7 @@
 package org.graylog.security;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
@@ -17,11 +18,12 @@ public abstract class GrantChangedEvent {
     @JsonProperty(FIELD_GRANT_IDS)
     public abstract Set<String> grantIds();
 
-    public static GrantChangedEvent create(Set<String> grantIds) {
+    @JsonCreator
+    public static GrantChangedEvent create(@JsonProperty(FIELD_GRANT_IDS) Set<String> grantIds) {
         return new AutoValue_GrantChangedEvent(grantIds);
     }
 
     public static GrantChangedEvent create(String grantId) {
-        return new AutoValue_GrantChangedEvent(ImmutableSet.of(grantId));
+        return create(ImmutableSet.of(grantId));
     }
 }

--- a/graylog2-server/src/main/java/org/graylog/security/GrantChangedEvent.java
+++ b/graylog2-server/src/main/java/org/graylog/security/GrantChangedEvent.java
@@ -1,3 +1,19 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.graylog.security;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;

--- a/graylog2-server/src/main/java/org/graylog2/security/realm/MongoDbAuthorizationRealm.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/realm/MongoDbAuthorizationRealm.java
@@ -31,6 +31,7 @@ import org.apache.shiro.subject.PrincipalCollection;
 import org.graylog.grn.GRN;
 import org.graylog.grn.GRNRegistry;
 import org.graylog.grn.GRNTypes;
+import org.graylog.security.GrantChangedEvent;
 import org.graylog.security.PermissionAndRoleResolver;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.security.MongoDbAuthorizationCacheManager;
@@ -141,6 +142,11 @@ public class MongoDbAuthorizationRealm extends AuthorizingRealm {
 
     @Subscribe
     public void handleUserSave(UserChangedEvent event) {
+        getAuthorizationCache().clear();
+    }
+
+    @Subscribe
+    public void handleGrantChange(GrantChangedEvent event) {
         getAuthorizationCache().clear();
     }
 }

--- a/graylog2-server/src/test/java/org/graylog/security/DBGrantServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/DBGrantServiceTest.java
@@ -17,6 +17,7 @@
 package org.graylog.security;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.eventbus.EventBus;
 import org.graylog.grn.GRN;
 import org.graylog.grn.GRNRegistry;
 import org.graylog.grn.GRNTypes;
@@ -53,7 +54,7 @@ public class DBGrantServiceTest {
     @Before
     public void setUp() throws Exception {
         final MongoJackObjectMapperProvider mapper = new MongoJackObjectMapperProvider(new ObjectMapperProvider().get());
-        this.dbService = new DBGrantService(mongodb.mongoConnection(), mapper, grnRegistry);
+        this.dbService = new DBGrantService(mongodb.mongoConnection(), mapper, grnRegistry, mock(EventBus.class));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/security/DBGrantServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/DBGrantServiceTest.java
@@ -17,13 +17,13 @@
 package org.graylog.security;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.eventbus.EventBus;
 import org.graylog.grn.GRN;
 import org.graylog.grn.GRNRegistry;
 import org.graylog.grn.GRNTypes;
 import org.graylog.testing.mongodb.MongoDBFixtures;
 import org.graylog.testing.mongodb.MongoDBInstance;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.events.ClusterEventBus;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.bindings.providers.ObjectMapperProvider;
 import org.junit.Before;
@@ -54,7 +54,7 @@ public class DBGrantServiceTest {
     @Before
     public void setUp() throws Exception {
         final MongoJackObjectMapperProvider mapper = new MongoJackObjectMapperProvider(new ObjectMapperProvider().get());
-        this.dbService = new DBGrantService(mongodb.mongoConnection(), mapper, grnRegistry, mock(EventBus.class));
+        this.dbService = new DBGrantService(mongodb.mongoConnection(), mapper, grnRegistry, mock(ClusterEventBus.class));
     }
 
     @Test

--- a/graylog2-server/src/test/java/org/graylog/security/shares/EntitySharesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/shares/EntitySharesServiceTest.java
@@ -74,7 +74,7 @@ public class EntitySharesServiceTest {
                GRNRegistry grnRegistry) {
         this.grnRegistry = grnRegistry;
 
-        final DBGrantService dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, this.grnRegistry);
+        final DBGrantService dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, this.grnRegistry, mock(EventBus.class));
 
         lenient().when(entityDependencyResolver.resolve(any())).thenReturn(ImmutableSet.of());
         lenient().when(entityDependencyPermissionChecker.check(any(), any(), any())).thenReturn(ImmutableMultimap.of());

--- a/graylog2-server/src/test/java/org/graylog/security/shares/EntitySharesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/shares/EntitySharesServiceTest.java
@@ -35,6 +35,7 @@ import org.graylog.testing.mongodb.MongoDBFixtures;
 import org.graylog.testing.mongodb.MongoDBTestService;
 import org.graylog.testing.mongodb.MongoJackExtension;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.events.ClusterEventBus;
 import org.graylog2.plugin.database.users.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -74,7 +75,7 @@ public class EntitySharesServiceTest {
                GRNRegistry grnRegistry) {
         this.grnRegistry = grnRegistry;
 
-        final DBGrantService dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, this.grnRegistry, mock(EventBus.class));
+        final DBGrantService dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, this.grnRegistry, mock(ClusterEventBus.class));
 
         lenient().when(entityDependencyResolver.resolve(any())).thenReturn(ImmutableSet.of());
         lenient().when(entityDependencyPermissionChecker.check(any(), any(), any())).thenReturn(ImmutableMultimap.of());

--- a/graylog2-server/src/test/java/org/graylog/security/shares/GranteeSharesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/shares/GranteeSharesServiceTest.java
@@ -16,7 +16,6 @@
  */
 package org.graylog.security.shares;
 
-import com.google.common.eventbus.EventBus;
 import org.graylog.grn.GRN;
 import org.graylog.grn.GRNDescriptor;
 import org.graylog.grn.GRNDescriptorService;
@@ -31,6 +30,7 @@ import org.graylog.testing.mongodb.MongoDBFixtures;
 import org.graylog.testing.mongodb.MongoDBTestService;
 import org.graylog.testing.mongodb.MongoJackExtension;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
+import org.graylog2.events.ClusterEventBus;
 import org.graylog2.rest.PaginationParameters;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -60,7 +60,7 @@ class GranteeSharesServiceTest {
                GRNRegistry grnRegistry,
                @Mock GRNDescriptorService grnDescriptorService) {
         this.grnDescriptorService = grnDescriptorService;
-        final DBGrantService dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry, mock(EventBus.class));
+        final DBGrantService dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry, mock(ClusterEventBus.class));
         this.granteeSharesService = new GranteeSharesService(dbGrantService, grnDescriptorService);
     }
 

--- a/graylog2-server/src/test/java/org/graylog/security/shares/GranteeSharesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/shares/GranteeSharesServiceTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog.security.shares;
 
+import com.google.common.eventbus.EventBus;
 import org.graylog.grn.GRN;
 import org.graylog.grn.GRNDescriptor;
 import org.graylog.grn.GRNDescriptorService;
@@ -43,6 +44,7 @@ import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MongoDBExtension.class)
 @ExtendWith(MongoJackExtension.class)
@@ -58,7 +60,7 @@ class GranteeSharesServiceTest {
                GRNRegistry grnRegistry,
                @Mock GRNDescriptorService grnDescriptorService) {
         this.grnDescriptorService = grnDescriptorService;
-        final DBGrantService dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry);
+        final DBGrantService dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry, mock(EventBus.class));
         this.granteeSharesService = new GranteeSharesService(dbGrantService, grnDescriptorService);
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/RolesToGrantsMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/RolesToGrantsMigrationTest.java
@@ -18,6 +18,7 @@ package org.graylog2.migrations.V20200803120800_GrantsMigrations;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.eventbus.EventBus;
 import org.graylog.grn.GRNRegistry;
 import org.graylog.security.Capability;
 import org.graylog.security.DBGrantService;
@@ -48,6 +49,7 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MongoDBExtension.class)
@@ -82,9 +84,9 @@ class RolesToGrantsMigrationTest {
 
         roleService = new RoleServiceImpl(mongodb.mongoConnection(), mongoJackObjectMapperProvider, permissions, validator);
 
-        dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry);
+        dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry, mock(EventBus.class));
         this.userService = userService;
-        DBGrantService dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry);
+        DBGrantService dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry, mock(EventBus.class));
         migration = new RolesToGrantsMigration(roleService, userService, dbGrantService, grnRegistry, "admin");
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/RolesToGrantsMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/RolesToGrantsMigrationTest.java
@@ -18,7 +18,6 @@ package org.graylog2.migrations.V20200803120800_GrantsMigrations;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.eventbus.EventBus;
 import org.graylog.grn.GRNRegistry;
 import org.graylog.security.Capability;
 import org.graylog.security.DBGrantService;
@@ -32,6 +31,7 @@ import org.graylog.testing.mongodb.MongoDBTestService;
 import org.graylog.testing.mongodb.MongoJackExtension;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.NotFoundException;
+import org.graylog2.events.ClusterEventBus;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.security.Permissions;
 import org.graylog2.shared.users.UserService;
@@ -84,9 +84,9 @@ class RolesToGrantsMigrationTest {
 
         roleService = new RoleServiceImpl(mongodb.mongoConnection(), mongoJackObjectMapperProvider, permissions, validator);
 
-        dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry, mock(EventBus.class));
+        dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry, mock(ClusterEventBus.class));
         this.userService = userService;
-        DBGrantService dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry, mock(EventBus.class));
+        DBGrantService dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry, mock(ClusterEventBus.class));
         migration = new RolesToGrantsMigration(roleService, userService, dbGrantService, grnRegistry, "admin");
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/UserPermissionsToGrantsMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/UserPermissionsToGrantsMigrationTest.java
@@ -17,7 +17,6 @@
 package org.graylog2.migrations.V20200803120800_GrantsMigrations;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.eventbus.EventBus;
 import org.graylog.grn.GRNRegistry;
 import org.graylog.security.Capability;
 import org.graylog.security.DBGrantService;
@@ -31,6 +30,7 @@ import org.graylog.testing.mongodb.MongoDBTestService;
 import org.graylog.testing.mongodb.MongoJackExtension;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.NotFoundException;
+import org.graylog2.events.ClusterEventBus;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.security.Permissions;
 import org.graylog2.shared.users.UserService;
@@ -77,9 +77,9 @@ class UserPermissionsToGrantsMigrationTest {
 
         this.userSelfEditPermissionCount = new Permissions(ImmutableSet.of()).userSelfEditPermissions("dummy").size();
 
-        dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry, mock(EventBus.class));
+        dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry, mock(ClusterEventBus.class));
         this.userService = userService;
-        DBGrantService dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry, mock(EventBus.class));
+        DBGrantService dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry, mock(ClusterEventBus.class));
         migration = new UserPermissionsToGrantsMigration(userService, dbGrantService, grnRegistry, "admin");
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/UserPermissionsToGrantsMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/UserPermissionsToGrantsMigrationTest.java
@@ -17,6 +17,7 @@
 package org.graylog2.migrations.V20200803120800_GrantsMigrations;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.eventbus.EventBus;
 import org.graylog.grn.GRNRegistry;
 import org.graylog.security.Capability;
 import org.graylog.security.DBGrantService;
@@ -43,6 +44,7 @@ import javax.validation.Validator;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 @ExtendWith(MongoDBExtension.class)
 @ExtendWith(MongoJackExtension.class)
@@ -75,9 +77,9 @@ class UserPermissionsToGrantsMigrationTest {
 
         this.userSelfEditPermissionCount = new Permissions(ImmutableSet.of()).userSelfEditPermissions("dummy").size();
 
-        dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry);
+        dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry, mock(EventBus.class));
         this.userService = userService;
-        DBGrantService dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry);
+        DBGrantService dbGrantService = new DBGrantService(mongodb.mongoConnection(), mongoJackObjectMapperProvider, grnRegistry, mock(EventBus.class));
         migration = new UserPermissionsToGrantsMigration(userService, dbGrantService, grnRegistry, "admin");
     }
 

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/ViewOwnershipToGrantsMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/ViewOwnershipToGrantsMigrationTest.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.migrations.V20200803120800_GrantsMigrations;
 
+import com.google.common.eventbus.EventBus;
 import org.graylog.grn.GRN;
 import org.graylog.grn.GRNRegistry;
 import org.graylog.grn.GRNTypes;
@@ -66,7 +67,7 @@ class ViewOwnershipToGrantsMigrationTest {
                @Mock UserService userService) {
 
         this.userService = userService;
-        this.grantService = new DBGrantService(mongodb.mongoConnection(), objectMapperProvider, grnRegistry);
+        this.grantService = new DBGrantService(mongodb.mongoConnection(), objectMapperProvider, grnRegistry, mock(EventBus.class));
 
         final EntityOwnershipService entityOwnershipService = new EntityOwnershipService(grantService, grnRegistry);
         final TestViewService viewService = new TestViewService(mongodb.mongoConnection(), objectMapperProvider, clusterConfigService, entityOwnershipService);

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/ViewOwnershipToGrantsMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/ViewOwnershipToGrantsMigrationTest.java
@@ -16,7 +16,6 @@
  */
 package org.graylog2.migrations.V20200803120800_GrantsMigrations;
 
-import com.google.common.eventbus.EventBus;
 import org.graylog.grn.GRN;
 import org.graylog.grn.GRNRegistry;
 import org.graylog.grn.GRNTypes;
@@ -32,6 +31,7 @@ import org.graylog.testing.mongodb.MongoDBTestService;
 import org.graylog.testing.mongodb.MongoJackExtension;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
+import org.graylog2.events.ClusterEventBus;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.users.UserService;
@@ -67,7 +67,7 @@ class ViewOwnershipToGrantsMigrationTest {
                @Mock UserService userService) {
 
         this.userService = userService;
-        this.grantService = new DBGrantService(mongodb.mongoConnection(), objectMapperProvider, grnRegistry, mock(EventBus.class));
+        this.grantService = new DBGrantService(mongodb.mongoConnection(), objectMapperProvider, grnRegistry, mock(ClusterEventBus.class));
 
         final EntityOwnershipService entityOwnershipService = new EntityOwnershipService(grantService, grnRegistry);
         final TestViewService viewService = new TestViewService(mongodb.mongoConnection(), objectMapperProvider, clusterConfigService, entityOwnershipService);

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/ViewSharingToGrantsMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/ViewSharingToGrantsMigrationTest.java
@@ -18,7 +18,6 @@
 package org.graylog2.migrations.V20200803120800_GrantsMigrations;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.eventbus.EventBus;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
 import org.bson.Document;
@@ -39,6 +38,7 @@ import org.graylog.testing.mongodb.MongoJackExtension;
 import org.graylog2.bindings.providers.MongoJackObjectMapperProvider;
 import org.graylog2.database.MongoConnection;
 import org.graylog2.database.NotFoundException;
+import org.graylog2.events.ClusterEventBus;
 import org.graylog2.plugin.cluster.ClusterConfigService;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.users.Role;
@@ -84,7 +84,7 @@ class ViewSharingToGrantsMigrationTest {
         this.dbCollection = mongodb.mongoCollection("view_sharings");
         this.userService = userService;
         this.roleService = roleService;
-        this.grantService = new DBGrantService(mongodb.mongoConnection(), objectMapperProvider, grnRegistry, mock(EventBus.class));
+        this.grantService = new DBGrantService(mongodb.mongoConnection(), objectMapperProvider, grnRegistry, mock(ClusterEventBus.class));
 
         when(userService.load(anyString())).thenAnswer(a -> {
             final String argument = a.getArgument(0);

--- a/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/ViewSharingToGrantsMigrationTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/migrations/V20200803120800_GrantsMigrations/ViewSharingToGrantsMigrationTest.java
@@ -18,6 +18,7 @@
 package org.graylog2.migrations.V20200803120800_GrantsMigrations;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.eventbus.EventBus;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
 import org.bson.Document;
@@ -83,7 +84,7 @@ class ViewSharingToGrantsMigrationTest {
         this.dbCollection = mongodb.mongoCollection("view_sharings");
         this.userService = userService;
         this.roleService = roleService;
-        this.grantService = new DBGrantService(mongodb.mongoConnection(), objectMapperProvider, grnRegistry);
+        this.grantService = new DBGrantService(mongodb.mongoConnection(), objectMapperProvider, grnRegistry, mock(EventBus.class));
 
         when(userService.load(anyString())).thenAnswer(a -> {
             final String argument = a.getArgument(0);


### PR DESCRIPTION

Clear the Shiro authorization cache if grants change

Otherwise the we might run into a race when ownership grants
are created for new entities, but the cache doesn't contain
the new permissions.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1862