### PR TITLE
Fail graciously when cannot get node metrics

### DIFF
--- a/graylog2-web-interface/src/components/metrics/MetricsComponent.jsx
+++ b/graylog2-web-interface/src/components/metrics/MetricsComponent.jsx
@@ -9,7 +9,7 @@ import { MetricsFilterInput, MetricsList } from 'components/metrics';
 const StyledWarningDiv = styled.div(({ theme }) => `
   height: 20px;
   margin-bottom: 5px;
-  color: ${theme.color.variant.dark.danger};
+  color: ${theme.colors.variant.dark.danger};
 `);
 
 class MetricsComponent extends React.Component {

--- a/graylog2-web-interface/src/components/metrics/MetricsComponent.jsx
+++ b/graylog2-web-interface/src/components/metrics/MetricsComponent.jsx
@@ -1,18 +1,34 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import styled from 'styled-components';
 
-import { Col, Row } from 'components/graylog';
+import { Alert, Col, Row } from 'components/graylog';
+import { Icon } from 'components/common';
 import { MetricsFilterInput, MetricsList } from 'components/metrics';
+
+const StyledWarningDiv = styled.div(({ theme }) => `
+  height: 20px;
+  margin-bottom: 5px;
+  color: ${theme.color.variant.dark.danger};
+`);
 
 class MetricsComponent extends React.Component {
   static propTypes = {
-    names: PropTypes.arrayOf(PropTypes.object).isRequired,
+    names: PropTypes.arrayOf(PropTypes.object),
     namespace: PropTypes.string.isRequired,
     nodeId: PropTypes.string.isRequired,
     filter: PropTypes.string,
+    error: PropTypes.shape({
+      responseMessage: PropTypes.string,
+      status: PropTypes.number,
+    }),
   };
 
-  static defaultProps = { filter: '' };
+  static defaultProps = {
+    names: undefined,
+    filter: '',
+    error: undefined,
+  };
 
   state = { filter: this.props.filter };
 
@@ -29,13 +45,27 @@ class MetricsComponent extends React.Component {
 
   render() {
     const { filter } = this.state;
+    const { names, error } = this.props;
+
+    if (!names) {
+      return (
+        <Row className="content">
+          <Col md={12}>
+            <Alert bsStyle="danger">
+              <Icon name="exclamation-triangle" />&nbsp;
+              There was a problem fetching node metrics. Graylog will keep trying to get them in the background.
+            </Alert>
+          </Col>
+        </Row>
+      );
+    }
 
     let filteredNames;
 
     try {
       const filterRegex = new RegExp(filter, 'i');
 
-      filteredNames = this.props.names.filter((metric) => String(metric.full_name).match(filterRegex));
+      filteredNames = names.filter((metric) => String(metric.full_name).match(filterRegex));
     } catch (e) {
       filteredNames = [];
     }
@@ -43,6 +73,15 @@ class MetricsComponent extends React.Component {
     return (
       <Row className="content">
         <Col md={12}>
+          <StyledWarningDiv className="text-warning">
+            {error && (
+              <>
+                <Icon name="exclamation-triangle" />&nbsp;
+                Fetching metrics from node returned {error.responseMessage || ''} with a {error.status} status code,{' '}
+                displaying last metrics available.
+              </>
+            )}
+          </StyledWarningDiv>
           <MetricsFilterInput filter={filter} onChange={this.onFilterChange} />
           <MetricsList names={filteredNames} namespace={this.props.namespace} nodeId={this.props.nodeId} />
         </Col>

--- a/graylog2-web-interface/src/components/metrics/MetricsComponent.jsx
+++ b/graylog2-web-interface/src/components/metrics/MetricsComponent.jsx
@@ -53,7 +53,15 @@ class MetricsComponent extends React.Component {
           <Col md={12}>
             <Alert bsStyle="danger">
               <Icon name="exclamation-triangle" />&nbsp;
-              There was a problem fetching node metrics. Graylog will keep trying to get them in the background.
+              {error ? (
+                <span>
+                  Could not fetch metrics from node: server returned <em>{error.responseMessage || ''}</em>{' '}
+                  with a {error.status} status code.
+                </span>
+              ) : (
+                <span>There was a problem fetching node metrics.</span>
+              )}
+              {' '}Graylog will keep trying to get them in the background.
             </Alert>
           </Col>
         </Row>
@@ -77,8 +85,8 @@ class MetricsComponent extends React.Component {
             {error && (
               <>
                 <Icon name="exclamation-triangle" />&nbsp;
-                Fetching metrics from node returned {error.responseMessage || ''} with a {error.status} status code,{' '}
-                displaying last metrics available.
+                Could not fetch metrics from node: server returned <em>{error.responseMessage || ''}</em>{' '}
+                with a {error.status} status code. Displaying last metrics available.
               </>
             )}
           </StyledWarningDiv>

--- a/graylog2-web-interface/src/pages/ShowMetricsPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowMetricsPage.jsx
@@ -5,7 +5,8 @@ import Reflux from 'reflux';
 
 import StoreProvider from 'injection/StoreProvider';
 import ActionsProvider from 'injection/ActionsProvider';
-import { DocumentTitle, PageHeader, Spinner } from 'components/common';
+import { DocumentTitle, Icon, PageHeader, Spinner } from 'components/common';
+import { Alert, Col, Row } from 'components/graylog';
 import { MetricsComponent } from 'components/metrics';
 import withParams from 'routing/withParams';
 import withLocation from 'routing/withLocation';
@@ -57,10 +58,26 @@ const ShowMetricsPage = createReactClass({
               All Graylog nodes provide a set of internal metrics for diagnosis, debugging and monitoring. Note that you can access
               all metrics via JMX, too.
             </span>
-            <span>This node is reporting a total of {names.length} metrics.</span>
+            {names ? (
+              <span>This node is reporting a total of {names.length} metrics.</span>
+            ) : (
+              <span>Could not fetch metrics for this node.</span>
+            )}
+
           </PageHeader>
 
-          <MetricsComponent names={names} namespace={namespace} nodeId={nodeId} filter={filter} />
+          {names ? (
+            <MetricsComponent names={names} namespace={namespace} nodeId={nodeId} filter={filter} />
+          ) : (
+            <Row className="content">
+              <Col md={12}>
+                <Alert bsStyle="danger">
+                  <Icon name="exclamation-triangle" />&nbsp;
+                  There was a problem fetching node metrics. Graylog will keep trying to get them in the background.
+                </Alert>
+              </Col>
+            </Row>
+          )}
         </span>
       </DocumentTitle>
     );

--- a/graylog2-web-interface/src/pages/ShowMetricsPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowMetricsPage.jsx
@@ -5,8 +5,7 @@ import Reflux from 'reflux';
 
 import StoreProvider from 'injection/StoreProvider';
 import ActionsProvider from 'injection/ActionsProvider';
-import { DocumentTitle, Icon, PageHeader, Spinner } from 'components/common';
-import { Alert, Col, Row } from 'components/graylog';
+import { DocumentTitle, PageHeader, Spinner } from 'components/common';
 import { MetricsComponent } from 'components/metrics';
 import withParams from 'routing/withParams';
 import withLocation from 'routing/withLocation';
@@ -44,10 +43,13 @@ const ShowMetricsPage = createReactClass({
       nodeId = masterNodes[0] || nodeIDs[0];
     }
 
+    const { metricsNames, metricsErrors } = this.state;
+
     const node = this.state.nodes[nodeId];
     const title = <span>Metrics of node {node.short_node_id} / {node.hostname}</span>;
     const { namespace } = MetricsStore;
-    const names = this.state.metricsNames[nodeId];
+    const names = metricsNames[nodeId];
+    const error = metricsErrors ? metricsErrors[nodeId] : undefined;
     const { filter } = this.props.location.query;
 
     return (
@@ -63,21 +65,9 @@ const ShowMetricsPage = createReactClass({
             ) : (
               <span>Could not fetch metrics for this node.</span>
             )}
-
           </PageHeader>
 
-          {names ? (
-            <MetricsComponent names={names} namespace={namespace} nodeId={nodeId} filter={filter} />
-          ) : (
-            <Row className="content">
-              <Col md={12}>
-                <Alert bsStyle="danger">
-                  <Icon name="exclamation-triangle" />&nbsp;
-                  There was a problem fetching node metrics. Graylog will keep trying to get them in the background.
-                </Alert>
-              </Col>
-            </Row>
-          )}
+          <MetricsComponent names={names} namespace={namespace} nodeId={nodeId} filter={filter} error={error} />
         </span>
       </DocumentTitle>
     );

--- a/graylog2-web-interface/src/pages/ShowMetricsPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowMetricsPage.jsx
@@ -60,11 +60,7 @@ const ShowMetricsPage = createReactClass({
               All Graylog nodes provide a set of internal metrics for diagnosis, debugging and monitoring. Note that you can access
               all metrics via JMX, too.
             </span>
-            {names ? (
-              <span>This node is reporting a total of {names.length} metrics.</span>
-            ) : (
-              <span>Could not fetch metrics for this node.</span>
-            )}
+            <span>This node is reporting a total of {(names || []).length} metrics.</span>
           </PageHeader>
 
           <MetricsComponent names={names} namespace={namespace} nodeId={nodeId} filter={filter} error={error} />

--- a/graylog2-web-interface/src/stores/metrics/MetricsStore.js
+++ b/graylog2-web-interface/src/stores/metrics/MetricsStore.js
@@ -7,7 +7,6 @@ import fetch, { fetchPeriodically } from 'logic/rest/FetchProvider';
 import TimeHelper from 'util/TimeHelper';
 import StoreProvider from 'injection/StoreProvider';
 import ActionsProvider from 'injection/ActionsProvider';
-import UserNotification from 'util/UserNotification';
 
 const SessionStore = StoreProvider.getStore('Session');
 const NodesStore = StoreProvider.getStore('Nodes');
@@ -171,21 +170,20 @@ const MetricsStore = Reflux.createStore({
       return fetch('GET', url).then((response) => {
         return { nodeId: nodeId, names: response.metrics };
       }, (error) => {
-        UserNotification.error(`Fetching metrics for node [${nodeId}] failed with: ${error}.`,
-          'Could not fetch node metrics');
         // When fetching metrics fails, keep previous available metrics around, letting user see them
         return { nodeId: nodeId, names: this.metricsNames[nodeId], error: error };
       });
     })).then((responses) => {
       const metricsNames = {};
-
+      const metricsErrors = {};
       responses.forEach((response) => {
         if (response.nodeId) {
           metricsNames[response.nodeId] = response.names;
+          metricsErrors[response.nodeId] = response.error;
         }
       });
 
-      this.trigger({ metricsNames: metricsNames });
+      this.trigger({ metricsNames: metricsNames, metricsErrors: metricsErrors });
       this.metricsNames = metricsNames;
 
       return metricsNames;

--- a/graylog2-web-interface/src/stores/metrics/MetricsStore.js
+++ b/graylog2-web-interface/src/stores/metrics/MetricsStore.js
@@ -7,6 +7,7 @@ import fetch, { fetchPeriodically } from 'logic/rest/FetchProvider';
 import TimeHelper from 'util/TimeHelper';
 import StoreProvider from 'injection/StoreProvider';
 import ActionsProvider from 'injection/ActionsProvider';
+import UserNotification from 'util/UserNotification';
 
 const SessionStore = StoreProvider.getStore('Session');
 const NodesStore = StoreProvider.getStore('Nodes');
@@ -169,6 +170,11 @@ const MetricsStore = Reflux.createStore({
 
       return fetch('GET', url).then((response) => {
         return { nodeId: nodeId, names: response.metrics };
+      }, (error) => {
+        UserNotification.error(`Fetching metrics for node [${nodeId}] failed with: ${error}.`,
+          'Could not fetch node metrics');
+        // When fetching metrics fails, keep previous available metrics around, letting user see them
+        return { nodeId: nodeId, names: this.metricsNames[nodeId], error: error };
       });
     })).then((responses) => {
       const metricsNames = {};


### PR DESCRIPTION
Ensure we can load the node metrics page, also when it was not possible getting node metrics.

This was tested with the patch included in the issue description:

```
--- a/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterNodeMetricsResource.java
+++ b/graylog2-server/src/main/java/org/graylog2/rest/resources/cluster/ClusterNodeMetricsResource.java
@@ -120,6 +120,9 @@ public class ClusterNodeMetricsResource extends ProxiedResource {
                                               @ApiParam(name = "namespace", required = true)
                                               @PathParam("namespace") String namespace) throws IOException, NodeNotFoundException {
         final Response<MetricsSummaryResponse> result = getResourceForNode(nodeId).byNamespace(namespace).execute();
+        if (Math.random() > 0.25) {
+            throw new RuntimeException("YOLO");
+        }
         if (result.isSuccessful()) {
             return result.body();
         } else {
```

This also needs to be backported into 3.3.

Fixes #9315
