### PR TITLE
Add migration for legacy LDAP/AD configuration

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/MigrationsModule.java
@@ -16,6 +16,7 @@
  */
 package org.graylog2.migrations;
 
+import com.google.inject.multibindings.Multibinder;
 import org.graylog2.migrations.V20180214093600_AdjustDashboardPositionToNewResolution.Migration;
 import org.graylog2.migrations.V20200803120800_GrantsMigrations.GrantsMetaMigration;
 import org.graylog2.plugin.PluginModule;
@@ -49,5 +50,9 @@ public class MigrationsModule extends PluginModule {
         addMigration(V20200226181600_EncryptAccessTokensMigration.class);
         addMigration(V20200722110800_AddBuiltinRoles.class);
         addMigration(GrantsMetaMigration.class);
+        addMigration(V20201103145400_LegacyAuthServiceMigration.class);
+
+        // Make sure there is always a binder for migration modules
+        Multibinder.newSetBinder(binder(), V20201103145400_LegacyAuthServiceMigration.MigrationModule.class);
     }
 }

--- a/graylog2-server/src/main/java/org/graylog2/migrations/V20201103145400_LegacyAuthServiceMigration.java
+++ b/graylog2-server/src/main/java/org/graylog2/migrations/V20201103145400_LegacyAuthServiceMigration.java
@@ -1,0 +1,272 @@
+/**
+ * This file is part of Graylog.
+ *
+ * Graylog is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Graylog is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Graylog.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.graylog2.migrations;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Sorts;
+import org.apache.commons.lang3.StringUtils;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.graylog.security.authservice.AuthServiceBackendDTO;
+import org.graylog.security.authservice.DBAuthServiceBackendService;
+import org.graylog.security.authservice.backend.ADAuthServiceBackendConfig;
+import org.graylog.security.authservice.backend.LDAPAuthServiceBackendConfig;
+import org.graylog.security.authservice.ldap.LDAPTransportSecurity;
+import org.graylog.security.authzroles.AuthzRoleDTO;
+import org.graylog.security.authzroles.PaginatedAuthzRolesService;
+import org.graylog2.Configuration;
+import org.graylog2.database.MongoConnection;
+import org.graylog2.notifications.Notification;
+import org.graylog2.notifications.NotificationService;
+import org.graylog2.plugin.cluster.ClusterConfigService;
+import org.graylog2.security.AESTools;
+import org.graylog2.security.encryption.EncryptedValue;
+import org.graylog2.security.encryption.EncryptedValueService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.net.URI;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+public class V20201103145400_LegacyAuthServiceMigration extends Migration {
+    private static final Logger LOG = LoggerFactory.getLogger(V20201103145400_LegacyAuthServiceMigration.class);
+
+    public interface MigrationModule {
+        void upgrade(Document document, AuthServiceBackendDTO authServiceConfig);
+    }
+
+    private final MongoCollection<Document> ldapSettings;
+    private final Set<MigrationModule> migrationModules;
+    private final EncryptedValueService encryptedValueService;
+    private final PaginatedAuthzRolesService rolesService;
+    private final DBAuthServiceBackendService authServiceBackendService;
+    private final NotificationService notificationService;
+    private final ClusterConfigService clusterConfigService;
+    private final String encryptionKey;
+
+    @Inject
+    public V20201103145400_LegacyAuthServiceMigration(MongoConnection mongoConnection,
+                                                      Set<MigrationModule> migrationModules,
+                                                      EncryptedValueService encryptedValueService,
+                                                      Configuration configuration,
+                                                      PaginatedAuthzRolesService rolesService,
+                                                      DBAuthServiceBackendService authServiceBackendService,
+                                                      NotificationService notificationService,
+                                                      ClusterConfigService clusterConfigService) {
+        this.ldapSettings = mongoConnection.getMongoDatabase().getCollection("ldap_settings");
+        this.migrationModules = migrationModules;
+        this.encryptedValueService = encryptedValueService;
+        this.encryptionKey = configuration.getPasswordSecret().substring(0, 16);
+        this.rolesService = rolesService;
+        this.authServiceBackendService = authServiceBackendService;
+        this.notificationService = notificationService;
+        this.clusterConfigService = clusterConfigService;
+    }
+
+    @Override
+    public ZonedDateTime createdAt() {
+        return ZonedDateTime.parse("2020-11-03T14:54:00Z");
+    }
+
+    @Override
+    public void upgrade() {
+        final MigrationCompleted migrationState = clusterConfigService.getOrDefault(MigrationCompleted.class, MigrationCompleted.createEmpty());
+        final ImmutableSet.Builder<String> migratedConfigsBuilder = ImmutableSet.builder();
+
+        // While the LDAP settings collection could contain more than one document, in practice we only expect a
+        // single one. That's why we are using the ID of the last created auth service for the notification.
+        String lastCreatedAuthServiceId = null;
+
+        // Add all configs that have already been migrated
+        migratedConfigsBuilder.addAll(migrationState.migratedConfigs());
+
+        for (final Document document : ldapSettings.find().sort(Sorts.ascending("_id"))) {
+            final String idString = document.getObjectId("_id").toHexString();
+
+            if (!document.getBoolean("enabled")) {
+                LOG.debug("Skipping disabled configuration <{}>", idString);
+                continue;
+            }
+
+            if (migrationState.isDone(idString)) {
+                LOG.debug("Configuration <{}> already migrated", idString);
+                continue;
+            }
+
+            final AuthServiceBackendDTO newConfig;
+            if (document.getBoolean("active_directory")) {
+                newConfig = buildActiveDirectoryConfig(document);
+            } else {
+                newConfig = buildLDAPConfig(document);
+            }
+
+            final AuthServiceBackendDTO savedConfig = authServiceBackendService.save(newConfig);
+
+            for (final MigrationModule migrationModule : migrationModules) {
+                migrationModule.upgrade(document, savedConfig);
+            }
+
+            lastCreatedAuthServiceId = savedConfig.id();
+
+            migratedConfigsBuilder.add(idString);
+        }
+
+        final ImmutableSet<String> migratedConfigs = migratedConfigsBuilder.build();
+        clusterConfigService.write(MigrationCompleted.create(migratedConfigs));
+
+        if (lastCreatedAuthServiceId != null) {
+            final Notification notification = notificationService.buildNow()
+                    .addType(Notification.Type.LEGACY_LDAP_CONFIG_MIGRATION)
+                    .addSeverity(Notification.Severity.URGENT)
+                    .addDetail("auth_service_id", lastCreatedAuthServiceId);
+            notificationService.publishIfFirst(notification);
+        }
+    }
+
+    private AuthServiceBackendDTO buildActiveDirectoryConfig(Document document) {
+        return AuthServiceBackendDTO.builder()
+                .title(getTitle(document, "Active Directory"))
+                .description("Migrated from legacy Active Directory configuration.")
+                .defaultRoles(getDefaultRoles(document))
+                .config(ADAuthServiceBackendConfig.builder()
+                        .servers(Collections.singletonList(getADHostAndPort(document)))
+                        .transportSecurity(getTransportSecurity(document))
+                        .verifyCertificates(getVerifyCertificates(document))
+                        .systemUserDn(document.getString("system_username"))
+                        .systemUserPassword(getSystemUserPassword(document))
+                        .userSearchBase(document.getString("search_base"))
+                        .userSearchPattern(document.getString("principal_search_pattern"))
+                        .userNameAttribute("sAMAccountName")
+                        .userFullNameAttribute(document.getString("username_attribute"))
+                        .build())
+                .build();
+    }
+
+    private AuthServiceBackendDTO buildLDAPConfig(Document document) {
+        return AuthServiceBackendDTO.builder()
+                .title(getTitle(document, "LDAP"))
+                .description("Migrated from legacy LDAP configuration.")
+                .defaultRoles(getDefaultRoles(document))
+                .config(LDAPAuthServiceBackendConfig.builder()
+                        .servers(Collections.singletonList(getLDAPHostAndPort(document)))
+                        .transportSecurity(getTransportSecurity(document))
+                        .verifyCertificates(getVerifyCertificates(document))
+                        .systemUserDn(document.getString("system_username"))
+                        .systemUserPassword(getSystemUserPassword(document))
+                        .userSearchBase(document.getString("search_base"))
+                        .userSearchPattern(document.getString("principal_search_pattern"))
+                        .userUniqueIdAttribute("entryUUID")
+                        .userNameAttribute("uid")
+                        .userFullNameAttribute(document.getString("username_attribute"))
+                        .build())
+                .build();
+    }
+
+    private String getTitle(Document document, String prefix) {
+        final String ldapUriString = document.getString("ldap_uri");
+        return String.format(Locale.US, "%s- %s", prefix, ldapUriString);
+    }
+
+    private LDAPAuthServiceBackendConfig.HostAndPort getLDAPHostAndPort(Document document) {
+        final String ldapUriString = document.getString("ldap_uri");
+        final URI ldapUri = URI.create(ldapUriString);
+
+        return LDAPAuthServiceBackendConfig.HostAndPort.create(ldapUri.getHost(), ldapUri.getPort());
+    }
+
+    private ADAuthServiceBackendConfig.HostAndPort getADHostAndPort(Document document) {
+        final String ldapUriString = document.getString("ldap_uri");
+        final URI ldapUri = URI.create(ldapUriString);
+
+        return ADAuthServiceBackendConfig.HostAndPort.create(ldapUri.getHost(), ldapUri.getPort());
+    }
+
+    private LDAPTransportSecurity getTransportSecurity(Document document) {
+        final String ldapUriString = document.getString("ldap_uri");
+        final Boolean isStartTLS = document.getBoolean("use_start_tls");
+
+        if (isStartTLS) {
+            return LDAPTransportSecurity.START_TLS;
+        } else if (ldapUriString.toLowerCase(Locale.US).startsWith("ldaps://")) {
+            return LDAPTransportSecurity.TLS;
+        } else {
+            return LDAPTransportSecurity.NONE;
+        }
+    }
+
+    private boolean getVerifyCertificates(Document document) {
+        return !document.getBoolean("trust_all_certificates", false);
+    }
+
+    private EncryptedValue getSystemUserPassword(Document document) {
+        final String encryptedPassword = document.getString("system_password");
+        final String salt = document.getString("system_password_salt");
+
+        if (isNotBlank(encryptedPassword) && isNotBlank(salt)) {
+            return encryptedValueService.encrypt(AESTools.decrypt(encryptedPassword, encryptionKey, salt));
+        }
+
+        return EncryptedValue.createUnset();
+    }
+
+    private Set<String> getDefaultRoles(Document document) {
+        final String defaultRole = document.getString("default_group");
+        final List<String> additionalDefaultRoles = document.getList("additional_default_groups", String.class, Collections.emptyList());
+
+        final Set<String> roleIds = Stream.concat(Stream.of(defaultRole), additionalDefaultRoles.stream())
+                .filter(StringUtils::isNotBlank)
+                .filter(ObjectId::isValid)
+                .collect(Collectors.toSet());
+
+        // Only return roles that actually exist
+        return rolesService.findByIds(roleIds).stream()
+                .map(AuthzRoleDTO::id)
+                .collect(Collectors.toSet());
+    }
+
+    @AutoValue
+    public static abstract class MigrationCompleted {
+        @JsonProperty("migrated_configs")
+        public abstract Set<String> migratedConfigs();
+
+        public boolean isDone(String id) {
+            return migratedConfigs().contains(id);
+        }
+
+        @JsonCreator
+        public static MigrationCompleted create(@JsonProperty("migrated_configs") Set<String> migratedConfigs) {
+            return new AutoValue_V20201103145400_LegacyAuthServiceMigration_MigrationCompleted(migratedConfigs);
+        }
+
+        public static MigrationCompleted createEmpty() {
+            return create(Collections.emptySet());
+        }
+    }
+}

--- a/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
+++ b/graylog2-server/src/main/java/org/graylog2/notifications/Notification.java
@@ -68,7 +68,8 @@ public interface Notification extends Persisted {
         ES_NODE_DISK_WATERMARK_LOW,
         ES_NODE_DISK_WATERMARK_HIGH,
         ES_NODE_DISK_WATERMARK_FLOOD_STAGE,
-        ES_VERSION_MISMATCH
+        ES_VERSION_MISMATCH,
+        LEGACY_LDAP_CONFIG_MIGRATION
     }
 
     enum Severity {

--- a/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
+++ b/graylog2-web-interface/src/logic/notifications/NotificationsFactory.js
@@ -303,6 +303,27 @@ class NotificationsFactory {
             </span>
           ),
         }
+      case 'legacy_ldap_config_migration':
+        const { auth_service_id: authServiceId } = notification.details;
+        const authServiceLink = <Link to={Routes.SYSTEM.AUTHENTICATION.BACKENDS.show(authServiceId)}>Authentication Service</Link>;
+        return {
+          title: 'Legacy LDAP/Active Directory configuration has been migrated to an Authentication Service',
+          description:(
+            <span>
+              The legacy LDAP/Active Directory configuration of this system has been upgraded to a new {authServiceLink}.
+              Since the new {authServiceLink} requires some information that is not present in the legacy
+              configuration, the {authServiceLink} <strong>requires a manual review</strong>!
+              <br />
+              <br />
+              <strong>After reviewing the {authServiceLink} it must be enabled to allow LDAP or Active Directory users
+              to log in again!</strong>
+              <br />
+              <br />
+              Please check the <DocumentationLink page={DocsHelper.PAGES.UPGRADE_GUIDE} text="upgrade guide" />
+              for more details.
+            </span>
+          ),
+        }
       default:
         return { title: `unknown (${notification.type})`, description: 'unknown' };
     }

--- a/graylog2-web-interface/src/util/DocsHelper.js
+++ b/graylog2-web-interface/src/util/DocsHelper.js
@@ -30,6 +30,7 @@ class DocsHelper {
     SEARCH_QUERY_LANGUAGE: 'queries.html',
     STREAMS: 'streams.html',
     STREAM_PROCESSING_RUNTIME_LIMITS: 'streams.html#stream-processing-runtime-limits',
+    UPGRADE_GUIDE: 'upgrade/graylog-%%version%%.html',
     USERS_ROLES: 'users_and_roles.html',
     WELCOME: '', // Welcome page to the documentation
   };
@@ -37,9 +38,10 @@ class DocsHelper {
   DOCS_URL = 'https://docs.graylog.org/en/';
 
   toString(path) {
-    const baseUrl = this.DOCS_URL + Version.getMajorAndMinorVersion();
+    const version = Version.getMajorAndMinorVersion();
+    const baseUrl = this.DOCS_URL + version;
 
-    return path === '' ? baseUrl : `${baseUrl}/pages/${path}`;
+    return path === '' ? baseUrl : `${baseUrl}/pages/${path.replace('%%version%%', version)}`;
   }
 
   toLink(path, title) {


### PR DESCRIPTION
This creates a migration to create a new authentication service based on
an existing legacy LDAP/AD configuration.

Since the legacy LDAP/AD configuration doesn't contain all information
we need for a new authentication service, we guess some config fields
and create a system notification to make sure an admin will notice it
and reviews and activates the migrated configuration.

Closes #9078