### PR TITLE
Deprecation notices for Legacy Alarm Callbacks

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/EmailAlarmCallback.java
@@ -229,7 +229,7 @@ public class EmailAlarmCallback implements AlarmCallback {
 
     @Override
     public String getName() {
-        return "Email Alert Callback";
+        return "Email Alarm Callback [Deprecated]";
     }
 
     @Override

--- a/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/HTTPAlarmCallback.java
+++ b/graylog2-server/src/main/java/org/graylog2/alarmcallbacks/HTTPAlarmCallback.java
@@ -118,7 +118,7 @@ public class HTTPAlarmCallback implements AlarmCallback {
 
     @Override
     public String getName() {
-        return "HTTP Alarm Callback";
+        return "HTTP Alarm Callback [Deprecated]";
     }
 
     @Override

--- a/graylog2-server/src/test/java/org/graylog2/alarmcallbacks/HTTPAlarmCallbackTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/alarmcallbacks/HTTPAlarmCallbackTest.java
@@ -268,7 +268,7 @@ public class HTTPAlarmCallbackTest {
 
     @Test
     public void getNameReturnsNameOfHTTPAlarmCallback() throws Exception {
-        assertThat(alarmCallback.getName()).isEqualTo("HTTP Alarm Callback");
+        assertThat(alarmCallback.getName()).isEqualTo("HTTP Alarm Callback [Deprecated]");
     }
 
     @Test

--- a/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationForm.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notification-types/LegacyNotificationForm.jsx
@@ -123,7 +123,7 @@ class LegacyNotificationForm extends React.Component {
         </fieldset>
 
         <Alert bsStyle="danger" className={commonStyles.legacyNotificationAlert}>
-          Legacy alarm callbacks are deprecated. Please switch to the new notification types as soon as possible!
+          Legacy alarm callbacks are deprecated and will be removed in Graylog 4.1. Please switch to the new notification types as soon as possible!
         </Alert>
 
         {content}


### PR DESCRIPTION
## Description
This change updates text displayed when creating Legacy Alarm Callbacks to inform the user that they are deprecated and will be removed in a future version of Graylog.

## Motivation and Context
As of Graylog 3.2, Legacy Alarm Callbacks were replaced with the new Notifications feature.  With Graylog 4.0, the final Legacy Alarm Callback (Script Alarm Callback) has been made available as a Notification.  In order to support the desired removal of Legacy Alarm Callbacks from the codebase, we are updating the text associated with Legacy Alarm Callbacks to clearly mark them as deprecated and nudge users to migrate to Notifications.

## How Has This Been Tested?
Verified the UI changes locally

## Screenshots (if appropriate):
![Screen Shot 2020-10-26 at 3 45 54 PM](https://user-images.githubusercontent.com/6466251/97221256-0bcca080-17a3-11eb-8492-5fd6a8ce470d.png)
![Screen Shot 2020-10-26 at 3 46 18 PM](https://user-images.githubusercontent.com/6466251/97221270-10915480-17a3-11eb-8c39-bb214f4d3669.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.

