### PR TITLE
Ensure a user has at least reader or admin role

### DIFF
--- a/graylog2-web-interface/src/components/roles/RoleEdit/UsersSection.jsx
+++ b/graylog2-web-interface/src/components/roles/RoleEdit/UsersSection.jsx
@@ -4,10 +4,11 @@ import { useState, useCallback } from 'react';
 import styled from 'styled-components';
 import * as Immutable from 'immutable';
 
+import { Alert, Button } from 'components/graylog';
+import { Icon, PaginatedItemOverview } from 'components/common';
 import AuthzRolesDomain from 'domainActions/roles/AuthzRolesDomain';
 import UserOverview from 'logic/users/UserOverview';
 import { DEFAULT_PAGINATION } from 'components/common/PaginatedItemOverview';
-import { PaginatedItemOverview } from 'components/common';
 import SectionComponent from 'components/common/Section/SectionComponent';
 import Role from 'logic/roles/Role';
 
@@ -25,6 +26,7 @@ const Container = styled.div`
 const UsersSection = ({ role: { id, name }, role }: Props) => {
   const [loading, setLoading] = useState(false);
   const [paginatedUsers, setPaginatedUsers] = useState();
+  const [errors, setErrors] = useState();
 
   const _onLoad = useCallback((pagination) => {
     setLoading(true);
@@ -42,6 +44,16 @@ const UsersSection = ({ role: { id, name }, role }: Props) => {
     .then(setPaginatedUsers));
 
   const _onUnassignUser = (user) => {
+    if ((role.name === 'Reader' || role.name === 'Admin')
+      && (!user.roles.includes('Reader') || !user.roles.includes('Admin'))) {
+      setErrors(`User '${user.name}' needs at least a Reader or Admin role.`);
+      _onLoad(DEFAULT_PAGINATION).then(setPaginatedUsers);
+
+      return;
+    }
+
+    setErrors();
+
     AuthzRolesDomain.removeMember(id, user.name).then(() => {
       _onLoad(DEFAULT_PAGINATION).then(setPaginatedUsers);
     });
@@ -53,6 +65,16 @@ const UsersSection = ({ role: { id, name }, role }: Props) => {
       <Container>
         <UsersSelector onSubmit={_onAssignUser} role={role} />
       </Container>
+      { errors && (
+        <Container>
+          <Alert bsStyle="warning">
+            {errors}
+            <Button bsSize="xsmall" bsStyle="warning" className="pull-right" onClick={() => setErrors()}>
+              <Icon name="times" />
+            </Button>
+          </Alert>
+        </Container>
+      )}
       <h3>Selected Users</h3>
       <Container>
         <PaginatedItemOverview noDataText="No selected users have been found."


### PR DESCRIPTION
## Motivation
Prior to this change, an admin could remove all roles from a user which
would render the user useless.

## Description
This change will check if the roles after a deletion will at least
contain a reader or an admin role and otherwise prevent deletion and
showing a warning.

Fixes #8752 