### PR TITLE
Fix behavior of Apply for new Pipeline Rules

### DIFF
--- a/graylog2-web-interface/src/components/rules/RuleContext.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleContext.jsx
@@ -68,7 +68,7 @@ export const PipelineRulesProvider = ({ children, usedInPipelines, rule }) => {
     if (descriptionRef.current) {
       descriptionRef.current.value = rule.description;
     }
-  }, [rule]);
+  });
 
   useEffect(() => {
     if (ruleSourceRef.current) {

--- a/graylog2-web-interface/src/components/rules/RuleContext.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleContext.jsx
@@ -1,6 +1,5 @@
-import React, { createContext, useEffect, useRef } from 'react';
+import React, { createContext, useEffect, useRef, useCallback } from 'react';
 import PropTypes from 'prop-types';
-
 import CombinedProvider from 'injection/CombinedProvider';
 
 const { RulesActions } = CombinedProvider.get('Rules');
@@ -20,7 +19,7 @@ export const PipelineRulesProvider = ({ children, usedInPipelines, rule }) => {
     ruleSourceRef.current.editor.getSession().setAnnotations(nextErrorAnnotations);
   };
 
-  const validateNewRule = (callback) => {
+  const validateNewRule = useCallback((callback) => {
     const nextRule = {
       ...rule,
       source: ruleSourceRef.current.editor.getSession().getValue(),
@@ -28,7 +27,7 @@ export const PipelineRulesProvider = ({ children, usedInPipelines, rule }) => {
     };
 
     RulesActions.parse(nextRule, callback);
-  };
+  }, [rule]);
 
   const validateBeforeSave = (callback = () => {}) => {
     const savedRule = {

--- a/graylog2-web-interface/src/components/rules/RuleContext.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleContext.jsx
@@ -1,5 +1,6 @@
 import React, { createContext, useEffect, useRef, useCallback } from 'react';
 import PropTypes from 'prop-types';
+
 import CombinedProvider from 'injection/CombinedProvider';
 
 const { RulesActions } = CombinedProvider.get('Rules');

--- a/graylog2-web-interface/src/components/rules/RuleContext.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleContext.jsx
@@ -53,7 +53,7 @@ export const PipelineRulesProvider = ({ children, usedInPipelines, rule }) => {
       promise = RulesActions.save.triggerPromise(nextRule);
     }
 
-    promise.then(() => callback());
+    promise.then((response) => callback(response));
   };
 
   const handleSavePipelineRule = (callback = () => {}) => {
@@ -88,7 +88,7 @@ export const PipelineRulesProvider = ({ children, usedInPipelines, rule }) => {
         }, 500);
       });
     }
-  }, [ruleSourceRef.current]);
+  }, [validateNewRule]);
 
   return (
     <PipelineRulesContext.Provider value={{

--- a/graylog2-web-interface/src/components/rules/RuleForm.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleForm.jsx
@@ -32,7 +32,7 @@ const RuleForm = ({ create }) => {
   };
 
   const handleCancel = () => {
-    history.goBack();
+    history.push(Routes.SYSTEM.PIPELINES.RULES);
   };
 
   return (

--- a/graylog2-web-interface/src/components/rules/RuleForm.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleForm.jsx
@@ -24,7 +24,7 @@ const RuleForm = ({ create }) => {
   };
 
   const handleApply = () => {
-    handleSavePipelineRule();
+    handleSavePipelineRule((rule) => { history.push(Routes.SYSTEM.PIPELINES.RULE(rule.id)); });
   };
 
   const handleDescriptionChange = (event) => {

--- a/graylog2-web-interface/src/components/rules/RuleForm.jsx
+++ b/graylog2-web-interface/src/components/rules/RuleForm.jsx
@@ -20,11 +20,11 @@ const RuleForm = ({ create }) => {
 
   const handleSubmit = (event) => {
     event.preventDefault();
-    handleSavePipelineRule(() => { history.push(Routes.SYSTEM.PIPELINES.RULES); });
+    handleSavePipelineRule(() => { history.goBack(); });
   };
 
   const handleApply = () => {
-    handleSavePipelineRule((rule) => { history.push(Routes.SYSTEM.PIPELINES.RULE(rule.id)); });
+    handleSavePipelineRule((rule) => { history.replace(Routes.SYSTEM.PIPELINES.RULE(rule.id)); });
   };
 
   const handleDescriptionChange = (event) => {
@@ -32,7 +32,7 @@ const RuleForm = ({ create }) => {
   };
 
   const handleCancel = () => {
-    history.push(Routes.SYSTEM.PIPELINES.RULES);
+    history.goBack();
   };
 
   return (

--- a/graylog2-web-interface/src/stores/rules/RulesStore.js
+++ b/graylog2-web-interface/src/stores/rules/RulesStore.js
@@ -2,7 +2,7 @@ import Reflux from 'reflux';
 import naturalSort from 'javascript-natural-sort';
 
 import UserNotification from 'util/UserNotification';
-import URLUtils from 'util/URLUtils';
+import { qualifyUrl } from 'util/URLUtils';
 import ApiRoutes from 'routing/ApiRoutes';
 import fetch from 'logic/rest/FetchProvider';
 import CombinedProvider from 'injection/CombinedProvider';
@@ -49,7 +49,7 @@ const RulesStore = Reflux.createStore({
         'Could not retrieve processing rules');
     };
 
-    const url = URLUtils.qualifyUrl(ApiRoutes.RulesController.list().url);
+    const url = qualifyUrl(ApiRoutes.RulesController.list().url);
 
     return fetch('GET', url).then((response) => {
       this.rules = response;
@@ -63,7 +63,7 @@ const RulesStore = Reflux.createStore({
         `Could not retrieve processing rule "${ruleId}"`);
     };
 
-    const url = URLUtils.qualifyUrl(ApiRoutes.RulesController.get(ruleId).url);
+    const url = qualifyUrl(ApiRoutes.RulesController.get(ruleId).url);
     const promise = fetch('GET', url);
 
     promise.then(this._updateRulesState, failCallback);
@@ -77,7 +77,7 @@ const RulesStore = Reflux.createStore({
         `Could not save processing rule "${ruleSource.title}"`);
     };
 
-    const url = URLUtils.qualifyUrl(ApiRoutes.RulesController.create().url);
+    const url = qualifyUrl(ApiRoutes.RulesController.create().url);
     const rule = {
       title: ruleSource.title,
       description: ruleSource.description,
@@ -88,6 +88,8 @@ const RulesStore = Reflux.createStore({
     promise.then((response) => {
       this._updateRulesState(response);
       UserNotification.success(`Rule "${response.title}" created successfully`);
+
+      return response;
     }, failCallback);
 
     RulesActions.save.promise(promise);
@@ -101,7 +103,7 @@ const RulesStore = Reflux.createStore({
         `Could not update processing rule "${ruleSource.title}"`);
     };
 
-    const url = URLUtils.qualifyUrl(ApiRoutes.RulesController.update(ruleSource.id).url);
+    const url = qualifyUrl(ApiRoutes.RulesController.update(ruleSource.id).url);
     const rule = {
       id: ruleSource.id,
       title: ruleSource.title,
@@ -113,6 +115,8 @@ const RulesStore = Reflux.createStore({
     promise.then((response) => {
       this._updateRulesState(response);
       UserNotification.success(`Rule "${response.title}" updated successfully`);
+
+      return response;
     }, failCallback);
 
     RulesActions.update.promise(promise);
@@ -125,7 +129,7 @@ const RulesStore = Reflux.createStore({
         `Could not delete processing rule "${rule.title}"`);
     };
 
-    const url = URLUtils.qualifyUrl(ApiRoutes.RulesController.delete(rule.id).url);
+    const url = qualifyUrl(ApiRoutes.RulesController.delete(rule.id).url);
 
     return fetch('DELETE', url).then(() => {
       this.rules = this.rules.filter((el) => el.id !== rule.id);
@@ -134,7 +138,7 @@ const RulesStore = Reflux.createStore({
     }, failCallback);
   },
   parse(ruleSource, callback) {
-    const url = URLUtils.qualifyUrl(ApiRoutes.RulesController.parse().url);
+    const url = qualifyUrl(ApiRoutes.RulesController.parse().url);
     const rule = {
       title: ruleSource.title,
       description: ruleSource.description,
@@ -159,7 +163,7 @@ const RulesStore = Reflux.createStore({
     );
   },
   multiple(ruleNames, callback) {
-    const url = URLUtils.qualifyUrl(ApiRoutes.RulesController.multiple().url);
+    const url = qualifyUrl(ApiRoutes.RulesController.multiple().url);
     const promise = fetch('POST', url, { rules: ruleNames });
 
     promise.then(callback);
@@ -171,13 +175,13 @@ const RulesStore = Reflux.createStore({
       return undefined;
     }
 
-    const url = URLUtils.qualifyUrl(ApiRoutes.RulesController.functions().url);
+    const url = qualifyUrl(ApiRoutes.RulesController.functions().url);
 
     return fetch('GET', url)
       .then(this._updateFunctionDescriptors);
   },
   loadMetricsConfig() {
-    const url = URLUtils.qualifyUrl(ApiRoutes.RulesController.metricsConfig().url);
+    const url = qualifyUrl(ApiRoutes.RulesController.metricsConfig().url);
     const promise = fetch('GET', url);
 
     promise.then(
@@ -193,7 +197,7 @@ const RulesStore = Reflux.createStore({
     RulesActions.loadMetricsConfig.promise(promise);
   },
   updateMetricsConfig(nextConfig) {
-    const url = URLUtils.qualifyUrl(ApiRoutes.RulesController.metricsConfig().url);
+    const url = qualifyUrl(ApiRoutes.RulesController.metricsConfig().url);
     const promise = fetch('PUT', url, nextConfig);
 
     promise.then(


### PR DESCRIPTION
## Motivation
Prior to this change, if a user was clicking 'Apply' when creating a
rule a new rule was created but the page was still on the new page which
would lead into an error when clicking 'Save & Close' next.

Fixes #7348
Fixes #8660

## Description
This change will change the browsers url to the edit page after clicking
apply which will fix the state after coming from a new rule page.

Also it fixes a problem if you come to the rules edit page directly, where the source code was not loaded.