### PR TITLE
Improve SearchForm, PageSizeSelect and PageHeader layout responsiveness

### DIFF
--- a/graylog2-web-interface/src/components/common/PageHeader.jsx
+++ b/graylog2-web-interface/src/components/common/PageHeader.jsx
@@ -21,6 +21,16 @@ const H1 = styled.h1`
   margin-bottom: 0.2em;
 `;
 
+const ActionsSM = styled.div`
+  > * {
+    display: inline-block;
+    vertical-align: top;
+  }
+  > :not(:last-child) {
+    margin-right: 5px;
+  }
+`;
+
 const LIFECYCLE_DEFAULT_MESSAGES = {
   experimental: 'This Graylog feature is new and should be considered experimental.',
   legacy: 'This feature has been discontinued and will be removed in a future Graylog version.',
@@ -126,7 +136,7 @@ class PageHeader extends React.Component<Props> {
             )}
 
             {subactions && (
-              <div className="pull-right">
+              <div className="pull-right visible-lg visible-md">
                 {subactions}
               </div>
             )}
@@ -134,7 +144,9 @@ class PageHeader extends React.Component<Props> {
 
           {children[2] && (
             <Col sm={12} lgHidden mdHidden className="actions-sm">
-              {children[2]}
+              <ActionsSM>
+                {children[2]}{subactions}
+              </ActionsSM>
             </Col>
           )}
         </ContentHeadRow>

--- a/graylog2-web-interface/src/components/common/PageSizeSelect.jsx
+++ b/graylog2-web-interface/src/components/common/PageSizeSelect.jsx
@@ -5,14 +5,19 @@ import styled, { type StyledComponent } from 'styled-components';
 
 import { type ThemeInterface } from 'theme';
 import { Input } from 'components/bootstrap';
-import { Col } from 'components/graylog';
 
 const Wrapper: StyledComponent<{}, ThemeInterface, HTMLDivElement> = styled.div`
+  margin-bottom: 5px;
+
   && .form-group {
     margin-bottom: 0
   }
   .control-label {
     padding-top: 0;
+  }
+  .page-size-select {
+    display: flex;
+    align-items: baseline;
   }
 `;
 
@@ -27,11 +32,15 @@ type Props = {
 
 const PageSizeSelect = ({ pageSizes, pageSize, onChange, className }: Props) => (
   <Wrapper className={`${className ?? ''} form-inline page-size pull-right`}>
-    <Col xs={12}>
-      <Input id="page-size" type="select" bsSize="small" label="Show" value={pageSize} onChange={onChange}>
-        {pageSizes.map((size) => <option key={`option-${size}`} value={size}>{size}</option>)}
-      </Input>
-    </Col>
+    <Input id="page-size"
+           type="select"
+           bsSize="small"
+           label="Show"
+           value={pageSize}
+           onChange={onChange}
+           formGroupClassName="page-size-select">
+      {pageSizes.map((size) => <option key={`option-${size}`} value={size}>{size}</option>)}
+    </Input>
   </Wrapper>
 );
 

--- a/graylog2-web-interface/src/components/common/SearchForm.css
+++ b/graylog2-web-interface/src/components/common/SearchForm.css
@@ -1,7 +1,0 @@
-:local(.helpFeedback).form-control-feedback {
-    pointer-events: auto;
-}
-
-:local(.helpFeedback) .btn {
-    max-width: 34px;
-}

--- a/graylog2-web-interface/src/components/common/SearchForm.jsx
+++ b/graylog2-web-interface/src/components/common/SearchForm.jsx
@@ -226,9 +226,9 @@ class SearchForm extends React.Component {
           <FormContent buttonLeftMargin={buttonLeftMargin}>
             <div className={`form-group ${queryHelpComponent ? 'has-feedback' : ''}`}>
               {label && (
-              <label htmlFor="common-search-form-query-input" className="control-label">
-                {label}
-              </label>
+                <label htmlFor="common-search-form-query-input" className="control-label">
+                  {label}
+                </label>
               )}
               <input id="common-search-form-query-input"
                    /* eslint-disable-next-line jsx-a11y/no-autofocus */
@@ -242,7 +242,7 @@ class SearchForm extends React.Component {
                      autoComplete="off"
                      spellCheck="false" />
               {queryHelpComponent && (
-              <HelpFeedback className="form-control-feedback">{queryHelpComponent}</HelpFeedback>
+                <HelpFeedback className="form-control-feedback">{queryHelpComponent}</HelpFeedback>
               )}
             </div>
 
@@ -254,9 +254,9 @@ class SearchForm extends React.Component {
             </Button>
 
             {onReset && (
-            <Button type="reset" className="reset-button" onClick={this._onReset}>
-              {resetButtonLabel}
-            </Button>
+              <Button type="reset" className="reset-button" onClick={this._onReset}>
+                {resetButtonLabel}
+              </Button>
             )}
             {children}
           </FormContent>

--- a/graylog2-web-interface/src/components/common/SearchForm.jsx
+++ b/graylog2-web-interface/src/components/common/SearchForm.jsx
@@ -1,11 +1,32 @@
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import Promise from 'bluebird';
+import styled from 'styled-components';
 
 import { Button } from 'components/graylog';
 import Spinner from 'components/common/Spinner';
 
-import style from './SearchForm.css';
+const FormContent = styled.div(({ buttonLeftMargin }) => `
+  > :not(:last-child) {
+    margin-right: ${buttonLeftMargin}px;
+  }
+
+  > * {
+    display: inline-block;
+    vertical-align: top;
+    margin-bottom: 5px;
+  }
+`);
+
+const HelpFeedback = styled.span`
+  &.form-control-feedback {
+    pointer-events: auto;
+  }
+
+  .btn {
+    max-width: 34px;
+  }
+`;
 
 /**
  * Component that renders a customizable search form. The component
@@ -202,40 +223,43 @@ class SearchForm extends React.Component {
     return (
       <div className={`${wrapperClass} ${className}`} style={{ marginTop: topMargin }}>
         <form className="form-inline" onSubmit={this._onSearch}>
-          <div className={`form-group ${queryHelpComponent ? 'has-feedback' : ''}`}>
-            {label && <label htmlFor="common-search-form-query-input" className="control-label">{label}</label>}
-            <input id="common-search-form-query-input"
+          <FormContent buttonLeftMargin={buttonLeftMargin}>
+            <div className={`form-group ${queryHelpComponent ? 'has-feedback' : ''}`}>
+              {label && (
+              <label htmlFor="common-search-form-query-input" className="control-label">
+                {label}
+              </label>
+              )}
+              <input id="common-search-form-query-input"
                    /* eslint-disable-next-line jsx-a11y/no-autofocus */
-                   autoFocus={focusAfterMount}
-                   onChange={this.handleQueryChange}
-                   value={query}
-                   placeholder={placeholder}
-                   type="text"
-                   style={{ width: queryWidth }}
-                   className="query form-control"
-                   autoComplete="off"
-                   spellCheck="false" />
-            {queryHelpComponent
-              && <span className={`form-control-feedback ${style.helpFeedback}`}>{queryHelpComponent}</span>}
-          </div>
+                     autoFocus={focusAfterMount}
+                     onChange={this.handleQueryChange}
+                     value={query}
+                     placeholder={placeholder}
+                     type="text"
+                     style={{ width: queryWidth }}
+                     className="query form-control"
+                     autoComplete="off"
+                     spellCheck="false" />
+              {queryHelpComponent && (
+              <HelpFeedback className="form-control-feedback">{queryHelpComponent}</HelpFeedback>
+              )}
+            </div>
 
-          <div className="form-group" style={{ marginLeft: buttonLeftMargin }}>
             <Button bsStyle={searchBsStyle}
                     type="submit"
                     disabled={isLoading}
                     className="submit-button">
               {isLoading ? <Spinner text={loadingLabel} delay={0} /> : searchButtonLabel}
             </Button>
-          </div>
-          {onReset
-            && (
-            <div className="form-group" style={{ marginLeft: buttonLeftMargin }}>
-              <Button type="reset" className="reset-button" onClick={this._onReset}>
-                {resetButtonLabel}
-              </Button>
-            </div>
+
+            {onReset && (
+            <Button type="reset" className="reset-button" onClick={this._onReset}>
+              {resetButtonLabel}
+            </Button>
             )}
-          {children}
+            {children}
+          </FormContent>
         </form>
       </div>
     );


### PR DESCRIPTION
Previously the layout of pages like the user overview looked slightly broken with a window width < 992px.
![image](https://user-images.githubusercontent.com/46300478/97869643-1bebff00-1d12-11eb-8702-efd4716be83e.png)

This PR is improving the responsiveness by adjusting the SearchForm, PageSizeSelect and PageHeader styling.
![image](https://user-images.githubusercontent.com/46300478/97869932-869d3a80-1d12-11eb-9480-7179eba72cd3.png)

Fixes: #8794

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
