### PR TITLE
Show grok patterns to users with reader role

### DIFF
--- a/graylog2-web-interface/src/components/navigation/SystemMenu.jsx
+++ b/graylog2-web-interface/src/components/navigation/SystemMenu.jsx
@@ -124,7 +124,7 @@ const SystemMenu = ({ location }) => {
       <IfPermitted permissions={['dashboards:create', 'inputs:create', 'streams:create']}>
         <NavigationLink path={Routes.SYSTEM.CONTENTPACKS.LIST} description="Content Packs" />
       </IfPermitted>
-      <IfPermitted permissions={['inputs:edit']}>
+      <IfPermitted permissions={['inputs:read']}>
         <NavigationLink path={Routes.SYSTEM.GROKPATTERNS} description="Grok Patterns" />
       </IfPermitted>
       <IfPermitted permissions={['inputs:edit']}>

--- a/graylog2-web-interface/src/components/navigation/SystemMenu.test.jsx
+++ b/graylog2-web-interface/src/components/navigation/SystemMenu.test.jsx
@@ -63,7 +63,7 @@ describe('SystemMenu', () => {
     permissions                    | count | links
     ${[]}                          | ${2}  | ${['Overview', 'Nodes']}
     ${['clusterconfigentry:read']} | ${3}  | ${['Configurations']}
-    ${['inputs:read']}             | ${3}  | ${['Inputs']}
+    ${['inputs:read']}             | ${4}  | ${['Inputs', 'Grok Patterns']}
     ${['outputs:read']}            | ${3}  | ${['Outputs']}
     ${['indices:read']}            | ${3}  | ${['Indices']}
     ${['loggers:read']}            | ${3}  | ${['Logging']}
@@ -71,7 +71,7 @@ describe('SystemMenu', () => {
     ${['users:list']}              | ${3}  | ${['Users and Teams']}
     ${['roles:read']}              | ${3}  | ${['Roles']}
     ${['dashboards:create', 'inputs:create', 'streams:create']} | ${4}  | ${['Content Packs']}
-    ${['inputs:edit']}             | ${5}  | ${['Grok Patterns', 'Lookup Tables', 'Sidecars']}
+    ${['inputs:edit']}             | ${4}  | ${['Lookup Tables', 'Sidecars']}
     ${['inputs:create']}           | ${3}  | ${['Pipelines']}
   `('shows $links for user with $permissions permissions', verifyPermissions);
   });


### PR DESCRIPTION
## Motivation
Prior to this change, the grok patterns were acutally already
accesisable for users with Reader role, but we hid the Navigation Item.

## Description
This change will change the permission check for the grok patterns
navigation item for reader role.

