### PR TITLE
Hide edit profile and password section for external user

### DIFF
--- a/graylog2-web-interface/src/components/users/UserEdit/UserEdit.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/UserEdit.jsx
@@ -1,6 +1,7 @@
 // @flow strict
 import * as React from 'react';
 import { useContext } from 'react';
+
 import UsersDomain from 'domainActions/users/UsersDomain';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import { Spinner, IfPermitted } from 'components/common';

--- a/graylog2-web-interface/src/components/users/UserEdit/UserEdit.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/UserEdit.jsx
@@ -5,6 +5,8 @@ import { useContext } from 'react';
 import UsersDomain from 'domainActions/users/UsersDomain';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import { Spinner, IfPermitted } from 'components/common';
+import SectionComponent from 'components/common/Section/SectionComponent';
+import { Alert } from 'components/graylog';
 import User from 'logic/users/User';
 import CombinedProvider from 'injection/CombinedProvider';
 
@@ -48,6 +50,14 @@ const UserEdit = ({ user }: Props) => {
     <SectionGrid>
       <IfPermitted permissions={`users:edit:${user.username}`}>
         <div>
+          { user.external && (
+            <SectionComponent>
+              <Alert bsStyle="warning">
+                This user was synced from an external server, therefore neither
+                the profile nor the password can be changed. Please contact your administrator for more information.
+              </Alert>
+            </SectionComponent>
+          ) }
           { !user.external && (
           <ProfileSection user={user}
                           onSubmit={(data) => _updateUser(data, currentUser, user.id)} />

--- a/graylog2-web-interface/src/components/users/UserEdit/UserEdit.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/UserEdit.jsx
@@ -1,7 +1,6 @@
 // @flow strict
 import * as React from 'react';
 import { useContext } from 'react';
-
 import UsersDomain from 'domainActions/users/UsersDomain';
 import CurrentUserContext from 'contexts/CurrentUserContext';
 import { Spinner, IfPermitted } from 'components/common';
@@ -48,14 +47,16 @@ const UserEdit = ({ user }: Props) => {
     <SectionGrid>
       <IfPermitted permissions={`users:edit:${user.username}`}>
         <div>
+          { !user.external && (
           <ProfileSection user={user}
                           onSubmit={(data) => _updateUser(data, currentUser, user.id)} />
+          ) }
           <IfPermitted permissions="*">
             <SettingsSection user={user}
                              onSubmit={(data) => _updateUser(data, currentUser, user.id)} />
           </IfPermitted>
           <IfPermitted permissions={`users:passwordchange:${user.username}`}>
-            <PasswordSection user={user} />
+            { !user.external && <PasswordSection user={user} /> }
           </IfPermitted>
           <PreferencesSection user={user} />
         </div>
@@ -71,7 +72,6 @@ const UserEdit = ({ user }: Props) => {
         </div>
       </IfPermitted>
     </SectionGrid>
-
   );
 };
 

--- a/graylog2-web-interface/src/components/users/UserEdit/UserEdit.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/UserEdit.jsx
@@ -51,7 +51,7 @@ const UserEdit = ({ user }: Props) => {
       <IfPermitted permissions={`users:edit:${user.username}`}>
         <div>
           { user.external && (
-            <SectionComponent>
+            <SectionComponent title="External User">
               <Alert bsStyle="warning">
                 This user was synced from an external server, therefore neither
                 the profile nor the password can be changed. Please contact your administrator for more information.

--- a/graylog2-web-interface/src/components/users/UserEdit/UserEdit.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/UserEdit.test.jsx
@@ -1,7 +1,7 @@
 // @flow strict
 import React from 'react';
 import { screen, render, act } from 'wrappedTestingLibrary';
-import { adminUser } from 'fixtures/users';
+import { adminUser, bob } from 'fixtures/users';
 
 import CurrentUserContext from 'contexts/CurrentUserContext';
 
@@ -9,6 +9,7 @@ import UserEdit from './UserEdit';
 
 const exampleUser = adminUser.toBuilder()
   .readOnly(false)
+  .external(false)
   .build();
 
 jest.mock('./ProfileSection', () => () => <div>ProfileSection</div>);
@@ -58,4 +59,13 @@ describe('<UserEdit />', () => {
     expect(screen.getByText('RolesSection')).toBeInTheDocument();
     expect(screen.getByText('PasswordSection')).toBeInTheDocument();
   });
+
+  describe('external user', () => {
+    it('should not render profile section for external user', () => {
+      render(<SimpleUserEdit user={bob} />);
+
+      expect(bob.external).toBeTruthy();
+      expect(screen.queryByLabelText('Full Name')).not.toBeInTheDocument();
+    });
+  })
 });

--- a/graylog2-web-interface/src/components/users/UserEdit/UserEdit.test.jsx
+++ b/graylog2-web-interface/src/components/users/UserEdit/UserEdit.test.jsx
@@ -67,5 +67,5 @@ describe('<UserEdit />', () => {
       expect(bob.external).toBeTruthy();
       expect(screen.queryByLabelText('Full Name')).not.toBeInTheDocument();
     });
-  })
+  });
 });


### PR DESCRIPTION
## Motivation
Prior to this change, synced (external) users had the profile and
password section on their edit page, which should be in sync with the
configured authentication service and not be managed by graylog itself.

## Description
This change will hide these sections so a admin does not change anything
and expects a different password.

Fixes #9222