### PR TITLE
Provide active className for Buttons wrapped with LinkContainer if link target equals current pathname

### DIFF
--- a/graylog2-web-interface/src/components/graylog/router.jsx
+++ b/graylog2-web-interface/src/components/graylog/router.jsx
@@ -1,17 +1,16 @@
 // @flow strict
 import * as React from 'react';
 import { useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import type { LocationShape } from 'react-router';
 
-import withLocation, { type Location } from 'routing/withLocation';
 import history from 'util/History';
 
 export type HistoryElement = LocationShape;
 
-const _setActiveClassName = (location, to, currentClassName, displayName) => {
+const _setActiveClassName = (pathname, to, currentClassName, displayName) => {
   const props = {};
-  const isActive = to === location.pathname;
+  const isActive = to === pathname;
 
   if (displayName === 'Button' && isActive) {
     let className = 'active';
@@ -30,11 +29,12 @@ type Props = {
   children: React.Node,
   onClick?: () => mixed,
   to: string | HistoryElement,
-  location: Location,
 };
 
-const LinkContainer = withLocation(({ children, onClick, to, location, ...rest }: Props) => {
+const LinkContainer = ({ children, onClick, to, ...rest }: Props) => {
+  const { pathname } = useLocation();
   const { props: { onClick: childrenOnClick, className }, type: { displayName } } = React.Children.only(children);
+  const childrenClassName = _setActiveClassName(pathname, to, className, displayName);
   const _onClick = useCallback(() => {
     if (childrenOnClick) {
       childrenOnClick();
@@ -46,10 +46,9 @@ const LinkContainer = withLocation(({ children, onClick, to, location, ...rest }
 
     history.push(to);
   }, [childrenOnClick, onClick, to]);
-  const childrenClassName = _setActiveClassName(location, to, className, displayName);
 
   return React.cloneElement(React.Children.only(children), { ...rest, ...childrenClassName, onClick: _onClick });
-});
+};
 
 export {
   Link,

--- a/graylog2-web-interface/src/components/graylog/router.jsx
+++ b/graylog2-web-interface/src/components/graylog/router.jsx
@@ -4,18 +4,37 @@ import { useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import type { LocationShape } from 'react-router';
 
+import withLocation, { type Location } from 'routing/withLocation';
 import history from 'util/History';
 
 export type HistoryElement = LocationShape;
+
+const _setActiveClassName = (location, to, currentClassName, displayName) => {
+  const props = {};
+  const isActive = to === location.pathname;
+
+  if (displayName === 'Button' && isActive) {
+    let className = 'active';
+
+    if (currentClassName) {
+      className = `${className} ${currentClassName}`;
+    }
+
+    props.className = className;
+  }
+
+  return props;
+};
 
 type Props = {
   children: React.Node,
   onClick?: () => mixed,
   to: string | HistoryElement,
+  location: Location,
 };
 
-const LinkContainer = ({ children, onClick, to, ...rest }: Props) => {
-  const { props: { onClick: childrenOnClick } } = React.Children.only(children);
+const LinkContainer = withLocation(({ children, onClick, to, location, ...rest }: Props) => {
+  const { props: { onClick: childrenOnClick, className }, type: { displayName } } = React.Children.only(children);
   const _onClick = useCallback(() => {
     if (childrenOnClick) {
       childrenOnClick();
@@ -27,9 +46,10 @@ const LinkContainer = ({ children, onClick, to, ...rest }: Props) => {
 
     history.push(to);
   }, [childrenOnClick, onClick, to]);
+  const childrenClassName = _setActiveClassName(location, to, className, displayName);
 
-  return React.cloneElement(React.Children.only(children), { ...rest, onClick: _onClick });
-};
+  return React.cloneElement(React.Children.only(children), { ...rest, ...childrenClassName, onClick: _onClick });
+});
 
 export {
   Link,

--- a/graylog2-web-interface/src/components/graylog/router.jsx
+++ b/graylog2-web-interface/src/components/graylog/router.jsx
@@ -8,9 +8,17 @@ import history from 'util/History';
 
 export type HistoryElement = LocationShape;
 
+const _targetPathname = (to) => {
+  const target = typeof to?.pathname === 'string' ? to.pathname : to;
+  const targetWithoutQuery = String(target).split(/[?#]/)[0];
+
+  return targetWithoutQuery;
+};
+
 const _setActiveClassName = (pathname, to, currentClassName, displayName) => {
   const props = {};
-  const isActive = to === pathname;
+  const targetPathname = _targetPathname(to);
+  const isActive = targetPathname === pathname;
 
   if (displayName === 'Button' && isActive) {
     let className = 'active';

--- a/graylog2-web-interface/src/components/rules/Rule.jsx
+++ b/graylog2-web-interface/src/components/rules/Rule.jsx
@@ -40,7 +40,7 @@ const Rule = ({ create, title }) => {
           </LinkContainer>
             &nbsp;
           <LinkContainer to={Routes.SYSTEM.PIPELINES.RULES}>
-            <Button bsStyle="info" className="active">Manage rules</Button>
+            <Button bsStyle="info">Manage rules</Button>
           </LinkContainer>
             &nbsp;
           <LinkContainer to={Routes.SYSTEM.PIPELINES.SIMULATOR}>

--- a/graylog2-web-interface/src/pages/EventDefinitionsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventDefinitionsPage.jsx
@@ -28,7 +28,7 @@ const EventDefinitionsPage = () => {
               <Button bsStyle="info">Alerts & Events</Button>
             </LinkContainer>
             <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
-              <Button bsStyle="info" className="active">Event Definitions</Button>
+              <Button bsStyle="info">Event Definitions</Button>
             </LinkContainer>
             <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
               <Button bsStyle="info">Notifications</Button>

--- a/graylog2-web-interface/src/pages/EventNotificationsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventNotificationsPage.jsx
@@ -28,7 +28,7 @@ const EventNotificationsPage = () => {
               <Button bsStyle="info">Event Definitions</Button>
             </LinkContainer>
             <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.LIST}>
-              <Button bsStyle="info" className="active">Notifications</Button>
+              <Button bsStyle="info">Notifications</Button>
             </LinkContainer>
           </ButtonToolbar>
         </PageHeader>

--- a/graylog2-web-interface/src/pages/EventsPage.jsx
+++ b/graylog2-web-interface/src/pages/EventsPage.jsx
@@ -29,7 +29,7 @@ const EventsPage = ({ location }) => {
 
           <ButtonToolbar>
             <LinkContainer to={Routes.ALERTS.LIST}>
-              <Button bsStyle="info" className="active">Alerts &amp; Events</Button>
+              <Button bsStyle="info">Alerts &amp; Events</Button>
             </LinkContainer>
             <LinkContainer to={Routes.ALERTS.DEFINITIONS.LIST}>
               <Button bsStyle="info">Event Definitions</Button>

--- a/graylog2-web-interface/src/pages/LUTCachesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTCachesPage.jsx
@@ -119,7 +119,7 @@ class LUTCachesPage extends React.Component {
                   <Button bsStyle="info">Lookup Tables</Button>
                 </LinkContainer>
                 <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.CACHES.OVERVIEW}>
-                  <Button bsStyle="info" className="active">Caches</Button>
+                  <Button bsStyle="info">Caches</Button>
                 </LinkContainer>
                 <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.OVERVIEW}>
                   <Button bsStyle="info">Data Adapters</Button>

--- a/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTDataAdaptersPage.jsx
@@ -161,7 +161,7 @@ class LUTDataAdaptersPage extends React.Component {
                   <Button bsStyle="info">Caches</Button>
                 </LinkContainer>
                 <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.DATA_ADAPTERS.OVERVIEW}>
-                  <Button bsStyle="info" className="active">Data Adapters</Button>
+                  <Button bsStyle="info">Data Adapters</Button>
                 </LinkContainer>
               </ButtonToolbar>
             </span>

--- a/graylog2-web-interface/src/pages/LUTTablesPage.jsx
+++ b/graylog2-web-interface/src/pages/LUTTablesPage.jsx
@@ -158,7 +158,7 @@ class LUTTablesPage extends React.Component {
             <span>
               <ButtonToolbar>
                 <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.OVERVIEW}>
-                  <Button bsStyle="info" className="active">Lookup Tables</Button>
+                  <Button bsStyle="info">Lookup Tables</Button>
                 </LinkContainer>
                 <LinkContainer to={Routes.SYSTEM.LOOKUPTABLES.CACHES.OVERVIEW}>
                   <Button bsStyle="info">Caches</Button>

--- a/graylog2-web-interface/src/pages/PipelineDetailsPage.jsx
+++ b/graylog2-web-interface/src/pages/PipelineDetailsPage.jsx
@@ -165,7 +165,7 @@ const PipelineDetailsPage = createReactClass({
 
             <span>
               <LinkContainer to={Routes.SYSTEM.PIPELINES.OVERVIEW}>
-                <Button bsStyle="info" className="active">Manage pipelines</Button>
+                <Button bsStyle="info">Manage pipelines</Button>
               </LinkContainer>
               &nbsp;
               <LinkContainer to={Routes.SYSTEM.PIPELINES.RULES}>

--- a/graylog2-web-interface/src/pages/PipelinesOverviewPage.jsx
+++ b/graylog2-web-interface/src/pages/PipelinesOverviewPage.jsx
@@ -8,44 +8,40 @@ import ProcessingTimelineComponent from 'components/pipelines/ProcessingTimeline
 import Routes from 'routing/Routes';
 import DocsHelper from 'util/DocsHelper';
 
-class PipelinesOverviewPage extends React.Component {
-  render() {
-    return (
-      <DocumentTitle title="Pipelines">
-        <div>
-          <PageHeader title="Pipelines overview">
-            <span>
-              Pipelines let you transform and process messages coming from streams. Pipelines consist of stages where
-              rules are evaluated and applied. Messages can go through one or more stages.
-            </span>
-            <span>
-              Read more about Graylog pipelines in the <DocumentationLink page={DocsHelper.PAGES.PIPELINES} text="documentation" />.
-            </span>
+const PipelinesOverviewPage = () => (
+  <DocumentTitle title="Pipelines">
+    <div>
+      <PageHeader title="Pipelines overview">
+        <span>
+          Pipelines let you transform and process messages coming from streams. Pipelines consist of stages where
+          rules are evaluated and applied. Messages can go through one or more stages.
+        </span>
+        <span>
+          Read more about Graylog pipelines in the <DocumentationLink page={DocsHelper.PAGES.PIPELINES} text="documentation" />.
+        </span>
 
-            <span>
-              <LinkContainer to={Routes.SYSTEM.PIPELINES.OVERVIEW}>
-                <Button bsStyle="info" className="active">Manage pipelines</Button>
-              </LinkContainer>
+        <span>
+          <LinkContainer to={Routes.SYSTEM.PIPELINES.OVERVIEW}>
+            <Button bsStyle="info">Manage pipelines</Button>
+          </LinkContainer>
               &nbsp;
-              <LinkContainer to={Routes.SYSTEM.PIPELINES.RULES}>
-                <Button bsStyle="info">Manage rules</Button>
-              </LinkContainer>
+          <LinkContainer to={Routes.SYSTEM.PIPELINES.RULES}>
+            <Button bsStyle="info">Manage rules</Button>
+          </LinkContainer>
               &nbsp;
-              <LinkContainer to={Routes.SYSTEM.PIPELINES.SIMULATOR}>
-                <Button bsStyle="info">Simulator</Button>
-              </LinkContainer>
-            </span>
-          </PageHeader>
+          <LinkContainer to={Routes.SYSTEM.PIPELINES.SIMULATOR}>
+            <Button bsStyle="info">Simulator</Button>
+          </LinkContainer>
+        </span>
+      </PageHeader>
 
-          <Row className="content">
-            <Col md={12}>
-              <ProcessingTimelineComponent />
-            </Col>
-          </Row>
-        </div>
-      </DocumentTitle>
-    );
-  }
-}
+      <Row className="content">
+        <Col md={12}>
+          <ProcessingTimelineComponent />
+        </Col>
+      </Row>
+    </div>
+  </DocumentTitle>
+);
 
 export default PipelinesOverviewPage;

--- a/graylog2-web-interface/src/pages/RulesPage.jsx
+++ b/graylog2-web-interface/src/pages/RulesPage.jsx
@@ -45,7 +45,7 @@ const RulesPage = createReactClass({
               </LinkContainer>
               &nbsp;
               <LinkContainer to={Routes.SYSTEM.PIPELINES.RULES}>
-                <Button bsStyle="info" className="active">Manage rules</Button>
+                <Button bsStyle="info">Manage rules</Button>
               </LinkContainer>
               &nbsp;
               <LinkContainer to={Routes.SYSTEM.PIPELINES.SIMULATOR}>

--- a/graylog2-web-interface/src/pages/ShowAlertPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowAlertPage.jsx
@@ -136,7 +136,7 @@ const ShowAlertPage = createReactClass({
             <span>
               <ButtonToolbar>
                 <LinkContainer to={Routes.LEGACY_ALERTS.LIST}>
-                  <Button bsStyle="info" className="active">Alerts</Button>
+                  <Button bsStyle="info">Alerts</Button>
                 </LinkContainer>
                 <OverlayElement overlay={conditionDetailsTooltip}
                                 placement="top"

--- a/graylog2-web-interface/src/pages/SidecarAdministrationPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarAdministrationPage.jsx
@@ -28,7 +28,7 @@ const SidecarAdministrationPage = ({ location: { query: { node_id: nodeId } } })
             <Button bsStyle="info">Overview</Button>
           </LinkContainer>
           <LinkContainer to={Routes.SYSTEM.SIDECARS.ADMINISTRATION}>
-            <Button bsStyle="info" className="active">Administration</Button>
+            <Button bsStyle="info">Administration</Button>
           </LinkContainer>
           <LinkContainer to={Routes.SYSTEM.SIDECARS.CONFIGURATION}>
             <Button bsStyle="info">Configuration</Button>

--- a/graylog2-web-interface/src/pages/SidecarConfigurationPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarConfigurationPage.jsx
@@ -9,49 +9,45 @@ import Routes from 'routing/Routes';
 import ConfigurationListContainer from 'components/sidecars/configurations/ConfigurationListContainer';
 import CollectorListContainer from 'components/sidecars/configurations/CollectorListContainer';
 
-class SidecarConfigurationPage extends React.Component {
-  render() {
-    return (
-      <DocumentTitle title="Collectors Configuration">
+const SidecarConfigurationPage = () => (
+  <DocumentTitle title="Collectors Configuration">
+    <span>
+      <PageHeader title="Collectors Configuration">
         <span>
-          <PageHeader title="Collectors Configuration">
-            <span>
-              The Collector Sidecar runs next to your favourite log collector and configures it for you. Here you can
-              manage the Sidecar configurations.
-            </span>
-
-            <span>
-              Read more about the collector sidecar in the{' '}
-              <DocumentationLink page={DocsHelper.PAGES.COLLECTOR_SIDECAR} text="Graylog documentation" />.
-            </span>
-
-            <ButtonToolbar>
-              <LinkContainer to={Routes.SYSTEM.SIDECARS.OVERVIEW}>
-                <Button bsStyle="info">Overview</Button>
-              </LinkContainer>
-              <LinkContainer to={Routes.SYSTEM.SIDECARS.ADMINISTRATION}>
-                <Button bsStyle="info">Administration</Button>
-              </LinkContainer>
-              <LinkContainer to={Routes.SYSTEM.SIDECARS.CONFIGURATION}>
-                <Button bsStyle="info" className="active">Configuration</Button>
-              </LinkContainer>
-            </ButtonToolbar>
-          </PageHeader>
-
-          <Row className="content">
-            <Col md={12}>
-              <ConfigurationListContainer />
-            </Col>
-          </Row>
-          <Row className="content">
-            <Col md={12}>
-              <CollectorListContainer />
-            </Col>
-          </Row>
+          The Collector Sidecar runs next to your favourite log collector and configures it for you. Here you can
+          manage the Sidecar configurations.
         </span>
-      </DocumentTitle>
-    );
-  }
-}
+
+        <span>
+          Read more about the collector sidecar in the{' '}
+          <DocumentationLink page={DocsHelper.PAGES.COLLECTOR_SIDECAR} text="Graylog documentation" />.
+        </span>
+
+        <ButtonToolbar>
+          <LinkContainer to={Routes.SYSTEM.SIDECARS.OVERVIEW}>
+            <Button bsStyle="info">Overview</Button>
+          </LinkContainer>
+          <LinkContainer to={Routes.SYSTEM.SIDECARS.ADMINISTRATION}>
+            <Button bsStyle="info">Administration</Button>
+          </LinkContainer>
+          <LinkContainer to={Routes.SYSTEM.SIDECARS.CONFIGURATION}>
+            <Button bsStyle="info">Configuration</Button>
+          </LinkContainer>
+        </ButtonToolbar>
+      </PageHeader>
+
+      <Row className="content">
+        <Col md={12}>
+          <ConfigurationListContainer />
+        </Col>
+      </Row>
+      <Row className="content">
+        <Col md={12}>
+          <CollectorListContainer />
+        </Col>
+      </Row>
+    </span>
+  </DocumentTitle>
+);
 
 export default SidecarConfigurationPage;

--- a/graylog2-web-interface/src/pages/SidecarsPage.jsx
+++ b/graylog2-web-interface/src/pages/SidecarsPage.jsx
@@ -25,7 +25,7 @@ class SidecarsPage extends React.Component {
 
             <ButtonToolbar>
               <LinkContainer to={Routes.SYSTEM.SIDECARS.OVERVIEW}>
-                <Button bsStyle="info" className="active">Overview</Button>
+                <Button bsStyle="info">Overview</Button>
               </LinkContainer>
               <LinkContainer to={Routes.SYSTEM.SIDECARS.ADMINISTRATION}>
                 <Button bsStyle="info">Administration</Button>

--- a/graylog2-web-interface/src/pages/SimulatorPage.jsx
+++ b/graylog2-web-interface/src/pages/SimulatorPage.jsx
@@ -63,7 +63,7 @@ class SimulatorPage extends React.Component {
               </LinkContainer>
               &nbsp;
               <LinkContainer to={Routes.SYSTEM.PIPELINES.SIMULATOR}>
-                <Button bsStyle="info" className="active">Simulator</Button>
+                <Button bsStyle="info">Simulator</Button>
               </LinkContainer>
             </span>
           </PageHeader>


### PR DESCRIPTION
## Description
With https://github.com/Graylog2/graylog2-server/pull/9135 we've added an own implementation of `LinkContainer`, because the `LinkContainer` provided by `react-router-bootstrap` changed its behaviour with a previous update.
Instead of defining `onClick` for its children it transformed them into a link.

With this PR we are adding the functionality that `Buttons` wrapped with `LinkContainer` receive the `active` class, if the target of the `LinkContainer` equals the current pathname.

We are also removing not needed `className="active"` props from `Buttons` wrapped with `LinkContainer`.
There are still some buttons where we need to set this prop manually.

Please note there is a linter warning which is not related to these changes.

Fixes: #9244

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)