### PR TITLE
Return correct PaginatedList results

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/database/PaginatedList.java
+++ b/graylog2-server/src/main/java/org/graylog2/database/PaginatedList.java
@@ -37,10 +37,25 @@ public class PaginatedList<E> extends ForwardingList<E> {
 
     private final Long grandTotal;
 
+    /**
+     * Creates a PaginatedList
+     * @param delegate the actual entries
+     * @param total the count of all entries (ignoring pagination)
+     * @param page  the page this PaginatedList represents
+     * @param perPage the size limit for each page
+     */
     public PaginatedList(@Nonnull List<E> delegate, int total, int page, int perPage) {
         this(delegate, total, page, perPage, null);
     }
 
+    /**
+     * Creates a PaginatedList
+     * @param delegate the actual entries
+     * @param total the count of all entries (ignoring pagination)
+     * @param page  the page this PaginatedList represents
+     * @param perPage the size limit for each page
+     * @param grandTotal the count of all entries (ignoring query filters and pagination)
+     */
     public PaginatedList(@Nonnull List<E> delegate, int total, int page, int perPage, Long grandTotal) {
         this.delegate = delegate;
         this.paginationInfo = PaginationInfo.create(total, delegate.size(), page, perPage);

--- a/graylog2-server/src/test/java/org/graylog/security/shares/GranteeSharesServiceTest.java
+++ b/graylog2-server/src/test/java/org/graylog/security/shares/GranteeSharesServiceTest.java
@@ -168,6 +168,8 @@ class GranteeSharesServiceTest {
                 assertThat(response.capabilities()).doesNotContainKey(dashboard0);
                 assertThat(response.capabilities()).doesNotContainKey(dashboard1);
                 assertThat(response.capabilities()).doesNotContainKey(stream0);
+
+                assertThat(response.paginatedEntities().pagination().total()).isEqualTo(3);
             }
 
             @DisplayName("paginated shares with reverse order")


### PR DESCRIPTION

 - 'total' should contain the count of all filtered results (ignoring pagination)
 - 'grand_total' should contain the count of all results (also ignoring filters)

fixes #9291 