### PR TITLE
Display entity share buttons next to entity action menu

### DIFF
--- a/graylog2-web-interface/src/components/common/HoverForHelp.jsx
+++ b/graylog2-web-interface/src/components/common/HoverForHelp.jsx
@@ -10,9 +10,10 @@ type Props = {
   id?: string,
   title: string,
   className: string,
+  pullRight: boolean,
 };
 
-const HoverForHelp = ({ children, className, title, id }: Props) => (
+const HoverForHelp = ({ children, className, title, id, pullRight }: Props) => (
   <OverlayTrigger trigger={['hover', 'focus']}
                   placement="bottom"
                   overlay={(
@@ -20,7 +21,7 @@ const HoverForHelp = ({ children, className, title, id }: Props) => (
                       {children}
                     </Popover>
                   )}>
-    <Icon className={`${className} pull-right`} name="question-circle" />
+    <Icon className={`${className} ${pullRight ? 'pull-right' : ''}`} name="question-circle" />
   </OverlayTrigger>
 );
 
@@ -29,11 +30,13 @@ HoverForHelp.propTypes = {
   className: PropTypes.string,
   title: PropTypes.string.isRequired,
   id: PropTypes.string,
+  pullRight: PropTypes.bool,
 };
 
 HoverForHelp.defaultProps = {
   id: 'help-popover',
   className: '',
+  pullRight: true,
 };
 
 export default HoverForHelp;

--- a/graylog2-web-interface/src/components/common/ShareButton.jsx
+++ b/graylog2-web-interface/src/components/common/ShareButton.jsx
@@ -16,9 +16,9 @@ type Props = {
 
 const ShareButton = ({ bsStyle, entityId, entityType, onClick, disabled }: Props) => (
   <HasOwnership id={entityId} type={entityType}>
-    {({ disabled: missingPermissions }) => (
-      <Button bsStyle={bsStyle} onClick={onClick} disabled={disabled || missingPermissions}>
-        <Icon name="user-plus" /> Share {(!disabled && missingPermissions) && <SharingDisabledPopover type={entityType} />}
+    {({ disabled: hasMissingPermissions }) => (
+      <Button bsStyle={bsStyle} onClick={onClick} disabled={disabled || hasMissingPermissions} title="Share">
+        <Icon name="user-plus" /> Share {(!disabled && hasMissingPermissions) && <SharingDisabledPopover type={entityType} />}
       </Button>
     )}
   </HasOwnership>

--- a/graylog2-web-interface/src/components/common/ShareButton.jsx
+++ b/graylog2-web-interface/src/components/common/ShareButton.jsx
@@ -7,19 +7,26 @@ import HasOwnership from 'components/common/HasOwnership';
 import Icon from 'components/common/Icon';
 
 type Props = {
+  disabled?: boolean,
   entityId: string,
   entityType: string,
   onClick: () => void,
+  bsStyle?: string,
 };
 
-const ShareButton = ({ entityId, entityType, onClick }: Props) => (
+const ShareButton = ({ bsStyle, entityId, entityType, onClick, disabled }: Props) => (
   <HasOwnership id={entityId} type={entityType}>
-    {({ disabled }) => (
-      <Button bsStyle="info" onClick={onClick} disabled={disabled}>
-        <Icon name="user-plus" /> Share {disabled && <SharingDisabledPopover type={entityType} />}
+    {({ disabled: missingPermissions }) => (
+      <Button bsStyle={bsStyle} onClick={onClick} disabled={disabled || missingPermissions}>
+        <Icon name="user-plus" /> Share {(!disabled && missingPermissions) && <SharingDisabledPopover type={entityType} />}
       </Button>
     )}
   </HasOwnership>
 );
+
+ShareButton.defaultProps = {
+  bsStyle: 'info',
+  disabled: false,
+};
 
 export default ShareButton;

--- a/graylog2-web-interface/src/components/common/ShareButton.jsx
+++ b/graylog2-web-interface/src/components/common/ShareButton.jsx
@@ -1,0 +1,25 @@
+// @flow strict
+import * as React from 'react';
+
+import Button from 'components/graylog/Button';
+import SharingDisabledPopover from 'components/permissions/SharingDisabledPopover';
+import HasOwnership from 'components/common/HasOwnership';
+import Icon from 'components/common/Icon';
+
+type Props = {
+  entityId: string,
+  entityType: string,
+  onClick: () => void,
+};
+
+const ShareButton = ({ entityId, entityType, onClick }: Props) => (
+  <HasOwnership id={entityId} type={entityType}>
+    {({ disabled }) => (
+      <Button bsStyle="info" onClick={onClick} disabled={disabled}>
+        <Icon name="user-plus" /> Share {disabled && <SharingDisabledPopover type={entityType} />}
+      </Button>
+    )}
+  </HasOwnership>
+);
+
+export default ShareButton;

--- a/graylog2-web-interface/src/components/common/ShareButton.test.jsx
+++ b/graylog2-web-interface/src/components/common/ShareButton.test.jsx
@@ -1,0 +1,50 @@
+// @flow strict
+import React from 'react';
+import { render, screen, fireEvent } from 'wrappedTestingLibrary';
+import { viewsManager } from 'fixtures/users';
+
+import { createGRN } from 'logic/permissions/GRN';
+import CurrentUserContext from 'contexts/CurrentUserContext';
+
+import ShareButton from './ShareButton';
+
+const entityType = 'dashboard';
+const entityId = 'dashboard-id';
+const entityGRN = createGRN(entityType, entityId);
+const SimpleShareButton = ({ onClick, grnPermissions, ...rest }: { onClick: () => void, grnPermissions: Array<string> }) => (
+  <CurrentUserContext.Provider value={{ ...viewsManager, grn_permissions: grnPermissions }}>
+    <ShareButton {...rest} onClick={onClick} entityType={entityType} entityId={entityId} />
+  </CurrentUserContext.Provider>
+);
+
+describe('<ShareButton />', () => {
+  it('should be clickable if user has correct permissions', async () => {
+    const onClickStub = jest.fn();
+    render(<SimpleShareButton onClick={onClickStub} grnPermissions={[`entity:own:${entityGRN}`]} />);
+
+    const button = screen.getByRole('button', { name: /Share/ });
+    fireEvent.click(button);
+
+    expect(onClickStub).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not be clickable if user has incorrect permissions', async () => {
+    const onClickStub = jest.fn();
+    render(<SimpleShareButton onClick={onClickStub} grnPermissions={[]} />);
+
+    const button = screen.getByRole('button', { name: /Share/ });
+    fireEvent.click(button);
+
+    expect(onClickStub).not.toHaveBeenCalled();
+  });
+
+  it('should not be clickable if button is disabled', async () => {
+    const onClickStub = jest.fn();
+    render(<SimpleShareButton onClick={onClickStub} grnPermissions={[`entity:own:${entityGRN}`]} disabled />);
+
+    const button = screen.getByRole('button', { name: /Share/ });
+    fireEvent.click(button);
+
+    expect(onClickStub).not.toHaveBeenCalled();
+  });
+});

--- a/graylog2-web-interface/src/components/common/index.jsx
+++ b/graylog2-web-interface/src/components/common/index.jsx
@@ -57,6 +57,7 @@ export { default as Select } from './Select';
 export { default as SelectableList } from './SelectableList';
 export { default as SelectPopover } from './SelectPopover';
 export { default as SortableList } from './SortableList';
+export { default as ShareButton } from './ShareButton';
 export { default as SortableListItem } from './SortableListItem';
 export { SourceCodeEditor };
 export { default as Spinner } from './Spinner';

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.jsx
@@ -4,7 +4,6 @@ import lodash from 'lodash';
 import { PluginStore } from 'graylog-web-plugin/plugin';
 
 import EntityShareModal from 'components/permissions/EntityShareModal';
-import SharingDisabledPopover from 'components/permissions/SharingDisabledPopover';
 import Routes from 'routing/Routes';
 import { Link, LinkContainer } from 'components/graylog/router';
 import {
@@ -16,7 +15,8 @@ import {
 import {
   EntityListItem,
   IfPermitted,
-  HasOwnership,
+  Icon,
+  ShareButton,
 } from 'components/common';
 
 import EventDefinitionDescription from './EventDefinitionDescription';
@@ -75,21 +75,17 @@ const EventDefinitionEntry = ({
     <React.Fragment key={`actions-${eventDefinition.id}`}>
       <IfPermitted permissions={`eventdefinitions:edit:${eventDefinition.id}`}>
         <LinkContainer to={Routes.ALERTS.DEFINITIONS.edit(eventDefinition.id)}>
-          <Button bsStyle="info">Edit</Button>
+          <Button bsStyle="info">
+            <Icon name="edit" /> Edit
+          </Button>
         </LinkContainer>
       </IfPermitted>
+      <ShareButton entryId={eventDefinition.id} entityType="event_definition" onClick={() => setShowEntityShareModal(true)} />
       <IfPermitted permissions={`eventdefinitions:delete:${eventDefinition.id}`}>
         <DropdownButton id="more-dropdown" title="More" pullRight>
           {toggle}
           <MenuItem divider />
           <MenuItem onClick={onDelete(eventDefinition)}>Delete</MenuItem>
-          <HasOwnership id={eventDefinition.id} type="event_definition">
-            {({ disabled }) => (
-              <MenuItem key={`share-${eventDefinition.id}`} onSelect={() => setShowEntityShareModal(true)} disabled={disabled}>
-                Share {disabled && <SharingDisabledPopover type="stream" />}
-              </MenuItem>
-            )}
-          </HasOwnership>
         </DropdownButton>
       </IfPermitted>
     </React.Fragment>
@@ -102,7 +98,7 @@ const EventDefinitionEntry = ({
     titleSuffix = (<span>{titleSuffix} <Label bsStyle="warning">disabled</Label></span>);
   }
 
-  const linkTitle = <Link to={Routes.ALERTS.DEFINITIONS.view(eventDefinition.id)}>{eventDefinition.title}</Link>;
+  const linkTitle = <Link to={Routes.ALERTS.DEFINITIONS.show(eventDefinition.id)}>{eventDefinition.title}</Link>;
 
   return (
     <>

--- a/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.jsx
+++ b/graylog2-web-interface/src/components/event-definitions/event-definitions/EventDefinitionEntry.jsx
@@ -111,6 +111,7 @@ const EventDefinitionEntry = ({
       { showEntityShareModal && (
         <EntityShareModal entityId={eventDefinition.id}
                           entityType="event_definition"
+                          entityTypeTitle="event definition"
                           entityTitle={eventDefinition.title}
                           description="Search for a User or Team to add as collaborator on this event definition."
                           onClose={() => setShowEntityShareModal(false)} />

--- a/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.jsx
+++ b/graylog2-web-interface/src/components/event-notifications/event-notifications/EventNotifications.jsx
@@ -9,13 +9,13 @@ import {
   EmptyEntity,
   EntityList,
   EntityListItem,
-  HasOwnership,
+  ShareButton,
   IfPermitted,
   PaginatedList,
   SearchForm,
   Spinner,
+  Icon,
 } from 'components/common';
-import SharingDisabledPopover from 'components/permissions/SharingDisabledPopover';
 import Routes from 'routing/Routes';
 
 import styles from './EventNotifications.css';
@@ -113,9 +113,12 @@ class EventNotifications extends React.Component {
       <>
         <LinkContainer to={Routes.ALERTS.NOTIFICATIONS.edit(notification.id)}>
           <IfPermitted permissions={`eventnotifications:edit:${notification.id}`}>
-            <Button bsStyle="info">Edit</Button>
+            <Button bsStyle="info">
+              <Icon name="edit" /> Edit
+            </Button>
           </IfPermitted>
         </LinkContainer>
+        <ShareButton entityType="notification" entityId={notification.id} onClick={() => setNotificationToShare(notification)} />
         <IfPermitted permissions={[`eventnotifications:edit:${notification.id}`, `eventnotifications:delete:${notification.id}`]} anyPermissions>
           <DropdownButton id={`more-dropdown-${notification.id}`} title="More" pullRight>
             <IfPermitted permissions={`eventnotifications:edit:${notification.id}`}>
@@ -123,13 +126,6 @@ class EventNotifications extends React.Component {
                 {isTestLoading ? 'Testing...' : 'Test Notification'}
               </MenuItem>
             </IfPermitted>
-            <HasOwnership type="notification" id={notification.id}>
-              {({ disabled }) => (
-                <MenuItem disabled={disabled} onSelect={() => setNotificationToShare(notification)}>
-                  Share {disabled && <SharingDisabledPopover type="notification" />}
-                </MenuItem>
-              )}
-            </HasOwnership>
             <MenuItem divider />
             <IfPermitted permissions={`eventnotifications:delete:${notification.id}`}>
               <MenuItem onClick={onDelete(notification)}>Delete</MenuItem>

--- a/graylog2-web-interface/src/components/permissions/EntityShareModal.jsx
+++ b/graylog2-web-interface/src/components/permissions/EntityShareModal.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import EntityShareDomain from 'domainActions/permissions/EntityShareDomain';
 import { createGRN } from 'logic/permissions/GRN';
 import { useStore } from 'stores/connect';
-import { Spinner, Icon } from 'components/common';
+import { Spinner } from 'components/common';
 import { EntityShareStore } from 'stores/permissions/EntityShareStore';
 import { type EntitySharePayload } from 'actions/permissions/EntityShareActions';
 import SharedEntity from 'logic/permissions/SharedEntity';
@@ -70,7 +70,7 @@ const EntityShareModal = ({ description, entityId, entityType, entityTitle, enti
                            onConfirm={_handleSave}
                            onModalClose={onClose}
                            showModal
-                           title={<><Icon name="user-plus" /> Sharing {entityTypeTitle ?? entityType}: <i>{entityTitle}</i></>}>
+                           title={<>Sharing {entityTypeTitle ?? entityType}: <i>{entityTitle}</i></>}>
       <>
         {(entityShareState && entityShareState.entity === entityGRN) ? (
           <EntityShareSettings description={description}

--- a/graylog2-web-interface/src/components/permissions/EntityShareModal.jsx
+++ b/graylog2-web-interface/src/components/permissions/EntityShareModal.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import EntityShareDomain from 'domainActions/permissions/EntityShareDomain';
 import { createGRN } from 'logic/permissions/GRN';
 import { useStore } from 'stores/connect';
-import { Spinner } from 'components/common';
+import { Spinner, Icon } from 'components/common';
 import { EntityShareStore } from 'stores/permissions/EntityShareStore';
 import { type EntitySharePayload } from 'actions/permissions/EntityShareActions';
 import SharedEntity from 'logic/permissions/SharedEntity';
@@ -69,7 +69,7 @@ const EntityShareModal = ({ description, entityId, entityType, entityTitle, onCl
                            onConfirm={_handleSave}
                            onModalClose={onClose}
                            showModal
-                           title={<>Sharing {entityType}: <i>{entityTitle}</i></>}>
+                           title={<><Icon name="user-plus" /> Sharing {entityType}: <i>{entityTitle}</i></>}>
       <>
         {(entityShareState && entityShareState.entity === entityGRN) ? (
           <EntityShareSettings description={description}

--- a/graylog2-web-interface/src/components/permissions/EntityShareModal.jsx
+++ b/graylog2-web-interface/src/components/permissions/EntityShareModal.jsx
@@ -19,10 +19,11 @@ type Props = {
   entityId: $PropertyType<SharedEntity, 'id'>,
   entityTitle: $PropertyType<SharedEntity, 'title'>,
   entityType: $PropertyType<SharedEntity, 'type'>,
+  entityTypeTitle: ?string,
   onClose: () => void,
 };
 
-const EntityShareModal = ({ description, entityId, entityType, entityTitle, onClose }: Props) => {
+const EntityShareModal = ({ description, entityId, entityType, entityTitle, entityTypeTitle, onClose }: Props) => {
   const { state: entityShareState } = useStore(EntityShareStore);
   const [disableSubmit, setDisableSubmit] = useState(entityShareState?.validationResult?.failed);
   const entityGRN = createGRN(entityType, entityId);
@@ -69,13 +70,14 @@ const EntityShareModal = ({ description, entityId, entityType, entityTitle, onCl
                            onConfirm={_handleSave}
                            onModalClose={onClose}
                            showModal
-                           title={<><Icon name="user-plus" /> Sharing {entityType}: <i>{entityTitle}</i></>}>
+                           title={<><Icon name="user-plus" /> Sharing {entityTypeTitle ?? entityType}: <i>{entityTitle}</i></>}>
       <>
         {(entityShareState && entityShareState.entity === entityGRN) ? (
           <EntityShareSettings description={description}
                                entityGRN={entityGRN}
                                entityType={entityType}
                                entityTitle={entityTitle}
+                               entityTypeTitle={entityTypeTitle}
                                entityShareState={entityShareState}
                                granteesSelectRef={granteesSelectRef}
                                setDisableSubmit={setDisableSubmit} />
@@ -92,7 +94,12 @@ EntityShareModal.propTypes = {
   entityId: PropTypes.string.isRequired,
   entityTitle: PropTypes.string.isRequired,
   entityType: PropTypes.string.isRequired,
+  entityTypeTitle: PropTypes.string,
   onClose: PropTypes.func.isRequired,
+};
+
+EntityShareModal.defaultProps = {
+  entityTypeTitle: undefined,
 };
 
 export default EntityShareModal;

--- a/graylog2-web-interface/src/components/permissions/SharingDisabledPopover.jsx
+++ b/graylog2-web-interface/src/components/permissions/SharingDisabledPopover.jsx
@@ -3,13 +3,13 @@ import * as React from 'react';
 import styled, { type StyledComponent } from 'styled-components';
 
 import type { ThemeInterface } from 'theme';
-import { HoverForHelp } from 'components/common';
+import HoverForHelp from 'components/common/HoverForHelp';
 
 type Props = {
   type: string,
 };
 
-const StyledHoverForHelp: StyledComponent<{}, ThemeInterface, HoverForHelp> = styled(HoverForHelp)`
+const StyledHoverForHelp: StyledComponent<{}, ThemeInterface, typeof HoverForHelp> = styled(HoverForHelp)`
   margin-left: 8px;
 `;
 

--- a/graylog2-web-interface/src/components/permissions/SharingDisabledPopover.jsx
+++ b/graylog2-web-interface/src/components/permissions/SharingDisabledPopover.jsx
@@ -10,11 +10,11 @@ type Props = {
 };
 
 const StyledHoverForHelp: StyledComponent<{}, ThemeInterface, HoverForHelp> = styled(HoverForHelp)`
-  margin-top: 3px;
+  margin-left: 8px;
 `;
 
 const SharingDisabledPopover = ({ type }: Props) => (
-  <StyledHoverForHelp title="Sharing not possible">
+  <StyledHoverForHelp title="Sharing not possible" pullRight={false}>
     Only owners of this {type} are allowed to share it.
   </StyledHoverForHelp>
 );

--- a/graylog2-web-interface/src/components/streams/Stream.jsx
+++ b/graylog2-web-interface/src/components/streams/Stream.jsx
@@ -163,7 +163,6 @@ class Stream extends React.Component {
       ? <Tooltip id="default-stream-tooltip">Action not available for the default stream</Tooltip> : null;
 
     let editRulesLink;
-    let manageOutputsLink;
     let manageAlertsLink;
 
     if (isPermitted(permissions, [`streams:edit:${stream.id}`])) {
@@ -180,14 +179,6 @@ class Stream extends React.Component {
           <Button bsStyle="info">Manage Alerts</Button>
         </LinkContainer>
       );
-
-      if (isPermitted(permissions, ['stream_outputs:read'])) {
-        manageOutputsLink = (
-          <LinkContainer to={Routes.stream_outputs(stream.id)}>
-            <Button bsStyle="info">Manage Outputs</Button>
-          </LinkContainer>
-        );
-      }
     }
 
     let toggleStreamLink;
@@ -240,7 +231,6 @@ class Stream extends React.Component {
       <StreamListItem>
         <div className="stream-actions pull-right">
           {editRulesLink}{' '}
-          {manageOutputsLink}{' '}
           {manageAlertsLink}{' '}
           <HasOwnership id={stream.id} type="stream">
             {({ disabled }) => (

--- a/graylog2-web-interface/src/components/streams/Stream.jsx
+++ b/graylog2-web-interface/src/components/streams/Stream.jsx
@@ -169,7 +169,7 @@ class Stream extends React.Component {
         <OverlayElement overlay={defaultStreamTooltip} placement="top" useOverlay={isDefaultStream}>
           <LinkContainer disabled={isDefaultStream} to={Routes.stream_edit(stream.id)}>
             <Button bsStyle="info">
-              <Icon name="inbox" /> Manage Rules
+              <Icon name="stream" /> Manage Rules
             </Button>
           </LinkContainer>
         </OverlayElement>

--- a/graylog2-web-interface/src/components/streams/Stream.jsx
+++ b/graylog2-web-interface/src/components/streams/Stream.jsx
@@ -62,7 +62,7 @@ const StreamListItem = styled.li(({ theme }) => css`
 `);
 
 const ToggleButton = styled(Button)`
-  width: 8.5em;
+  min-width: 8.8em;
 `;
 
 class Stream extends React.Component {
@@ -169,14 +169,18 @@ class Stream extends React.Component {
       editRulesLink = (
         <OverlayElement overlay={defaultStreamTooltip} placement="top" useOverlay={isDefaultStream}>
           <LinkContainer disabled={isDefaultStream} to={Routes.stream_edit(stream.id)}>
-            <Button bsStyle="info">Manage Rules</Button>
+            <Button bsStyle="info">
+              <Icon name="inbox" /> Manage Rules
+            </Button>
           </LinkContainer>
         </OverlayElement>
       );
 
       manageAlertsLink = (
         <LinkContainer to={Routes.stream_alerts(stream.id)}>
-          <Button bsStyle="info">Manage Alerts</Button>
+          <Button bsStyle="info">
+            <Icon name="bell" /> Manage Alerts
+          </Button>
         </LinkContainer>
       );
     }
@@ -190,7 +194,7 @@ class Stream extends React.Component {
             <ToggleButton bsStyle="success"
                           onClick={this._onResume}
                           disabled={isDefaultStream || loading}>
-              {loading ? 'Starting...' : 'Start Stream'}
+              <Icon name="play" /> {loading ? 'Starting...' : 'Start Stream'}
             </ToggleButton>
           </OverlayElement>
         );
@@ -200,7 +204,7 @@ class Stream extends React.Component {
             <ToggleButton bsStyle="primary"
                           onClick={this._onPause}
                           disabled={isDefaultStream || loading}>
-              {loading ? 'Pausing...' : 'Pause Stream'}
+              <Icon name="pause" /> {loading ? 'Pausing...' : 'Pause Stream'}
             </ToggleButton>
           </OverlayElement>
         );

--- a/graylog2-web-interface/src/components/streams/Stream.jsx
+++ b/graylog2-web-interface/src/components/streams/Stream.jsx
@@ -3,9 +3,10 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 
 import EntityShareModal from 'components/permissions/EntityShareModal';
+import SharingDisabledPopover from 'components/permissions/SharingDisabledPopover';
 import { Link, LinkContainer } from 'components/graylog/router';
 import { Button, Tooltip } from 'components/graylog';
-import { OverlayElement, Icon } from 'components/common';
+import { OverlayElement, Icon, HasOwnership } from 'components/common';
 import StreamRuleForm from 'components/streamrules/StreamRuleForm';
 import { isPermitted, isAnyPermitted } from 'util/PermissionsMixin';
 import UserNotification from 'util/UserNotification';
@@ -226,7 +227,6 @@ class Stream extends React.Component {
                         onDelete={this._onDelete}
                         onUpdate={this._onUpdate}
                         onClone={this._onClone}
-                        onShare={this._openEntityShareModal}
                         onQuickAdd={this._openStreamRuleForm}
                         indexSets={indexSets}
                         isDefaultStream={isDefaultStream} />
@@ -242,6 +242,13 @@ class Stream extends React.Component {
           {editRulesLink}{' '}
           {manageOutputsLink}{' '}
           {manageAlertsLink}{' '}
+          <HasOwnership id={stream.id} type="stream">
+            {({ disabled }) => (
+              <Button bsStyle="info" onClick={this._openEntityShareModal} disabled={disabled}>
+                <Icon name="user-plus" /> Share {disabled && <SharingDisabledPopover type="stream" />}
+              </Button>
+            )}
+          </HasOwnership>
           {toggleStreamLink}{' '}
 
           {streamControls}

--- a/graylog2-web-interface/src/components/streams/Stream.jsx
+++ b/graylog2-web-interface/src/components/streams/Stream.jsx
@@ -3,10 +3,9 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 
 import EntityShareModal from 'components/permissions/EntityShareModal';
-import SharingDisabledPopover from 'components/permissions/SharingDisabledPopover';
 import { Link, LinkContainer } from 'components/graylog/router';
 import { Button, Tooltip } from 'components/graylog';
-import { OverlayElement, Icon, HasOwnership } from 'components/common';
+import { OverlayElement, Icon, ShareButton } from 'components/common';
 import StreamRuleForm from 'components/streamrules/StreamRuleForm';
 import { isPermitted, isAnyPermitted } from 'util/PermissionsMixin';
 import UserNotification from 'util/UserNotification';
@@ -236,13 +235,7 @@ class Stream extends React.Component {
         <div className="stream-actions pull-right">
           {editRulesLink}{' '}
           {manageAlertsLink}{' '}
-          <HasOwnership id={stream.id} type="stream">
-            {({ disabled }) => (
-              <Button bsStyle="info" onClick={this._openEntityShareModal} disabled={disabled}>
-                <Icon name="user-plus" /> Share {disabled && <SharingDisabledPopover type="stream" />}
-              </Button>
-            )}
-          </HasOwnership>
+          <ShareButton entityId={stream.id} entityType="stream" onClick={this._openEntityShareModal} />
           {toggleStreamLink}{' '}
 
           {streamControls}

--- a/graylog2-web-interface/src/components/streams/StreamControls.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamControls.jsx
@@ -5,7 +5,7 @@ import createReactClass from 'create-react-class';
 
 import SharingDisabledPopover from 'components/permissions/SharingDisabledPopover';
 import { DropdownButton, MenuItem } from 'components/graylog';
-import { IfPermitted, HasOwnership } from 'components/common';
+import { IfPermitted } from 'components/common';
 import PermissionsMixin from 'util/PermissionsMixin';
 import StoreProvider from 'injection/StoreProvider';
 
@@ -85,14 +85,6 @@ const StreamControls = createReactClass({
           <MenuItem key={`setAsStartpage-${stream.id}`} onSelect={this._setStartpage} disabled={user.read_only}>
             Set as startpage
           </MenuItem>
-
-          <HasOwnership id={stream.id} type="stream">
-            {({ disabled }) => (
-              <MenuItem key={`share-${stream.id}`} onSelect={onShare} disabled={disabled}>
-                Share {disabled && <SharingDisabledPopover type="stream" />}
-              </MenuItem>
-            )}
-          </HasOwnership>
           <IfPermitted permissions={`streams:edit:${stream.id}`}>
             <MenuItem key={`divider-${stream.id}`} divider />
           </IfPermitted>

--- a/graylog2-web-interface/src/components/streams/StreamControls.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamControls.jsx
@@ -22,7 +22,6 @@ const StreamControls = createReactClass({
     indexSets: PropTypes.array.isRequired,
     onDelete: PropTypes.func.isRequired,
     onClone: PropTypes.func.isRequired,
-    onShare: PropTypes.func.isRequired,
     onQuickAdd: PropTypes.func.isRequired,
     onUpdate: PropTypes.func.isRequired,
     isDefaultStream: PropTypes.bool,
@@ -65,7 +64,7 @@ const StreamControls = createReactClass({
   },
 
   render() {
-    const { stream, isDefaultStream, user, onShare, onUpdate, indexSets } = this.props;
+    const { stream, isDefaultStream, user, onUpdate, indexSets } = this.props;
 
     return (
       <span>

--- a/graylog2-web-interface/src/components/streams/StreamControls.jsx
+++ b/graylog2-web-interface/src/components/streams/StreamControls.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 // eslint-disable-next-line no-restricted-imports
 import createReactClass from 'create-react-class';
 
-import SharingDisabledPopover from 'components/permissions/SharingDisabledPopover';
+import Routes from 'routing/Routes';
 import { DropdownButton, MenuItem } from 'components/graylog';
 import { IfPermitted } from 'components/common';
 import PermissionsMixin from 'util/PermissionsMixin';
@@ -82,9 +82,15 @@ const StreamControls = createReactClass({
           <IfPermitted permissions={['streams:create', `streams:read:${stream.id}`]}>
             <MenuItem key={`cloneStream-${stream.id}`} onSelect={this._onClone}>Clone this stream</MenuItem>
           </IfPermitted>
+          <IfPermitted permissions="stream_outputs:read">
+            <MenuItem key={`manageOutputs-${stream.id}`} href={Routes.stream_outputs(stream.id)}>
+              Manage Outputs
+            </MenuItem>
+          </IfPermitted>
           <MenuItem key={`setAsStartpage-${stream.id}`} onSelect={this._setStartpage} disabled={user.read_only}>
             Set as startpage
           </MenuItem>
+
           <IfPermitted permissions={`streams:edit:${stream.id}`}>
             <MenuItem key={`divider-${stream.id}`} divider />
           </IfPermitted>

--- a/graylog2-web-interface/src/routing/AppRouter.jsx
+++ b/graylog2-web-interface/src/routing/AppRouter.jsx
@@ -157,7 +157,7 @@ const AppRouter = () => {
                                path={Routes.ALERTS.DEFINITIONS.edit(':definitionId')}
                                component={EditEventDefinitionPage} />
                         <Route exact
-                               path={Routes.ALERTS.DEFINITIONS.view(':definitionId')}
+                               path={Routes.ALERTS.DEFINITIONS.show(':definitionId')}
                                component={ViewEventDefinitionPage} />
                         <Route exact path={Routes.ALERTS.NOTIFICATIONS.LIST} component={EventNotificationsPage} />
                         <Route exact path={Routes.ALERTS.NOTIFICATIONS.CREATE} component={CreateEventNotificationPage} />

--- a/graylog2-web-interface/src/routing/Routes.jsx
+++ b/graylog2-web-interface/src/routing/Routes.jsx
@@ -22,7 +22,7 @@ const Routes = {
       LIST: '/alerts/definitions',
       CREATE: '/alerts/definitions/new',
       edit: (definitionId) => `/alerts/definitions/${definitionId}/edit`,
-      view: (definitionId) => `/alerts/definitions/${definitionId}`,
+      show: (definitionId) => `/alerts/definitions/${definitionId}`,
     },
     NOTIFICATIONS: {
       LIST: '/alerts/notifications',

--- a/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
+++ b/graylog2-web-interface/src/views/components/DashboardSearchBar.jsx
@@ -59,7 +59,7 @@ const DashboardSearchBar = ({ config, globalOverride, disableSearch = false, onE
                 </TopRow>
 
                 <Row className="no-bm">
-                  <Col md={9} xs={8}>
+                  <Col md={8} lg={9}>
                     <div className="pull-right search-help">
                       <DocumentationLink page={DocsHelper.PAGES.SEARCH_QUERY_LANGUAGE}
                                          title="Search query syntax documentation"
@@ -83,7 +83,7 @@ const DashboardSearchBar = ({ config, globalOverride, disableSearch = false, onE
                       )}
                     </Field>
                   </Col>
-                  <Col md={3} xs={4}>
+                  <Col md={4} lg={3}>
                     <div className="pull-right">
                       <ViewActionsMenu />
                     </div>

--- a/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
+++ b/graylog2-web-interface/src/views/components/ViewActionsMenu.jsx
@@ -7,7 +7,7 @@ import connect from 'stores/connect';
 import { isPermitted } from 'util/PermissionsMixin';
 import AppConfig from 'util/AppConfig';
 import { DropdownButton, MenuItem, Button, ButtonGroup } from 'components/graylog';
-import { Icon, HasOwnership } from 'components/common';
+import { Icon, ShareButton } from 'components/common';
 import CSVExportModal from 'views/components/searchbar/csvexport/CSVExportModal';
 import DebugOverlay from 'views/components/DebugOverlay';
 import onSaveView from 'views/logic/views/OnSaveViewAction';
@@ -21,7 +21,6 @@ import type { UserJSON } from 'logic/users/User';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import EntityShareModal from 'components/permissions/EntityShareModal';
 import ViewTypeLabel from 'views/components/ViewTypeLabel';
-import SharingDisabledPopover from 'components/permissions/SharingDisabledPopover';
 
 import ViewPropertiesModal from './views/ViewPropertiesModal';
 import IfDashboard from './dashboard/IfDashboard';
@@ -63,17 +62,15 @@ const ViewActionsMenu = ({ view, isNewView, metadata }) => {
               data-testid="dashboard-save-as-button">
         <Icon name="copy" /> Save as
       </Button>
+      <ShareButton entityType="dashboard"
+                   entityId={view.id}
+                   onClick={() => setShareViewOpen(true)}
+                   bsStyle="default"
+                   disabled={isNewView || !allowedToEdit} />
       <DropdownButton title={<Icon name="ellipsis-h" />} id="query-tab-actions-dropdown" pullRight noCaret>
         <MenuItem onSelect={() => setEditViewOpen(true)} disabled={isNewView || !allowedToEdit}>
           <Icon name="edit" /> Edit metadata
         </MenuItem>
-        <HasOwnership id={view.id} type="dashboard">
-          {({ disabled }) => (
-            <MenuItem onSelect={() => setShareViewOpen(true)} disabled={isNewView || !allowedToEdit || disabled}>
-              <Icon name="share-alt" /> Share {disabled && <SharingDisabledPopover type="dashboard" />}
-            </MenuItem>
-          )}
-        </HasOwnership>
         <MenuItem onSelect={() => setCsvExportOpen(true)}><Icon name="cloud-download-alt" /> Export to CSV</MenuItem>
         {debugOverlay}
         <IfDashboard>

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.jsx
@@ -7,7 +7,7 @@ import connect from 'stores/connect';
 import type { ThemeInterface } from 'theme';
 import { isPermitted } from 'util/PermissionsMixin';
 import { Button, ButtonGroup, DropdownButton, MenuItem } from 'components/graylog';
-import { Icon, HasOwnership } from 'components/common';
+import { Icon, ShareButton } from 'components/common';
 import { ViewManagementActions } from 'views/stores/ViewManagementStore';
 import UserNotification from 'util/UserNotification';
 import { ViewStore, ViewActions } from 'views/stores/ViewStore';
@@ -24,7 +24,6 @@ import * as Permissions from 'views/Permissions';
 import type { UserJSON } from 'logic/users/User';
 import ViewPropertiesModal from 'views/components/views/ViewPropertiesModal';
 import { loadAsDashboard, loadNewSearch } from 'views/logic/views/Actions';
-import SharingDisabledPopover from 'components/permissions/SharingDisabledPopover';
 
 import SavedSearchForm from './SavedSearchForm';
 import SavedSearchList from './SavedSearchList';
@@ -250,6 +249,11 @@ class SavedSearchControls extends React.Component<Props, State> {
                                        deleteSavedSearch={this.deleteSavedSearch}
                                        toggleModal={this.toggleListModal} />
                     )}
+                    <ShareButton entityType="search"
+                                 entityId={view.id}
+                                 onClick={this.toggleShareSearch}
+                                 bsStyle="default"
+                                 disabled={!isAllowedToEdit} />
                     <DropdownButton title={<Icon name="ellipsis-h" />} id="search-actions-dropdown" pullRight noCaret>
                       <MenuItem onSelect={this.toggleMetadataEdit} disabled={!isAllowedToEdit}>
                         <Icon name="edit" /> Edit metadata
@@ -260,13 +264,6 @@ class SavedSearchControls extends React.Component<Props, State> {
                         <Icon name="eraser" /> Reset search
                       </MenuItem>
                       <MenuItem divider />
-                      <HasOwnership id={view.id} type="search">
-                        {({ disabled }) => (
-                          <MenuItem onSelect={this.toggleShareSearch} title="Share search" disabled={!isAllowedToEdit || disabled}>
-                            <Icon name="share-alt" /> Share {disabled && <SharingDisabledPopover type="search" />}
-                          </MenuItem>
-                        )}
-                      </HasOwnership>
                     </DropdownButton>
                     {showCSVExport && (
                       <CSVExportModal view={view} closeModal={this.toggleCSVExport} />

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.test.jsx
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/SavedSearchControls.test.jsx
@@ -86,17 +86,17 @@ describe('SavedSearchControls', () => {
       });
     });
 
-    describe('has "Share search" option', () => {
+    describe('has "Share" option', () => {
       it('includes the option to share the current search', () => {
         const wrapper = mount(<SimpleSavedSearchControls viewStoreState={createViewStoreState(false, 'some-id')} />);
 
-        expect(wrapper.find('MenuItem[title="Share search"]')).toExist();
+        expect(wrapper.find('button[title="Share"]')).toExist();
       });
 
       it('which should be disabled if current user is neither owner nor permitted to edit search', () => {
         const wrapper = mount(<SimpleSavedSearchControls viewStoreState={createViewStoreState(false, 'some-id')} />);
 
-        const shareSearch = wrapper.find('MenuItem[title="Share search"]');
+        const shareSearch = wrapper.find('button[title="Share"]');
 
         expect(shareSearch).toBeDisabled();
       });
@@ -109,7 +109,7 @@ describe('SavedSearchControls', () => {
           grn_permissions: ['entity:own:grn::::search:user-id-1'],
         };
         const wrapper = mount(<SimpleSavedSearchControls currentUser={owningUser} viewStoreState={createViewStoreState(false, owningUser.id)} />);
-        const shareSearch = wrapper.find('MenuItem[title="Share search"]');
+        const shareSearch = wrapper.find('button[title="Share"]');
 
         expect(shareSearch).not.toBeDisabled();
       });
@@ -124,7 +124,7 @@ describe('SavedSearchControls', () => {
 
         const wrapper = mount(<SimpleSavedSearchControls currentUser={owningUser} viewStoreState={createViewStoreState(false, owningUser.id)} />);
 
-        const shareSearch = wrapper.find('MenuItem[title="Share search"]');
+        const shareSearch = wrapper.find('button[title="Share"]');
 
         expect(shareSearch).not.toBeDisabled();
       });
@@ -132,7 +132,7 @@ describe('SavedSearchControls', () => {
       it('which should be enabled if current user is admin', () => {
         const wrapper = mount(<SimpleSavedSearchControls currentUser={admin} viewStoreState={createViewStoreState(false, admin.id)} />);
 
-        const shareSearch = wrapper.find('MenuItem[title="Share search"]');
+        const shareSearch = wrapper.find('button[title="Share"]');
 
         expect(shareSearch).not.toBeDisabled();
       });
@@ -140,7 +140,7 @@ describe('SavedSearchControls', () => {
       it('which should be hidden if search is unsaved', () => {
         const wrapper = mount(<SimpleSavedSearchControls />);
 
-        const shareSearch = wrapper.find('MenuItem[title="Share search"]');
+        const shareSearch = wrapper.find('button[title="Share"]');
 
         expect(shareSearch).toMatchSnapshot();
       });

--- a/graylog2-web-interface/src/views/components/searchbar/saved-search/__snapshots__/SavedSearchControls.test.jsx.snap
+++ b/graylog2-web-interface/src/views/components/searchbar/saved-search/__snapshots__/SavedSearchControls.test.jsx.snap
@@ -1,121 +1,310 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SavedSearchControls Button handling has "Share search" option which should be hidden if search is unsaved 1`] = `
-.c0 {
-  margin-top: 3px;
+exports[`SavedSearchControls Button handling has "Share" option which should be hidden if search is unsaved 1`] = `
+.c0.btn-danger {
+  background-color: #ad0707;
+  border-color: #b23939;
+  color: rgb(252,249,249);
+  -webkit-transition: background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;
+  transition: background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;
 }
 
-<MenuItem
-  bsClass="dropdown"
+.c0.btn-danger:hover {
+  background-color: #a00e0e;
+  border-color: #a53636;
+  color: #e9e6e6;
+}
+
+.c0.btn-danger.active {
+  background-color: #b75151;
+  border-color: #bc6363;
+  color: rgb(252,249,249);
+}
+
+.c0.btn-danger.active:hover {
+  background-color: #a94c4c;
+  border-color: #ad5c5c;
+  color: #e9e6e6;
+}
+
+.c0.btn-danger[disabled],
+.c0.btn-danger.disabled {
+  background-color: #c07272;
+  border-color: #bc6363;
+  color: rgb(252,250,250);
+}
+
+.c0.btn-danger[disabled]:hover,
+.c0.btn-danger.disabled:hover {
+  background-color: #c07272;
+  border-color: #bc6363;
+  color: rgb(252,250,250);
+}
+
+.c0.btn-default {
+  background-color: #e6e6e6;
+  border-color: #e0e0e0;
+  color: rgb(73,73,73);
+  -webkit-transition: background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;
+  transition: background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;
+}
+
+.c0.btn-default:hover {
+  background-color: #d4d4d4;
+  border-color: #cfcfcf;
+  color: #444444;
+}
+
+.c0.btn-default.active {
+  background-color: #dadada;
+  border-color: #d4d4d4;
+  color: rgb(49,49,49);
+}
+
+.c0.btn-default.active:hover {
+  background-color: #cacaca;
+  border-color: #c4c4c4;
+  color: #2f2f2f;
+}
+
+.c0.btn-default[disabled],
+.c0.btn-default.disabled {
+  background-color: #cecece;
+  border-color: #d4d4d4;
+  color: rgb(80,80,80);
+}
+
+.c0.btn-default[disabled]:hover,
+.c0.btn-default.disabled:hover {
+  background-color: #cecece;
+  border-color: #d4d4d4;
+  color: rgb(80,80,80);
+}
+
+.c0.btn-info {
+  background-color: #0063be;
+  border-color: #3970c2;
+  color: rgb(249,250,252);
+  -webkit-transition: background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;
+  transition: background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;
+}
+
+.c0.btn-info:hover {
+  background-color: #0c5cb0;
+  border-color: #3668b3;
+  color: #e6e7e9;
+}
+
+.c0.btn-info.active {
+  background-color: #517cc5;
+  border-color: #6386c9;
+  color: rgb(249,250,252);
+}
+
+.c0.btn-info.active:hover {
+  background-color: #4b73b6;
+  border-color: #5c7dba;
+  color: #e6e7e9;
+}
+
+.c0.btn-info[disabled],
+.c0.btn-info.disabled {
+  background-color: #7290cd;
+  border-color: #6386c9;
+  color: rgb(250,251,253);
+}
+
+.c0.btn-info[disabled]:hover,
+.c0.btn-info.disabled:hover {
+  background-color: #7290cd;
+  border-color: #6386c9;
+  color: rgb(250,251,253);
+}
+
+.c0.btn-link {
+  background-color: rgba(255,255,255,0);
+  border-color: rgba(255,255,255,0);
+  color: #702785;
+  -webkit-transition: background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;
+  transition: background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;
+}
+
+.c0.btn-link:hover {
+  background-color: transparent;
+  border-color: transparent;
+  color: #410057;
+}
+
+.c0.btn-link.active {
+  background-color: rgba(255,255,255,0);
+  border-color: rgba(255,255,255,0);
+  color: #410057;
+}
+
+.c0.btn-link.active:hover {
+  background-color: rgba(255,255,255,0);
+  border-color: transparent;
+  color: #410057;
+}
+
+.c0.btn-link[disabled],
+.c0.btn-link.disabled {
+  background-color: rgba(255,255,255,0);
+  border-color: rgba(255,255,255,0);
+  color: #702785;
+}
+
+.c0.btn-link[disabled]:hover,
+.c0.btn-link.disabled:hover {
+  background-color: rgba(255,255,255,0);
+  border-color: rgba(255,255,255,0);
+  color: #702785;
+}
+
+.c0.btn-primary {
+  background-color: #702785;
+  border-color: #7b458e;
+  color: rgb(234,229,236);
+  -webkit-transition: background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;
+  transition: background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;
+}
+
+.c0.btn-primary:hover {
+  background-color: #68267b;
+  border-color: #724083;
+  color: #d8d3da;
+}
+
+.c0.btn-primary.active {
+  background-color: #855996;
+  border-color: #8f699d;
+  color: rgb(250,249,251);
+}
+
+.c0.btn-primary.active:hover {
+  background-color: #7c538b;
+  border-color: #846292;
+  color: #e7e6e8;
+}
+
+.c0.btn-primary[disabled],
+.c0.btn-primary.disabled {
+  background-color: #9877a5;
+  border-color: #8f699d;
+  color: rgb(251,250,251);
+}
+
+.c0.btn-primary[disabled]:hover,
+.c0.btn-primary.disabled:hover {
+  background-color: #9877a5;
+  border-color: #8f699d;
+  color: rgb(251,250,251);
+}
+
+.c0.btn-success {
+  background-color: #00ae42;
+  border-color: #39b356;
+  color: rgb(249,252,249);
+  -webkit-transition: background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;
+  transition: background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;
+}
+
+.c0.btn-success:hover {
+  background-color: #0ca13e;
+  border-color: #36a550;
+  color: #e6e9e6;
+}
+
+.c0.btn-success.active {
+  background-color: #51b866;
+  border-color: #63bc74;
+  color: rgb(249,252,250);
+}
+
+.c0.btn-success.active:hover {
+  background-color: #4baa5f;
+  border-color: #5cae6c;
+  color: #e6e9e7;
+}
+
+.c0.btn-success[disabled],
+.c0.btn-success.disabled {
+  background-color: #72c180;
+  border-color: #63bc74;
+  color: rgb(250,252,250);
+}
+
+.c0.btn-success[disabled]:hover,
+.c0.btn-success.disabled:hover {
+  background-color: #72c180;
+  border-color: #63bc74;
+  color: rgb(250,252,250);
+}
+
+.c0.btn-warning {
+  background-color: #ffd200;
+  border-color: #f9cd07;
+  color: rgb(57,47,0);
+  -webkit-transition: background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;
+  transition: background-color 150ms ease-in-out,border 150ms ease-in-out,color 150ms ease-in-out;
+}
+
+.c0.btn-warning:hover {
+  background-color: #ebc20c;
+  border-color: #e6bd0e;
+  color: #362d0c;
+}
+
+.c0.btn-warning.active {
+  background-color: #f2c70a;
+  border-color: #ebc20c;
+  color: rgb(54,45,2);
+}
+
+.c0.btn-warning.active:hover {
+  background-color: #e0b80f;
+  border-color: #d9b310;
+  color: #332b0c;
+}
+
+.c0.btn-warning[disabled],
+.c0.btn-warning.disabled {
+  background-color: #e4bc0e;
+  border-color: #ebc20c;
+  color: rgb(88,73,5);
+}
+
+.c0.btn-warning[disabled]:hover,
+.c0.btn-warning.disabled:hover {
+  background-color: #e4bc0e;
+  border-color: #ebc20c;
+  color: rgb(88,73,5);
+}
+
+<button
+  className="c0 btn btn-default"
   disabled={true}
-  divider={false}
-  header={false}
-  onSelect={[Function]}
-  title="Share search"
+  onClick={[Function]}
+  title="Share"
+  type="button"
 >
-  <li
-    className="disabled"
-    role="presentation"
+  <Icon
+    name="user-plus"
+    type="solid"
   >
-    <SafeAnchor
-      componentClass="a"
-      onClick={[Function]}
-      role="menuitem"
-      tabIndex="-1"
-      title="Share search"
+    <FontAwesomeIcon
+      icon={
+        Object {
+          "iconName": "user-plus",
+          "prefix": "fas",
+        }
+      }
     >
-      <a
-        href="#"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        role="menuitem"
-        tabIndex="-1"
-        title="Share search"
-      >
-        <Icon
-          name="share-alt"
-          type="solid"
-        >
-          <FontAwesomeIcon
-            icon={
-              Object {
-                "iconName": "share-alt",
-                "prefix": "fas",
-              }
-            }
-          >
-            <svg
-              className="svg-inline--fa fa-share-alt"
-            />
-          </FontAwesomeIcon>
-        </Icon>
-         Share 
-        <SharingDisabledPopover
-          type="search"
-        >
-          <SharingDisabledPopover__StyledHoverForHelp
-            title="Sharing not possible"
-          >
-            <HoverForHelp
-              className="c0"
-              id="help-popover"
-              title="Sharing not possible"
-            >
-              <OverlayTrigger
-                defaultOverlayShown={false}
-                overlay={
-                  <Popover
-                    id="help-popover"
-                    title="Sharing not possible"
-                  >
-                    Only owners of this 
-                    search
-                     are allowed to share it.
-                  </Popover>
-                }
-                placement="bottom"
-                trigger={
-                  Array [
-                    "hover",
-                    "focus",
-                  ]
-                }
-              >
-                <Icon
-                  className="c0 pull-right"
-                  name="question-circle"
-                  onBlur={[Function]}
-                  onClick={null}
-                  onFocus={[Function]}
-                  onMouseOut={[Function]}
-                  onMouseOver={[Function]}
-                  type="solid"
-                >
-                  <FontAwesomeIcon
-                    className="c0 pull-right"
-                    icon={
-                      Object {
-                        "iconName": "question-circle",
-                        "prefix": "fas",
-                      }
-                    }
-                    onBlur={[Function]}
-                    onClick={null}
-                    onFocus={[Function]}
-                    onMouseOut={[Function]}
-                    onMouseOver={[Function]}
-                  >
-                    <svg
-                      className="svg-inline--fa fa-question-circle"
-                    />
-                  </FontAwesomeIcon>
-                </Icon>
-              </OverlayTrigger>
-            </HoverForHelp>
-          </SharingDisabledPopover__StyledHoverForHelp>
-        </SharingDisabledPopover>
-      </a>
-    </SafeAnchor>
-  </li>
-</MenuItem>
+      <svg
+        className="svg-inline--fa fa-user-plus"
+      />
+    </FontAwesomeIcon>
+  </Icon>
+   Share 
+</button>
 `;

--- a/graylog2-web-interface/src/views/components/views/ViewList.jsx
+++ b/graylog2-web-interface/src/views/components/views/ViewList.jsx
@@ -2,8 +2,7 @@ import React, { useEffect, useReducer, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { ButtonToolbar, DropdownButton, MenuItem } from 'components/graylog';
-import { IfPermitted, HasOwnership, PaginatedList, SearchForm, Spinner, EntityList } from 'components/common';
-import SharingDisabledPopover from 'components/permissions/SharingDisabledPopover';
+import { IfPermitted, PaginatedList, SearchForm, Spinner, EntityList, ShareButton } from 'components/common';
 import EntityShareModal from 'components/permissions/EntityShareModal';
 
 import View from './View';
@@ -13,14 +12,8 @@ import ViewTypeLabel from '../ViewTypeLabel';
 const itemActionsFactory = (view, onViewDelete, setViewToShare) => {
   return (
     <ButtonToolbar>
-      <DropdownButton title="Actions" id={`view-actions-dropdown-${view.id}`} bsSize="small" pullRight>
-        <HasOwnership type="dashboard" id={view.id}>
-          {({ disabled }) => (
-            <MenuItem disabled={disabled} onSelect={() => setViewToShare(view)}>
-              Share {disabled && <SharingDisabledPopover type="dashboard" />}
-            </MenuItem>
-          )}
-        </HasOwnership>
+      <ShareButton entityId={view.id} entityType="dashboard" onClick={() => setViewToShare(view)} />
+      <DropdownButton title="Actions" id={`view-actions-dropdown-${view.id}`} pullRight>
         <IfPermitted permissions={[`view:edit:${view.id}`, 'view:edit']} anyPermissions>
           <MenuItem onSelect={onViewDelete(view)}>Delete</MenuItem>
         </IfPermitted>


### PR DESCRIPTION
## Description
Entities like dashboards, streams and event definitions can be shared with the share action. This action is currently part of the entities action menu:
![image](https://user-images.githubusercontent.com/46300478/97339729-3857e980-1883-11eb-8016-916be8263c7b.png)


With this PR we are creating an own button for the share actions on the highest level:
![image](https://user-images.githubusercontent.com/46300478/97337865-13fb0d80-1881-11eb-9e89-f8d8a7023151.png)

Please note, there are unrelated ESlint warnings.

Fixes: #9247

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

