### PR TITLE
Display info about permissions update on user edit and details page

### DIFF
--- a/graylog2-web-interface/src/components/users/PermissionsUpdateInfo.jsx
+++ b/graylog2-web-interface/src/components/users/PermissionsUpdateInfo.jsx
@@ -1,0 +1,21 @@
+// @flow strict
+import * as React from 'react';
+
+import DocsHelper from 'util/DocsHelper';
+import DocumentationLink from 'components/support/DocumentationLink';
+import { Col, Row, Alert } from 'components/graylog';
+import { Icon } from 'components/common';
+
+const PermissionsUpdateInfo = () => (
+  <Row className="content">
+    <Col xs={12}>
+      <Alert bsStyle="info">
+        <Icon name="info-circle" />{' '}<b>Granting Permissions</b><br />
+        With Graylog 4.0 we&apos;ve updated the permissions system. Granting permissions for an entity like streams and dashboards is no longer part of the user edit page.
+        It can now be configured using the <b><Icon name="user-plus" /> Share</b> button of an entity. You can find the button e.g. on the entities overview page. Learn more in the <DocumentationLink page={DocsHelper.PAGES.PERMISSIONS} text="documentation" />.
+      </Alert>
+    </Col>
+  </Row>
+);
+
+export default PermissionsUpdateInfo;

--- a/graylog2-web-interface/src/components/users/UserDetails/UserDetails.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/UserDetails.jsx
@@ -12,6 +12,8 @@ import SettingsSection from './SettingsSection';
 import SharedEntitiesSection from './SharedEntitiesSection';
 import TeamsSection from './TeamsSection';
 
+import PermissionsUpdateInfo from '../PermissionsUpdateInfo';
+
 type Props = {
   user: ?User,
 };
@@ -33,6 +35,7 @@ const UserDetails = ({ user }: Props) => {
             <PreferencesSection user={user} />
           </div>
           <div>
+            <PermissionsUpdateInfo />
             <IfPermitted permissions={`users:rolesedit:${user.username}`}>
               <RolesSection user={user} />
             </IfPermitted>

--- a/graylog2-web-interface/src/components/users/UserEdit/UserEdit.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/UserEdit.jsx
@@ -16,6 +16,7 @@ import PreferencesSection from './PreferencesSection';
 import RolesSection from './RolesSection';
 import TeamsSection from './TeamsSection';
 
+import PermissionsUpdateInfo from '../PermissionsUpdateInfo';
 import SectionGrid from '../../common/Section/SectionGrid';
 
 const { CurrentUserStore } = CombinedProvider.get('CurrentUser');
@@ -59,6 +60,7 @@ const UserEdit = ({ user }: Props) => {
           <PreferencesSection user={user} />
         </div>
         <div>
+          <PermissionsUpdateInfo />
           <IfPermitted permissions="users:rolesedit">
             <RolesSection user={user}
                           onSubmit={(data) => _updateUser(data, currentUser, user)} />

--- a/graylog2-web-interface/src/util/DocsHelper.js
+++ b/graylog2-web-interface/src/util/DocsHelper.js
@@ -21,6 +21,7 @@ class DocsHelper {
     LOOKUPTABLES: 'lookuptables.html',
     PAGE_FLEXIBLE_DATE_CONVERTER: 'extractors.html#the-flexible-date-converter',
     PAGE_STANDARD_DATE_CONVERTER: 'extractors.html#the-standard-date-converter',
+    PERMISSIONS: 'users_and_roles/permission_system.html',
     PIPELINE_FUNCTIONS: 'pipelines/functions.html',
     PIPELINE_RULES: 'pipelines/rules.html',
     PIPELINES: 'pipelines.html',


### PR DESCRIPTION
## Description
With Graylog 4.0 we've update the permissions system. Previously, sharing entities like dashboards and streams has been part of the user edit page, now it can be done with the share button of an entity, which is e.g part of the entities overview page.

With this PR we explain this change on the user edit and details page, so users will understand where they can grant permissions for an entity.

Initially I planned to include the share button component inside the info text, but this way the text would take up even more space.

Fixes: #9249

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
