### PR TITLE
Fix grid layout for user create form buttons

### DIFF
--- a/graylog2-web-interface/src/components/users/UserCreate/UserCreate.jsx
+++ b/graylog2-web-interface/src/components/users/UserCreate/UserCreate.jsx
@@ -134,7 +134,7 @@ const UserCreate = () => {
                 </Row>
               )}
               <Row>
-                <Col xs={9} xsOffset={3}>
+                <Col md={9} mdOffset={3}>
                   <ButtonToolbar>
                     <Button bsStyle="success"
                             disabled={isSubmitting || !isValid || !hasValidRole}


### PR DESCRIPTION
## Description
Previously the user create form buttons column had a not needed offset with a window width < 992px:
![image](https://user-images.githubusercontent.com/46300478/97871561-fc0a0a80-1d14-11eb-88f6-33243851ee54.png)

With this PR we only display the offset when needed:
![image](https://user-images.githubusercontent.com/46300478/97871476-dbda4b80-1d14-11eb-8c2e-c0a891227fd1.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)