### PR TITLE
Use gray to display a logged of user

### DIFF
--- a/graylog2-web-interface/src/components/users/LoggedInIcon.jsx
+++ b/graylog2-web-interface/src/components/users/LoggedInIcon.jsx
@@ -6,7 +6,7 @@ import { type ThemeInterface } from 'theme';
 import { Icon } from 'components/common';
 
 const Wrapper: StyledComponent<{active?: boolean}, ThemeInterface, HTMLDivElement> = styled.div(({ theme, active }) => `
-  color: ${active ? theme.colors.variant.success : theme.colors.variant.danger};
+  color: ${active ? theme.colors.variant.success : theme.colors.variant.default};
 `);
 
 const LoggedInIcon = ({ active, ...rest }: { active: boolean }) => (


### PR DESCRIPTION
## Motivation
Prior to this change, we displayed a red filled cirle to the user if a
user was logged of. This has several disadvantages:
   - It is signaling an error
   - it is unsuitable for people with a red green weakness.

## Description
This change will change the color from red to gray.

Fixes #9240 
