### PR TITLE
Don't expose shares with invisible grantees

### DIFF
--- a/graylog2-server/src/test/resources/org/graylog/security/shares/EntitySharesServiceTest.json
+++ b/graylog2-server/src/test/resources/org/graylog/security/shares/EntitySharesServiceTest.json
@@ -26,6 +26,15 @@
       "capability": "view",
       "target": "grn::::dashboard:54e3deadbeefdeadbeefaffe",
       "created_by": "grn::::user:admin"
+    },
+    {
+      "_id": {
+        "$oid": "55e0261a0cc6210000000006"
+      },
+      "grantee": "grn::::user:invisible",
+      "capability": "manage",
+      "target": "grn::::stream:54e3deadbeefdeadbeefaffe",
+      "created_by": "grn::::user:admin"
     }
   ],
 

--- a/graylog2-server/src/test/resources/org/graylog/security/shares/EntitySharesServiceTest.json
+++ b/graylog2-server/src/test/resources/org/graylog/security/shares/EntitySharesServiceTest.json
@@ -32,8 +32,17 @@
         "$oid": "55e0261a0cc6210000000006"
       },
       "grantee": "grn::::user:invisible",
-      "capability": "manage",
+      "capability": "own",
       "target": "grn::::stream:54e3deadbeefdeadbeefaffe",
+      "created_by": "grn::::user:admin"
+    },
+    {
+      "_id": {
+        "$oid": "55e0261a0cc6210000000007"
+      },
+      "grantee": "grn::::user:bob",
+      "capability": "own",
+      "target": "grn::::event_definition:54e3deadbeefdeadbeefaffe",
       "created_by": "grn::::user:admin"
     }
   ],


### PR DESCRIPTION
Filter the activeShares result so it contains only grantees
that are visible to the requesting user.

