### PR TITLE
Saved Search: Hide Save button for missing edit perissions

### DIFF
--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.jsx
@@ -236,7 +236,7 @@ class SavedSearchControls extends React.Component<Props, State> {
                                        saveSearch={this.saveSearch}
                                        saveAsSearch={this.saveAsSearch}
                                        disableCreateNew={newTitle === view.title}
-                                       isCreateNew={!view.id}
+                                       isCreateNew={!view.id || !isAllowedToEdit}
                                        toggleModal={this.toggleFormModal}
                                        value={newTitle} />
                       )}


### PR DESCRIPTION
## Motivation
Prior to this change, the Save button was shown to a user which only had
view permissions to a Saved Search. If he clicked on that button the
result was an error page.

## Description
This change will hide the 'Save' and 'Save as' button and shows a
'Create New' button to make clear he has to create a new Search which he
can edit.

Fixes #8894 

