### PR TITLE
Fix JDK TLS protocol detection

### DIFF
--- a/graylog2-server/src/main/java/org/graylog2/shared/security/tls/DefaultTLSProtocolProvider.java
+++ b/graylog2-server/src/main/java/org/graylog2/shared/security/tls/DefaultTLSProtocolProvider.java
@@ -39,7 +39,7 @@ public abstract class DefaultTLSProtocolProvider {
 
         final Set<String> tlsProtocols = Sets.newHashSet(DEFAULT_TLS_PROTOCOLS);
         try {
-            final Set<String> supportedProtocols = ImmutableSet.copyOf(SSLContext.getDefault().createSSLEngine().getEnabledProtocols());
+            final Set<String> supportedProtocols = ImmutableSet.copyOf(SSLContext.getDefault().createSSLEngine().getSupportedProtocols());
             if (tlsProtocols.retainAll(supportedProtocols)) {
                 LOG.warn("JRE doesn't support all default TLS protocols. Changing <{}> to <{}>", DEFAULT_TLS_PROTOCOLS, tlsProtocols);
             }


### PR DESCRIPTION
Previously we only checked the protocols that are enabled by default
instead of checking all available.

This allows the usage of TLSv1.3 in OpenJDK 8u272 and later.

See: https://blog.adoptopenjdk.net/2020/10/adoptopenjdk-8u272-1109-and-1501-available/