### PR TITLE
Prevent empty string in directory service update and create password payload

### DIFF
--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizard.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizard.jsx
@@ -43,7 +43,7 @@ const SubmitAllError = ({ error, backendId }: { error: FetchError, backendId: ?s
 
 export const _passwordPayload = (backendId: ?string, systemUserPassword: ?string) => {
   const _formatPayload = (password) => {
-    if (password) {
+    if (!password) {
       return undefined;
     }
 

--- a/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizard.jsx
+++ b/graylog2-web-interface/src/components/authentication/directoryServices/BackendWizard/BackendWizard.jsx
@@ -42,6 +42,14 @@ const SubmitAllError = ({ error, backendId }: { error: FetchError, backendId: ?s
 );
 
 export const _passwordPayload = (backendId: ?string, systemUserPassword: ?string) => {
+  const _formatPayload = (password) => {
+    if (password) {
+      return undefined;
+    }
+
+    return password;
+  };
+
   // Only update password on edit if necessary,
   // if a users resets the previously defined password its form value is an empty string
   if (backendId) {
@@ -53,10 +61,10 @@ export const _passwordPayload = (backendId: ?string, systemUserPassword: ?string
       return { delete_value: true };
     }
 
-    return { set_value: systemUserPassword };
+    return { set_value: _formatPayload(systemUserPassword) };
   }
 
-  return systemUserPassword;
+  return _formatPayload(systemUserPassword);
 };
 
 const _prepareSubmitPayload = (stepsState, getUpdatedFormsValues) => (overrideFormValues): WizardSubmitPayload => {


### PR DESCRIPTION
## Description
Previously it was possible that the directory service payload contains a password with an empty string.

This was the case when a user:
1. Fills out the password input in the server config step
2. Goes to the another step
3. Goes back to the server config step
4. Removes the previously defined password
5. Triggers a connection test

With this PR we ensure that we do not submit an empty string for the password value.

Fixes #9183


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
