### PR TITLE
Do not disable user create submit button on server error

### DIFF
--- a/graylog2-web-interface/src/components/users/UserCreate/UserCreate.jsx
+++ b/graylog2-web-interface/src/components/users/UserCreate/UserCreate.jsx
@@ -30,7 +30,7 @@ const _onSubmit = (formData, roles, setSubmitError) => {
 
   setSubmitError(null);
 
-  UsersDomain.create(data).then(() => {
+  return UsersDomain.create(data).then(() => {
     history.push(Routes.SYSTEM.USERS.OVERVIEW);
   }, (error) => setSubmitError(error));
 };


### PR DESCRIPTION
## Description
The submit button on the user create form is disabled when the create request is pending.
Previously the submit button never got enabled., if there the request returned a server error:
![image](https://user-images.githubusercontent.com/46300478/97429889-53286d80-1918-11eb-8323-57159741c193.png)
(Please note, I removed the client side validation  locally to receive this error)

With this PR we are returning the create promise to ensure formik updates `isSubmitting` correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)