### PR TITLE
Fix z-index of the search loading indicator

### DIFF
--- a/graylog2-web-interface/src/views/components/Search.jsx
+++ b/graylog2-web-interface/src/views/components/Search.jsx
@@ -61,7 +61,6 @@ const GridContainer: StyledComponent<{ interactive: boolean }, void, HTMLDivElem
 
 const SearchArea: StyledComponent<{}, void, *> = styled(AppContentGrid)`
   height: 100%;
-  z-index: 1;
   overflow-y: auto;
 `;
 

--- a/graylog2-web-interface/src/views/components/searchbar/queryinput/StyledAceEditor.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/queryinput/StyledAceEditor.jsx
@@ -144,6 +144,7 @@ const StyledAceEditor = styled(AceEditor).attrs(({ aceTheme, theme }) => ({
 
     .ace_placeholder {
       font-family: inherit !important;
+      z-index: auto;
     }
   }
 `);


### PR DESCRIPTION
## Description
Previously the search loading indicator was not visible when a modal is being displayed. A result was that a user could not see the indicator while editing the query of a widget.

The loading indicator and the modal already had the correct `z-index`, but the indicator was not visible because it is part of the search grid which had an index of 1. We probably added this index to make sure its content is not being displayed above any overlay. This PR removes this index. It also adjusts the `z-index` of the search query placeholder, to ensure it is not being displayed above an overlay.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
