### PR TITLE
Avoid using throw by displaying an Alert

### DIFF
--- a/graylog2-web-interface/src/components/common/ErrorAlert.jsx
+++ b/graylog2-web-interface/src/components/common/ErrorAlert.jsx
@@ -1,0 +1,51 @@
+// @flow strict
+import * as React from 'react';
+import styled, { StyledComponent } from 'styled-components';
+
+import { Alert, Button, Col, Row } from 'components/graylog';
+import Icon from 'components/common/Icon';
+
+const StyledRow = styled(Row)`
+  margin-bottom: 0px !important;
+`;
+
+const Container: StyledComponent<{margin: number}, HTMLElement<'div'>> = styled.div(({ margin }) => `
+  margin-top: ${margin}px;
+  margin-bottom: ${margin}px;
+`);
+
+type Props = {
+  onClose: () => void,
+  children: React.Node,
+  bsStyle: string,
+  marginTopBottom: number,
+  runtimeError: boolean,
+};
+
+const ErrorAlert = ({ children, onClose, bsStyle = 'warning', marginTopBottom = 15, runtimeError }: Props) => {
+  const finalBsStyle = runtimeError ? 'danger' : bsStyle;
+
+  if (!children) {
+    return null;
+  }
+
+  return (
+    <Container margin={marginTopBottom}>
+      <Alert bsStyle={finalBsStyle}>
+        <StyledRow>
+          <Col md={11}>
+            {runtimeError && <h4>Runtime Error</h4>}
+            {children}
+          </Col>
+          <Col md={1}>
+            <Button bsSize="xsmall" bsStyle={finalBsStyle} className="pull-right" onClick={() => onClose()}>
+              <Icon name="times" />
+            </Button>
+          </Col>
+        </StyledRow>
+      </Alert>
+    </Container>
+  );
+};
+
+export default ErrorAlert;

--- a/graylog2-web-interface/src/components/common/ErrorAlert.jsx
+++ b/graylog2-web-interface/src/components/common/ErrorAlert.jsx
@@ -1,16 +1,17 @@
 // @flow strict
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import styled, { StyledComponent } from 'styled-components';
+import styled, { type StyledComponent } from 'styled-components';
 
+import { type ThemeInterface } from 'theme';
 import { Alert, Button, Col, Row } from 'components/graylog';
 import Icon from 'components/common/Icon';
 
 const StyledRow = styled(Row)`
-  margin-bottom: 0px !important;
+  margin-bottom: 0 !important;
 `;
 
-const Container: StyledComponent<{margin: number}, HTMLElement<'div'>> = styled.div(({ margin }) => `
+const Container: StyledComponent<{margin: number}, ThemeInterface, HTMLElement> = styled.div(({ margin }) => `
   margin-top: ${margin}px;
   margin-bottom: ${margin}px;
 `);

--- a/graylog2-web-interface/src/components/common/ErrorAlert.jsx
+++ b/graylog2-web-interface/src/components/common/ErrorAlert.jsx
@@ -1,5 +1,6 @@
 // @flow strict
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import styled, { StyledComponent } from 'styled-components';
 
 import { Alert, Button, Col, Row } from 'components/graylog';
@@ -46,6 +47,26 @@ const ErrorAlert = ({ children, onClose, bsStyle = 'warning', marginTopBottom = 
       </Alert>
     </Container>
   );
+};
+
+ErrorAlert.propTypes = {
+  bsStyle: PropTypes.string,
+  runtimeError: PropTypes.bool,
+  marginTopBottom: PropTypes.number,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.element),
+    PropTypes.element,
+    PropTypes.string,
+  ]),
+  onClose: PropTypes.func,
+};
+
+ErrorAlert.defaultProps = {
+  bsStyle: 'warning',
+  runtimeError: false,
+  marginTopBottom: 15,
+  children: null,
+  onClose: () => {},
 };
 
 export default ErrorAlert;

--- a/graylog2-web-interface/src/components/common/ErrorAlert.test.jsx
+++ b/graylog2-web-interface/src/components/common/ErrorAlert.test.jsx
@@ -1,0 +1,39 @@
+// @flow strict
+import React from 'react';
+import { render, screen, fireEvent } from 'wrappedTestingLibrary';
+
+import ErrorAlert from './ErrorAlert';
+
+describe('ErrorAlert', () => {
+  it('should display an Error', () => {
+    render(<ErrorAlert>Franz</ErrorAlert>);
+
+    expect(screen.queryByText('Franz')).not.toBeNull();
+    expect(screen.queryByText('Runtime Error')).toBeNull();
+  });
+
+  it('should display an Runtime Error', () => {
+    render(<ErrorAlert runtimeError>Franz</ErrorAlert>);
+
+    expect(screen.queryByText('Franz')).not.toBeNull();
+    expect(screen.queryByText('Runtime Error')).not.toBeNull();
+  });
+
+  it('should display nothing without children', () => {
+    render(<ErrorAlert />);
+
+    expect(screen.queryByText('Franz')).toBeNull();
+    expect(screen.queryByText('Runtime Error')).toBeNull();
+  });
+
+  it('should call onClose handler', () => {
+    const onClose = jest.fn();
+    render(<ErrorAlert onClose={onClose}>Franz</ErrorAlert>);
+
+    const closeBtn = screen.getByRole('button');
+
+    fireEvent.click(closeBtn);
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/graylog2-web-interface/src/components/common/index.jsx
+++ b/graylog2-web-interface/src/components/common/index.jsx
@@ -18,6 +18,7 @@ export { default as EmptyResult } from './EmptyResult';
 export { default as EnterprisePluginNotFound } from './EnterprisePluginNotFound';
 export { default as EntityList } from './EntityList';
 export { default as EntityListItem } from './EntityListItem';
+export { default as ErrorAlert } from './ErrorAlert';
 export { default as ExpandableList } from './ExpandableList';
 export { default as ExpandableListItem } from './ExpandableListItem';
 export { default as ExternalLink } from './ExternalLink';

--- a/graylog2-web-interface/src/components/permissions/RolesSelector.jsx
+++ b/graylog2-web-interface/src/components/permissions/RolesSelector.jsx
@@ -10,7 +10,7 @@ import type { PaginatedRoles } from 'actions/roles/AuthzRolesActions';
 import AuthzRolesDomain from 'domainActions/roles/AuthzRolesDomain';
 import Role from 'logic/roles/Role';
 import { Button } from 'components/graylog';
-import { Select, Spinner } from 'components/common';
+import { Select, Spinner, ErrorAlert } from 'components/common';
 
 type Props = {
   assignedRolesIds: Immutable.Set<string>,
@@ -44,7 +44,7 @@ const _options = (roles, assignedRolesIds, identifier) => roles
   .toArray()
   .map((r) => ({ label: r.name, value: r.name, role: r }));
 
-const _assignRole = (selectedRoleName, roles, onSubmit, setSelectedRoleName, setIsSubmitting) => {
+const _assignRole = (selectedRoleName, roles, onSubmit, setSelectedRoleName, setIsSubmitting, setError) => {
   if (!selectedRoleName) {
     return;
   }
@@ -56,7 +56,9 @@ const _assignRole = (selectedRoleName, roles, onSubmit, setSelectedRoleName, set
   })));
 
   if (selectedRoles.size <= 0) {
-    throw Error(`Role assignment failed, because the roles ${selectedRoleName ?? '(undefined)'} does not exist`);
+    setError(`Role assignment failed, because the roles ${selectedRoleName ?? '(undefined)'} does not exist`);
+
+    return;
   }
 
   setIsSubmitting(true);
@@ -77,6 +79,7 @@ const RolesSelector = ({ assignedRolesIds, onSubmit, identifier }: Props) => {
   const [paginatedRoles, setPaginatedRoles] = useState<?PaginatedRoles>();
   const [selectedRoleName, setSelectedRoleName] = useState();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState();
 
   useEffect(() => _loadRoles(setPaginatedRoles), []);
 
@@ -84,7 +87,7 @@ const RolesSelector = ({ assignedRolesIds, onSubmit, identifier }: Props) => {
     return <Spinner />;
   }
 
-  const _onSubmit = () => _assignRole(selectedRoleName, paginatedRoles.list, onSubmit, setSelectedRoleName, setIsSubmitting);
+  const _onSubmit = () => _assignRole(selectedRoleName, paginatedRoles.list, onSubmit, setSelectedRoleName, setIsSubmitting, setError);
   const options = _options(paginatedRoles.list, assignedRolesIds, identifier);
 
   return (
@@ -105,6 +108,9 @@ const RolesSelector = ({ assignedRolesIds, onSubmit, identifier }: Props) => {
           Assign Role
         </SubmitButton>
       </FormElements>
+      <ErrorAlert runtimeError onClose={setError}>
+        {error}
+      </ErrorAlert>
     </div>
   );
 };

--- a/graylog2-web-interface/src/components/permissions/RolesSelector.jsx
+++ b/graylog2-web-interface/src/components/permissions/RolesSelector.jsx
@@ -61,6 +61,7 @@ const _assignRole = (selectedRoleName, roles, onSubmit, setSelectedRoleName, set
     return;
   }
 
+  setError();
   setIsSubmitting(true);
 
   onSubmit(selectedRoles).then(() => {

--- a/graylog2-web-interface/src/components/roles/RoleEdit/UsersSection.jsx
+++ b/graylog2-web-interface/src/components/roles/RoleEdit/UsersSection.jsx
@@ -4,8 +4,7 @@ import { useState, useCallback } from 'react';
 import styled from 'styled-components';
 import * as Immutable from 'immutable';
 
-import { Alert, Button } from 'components/graylog';
-import { Icon, PaginatedItemOverview } from 'components/common';
+import { ErrorAlert, PaginatedItemOverview } from 'components/common';
 import AuthzRolesDomain from 'domainActions/roles/AuthzRolesDomain';
 import UserOverview from 'logic/users/UserOverview';
 import { DEFAULT_PAGINATION } from 'components/common/PaginatedItemOverview';
@@ -65,16 +64,9 @@ const UsersSection = ({ role: { id, name }, role }: Props) => {
       <Container>
         <UsersSelector onSubmit={_onAssignUser} role={role} />
       </Container>
-      { errors && (
-        <Container>
-          <Alert bsStyle="warning">
-            {errors}
-            <Button bsSize="xsmall" bsStyle="warning" className="pull-right" onClick={() => setErrors()}>
-              <Icon name="times" />
-            </Button>
-          </Alert>
-        </Container>
-      )}
+      <ErrorAlert onClose={setErrors}>
+        {errors}
+      </ErrorAlert>
       <h3>Selected Users</h3>
       <Container>
         <PaginatedItemOverview noDataText="No selected users have been found."

--- a/graylog2-web-interface/src/components/roles/RoleEdit/UsersSelector.jsx
+++ b/graylog2-web-interface/src/components/roles/RoleEdit/UsersSelector.jsx
@@ -14,7 +14,7 @@ import UserOverview from 'logic/users/UserOverview';
 import UsersDomain from 'domainActions/users/UsersDomain';
 import { type ThemeInterface } from 'theme';
 import { Button } from 'components/graylog';
-import { Select } from 'components/common';
+import { Select, ErrorAlert } from 'components/common';
 
 type Props = {
   onSubmit: (user: Immutable.Set<UserOverview>) => Promise<?PaginatedListType>,
@@ -61,6 +61,7 @@ const _isRequired = (field) => (value) => (!value ? `The ${field} is required` :
 const UsersSelector = ({ role, onSubmit }: Props) => {
   const [users, setUsers] = useState([]);
   const [options, setOptions] = useState([]);
+  const [error, setError] = useState();
 
   const _loadUsers = useCallback(() => {
     const getUnlimited = { page: 1, perPage: 0, query: '' };
@@ -88,7 +89,9 @@ const UsersSelector = ({ role, onSubmit }: Props) => {
     })));
 
     if (!userOverview) {
-      throw new Error(`Unable to find user with name ${user} in ${users.map((u) => u.username).join(', ')}`);
+      setError(`This is an exceptional error! Unable to find user with name ${user} in ${users.map((u) => u.username).join(', ')}`);
+
+      return;
     }
 
     onSubmit(userOverview).then(() => { resetForm(); });
@@ -108,6 +111,9 @@ const UsersSelector = ({ role, onSubmit }: Props) => {
 
   return (
     <div>
+      <ErrorAlert onClose={setError} runtimeError>
+        {error}
+      </ErrorAlert>
       <Formik onSubmit={onUpdate}
               initialValues={{ user: undefined }}>
         {({ isSubmitting, isValid, errors }) => (

--- a/graylog2-web-interface/src/components/roles/RoleEdit/UsersSelector.jsx
+++ b/graylog2-web-interface/src/components/roles/RoleEdit/UsersSelector.jsx
@@ -94,6 +94,7 @@ const UsersSelector = ({ role, onSubmit }: Props) => {
       return;
     }
 
+    setError();
     onSubmit(userOverview).then(() => { resetForm(); });
   };
 

--- a/graylog2-web-interface/src/components/users/UserEdit/RolesSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/RolesSection.jsx
@@ -6,8 +6,7 @@ import styled from 'styled-components';
 
 import UsersDomain from 'domainActions/users/UsersDomain';
 import AuthzRolesDomain from 'domainActions/roles/AuthzRolesDomain';
-import { Alert, Button } from 'components/graylog';
-import { Icon } from 'components/common';
+import { ErrorAlert } from 'components/common';
 import User from 'logic/users/User';
 import PaginatedItemOverview, {
   DEFAULT_PAGINATION,
@@ -83,16 +82,9 @@ const RolesSection = ({ user, onSubmit }: Props) => {
         <RolesSelector onSubmit={_onAssignRole} assignedRolesIds={user.roles} identifier={(role) => role.name} />
       </Container>
 
-      { errors && (
-        <Container>
-          <Alert bsStyle="warning">
-            {errors}
-            <Button bsSize="xsmall" bsStyle="warning" className="pull-right" onClick={() => setErrors()}>
-              <Icon name="times" />
-            </Button>
-          </Alert>
-        </Container>
-      )}
+      <ErrorAlert onClose={setErrors}>
+        {errors}
+      </ErrorAlert>
       <h3>Selected Roles</h3>
       <Container>
         <PaginatedItemOverview noDataText="No selected roles have been found."


### PR DESCRIPTION
## Motivation
Prior to this change, when we had an runtime error we rendered the error
page to the user even though he might have been able to workarround an
issue.

## Description
This change implements a ErrorAlert component which is closable and
which will display an runtime error or warning. It replaces the
warnings already implemented and does also replace the `throw` errors
for users and roles components.

Fixes #8756 