### PR TITLE
Fix session activity indicator for users

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/security/MongoDbSession.java
+++ b/graylog2-server/src/main/java/org/graylog2/security/MongoDbSession.java
@@ -94,7 +94,7 @@ public class MongoDbSession extends PersistedImpl {
         }
     }
 
-    public Optional<String> getUsernameAttribute() {
+    public Optional<String> getUserIdAttribute() {
         final Map<Object, Object> attributes = getAttributes();
         if (attributes == null) {
             return Optional.empty();
@@ -108,7 +108,9 @@ public class MongoDbSession extends PersistedImpl {
 
     public long getTimeout() {
         final Object timeout = fields.get("timeout");
-        if (timeout == null) return 0;
+        if (timeout == null) {
+            return 0;
+        }
         return ((Number) timeout).longValue();
     }
 


### PR DESCRIPTION
The session activity indicators on the users overview and the user
details page were broken because of the following:

1. The `GET /users/<username>` endpoint didn't load the session
   information for the given user
2. The code tried to find the user sessions by username but we recently
   switched to user IDs for the principal session key

This change also refactors the session lookup to avoid code duplication
in several places.

Fixes #9175
Fixes #9241