### PR TITLE
Don't sign any artifacts in the distribution module

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -15,7 +15,10 @@
     <packaging>pom</packaging>
 
     <properties>
-        <!-- We don't need to sign anything in this module. This fixes a release build error. -->
+        <!--
+           We don't need to sign anything in this module. This fixes a release build error related to setting
+           the <outputDirectory> to a different path: https://issues.apache.org/jira/browse/MGPG-44
+        -->
         <gpg.skip>true</gpg.skip>
         <maven.source.skip>true</maven.source.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -12,8 +12,15 @@
     <artifactId>distribution</artifactId>
     <name>Graylog Binary Distribution Tarball</name>
     <description>Module solely performing final assembly step after all other modules artifacts have been built</description>
+    <packaging>pom</packaging>
 
     <properties>
+        <!-- We don't need to sign anything in this module. This fixes a release build error. -->
+        <gpg.skip>true</gpg.skip>
+        <maven.source.skip>true</maven.source.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
     </properties>
 


### PR DESCRIPTION
This fixes an error in release builds.

Also switch packaging to pom and skip source, javadoc, install and
deploy.
