### PR TITLE
Fix active backend fetching on authentication pages

### DIFF
--- a/graylog2-web-interface/src/components/authentication/useActiveBackend.js
+++ b/graylog2-web-interface/src/components/authentication/useActiveBackend.js
@@ -14,8 +14,9 @@ const useActiveBackend = <T>(listenableActions: Array<ListenableAction<T>> = [])
     setLoadActiveResponse(response);
   });
 
+  useEffect(() => { _loadActive(); }, []);
+
   useEffect(() => {
-    _loadActive();
     const unlistenActions = listenableActions.map((action) => action.completed.listen(_loadActive));
 
     return () => {


### PR DESCRIPTION
## Description
Previously the active backend fetching was part of an `useEffect` which had unrelated dependencies. This resulted in a loop. This PR is fixing the behaviour by creating an own `useEffect` for the active backend fetching.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)