### PR TITLE
Implement teams management for roles

### DIFF
--- a/graylog2-web-interface/src/components/roles/RoleDetails/RoleDetails.jsx
+++ b/graylog2-web-interface/src/components/roles/RoleDetails/RoleDetails.jsx
@@ -5,6 +5,7 @@ import { Spinner } from 'components/common';
 import SectionGrid from 'components/common/Section/SectionGrid';
 import Role from 'logic/roles/Role';
 
+import TeamsSection from './TeamsSection';
 import ProfileSection from './ProfileSection';
 import UsersSection from './UsersSection';
 
@@ -24,6 +25,7 @@ const RoleDetails = ({ role }: Props) => {
       </div>
       <div>
         <UsersSection role={role} />
+        <TeamsSection role={role} />
       </div>
     </SectionGrid>
   );

--- a/graylog2-web-interface/src/components/roles/RoleDetails/TeamsSection.jsx
+++ b/graylog2-web-interface/src/components/roles/RoleDetails/TeamsSection.jsx
@@ -1,0 +1,25 @@
+// @flow strict
+import * as React from 'react';
+import { PluginStore } from 'graylog-web-plugin/plugin';
+
+import Role from 'logic/roles/Role';
+import { EnterprisePluginNotFound } from 'components/common';
+import SectionComponent from 'components/common/Section/SectionComponent';
+
+type Props = {
+  role: Role,
+};
+
+const TeamsSection = ({ role }: Props) => {
+  const teamsPlugin = PluginStore.exports('teams');
+
+  const RoleTeamsAssignment = teamsPlugin?.[0]?.RoleTeamsAssignment;
+
+  return (
+    <SectionComponent title="Teams">
+      {RoleTeamsAssignment ? <RoleTeamsAssignment role={role} readOnly /> : <EnterprisePluginNotFound featureName="teams" />}
+    </SectionComponent>
+  );
+};
+
+export default TeamsSection;

--- a/graylog2-web-interface/src/components/roles/RoleEdit/RoleEdit.jsx
+++ b/graylog2-web-interface/src/components/roles/RoleEdit/RoleEdit.jsx
@@ -1,10 +1,11 @@
 // @flow strict
 import * as React from 'react';
 
-import { Spinner } from 'components/common';
+import { Spinner, IfPermitted } from 'components/common';
 import Role from 'logic/roles/Role';
 
 import UsersSection from './UsersSection';
+import TeamsSection from './TeamsSection';
 
 import ProfileSection from '../RoleDetails/ProfileSection';
 import SectionGrid from '../../common/Section/SectionGrid';
@@ -25,6 +26,9 @@ const RoleEdit = ({ role }: Props) => {
       </div>
       <div>
         <UsersSection role={role} />
+        <IfPermitted permissions="teams:edit">
+          <TeamsSection role={role} />
+        </IfPermitted>
       </div>
     </SectionGrid>
   );

--- a/graylog2-web-interface/src/components/roles/RoleEdit/TeamsSection.jsx
+++ b/graylog2-web-interface/src/components/roles/RoleEdit/TeamsSection.jsx
@@ -1,0 +1,24 @@
+// @flow strict
+import * as React from 'react';
+import { PluginStore } from 'graylog-web-plugin/plugin';
+
+import Role from 'logic/roles/Role';
+import { EnterprisePluginNotFound } from 'components/common';
+import SectionComponent from 'components/common/Section/SectionComponent';
+
+type Props = {
+  role: Role,
+};
+
+const TeamsSection = ({ role }: Props) => {
+  const teamsPlugin = PluginStore.exports('teams');
+  const RoleTeamsAssignment = teamsPlugin?.[0]?.RoleTeamsAssignment;
+
+  return (
+    <SectionComponent title="Teams">
+      {RoleTeamsAssignment ? <RoleTeamsAssignment role={role} /> : <EnterprisePluginNotFound featureName="teams" />}
+    </SectionComponent>
+  );
+};
+
+export default TeamsSection;

--- a/graylog2-web-interface/src/components/users/UserDetails/TeamsSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserDetails/TeamsSection.jsx
@@ -13,11 +13,11 @@ type Props = {
 const TeamsSection = ({ user }: Props) => {
   const teamsPlugin = PluginStore.exports('teams');
 
-  const TeamEditComponent = teamsPlugin?.[0]?.TeamEditComponent;
+  const UserTeamsAssignment = teamsPlugin?.[0]?.UserTeamsAssignment;
 
   return (
     <SectionComponent title="Teams">
-      {TeamEditComponent ? <TeamEditComponent user={user} readOnly /> : <EnterprisePluginNotFound featureName="teams" />}
+      {UserTeamsAssignment ? <UserTeamsAssignment user={user} readOnly /> : <EnterprisePluginNotFound featureName="teams" />}
     </SectionComponent>
   );
 };

--- a/graylog2-web-interface/src/components/users/UserEdit/TeamsSection.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/TeamsSection.jsx
@@ -12,11 +12,11 @@ type Props = {
 
 const TeamsSection = ({ user }: Props) => {
   const teamsPlugin = PluginStore.exports('teams');
-  const TeamEditComponent = teamsPlugin?.[0]?.TeamEditComponent;
+  const UserTeamsAssignment = teamsPlugin?.[0]?.UserTeamsAssignment;
 
   return (
     <SectionComponent title="Teams">
-      {TeamEditComponent ? <TeamEditComponent user={user} /> : <EnterprisePluginNotFound featureName="teams" />}
+      {UserTeamsAssignment ? <UserTeamsAssignment user={user} /> : <EnterprisePluginNotFound featureName="teams" />}
     </SectionComponent>
   );
 };

--- a/graylog2-web-interface/src/components/users/UserEdit/UserEdit.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/UserEdit.jsx
@@ -66,8 +66,7 @@ const UserEdit = ({ user }: Props) => {
                           onSubmit={(data) => _updateUser(data, currentUser, user.id)} />
           </IfPermitted>
           <IfPermitted permissions="teams:edit">
-            <TeamsSection user={user}
-                          onSubmit={(data) => _updateUser(data, currentUser, user.id)} />
+            <TeamsSection user={user} />
           </IfPermitted>
         </div>
       </IfPermitted>


### PR DESCRIPTION
This PR implements a `TeamsSection` for the role edit and details page which references the enterprise `RoleTeamsAssignment` component. This way we display all assigned teams on the role details page and allow the team assignment on the role edit page.

/jenkins-pr-deps Graylog2/graylog-plugin-enterprise#1891