### PR TITLE
Display info about permissions update on roles overview page

### DIFF
--- a/graylog2-web-interface/src/pages/RolesOverviewPage.jsx
+++ b/graylog2-web-interface/src/pages/RolesOverviewPage.jsx
@@ -29,7 +29,7 @@ const RolesOverviewPage = () => (
       <Col xs={12}>
         <Alert bsStyle="info">
           <Icon name="info-circle" />{' '}<b>Granting Permissions</b><br />
-          With Graylog 4.0 we&apos;ve update the permissions system and changed the purpose of roles.
+          With Graylog 4.0 we&apos;ve updated the permissions system and changed the purpose of roles.
           The built-in roles still allow granting capabilities to users, like creating dashboards or viewing the archive catalog.
           But they no longer grant permissions for a specific dashboard or stream. It is also not possible to create an own role.
           Granting permissions for a specific entity can now be done by using its <b><Icon name="user-plus" /> Share</b> button. You can find the button e.g. on the entities overview page.

--- a/graylog2-web-interface/src/pages/RolesOverviewPage.jsx
+++ b/graylog2-web-interface/src/pages/RolesOverviewPage.jsx
@@ -5,14 +5,14 @@ import { LinkContainer } from 'components/graylog/router';
 import RolesOverview from 'components/roles/RolesOverview';
 import Routes from 'routing/Routes';
 import DocsHelper from 'util/DocsHelper';
-import { Button } from 'components/graylog';
-import { PageHeader, DocumentTitle } from 'components/common';
+import { Button, Row, Col, Alert } from 'components/graylog';
+import { PageHeader, DocumentTitle, Icon } from 'components/common';
 import DocumentationLink from 'components/support/DocumentationLink';
 
 const RolesOverviewPage = () => (
   <DocumentTitle title="Roles Overview">
     <PageHeader title="Roles Overview">
-      <span>Overview of Graylog&apos;s roles.</span>
+      <span>Overview of Graylog&apos;s roles. Roles allow granting capabilities to users, like creating dashboards or event definitions.</span>
 
       <span>
         Learn more in the{' '}
@@ -24,6 +24,20 @@ const RolesOverviewPage = () => (
         <Button bsStyle="info">Roles Overview</Button>
       </LinkContainer>
     </PageHeader>
+
+    <Row className="content">
+      <Col xs={12}>
+        <Alert bsStyle="info">
+          <Icon name="info-circle" />{' '}<b>Granting Permissions</b><br />
+          With Graylog 4.0 we&apos;ve update the permissions system and changed the purpose of roles.
+          The built-in roles still allow granting capabilities to users, like creating dashboards or viewing the archive catalog.
+          But they no longer grant permissions for a specific dashboard or stream. It is also not possible to create an own role.
+          Granting permissions for a specific entity can now be done by using its <b><Icon name="user-plus" /> Share</b> button. You can find the button e.g. on the entities overview page.
+          If you want to grant permissions for an entity to multiple users at once, you can use teams.
+          Learn more in the <DocumentationLink page={DocsHelper.PAGES.PERMISSIONS} text="documentation" />.
+        </Alert>
+      </Col>
+    </Row>
 
     <RolesOverview />
   </DocumentTitle>


### PR DESCRIPTION
## Description
With Graylog 4.0 we've update the permissions system. Previously, granting permissions for an entity like dashboards and streams could be done by using roles. Now roles only grant capabilities like creating dashboards.

With this PR we explain this change on the roles overview page, so users will understand where they can grant permissions for an entity.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
