### PR TITLE
Display an warning if a grantee was not found

### DIFF
--- a/graylog2-web-interface/src/components/permissions/GranteeIcon.jsx
+++ b/graylog2-web-interface/src/components/permissions/GranteeIcon.jsx
@@ -28,6 +28,8 @@ const _iconName = (type) => {
       return 'building';
     case 'team':
       return 'users';
+    case 'error':
+      return 'exclamation';
     case 'user':
     default:
       return 'user';

--- a/graylog2-web-interface/src/components/permissions/GranteesListItem.jsx
+++ b/graylog2-web-interface/src/components/permissions/GranteesListItem.jsx
@@ -88,7 +88,7 @@ const GranteesListItem = ({ availableCapabilities, currentGranteeState, grantee:
     <Formik initialValues={{ capabilityId }} onSubmit={() => {}}>
       <Form>
         <Container currentState={currentGranteeState}>
-          <GranteeInfo>
+          <GranteeInfo title={title}>
             <StyledGranteeIcon type={type} />
             <Title>{title}</Title>
           </GranteeInfo>

--- a/graylog2-web-interface/src/logic/permissions/EntityShareState.js
+++ b/graylog2-web-interface/src/logic/permissions/EntityShareState.js
@@ -42,6 +42,7 @@ const _sortAndOrderGrantees = <T: GranteeInterface>(grantees: Immutable.List<T>)
     .groupBy((grantee) => grantee.type);
 
   return Immutable.List().concat(
+    granteesByType.get('error'),
     granteesByType.get('global'),
     granteesByType.get('team'),
     granteesByType.get('user'),
@@ -128,7 +129,7 @@ export default class EntityShareState {
       const grantee = _userLookup(granteeId);
 
       if (!grantee) {
-        throw new Error(`Cannot find grantee with id ${granteeId} in available grantees`);
+        return SelectedGrantee.create(granteeId, `not found ${granteeId} (error)`, 'error', roleId);
       }
 
       return SelectedGrantee.create(grantee.id, grantee.title, grantee.type, roleId);

--- a/graylog2-web-interface/src/logic/permissions/types.js
+++ b/graylog2-web-interface/src/logic/permissions/types.js
@@ -13,7 +13,7 @@ export type CapabilityType = {|
 export type GranteeType = {|
   id: GRN,
   title: string,
-  type: 'global' | 'team' | 'user',
+  type: 'global' | 'team' | 'user' | 'error',
 |};
 
 export type ActiveShareType = {|


### PR DESCRIPTION
## Motivation
Prior to this change, if grantee was not found for the share dialog the
gui threw an error.

## Description
This change will display the grantees ID together with an exclamation
icon and a note that this is an error.

![Graylog (19)](https://user-images.githubusercontent.com/448763/98116828-21c81880-1ea9-11eb-9e3e-ee61be5ba98b.png)

Fixes #9355 