### PR TITLE
Display Finish & Save button for the directory service group sync step if no enterprise plugin exists

### DIFF
--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizard.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizard.jsx
@@ -125,7 +125,7 @@ const _getInvalidStepKeys = (formValues, excludedFields) => {
   return compact(invalidStepKeys);
 };
 
-const _onSubmitAll = (stepsState, setSubmitAllError, onSubmit, getUpdatedFormsValues, getSubmitPayload, validateSteps, licenseIsValid) => {
+const _onSubmitAll = (stepsState, setSubmitAllError, onSubmit, getUpdatedFormsValues, getSubmitPayload, validateSteps, shouldUpdateGroupSync) => {
   const formValues = getUpdatedFormsValues();
   const invalidStepKeys = validateSteps(formValues);
 
@@ -138,7 +138,7 @@ const _onSubmitAll = (stepsState, setSubmitAllError, onSubmit, getUpdatedFormsVa
   setSubmitAllError(null);
 
   const payload = getSubmitPayload(formValues);
-  const _submit = () => onSubmit(payload, formValues, stepsState.authBackendMeta.serviceType, licenseIsValid).then(() => {
+  const _submit = () => onSubmit(payload, formValues, stepsState.authBackendMeta.serviceType, shouldUpdateGroupSync).then(() => {
     history.push(Routes.SYSTEM.AUTHENTICATION.BACKENDS.OVERVIEW);
   }).catch((error) => {
     setSubmitAllError(error);
@@ -170,7 +170,7 @@ type Props = {
   initialValues: WizardFormValues,
   excludedFields: {[ inputName: string ]: boolean },
   help: { [inputName: string]: ?React.Node },
-  onSubmit: (WizardSubmitPayload, WizardFormValues, serviceType: $PropertyType<AuthBackendMeta, 'serviceType'>, licenseIsValid?: boolean) => Promise<LoadBackendResponse>,
+  onSubmit: (WizardSubmitPayload, WizardFormValues, serviceType: $PropertyType<AuthBackendMeta, 'serviceType'>, shouldUpdateGroupSync?: boolean) => Promise<LoadBackendResponse>,
 };
 
 const _loadRoles = (setPaginatedRoles) => {
@@ -249,14 +249,14 @@ const BackendWizard = ({ initialValues, initialStepKey, onSubmit, authBackendMet
     });
   };
 
-  const _handleSubmitAll = (licenseIsValid?: boolean) => _onSubmitAll(
+  const _handleSubmitAll = (shouldUpdateGroupSync?: boolean) => _onSubmitAll(
     stepsState,
     setSubmitAllError,
     onSubmit,
     _getUpdatedFormsValues,
     _getSubmitPayload,
     _validateSteps,
-    licenseIsValid,
+    shouldUpdateGroupSync,
   );
 
   const steps = wizardSteps({

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/GroupSyncStep.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/GroupSyncStep.jsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import * as Immutable from 'immutable';
 import { Formik } from 'formik';
 
+import { Row, Col, Button, ButtonToolbar } from 'components/graylog';
 import Role from 'logic/roles/Role';
 import { getEnterpriseGroupSyncPlugin } from 'util/AuthenticationService';
 import type { WizardSubmitPayload } from 'logic/authentication/directoryServices/types';
@@ -13,7 +14,7 @@ export const STEP_KEY: StepKeyType = 'group-synchronization';
 
 export type Props = {
   formRef: React.Ref<typeof Formik>,
-  onSubmitAll: (licenseIsValid?: boolean) => Promise<void>,
+  onSubmitAll: (shouldUpdateGroupSync?: boolean) => Promise<void>,
   help: { [inputName: string]: ?React.Node },
   excludedFields: { [inputName: string]: boolean },
   prepareSubmitPayload: () => WizardSubmitPayload,
@@ -27,7 +28,21 @@ const GroupSyncStep = ({ onSubmitAll, prepareSubmitPayload, formRef, submitAllEr
   const GroupSyncForm = enterpriseGroupSyncPlugin?.components?.GroupSyncForm;
 
   if (!GroupSyncForm) {
-    return <EnterprisePluginNotFound featureName="group synchronization" />;
+    return (
+      <>
+        <Row>
+          <Col xs={12}>
+            <EnterprisePluginNotFound featureName="group synchronization" />
+          </Col>
+        </Row>
+        <ButtonToolbar className="pull-right">
+          <Button bsStyle="primary"
+                  onClick={() => onSubmitAll(false)}>
+            Finish & Save Service
+          </Button>
+        </ButtonToolbar>
+      </>
+    );
   }
 
   return (

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/wizardSteps.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/wizardSteps.jsx
@@ -16,7 +16,7 @@ type Props = {
     [ServerConfigKey | UserSyncKey | GroupSyncKey]: React.Ref<typeof Formik>,
   },
   excludedFields: { [inputName: string]: boolean },
-  handleSubmitAll: (licenseIsValid?: boolean) => Promise<void>,
+  handleSubmitAll: (shouldUpdateGroupSync?: boolean) => Promise<void>,
   help: { [inputName: string]: ?React.Node },
   invalidStepKeys: Array<string>,
   prepareSubmitPayload: () => WizardSubmitPayload,

--- a/graylog2-web-interface/src/components/authentication/directoryServices/activeDirectory/BackendEdit.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/activeDirectory/BackendEdit.jsx
@@ -56,7 +56,7 @@ const BackendEdit = ({ authenticationBackend, initialStepKey }: Props) => {
     backendHasPassword: authenticationBackend.config.systemUserPassword.isSet,
     backendGroupSyncIsActive: !!initialValues.synchronizeGroups,
   };
-  const _handleSubmit = (payload, formValues, serviceType, licenseIsValid) => handleSubmit(payload, formValues, authenticationBackend.id, !!initialValues.synchronizeGroups, serviceType, licenseIsValid);
+  const _handleSubmit = (payload, formValues, serviceType, shouldUpdateGroupSync) => handleSubmit(payload, formValues, authenticationBackend.id, !!initialValues.synchronizeGroups, serviceType, shouldUpdateGroupSync);
 
   return (
     <DocumentTitle title="Edit Active Directory Authentication Service">

--- a/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendCreate.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendCreate.jsx
@@ -68,15 +68,15 @@ const INITIAL_VALUES = {
   verifyCertificates: true,
 };
 
-export const handleSubmit = (payload: WizardSubmitPayload, formValues: WizardFormValues, serviceType: $PropertyType<AuthBackendMeta, 'serviceType'>, licenseIsValid?: boolean = true) => {
+export const handleSubmit = (payload: WizardSubmitPayload, formValues: WizardFormValues, serviceType: $PropertyType<AuthBackendMeta, 'serviceType'>, shouldUpdateGroupSync?: boolean = true) => {
   const enterpriseGroupSyncPlugin = getEnterpriseGroupSyncPlugin();
-  const shouldCreateGroupSync = formValues.synchronizeGroups && enterpriseGroupSyncPlugin && licenseIsValid;
+  const shouldCreateGroupSync = formValues.synchronizeGroups && enterpriseGroupSyncPlugin && shouldUpdateGroupSync;
   const backendCreateNotificationSettings = {
     notifyOnSuccess: !shouldCreateGroupSync,
   };
 
   return AuthenticationDomain.create(backendCreateNotificationSettings)(payload).then((result) => {
-    if (result.backend && formValues.synchronizeGroups && enterpriseGroupSyncPlugin && licenseIsValid) {
+    if (result.backend && formValues.synchronizeGroups && enterpriseGroupSyncPlugin && shouldUpdateGroupSync) {
       return enterpriseGroupSyncPlugin.actions.onDirectoryServiceBackendUpdate(false, formValues, result.backend.id, AUTH_BACKEND_META.serviceType);
     }
 

--- a/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendEdit.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/ldap/BackendEdit.jsx
@@ -57,7 +57,7 @@ const _optionalWizardProps = (initialStepKey: ?string) => {
   return props;
 };
 
-export const handleSubmit = (payload: WizardSubmitPayload, formValues: WizardFormValues, backendId: string, backendGroupSyncIsActive: boolean, serviceType: string, licenseIsValid: ?boolean = true) => {
+export const handleSubmit = (payload: WizardSubmitPayload, formValues: WizardFormValues, backendId: string, backendGroupSyncIsActive: boolean, serviceType: string, shouldUpdateGroupSync: ?boolean = true) => {
   const enterpriseGroupSyncPlugin = getEnterpriseGroupSyncPlugin();
   const backendUpdateNotificationSettings = {
     notifyOnSuccess: !formValues.synchronizeGroups,
@@ -67,7 +67,7 @@ export const handleSubmit = (payload: WizardSubmitPayload, formValues: WizardFor
     ...payload,
     id: backendId,
   }).then((result) => {
-    if (enterpriseGroupSyncPlugin && licenseIsValid) {
+    if (enterpriseGroupSyncPlugin && shouldUpdateGroupSync) {
       return enterpriseGroupSyncPlugin.actions.onDirectoryServiceBackendUpdate(backendGroupSyncIsActive, formValues, backendId, serviceType);
     }
 
@@ -103,7 +103,7 @@ const BackendEdit = ({ authenticationBackend, initialStepKey }: Props) => {
     backendHasPassword: authenticationBackend.config.systemUserPassword.isSet,
     backendGroupSyncIsActive: !!initialValues.synchronizeGroups,
   };
-  const _handleSubmit = (payload, formValues, serviceType, licenseIsValid) => handleSubmit(payload, formValues, authenticationBackend.id, !!initialValues.synchronizeGroups, serviceType, licenseIsValid);
+  const _handleSubmit = (payload, formValues, serviceType, shouldUpdateGroupSync) => handleSubmit(payload, formValues, authenticationBackend.id, !!initialValues.synchronizeGroups, serviceType, shouldUpdateGroupSync);
 
   return (
     <DocumentTitle title="Edit LDAP Authentication Service">


### PR DESCRIPTION
Previously there was no Finish & Save on the directory service group sync step, if no enterprise plugin exists.

Fixes https://github.com/Graylog2/graylog-plugin-enterprise/issues/1858

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
