### PR TITLE
Fix field types of current query if no stream is selected.

### DIFF
--- a/graylog2-web-interface/src/views/components/Search.jsx
+++ b/graylog2-web-interface/src/views/components/Search.jsx
@@ -129,8 +129,6 @@ const Search = ({ location }: Props) => {
   useEffect(() => {
     SearchConfigActions.refresh();
 
-    FieldTypesActions.all();
-
     StreamsActions.refresh();
 
     let storeListenersUnsubscribes = Immutable.List();

--- a/graylog2-web-interface/src/views/stores/FieldTypesStore.js
+++ b/graylog2-web-interface/src/views/stores/FieldTypesStore.js
@@ -49,14 +49,16 @@ export const FieldTypesStore: FieldTypesStoreType = singletonStore(
     },
 
     onQueryFiltersUpdate(newFilters) {
-      const promises = newFilters
-        .filter((filter) => filter !== undefined && filter !== null)
-        .map((filter) => filter.get('filters', Immutable.List()).filter((f) => f.get('type') === 'stream').map((f) => f.get('id')))
-        .filter((streamFilters) => streamFilters.size > 0)
-        .map((filters, queryId) => this.forStreams(filters.toArray()).then((response) => ({
-          queryId,
-          response,
-        })))
+      const streamIds = newFilters
+        .map((filter) => filter.get('filters', Immutable.List()).filter((f) => f.get('type') === 'stream').map((f) => f.get('id')));
+      const promises = streamIds
+        .map((filters, queryId) => (filters.size > 0
+          ? this.forStreams(filters.toArray())
+          : Promise.resolve(this._all))
+          .then((response) => ({
+            queryId,
+            response,
+          })))
         .valueSeq()
         .toJS();
 

--- a/graylog2-web-interface/src/views/stores/QueryFiltersStore.js
+++ b/graylog2-web-interface/src/views/stores/QueryFiltersStore.js
@@ -49,7 +49,7 @@ export const QueryFiltersStore = singletonStore(
     },
 
     _state() {
-      return this.queries.map((q) => q.filter).filter((f) => f !== undefined);
+      return this.queries.map((q) => q.filter ?? Immutable.Map());
     },
     _trigger() {
       this.trigger(this._state());


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, the `FieldTypesStore` returns empty field types for the current query, if the current query has no streams selected (which results in all streams being queried).

This change is now fixing the `QueryFiltersStore` to return queries with an empty filter as well, and fixes the `FieldTypesStore` to return all field types for queries which have an empty filter.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Start a new search. Enter any field name in the query input, see if it states that it is "not in streams" in the auto-completion.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.