### PR TITLE
Retry indexing message if primary shard is not active for ES6.

### DIFF
--- a/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/MessagesAdapterES6.java
+++ b/graylog-storage-elasticsearch6/src/main/java/org/graylog/storage/elasticsearch6/MessagesAdapterES6.java
@@ -44,6 +44,8 @@ public class MessagesAdapterES6 implements MessagesAdapter {
     static final String INDEX_BLOCK_ERROR = "cluster_block_exception";
     static final String INDEX_BLOCK_REASON = "blocked by: [FORBIDDEN/12/index read-only / allow delete (api)];";
     static final String MAPPER_PARSING_EXCEPTION = "mapper_parsing_exception";
+    static final String UNAVAILABLE_SHARDS_EXCEPTION = "unavailable_shards_exception";
+    static final String PRIMARY_SHARD_NOT_ACTIVE_REASON = "primary shard is not active";
 
     private final JestClient client;
     private final boolean useExpectContinue;
@@ -122,6 +124,7 @@ public class MessagesAdapterES6 implements MessagesAdapter {
         switch (item.errorType) {
             case INDEX_BLOCK_ERROR: return Messages.IndexingError.ErrorType.IndexBlocked;
             case MAPPER_PARSING_EXCEPTION: return Messages.IndexingError.ErrorType.MappingError;
+            case UNAVAILABLE_SHARDS_EXCEPTION: if (item.errorReason.contains(PRIMARY_SHARD_NOT_ACTIVE_REASON)) return Messages.IndexingError.ErrorType.IndexBlocked;
             default: return Messages.IndexingError.ErrorType.Unknown;
         }
     }

--- a/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
+++ b/graylog2-server/src/test/java/org/graylog2/indexer/messages/MessagesIT.java
@@ -14,22 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
  */
-/**
- * This file is part of Graylog.
- * <p>
- * Graylog is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- * <p>
- * Graylog is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- * <p>
- * You should have received a copy of the GNU General Public License
- * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
- */
+
 package org.graylog2.indexer.messages;
 
 import com.codahale.metrics.MetricRegistry;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

**Note:** This PR is porting #9065 for ES6.

Prior to this change, when a message is tried to be ingested into Elasticsearch when the primary shard of an index is unavailable, indexing will fail and the message will be turned into an indexing failure. Most probably, this is not what a user wants.
In most cases an unavailable primary shard is a) affecting most, if not all indices, b) is a temporary condition. These properties and the similarities to scenarios where a watermark threshold switches indices to read-only do justify a handling of this that attempts retries indefinitely until the condition is resolved.

While this prevents message loss, it can also cause journal overflow (and causing message loss at the other end of ingestion), while it buys operations time to fix the issue. Due to the watermark scenario, proper sizing of the journal is required anyway to prevent catastrophic scenarios where message indexing stops completely.

This change is extending parsing of ES errors returned during ingestion and categorizes the "primary shard not available" error in the same way as the "index r/o" error. Therefore, errors like this will be retried indefinitely, until the condition is resolved.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.