### PR TITLE
Display correct sharable URL on entity overview pages

### DIFF
--- a/graylog2-web-interface/.vscode/settings.json
+++ b/graylog2-web-interface/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "cSpell.words": [
+    "formik"
+  ]
+}

--- a/graylog2-web-interface/.vscode/settings.json
+++ b/graylog2-web-interface/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "cSpell.words": [
-    "formik"
-  ]
-}

--- a/graylog2-web-interface/src/components/permissions/EntityShareModal.test.jsx
+++ b/graylog2-web-interface/src/components/permissions/EntityShareModal.test.jsx
@@ -111,7 +111,7 @@ describe('EntityShareModal', () => {
       // Provided title
       expect(getByText('The title')).not.toBeNull();
       // sharable urls
-      expect(getByDisplayValue('http://localhost/')).not.toBeNull();
+      expect(getByDisplayValue('http://localhost/dashboards/dashboard-id')).not.toBeNull();
       // missing dependencies warning
       expect(getByText('There are missing dependencies for the current set of collaborators')).not.toBeNull();
       expect(getByText(/needs access to/)).not.toBeNull();

--- a/graylog2-web-interface/src/components/permissions/EntityShareSettings.jsx
+++ b/graylog2-web-interface/src/components/permissions/EntityShareSettings.jsx
@@ -129,7 +129,7 @@ const EntityShareSettings = ({
         </Section>
       )}
       <Section>
-        <ShareableEntityURL />
+        <ShareableEntityURL entityGRN={entityGRN} />
       </Section>
     </>
   );

--- a/graylog2-web-interface/src/components/permissions/ShareableEntityURL.jsx
+++ b/graylog2-web-interface/src/components/permissions/ShareableEntityURL.jsx
@@ -3,9 +3,11 @@ import * as React from 'react';
 import { useRef } from 'react';
 import styled, { type StyledComponent } from 'styled-components';
 
+import withLocation from 'routing/withLocation';
 import { ClipboardButton, Icon } from 'components/common';
 import { Alert, FormGroup, InputGroup, FormControl } from 'components/graylog';
 import { type ThemeInterface } from 'theme';
+import { getShowRouteFromGRN } from 'logic/permissions/GRN';
 
 const Container: StyledComponent<{}, ThemeInterface, Alert> = styled(Alert)`
   display: flex;
@@ -39,11 +41,13 @@ const StyledClipboardButton = styled(ClipboardButton)`
 `;
 
 type Props = {
-  entityURL?: string,
+  entityGRN: string,
 };
 
-const ShareableEntityURL = ({ entityURL }: Props) => {
+const ShareableEntityURL = ({ entityGRN }: Props) => {
   const container = useRef();
+  const entityRoute = getShowRouteFromGRN(entityGRN);
+  const entityUrl = `${window.location.origin.toString()}${entityRoute}`;
 
   return (
     <Container>
@@ -53,11 +57,11 @@ const ShareableEntityURL = ({ entityURL }: Props) => {
       <URLColumn>
         <FormGroup>
           <InputGroup>
-            <StyledFormControl type="text" value={entityURL} readOnly />
+            <StyledFormControl type="text" value={entityUrl} readOnly />
             <InputGroupAddon>
               <span ref={container}>
                 {container.current && (
-                  <StyledClipboardButton text={entityURL}
+                  <StyledClipboardButton text={entityUrl}
                                          container={container.current}
                                          buttonTitle="Copy parameter to clipboard"
                                          title={<Icon name="copy" fixedWidth />} />
@@ -72,10 +76,6 @@ const ShareableEntityURL = ({ entityURL }: Props) => {
       </URLColumn>
     </Container>
   );
-};
-
-ShareableEntityURL.defaultProps = {
-  entityURL: window.location.href,
 };
 
 export default ShareableEntityURL;

--- a/graylog2-web-interface/src/components/permissions/ShareableEntityURL.jsx
+++ b/graylog2-web-interface/src/components/permissions/ShareableEntityURL.jsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 import { useRef } from 'react';
 import styled, { type StyledComponent } from 'styled-components';
 
-import withLocation from 'routing/withLocation';
 import { ClipboardButton, Icon } from 'components/common';
 import { Alert, FormGroup, InputGroup, FormControl } from 'components/graylog';
 import { type ThemeInterface } from 'theme';

--- a/graylog2-web-interface/src/logic/permissions/GRN.js
+++ b/graylog2-web-interface/src/logic/permissions/GRN.js
@@ -24,9 +24,9 @@ export const getShowRouteFromGRN = (grn: string) => {
     case 'dashboard':
       return Routes.dashboard_show(id);
     case 'event_definition':
-      return Routes.ALERTS.DEFINITIONS.edit(id);
+      return Routes.ALERTS.DEFINITIONS.show(id);
     case 'notification':
-      return Routes.ALERTS.NOTIFICATIONS.edit(id);
+      return Routes.ALERTS.NOTIFICATIONS.show(id);
     case 'search':
       return Routes.getPluginRoute('SEARCH_VIEWID')(id);
     case 'stream':


### PR DESCRIPTION
## Description

As described in #9270 the sharable URL displayed inside the share modal is not correct when opening the modal for an entry of an overview, like the dashboards list. With this PR the URL is always based on the `entityGRN` and not the current location.

Fixes #9270


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
