### PR TITLE
Fix audit event types for auth service endpoints

### DIFF
--- a/graylog2-server/src/main/java/org/graylog/security/SecurityAuditEventTypes.java
+++ b/graylog2-server/src/main/java/org/graylog/security/SecurityAuditEventTypes.java
@@ -23,16 +23,17 @@ import java.util.Set;
 
 public class SecurityAuditEventTypes implements PluginAuditEventTypes {
     public static final String NAMESPACE = "security:";
-    public static final String NAMESPACE_AUTH_SERVICE = NAMESPACE + "auth-service:";
+    public static final String NAMESPACE_AUTH_SERVICE_GLOBAL_CONFIG = NAMESPACE + "auth_service_global_config:";
+    public static final String NAMESPACE_AUTH_SERVICE_BACKEND = NAMESPACE + "auth_service_backend:";
 
     public static final String SHARE_CREATE = NAMESPACE + "share:create";
     public static final String SHARE_UPDATE = NAMESPACE + "share:update";
     public static final String SHARE_DELETE = NAMESPACE + "share:delete";
 
-    public static final String AUTH_SERVICE_GLOBAL_CONFIG_UPDATE = NAMESPACE_AUTH_SERVICE + "global-config:update";
-    public static final String AUTH_SERVICE_BACKEND_CREATE = NAMESPACE_AUTH_SERVICE + "backend:create";
-    public static final String AUTH_SERVICE_BACKEND_DELETE = NAMESPACE_AUTH_SERVICE + "backend:delete";
-    public static final String AUTH_SERVICE_BACKEND_UPDATE = NAMESPACE_AUTH_SERVICE + "backend:update";
+    public static final String AUTH_SERVICE_GLOBAL_CONFIG_UPDATE = NAMESPACE_AUTH_SERVICE_GLOBAL_CONFIG + "update";
+    public static final String AUTH_SERVICE_BACKEND_CREATE = NAMESPACE_AUTH_SERVICE_BACKEND + "create";
+    public static final String AUTH_SERVICE_BACKEND_DELETE = NAMESPACE_AUTH_SERVICE_BACKEND + "delete";
+    public static final String AUTH_SERVICE_BACKEND_UPDATE = NAMESPACE_AUTH_SERVICE_BACKEND + "update";
 
     private static final ImmutableSet<String> EVENT_TYPES = ImmutableSet.of(
             SHARE_CREATE,


### PR DESCRIPTION
The audit event types for the authentication service resources didn't adhere to the naming convention of `<namespace>:<object>:<action>`.