### PR TITLE
Fix read handling of corrupted journal segments

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/journal/KafkaJournal.java
@@ -564,26 +564,37 @@ public class KafkaJournal extends AbstractIdleService implements Journal {
 
     @Override
     public List<JournalReadEntry> read(long requestedMaximumCount) {
-        return read(nextReadOffset, requestedMaximumCount);
+        return readNext(nextReadOffset, requestedMaximumCount);
     }
 
-    public List<JournalReadEntry> read(long readOffset, long requestedMaximumCount) {
-        List<JournalReadEntry> messages = doRead(readOffset, requestedMaximumCount);
+    /**
+     * Read next messages from the journal, starting at the given offset. If the underlying journal implementation
+     * returns an empty list of entries, but we know there are more entries in the journal, we'll try to skip the
+     * problematic offset(s) until we find entries again.
+     *
+     * @param startOffset Offset to start reading at
+     * @param requestedMaximumCount Maximum number of entries to return.
+     * @return A list of entries
+     */
+    public List<JournalReadEntry> readNext(long startOffset, long requestedMaximumCount) {
+        List<JournalReadEntry> messages = read(startOffset, requestedMaximumCount);
 
         if (messages.isEmpty()) {
             // If we got an empty result BUT we know that there are more messages in the log, we bump the readOffset
             // by 1 and try to read again. We continue until we either get an non-empty result or we reached the
             // end of the log.
             // This can happen when a log segment is truncated at the end but later segments have valid messages again.
-            long failedReadOffset = readOffset;
+            long failedReadOffset = startOffset;
             long retryReadOffset = failedReadOffset + 1;
 
             while (messages.isEmpty() && failedReadOffset < (getLogEndOffset() - 1)) {
-                LOG.warn("Couldn't read any messages from offset <{}> but journal has more messages. Skipping and trying to read from offset <{}>",
+                LOG.warn(
+                        "Couldn't read any messages from offset <{}> but journal has more messages. Skipping and " +
+                                "trying to read from offset <{}>",
                         failedReadOffset, retryReadOffset);
 
                 // Retry the read with an increased offset to skip corrupt segments
-                messages = doRead(retryReadOffset, requestedMaximumCount);
+                messages = read(retryReadOffset, requestedMaximumCount);
 
                 // Bump offsets in case we still read an empty result
                 failedReadOffset++;
@@ -594,7 +605,15 @@ public class KafkaJournal extends AbstractIdleService implements Journal {
         return messages;
     }
 
-    private List<JournalReadEntry> doRead(long readOffset, long requestedMaximumCount) {
+    /**
+     * Read from the journal, starting at the given offset. If the underlying journal implementation returns an empty
+     * list of entries, it will be returned even if we know there are more entries in the journal.
+     *
+     * @param readOffset Offset to start reading at
+     * @param requestedMaximumCount Maximum number of entries to return.
+     * @return A list of entries
+     */
+    public List<JournalReadEntry> read(long readOffset, long requestedMaximumCount) {
         // Always read at least one!
         final long maximumCount = Math.max(1, requestedMaximumCount);
         long maxOffset = readOffset + maximumCount;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously the journal reader got stuck waiting when reading from an offset that returned an empty result.

In that case the journal reader assumes that it reached the end of the journal and waits for more messages to come in. Once new messages have been written to the journal, the reader is trying again with the same offset.

With a corrupted log segment, reading the same offset will return an empty result again. Even though there are valid messages in new segments after the corrupted one.

This put the journal reader in an infinite loop until the corrupted journal segment gets deleted manually or users delete the complete journal.

The code is now checking if there are more messages after the current read offset when an empty result is received from the read operation. In that case it increases the offset one by one and retries the read until the result is not empty anymore or the end of the log has been reached.

We reproduced this issue with a journal where the first segment was truncated at the end. Later log segments contained valid messages.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #9305 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

See steps to reproduce in #9305.
Tested by manually truncating a journal segment with a stopped server and then re-starting the server. Before the fix, the server would get stuck and not process any more incoming messages. After the change, the server would log the warning message about the faulty journal offset and then carry on processing messages.

Tested that the `journal decode` command still returns entries at the requested offsets. If a corrupted offset is requested, it will return an empty result for this offset and not return a result for the next non-corrupted offset.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

