### PR TITLE
Trim string of username when creating a user

### DIFF
--- a/graylog2-web-interface/src/components/users/UserCreate/UserCreate.jsx
+++ b/graylog2-web-interface/src/components/users/UserCreate/UserCreate.jsx
@@ -27,6 +27,7 @@ import { Headline } from '../../common/Section/SectionComponent';
 const _onSubmit = (formData, roles, setSubmitError) => {
   const data = { ...formData, roles: roles.toJS(), permissions: [] };
   delete data.password_repeat;
+  data.username = data.username.trim();
 
   setSubmitError(null);
 

--- a/graylog2-web-interface/src/components/users/UserCreate/UserCreate.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserCreate/UserCreate.test.jsx
@@ -82,6 +82,35 @@ describe('<UserCreate />', () => {
     }));
   });
 
+  it('should trim the username', async () => {
+    const { findByLabelText, findByPlaceholderText, findByText } = render(<UserCreate />);
+
+    const usernameInput = await findByLabelText('Username');
+    const fullNameInput = await findByLabelText('Full Name');
+    const emailInput = await findByLabelText('E-Mail Address');
+    const passwordInput = await findByPlaceholderText('Password');
+    const passwordRepeatInput = await findByPlaceholderText('Repeat password');
+    const submitButton = await findByText('Create User');
+
+    fireEvent.change(usernameInput, { target: { value: '   username   ' } });
+    fireEvent.change(fullNameInput, { target: { value: 'The full name' } });
+    fireEvent.change(emailInput, { target: { value: 'username@example.org' } });
+    fireEvent.change(passwordInput, { target: { value: 'thepassword' } });
+    fireEvent.change(passwordRepeatInput, { target: { value: 'thepassword' } });
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => expect(UsersActions.create).toHaveBeenCalledWith({
+      username: 'username',
+      full_name: 'The full name',
+      roles: ['Reader'],
+      email: 'username@example.org',
+      permissions: [],
+      session_timeout_ms: 3600000,
+      password: 'thepassword',
+    }));
+  });
+
   // The following tests will work when we use @testing-library/user-event instead of fireEvent
   // it('should display warning if username is already taken', async () => {
   //   const { findByLabelText, findByText } = render(<UserCreate />);


### PR DESCRIPTION
## Motivation
Prior to this change, if a user was creating a user with leading spaces
the leading spaces were stored into the backend and the user would have
to login with this leading spaces.

## Description
This change will trim the username input before submiting it to the
server.

Fixes #8593 