### PR TITLE
Close active search sidebar section when clicking on its navigation item

### DIFF
--- a/graylog2-web-interface/src/views/components/sidebar/Sidebar.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/Sidebar.jsx
@@ -43,7 +43,7 @@ const ContentOverlay: StyledComponent<{}, ThemeInterface, HTMLDivElement> = styl
   z-index: 2;
 `);
 
-const handleToggleSidebar = (initialSectionKey: string, activeSectionKey: ?string, setActiveSectionKey) => {
+const _toggleSidebar = (initialSectionKey: string, activeSectionKey: ?string, setActiveSectionKey) => {
   if (activeSectionKey) {
     setActiveSectionKey(null);
 
@@ -53,18 +53,29 @@ const handleToggleSidebar = (initialSectionKey: string, activeSectionKey: ?strin
   setActiveSectionKey(initialSectionKey);
 };
 
+const _selectSidebarSection = (sectionKey, activeSectionKey, setActiveSectionKey, toggleSidebar) => {
+  if (sectionKey === activeSectionKey) {
+    toggleSidebar();
+
+    return;
+  }
+
+  setActiveSectionKey(sectionKey);
+};
+
 const Sidebar = ({ searchPageLayout, results, children, queryId, sections, viewMetadata, viewIsNew }: Props) => {
   const sidebarIsPinned = searchPageLayout?.config.sidebar.isPinned ?? false;
   const initialSectionKey = sections[0].key;
   const [activeSectionKey, setActiveSectionKey] = useState<?string>(sidebarIsPinned ? initialSectionKey : null);
   const activeSection = sections.find((section) => section.key === activeSectionKey);
-  const toggleSidebar = () => handleToggleSidebar(initialSectionKey, activeSectionKey, setActiveSectionKey);
+  const toggleSidebar = () => _toggleSidebar(initialSectionKey, activeSectionKey, setActiveSectionKey);
+  const selectSidebarSection = (sectionKey: string) => _selectSidebarSection(sectionKey, activeSectionKey, setActiveSectionKey, toggleSidebar);
   const SectionContent = activeSection?.content;
 
   return (
     <Container>
       <SidebarNavigation activeSection={activeSection}
-                         setActiveSectionKey={setActiveSectionKey}
+                         selectSidebarSection={selectSidebarSection}
                          toggleSidebar={toggleSidebar}
                          sections={sections}
                          sidebarIsPinned={sidebarIsPinned} />

--- a/graylog2-web-interface/src/views/components/sidebar/Sidebar.test.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/Sidebar.test.jsx
@@ -344,4 +344,25 @@ describe('<Sidebar />', () => {
 
     expect(wrapper.find('SearchResultOverview')).not.toExist();
   });
+
+  it('should close an active section when clicking on its navigation item', () => {
+    const wrapper = mount(
+      <Sidebar viewMetadata={viewMetaData}
+               viewIsNew={false}
+               toggleOpen={jest.fn}
+               queryId={query.id}
+               results={queryResult}>
+        <TestComponent />
+      </Sidebar>,
+    );
+
+    wrapper.find('SidebarNavigation NavItem').first().simulate('click');
+    wrapper.find('div[aria-label="Create"]').simulate('click');
+
+    expect(wrapper.find('h2').text()).toBe('Create');
+
+    wrapper.find('div[aria-label="Create"]').simulate('click');
+
+    expect(wrapper.find('h2')).not.toExist();
+  });
 });

--- a/graylog2-web-interface/src/views/components/sidebar/SidebarNavigation.jsx
+++ b/graylog2-web-interface/src/views/components/sidebar/SidebarNavigation.jsx
@@ -11,7 +11,7 @@ import { type SidebarSection } from './sidebarSections';
 type Props = {
   activeSection: ?SidebarSection,
   sections: Array<SidebarSection>,
-  setActiveSectionKey: (sectionKey: string) => void,
+  selectSidebarSection: (sectionKey: string) => void,
   sidebarIsPinned: boolean,
   toggleSidebar: () => void,
 };
@@ -58,7 +58,7 @@ const HorizontalRuleWrapper = styled.div`
   }
 `;
 
-const SidebarNavigation = ({ sections, activeSection, setActiveSectionKey, sidebarIsPinned, toggleSidebar }: Props) => {
+const SidebarNavigation = ({ sections, activeSection, selectSidebarSection, sidebarIsPinned, toggleSidebar }: Props) => {
   const toggleIcon = activeSection ? 'chevron-left' : 'chevron-right';
   const activeSectionKey = activeSection?.key;
 
@@ -74,7 +74,7 @@ const SidebarNavigation = ({ sections, activeSection, setActiveSectionKey, sideb
         {sections.map(({ key, icon, title }) => (
           <NavItem isSelected={activeSectionKey === key}
                    icon={icon}
-                   onClick={() => setActiveSectionKey(key)}
+                   onClick={() => selectSidebarSection(key)}
                    key={key}
                    title={title}
                    sidebarIsPinned={sidebarIsPinned} />


### PR DESCRIPTION
## Description
Previously, clicking on the navigation item of an active search sidebar section had no effect.
![image](https://user-images.githubusercontent.com/46300478/97877859-172d4800-1d1e-11eb-8130-f5c4acec6f98.png)

With this PR we are closing the sidebar in this case. This improves the usability and unifies the behaviour with the Graylog 3.x sidebar.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.

