### PR TITLE
Add target as href to `LinkContainer` children.

### DIFF
--- a/graylog2-web-interface/src/components/graylog/LinkContainer.test.jsx
+++ b/graylog2-web-interface/src/components/graylog/LinkContainer.test.jsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render } from 'wrappedTestingLibrary';
+import { render, waitFor } from 'wrappedTestingLibrary';
 import { fireEvent } from '@testing-library/dom';
 
 import history from 'util/History';
@@ -64,5 +64,26 @@ describe('LinkContainer', () => {
     const button = await findByText('Alerts');
 
     expect(button.href).toEqual('http://localhost/alerts');
+  });
+
+  it('should stop event in generated `onClick`', async () => {
+    const onClick = jest.fn();
+    const childOnClick = jest.fn();
+    const { findByText } = render((
+      // eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
+      <div onClick={onClick}>
+        <LinkContainer to="/">
+          <Button bsStyle="info" onClick={childOnClick}>All Alerts</Button>
+        </LinkContainer>
+      </div>
+    ));
+
+    const button = await findByText('All Alerts');
+
+    fireEvent.click(button);
+
+    await waitFor(() => expect(childOnClick).toHaveBeenCalled());
+
+    expect(onClick).not.toHaveBeenCalled();
   });
 });

--- a/graylog2-web-interface/src/components/graylog/LinkContainer.test.jsx
+++ b/graylog2-web-interface/src/components/graylog/LinkContainer.test.jsx
@@ -11,13 +11,13 @@ jest.mock('util/History');
 
 describe('LinkContainer', () => {
   it('should use component passed in children', async () => {
-    const { findByRole } = render((
+    const { findByText } = render((
       <LinkContainer to="/">
         <Button bsStyle="info">All Alerts</Button>
       </LinkContainer>
     ));
 
-    const button = await findByRole('button', { name: 'All Alerts' });
+    const button = await findByText('All Alerts');
 
     fireEvent.click(button);
 
@@ -26,13 +26,13 @@ describe('LinkContainer', () => {
 
   it('should call onClick', async () => {
     const onClick = jest.fn();
-    const { findByRole } = render((
+    const { findByText } = render((
       <LinkContainer to="/" onClick={onClick}>
         <Button bsStyle="info">All Alerts</Button>
       </LinkContainer>
     ));
 
-    const button = await findByRole('button', { name: 'All Alerts' });
+    const button = await findByText('All Alerts');
 
     fireEvent.click(button);
 
@@ -41,16 +41,28 @@ describe('LinkContainer', () => {
 
   it('should call onClick of children', async () => {
     const onClick = jest.fn();
-    const { findByRole } = render((
+    const { findByText } = render((
       <LinkContainer to="/">
         <Button bsStyle="info" onClick={onClick}>All Alerts</Button>
       </LinkContainer>
     ));
 
-    const button = await findByRole('button', { name: 'All Alerts' });
+    const button = await findByText('All Alerts');
 
     fireEvent.click(button);
 
     expect(onClick).toHaveBeenCalled();
+  });
+
+  it('should add target URL as href to children', async () => {
+    const { findByText } = render((
+      <LinkContainer to="/alerts">
+        <Button bsStyle="info" onClick={jest.fn()}>Alerts</Button>
+      </LinkContainer>
+    ));
+
+    const button = await findByText('Alerts');
+
+    expect(button.href).toEqual('http://localhost/alerts');
   });
 });

--- a/graylog2-web-interface/src/components/graylog/router.jsx
+++ b/graylog2-web-interface/src/components/graylog/router.jsx
@@ -1,6 +1,6 @@
 // @flow strict
 import * as React from 'react';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import type { LocationShape } from 'react-router';
 
@@ -10,27 +10,18 @@ export type HistoryElement = LocationShape;
 
 const _targetPathname = (to) => {
   const target = typeof to?.pathname === 'string' ? to.pathname : to;
-  const targetWithoutQuery = String(target).split(/[?#]/)[0];
 
-  return targetWithoutQuery;
+  return String(target).split(/[?#]/)[0];
 };
 
 const _setActiveClassName = (pathname, to, currentClassName, displayName) => {
-  const props = {};
   const targetPathname = _targetPathname(to);
   const isActive = targetPathname === pathname;
+  const isButton = displayName === 'Button';
 
-  if (displayName === 'Button' && isActive) {
-    let className = 'active';
-
-    if (currentClassName) {
-      className = `${className} ${currentClassName}`;
-    }
-
-    props.className = className;
-  }
-
-  return props;
+  return isButton && isActive
+    ? `active ${currentClassName ?? ''}`
+    : currentClassName;
 };
 
 type Props = {
@@ -42,7 +33,7 @@ type Props = {
 const LinkContainer = ({ children, onClick, to, ...rest }: Props) => {
   const { pathname } = useLocation();
   const { props: { onClick: childrenOnClick, className }, type: { displayName } } = React.Children.only(children);
-  const childrenClassName = _setActiveClassName(pathname, to, className, displayName);
+  const childrenClassName = useMemo(() => _setActiveClassName(pathname, to, className, displayName), [pathname, to, className, displayName]);
   const _onClick = useCallback((e) => {
     e.preventDefault();
     e.stopPropagation();

--- a/graylog2-web-interface/src/components/graylog/router.jsx
+++ b/graylog2-web-interface/src/components/graylog/router.jsx
@@ -43,7 +43,10 @@ const LinkContainer = ({ children, onClick, to, ...rest }: Props) => {
   const { pathname } = useLocation();
   const { props: { onClick: childrenOnClick, className }, type: { displayName } } = React.Children.only(children);
   const childrenClassName = _setActiveClassName(pathname, to, className, displayName);
-  const _onClick = useCallback(() => {
+  const _onClick = useCallback((e) => {
+    e.preventDefault();
+    e.stopPropagation();
+
     if (childrenOnClick) {
       childrenOnClick();
     }
@@ -55,7 +58,7 @@ const LinkContainer = ({ children, onClick, to, ...rest }: Props) => {
     history.push(to);
   }, [childrenOnClick, onClick, to]);
 
-  return React.cloneElement(React.Children.only(children), { ...rest, ...childrenClassName, onClick: _onClick });
+  return React.cloneElement(React.Children.only(children), { ...rest, ...childrenClassName, onClick: _onClick, href: to });
 };
 
 export {

--- a/graylog2-web-interface/src/components/graylog/router.jsx
+++ b/graylog2-web-interface/src/components/graylog/router.jsx
@@ -49,7 +49,7 @@ const LinkContainer = ({ children, onClick, to, ...rest }: Props) => {
     history.push(to);
   }, [childrenOnClick, onClick, to]);
 
-  return React.cloneElement(React.Children.only(children), { ...rest, ...childrenClassName, onClick: _onClick, href: to });
+  return React.cloneElement(React.Children.only(children), { ...rest, className: childrenClassName, onClick: _onClick, href: to });
 };
 
 export {

--- a/graylog2-web-interface/src/components/roles/RolesOverview/ActionsCell.test.jsx
+++ b/graylog2-web-interface/src/components/roles/RolesOverview/ActionsCell.test.jsx
@@ -114,8 +114,8 @@ describe('ActionsCell', () => {
       }));
 
       // Ensure that the component rendered correctly
-      expect(screen.queryByRole('button', { name: `Edit role ${builtInRoleName}` })).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: `Delete role ${builtInRoleName}` })).not.toBeInTheDocument();
+      expect(screen.queryByTitle(`Edit role ${builtInRoleName}`)).toBeInTheDocument();
+      expect(screen.queryByTitle(`Delete role ${builtInRoleName}`)).not.toBeInTheDocument();
     });
 
     it('should not be possible if user does not have correct permissions', () => {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, the `LinkContainer` component did add an `onClick` handler to its children to perform a route change without reloading the app. This lead to the element being created not having an `href` prop, so clicking on it and opening it in a new tab did not work.

This change is adding an `href` prop containing the value of the `to` prop to its children, so the html element contains a valid target.

Fixes #9298.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.