### PR TITLE
Add a new notification type for input shutdown due to failures.

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
@@ -52,6 +52,7 @@ public interface Notification extends Persisted {
         ES_UNAVAILABLE,
         NO_INPUT_RUNNING,
         INPUT_FAILED_TO_START,
+        INPUT_FAILURE_SHUTDOWN,
         CHECK_SERVER_CLOCKS,
         OUTDATED_VERSION,
         EMAIL_TRANSPORT_CONFIGURATION_INVALID,

--- a/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
+++ b/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
@@ -128,6 +128,18 @@ class NotificationsFactory {
             </span>
           ),
         };
+      case 'input_failure_shutdown':
+        return {
+          title: 'An input has shut down due to failures',
+          description: (
+            <span>
+              Input {notification.details.input_title} has shut down on node {notification.node_id} for this reason:
+              »{notification.details.reason}«. This means that you are unable to receive any messages from this input.
+              This is often an indication of persistent network failures.
+              You can click {' '} <Link to={Routes.SYSTEM.INPUTS}>here</Link> to see the input.
+            </span>
+          ),
+        };
       case 'journal_uncommitted_messages_deleted':
         return {
           title: 'Uncommited messages deleted from journal',


### PR DESCRIPTION
## Description
In some rare circumstances, we may need to shut down a running Input due to persistent failures.  This change adds a new notification type to be used in that case.

## How Has This Been Tested?
This has been tested locally with the Office 365 input.

## Screenshots (if appropriate):
![Screen Shot 2020-10-22 at 4 12 31 PM](https://user-images.githubusercontent.com/6466251/96924955-6d2e0000-1481-11eb-955e-675670d1afe7.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

