### PR TITLE
Remove Jetbrains NotNull annotation

### DIFF
--- a/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorSSLTLSIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorSSLTLSIT.java
@@ -22,7 +22,6 @@ import org.apache.directory.ldap.client.api.LdapNetworkConnection;
 import org.assertj.core.api.Assertions;
 import org.graylog2.rest.models.system.ldap.requests.LdapTestConfigRequest;
 import org.graylog2.security.DefaultX509TrustManager;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,6 +31,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import javax.net.ssl.TrustManager;
+import javax.validation.constraints.NotNull;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;

--- a/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorSSLTLSIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/security/ldap/LdapConnectorSSLTLSIT.java
@@ -31,7 +31,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import javax.net.ssl.TrustManager;
-import javax.validation.constraints.NotNull;
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -159,12 +159,12 @@ public class LdapConnectorSSLTLSIT {
         assertConnectionSuccess(request);
     }
 
-    @NotNull
+    @Nonnull
     private LdapTestConfigRequest createTLSTestRequest(boolean trustAllCertificates) {
         return createRequest(internalSSLUri(), true, trustAllCertificates);
     }
 
-    @NotNull
+    @Nonnull
     private LdapTestConfigRequest createSSLTestRequest(boolean trustAllCertificates) {
         return createRequest(internalSSLUri(), false, trustAllCertificates);
     }

--- a/graylog2-server/src/test/java/org/graylog2/shared/security/SessionCreatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/security/SessionCreatorTest.java
@@ -36,7 +36,6 @@ import org.graylog2.audit.AuditActor;
 import org.graylog2.audit.AuditEventSender;
 import org.graylog2.plugin.database.users.User;
 import org.graylog2.shared.users.UserService;
-import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,6 +43,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;

--- a/graylog2-server/src/test/java/org/graylog2/shared/security/SessionCreatorTest.java
+++ b/graylog2-server/src/test/java/org/graylog2/shared/security/SessionCreatorTest.java
@@ -43,7 +43,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import javax.validation.constraints.NotNull;
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -239,7 +239,7 @@ public class SessionCreatorTest {
         when(userService.load("username")).thenReturn(user);
     }
 
-    @NotNull
+    @Nonnull
     private SimpleAccountRealm throwingRealm() {
         return new SimpleAccountRealm() {
             @Override


### PR DESCRIPTION
Use the `javax.annotation.Nonnull` annotation instead of `org.jetbrains.annotations.NotNull` which is not available in all environments. The same change was made in https://github.com/Graylog2/graylog2-server/pull/9169 and ports the compatible `3.3` file changes over to `cloud-3.3`.

This incorrect import only caused the following error in some environments, such as running the Graylog Server with the [Docker tool](https://github.com/Graylog2/graylog-project-internal/blob/5dbe21d3b37fca04570620bf177a3525e1104fb3/runner/README.md).