### PR TITLE
Fail graciously when cannot get node metrics (#9316)

### DIFF
--- a/graylog2-web-interface/src/components/metrics/MetricsComponent.jsx
+++ b/graylog2-web-interface/src/components/metrics/MetricsComponent.jsx
@@ -1,18 +1,34 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Col, Row } from 'components/graylog';
+import styled from 'styled-components';
 
+import { Alert, Col, Row } from 'components/graylog';
+import { Icon } from 'components/common';
 import { MetricsFilterInput, MetricsList } from 'components/metrics';
+
+const StyledWarningDiv = styled.div(({ theme }) => `
+  height: 20px;
+  margin-bottom: 5px;
+  color: ${theme.color.variant.dark.danger};
+`);
 
 class MetricsComponent extends React.Component {
   static propTypes = {
-    names: PropTypes.arrayOf(PropTypes.object).isRequired,
+    names: PropTypes.arrayOf(PropTypes.object),
     namespace: PropTypes.string.isRequired,
     nodeId: PropTypes.string.isRequired,
     filter: PropTypes.string,
+    error: PropTypes.shape({
+      responseMessage: PropTypes.string,
+      status: PropTypes.number,
+    }),
   };
 
-  static defaultProps = { filter: '' };
+  static defaultProps = {
+    names: undefined,
+    filter: '',
+    error: undefined,
+  };
 
   state = { filter: this.props.filter };
 
@@ -28,17 +44,48 @@ class MetricsComponent extends React.Component {
 
   render() {
     const { filter } = this.state;
+    const { names, error } = this.props;
+
+    if (!names) {
+      return (
+        <Row className="content">
+          <Col md={12}>
+            <Alert bsStyle="danger">
+              <Icon name="exclamation-triangle" />&nbsp;
+              {error ? (
+                <span>
+                  Could not fetch metrics from node: server returned <em>{error.responseMessage || ''}</em>{' '}
+                  with a {error.status} status code.
+                </span>
+              ) : (
+                <span>There was a problem fetching node metrics.</span>
+              )}
+              {' '}Graylog will keep trying to get them in the background.
+            </Alert>
+          </Col>
+        </Row>
+      );
+    }
 
     let filteredNames;
     try {
       const filterRegex = new RegExp(filter, 'i');
-      filteredNames = this.props.names.filter((metric) => String(metric.full_name).match(filterRegex));
+      filteredNames = names.filter((metric) => String(metric.full_name).match(filterRegex));
     } catch (e) {
       filteredNames = [];
     }
     return (
       <Row className="content">
         <Col md={12}>
+          <StyledWarningDiv className="text-warning">
+            {error && (
+              <>
+                <Icon name="exclamation-triangle" />&nbsp;
+                Could not fetch metrics from node: server returned <em>{error.responseMessage || ''}</em>{' '}
+                with a {error.status} status code. Displaying last metrics available.
+              </>
+            )}
+          </StyledWarningDiv>
           <MetricsFilterInput filter={filter} onChange={this.onFilterChange} />
           <MetricsList names={filteredNames} namespace={this.props.namespace} nodeId={this.props.nodeId} />
         </Col>

--- a/graylog2-web-interface/src/pages/ShowMetricsPage.jsx
+++ b/graylog2-web-interface/src/pages/ShowMetricsPage.jsx
@@ -41,10 +41,13 @@ const ShowMetricsPage = createReactClass({
       nodeId = masterNodes[0] || nodeIDs[0];
     }
 
+    const { metricsNames, metricsErrors } = this.state;
+
     const node = this.state.nodes[nodeId];
     const title = <span>Metrics of node {node.short_node_id} / {node.hostname}</span>;
     const { namespace } = MetricsStore;
-    const names = this.state.metricsNames[nodeId];
+    const names = metricsNames[nodeId];
+    const error = metricsErrors ? metricsErrors[nodeId] : undefined;
     const { filter } = this.props.location.query;
     return (
       <DocumentTitle title={`Metrics of node ${node.short_node_id} / ${node.hostname}`}>
@@ -54,10 +57,10 @@ const ShowMetricsPage = createReactClass({
               All Graylog nodes provide a set of internal metrics for diagnosis, debugging and monitoring. Note that you can access
               all metrics via JMX, too.
             </span>
-            <span>This node is reporting a total of {names.length} metrics.</span>
+            <span>This node is reporting a total of {(names || []).length} metrics.</span>
           </PageHeader>
 
-          <MetricsComponent names={names} namespace={namespace} nodeId={nodeId} filter={filter} />
+          <MetricsComponent names={names} namespace={namespace} nodeId={nodeId} filter={filter} error={error} />
         </span>
       </DocumentTitle>
     );

--- a/graylog2-web-interface/src/stores/metrics/MetricsStore.js
+++ b/graylog2-web-interface/src/stores/metrics/MetricsStore.js
@@ -163,15 +163,21 @@ const MetricsStore = Reflux.createStore({
       const url = URLUtils.qualifyUrl(ApiRoutes.ClusterMetricsApiController.byNamespace(nodeId, this.namespace).url);
       return fetch('GET', url).then((response) => {
         return { nodeId: nodeId, names: response.metrics };
+      }, (error) => {
+        // When fetching metrics fails, keep previous available metrics around, letting user see them
+        return { nodeId: nodeId, names: this.metricsNames[nodeId], error: error };
       });
     })).then((responses) => {
       const metricsNames = {};
+      const metricsErrors = {};
       responses.forEach((response) => {
         if (response.nodeId) {
           metricsNames[response.nodeId] = response.names;
+          metricsErrors[response.nodeId] = response.error;
         }
       });
-      this.trigger({ metricsNames: metricsNames });
+
+      this.trigger({ metricsNames: metricsNames, metricsErrors: metricsErrors });
       this.metricsNames = metricsNames;
       return metricsNames;
     });


### PR DESCRIPTION
Backport of #9316 for 3.3.

Fixes #9315.