### PR TITLE
Do not stop click events on `LinkContainer` if modifier-keys are used.

### DIFF
--- a/graylog2-web-interface/src/components/graylog/LinkContainer.test.jsx
+++ b/graylog2-web-interface/src/components/graylog/LinkContainer.test.jsx
@@ -1,9 +1,9 @@
-import history from 'util/History';
-
 import * as React from 'react';
 import { render, waitFor } from 'wrappedTestingLibrary';
 import { fireEvent } from '@testing-library/dom';
+
 import { Button } from 'components/graylog';
+simport history from 'util/History';
 
 import { LinkContainer } from './router';
 

--- a/graylog2-web-interface/src/components/graylog/LinkContainer.test.jsx
+++ b/graylog2-web-interface/src/components/graylog/LinkContainer.test.jsx
@@ -1,8 +1,8 @@
+import history from 'util/History';
+
 import * as React from 'react';
 import { render, waitFor } from 'wrappedTestingLibrary';
 import { fireEvent } from '@testing-library/dom';
-
-import history from 'util/History';
 import { Button } from 'components/graylog';
 
 import { LinkContainer } from './router';
@@ -52,6 +52,21 @@ describe('LinkContainer', () => {
     fireEvent.click(button);
 
     expect(onClick).toHaveBeenCalled();
+  });
+
+  it('should not call onClick of children for ctrl+click', async () => {
+    const onClick = jest.fn();
+    const { findByText } = render((
+      <LinkContainer to="/">
+        <Button bsStyle="info" onClick={onClick}>All Alerts</Button>
+      </LinkContainer>
+    ));
+
+    const button = await findByText('All Alerts');
+
+    fireEvent.click(button, { ctrlKey: true });
+
+    expect(onClick).not.toHaveBeenCalled();
   });
 
   it('should add target URL as href to children', async () => {

--- a/graylog2-web-interface/src/components/graylog/LinkContainer.test.jsx
+++ b/graylog2-web-interface/src/components/graylog/LinkContainer.test.jsx
@@ -3,7 +3,7 @@ import { render, waitFor } from 'wrappedTestingLibrary';
 import { fireEvent } from '@testing-library/dom';
 
 import { Button } from 'components/graylog';
-simport history from 'util/History';
+import history from 'util/History';
 
 import { LinkContainer } from './router';
 

--- a/graylog2-web-interface/src/components/graylog/router.jsx
+++ b/graylog2-web-interface/src/components/graylog/router.jsx
@@ -30,11 +30,19 @@ type Props = {
   to: string | HistoryElement,
 };
 
+const isLeftClickEvent = (e) => (e.button === 0);
+
+const isModifiedEvent = (e) => !!(e.metaKey || e.altKey || e.ctrlKey || e.shiftKey);
+
 const LinkContainer = ({ children, onClick, to, ...rest }: Props) => {
   const { pathname } = useLocation();
   const { props: { onClick: childrenOnClick, className }, type: { displayName } } = React.Children.only(children);
   const childrenClassName = useMemo(() => _setActiveClassName(pathname, to, className, displayName), [pathname, to, className, displayName]);
   const _onClick = useCallback((e) => {
+    if (!isLeftClickEvent(e) || isModifiedEvent(e)) {
+      return;
+    }
+
     e.preventDefault();
     e.stopPropagation();
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before this change, all click events on a `LinkContainer` were stopped, including click events with modifier keys (e.g. Ctrl) being held. This prevents browser functionality like Ctrl+Click to open a link in a new tab.

This change is adding a check to the generated `onClick` handler, stopping all processing and stopping the event if a modifier was held during clicking.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.